### PR TITLE
Add encryption to blob storage for request logs

### DIFF
--- a/internal/request_log/full_store.go
+++ b/internal/request_log/full_store.go
@@ -7,8 +7,16 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apblob"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/util"
 )
+
+// Encryptor provides namespace-scoped encryption/decryption for blob storage.
+// Satisfied by encrypt.E via duck typing.
+type Encryptor interface {
+	EncryptForNamespace(ctx context.Context, namespacePath string, data []byte) (encfield.EncryptedField, error)
+	Decrypt(ctx context.Context, ef encfield.EncryptedField) ([]byte, error)
+}
 
 type FullStore interface {
 	// Store persists a FullLog to the storage backend.
@@ -19,35 +27,44 @@ type FullStore interface {
 }
 
 type blobStore struct {
-	client apblob.Client
-	logger *slog.Logger
+	client    apblob.Client
+	encryptor Encryptor
+	logger    *slog.Logger
 }
 
-func NewBlobStore(client apblob.Client, logger *slog.Logger) FullStore {
+func NewBlobStore(client apblob.Client, encryptor Encryptor, logger *slog.Logger) FullStore {
 	return &blobStore{
-		client: client,
-		logger: logger,
+		client:    client,
+		encryptor: encryptor,
+		logger:    logger,
 	}
 }
 
 func (s *blobStore) pathFor(ns string, id apid.ID) string {
-	return ns + "/" + id.String() + ".json"
+	return ns + "/" + id.String() + ".enc"
 }
 
 func (s *blobStore) Store(ctx context.Context, log *FullLog) error {
 	jsonData, err := json.Marshal(log)
 	if err != nil {
 		s.logger.Error("error serializing entry to JSON", "error", err, "record_id", log.Id.String())
-	} else {
-		if err := s.client.Put(
-			ctx,
-			apblob.PutInput{
-				Key:         s.pathFor(log.Namespace, log.Id),
-				Data:        jsonData,
-				ContentType: util.ToPtr("application/json"),
-			}); err != nil {
-			s.logger.Error("error storing full HTTP log entry in blob storage", "error", err, "record_id", log.Id.String())
-		}
+		return nil
+	}
+
+	ef, err := s.encryptor.EncryptForNamespace(ctx, log.Namespace, jsonData)
+	if err != nil {
+		s.logger.Error("error encrypting full HTTP log entry", "error", err, "record_id", log.Id.String())
+		return nil
+	}
+
+	if err := s.client.Put(
+		ctx,
+		apblob.PutInput{
+			Key:         s.pathFor(log.Namespace, log.Id),
+			Data:        []byte(ef.ToInlineString()),
+			ContentType: util.ToPtr("application/octet-stream"),
+		}); err != nil {
+		s.logger.Error("error storing full HTTP log entry in blob storage", "error", err, "record_id", log.Id.String())
 	}
 
 	return nil
@@ -59,6 +76,16 @@ func (s *blobStore) GetFullLog(ctx context.Context, ns string, id apid.ID) (*Ful
 		return nil, err
 	}
 
+	ef, err := encfield.ParseInlineString(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := s.encryptor.Decrypt(ctx, ef)
+	if err != nil {
+		return nil, err
+	}
+
 	var log FullLog
-	return &log, json.Unmarshal(data, &log)
+	return &log, json.Unmarshal(plaintext, &log)
 }

--- a/internal/request_log/storage_service.go
+++ b/internal/request_log/storage_service.go
@@ -103,6 +103,7 @@ func NewStorageService(
 	ctx context.Context,
 	cfg *config.HttpLogging,
 	cursorKey config.KeyDataType,
+	encryptor Encryptor,
 	logger *slog.Logger,
 ) (*StorageService, error) {
 	logger = logger.With("service", "request_log")
@@ -112,7 +113,7 @@ func NewStorageService(
 	if err != nil {
 		return nil, err
 	}
-	fullStore := NewBlobStore(blobStore, logger)
+	fullStore := NewBlobStore(blobStore, encryptor, logger)
 
 	cc := captureConfig{}
 	cc.setFromConfig(cfg)

--- a/internal/request_log/storage_service_test.go
+++ b/internal/request_log/storage_service_test.go
@@ -3,6 +3,7 @@ package request_log
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"log/slog"
 	"net/http"
@@ -10,12 +11,27 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apblob"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// noopEncryptor implements Encryptor using base64 encoding (no real encryption).
+type noopEncryptor struct{}
+
+func (noopEncryptor) EncryptForNamespace(_ context.Context, _ string, data []byte) (encfield.EncryptedField, error) {
+	return encfield.EncryptedField{
+		ID:   apid.ID("ekv_noop"),
+		Data: base64.StdEncoding.EncodeToString(data),
+	}, nil
+}
+
+func (noopEncryptor) Decrypt(_ context.Context, ef encfield.EncryptedField) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(ef.Data)
+}
 
 type fakeTransport struct {
 	status      int
@@ -195,7 +211,7 @@ func TestNamespacePopulated(t *testing.T) {
 func TestGetFullLog_BlobStore(t *testing.T) {
 	logger := newNoopLogger()
 	blob := apblob.NewMemoryClient()
-	fullStore := NewBlobStore(blob, logger)
+	fullStore := NewBlobStore(blob, noopEncryptor{}, logger)
 
 	testId := apid.New(apid.PrefixRequestLog)
 	ns := "root.test"

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -217,6 +217,7 @@ func (dm *DependencyManager) GetLogStorageService() *request_log.StorageService 
 			ctx,
 			dm.GetConfigRoot().HttpLogging,
 			dm.GetConfigRoot().SystemAuth.GlobalAESKey,
+			dm.GetEncryptService(),
 			dm.GetLogger(),
 		)
 


### PR DESCRIPTION
## Summary
- Encrypt full request/response logs (FullLog JSON) before writing to blob storage using namespace-scoped encryption keys
- Blobs are stored as `EncryptedField` inline strings (`.enc` files) with `application/octet-stream` content type
- On read, blobs are parsed, decrypted, then unmarshalled back to FullLog
- Ensures sensitive request data is unreadable if blob storage is compromised, and key rotation/destruction makes old data irrecoverable

Closes #60

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/request_log/...` — all tests pass (including round-trip encrypt/decrypt via noopEncryptor)
- [x] `go test ./...` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)