### PR TITLE
Add ping registry for extensible health checks

### DIFF
--- a/internal/request_log/ping_test.go
+++ b/internal/request_log/ping_test.go
@@ -1,0 +1,106 @@
+package request_log
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/assert"
+)
+
+// pingTestPingableStore implements RecordStore and pingable.
+type pingTestPingableStore struct {
+	pingResult bool
+}
+
+func (m *pingTestPingableStore) StoreRecord(ctx context.Context, record *LogRecord) error {
+	return nil
+}
+func (m *pingTestPingableStore) StoreRecords(ctx context.Context, records []*LogRecord) error {
+	return nil
+}
+func (m *pingTestPingableStore) Ping(ctx context.Context) bool {
+	return m.pingResult
+}
+
+// pingTestNonPingableStore implements RecordStore but not pingable.
+type pingTestNonPingableStore struct{}
+
+func (m *pingTestNonPingableStore) StoreRecord(ctx context.Context, record *LogRecord) error {
+	return nil
+}
+func (m *pingTestNonPingableStore) StoreRecords(ctx context.Context, records []*LogRecord) error {
+	return nil
+}
+
+// pingTestFullStore implements FullStore but not pingable.
+type pingTestFullStore struct{}
+
+func (m *pingTestFullStore) Store(ctx context.Context, log *FullLog) error { return nil }
+func (m *pingTestFullStore) GetFullLog(ctx context.Context, ns string, id apid.ID) (*FullLog, error) {
+	return nil, nil
+}
+
+// pingTestPingableFullStore implements FullStore and pingable.
+type pingTestPingableFullStore struct {
+	pingResult bool
+}
+
+func (m *pingTestPingableFullStore) Store(ctx context.Context, log *FullLog) error { return nil }
+func (m *pingTestPingableFullStore) GetFullLog(ctx context.Context, ns string, id apid.ID) (*FullLog, error) {
+	return nil, nil
+}
+func (m *pingTestPingableFullStore) Ping(ctx context.Context) bool {
+	return m.pingResult
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestStorageServicePing_PingableStoreOk(t *testing.T) {
+	ss := &StorageService{
+		logger:    testLogger(),
+		store:     &pingTestPingableStore{pingResult: true},
+		fullStore: &pingTestFullStore{},
+	}
+	assert.True(t, ss.Ping(context.Background()))
+}
+
+func TestStorageServicePing_PingableStoreFails(t *testing.T) {
+	ss := &StorageService{
+		logger:    testLogger(),
+		store:     &pingTestPingableStore{pingResult: false},
+		fullStore: &pingTestFullStore{},
+	}
+	assert.False(t, ss.Ping(context.Background()))
+}
+
+func TestStorageServicePing_NonPingableStore(t *testing.T) {
+	ss := &StorageService{
+		logger:    testLogger(),
+		store:     &pingTestNonPingableStore{},
+		fullStore: &pingTestFullStore{},
+	}
+	assert.True(t, ss.Ping(context.Background()))
+}
+
+func TestStorageServicePing_PingableFullStoreOk(t *testing.T) {
+	ss := &StorageService{
+		logger:    testLogger(),
+		store:     &pingTestNonPingableStore{},
+		fullStore: &pingTestPingableFullStore{pingResult: true},
+	}
+	assert.True(t, ss.Ping(context.Background()))
+}
+
+func TestStorageServicePing_PingableFullStoreFails(t *testing.T) {
+	ss := &StorageService{
+		logger:    testLogger(),
+		store:     &pingTestNonPingableStore{},
+		fullStore: &pingTestPingableFullStore{pingResult: false},
+	}
+	assert.False(t, ss.Ping(context.Background()))
+}

--- a/internal/request_log/provider.go
+++ b/internal/request_log/provider.go
@@ -20,6 +20,11 @@ type migratable interface {
 	Migrate(ctx context.Context) error
 }
 
+type pingable interface {
+	// Ping checks if the storage backend is reachable.
+	Ping(ctx context.Context) bool
+}
+
 // RecordRetriever handles querying LogRecord metadata from a storage backend.
 type RecordRetriever interface {
 	// GetRecord retrieves a single LogRecord by its request ID.

--- a/internal/request_log/provider_clickhouse.go
+++ b/internal/request_log/provider_clickhouse.go
@@ -135,6 +135,10 @@ func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 	return nil
 }
 
+func (s *clickhouseRecordStore) Ping(ctx context.Context) bool {
+	return s.db.PingContext(ctx) == nil
+}
+
 var _ RecordStore = (*clickhouseRecordStore)(nil)
 
 // --- ClickHouse RecordRetriever ---

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -168,6 +168,10 @@ func (s *sqlRecordStore) Migrate(ctx context.Context) error {
 	return nil
 }
 
+func (s *sqlRecordStore) Ping(ctx context.Context) bool {
+	return s.db.PingContext(ctx) == nil
+}
+
 var _ RecordStore = (*sqlRecordStore)(nil)
 
 // --- SQL RecordRetriever ---

--- a/internal/request_log/storage_service.go
+++ b/internal/request_log/storage_service.go
@@ -55,6 +55,25 @@ func (ss *StorageService) GetFullLog(ctx context.Context, id apid.ID) (*FullLog,
 	return ss.fullStore.GetFullLog(ctx, log.Namespace, id)
 }
 
+// Ping checks if the storage backends are reachable.
+func (ss *StorageService) Ping(ctx context.Context) bool {
+	if p, ok := ss.store.(pingable); ok {
+		if !p.Ping(ctx) {
+			return false
+		}
+	}
+
+	if util.SameInstance(ss.store, ss.fullStore) {
+		return true
+	}
+
+	if p, ok := ss.fullStore.(pingable); ok {
+		return p.Ping(ctx)
+	}
+
+	return true
+}
+
 // Migrate runs any necessary schema migrations for the storage backend.
 func (ss *StorageService) Migrate(ctx context.Context) error {
 	ss.logger.Info("running request log migrations")

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -1,6 +1,7 @@
 package admin_api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"sync"
@@ -91,11 +92,25 @@ func GetGinServer(
 		})
 	})
 
