### PR TITLE
Add 429 rate limiting at connection level

### DIFF
--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 // Connection is a wrapper for the lower level database equivalent that handles wiring up logic specified in this
@@ -83,5 +85,14 @@ func (c *connection) Logger() *slog.Logger {
 	return c.logger
 }
 
+func (c *connection) GetRateLimitConfig() *connectors.RateLimiting {
+	def := c.cv.GetDefinition()
+	if def == nil {
+		return nil
+	}
+	return def.RateLimiting
+}
+
 var _ iface.Connection = (*connection)(nil)
 var _ aplog.HasLogger = (*connection)(nil)
+var _ httpf.RateLimitConfigProvider = (*connection)(nil)

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -30,9 +30,16 @@ func CreateFactory(
 	r apredis.Client,
 	requestLog RoundTripperFactory,
 	logger *slog.Logger,
+	additionalMiddlewares ...RoundTripperFactory,
 ) F {
-	// Order matters here to determine the order of middlewares
+	// Order matters here to determine the order of middlewares.
+	// Request logging is outermost so all requests (including rate-limited ones) are logged.
 	middlewares := []RoundTripperFactory{requestLog}
+	for _, m := range additionalMiddlewares {
+		if m != nil {
+			middlewares = append(middlewares, m)
+		}
+	}
 
 	return &clientFactory{
 		cfg:         cfg,
@@ -85,6 +92,10 @@ func (f *clientFactory) ForConnection(c Connection) F {
 	ri.Namespace = c.GetNamespace()
 	ri.ConnectorId = c.GetConnectorId()
 	ri.ConnectorVersion = c.GetConnectorVersion()
+
+	if rlp, ok := c.(RateLimitConfigProvider); ok {
+		ri.RateLimiting = rlp.GetRateLimitConfig()
+	}
 
 	return fp.ForRequestInfo(ri)
 }

--- a/internal/httpf/interface.go
+++ b/internal/httpf/interface.go
@@ -2,6 +2,7 @@ package httpf
 
 import (
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
 	"gopkg.in/h2non/gentleman.v2"
 )
 
@@ -13,6 +14,12 @@ type ConnectorVersion interface {
 
 type GettableConnectorVersion interface {
 	GetConnectorVersionEntity() ConnectorVersion
+}
+
+// RateLimitConfigProvider is an optional interface that connections can implement to provide
+// rate limiting configuration from the connector definition.
+type RateLimitConfigProvider interface {
+	GetRateLimitConfig() *connectors.RateLimiting
 }
 
 type Connection interface {

--- a/internal/httpf/request_info.go
+++ b/internal/httpf/request_info.go
@@ -1,6 +1,9 @@
 package httpf
 
-import "github.com/rmorlok/authproxy/internal/apid"
+import (
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+)
 
 type RequestType string
 
@@ -18,4 +21,8 @@ type RequestInfo struct {
 	ConnectorId      apid.ID
 	ConnectorVersion uint64
 	ConnectionId     apid.ID
+
+	// RateLimiting is the rate limiting configuration for the connector, if available.
+	// Nil means use default behavior (enabled with standard Retry-After parsing).
+	RateLimiting *connectors.RateLimiting
 }

--- a/internal/ratelimit/retry_after.go
+++ b/internal/ratelimit/retry_after.go
@@ -1,0 +1,86 @@
+package ratelimit
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseRetryAfter checks the given response headers for retry-after information.
+// It iterates through headerNames in order and returns the first successfully parsed duration.
+// Supported formats:
+//   - Integer seconds (e.g., "120")
+//   - HTTP-date per RFC 7231 (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
+//   - ISO 8601 timestamp (e.g., "2026-01-01T01:01:01Z") used by Atlassian X-RateLimit-Reset
+//
+// Returns the parsed duration and true if a valid value was found, or (0, false) if not.
+func ParseRetryAfter(headers http.Header, headerNames []string, now time.Time) (time.Duration, bool) {
+	for _, name := range headerNames {
+		value := headers.Get(name)
+		if value == "" {
+			continue
+		}
+
+		value = strings.TrimSpace(value)
+
+		if d, ok := parseAsSeconds(value); ok {
+			return d, true
+		}
+
+		if d, ok := parseAsHTTPDate(value, now); ok {
+			return d, true
+		}
+
+		if d, ok := parseAsISO8601(value, now); ok {
+			return d, true
+		}
+	}
+
+	return 0, false
+}
+
+func parseAsSeconds(value string) (time.Duration, bool) {
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if seconds < 0 {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+func parseAsHTTPDate(value string, now time.Time) (time.Duration, bool) {
+	t, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+
+	d := t.Sub(now)
+	if d < 0 {
+		d = 0
+	}
+	return d, true
+}
+
+var iso8601Formats = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04:05-07:00",
+	"2006-01-02T15:04:05",
+}
+
+func parseAsISO8601(value string, now time.Time) (time.Duration, bool) {
+	for _, format := range iso8601Formats {
+		t, err := time.Parse(format, value)
+		if err == nil {
+			d := t.Sub(now)
+			if d < 0 {
+				d = 0
+			}
+			return d, true
+		}
+	}
+	return 0, false
+}

--- a/internal/ratelimit/retry_after_test.go
+++ b/internal/ratelimit/retry_after_test.go
@@ -1,0 +1,116 @@
+package ratelimit
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "120")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 120*time.Second, d)
+}
+
+func TestParseRetryAfter_ZeroSeconds(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "0")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, time.Duration(0), d)
+}
+
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "Thu, 01 Jan 2026 00:02:00 GMT")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 120*time.Second, d)
+}
+
+func TestParseRetryAfter_HTTPDateInPast(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "Thu, 01 Jan 2026 00:02:00 GMT")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, time.Duration(0), d)
+}
+
+func TestParseRetryAfter_ISO8601(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("X-RateLimit-Reset", "2026-01-01T00:05:00Z")
+
+	d, ok := ParseRetryAfter(headers, []string{"X-RateLimit-Reset"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 5*time.Minute, d)
+}
+
+func TestParseRetryAfter_MultipleHeaders_FirstWins(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "30")
+	headers.Set("X-RateLimit-Reset", "2026-01-01T00:05:00Z")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After", "X-RateLimit-Reset"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 30*time.Second, d)
+}
+
+func TestParseRetryAfter_FallsThrough(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("X-RateLimit-Reset", "2026-01-01T00:05:00Z")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After", "X-RateLimit-Reset"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 5*time.Minute, d)
+}
+
+func TestParseRetryAfter_NoHeaders(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+
+	_, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.False(t, ok)
+}
+
+func TestParseRetryAfter_UnparseableValue(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "not-a-number")
+
+	_, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.False(t, ok)
+}
+
+func TestParseRetryAfter_NegativeSeconds(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "-5")
+
+	_, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.False(t, ok)
+}
+
+func TestParseRetryAfter_Whitespace(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "  60  ")
+
+	d, ok := ParseRetryAfter(headers, []string{"Retry-After"}, now)
+	assert.True(t, ok)
+	assert.Equal(t, 60*time.Second, d)
+}

