### PR TITLE
Prevent deletion of ek_global encryption key

### DIFF
--- a/internal/core/error.go
+++ b/internal/core/error.go
@@ -6,5 +6,6 @@ import (
 
 var ErrNotFound = iface.ErrNotFound
 var ErrConnectionNotFound = iface.ErrConnectionNotFound
+var ErrProtected = iface.ErrProtected
 var ErrDraftAlreadyExists = iface.ErrDraftAlreadyExists
 var ErrNotDraft = iface.ErrNotDraft

--- a/internal/core/iface/errors.go
+++ b/internal/core/iface/errors.go
@@ -9,5 +9,6 @@ import (
 
 var ErrNotFound = database.ErrNotFound
 var ErrConnectionNotFound = errors.Wrap(ErrNotFound, "connection not found")
+var ErrProtected = database.ErrProtected
 var ErrDraftAlreadyExists = stderrors.New("a draft version already exists")
 var ErrNotDraft = stderrors.New("version is not a draft")

--- a/internal/core/service_encryption_key.go
+++ b/internal/core/service_encryption_key.go
@@ -66,6 +66,9 @@ func (s *service) DeleteEncryptionKey(ctx context.Context, id apid.ID) error {
 		if errors.Is(err, database.ErrNotFound) {
 			return ErrNotFound
 		}
+		if errors.Is(err, database.ErrProtected) {
+			return err
+		}
 		return err
 	}
 	return nil

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -27,6 +27,10 @@ func init() {
 
 const EncryptionKeysTable = "encryption_keys"
 
+// GlobalEncryptionKeyID is the ID of the global encryption key created by migration. It is the root
+// of the encryption key hierarchy and must not be deleted.
+var GlobalEncryptionKeyID = apid.ID("ek_global")
+
 type EncryptionKeyState string
 
 const (
@@ -234,6 +238,10 @@ func (s *service) UpdateEncryptionKey(ctx context.Context, id apid.ID, updates m
 }
 
 func (s *service) DeleteEncryptionKey(ctx context.Context, id apid.ID) error {
+	if id == GlobalEncryptionKeyID {
+		return fmt.Errorf("cannot delete the global encryption key: %w", ErrProtected)
+	}
+
 	now := apctx.GetClock(ctx).Now()
 	dbResult, err := s.sq.
 		Update(EncryptionKeysTable).

--- a/internal/database/encryption_key_test.go
+++ b/internal/database/encryption_key_test.go
@@ -71,6 +71,20 @@ func TestEncryptionKey(t *testing.T) {
 		require.ErrorIs(t, err, ErrNotFound)
 	})
 
+	t.Run("DeleteGlobalKeyRejected", func(t *testing.T) {
+		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
+		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		err := db.DeleteEncryptionKey(ctx, GlobalEncryptionKeyID)
+		require.ErrorIs(t, err, ErrProtected)
+
+		// Verify the global key still exists
+		ek, err := db.GetEncryptionKey(ctx, GlobalEncryptionKeyID)
+		require.NoError(t, err)
+		require.Equal(t, GlobalEncryptionKeyID, ek.Id)
+	})
+
 	t.Run("SetState", func(t *testing.T) {
 		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)

--- a/internal/database/error.go
+++ b/internal/database/error.go
@@ -16,3 +16,7 @@ var ErrDuplicate = errors.New("duplicate record")
 // ErrViolation is returned when a constraint in the database is violated (e.g. multiple rows with the same ID)
 // after an operation that should have been unique.
 var ErrViolation = errors.New("database constraint violation")
+
+// ErrProtected is returned when an operation is attempted on a protected resource that cannot be modified in
+// the requested way.
+var ErrProtected = errors.New("resource is protected")

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -28,7 +28,7 @@ const globalScope = "global"
 const memorySyncPeriod = 5 * time.Minute
 const maxInitialWait = 5 * time.Minute
 
-var globalEncryptionKeyID = apid.ID("ek_global")
+var globalEncryptionKeyID = database.GlobalEncryptionKeyID
 
 type service struct {
 	cfg    config.C

--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -504,6 +504,16 @@ func (r *EncryptionKeysRoutes) delete(gctx *gin.Context) {
 		return
 	}
 
+	if id == database.GlobalEncryptionKeyID {
+		api_common.NewHttpStatusErrorBuilder().
+			WithStatusBadRequest().
+			WithResponseMsg("the global encryption key cannot be deleted").
+			BuildStatusError().
+			WriteGinResponse(nil, gctx)
+		val.MarkErrorReturn()
+		return
+	}
+
 	// Get existing key for authorization check
 	ek, err := r.core.GetEncryptionKey(ctx, id)
 	if err != nil {

--- a/internal/routes/encryption_keys_test.go
+++ b/internal/routes/encryption_keys_test.go
@@ -762,6 +762,26 @@ func TestEncryptionKeys(t *testing.T) {
 			require.Equal(t, http.StatusNotFound, w.Code)
 		})
 
+		t.Run("rejects deletion of ek_global", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodDelete,
+				fmt.Sprintf("/encryption-keys/%s", database.GlobalEncryptionKeyID),
+				nil,
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			var errResp api_common.ErrorResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+			require.Contains(t, errResp.Error, "global encryption key cannot be deleted")
+		})
+
 		t.Run("delete is idempotent", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(


### PR DESCRIPTION
## Summary
- Add route-layer guard returning 400 Bad Request when attempting to delete `ek_global`
- Add database-layer guard returning `ErrProtected` when attempting to delete `ek_global`
- Add `ErrProtected` sentinel error to the database, core/iface, and core error packages
- Export `GlobalEncryptionKeyID` constant from the database package (replaces private duplicate in encrypt package)
- Add tests at both the database and route layers

Closes #81

## Test plan
- [x] `TestEncryptionKey/DeleteGlobalKeyRejected` — database layer rejects deletion with `ErrProtected` and key remains accessible
- [x] `TestEncryptionKeys/delete_encryption_key/rejects_deletion_of_ek_global` — route returns 400 with descriptive message
- [x] All existing encryption key tests continue to pass
- [x] Encrypt package tests pass with shared constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)