+	dm.RegisterDatabasePing()
+	dm.RegisterRedisPing()
+	dm.RegisterLogStoragePing()
+
 	healthChecker.GET("/healthz", func(c *gin.Context) {
-		c.PureJSON(http.StatusOK, gin.H{
-			"service": "admin-api",
-			"ok":      true,
-		})
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 1*time.Second)
+		defer cancel()
+
+		results, allOk := dm.RunPings(ctx)
+		status := http.StatusOK
+		if !allOk {
+			status = http.StatusServiceUnavailable
+		}
+
+		response := gin.H{"service": "admin-api", "ok": allOk}
+		for k, v := range results {
+			response[k] = v
+		}
+		c.PureJSON(status, response)
 	})
 
 	routesConnectors := common_routes.NewConnectorsRoutes(

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -12,7 +12,6 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/api_common"
 	"github.com/rmorlok/authproxy/internal/aplog"
-	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
 	common_routes "github.com/rmorlok/authproxy/internal/routes"
 	"github.com/rmorlok/authproxy/internal/service"
@@ -71,35 +70,25 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		})
 	})
 
+	dm.RegisterDatabasePing()
+	dm.RegisterRedisPing()
+	dm.RegisterLogStoragePing()
+
 	healthChecker.GET("/healthz", func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 1*time.Second)
 		defer cancel()
 
-		dbChan := make(chan bool, 1)
-		redisChan := make(chan bool, 1)
-
-		go func() {
-			dbChan <- dm.GetDatabase().Ping(ctx)
-		}()
-
-		go func() {
-			redisChan <- apredis.Ping(ctx, dm.GetRedisClient())
-		}()
-
-		dbOk := <-dbChan
-		redisOk := <-redisChan
-		everythingOk := dbOk && redisOk
+		results, allOk := dm.RunPings(ctx)
 		status := http.StatusOK
