### PR TITLE
Fix flaky SecureDecryptedJsonValue test

### DIFF
--- a/internal/util/secure_encrypted_value_test.go
+++ b/internal/util/secure_encrypted_value_test.go
@@ -49,7 +49,7 @@ func TestSecureDecryptedJsonValue(t *testing.T) {
 		assert.NoError(t, err)
 
 		encryptedBytes := []byte(encrypted)
-		encryptedBytes[5] = 'x'
+		encryptedBytes[5] ^= 0xff
 
 		_, err = SecureDecryptedJsonValue[Foo](key, string(encryptedBytes))
 		assert.Error(t, err)


### PR DESCRIPTION
## Summary
- Fix flaky `TestSecureDecryptedJsonValue/fails_if_data_changes` that was causing intermittent CI failures
- The test corrupted encrypted data by setting `encryptedBytes[5] = 'x'`, but if that byte was already `'x'`, the data was unchanged and decryption succeeded unexpectedly
- Changed to `encryptedBytes[5] ^= 0xff` (XOR) which guarantees the byte always flips

## Test plan
- [x] Ran the test 100 times locally with `-count=100` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)