### PR TITLE
Add script to tear down docker environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,22 @@ AuthProxy is an open-source, embeddable integration platform-as-a-service (iPaaS
 
 ### Backend (Go)
 
-**Start Dependencies:**
+**Start Dependencies (Docker Compose — recommended):**
+```bash
+# Start all data stores (PostgreSQL, Redis, MinIO, ClickHouse)
+docker compose up -d
+
+# Or start full stack including AuthProxy server
+docker compose --profile server up -d
+```
+
+**Reset Data Environment:**
+```bash
+# Tear down all containers, volumes, and networks to start fresh
+./scripts/teardown-docker.sh
+```
+
+**Start Dependencies (Manual — alternative):**
 ```bash
 # Create network
 docker network create authproxy

--- a/README.md
+++ b/README.md
@@ -274,6 +274,14 @@ docker compose --profile server --profile tools down
 
 Add `-v` to also remove data volumes.
 
+**Reset the data environment** (tear down everything and start fresh):
+
+```bash
+./scripts/teardown-docker.sh
+```
+
+This stops all Docker containers (both docker-compose and manually-started), removes all data volumes, and cleans up the network. The next `docker compose up -d` will recreate everything from scratch.
+
 ### Manual Setup
 
 If you prefer to manage dependencies yourself:

--- a/scripts/teardown-docker.sh
+++ b/scripts/teardown-docker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Tear down the Docker development environment for AuthProxy
+# This stops all containers, removes volumes, and cleans up the network
+# so the next startup will create everything from fresh.
+#
+# Usage:
+#   ./scripts/teardown-docker.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+echo "Tearing down AuthProxy Docker environment..."
+
+# Stop and remove all containers and volumes managed by docker-compose
+# Include all profiles to ensure everything is cleaned up
+echo "Stopping docker compose services and removing volumes..."
+docker compose --profile server --profile tools down -v 2>/dev/null || true
+
+# Also clean up any manually-started containers from the manual setup instructions
+MANUAL_CONTAINERS="redis-server postgres-server clickhouse-server minio redisinsight asynqmon"
+for container in $MANUAL_CONTAINERS; do
+    if docker ps -a --format '{{.Names}}' | grep -q "^${container}$"; then
+        echo "Removing manually-started container: ${container}"
+        docker rm -f "$container" 2>/dev/null || true
+    fi
+done
+
+# Remove manually-created volumes (from docker run -v name:/path)
+MANUAL_VOLUMES="redisinsight"
+for volume in $MANUAL_VOLUMES; do
+    if docker volume ls --format '{{.Name}}' | grep -q "^${volume}$"; then
+        echo "Removing volume: ${volume}"
+        docker volume rm "$volume" 2>/dev/null || true
+    fi
+done
+
+# Remove the authproxy network if it was created manually
+if docker network ls --format '{{.Name}}' | grep -q "^authproxy$"; then
+    echo "Removing manually-created 'authproxy' network..."
+    docker network rm authproxy 2>/dev/null || true
+fi
+
+echo ""
+echo "Teardown complete. All containers, volumes, and networks have been removed."
+echo "Run 'docker compose up -d' to start fresh."


### PR DESCRIPTION
## Summary
- Add `scripts/teardown-docker.sh` to reset the Docker data environment (stops containers, removes volumes/networks) so the next startup creates everything fresh
- Update README.md with teardown instructions in the Docker Compose section
- Update AGENTS.md to recommend docker-compose as the primary way to start dependencies, with manual commands as an alternative

Closes #106

## Test plan
- [x] Run `./scripts/teardown-docker.sh` with docker-compose services running — verify all containers, volumes, and networks are removed
- [x] Run `./scripts/teardown-docker.sh` with manually-started containers — verify they are also cleaned up
- [x] Run `docker compose up -d` after teardown — verify fresh environment starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)