### PR TITLE
Replace SelfSigned with SystemSigned and ActorSigned on JWT claims

### DIFF
--- a/cmd/cli/config/resolver.go
+++ b/cmd/cli/config/resolver.go
@@ -167,6 +167,7 @@ func (j *Resolver) ResolveBuilder() (jwt.TokenBuilder, error) {
 
 	b := jwt.NewJwtTokenBuilder().
 		WithActorExternalId(actorId).
+		WithActorSigned().
 		WithServiceIds(serviceIds)
 
 	if privateKeyPath != "" {

--- a/internal/apauth/jwt/auth_proxy_claims.go
+++ b/internal/apauth/jwt/auth_proxy_claims.go
@@ -32,9 +32,13 @@ type AuthProxyClaims struct {
 	// base claims.
 	Actor *core.Actor `json:"actor,omitempty"`
 
-	// SelfSigned indicates this token is signed with the GlobalAESKey. This means that AuthProxy has signed
-	// this token to itself for auth transfer between services, etc.
-	SelfSigned bool `json:"self_signed,omitempty"`
+	// SystemSigned indicates this token was signed by an AuthProxy service using the GlobalAESKey (HMAC).
+	// This is used for internal auth transfer between services, OAuth redirects, etc.
+	SystemSigned bool `json:"system_signed,omitempty"`
+
+	// ActorSigned indicates this token was signed by an actor using their own private key (asymmetric).
+	// This is used by the CLI and other external callers that have actor credentials.
+	ActorSigned bool `json:"actor_signed,omitempty"`
 
 	// Nonce is a one-time-use value. Adding a nonce to the JWT make it a one-time-use for auth purposes. If you use
 	// a nonce, the JWT must also have an expiry so that tracking of the nonce values do not need to be kept forever.

--- a/internal/apauth/jwt/claims_builder.go
+++ b/internal/apauth/jwt/claims_builder.go
@@ -24,7 +24,8 @@ type ClaimsBuilder interface {
 	WithExpiration(expiration time.Time) ClaimsBuilder
 	WithExpiresIn(expiresIn time.Duration) ClaimsBuilder
 	WithExpiresInCtx(ctx context.Context, expiresIn time.Duration) ClaimsBuilder
-	WithSelfSigned() ClaimsBuilder
+	WithSystemSigned() ClaimsBuilder
+	WithActorSigned() ClaimsBuilder
 	WithActorExternalId(id string) ClaimsBuilder
 	WithNamespace(namespace string) ClaimsBuilder
 	WithActor(actor core.IActorData) ClaimsBuilder
@@ -46,7 +47,8 @@ type claimsBuilder struct {
 	namespace  *string
 	actor      *core.Actor
 	labels     map[string]string
-	selfSigned bool
+	systemSigned bool
+	actorSigned  bool
 	nonce      *uuid.UUID
 }
 
@@ -89,8 +91,13 @@ func (b *claimsBuilder) WithExpiresInCtx(ctx context.Context, expiresIn time.Dur
 	return b
 }
 
-func (b *claimsBuilder) WithSelfSigned() ClaimsBuilder {
-	b.selfSigned = true
+func (b *claimsBuilder) WithSystemSigned() ClaimsBuilder {
+	b.systemSigned = true
+	return b
+}
+
+func (b *claimsBuilder) WithActorSigned() ClaimsBuilder {
+	b.actorSigned = true
 	return b
 }
 
@@ -176,8 +183,9 @@ func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) 
 			IssuedAt: &jwt.NumericDate{apctx.GetClock(ctx).Now()},
 			ID:       apctx.GetUuidGenerator(ctx).NewString(),
 		},
-		Actor:      b.actor,
-		SelfSigned: b.selfSigned,
+		Actor:        b.actor,
+		SystemSigned: b.systemSigned,
+		ActorSigned:  b.actorSigned,
 	}
 
 	if b.namespace != nil {

--- a/internal/apauth/jwt/token_builder.go
+++ b/internal/apauth/jwt/token_builder.go
@@ -36,7 +36,8 @@ type TokenBuilder interface {
 	WithExpiration(expiration time.Time) TokenBuilder
 	WithExpiresIn(expiresIn time.Duration) TokenBuilder
 	WithExpiresInCtx(ctx context.Context, expiresIn time.Duration) TokenBuilder
-	WithSelfSigned() TokenBuilder
+	WithSystemSigned() TokenBuilder
+	WithActorSigned() TokenBuilder
 	WithActorExternalId(id string) TokenBuilder
 	WithNamespace(namespace string) TokenBuilder
 	WithActor(actor core.IActorData) TokenBuilder
@@ -114,8 +115,13 @@ func (tb *tokenBuilder) WithExpiresInCtx(ctx context.Context, expiresIn time.Dur
 	return tb
 }
 
-func (tb *tokenBuilder) WithSelfSigned() TokenBuilder {
-	tb.jwtBuilder.WithSelfSigned()
+func (tb *tokenBuilder) WithSystemSigned() TokenBuilder {
+	tb.jwtBuilder.WithSystemSigned()
+	return tb
+}
+
+func (tb *tokenBuilder) WithActorSigned() TokenBuilder {
+	tb.jwtBuilder.WithActorSigned()
 	return tb
 }
 

--- a/internal/auth_methods/oauth2/auth_url.go
+++ b/internal/auth_methods/oauth2/auth_url.go
@@ -26,7 +26,7 @@ func (o *oAuth2Connection) getPublicRedirectUrl(ctx context.Context, stateId uui
 		WithActor(actor).
 		WithExpiresInCtx(ctx, o.cfg.GetRoot().Oauth.GetInitiateToRedirectTtlOrDefault()).
 		WithServiceId(config.ServiceIdPublic).
-		WithSelfSigned().
+		WithSystemSigned().
 		WithSecretConfigKeyData(ctx, o.cfg.GetRoot().SystemAuth.GlobalAESKey)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Split the overloaded `SelfSigned` JWT claim** into two explicit flags: `SystemSigned` (HMAC tokens minted by services via GlobalAESKey) and `ActorSigned` (asymmetric tokens signed by actors with their own private key)
- **Simplified the JWT parser key selection** by removing the `alg` header workaround — the parser now selects the correct verification key directly from the claims flags
- **Updated all builders, services, and tests** to use the new flags, including the OAuth flow (`WithSystemSigned`) and CLI (`WithActorSigned`)

## Context

The `SelfSigned` boolean on `AuthProxyClaims` was set `true` for two fundamentally different signing scenarios — system-signed HMAC tokens (internal service auth, OAuth redirects) and actor-signed asymmetric tokens (CLI). This ambiguity required a workaround in the parser that inspected the raw JWT `alg` header to distinguish which key to use. This change makes the intent explicit, eliminating the need for that workaround.

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/apauth/...` — all auth package tests pass
- [x] `go test ./...` — full test suite passes
- [x] Manual: restart server + raw-proxy, verify OAuth flow completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)