### PR TITLE
Fix post-OAuth configure step flow

### DIFF
--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -35,6 +35,12 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 		return errorRedirectPage, errors.New("state is nil")
 	}
 
+	// Delete the state from Redis now that the callback is consuming it.
+	// This is the terminal step of the OAuth flow, so the state is no longer needed.
+	if err := deleteStateFromRedis(ctx, o.r, o.state.Id); err != nil {
+		return errorRedirectPage, fmt.Errorf("failed to clean up oauth state: %w", err)
+	}
+
 	code := query.Get("code")
 	if code == "" {
 		return errorRedirectPage, errors.New("no code in query")

--- a/internal/auth_methods/oauth2/mustache_test.go
+++ b/internal/auth_methods/oauth2/mustache_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/redis/go-redis/v9"
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	mockRedis "github.com/rmorlok/authproxy/internal/apredis/mock"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
@@ -329,13 +331,17 @@ func TestCallbackFrom3rdParty_TemplatedEndpoint(t *testing.T) {
 		h := mockH.NewFactoryWithMockingClient(ctrl)
 		db := mockDb.NewMockDB(ctrl)
 		encrypt := mockEncrypt.NewMockE(ctrl)
+		r := mockRedis.NewMockClient(ctrl)
 		logger, _ := mockLog.NewTestLogger(t)
+
+		// CallbackFrom3rdParty deletes the OAuth state from Redis after consuming it
+		r.EXPECT().Del(gomock.Any(), gomock.Any()).Return(redis.NewIntCmd(context.Background())).AnyTimes()
 
 		return &oAuth2Connection{
 			cfg:     cfg,
 			db:      db,
 			httpf:   h,
-			r:       nil,
+			r:       r,
 			encrypt: encrypt,
 			logger:  logger,
 			connection: &mockCore.Connection{

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -135,10 +135,15 @@ func getOAuth2State(
 	o := newOAuth2(cfg, db, r, core, encrypt, logger, httpf, connection)
 	o.state = &s
 
-	deleteResult := r.Del(ctx, getStateRedisKey(stateId))
-	if deleteResult.Err() != nil {
-		return nil, fmt.Errorf("failed to delete oauth state from redis for id %s: %w", stateId.String(), result.Err())
-	}
-
 	return o, nil
+}
+
+// deleteStateFromRedis removes the OAuth state from Redis. This should be called
+// after the state has been fully consumed (i.e., after the callback processes it).
+func deleteStateFromRedis(ctx context.Context, r apredis.Client, stateId apid.ID) error {
+	result := r.Del(ctx, getStateRedisKey(stateId))
+	if result.Err() != nil {
+		return fmt.Errorf("failed to delete oauth state from redis for id %s: %w", stateId.String(), result.Err())
+	}
+	return nil
 }

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -104,6 +104,7 @@ export function isCompleteResponse(response: InitiateConnectionResponse): respon
 }
 
 export interface SubmitConnectionRequest {
+    step_id: string;
     data: unknown;
 }
 
@@ -173,8 +174,8 @@ export const initiateConnection = (
 /**
  * Submit form data for a connection setup step
  */
-export const submitConnection = (connectionId: string, data: unknown) => {
-    const request: SubmitConnectionRequest = { data };
+export const submitConnection = (connectionId: string, stepId: string, data: unknown) => {
+    const request: SubmitConnectionRequest = { step_id: stepId, data };
 
     return client.post<InitiateConnectionResponse>(
         `/api/v1/connections/${connectionId}/_submit`,

--- a/ui/marketplace/src/components/ConnectionFormStep.tsx
+++ b/ui/marketplace/src/components/ConnectionFormStep.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { JsonForms } from '@jsonforms/react';
 import { materialCells, materialRenderers } from '@jsonforms/material-renderers';
 import type { JsonFormsCore, UISchemaElement } from '@jsonforms/core';
 import type { JsonSchema } from '@jsonforms/core';
 import { Box, Button, CircularProgress, Typography, LinearProgress } from '@mui/material';
+import { connections, DataSourceOption } from '@authproxy/api';
 
 export interface ConnectionFormStepProps {
     connectionId: string;
@@ -16,6 +17,59 @@ export interface ConnectionFormStepProps {
     onSubmit: (connectionId: string, data: unknown) => void;
     onCancel: () => void;
     isSubmitting: boolean;
+}
+
+/**
+ * Scan JSON schema properties for x-data-source annotations and return
+ * a map of property name -> data source ID.
+ */
+function findDataSources(schema: Record<string, unknown>): Record<string, string> {
+    const result: Record<string, string> = {};
+    const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+    if (!properties) return result;
+
+    for (const [propName, propSchema] of Object.entries(properties)) {
+        const sourceId = propSchema['x-data-source'];
+        if (typeof sourceId === 'string') {
+            result[propName] = sourceId;
+        }
+    }
+    return result;
+}
+
+/**
+ * Return a copy of the schema with x-data-source properties replaced by
+ * oneOf enums so JsonForms renders them as select dropdowns.
+ */
+function applyDataSourcesToSchema(
+    schema: Record<string, unknown>,
+    optionsMap: Record<string, DataSourceOption[]>,
+): Record<string, unknown> {
+    const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+    if (!properties) return schema;
+
+    const newProperties: Record<string, Record<string, unknown>> = {};
+    let changed = false;
+
+    for (const [propName, propSchema] of Object.entries(properties)) {
+        const options = optionsMap[propName];
+        if (options) {
+            changed = true;
+            const { 'x-data-source': _, ...rest } = propSchema;
+            newProperties[propName] = {
+                ...rest,
+                oneOf: options.map((opt) => ({
+                    const: opt.value,
+                    title: opt.label,
+                })),
+            };
+        } else {
+            newProperties[propName] = propSchema;
+        }
+    }
+
+    if (!changed) return schema;
+    return { ...schema, properties: newProperties };
 }
 
 const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
@@ -32,6 +86,37 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
 }) => {
     const [data, setData] = useState<unknown>({});
     const [hasErrors, setHasErrors] = useState(false);
+    const [dataSourceOptions, setDataSourceOptions] = useState<Record<string, DataSourceOption[]>>({});
+    const [loadingDataSources, setLoadingDataSources] = useState(false);
+
+    const dataSources = useMemo(() => findDataSources(jsonSchema), [jsonSchema]);
+    const hasDataSources = Object.keys(dataSources).length > 0;
+
+    // Fetch options for all x-data-source properties
+    useEffect(() => {
+        const entries = Object.entries(dataSources);
+        if (entries.length === 0) return;
+
+        setLoadingDataSources(true);
+        Promise.all(
+            entries.map(([propName, sourceId]) =>
+                connections.getDataSource(connectionId, sourceId).then((resp) => [propName, resp.data] as const)
+            )
+        )
+            .then((results) => {
+                const opts: Record<string, DataSourceOption[]> = {};
+                for (const [propName, options] of results) {
+                    opts[propName] = options;
+                }
+                setDataSourceOptions(opts);
+            })
+            .finally(() => setLoadingDataSources(false));
+    }, [connectionId, dataSources]);
+
+    const resolvedSchema = useMemo(
+        () => (hasDataSources ? applyDataSourcesToSchema(jsonSchema, dataSourceOptions) : jsonSchema),
+        [jsonSchema, dataSourceOptions, hasDataSources],
+    );
 
     const handleChange = useCallback((state: Pick<JsonFormsCore, 'data' | 'errors'>) => {
         setData(state.data);
@@ -66,14 +151,20 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
                     {stepDescription}
                 </Typography>
             )}
-            <JsonForms
-                schema={jsonSchema as JsonSchema}
-                uischema={uiSchema as unknown as UISchemaElement}
-                data={data}
-                renderers={materialRenderers}
-                cells={materialCells}
-                onChange={handleChange}
-            />
+            {loadingDataSources ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                    <CircularProgress />
+                </Box>
+            ) : (
+                <JsonForms
+                    schema={resolvedSchema as JsonSchema}
+                    uischema={uiSchema as unknown as UISchemaElement}
+                    data={data}
+                    renderers={materialRenderers}
+                    cells={materialCells}
+                    onChange={handleChange}
+                />
+            )}
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 3 }}>
                 <Button
                     variant="outlined"
@@ -85,7 +176,7 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
                 <Button
                     variant="contained"
                     onClick={handleSubmit}
-                    disabled={isSubmitting || hasErrors}
+                    disabled={isSubmitting || hasErrors || loadingDataSources}
                     startIcon={isSubmitting ? <CircularProgress size={16} /> : undefined}
                 >
                     {isSubmitting ? 'Submitting...' : 'Submit'}

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -23,12 +23,13 @@ import {
   selectSubmittingForm,
   selectFormSubmitError,
   submitConnectionFormAsync,
+  getSetupStepAsync,
   clearFormStep,
 } from '../store';
 import ConnectionCard, { ConnectionCardSkeleton } from './ConnectionCard';
 import ConnectionFormStep from './ConnectionFormStep';
 import { AppDispatch } from '../store';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import AddIcon from '@mui/icons-material/Add';
 
 /**
@@ -36,6 +37,7 @@ import AddIcon from '@mui/icons-material/Add';
  */
 const ConnectionList: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
+  const [searchParams, setSearchParams] = useSearchParams();
   const connections = useSelector(selectConnections);
   const status = useSelector(selectConnectionsStatus);
   const error = useSelector(selectConnectionsError);
@@ -54,17 +56,35 @@ const ConnectionList: React.FC = () => {
     }
   }, [status, connectorsStatus, dispatch]);
 
+  // After OAuth completes, the callback redirects here with setup=pending&connection_id=...
+  // Detect these params and fetch the configure step to show the setup form.
+  useEffect(() => {
+    const setup = searchParams.get('setup');
+    const connectionId = searchParams.get('connection_id');
+
+    if (setup === 'pending' && connectionId) {
+      dispatch(getSetupStepAsync(connectionId));
+      // Clean up the URL params so a page refresh doesn't re-trigger
+      searchParams.delete('setup');
+      searchParams.delete('connection_id');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, dispatch]);
+
   const handleFormSubmit = useCallback((connectionId: string, data: unknown) => {
-    dispatch(submitConnectionFormAsync({ connectionId, data })).then((action) => {
+    const stepId = currentFormStep?.stepId ?? '';
+    dispatch(submitConnectionFormAsync({ connectionId, stepId, data })).then((action) => {
       if (action.meta.requestStatus === 'fulfilled') {
         const response = action.payload as any;
         if (isRedirectResponse(response)) {
           window.location.href = response.redirect_url;
+        } else {
+          // Refresh connections list to reflect updated state
+          dispatch(fetchConnectionsAsync());
         }
-        // If type === 'complete', Redux state clears the form and we should refresh
       }
     });
-  }, [dispatch]);
+  }, [dispatch, currentFormStep]);
 
   const handleFormCancel = useCallback(() => {
     dispatch(clearFormStep());

--- a/ui/marketplace/src/components/ConnectorList.tsx
+++ b/ui/marketplace/src/components/ConnectorList.tsx
@@ -68,7 +68,8 @@ const ConnectorList: React.FC = () => {
   };
 
   const handleFormSubmit = useCallback((connectionId: string, data: unknown) => {
-    dispatch(submitConnectionFormAsync({ connectionId, data })).then((action) => {
+    const stepId = currentFormStep?.stepId ?? '';
+    dispatch(submitConnectionFormAsync({ connectionId, stepId, data })).then((action) => {
       if (action.meta.requestStatus === 'fulfilled') {
         const response = action.payload as any;
         if (isRedirectResponse(response)) {
@@ -78,7 +79,7 @@ const ConnectorList: React.FC = () => {
         // If type === 'complete', Redux state clears the form
       }
     });
-  }, [dispatch]);
+  }, [dispatch, currentFormStep]);
 
   const handleFormCancel = useCallback(() => {
     if (currentFormStep) {

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -95,8 +95,8 @@ export const initiateConnectionAsync = createAsyncThunk(
 
 export const submitConnectionFormAsync = createAsyncThunk(
     'connections/submitConnectionForm',
-    async ({connectionId, data}: { connectionId: string, data: unknown }) => {
-        const response = await connections.submit(connectionId, data);
+    async ({connectionId, stepId, data}: { connectionId: string, stepId: string, data: unknown }) => {
+        const response = await connections.submit(connectionId, stepId, data);
         return response.data;
     }
 );


### PR DESCRIPTION
## Summary
- **ConnectionList**: Detect `setup=pending` and `connection_id` query params after OAuth callback redirect to automatically show the configure form dialog
- **ConnectionFormStep**: Fetch data source options for fields with `x-data-source` JSON schema annotations and render them as select dropdowns via `oneOf`
- **JS SDK / Redux**: Include `step_id` in form submission requests (previously omitted, causing 400 errors)
- **OAuth state**: Move Redis state deletion from `getOAuth2State` (called by both redirect and callback) to `CallbackFrom3rdParty` (the terminal consumer), fixing "redis: nil" errors when the redirect handler consumed the state first

## Test plan
- [x] Verified configure form dialog appears after OAuth redirect with `setup=pending` params
- [x] Verified calendar dropdown populates with options from data source API
- [x] Verified form submission succeeds with `step_id` included (previously 400)
- [x] Verified Go tests pass (`go test ./internal/auth_methods/oauth2/...`)
- [x] Verified frontend builds successfully (`yarn workspace @authproxy/marketplace build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)