### PR TITLE
Removed remaining old-style deserialization

### DIFF
--- a/internal/apredis/from_config.go
+++ b/internal/apredis/from_config.go
@@ -10,9 +10,7 @@ import (
 // NewForRoot creates a new redis client from the specified configuration. The type of the client
 // returned will be determined by the configuration.
 func NewForRoot(ctx context.Context, root *config.Root) (Client, error) {
-	redisConfig := root.Redis
-
-	switch v := redisConfig.(type) {
+	switch v := root.Redis.InnerVal.(type) {
 	case *config.RedisMiniredis:
 		return NewMiniredis(v)
 	case *config.RedisReal:

--- a/internal/apredis/test_config.go
+++ b/internal/apredis/test_config.go
@@ -32,7 +32,7 @@ func MustApplyTestConfig(cfg config.C) (config.C, Client) {
 	redisCfg := &sconfig.RedisMiniredis{
 		Provider: sconfig.RedisProviderMiniredis,
 	}
-	root.Redis = redisCfg
+	root.Redis = &sconfig.Redis{InnerVal: redisCfg}
 	if root.SystemAuth.GlobalAESKey == nil {
 		root.SystemAuth.GlobalAESKey = &sconfig.KeyData{InnerVal: &sconfig.KeyDataRandomBytes{}}
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
+	"gopkg.in/yaml.v3"
 )
 
 func LoadConfig(path string) (C, error) {
@@ -35,12 +36,12 @@ func LoadConfig(path string) (C, error) {
 		return nil, errors.Wrap(err, "config schema validation failed")
 	}
 
-	root, err := sconfig.UnmarshallYamlRoot(content)
-	if err != nil {
+	var root sconfig.Root
+	if err := yaml.Unmarshal(content, &root); err != nil {
 		return nil, err
 	}
 
-	return &config{root: root}, nil
+	return &config{root: &root}, nil
 }
 
 func FromRoot(root *sconfig.Root) C {

--- a/internal/database/service.go
+++ b/internal/database/service.go
@@ -18,14 +18,13 @@ import (
 // NewConnectionForRoot creates a new database connection from the specified configuration. The type of the database
 // returned will be determined by the configuration. Same as NewConnection.
 func NewConnectionForRoot(root *config.Root, logger *slog.Logger) (DB, error) {
-	dbConfig := root.Database
 	secretKey := root.SystemAuth.GlobalAESKey
 
-	switch dbConfig.(type) {
+	switch v := root.Database.InnerVal.(type) {
 	case *config.DatabaseSqlite:
-		return NewSqliteConnection(dbConfig.(*config.DatabaseSqlite), secretKey, logger)
+		return NewSqliteConnection(v, secretKey, logger)
 	case *config.DatabasePostgres:
-		return NewPostgresConnection(dbConfig.(*config.DatabasePostgres), secretKey, logger)
+		return NewPostgresConnection(v, secretKey, logger)
 	default:
 		return nil, errors.New("database type not supported")
 	}
@@ -100,7 +99,7 @@ func NewPostgresConnection(dbConfig *config.DatabasePostgres, secretKey config.K
 }
 
 type service struct {
-	cfg       config.Database
+	cfg       config.DatabaseImpl
 	sq        sq.StatementBuilderType
 	db        *sql.DB
 	secretKey config.KeyDataType // the AES key used to secure cursors

--- a/internal/database/test_db.go
+++ b/internal/database/test_db.go
@@ -115,9 +115,9 @@ func mustApplyBlankSqliteTestDbConfig(t testing.TB, cfg config.C) (config.C, DB,
 		t.Fatalf("failed to create sqlite test database: %v", err)
 	}
 
-	root.Database = &sconfig.DatabaseSqlite{
+	root.Database = &sconfig.Database{InnerVal: &sconfig.DatabaseSqlite{
 		Path: tempFilePath,
-	}
+	}}
 
 	db, err := NewConnectionForRoot(root, root.GetRootLogger())
 	if err != nil {
@@ -200,7 +200,7 @@ func mustApplyBlankPostgresTestDbConfig(t testing.TB, cfg config.C) (config.C, D
 		}
 	}
 
-	root.Database = &sconfig.DatabasePostgres{
+	root.Database = &sconfig.Database{InnerVal: &sconfig.DatabasePostgres{
 		Provider: sconfig.DatabaseProviderPostgres,
 		Host:     scommon.NewStringValueDirectInline(testDbConfig.Host),
 		Port:     scommon.NewIntegerValueDirectInline(int64(port)),
@@ -209,7 +209,7 @@ func mustApplyBlankPostgresTestDbConfig(t testing.TB, cfg config.C) (config.C, D
 		Database: scommon.NewStringValueDirectInline(testDbConfig.Database),
 		SSLMode:  scommon.NewStringValueDirectInline(sslMode),
 		Params:   params,
-	}
+	}}
 
 	db := &service{
 		cfg:       root.Database,

--- a/internal/schema/config/database_serialization_json.go
+++ b/internal/schema/config/database_serialization_json.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (d *Database) MarshalJSON() ([]byte, error) {
+	if d == nil || d.InnerVal == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(d.InnerVal)
+}
+
+// UnmarshalJSON handles unmarshalling from JSON while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (d *Database) UnmarshalJSON(data []byte) error {
+	var valueMap map[string]interface{}
+	if err := json.Unmarshal(data, &valueMap); err != nil {
+		return fmt.Errorf("failed to unmarshal database: %v", err)
+	}
+
+	var t DatabaseImpl
+
+	if provider, ok := valueMap["provider"]; ok {
+		switch DatabaseProvider(fmt.Sprintf("%v", provider)) {
+		case DatabaseProviderSqlite:
+			t = &DatabaseSqlite{}
+		case DatabaseProviderPostgres:
+			t = &DatabasePostgres{}
+		default:
+			return fmt.Errorf("unknown database provider %v", provider)
+		}
+	} else {
+		return fmt.Errorf("invalid structure for database; missing provider field")
+	}
+
+	if err := json.Unmarshal(data, t); err != nil {
+		return err
+	}
+
+	d.InnerVal = t
+	return nil
+}

--- a/internal/schema/config/database_serialization_yaml.go
+++ b/internal/schema/config/database_serialization_yaml.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (d *Database) MarshalYAML() (interface{}, error) {
+	if d.InnerVal == nil {
+		return nil, nil
+	}
+	return d.InnerVal, nil
+}
+
+// UnmarshalYAML handles unmarshalling from YAML while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (d *Database) UnmarshalYAML(value *yaml.Node) error {
+	// Ensure the node is a mapping node
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("database expected a mapping node, got %s", KindToString(value.Kind))
+	}
+
+	var database DatabaseImpl
+
+fieldLoop:
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+
+		switch keyNode.Value {
+		case "provider":
+			switch DatabaseProvider(valueNode.Value) {
+			case DatabaseProviderSqlite:
+				database = &DatabaseSqlite{Provider: DatabaseProviderSqlite}
+				break fieldLoop
+			case DatabaseProviderPostgres:
+				database = &DatabasePostgres{Provider: DatabaseProviderPostgres}
+				break fieldLoop
+			default:
+				return fmt.Errorf("unknown database provider %v", valueNode.Value)
+			}
+		}
+	}
+
+	if database == nil {
+		return fmt.Errorf("invalid structure for database; missing provider field")
+	}
+
+	if err := value.Decode(database); err != nil {
+		return err
+	}
+
+	d.InnerVal = database
+	return nil
+}

--- a/internal/schema/config/database_test.go
+++ b/internal/schema/config/database_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDatabase(t *testing.T) {
@@ -16,12 +17,12 @@ func TestDatabase(t *testing.T) {
       provider: sqlite
       path: ./some/path.db
 `
-			db, err := UnmarshallYamlDatabaseString(data)
-			assert.NoError(err)
-			assert.Equal(&DatabaseSqlite{
+			var db Database
+			assert.NoError(yaml.Unmarshal([]byte(data), &db))
+			assert.Equal(Database{InnerVal: &DatabaseSqlite{
 				Provider: DatabaseProviderSqlite,
 				Path:     "./some/path.db",
-			}, db)
+			}}, db)
 		})
 		t.Run("postgres", func(t *testing.T) {
 			data := `
@@ -35,9 +36,9 @@ func TestDatabase(t *testing.T) {
       params:
         application_name: authproxy-tests
 `
-			db, err := UnmarshallYamlDatabaseString(data)
-			assert.NoError(err)
-			assert.Equal(&DatabasePostgres{
+			var db Database
+			assert.NoError(yaml.Unmarshal([]byte(data), &db))
+			assert.Equal(Database{InnerVal: &DatabasePostgres{
 				Provider: DatabaseProviderPostgres,
 				Host:     common.NewStringValueDirectInline("localhost"),
 				Port:     common.NewIntegerValueDirectInline(5432),
@@ -48,7 +49,7 @@ func TestDatabase(t *testing.T) {
 				Params: map[string]string{
 					"application_name": "authproxy-tests",
 				},
-			}, db)
+			}}, db)
 		})
 	})
 }

--- a/internal/schema/config/logging.go
+++ b/internal/schema/config/logging.go
@@ -1,11 +1,8 @@
 package config
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
-
-	"gopkg.in/yaml.v3"
 )
 
 type LoggingConfigType string
@@ -62,66 +59,29 @@ func (l LoggingConfigOutput) Output() *os.File {
 	}
 }
 
-type LoggingConfig interface {
+// LoggingImpl is the interface implemented by concrete logging configurations.
+type LoggingImpl interface {
 	GetRootLogger() *slog.Logger
 	GetType() LoggingConfigType
 }
 
-func UnmarshallYamlLoggingString(data string) (LoggingConfig, error) {
-	return UnmarshallYamlLogging([]byte(data))
+// LoggingConfig is the holder for a LoggingImpl instance.
+type LoggingConfig struct {
+	InnerVal LoggingImpl `json:"-" yaml:"-"`
 }
 
-func UnmarshallYamlLogging(data []byte) (LoggingConfig, error) {
-	var rootNode yaml.Node
-
-	if err := yaml.Unmarshal(data, &rootNode); err != nil {
-		return nil, err
+func (l *LoggingConfig) GetRootLogger() *slog.Logger {
+	if l == nil || l.InnerVal == nil {
+		return (&LoggingConfigNone{Type: LoggingConfigTypeNone}).GetRootLogger()
 	}
-
-	return loggingUnmarshalYAML(rootNode.Content[0])
+	return l.InnerVal.GetRootLogger()
 }
 
-// loggingUnmarshalYAML handles unmarshalling from YAML while allowing us to make decisions
-// about how the data is unmarshalled based on the concrete type being represented
-func loggingUnmarshalYAML(value *yaml.Node) (LoggingConfig, error) {
-	// Ensure the node is a mapping node
-	if value.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("logger expected a mapping node, got %s", KindToString(value.Kind))
+func (l *LoggingConfig) GetType() LoggingConfigType {
+	if l == nil || l.InnerVal == nil {
+		return LoggingConfigTypeNone
 	}
-
-	var loggigConfig LoggingConfig
-
-fieldLoop:
-	for i := 0; i < len(value.Content); i += 2 {
-		keyNode := value.Content[i]
-		valueNode := value.Content[i+1]
-
-		switch keyNode.Value {
-		case "type":
-			switch LoggingConfigType(valueNode.Value) {
-			case LoggingConfigTypeText:
-				loggigConfig = &LoggingConfigText{Type: LoggingConfigTypeText}
-				break fieldLoop
-			case LoggingConfigTypeJson:
-				loggigConfig = &LoggingConfigJson{Type: LoggingConfigTypeJson}
-				break fieldLoop
-			case LoggingConfigTypeTint:
-				loggigConfig = &LoggingConfigTint{Type: LoggingConfigTypeTint}
-				break fieldLoop
-			default:
-				return nil, fmt.Errorf("unknown logging provider type %v", valueNode.Value)
-			}
-
-		}
-	}
-
-	if loggigConfig == nil {
-		return nil, fmt.Errorf("invalid structure for logging; missing type field")
-	}
-
-	if err := value.Decode(loggigConfig); err != nil {
-		return nil, err
-	}
-
-	return loggigConfig, nil
+	return l.InnerVal.GetType()
 }
+
+var _ LoggingImpl = (*LoggingConfig)(nil)

--- a/internal/schema/config/logging_serialization_json.go
+++ b/internal/schema/config/logging_serialization_json.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (l *LoggingConfig) MarshalJSON() ([]byte, error) {
+	if l == nil || l.InnerVal == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(l.InnerVal)
+}
+
+// UnmarshalJSON handles unmarshalling from JSON while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (l *LoggingConfig) UnmarshalJSON(data []byte) error {
+	var valueMap map[string]interface{}
+	if err := json.Unmarshal(data, &valueMap); err != nil {
+		return fmt.Errorf("failed to unmarshal logging: %v", err)
+	}
+
+	var t LoggingImpl
+
+	if typ, ok := valueMap["type"]; ok {
+		switch LoggingConfigType(fmt.Sprintf("%v", typ)) {
+		case LoggingConfigTypeText:
+			t = &LoggingConfigText{}
+		case LoggingConfigTypeJson:
+			t = &LoggingConfigJson{}
+		case LoggingConfigTypeTint:
+			t = &LoggingConfigTint{}
+		case LoggingConfigTypeNone:
+			t = &LoggingConfigNone{}
+		default:
+			return fmt.Errorf("unknown logging type %v", typ)
+		}
+	} else {
+		return fmt.Errorf("invalid structure for logging; missing type field")
+	}
+
+	if err := json.Unmarshal(data, t); err != nil {
+		return err
+	}
+
+	l.InnerVal = t
+	return nil
+}

--- a/internal/schema/config/logging_serialization_yaml.go
+++ b/internal/schema/config/logging_serialization_yaml.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (l *LoggingConfig) MarshalYAML() (interface{}, error) {
+	if l.InnerVal == nil {
+		return nil, nil
+	}
+	return l.InnerVal, nil
+}
+
+// UnmarshalYAML handles unmarshalling from YAML while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (l *LoggingConfig) UnmarshalYAML(value *yaml.Node) error {
+	// Ensure the node is a mapping node
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("logger expected a mapping node, got %s", KindToString(value.Kind))
+	}
+
+	var loggingConfig LoggingImpl
+
+fieldLoop:
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+
+		switch keyNode.Value {
+		case "type":
+			switch LoggingConfigType(valueNode.Value) {
+			case LoggingConfigTypeText:
+				loggingConfig = &LoggingConfigText{Type: LoggingConfigTypeText}
+				break fieldLoop
+			case LoggingConfigTypeJson:
+				loggingConfig = &LoggingConfigJson{Type: LoggingConfigTypeJson}
+				break fieldLoop
+			case LoggingConfigTypeTint:
+				loggingConfig = &LoggingConfigTint{Type: LoggingConfigTypeTint}
+				break fieldLoop
+			case LoggingConfigTypeNone:
+				loggingConfig = &LoggingConfigNone{Type: LoggingConfigTypeNone}
+				break fieldLoop
+			default:
+				return fmt.Errorf("unknown logging type %v", valueNode.Value)
+			}
+		}
+	}
+
+	if loggingConfig == nil {
+		return fmt.Errorf("invalid structure for logging; missing type field")
+	}
+
+	if err := value.Decode(loggingConfig); err != nil {
+		return err
+	}
+
+	l.InnerVal = loggingConfig
+	return nil
+}

--- a/internal/schema/config/logging_test.go
+++ b/internal/schema/config/logging_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoggingConfig(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("yaml parse", func(t *testing.T) {
+		t.Run("none", func(t *testing.T) {
+			var l LoggingConfig
+			assert.NoError(yaml.Unmarshal([]byte(`type: none`), &l))
+			assert.Equal(LoggingConfig{InnerVal: &LoggingConfigNone{
+				Type: LoggingConfigTypeNone,
+			}}, l)
+		})
+		t.Run("text minimal", func(t *testing.T) {
+			var l LoggingConfig
+			assert.NoError(yaml.Unmarshal([]byte(`type: text`), &l))
+			assert.Equal(LoggingConfig{InnerVal: &LoggingConfigText{
+				Type: LoggingConfigTypeText,
+			}}, l)
+		})
+		t.Run("text with options", func(t *testing.T) {
+			data := `
+type: text
+to: stderr
+level: debug
+source: true
+`
+			var l LoggingConfig
+			assert.NoError(yaml.Unmarshal([]byte(data), &l))
+			assert.Equal(LoggingConfig{InnerVal: &LoggingConfigText{
+				Type:   LoggingConfigTypeText,
+				To:     OutputStderr,
+				Level:  LevelDebug,
+				Source: true,
+			}}, l)
+		})
+		t.Run("json minimal", func(t *testing.T) {
+			var l LoggingConfig
+			assert.NoError(yaml.Unmarshal([]byte(`type: json`), &l))
+			assert.Equal(LoggingConfig{InnerVal: &LoggingConfigJson{
+				Type: LoggingConfigTypeJson,
+			}}, l)
+		})
+		t.Run("tint minimal", func(t *testing.T) {
+			var l LoggingConfig
+			assert.NoError(yaml.Unmarshal([]byte(`type: tint`), &l))
+			assert.Equal(LoggingConfig{InnerVal: &LoggingConfigTint{
+				Type: LoggingConfigTypeTint,
+			}}, l)
+		})
+		t.Run("unknown type returns error", func(t *testing.T) {
+			var l LoggingConfig
+			assert.Error(yaml.Unmarshal([]byte(`type: unknown`), &l))
+		})
+		t.Run("missing type returns error", func(t *testing.T) {
+			var l LoggingConfig
+			assert.Error(yaml.Unmarshal([]byte(`level: debug`), &l))
+		})
+	})
+}

--- a/internal/schema/config/redis.go
+++ b/internal/schema/config/redis.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-
-	"gopkg.in/yaml.v3"
-)
 
 type RedisProvider string
 
@@ -13,62 +8,21 @@ const (
 	RedisProviderRedis     RedisProvider = "redis"
 )
 
-type Redis interface {
+// RedisImpl is the interface implemented by concrete Redis configurations.
+type RedisImpl interface {
 	GetProvider() RedisProvider
 }
 
-func UnmarshallYamlRedisString(data string) (Redis, error) {
-	return UnmarshallYamlRedis([]byte(data))
+// Redis is the holder for a RedisImpl instance.
+type Redis struct {
+	InnerVal RedisImpl `json:"-" yaml:"-"`
 }
 
-func UnmarshallYamlRedis(data []byte) (Redis, error) {
-	var rootNode yaml.Node
-
-	if err := yaml.Unmarshal(data, &rootNode); err != nil {
-		return nil, err
+func (r *Redis) GetProvider() RedisProvider {
+	if r == nil || r.InnerVal == nil {
+		return ""
 	}
-
-	return redisUnmarshalYAML(rootNode.Content[0])
+	return r.InnerVal.GetProvider()
 }
 
-// RedisUnmarshalYAML handles unmarshalling from YAML while allowing us to make decisions
-// about how the data is unmarshalled based on the concrete type being represented
-func redisUnmarshalYAML(value *yaml.Node) (Redis, error) {
-	// Ensure the node is a mapping node
-	if value.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("Redis expected a mapping node, got %s", KindToString(value.Kind))
-	}
-
-	var redis Redis = &RedisReal{}
-
-fieldLoop:
-	for i := 0; i < len(value.Content); i += 2 {
-		keyNode := value.Content[i]
-		valueNode := value.Content[i+1]
-
-		switch keyNode.Value {
-		case "provider":
-			switch RedisProvider(valueNode.Value) {
-			case RedisProviderMiniredis:
-				redis = &RedisMiniredis{
-					Provider: RedisProviderMiniredis,
-				}
-				break fieldLoop
-			case RedisProviderRedis:
-				redis = &RedisReal{
-					Provider: RedisProviderRedis,
-				}
-				break fieldLoop
-			default:
-				return nil, fmt.Errorf("unknown redis provider %v", valueNode.Value)
-			}
-
-		}
-	}
-
-	if err := value.Decode(redis); err != nil {
-		return nil, err
-	}
-
-	return redis, nil
-}
+var _ RedisImpl = (*Redis)(nil)

--- a/internal/schema/config/redis_serialization_json.go
+++ b/internal/schema/config/redis_serialization_json.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (r *Redis) MarshalJSON() ([]byte, error) {
+	if r == nil || r.InnerVal == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(r.InnerVal)
+}
+
+// UnmarshalJSON handles unmarshalling from JSON while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (r *Redis) UnmarshalJSON(data []byte) error {
+	var valueMap map[string]interface{}
+	if err := json.Unmarshal(data, &valueMap); err != nil {
+		return fmt.Errorf("failed to unmarshal redis: %v", err)
+	}
+
+	var t RedisImpl
+
+	if provider, ok := valueMap["provider"]; ok {
+		switch RedisProvider(fmt.Sprintf("%v", provider)) {
+		case RedisProviderMiniredis:
+			t = &RedisMiniredis{}
+		case RedisProviderRedis:
+			t = &RedisReal{}
+		default:
+			return fmt.Errorf("unknown redis provider %v", provider)
+		}
+	} else {
+		// Default to real Redis when no provider specified
+		t = &RedisReal{}
+	}
+
+	if err := json.Unmarshal(data, t); err != nil {
+		return err
+	}
+
+	r.InnerVal = t
+	return nil
+}

--- a/internal/schema/config/redis_serialization_yaml.go
+++ b/internal/schema/config/redis_serialization_yaml.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (r *Redis) MarshalYAML() (interface{}, error) {
+	if r.InnerVal == nil {
+		return nil, nil
+	}
+	return r.InnerVal, nil
+}
+
+// UnmarshalYAML handles unmarshalling from YAML while allowing us to make decisions
+// about how the data is unmarshalled based on the concrete type being represented
+func (r *Redis) UnmarshalYAML(value *yaml.Node) error {
+	// Ensure the node is a mapping node
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("Redis expected a mapping node, got %s", KindToString(value.Kind))
+	}
+
+	var redis RedisImpl = &RedisReal{}
+
+fieldLoop:
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+
+		switch keyNode.Value {
+		case "provider":
+			switch RedisProvider(valueNode.Value) {
+			case RedisProviderMiniredis:
+				redis = &RedisMiniredis{
+					Provider: RedisProviderMiniredis,
+				}
+				break fieldLoop
+			case RedisProviderRedis:
+				redis = &RedisReal{
+					Provider: RedisProviderRedis,
+				}
+				break fieldLoop
+			default:
+				return fmt.Errorf("unknown redis provider %v", valueNode.Value)
+			}
+		}
+	}
+
+	if err := value.Decode(redis); err != nil {
+		return err
+	}
+
+	r.InnerVal = redis
+	return nil
+}

--- a/internal/schema/config/root.go
+++ b/internal/schema/config/root.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/rmorlok/authproxy/internal/util"
-	"gopkg.in/yaml.v3"
 )
 
 type Root struct {
@@ -18,9 +16,9 @@ type Root struct {
 	Marketplace     *Marketplace    `json:"marketplace,omitempty" yaml:"marketplace,omitempty"`
 	HostApplication HostApplication `json:"host_application" yaml:"host_application"`
 	SystemAuth      SystemAuth      `json:"system_auth" yaml:"system_auth"`
-	Database        Database        `json:"database" yaml:"database"`
-	Logging         LoggingConfig   `json:"logging,omitempty" yaml:"logging,omitempty"`
-	Redis           Redis           `json:"redis" yaml:"redis"`
+	Database        *Database       `json:"database" yaml:"database"`
+	Logging         *LoggingConfig  `json:"logging,omitempty" yaml:"logging,omitempty"`
+	Redis           *Redis          `json:"redis" yaml:"redis"`
 	Oauth           OAuth           `json:"oauth" yaml:"oauth"`
 	ErrorPages      ErrorPages      `json:"error_pages,omitempty" yaml:"error_pages,omitempty"`
 	Connectors      *Connectors     `json:"connectors" yaml:"connectors"`
@@ -31,7 +29,7 @@ type Root struct {
 
 func (r *Root) GetRootLogger() *slog.Logger {
 	if r == nil || r.Logging == nil {
-		return util.ToPtr(LoggingConfigNone{Type: LoggingConfigTypeNone}).GetRootLogger()
+		return (&LoggingConfigNone{Type: LoggingConfigTypeNone}).GetRootLogger()
 	}
 
 	return r.Logging.GetRootLogger()
@@ -69,75 +67,3 @@ func (r *Root) MustGetService(serviceId ServiceId) Service {
 	panic(fmt.Sprintf("invalid service id %s", serviceId))
 }
 
-func (sa *Root) UnmarshalYAML(value *yaml.Node) error {
-	// Ensure the node is a mapping node
-	if value.Kind != yaml.MappingNode {
-		return fmt.Errorf("root expected a mapping node, got %s", KindToString(value.Kind))
-	}
-
-	var database Database
-	var redis Redis
-	var logging LoggingConfig
-
-	// Handle custom unmarshalling for some attributes. Iterate through the mapping node's content,
-	// which will be sequences of keys, then values.
-	for i := 0; i < len(value.Content); i += 2 {
-		keyNode := value.Content[i]
-		valueNode := value.Content[i+1]
-
-		var err error
-		matched := false
-
-		switch keyNode.Value {
-		case "database":
-			if database, err = databaseUnmarshalYAML(valueNode); err != nil {
-				return err
-			}
-			matched = true
-		case "redis":
-			if redis, err = redisUnmarshalYAML(valueNode); err != nil {
-				return err
-			}
-			matched = true
-		case "logging":
-			if logging, err = loggingUnmarshalYAML(valueNode); err != nil {
-				return err
-			}
-			matched = true
-		}
-
-		if matched {
-			// Remove the key/value from the raw unmarshalling, and pull back our index
-			// because of the changing slice size to the left of what we are indexing
-			value.Content = append(value.Content[:i], value.Content[i+2:]...)
-			i -= 2
-		}
-	}
-
-	// Let the rest unmarshall normally
-	type RawType Root
-	raw := (*RawType)(sa)
-	if err := value.Decode(raw); err != nil {
-		return err
-	}
-
-	// Set the custom unmarshalled types
-	raw.Database = database
-	raw.Redis = redis
-	raw.Logging = logging
-
-	return nil
-}
-
-func UnmarshallYamlRootString(data string) (*Root, error) {
-	return UnmarshallYamlRoot([]byte(data))
-}
-
-func UnmarshallYamlRoot(data []byte) (*Root, error) {
-	var root Root
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		return nil, err
-	}
-
-	return &root, nil
-}

--- a/internal/schema/config/root_test.go
+++ b/internal/schema/config/root_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRootFullConfig(t *testing.T) {
@@ -102,7 +103,7 @@ connectors:
 		}),
 	}
 
-	root, err := UnmarshallYamlRootString(data)
-	assert.NoError(err)
-	assert.Equal(expected, root)
+	var root Root
+	assert.NoError(yaml.Unmarshal([]byte(data), &root))
+	assert.Equal(*expected, root)
 }


### PR DESCRIPTION
Previously config had a style of deserialization that required helper methods at the caller site. Moved to a mode that does it the standard way on the rest of the models.