### PR TITLE
Auto-create MinIO bucket on docker compose startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,24 @@ services:
     networks:
       - authproxy
     command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set minio http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing minio/authproxy-request-logs
+      "
+    networks:
+      - authproxy
 
   clickhouse:
     image: clickhouse/clickhouse-server:latest


### PR DESCRIPTION
## Summary
- Add a healthcheck to the `minio` service using MinIO's built-in health endpoint
- Add a `minio-init` service that automatically creates the `authproxy-request-logs` bucket on startup
- Uses `--ignore-existing` so it's safe to run repeatedly

Closes #104

## Test plan
- [x] Run `docker compose up` and verify the `minio-init` container creates the bucket and exits successfully
- [x] Verify the bucket exists via the MinIO console at http://localhost:9001

🤖 Generated with [Claude Code](https://claude.com/claude-code)