### PR TITLE
Clear stale session cookie on decryption failure

### DIFF
--- a/internal/apauth/service/auth_test.go
+++ b/internal/apauth/service/auth_test.go
@@ -1128,4 +1128,113 @@ func TestAuth(t *testing.T) {
 			require.Equal(t, 1, ts.GetPingCount())
 		})
 	})
+
+	t.Run("stale session cookie after encryption key rotation", func(t *testing.T) {
+		// This test verifies the fix for GitHub issue #108: after a data environment
+		// reset, encryption keys are recreated. The browser still has the old session
+		// cookie which can't be decrypted with the new keys. The system should clear the
+		// stale cookie instead of returning an error, so that subsequent requests succeed.
+
+		t.Run("required auth clears stale cookie and returns unauthorized", func(t *testing.T) {
+			ts := NewTestGinServerBuilder(t).
+				WithGetPingRequiredAuthRoute("/ping").
+				Build()
+
+			// Inject a stale session cookie that cannot be decrypted (simulates key rotation)
+			ts.CookieJar.SetCookies(
+				util.Must(url.Parse("http://example.com")),
+				[]*http.Cookie{{
+					Name:  sessionCookieName,
+					Value: "dGhpcy1pcy1ub3QtYS12YWxpZC1lbmNyeXB0ZWQtc2Vzc2lvbg", // garbage base64
+				}},
+			)
+
+			// First request: stale cookie is present, should get 401 but cookie gets cleared
+			_, statusCode, _ := ts.GET(ctx, "/ping")
+			require.Equal(t, http.StatusUnauthorized, statusCode)
+
+			// Verify the cookie was cleared (MaxAge=-1 causes the jar to remove it)
+			cookies := ts.CookieJar.Cookies(util.Must(url.Parse("http://example.com")))
+			hasSessionCookie := false
+			for _, c := range cookies {
+				if c.Name == sessionCookieName {
+					hasSessionCookie = true
+				}
+			}
+			require.False(t, hasSessionCookie, "stale session cookie should have been cleared")
+
+			// Second request: no stale cookie, clean 401 (no error, just unauthenticated)
+			_, statusCode, _ = ts.GET(ctx, "/ping")
+			require.Equal(t, http.StatusUnauthorized, statusCode)
+		})
+
+		t.Run("optional auth clears stale cookie and allows access", func(t *testing.T) {
+			ts := NewTestGinServerBuilder(t).
+				WithGetPingOptionalAuthRoute("/ping").
+				Build()
+
+			// Inject a stale session cookie
+			ts.CookieJar.SetCookies(
+				util.Must(url.Parse("http://example.com")),
+				[]*http.Cookie{{
+					Name:  sessionCookieName,
+					Value: "dGhpcy1pcy1ub3QtYS12YWxpZC1lbmNyeXB0ZWQtc2Vzc2lvbg",
+				}},
+			)
+
+			// Request with stale cookie on optional auth route should succeed (not error)
+			resp, statusCode, debugHeader := ts.GET(ctx, "/ping")
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, gin.H{"ok": true}, resp)
+			require.Equal(t, 1, ts.GetPingCount())
+		})
+
+		t.Run("stale cookie cleared then new session established", func(t *testing.T) {
+			ts := NewTestGinServerBuilder(t).
+				WithRequiredAuthRoute(http.MethodGet, "/initiate-session", func(gctx *gin.Context, auth A) {
+					ra := GetAuthFromGinContext(gctx)
+					err := auth.EstablishGinSession(gctx, ra)
+					if err != nil {
+						api_common.NewHttpStatusErrorBuilder().
+							WithInternalErr(err).
+							BuildStatusError().
+							WriteGinResponse(nil, gctx)
+						return
+					}
+					gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+				}).
+				WithGetPingRequiredAuthRoute("/ping").
+				Build()
+
+			// Inject a stale session cookie
+			ts.CookieJar.SetCookies(
+				util.Must(url.Parse("http://example.com")),
+				[]*http.Cookie{{
+					Name:  sessionCookieName,
+					Value: "dGhpcy1pcy1ub3QtYS12YWxpZC1lbmNyeXB0ZWQtc2Vzc2lvbg",
+				}},
+			)
+
+			// First request clears the stale cookie
+			_, statusCode, _ := ts.GET(ctx, "/ping")
+			require.Equal(t, http.StatusUnauthorized, statusCode)
+
+			// Now authenticate with JWT and establish a new session
+			s := jwt.NewJwtTokenBuilder().
+				WithActorExternalId(ts.MustGetValidUser(ctx).ExternalId).
+				WithServiceId(ts.Service).
+				MustWithConfigKey(ctx, ts.MustGetValidSigningTokenForUser()).
+				MustSignerCtx(ctx)
+
+			resp, statusCode, debugHeader := ts.GET(ctx, s.SignUrlQuery("/initiate-session"))
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, gin.H{"ok": true}, resp)
+
+			// Session works - can access without JWT
+			resp, statusCode, debugHeader = ts.GET(ctx, "/ping")
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, gin.H{"ok": true}, resp)
+			require.Equal(t, 1, ts.GetPingCount())
+		})
+	})
 }