--- a/internal/ratelimit/roundtripper.go
+++ b/internal/ratelimit/roundtripper.go
@@ -1,0 +1,220 @@
+package ratelimit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+// Factory implements httpf.RoundTripperFactory to create rate limiting roundtrippers.
+type Factory struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewFactory creates a new rate limiting middleware factory.
+func NewFactory(store *Store, logger *slog.Logger) *Factory {
+	return &Factory{
+		store:  store,
+		logger: logger,
+	}
+}
+
+func (f *Factory) NewRoundTripper(ri httpf.RequestInfo, transport http.RoundTripper) http.RoundTripper {
+	// Only apply rate limiting for proxy and probe requests with a connection context
+	if ri.ConnectionId == apid.Nil {
+		return nil
+	}
+	if ri.Type != httpf.RequestTypeProxy && ri.Type != httpf.RequestTypeProbe {
+		return nil
+	}
+
+	// Check if rate limiting is disabled
+	if ri.RateLimiting != nil && ri.RateLimiting.Disabled {
+		return nil
+	}
+
+	return &RoundTripper{
+		connectionId: ri.ConnectionId,
+		config:       ri.RateLimiting, // nil means use defaults
+		store:        f.store,
+		transport:    transport,
+		logger:       f.logger,
+	}
+}
+
+// RoundTripper is an http.RoundTripper that enforces 429-based rate limiting per connection.
+type RoundTripper struct {
+	connectionId apid.ID
+	config       *connectors.RateLimiting // nil means use defaults
+	store        *Store
+	transport    http.RoundTripper
+	logger       *slog.Logger
+}
+
+func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	// Check if this connection is currently rate-limited
+	remaining, limited, err := rt.store.IsRateLimited(ctx, rt.connectionId)
+	if err != nil {
+		rt.logger.WarnContext(ctx, "failed to check rate limit state",
+			slog.String("connection_id", rt.connectionId.String()),
+			slog.String("error", err.Error()),
+		)
+		// On Redis errors, allow the request through rather than blocking
+	} else if limited {
+		rt.logger.InfoContext(ctx, "request blocked by rate limiter",
+			slog.String("connection_id", rt.connectionId.String()),
+			slog.Duration("retry_after", remaining),
+		)
+		return rt.syntheticTooManyRequests(remaining), nil
+	}
+
+	// Execute the actual request
+	resp, err := rt.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	// Handle the response
+	if resp.StatusCode == http.StatusTooManyRequests {
+		rt.handle429(ctx, resp)
+	} else {
+		// Clear consecutive 429 counter on any non-429 response
+		if clearErr := rt.store.ClearConsecutive429Count(ctx, rt.connectionId); clearErr != nil {
+			rt.logger.WarnContext(ctx, "failed to clear consecutive 429 count",
+				slog.String("connection_id", rt.connectionId.String()),
+				slog.String("error", clearErr.Error()),
+			)
+		}
+	}
+
+	return resp, nil
+}
+
+func (rt *RoundTripper) handle429(ctx context.Context, resp *http.Response) {
+	now := apctx.GetClock(ctx).Now()
+	headerNames := rt.getConfig().GetRetryAfterHeaders()
+
+	retryAfter, found := ParseRetryAfter(resp.Header, headerNames, now)
+
+	if !found {
+		// No valid retry-after header; use backoff strategy
+		retryAfter = rt.computeBackoff(ctx)
+	}
+
+	// Cap at max retry-after
+	maxRetryAfter := rt.getConfig().GetMaxRetryAfter()
+	if retryAfter > maxRetryAfter {
+		retryAfter = maxRetryAfter
+	}
+
+	// Ensure minimum 1 second
+	if retryAfter < 1*time.Second {
+		retryAfter = 1 * time.Second
+	}
+
+	// Increment consecutive 429 count
+	count, err := rt.store.IncrementConsecutive429Count(ctx, rt.connectionId)
+	if err != nil {
+		rt.logger.WarnContext(ctx, "failed to increment consecutive 429 count",
+			slog.String("connection_id", rt.connectionId.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	// Store the rate limit
+	if err := rt.store.SetRateLimited(ctx, rt.connectionId, retryAfter); err != nil {
+		rt.logger.WarnContext(ctx, "failed to set rate limit",
+			slog.String("connection_id", rt.connectionId.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	rt.logger.InfoContext(ctx, "429 received, connection rate-limited",
+		slog.String("connection_id", rt.connectionId.String()),
+		slog.Duration("retry_after", retryAfter),
+		slog.Bool("header_found", found),
+		slog.Int("consecutive_429s", count),
+	)
+}
+
+func (rt *RoundTripper) computeBackoff(ctx context.Context) time.Duration {
+	cfg := rt.getConfig()
+
+	if cfg == nil || cfg.ExponentialBackoff == nil {
+		return cfg.GetDefaultRetryAfter()
+	}
+
+	eb := cfg.ExponentialBackoff
+
+	// Get the current consecutive count (before increment)
+	count, err := rt.store.GetConsecutive429Count(ctx, rt.connectionId)
+	if err != nil {
+		rt.logger.WarnContext(ctx, "failed to get consecutive 429 count for backoff",
+			slog.String("connection_id", rt.connectionId.String()),
+			slog.String("error", err.Error()),
+		)
+		return cfg.GetDefaultRetryAfter()
+	}
+
+	// Compute: initial * multiplier^count
+	initial := eb.GetInitialInterval()
+	multiplier := eb.GetMultiplier()
+	maxInterval := eb.GetMaxInterval()
+
+	backoff := float64(initial) * math.Pow(multiplier, float64(count))
+
+	// Apply jitter
+	jitter := eb.GetJitterFraction()
+	if jitter > 0 {
+		jitterRange := backoff * jitter
+		backoff = backoff - jitterRange + rand.Float64()*2*jitterRange
+	}
+
+	d := time.Duration(backoff)
+	if d > maxInterval {
+		d = maxInterval
+	}
+
+	return d
+}
+
+func (rt *RoundTripper) getConfig() *connectors.RateLimiting {
+	if rt.config != nil {
+		return rt.config
+	}
+	// Return a nil config which will cause the getter methods to return defaults
+	return nil
+}
+
+func (rt *RoundTripper) syntheticTooManyRequests(retryAfter time.Duration) *http.Response {
+	retryAfterSeconds := int(math.Ceil(retryAfter.Seconds()))
+	body := fmt.Sprintf(`{"error":"rate limited","retry_after_seconds":%d}`, retryAfterSeconds)
+
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Content-Type":          {"application/json"},
+			"Retry-After":          {strconv.Itoa(retryAfterSeconds)},
+			"X-Authproxy-Ratelimited": {"true"},
+		},
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+var _ httpf.RoundTripperFactory = (*Factory)(nil)

--- a/internal/ratelimit/roundtripper_test.go
+++ b/internal/ratelimit/roundtripper_test.go
@@ -1,0 +1,365 @@
+package ratelimit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log/slog"
+)
+
+type mockTransport struct {
+	resp *http.Response
+	err  error
+	// called tracks whether RoundTrip was invoked
+	called bool
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.called = true
+	return m.resp, m.err
+}
+
+func newTestStore(t *testing.T) (*Store, apredis.Client) {
+	_, r := apredis.MustApplyTestConfig(nil)
+	return NewStore(r), r
+}
+
+func testConnectionID() apid.ID {
+	return apid.New(apid.PrefixConnection)
+}
+
+func testCtx() context.Context {
+	return apctx.WithFixedClock(context.Background(), time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+}
+
+func testLogger() *slog.Logger {
+	return slog.Default()
+}
+
+func TestFactory_SkipsNonProxyRequests(t *testing.T) {
+	store, _ := newTestStore(t)
+	factory := NewFactory(store, testLogger())
+
+	rt := factory.NewRoundTripper(httpf.RequestInfo{
+		ConnectionId: testConnectionID(),
+		Type:         httpf.RequestTypeOAuth,
+	}, http.DefaultTransport)
+
+	assert.Nil(t, rt)
+}
+
+func TestFactory_SkipsNoConnectionId(t *testing.T) {
+	store, _ := newTestStore(t)
+	factory := NewFactory(store, testLogger())
+
+	rt := factory.NewRoundTripper(httpf.RequestInfo{
+		Type: httpf.RequestTypeProxy,
+	}, http.DefaultTransport)
+
+	assert.Nil(t, rt)
+}
+
+func TestFactory_SkipsDisabled(t *testing.T) {
+	store, _ := newTestStore(t)
+	factory := NewFactory(store, testLogger())
+
+	rt := factory.NewRoundTripper(httpf.RequestInfo{
+		ConnectionId: testConnectionID(),
+		Type:         httpf.RequestTypeProxy,
+		RateLimiting: &connectors.RateLimiting{Disabled: true},
+	}, http.DefaultTransport)
+
+	assert.Nil(t, rt)
+}
+
+func TestFactory_CreatesForProxy(t *testing.T) {
+	store, _ := newTestStore(t)
+	factory := NewFactory(store, testLogger())
+
+	rt := factory.NewRoundTripper(httpf.RequestInfo{
+		ConnectionId: testConnectionID(),
+		Type:         httpf.RequestTypeProxy,
+	}, http.DefaultTransport)
+
+	assert.NotNil(t, rt)
+}
+
+func TestFactory_CreatesForProbe(t *testing.T) {
+	store, _ := newTestStore(t)
+	factory := NewFactory(store, testLogger())
+
+	rt := factory.NewRoundTripper(httpf.RequestInfo{
+		ConnectionId: testConnectionID(),
+		Type:         httpf.RequestTypeProbe,
+	}, http.DefaultTransport)
+
+	assert.NotNil(t, rt)
+}
+
+func TestRoundTripper_PassthroughOnSuccess(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+
+	transport := &mockTransport{
+		resp: &http.Response{StatusCode: 200, Header: http.Header{}},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(testCtx(), "GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.True(t, transport.called)
+}
+
+func TestRoundTripper_429SetsRateLimit(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{"Retry-After": {"30"}},
+		},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 429, resp.StatusCode)
+
+	// Verify the connection is now rate-limited
+	remaining, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.True(t, limited)
+	assert.True(t, remaining > 0)
+}
+
+func TestRoundTripper_BlocksSubsequentRequests(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	// Pre-set a rate limit
+	err := store.SetRateLimited(ctx, connID, 30*time.Second)
+	require.NoError(t, err)
+
+	transport := &mockTransport{
+		resp: &http.Response{StatusCode: 200, Header: http.Header{}},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 429, resp.StatusCode)
+	assert.Equal(t, "true", resp.Header.Get("X-Authproxy-Ratelimited"))
+	assert.False(t, transport.called, "should not have called upstream transport")
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "rate limited")
+}
+
+func TestRoundTripper_ClearsCounterOnSuccess(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	// Set a consecutive count
+	_, err := store.IncrementConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	_, err = store.IncrementConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+
+	count, err := store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	transport := &mockTransport{
+		resp: &http.Response{StatusCode: 200, Header: http.Header{}},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	// Counter should be cleared
+	count, err = store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestRoundTripper_DefaultRetryAfterWhenNoHeader(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{}, // No Retry-After
+		},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	// Should be rate-limited with default duration
+	_, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.True(t, limited)
+}
+
+func TestRoundTripper_CustomRetryAfterHeaders(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header: http.Header{
+				"X-Custom-Retry": {"45"},
+			},
+		},
+	}
+
+	cfg := &connectors.RateLimiting{
+		RetryAfterHeaders: []string{"X-Custom-Retry"},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		config:       cfg,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	_, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.True(t, limited)
+}
+
+func TestRoundTripper_MaxRetryAfterCap(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{"Retry-After": {"999999"}}, // Very large
+		},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	remaining, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.True(t, limited)
+	// Should be capped at default max (15 minutes)
+	assert.LessOrEqual(t, remaining, connectors.DefaultMaxRetryAfter)
+}
+
+func TestRoundTripper_IncrementsConsecutiveCount(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{"Retry-After": {"10"}},
+		},
+	}
+
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	// First 429
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	count, err := store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Clear the rate limit to allow second request through
+	store.r.Del(ctx, blockedKey(connID))
+
+	// Second 429
+	req, _ = http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	count, err = store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}

--- a/internal/ratelimit/store.go
+++ b/internal/ratelimit/store.go
@@ -1,0 +1,94 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+)
+
+const (
+	redisKeyPrefix         = "ratelimit:"
+	blockedKeyPrefix       = redisKeyPrefix + "blocked:"
+	consecutive429KeyPrefix = redisKeyPrefix + "429count:"
+	// consecutiveCountTTL is how long the consecutive 429 counter persists without activity.
+	consecutiveCountTTL = 1 * time.Hour
+)
+
+// Store manages rate limiting state in Redis.
+type Store struct {
+	r apredis.Client
+}
+
+// NewStore creates a new rate limit store backed by Redis.
+func NewStore(r apredis.Client) *Store {
+	return &Store{r: r}
+}
+
+func blockedKey(connectionID apid.ID) string {
+	return fmt.Sprintf("%s%s", blockedKeyPrefix, connectionID.String())
+}
+
+func consecutive429Key(connectionID apid.ID) string {
+	return fmt.Sprintf("%s%s", consecutive429KeyPrefix, connectionID.String())
+}
+
+// IsRateLimited checks if a connection is currently rate-limited.
+// Returns the remaining TTL and true if limited, or (0, false) if not.
+func (s *Store) IsRateLimited(ctx context.Context, connectionID apid.ID) (time.Duration, bool, error) {
+	ttl, err := s.r.TTL(ctx, blockedKey(connectionID)).Result()
+	if err != nil {
+		return 0, false, err
+	}
+
+	// TTL returns -2 if key doesn't exist, -1 if no TTL set
+	if ttl <= 0 {
+		return 0, false, nil
+	}
+
+	return ttl, true, nil
+}
+
+// SetRateLimited marks a connection as rate-limited for the given duration.
+func (s *Store) SetRateLimited(ctx context.Context, connectionID apid.ID, duration time.Duration) error {
+	return s.r.Set(ctx, blockedKey(connectionID), "1", duration).Err()
+}
+
+// GetConsecutive429Count returns the consecutive 429 count for exponential backoff.
+func (s *Store) GetConsecutive429Count(ctx context.Context, connectionID apid.ID) (int, error) {
+	val, err := s.r.Get(ctx, consecutive429Key(connectionID)).Result()
+	if err != nil {
+		if err.Error() == "redis: nil" {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	count, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// IncrementConsecutive429Count increments the consecutive 429 counter and returns the new value.
+func (s *Store) IncrementConsecutive429Count(ctx context.Context, connectionID apid.ID) (int, error) {
+	key := consecutive429Key(connectionID)
+	count, err := s.r.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, err
+	}
+
+	// Reset the TTL on each increment
+	s.r.Expire(ctx, key, consecutiveCountTTL)
+
+	return int(count), nil
+}
+
+// ClearConsecutive429Count resets the counter (called on successful non-429 response).
+func (s *Store) ClearConsecutive429Count(ctx context.Context, connectionID apid.ID) error {
+	return s.r.Del(ctx, consecutive429Key(connectionID)).Err()
+}

--- a/internal/ratelimit/store_test.go
+++ b/internal/ratelimit/store_test.go
@@ -1,0 +1,69 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_IsRateLimited_NotLimited(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	connID := apid.New(apid.PrefixConnection)
+
+	_, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.False(t, limited)
+}
+
+func TestStore_SetAndCheckRateLimited(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	connID := apid.New(apid.PrefixConnection)
+
+	err := store.SetRateLimited(ctx, connID, 30*time.Second)
+	require.NoError(t, err)
+
+	remaining, limited, err := store.IsRateLimited(ctx, connID)
+	require.NoError(t, err)
+	assert.True(t, limited)
+	assert.True(t, remaining > 0)
+	assert.True(t, remaining <= 30*time.Second)
+}
+
+func TestStore_ConsecutiveCount(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	connID := apid.New(apid.PrefixConnection)
+
+	// Initially zero
+	count, err := store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	// Increment
+	count, err = store.IncrementConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	count, err = store.IncrementConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Read back
+	count, err = store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Clear
+	err = store.ClearConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+
+	count, err = store.GetConsecutive429Count(ctx, connID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/internal/schema/connectors/connector.go
+++ b/internal/schema/connectors/connector.go
@@ -67,6 +67,10 @@ type Connector struct {
 	// documentation for each struct for more details.
 	Auth *Auth `json:"auth" yaml:"auth"`
 
+	// RateLimiting configures how 429 rate limiting responses from the 3rd party are handled.
+	// If unset, default behavior is enabled (parse Retry-After header, 60s default backoff).
+	RateLimiting *RateLimiting `json:"rate_limiting,omitempty" yaml:"rate_limiting,omitempty"`
+
 	// Probes are a list of probes to run against connections of this connector type to validation the connection.
 	Probes []Probe `json:"probes,omitempty" yaml:"probes,omitempty"`
 
@@ -87,6 +91,10 @@ func (c *Connector) Clone() *Connector {
 
 	if c.Auth != nil {
 		clone.Auth = c.Auth.CloneValue()
+	}
+
+	if c.RateLimiting != nil {
+		clone.RateLimiting = c.RateLimiting.Clone()
 	}
 
 	if c.Labels != nil {
@@ -110,6 +118,12 @@ func (c *Connector) Validate(vc *common.ValidationContext) error {
 
 	if c.Namespace != nil {
 		if err := aschema.ValidateNamespacePath(*c.Namespace); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if c.RateLimiting != nil {
+		if err := c.RateLimiting.Validate(vc.PushField("rate_limiting")); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/internal/schema/connectors/rate_limiting.go
+++ b/internal/schema/connectors/rate_limiting.go
@@ -1,0 +1,224 @@
+package connectors
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"time"
+)
+
+const (
+	DefaultMaxRetryAfter        = 15 * time.Minute
+	DefaultDefaultRetryAfter    = 60 * time.Second
+	DefaultBackoffInitial       = 1 * time.Second
+	DefaultBackoffMultiplier    = 2.0
+	DefaultBackoffMaxInterval   = 5 * time.Minute
+	DefaultBackoffJitterFraction = 0.1
+)
+
+// RateLimiting configures how 429 rate limiting responses from the 3rd party are handled. When a 429 is received,
+// the system will parse retry-after information from the response headers and block subsequent requests for that
+// connection until the retry-after period has elapsed.
+type RateLimiting struct {
+	// Disabled turns off 429-based rate limiting entirely. When true, 429 responses are passed through
+	// to the caller without any blocking of future requests.
+	Disabled bool `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+
+	// RetryAfterHeaders is an ordered list of response header names to check for retry-after information.
+	// The system checks headers in order and uses the first one that contains a parseable value.
+	// Supported value formats: integer seconds, HTTP-date (RFC 7231), ISO 8601 timestamp.
+	// Defaults to ["Retry-After"] if unset.
+	RetryAfterHeaders []string `json:"retry_after_headers,omitempty" yaml:"retry_after_headers,omitempty"`
+
+	// MaxRetryAfter caps the maximum backoff duration to prevent unreasonably long waits.
+	// Defaults to 15 minutes if unset.
+	MaxRetryAfter *common.HumanDuration `json:"max_retry_after,omitempty" yaml:"max_retry_after,omitempty"`
+
+	// DefaultRetryAfter is used when a 429 is received but no parseable retry-after header is found
+	// and exponential backoff is not configured. Defaults to 60 seconds if unset.
+	DefaultRetryAfter *common.HumanDuration `json:"default_retry_after,omitempty" yaml:"default_retry_after,omitempty"`
+
+	// ExponentialBackoff configures backoff behavior when no retry-after header is present and
+	// consecutive 429s are received. If unset, DefaultRetryAfter is used as a flat backoff.
+	ExponentialBackoff *ExponentialBackoff `json:"exponential_backoff,omitempty" yaml:"exponential_backoff,omitempty"`
+}
+
+// ExponentialBackoff configures exponential backoff for 429 responses that lack retry-after headers.
+type ExponentialBackoff struct {
+	// InitialInterval is the starting backoff duration. Defaults to 1 second.
+	InitialInterval *common.HumanDuration `json:"initial_interval,omitempty" yaml:"initial_interval,omitempty"`
+
+	// Multiplier is the backoff multiplier applied for each consecutive 429. Defaults to 2.0.
+	Multiplier *float64 `json:"multiplier,omitempty" yaml:"multiplier,omitempty"`
+
+	// MaxInterval caps the maximum backoff interval. Defaults to 5 minutes.
+	MaxInterval *common.HumanDuration `json:"max_interval,omitempty" yaml:"max_interval,omitempty"`
+
+	// JitterFraction adds randomness to the backoff duration (0.0 to 1.0). The actual backoff will be
+	// between (1-jitter)*computed and (1+jitter)*computed. Defaults to 0.1.
+	JitterFraction *float64 `json:"jitter_fraction,omitempty" yaml:"jitter_fraction,omitempty"`
+}
+
+func (r *RateLimiting) Clone() *RateLimiting {
+	if r == nil {
+		return nil
+	}
+
+	clone := *r
+
+	if r.RetryAfterHeaders != nil {
+		clone.RetryAfterHeaders = make([]string, len(r.RetryAfterHeaders))
+		copy(clone.RetryAfterHeaders, r.RetryAfterHeaders)
+	}
+
+	if r.MaxRetryAfter != nil {
+		v := *r.MaxRetryAfter
+		clone.MaxRetryAfter = &v
+	}
+
+	if r.DefaultRetryAfter != nil {
+		v := *r.DefaultRetryAfter
+		clone.DefaultRetryAfter = &v
+	}
+
+	if r.ExponentialBackoff != nil {
+		clone.ExponentialBackoff = r.ExponentialBackoff.Clone()
+	}
+
+	return &clone
+}
+
+func (r *RateLimiting) Validate(vc *common.ValidationContext) error {
+	if r == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+
+	if r.MaxRetryAfter != nil && r.MaxRetryAfter.Duration <= 0 {
+		result = multierror.Append(result, vc.PushField("max_retry_after").NewError("must be positive"))
+	}
+
+	if r.DefaultRetryAfter != nil && r.DefaultRetryAfter.Duration <= 0 {
+		result = multierror.Append(result, vc.PushField("default_retry_after").NewError("must be positive"))
+	}
+
+	if r.ExponentialBackoff != nil {
+		if err := r.ExponentialBackoff.Validate(vc.PushField("exponential_backoff")); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+// GetRetryAfterHeaders returns the configured retry-after headers, defaulting to ["Retry-After"].
+func (r *RateLimiting) GetRetryAfterHeaders() []string {
+	if r == nil || len(r.RetryAfterHeaders) == 0 {
+		return []string{"Retry-After"}
+	}
+	return r.RetryAfterHeaders
+}
+
+// GetMaxRetryAfter returns the configured max retry-after duration, defaulting to 15 minutes.
+func (r *RateLimiting) GetMaxRetryAfter() time.Duration {
+	if r == nil || r.MaxRetryAfter == nil {
+		return DefaultMaxRetryAfter
+	}
+	return r.MaxRetryAfter.Duration
+}
+
+// GetDefaultRetryAfter returns the configured default retry-after duration, defaulting to 60 seconds.
+func (r *RateLimiting) GetDefaultRetryAfter() time.Duration {
+	if r == nil || r.DefaultRetryAfter == nil {
+		return DefaultDefaultRetryAfter
+	}
+	return r.DefaultRetryAfter.Duration
+}
+
+func (eb *ExponentialBackoff) Clone() *ExponentialBackoff {
+	if eb == nil {
+		return nil
+	}
+
+	clone := *eb
+
+	if eb.InitialInterval != nil {
+		v := *eb.InitialInterval
+		clone.InitialInterval = &v
+	}
+
+	if eb.Multiplier != nil {
+		v := *eb.Multiplier
+		clone.Multiplier = &v
+	}
+
+	if eb.MaxInterval != nil {
+		v := *eb.MaxInterval
+		clone.MaxInterval = &v
+	}
+
+	if eb.JitterFraction != nil {
+		v := *eb.JitterFraction
+		clone.JitterFraction = &v
+	}
+
+	return &clone
+}
+
+func (eb *ExponentialBackoff) Validate(vc *common.ValidationContext) error {
+	if eb == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+
+	if eb.InitialInterval != nil && eb.InitialInterval.Duration <= 0 {
+		result = multierror.Append(result, vc.PushField("initial_interval").NewError("must be positive"))
+	}
+
+	if eb.Multiplier != nil && *eb.Multiplier <= 0 {
+		result = multierror.Append(result, vc.PushField("multiplier").NewError("must be positive"))
+	}
+
+	if eb.MaxInterval != nil && eb.MaxInterval.Duration <= 0 {
+		result = multierror.Append(result, vc.PushField("max_interval").NewError("must be positive"))
+	}
+
+	if eb.JitterFraction != nil && (*eb.JitterFraction < 0 || *eb.JitterFraction > 1) {
+		result = multierror.Append(result, vc.PushField("jitter_fraction").NewError("must be between 0.0 and 1.0"))
+	}
+
+	return result.ErrorOrNil()
+}
+
+// GetInitialInterval returns the configured initial interval, defaulting to 1 second.
+func (eb *ExponentialBackoff) GetInitialInterval() time.Duration {
+	if eb == nil || eb.InitialInterval == nil {
+		return DefaultBackoffInitial
+	}
+	return eb.InitialInterval.Duration
+}
+
+// GetMultiplier returns the configured multiplier, defaulting to 2.0.
+func (eb *ExponentialBackoff) GetMultiplier() float64 {
+	if eb == nil || eb.Multiplier == nil {
+		return DefaultBackoffMultiplier
+	}
+	return *eb.Multiplier
+}
+
+// GetMaxInterval returns the configured max interval, defaulting to 5 minutes.
+func (eb *ExponentialBackoff) GetMaxInterval() time.Duration {
+	if eb == nil || eb.MaxInterval == nil {
+		return DefaultBackoffMaxInterval
+	}
+	return eb.MaxInterval.Duration
+}
+
+// GetJitterFraction returns the configured jitter fraction, defaulting to 0.1.
+func (eb *ExponentialBackoff) GetJitterFraction() float64 {
+	if eb == nil || eb.JitterFraction == nil {
+		return DefaultBackoffJitterFraction
+	}
+	return *eb.JitterFraction
+}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/ratelimit"
 	"github.com/rmorlok/authproxy/internal/request_log"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
@@ -227,6 +228,11 @@ func (dm *DependencyManager) GetLogStorageService() *request_log.StorageService 
 	return dm.logStorageService
 }
 
+func (dm *DependencyManager) GetRateLimitFactory() *ratelimit.Factory {
+	store := ratelimit.NewStore(dm.GetRedisClient())
+	return ratelimit.NewFactory(store, dm.GetLogger())
+}
+
 func (dm *DependencyManager) GetHttpf() httpf.F {
 	if dm.httpf == nil {
 		dm.httpf = httpf.CreateFactory(
@@ -234,6 +240,7 @@ func (dm *DependencyManager) GetHttpf() httpf.F {
 			dm.GetRedisClient(),
 			dm.GetLogStorageService(),
 			dm.GetLogger(),
+			dm.GetRateLimitFactory(),
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Adds `http.RoundTripper` middleware that detects 429 responses from 3rd party APIs, parses retry-after information from headers, and blocks subsequent requests per-connection in Redis until the backoff period elapses
- Supports standard `Retry-After` (seconds and HTTP-date), ISO 8601 timestamps (Atlassian `X-RateLimit-Reset`), and configurable custom header names
- Adds `rate_limiting` configuration section to connector schema with options to disable, customize headers, set max backoff caps, and configure exponential backoff for APIs that don't return retry-after headers
- Blocked requests receive a synthetic 429 with `X-Authproxy-Ratelimited: true` header to distinguish from upstream 429s

## Test plan
- [x] 27 unit tests covering header parsing (seconds, HTTP-date, ISO 8601, fallthrough, edge cases), Redis store operations, and roundtripper behavior (passthrough, blocking, counter management, config options)
- [x] Full project test suite passes (`go test ./...`)
- [ ] Manual test: configure a connector with rate limiting, trigger a 429 from a 3rd party, verify subsequent requests are blocked and unblocked after the retry-after period

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)