-		if !everythingOk {
+		if !allOk {
 			status = http.StatusServiceUnavailable
 		}
 
-		c.PureJSON(status, gin.H{
-			"service": "api",
-			"db":      dbOk,
-			"redis":   redisOk,
-			"ok":      everythingOk,
-		})
+		response := gin.H{"service": "api", "ok": allOk}
+		for k, v := range results {
+			response[k] = v
+		}
+		c.PureJSON(status, response)
 	})
 
 	routesConnectors := common_routes.NewConnectorsRoutes(

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/hibiken/asynq"
@@ -22,6 +23,10 @@ import (
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
+// PingFunc is a function that checks the health of a dependency.
+// It returns true if the dependency is healthy.
+type PingFunc func(ctx context.Context) bool
+
 type DependencyManager struct {
 	serviceId         string
 	cfg               config.C
@@ -36,13 +41,88 @@ type DependencyManager struct {
 	asynqClient       apasynq.Client
 	asynqInspector    *asynq.Inspector
 	c                 coreIface.C
+	pings             map[string]PingFunc
 }
 
 func NewDependencyManager(serviceId string, cfg config.C) *DependencyManager {
 	return &DependencyManager{
 		serviceId: serviceId,
 		cfg:       cfg,
+		pings:     make(map[string]PingFunc),
 	}
+}
+
+// RegisterPing registers a named ping function for health checking.
+func (dm *DependencyManager) RegisterPing(name string, fn PingFunc) {
+	dm.pings[name] = fn
+}
+
+// RunPings runs all registered ping functions concurrently and returns
+// a map of results and whether all pings succeeded.
+func (dm *DependencyManager) RunPings(ctx context.Context) (map[string]bool, bool) {
+	results := make(map[string]bool, len(dm.pings))
+	if len(dm.pings) == 0 {
+		return results, true
+	}
+
+	type pingResult struct {
+		name string
+		ok   bool
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for name, fn := range dm.pings {
+		wg.Add(1)
+		go func(name string, fn PingFunc) {
+			defer wg.Done()
+			ok := fn(ctx)
+			mu.Lock()
+			results[name] = ok
+			mu.Unlock()
+		}(name, fn)
+	}
+
+	wg.Wait()
+
+	allOk := true
+	for _, ok := range results {
+		if !ok {
+			allOk = false
+			break
+		}
+	}
+
+	return results, allOk
+}
+
+// RegisterDatabasePing registers a ping for the database.
+func (dm *DependencyManager) RegisterDatabasePing() {
+	dm.RegisterPing("db", func(ctx context.Context) bool {
+		return dm.GetDatabase().Ping(ctx)
+	})
+}
+
+// RegisterRedisPing registers a ping for Redis.
+func (dm *DependencyManager) RegisterRedisPing() {
+	dm.RegisterPing("redis", func(ctx context.Context) bool {
+		return apredis.Ping(ctx, dm.GetRedisClient())
+	})
+}
+
+// RegisterAsynqClientPing registers a ping for the Asynq client.
+func (dm *DependencyManager) RegisterAsynqClientPing() {
+	dm.RegisterPing("asynqClient", func(ctx context.Context) bool {
+		return dm.GetAsyncClient().Ping() == nil
+	})
+}
+
+// RegisterLogStoragePing registers a ping for the log storage service.
+func (dm *DependencyManager) RegisterLogStoragePing() {
+	dm.RegisterPing("logStorage", func(ctx context.Context) bool {
+		return dm.GetLogStorageService().Ping(ctx)
+	})
 }
 
 func (dm *DependencyManager) GetConfig() config.C {

--- a/internal/service/dependency_manager_test.go
+++ b/internal/service/dependency_manager_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterPingAndRunPings_AllOk(t *testing.T) {
+	dm := &DependencyManager{
+		pings: make(map[string]PingFunc),
+	}
+
+	dm.RegisterPing("db", func(ctx context.Context) bool { return true })
+	dm.RegisterPing("redis", func(ctx context.Context) bool { return true })
+
+	results, allOk := dm.RunPings(context.Background())
+	assert.True(t, allOk)
+	assert.True(t, results["db"])
+	assert.True(t, results["redis"])
+	assert.Len(t, results, 2)
+}
+
+func TestRunPings_OneFailure(t *testing.T) {
+	dm := &DependencyManager{
+		pings: make(map[string]PingFunc),
+	}
+
+	dm.RegisterPing("db", func(ctx context.Context) bool { return true })
+	dm.RegisterPing("redis", func(ctx context.Context) bool { return false })
+
+	results, allOk := dm.RunPings(context.Background())
+	assert.False(t, allOk)
+	assert.True(t, results["db"])
+	assert.False(t, results["redis"])
+}
+
+func TestRunPings_Empty(t *testing.T) {
+	dm := &DependencyManager{
+		pings: make(map[string]PingFunc),
+	}
+
+	results, allOk := dm.RunPings(context.Background())
+	assert.True(t, allOk)
+	assert.Empty(t, results)
+}
+
+func TestRunPings_ContextCancellation(t *testing.T) {
+	dm := &DependencyManager{
+		pings: make(map[string]PingFunc),
+	}
+
+	dm.RegisterPing("slow", func(ctx context.Context) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(5 * time.Second):
+			return true
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	results, allOk := dm.RunPings(ctx)
+	assert.False(t, allOk)
+	assert.False(t, results["slow"])
+}

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -12,7 +12,6 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/api_common"
 	"github.com/rmorlok/authproxy/internal/aplog"
-	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
 	common_routes "github.com/rmorlok/authproxy/internal/routes"
 	"github.com/rmorlok/authproxy/internal/service"
@@ -84,35 +83,25 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		})
 	})
 
+	dm.RegisterDatabasePing()
+	dm.RegisterRedisPing()
+	dm.RegisterLogStoragePing()
+
 	healthChecker.GET("/healthz", func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 1*time.Second)
 		defer cancel()
 
-		dbChan := make(chan bool, 1)
-		redisChan := make(chan bool, 1)
-
-		go func() {
-			dbChan <- dm.GetDatabase().Ping(ctx)
-		}()
-
-		go func() {
-			redisChan <- apredis.Ping(ctx, dm.GetRedisClient())
-		}()
-
-		dbOk := <-dbChan
-		redisOk := <-redisChan
-		everythingOk := dbOk && redisOk
+		results, allOk := dm.RunPings(ctx)
 		status := http.StatusOK
-		if !everythingOk {
+		if !allOk {
 			status = http.StatusServiceUnavailable
 		}
 
-		c.PureJSON(status, gin.H{
-			"service": "api",
-			"db":      dbOk,
-			"redis":   redisOk,
-			"ok":      everythingOk,
-		})
+		response := gin.H{"service": "public", "ok": allOk}
+		for k, v := range results {
+			response[k] = v
+		}
+		c.PureJSON(status, response)
 	})
 
 	routesError := common_routes.NewErrorRoutes(dm.GetConfig())

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -14,7 +14,6 @@ import (
 	authSync "github.com/rmorlok/authproxy/internal/apauth/tasks"
 	"github.com/rmorlok/authproxy/internal/api_common"
 	"github.com/rmorlok/authproxy/internal/aplog"
-	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/service"
@@ -53,48 +52,29 @@ func Serve(cfg config.C) {
 
 	dm.GetAsyncClient().Ping()
 
+	dm.RegisterDatabasePing()
+	dm.RegisterRedisPing()
+	dm.RegisterAsynqClientPing()
+	dm.RegisterLogStoragePing()
+	dm.RegisterPing("asynqServer", func(ctx context.Context) bool {
+		return asyncRunning && !asyncHasError
+	})
+
 	router.GET("/healthz", func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 1*time.Second)
 		defer cancel()
 
-		dbChan := make(chan bool, 1)
-		redisChan := make(chan bool, 1)
-		asynqClientChan := make(chan bool, 1)
-
-		go func() {
-			dbChan <- dm.GetDatabase().Ping(ctx)
-		}()
-
-		go func() {
-			redisChan <- apredis.Ping(ctx, dm.GetRedisClient())
-		}()
-
-		go func() {
-			if err := dm.GetAsyncClient().Ping(); err != nil {
-				asynqClientChan <- false
-			} else {
-				asynqClientChan <- true
-			}
-		}()
-
-		dbOk := <-dbChan
-		redisOk := <-redisChan
-		asyncClientOk := <-asynqClientChan
-		everythingOk := dbOk && redisOk && asyncRunning && !asyncHasError && asyncClientOk
+		results, allOk := dm.RunPings(ctx)
 		status := http.StatusOK
-		if !everythingOk {
+		if !allOk {
 			status = http.StatusServiceUnavailable
 		}
 
-		c.PureJSON(status, gin.H{
-			"service":          "worker",
-			"db":               dbOk,
-			"redis":            redisOk,
-			"asynqServer":      asyncRunning && !asyncHasError,
-			"asynqClient":      asyncClientOk,
-			"asyncIsScheduler": asyncIsScheduler,
-			"ok":               everythingOk,
-		})
+		response := gin.H{"service": "worker", "ok": allOk, "asyncIsScheduler": asyncIsScheduler}
+		for k, v := range results {
+			response[k] = v
+		}
+		c.PureJSON(status, response)
 	})
 
 	dm.AutoMigrateAll()


### PR DESCRIPTION
## Summary
- Adds a `PingFunc` type and ping registry to `DependencyManager` with `RegisterPing()` and `RunPings()` methods, plus convenience helpers (`RegisterDatabasePing`, `RegisterRedisPing`, `RegisterAsynqClientPing`, `RegisterLogStoragePing`)
- Adds `pingable` interface and `Ping()` methods to `clickhouseRecordStore`, `sqlRecordStore`, and `StorageService` in the `request_log` package
- Replaces duplicated goroutine+channel health check logic in all four services (api, admin-api, public, worker) with the centralized ping registry
- Fixes bug where public service reported `"service": "api"` instead of `"public"`
- admin-api now performs real DB/Redis/logStorage pings (previously always returned `ok: true`)

Closes #67

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/service/...` passes (new `dependency_manager_test.go` covers all-ok, one-failure, empty, and context cancellation)
- [x] `go test ./internal/request_log/...` passes (new `ping_test.go` covers pingable/non-pingable store combinations)
- [x] Manual verification: start services and hit `/healthz` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)