--- a/internal/apauth/service/session.go
+++ b/internal/apauth/service/session.go
@@ -138,10 +138,14 @@ func (s *service) establishAuthFromSession(
 		return fromJwt, fmt.Errorf("failed to read session cookie: %w", err)
 	}
 
-	// Parse the session cookie ID from the cookie's value
+	// Parse the session cookie ID from the cookie's value. If decryption fails (e.g. encryption keys
+	// were rotated after a data environment reset), clear the stale cookie so subsequent requests can
+	// establish a fresh session instead of failing repeatedly.
 	sessionCookieId, err := fromSessionCookieId(sessionCookie.Value, s.encrypt)
 	if err != nil || sessionCookieId.Id.IsNil() {
-		return fromJwt, fmt.Errorf("invalid session ID in cookie: %w", err)
+		s.logger.Warn("failed to parse session cookie, clearing stale cookie", "error", err)
+		s.clearSessionCookie(w)
+		return fromJwt, nil
 	}
 
 	sess, err := s.tryReadSessionFromRedis(ctx, sessionCookieId.Id)
@@ -344,6 +348,22 @@ func (s *service) setSessionCookie(ctx context.Context, w http.ResponseWriter, s
 	return nil
 }
 
+// clearSessionCookie writes a Set-Cookie header that expires the session cookie.
+func (s *service) clearSessionCookie(w http.ResponseWriter) {
+	sessionService := s.service.(config.HttpServiceWithSession)
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		HttpOnly: false,
+		Path:     "/",
+		Domain:   sessionService.CookieDomain(),
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+		Secure:   s.service.IsHttps(),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // EndSession terminates a session that is in progress by clearing the session information from redis and clearing
 // session id cookies on the response.
 func (s *service) EndSession(ctx context.Context, w http.ResponseWriter, ra *core.RequestAuth) error {
@@ -354,19 +374,7 @@ func (s *service) EndSession(ctx context.Context, w http.ResponseWriter, ra *cor
 		}
 	}
 
-	sessionService := s.service.(config.HttpServiceWithSession)
-	sessionCookie := http.Cookie{
-		Name:     sessionCookieName,
-		Value:    "",
-		HttpOnly: false,
-		Path:     "/",
-		Domain:   sessionService.CookieDomain(),
-		MaxAge:   -1,
-		Expires:  time.Unix(0, 0),
-		Secure:   s.service.IsHttps(),
-		SameSite: http.SameSiteLaxMode,
-	}
-	http.SetCookie(w, &sessionCookie)
+	s.clearSessionCookie(w)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- When session cookie decryption fails (e.g. after encryption keys are recreated during a data environment reset), clear the stale cookie instead of returning an error, so subsequent requests can establish a fresh session
- Extract `clearSessionCookie()` helper from `EndSession()` for reuse in the decryption failure path
- Add tests covering stale cookie behavior on required auth, optional auth, and full recovery flow

Closes #108

## Test plan
- [x] Stale cookie on required-auth route returns 401 and clears cookie; second request gets clean 401
- [x] Stale cookie on optional-auth route succeeds (200) instead of erroring
- [x] After stale cookie is cleared, JWT auth + session establishment works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)