### PR TITLE
Fix namespace missing on request log

### DIFF
--- a/internal/request_log/roundtripper.go
+++ b/internal/request_log/roundtripper.go
@@ -68,6 +68,7 @@ func (t *redisLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a log entry
 	entry := &Entry{
 		Id:            id,
+		Namespace:     t.requestInfo.Namespace,
 		CorrelationID: apctx.CorrelationID(ctx),
 		Timestamp:     startTime,
 		Full:          t.recordFullRequest,


### PR DESCRIPTION
Namespace was missing when full logging is enabled. Fixed issue.