### PR TITLE
Redirect unauthenticated OAuth2 endpoints through login flow

### DIFF
--- a/internal/apauth/service/auth_redirect_test.go
+++ b/internal/apauth/service/auth_redirect_test.go
@@ -1,0 +1,266 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRedirectGenerator is a test AuthRedirectUrlGenerator that builds a URL with the returnToUrl
+// embedded as a query parameter so tests can assert the expected return target.
+type stubRedirectGenerator struct {
+	loginUrl string
+}
+
+func (s *stubRedirectGenerator) GetInitiateSessionUrl(returnToUrl string) string {
+	u, _ := url.Parse(s.loginUrl)
+	q := u.Query()
+	q.Set("return_to", returnToUrl)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// authRedirectTestSetup wires a gin engine, a real auth service (service id Api), and helpers
+// to build authenticated requests — reused across the redirect tests.
+type authRedirectTestSetup struct {
+	Gin      *gin.Engine
+	Cfg      config.C
+	Auth     A
+	AuthUtil *AuthTestUtil
+	Gen      *stubRedirectGenerator
+}
+
+func newAuthRedirectTestSetup(t *testing.T, register func(g *gin.Engine, a A, gen AuthRedirectUrlGenerator)) *authRedirectTestSetup {
+	cfg, db := database.MustApplyBlankTestDbConfig(t, nil)
+	// GetBaseUrl — used to build the return_to URL on redirect — panics without a port.
+	cfg.GetRoot().Api.PortVal = common.NewIntegerValueDirect(8081)
+	cfg, auth, authUtil := TestAuthServiceWithDb(sconfig.ServiceIdApi, cfg, db)
+
+	gen := &stubRedirectGenerator{loginUrl: "https://login.example.com/login"}
+
+	r := gin.New()
+	register(r, auth, gen)
+
+	return &authRedirectTestSetup{
+		Gin:      r,
+		Cfg:      cfg,
+		Auth:     auth,
+		AuthUtil: authUtil,
+		Gen:      gen,
+	}
+}
+
+func okHandler(gctx *gin.Context) {
+	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func TestRequiredWithAuthRedirect(t *testing.T) {
+	t.Setenv("AUTHPROXY_DEBUG_MODE", "true")
+	ctx := context.Background()
+
+	register := func(g *gin.Engine, a A, gen AuthRedirectUrlGenerator) {
+		g.GET("/ping", a.RequiredWithAuthRedirect(gen), okHandler)
+	}
+
+	t.Run("unauthenticated redirects to login with return_to", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/ping?foo=bar", nil)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusFound, w.Code)
+
+		loc, err := url.Parse(w.Header().Get("Location"))
+		require.NoError(t, err)
+		assert.Equal(t, "login.example.com", loc.Host)
+		assert.Equal(t, "/login", loc.Path)
+
+		returnTo := loc.Query().Get("return_to")
+		require.NotEmpty(t, returnTo, "Location should include return_to query param")
+		assert.Contains(t, returnTo, "/ping")
+		assert.Contains(t, returnTo, "foo=bar")
+	})
+
+	t.Run("unauthenticated with valid auth_token query param proceeds", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		// The user arrives back at the endpoint after login with an auth_token query parameter
+		// issued by the host application. The middleware should authenticate via the token and
+		// let the handler run.
+		tokenString, err := tu.AuthUtil.GenerateBearerToken(
+			ctx, "some-actor", "root", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/ping?foo=bar&auth_token="+url.QueryEscape(tokenString), nil)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("authenticated via header proceeds", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/ping", nil, "root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("invalid JWT does not redirect", func(t *testing.T) {
+		// A JWT with the wrong audience is a parse/validation error, not a "session lapsed" case.
+		// The middleware should surface the error (401) rather than silently redirect — we don't
+		// want bad creds to bounce through the login flow.
+		tu := newAuthRedirectTestSetup(t, register)
+
+		s := jwt.NewJwtTokenBuilder().
+			WithActorExternalId("jimmycarter").
+			WithAudience("invalid").
+			MustWithConfigKey(ctx, tu.Cfg.GetRoot().SystemAuth.JwtSigningKey).
+			MustSignerCtx(ctx)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/ping", nil)
+		require.NoError(t, err)
+		s.SignAuthHeader(req)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("authenticated but validator fails returns 403", func(t *testing.T) {
+		// RequiredWithAuthRedirect still honors validators and returns 403 when an authenticated
+		// actor doesn't pass them — only unauthenticated triggers the redirect.
+		rejectAll := func(gctx *gin.Context, ra *core.RequestAuth) (bool, string) {
+			return false, "nope"
+		}
+		tu := newAuthRedirectTestSetup(t, func(g *gin.Engine, a A, gen AuthRedirectUrlGenerator) {
+			g.GET("/ping", a.RequiredWithAuthRedirect(gen, rejectAll), okHandler)
+		})
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/ping", nil, "root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+}
+
+func TestPermissionValidatorBuilder_WithRedirectOnUnauthenticated(t *testing.T) {
+	t.Setenv("AUTHPROXY_DEBUG_MODE", "true")
+	ctx := context.Background()
+
+	// A permission-gated route that also redirects on unauthenticated — the full OAuth2 routes
+	// shape. Includes MarkValidated so the post-validator doesn't panic (the handler confirms
+	// that the middleware-level permission check is sufficient for this endpoint).
+	handler := func(gctx *gin.Context) {
+		MustGetValidatorFromGinContext(gctx).MarkValidated()
+		gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	}
+
+	register := func(g *gin.Engine, a A, gen AuthRedirectUrlGenerator) {
+		mw := a.NewRequiredBuilder().
+			ForResource("connections").
+			ForVerb("create").
+			WithRedirectOnUnauthenticated(gen).
+			Build()
+		g.GET("/oauth2/callback", mw, handler)
+	}
+
+	t.Run("unauthenticated redirects to login", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/oauth2/callback?state=abc", nil)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusFound, w.Code)
+
+		loc, err := url.Parse(w.Header().Get("Location"))
+		require.NoError(t, err)
+		returnTo := loc.Query().Get("return_to")
+		require.NotEmpty(t, returnTo)
+		assert.Contains(t, returnTo, "/oauth2/callback")
+		assert.Contains(t, returnTo, "state=abc")
+	})
+
+	t.Run("authenticated with permission proceeds", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/callback?state=abc",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "create"),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("authenticated without required permission returns 403", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/callback?state=abc",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "list"), // wrong verb
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("unauthenticated with valid auth_token authenticates and proceeds", func(t *testing.T) {
+		tu := newAuthRedirectTestSetup(t, register)
+
+		// Simulates the second hit of the flow: user was redirected to login, came back with a
+		// freshly minted auth_token query param carrying the right permissions.
+		tokenString, err := tu.AuthUtil.GenerateBearerToken(
+			ctx, "some-actor", "root",
+			aschema.PermissionsSingle("root.**", "connections", "create"),
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/oauth2/callback?state=abc&auth_token="+url.QueryEscape(tokenString), nil)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+}

--- a/internal/apauth/service/gin.go
+++ b/internal/apauth/service/gin.go
@@ -68,15 +68,37 @@ func (j *service) Required(validators ...AuthValidator) gin.HandlerFunc {
 	return j.requiredWithPostValidation(validators, nil)
 }
 
+// RequiredWithAuthRedirect is like Required but, when the request is unauthenticated, issues a 302 redirect to
+// the login URL produced by gen rather than returning 401. The original request URL is passed through to gen so
+// the browser lands back on this endpoint after authenticating (typically with an auth_token query param).
+func (j *service) RequiredWithAuthRedirect(gen AuthRedirectUrlGenerator, validators ...AuthValidator) gin.HandlerFunc {
+	return j.requiredWithRedirectAndPostValidation(gen, validators, nil)
+}
+
 // Required middleware requires authentication and validates the actor. There must be an authenticated actor, and
 // the actor must pass the validators passed here and defaulted in the service.
 func (j *service) requiredWithPostValidation(validators []AuthValidator, postValidation func(gctx *gin.Context, ra *core.RequestAuth)) gin.HandlerFunc {
+	return j.requiredWithRedirectAndPostValidation(nil, validators, postValidation)
+}
+
+// requiredWithRedirectAndPostValidation is the shared implementation for Required/RequiredWithAuthRedirect and
+// the permission builder. If unauthRedirect is nil the behavior matches Required (401 on unauthenticated). If
+// set, unauthenticated requests are redirected to the URL produced by unauthRedirect.GetInitiateSessionUrl with
+// the current request URL as the return_to target.
+func (j *service) requiredWithRedirectAndPostValidation(unauthRedirect AuthRedirectUrlGenerator, validators []AuthValidator, postValidation func(gctx *gin.Context, ra *core.RequestAuth)) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		_next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			a := GetAuthFromRequest(r)
 
-			// This check is duplicative of the one in Auth, but it's here for clarity.
 			if !a.IsAuthenticated() {
+				if unauthRedirect != nil {
+					returnToUrl := j.service.GetBaseUrl() + r.URL.RequestURI()
+					http.Redirect(w, r, unauthRedirect.GetInitiateSessionUrl(returnToUrl), http.StatusFound)
+					c.Abort()
+					return
+				}
+
+				// This check is duplicative of the one in Auth, but it's here for clarity.
 				httperr.Unauthorized().
 					WriteResponse(r.Context(), nil, w)
 				c.Abort()
@@ -99,7 +121,14 @@ func (j *service) requiredWithPostValidation(validators []AuthValidator, postVal
 				postValidation(c, a)
 			}
 		})
-		j.Auth(_next, c.Abort).ServeHTTP(c.Writer, c.Request)
+
+		if unauthRedirect != nil {
+			// Use Trace so unauthenticated requests reach _next where we can redirect. Invalid/expired JWTs
+			// still short-circuit with an error from establishAuthFromRequest.
+			j.Trace(_next, c.Abort).ServeHTTP(c.Writer, c.Request)
+		} else {
+			j.Auth(_next, c.Abort).ServeHTTP(c.Writer, c.Request)
+		}
 	}
 }
 

--- a/internal/apauth/service/interface.go
+++ b/internal/apauth/service/interface.go
@@ -14,6 +14,14 @@ const (
 	JwtQueryParam = "auth_token"
 )
 
+// AuthRedirectUrlGenerator produces the URL a browser should be redirected to when a request
+// reaches an auth-required endpoint that is configured to redirect unauthenticated users
+// through the standard login flow. returnToUrl is the fully-qualified URL the user should
+// land back on after successful authentication, as a query parameter on the generated URL.
+type AuthRedirectUrlGenerator interface {
+	GetInitiateSessionUrl(returnToUrl string) string
+}
+
 type A interface {
 	/*
 	 * Gin middlewares for establishing auth
@@ -21,6 +29,12 @@ type A interface {
 
 	NewRequiredBuilder() *PermissionValidatorBuilder
 	Required(validators ...AuthValidator) gin.HandlerFunc
+	// RequiredWithAuthRedirect is like Required but, when the request is not authenticated,
+	// redirects the browser to the URL produced by gen rather than returning 401. The current
+	// request URL is passed through as the return_to target so the browser lands back on the
+	// same endpoint after re-authenticating (typically with an auth_token query param).
+	// Authenticated-but-invalid actors still receive 403 as usual.
+	RequiredWithAuthRedirect(gen AuthRedirectUrlGenerator, validators ...AuthValidator) gin.HandlerFunc
 	Optional(validators ...AuthValidator) gin.HandlerFunc
 	OptionalXsrfNotRequired(validators ...AuthValidator) gin.HandlerFunc
 

--- a/internal/apauth/service/permission_validator.go
+++ b/internal/apauth/service/permission_validator.go
@@ -201,6 +201,7 @@ type PermissionValidatorBuilder struct {
 	namespaceQueryParam string
 	namespacePathParam  string
 	idExtractor         IdExtractor
+	unauthRedirectGen   AuthRedirectUrlGenerator
 }
 
 // ForResource sets the resource type being accessed (e.g., "connections", "connectors").
@@ -250,6 +251,18 @@ func (pb *PermissionValidatorBuilder) ForNamespaceQueryParam(param string) *Perm
 // Example: ForNamespacePathParam("ns") extracts from "/namespaces/:ns/..."
 func (pb *PermissionValidatorBuilder) ForNamespacePathParam(param string) *PermissionValidatorBuilder {
 	pb.namespacePathParam = param
+	return pb
+}
+
+// WithRedirectOnUnauthenticated causes the generated middleware to issue a 302 redirect to the
+// URL produced by gen.GetInitiateSessionUrl(currentUrl) when the request arrives unauthenticated,
+// rather than returning 401. Authenticated-but-unauthorized requests still receive 403.
+//
+// This is intended for browser-initiated endpoints (e.g. OAuth2 redirects) where a bare 401 is
+// a dead end for the user. The generated login URL is expected to round-trip the user back to
+// the original endpoint with an auth_token query parameter after successful authentication.
+func (pb *PermissionValidatorBuilder) WithRedirectOnUnauthenticated(gen AuthRedirectUrlGenerator) *PermissionValidatorBuilder {
+	pb.unauthRedirectGen = gen
 	return pb
 }
 
@@ -330,5 +343,5 @@ func (pb *PermissionValidatorBuilder) Build() gin.HandlerFunc {
 		}
 	}
 
-	return pb.s.requiredWithPostValidation([]AuthValidator{permissionValidator}, postValidator)
+	return pb.s.requiredWithRedirectAndPostValidation(pb.unauthRedirectGen, []AuthValidator{permissionValidator}, postValidator)
 }

--- a/internal/routes/README.md
+++ b/internal/routes/README.md
@@ -1,5 +1,4 @@
 # Shared Routes
 
-This package contains routes that are shared across services. This allows the same functionality to be offered to
-different parts of the app and with different security considerations (e.g. session vs no session). Individual services
-will have their own service-specific routes in `services/<service>/routes`.
+This package contains routes for the application. Many of these routes are 
+shared across services, some are service-specific.

--- a/internal/routes/public_oauth2.go
+++ b/internal/routes/public_oauth2.go
@@ -20,27 +20,23 @@ import (
 )
 
 type PublicOauth2Routes struct {
-	cfg         config.C
-	authService auth.A
-	db          database.DB
-	r           apredis.Client
-	httpf       httpf.F
-	encrypt     encrypt.E
-	oauthf      oauth2.Factory
-	logger      *slog.Logger
+	cfg                         config.C
+	authService                 auth.A
+	sessionInitiateUrlGenerator SessionInitiateUrlGenerator
+	db                          database.DB
+	r                           apredis.Client
+	httpf                       httpf.F
+	encrypt                     encrypt.E
+	oauthf                      oauth2.Factory
+	logger                      *slog.Logger
 }
 
 func (r *PublicOauth2Routes) callback(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 
-	ra := auth.GetAuthFromGinContext(gctx)
-	if !ra.IsAuthenticated() {
-		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
-			Error:       sconfig.ErrorPageUnauthorized,
-			Description: "Request is not part of an authenticated session.",
-		}, errors.New("auth not present on context"))
-		return
-	}
+	ra := auth.MustGetAuthFromGinContext(gctx)
+	// Permission was checked at the middleware level; there's no per-resource namespace to validate here.
+	auth.MustGetValidatorFromGinContext(gctx).MarkValidated()
 
 	if gctx.Query("state") == "" {
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
@@ -93,13 +89,9 @@ type RedirectParams struct {
 func (r *PublicOauth2Routes) redirect(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 
-	ra := auth.GetAuthFromGinContext(gctx)
-	if !ra.IsAuthenticated() {
-		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
-			Error: sconfig.ErrorPageInternalError,
-		}, errors.New("auth not present on context"))
-		return
-	}
+	ra := auth.MustGetAuthFromGinContext(gctx)
+	// Permission was checked at the middleware level; there's no per-resource namespace to validate here.
+	auth.MustGetValidatorFromGinContext(gctx).MarkValidated()
 
 	// If we are not in a session, we create one, but cancel it after the oauth flow completes
 	shouldCancelSession := false
@@ -166,13 +158,23 @@ func (r *PublicOauth2Routes) redirect(gctx *gin.Context) {
 }
 
 func (r *PublicOauth2Routes) Register(g *gin.Engine) {
-	g.GET("/oauth2/callback", r.authService.Required(), r.callback)
-	g.GET("/oauth2/redirect", r.authService.Optional(), r.redirect) // Auth here is optional so we can handle nice redirects for unauthed requests
+	// Both endpoints are browser-initiated via 3rd-party OAuth providers. Require auth + permission to create
+	// connections, but redirect through the standard login flow on unauthenticated requests so an idled-out
+	// session doesn't dead-end the user mid-flow.
+	mw := r.authService.NewRequiredBuilder().
+		ForResource("connections").
+		ForVerb("create").
+		WithRedirectOnUnauthenticated(r.sessionInitiateUrlGenerator).
+		Build()
+
+	g.GET("/oauth2/callback", mw, r.callback)
+	g.GET("/oauth2/redirect", mw, r.redirect)
 }
 
 func NewPublicOauth2Routes(
 	cfg config.C,
 	authService auth.A,
+	sessionInitiateUrlGenerator SessionInitiateUrlGenerator,
 	db database.DB,
 	r apredis.Client,
 	c iface.C,
@@ -181,13 +183,14 @@ func NewPublicOauth2Routes(
 	logger *slog.Logger,
 ) *PublicOauth2Routes {
 	return &PublicOauth2Routes{
-		cfg:         cfg,
-		authService: authService,
-		db:          db,
-		r:           r,
-		httpf:       httpf,
-		encrypt:     encrypt,
-		oauthf:      oauth2.NewFactory(cfg, db, r, c, httpf, encrypt, logger),
-		logger:      logger,
+		cfg:                         cfg,
+		authService:                 authService,
+		sessionInitiateUrlGenerator: sessionInitiateUrlGenerator,
+		db:                          db,
+		r:                           r,
+		httpf:                       httpf,
+		encrypt:                     encrypt,
+		oauthf:                      oauth2.NewFactory(cfg, db, r, c, httpf, encrypt, logger),
+		logger:                      logger,
 	}
 }

--- a/internal/routes/public_oauth2.go
+++ b/internal/routes/public_oauth2.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
-	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
@@ -20,7 +19,7 @@ import (
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
-type Oauth2Routes struct {
+type PublicOauth2Routes struct {
 	cfg         config.C
 	authService auth.A
 	db          database.DB
@@ -31,75 +30,56 @@ type Oauth2Routes struct {
 	logger      *slog.Logger
 }
 
-func (r *Oauth2Routes) callback(gctx *gin.Context) {
+func (r *PublicOauth2Routes) callback(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
-	logger := r.logger.With("method", "callback")
 
 	ra := auth.GetAuthFromGinContext(gctx)
 	if !ra.IsAuthenticated() {
-		logger.Warn("callback called without auth")
-		apgin.AddDebugHeader(gctx, "auth not present on context")
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error:       sconfig.ErrorPageUnauthorized,
 			Description: "Request is not part of an authenticated session.",
-		})
+		}, errors.New("auth not present on context"))
 		return
 	}
 
 	if gctx.Query("state") == "" {
-		err := errors.New("failed to bind state param")
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
-		gctx.Redirect(http.StatusFound, r.cfg.GetErrorPageUrl(sconfig.ErrorPageInternalError))
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, errors.New("failed to bind state param"))
 		return
 	}
 
 	stateUUID, err := apid.Parse(gctx.Query("state"))
 	if err != nil {
-		err = fmt.Errorf("failed to parse state param to UUID: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to parse state param to UUID: %w", err))
 		return
 	}
 
 	oauthState, err := r.oauthf.GetOAuth2State(ctx, ra.MustGetActor(), stateUUID) // Get the OAuth2 state
 	if err != nil {
-		err = fmt.Errorf("failed to get oauth2 state: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to get oauth2 state: %w", err))
 		return
 	}
 
 	if oauthState.CancelSessionAfterAuth() {
 		err = r.authService.EndGinSession(gctx, ra)
 		if err != nil {
-			err = fmt.Errorf("failed to end gin session: %w", err)
-			logger.Error(err.Error(), "error", err)
-			apgin.AddDebugHeaderError(gctx, err)
 			r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 				Error: sconfig.ErrorPageInternalError,
-			})
+			}, fmt.Errorf("failed to end gin session: %w", err))
 			return
 		}
 	}
 
 	redirectUrl, err := oauthState.CallbackFrom3rdParty(ctx, gctx.Request.URL.Query())
 	if err != nil {
-		err = fmt.Errorf("failed to handle oauth2 callback: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to handle oauth2 callback: %w", err))
 		return
 	}
 
@@ -110,17 +90,14 @@ type RedirectParams struct {
 	StateId string `form:"state_id"`
 }
 
-func (r *Oauth2Routes) redirect(gctx *gin.Context) {
+func (r *PublicOauth2Routes) redirect(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
-	logger := r.logger.With("method", "redirect")
 
 	ra := auth.GetAuthFromGinContext(gctx)
 	if !ra.IsAuthenticated() {
-		logger.Warn("redirect called without auth")
-		apgin.AddDebugHeader(gctx, "auth not present on context")
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, errors.New("auth not present on context"))
 		return
 	}
 
@@ -130,77 +107,57 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		shouldCancelSession = true
 		err := r.authService.EstablishGinSession(gctx, ra)
 		if err != nil {
-			err = fmt.Errorf("failed to establish gin session: %w", err)
-			logger.Error(err.Error(), "error", err)
-			apgin.AddDebugHeaderError(gctx, err)
 			r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 				Error: sconfig.ErrorPageInternalError,
-			})
+			}, fmt.Errorf("failed to establish gin session: %w", err))
 			return
 		}
 	}
 
 	var req RedirectParams
 	if err := gctx.ShouldBindQuery(&req); err != nil {
-		err = fmt.Errorf("failed to bind redirect params: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to bind redirect params: %w", err))
 		return
 	}
 
 	if req.StateId == "" {
-		logger.Error("state_id is required")
-		apgin.AddDebugHeader(gctx, "state_id is required")
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, errors.New("state_id is required"))
 		return
 	}
 
 	stateId, err := apid.Parse(req.StateId)
 	if err != nil {
-		err = fmt.Errorf("failed to parse state_id: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to parse state_id: %w", err))
 		return
 	}
 
 	o2, err := r.oauthf.GetOAuth2State(ctx, ra.MustGetActor(), stateId)
 	if err != nil {
-		err = fmt.Errorf("failed to get oauth2 state: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to get oauth2 state: %w", err))
 		return
 	}
 
 	err = o2.RecordCancelSessionAfterAuth(ctx, shouldCancelSession)
 	if err != nil {
-		err = fmt.Errorf("failed to record cancel session after auth: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to record cancel session after auth: %w", err))
 		return
 	}
 
 	redirectUrl, err := o2.GenerateAuthUrl(ctx, ra.MustGetActor())
 	if err != nil {
-		err = fmt.Errorf("failed to generate oauth2 redirect url: %w", err)
-		logger.Error(err.Error(), "error", err)
-		apgin.AddDebugHeaderError(gctx, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		})
+		}, fmt.Errorf("failed to generate oauth2 redirect url: %w", err))
 		return
 	}
 
@@ -208,12 +165,12 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 	gctx.Redirect(http.StatusFound, redirectUrl)
 }
 
-func (r *Oauth2Routes) Register(g *gin.Engine) {
+func (r *PublicOauth2Routes) Register(g *gin.Engine) {
 	g.GET("/oauth2/callback", r.authService.Required(), r.callback)
 	g.GET("/oauth2/redirect", r.authService.Optional(), r.redirect) // Auth here is optional so we can handle nice redirects for unauthed requests
 }
 
-func NewOauth2Routes(
+func NewPublicOauth2Routes(
 	cfg config.C,
 	authService auth.A,
 	db database.DB,
@@ -222,8 +179,8 @@ func NewOauth2Routes(
 	httpf httpf.F,
 	encrypt encrypt.E,
 	logger *slog.Logger,
-) *Oauth2Routes {
-	return &Oauth2Routes{
+) *PublicOauth2Routes {
+	return &PublicOauth2Routes{
 		cfg:         cfg,
 		authService: authService,
 		db:          db,

--- a/internal/routes/public_oauth2_test.go
+++ b/internal/routes/public_oauth2_test.go
@@ -1,0 +1,238 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	asynqmock "github.com/rmorlok/authproxy/internal/apasynq/mock"
+	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	rmock "github.com/rmorlok/authproxy/internal/apredis/mock"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/core"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSessionInitiateUrlGenerator is the test double for SessionInitiateUrlGenerator; embeds
+// the returnToUrl in the Location query so the redirect assertion can verify the original
+// URL round-trips through the login flow.
+type stubSessionInitiateUrlGenerator struct {
+	loginUrl string
+}
+
+func (s *stubSessionInitiateUrlGenerator) GetInitiateSessionUrl(returnTo string) string {
+	u, _ := url.Parse(s.loginUrl)
+	q := u.Query()
+	q.Set("return_to", returnTo)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// setupPublicOauth2Test wires PublicOauth2Routes against real (but in-memory) deps.
+// For the scenarios exercised here — unauthenticated redirect, missing permission, and
+// invalid state params — no OAuth2 factory interaction is required, so the factory is
+// constructed normally.
+func setupPublicOauth2Test(t *testing.T) (*gin.Engine, *auth2.AuthTestUtil, *stubSessionInitiateUrlGenerator, func()) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Connectors: &sconfig.Connectors{
+			LoadFromList: []sconfig.Connector{},
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	// GetBaseUrl is called to build return_to on unauthenticated redirects; requires a port.
+	cfg.GetRoot().Public.PortVal = common.NewIntegerValueDirect(8080)
+	cfg, rds := apredis.MustApplyTestConfig(cfg)
+	cfg, auth, authUtil := auth2.TestAuthServiceWithDb(sconfig.ServiceIdPublic, cfg, db)
+	h := httpf2.CreateFactory(cfg, rds, nil, aplog.NewNoopLogger())
+	cfg, e := encrypt.NewTestEncryptService(cfg, db)
+
+	ctrl := gomock.NewController(t)
+	ac := asynqmock.NewMockClient(ctrl)
+	rs := rmock.NewMockClient(ctrl)
+	c := core.NewCoreService(cfg, db, e, rs, h, ac, test_utils.NewTestLogger())
+	require.NoError(t, c.Migrate(context.Background()))
+
+	gen := &stubSessionInitiateUrlGenerator{loginUrl: "https://login.example.com/login"}
+	routes := NewPublicOauth2Routes(cfg, auth, gen, db, rds, c, h, e, test_utils.NewTestLogger())
+
+	r := apgin.ForTest(nil)
+	r.Use(apgin.DebugModeMiddleware(true))
+	routes.Register(r)
+
+	return r, authUtil, gen, func() { ctrl.Finish() }
+}
+
+func TestPublicOauth2Routes_Redirect(t *testing.T) {
+	t.Setenv("AUTHPROXY_DEBUG_MODE", "true")
+	ctx := context.Background()
+
+	t.Run("unauthenticated redirects to login with return_to", func(t *testing.T) {
+		r, _, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/oauth2/redirect?state_id=abc", nil)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusFound, w.Code)
+		loc, err := url.Parse(w.Header().Get("Location"))
+		require.NoError(t, err)
+		assert.Equal(t, "login.example.com", loc.Host)
+
+		returnTo := loc.Query().Get("return_to")
+		require.NotEmpty(t, returnTo, "Location should include return_to")
+		assert.Contains(t, returnTo, "/oauth2/redirect")
+		assert.Contains(t, returnTo, "state_id=abc")
+	})
+
+	t.Run("authenticated without permission returns 403", func(t *testing.T) {
+		r, authUtil, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := authUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/redirect?state_id=abc",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "list"), // wrong verb
+		)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("authenticated with permission but malformed state_id reaches handler", func(t *testing.T) {
+		r, authUtil, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := authUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/redirect?state_id=not-a-uuid",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "create"),
+		)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		// Not 302 (no redirect), not 403 (permission accepted). Debug header is set by the error
+		// page renderer when the handler hits the parse failure, proving the middleware allowed
+		// the request to reach the handler.
+		require.NotEqual(t, http.StatusFound, w.Code)
+		require.NotEqual(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Header().Get("x-authproxy-debug"), "failed to parse state_id")
+	})
+
+	t.Run("unauthenticated with valid auth_token query param passes auth and reaches handler", func(t *testing.T) {
+		r, authUtil, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		tokenString, err := authUtil.GenerateBearerToken(
+			ctx, "some-actor", "root",
+			aschema.PermissionsSingle("root.**", "connections", "create"),
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		// state_id omitted so the handler hits the "state_id is required" branch — the middleware
+		// must still let the request through because the auth_token authenticates the user.
+		req, err := http.NewRequest(
+			http.MethodGet,
+			"/oauth2/redirect?auth_token="+url.QueryEscape(tokenString),
+			nil,
+		)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.NotEqual(t, http.StatusFound, w.Code)
+		require.NotEqual(t, http.StatusForbidden, w.Code)
+		require.NotEqual(t, http.StatusUnauthorized, w.Code)
+		assert.Contains(t, w.Header().Get("x-authproxy-debug"), "state_id is required")
+	})
+}
+
+func TestPublicOauth2Routes_Callback(t *testing.T) {
+	t.Setenv("AUTHPROXY_DEBUG_MODE", "true")
+
+	t.Run("unauthenticated redirects to login with return_to", func(t *testing.T) {
+		r, _, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/oauth2/callback?state=abc&code=xyz", nil)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusFound, w.Code)
+		loc, err := url.Parse(w.Header().Get("Location"))
+		require.NoError(t, err)
+		assert.Equal(t, "login.example.com", loc.Host)
+
+		returnTo := loc.Query().Get("return_to")
+		require.NotEmpty(t, returnTo)
+		assert.Contains(t, returnTo, "/oauth2/callback")
+		assert.Contains(t, returnTo, "state=abc")
+		assert.Contains(t, returnTo, "code=xyz")
+	})
+
+	t.Run("authenticated without permission returns 403", func(t *testing.T) {
+		r, authUtil, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := authUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/callback?state=abc",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "list"),
+		)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code, w.Header().Get("x-authproxy-debug"))
+	})
+
+	t.Run("authenticated with permission but missing state reaches handler", func(t *testing.T) {
+		r, authUtil, _, done := setupPublicOauth2Test(t)
+		defer done()
+
+		w := httptest.NewRecorder()
+		req, err := authUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/oauth2/callback", // no state
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "connections", "create"),
+		)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+
+		require.NotEqual(t, http.StatusFound, w.Code)
+		require.NotEqual(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Header().Get("x-authproxy-debug"), "failed to bind state param")
+	})
+}

--- a/internal/schema/config/error_pages.go
+++ b/internal/schema/config/error_pages.go
@@ -71,7 +71,7 @@ func (ep *ErrorPages) UrlForError(error ErrorPage, publicBaseUrl string) string 
 	return parsedUrl.String()
 }
 
-func (ep *ErrorPages) RenderRenderOrRedirect(gctx *gin.Context, vals ErrorTemplateValues) {
+func (ep *ErrorPages) RenderErrorOrRedirect(gctx *gin.Context, vals ErrorTemplateValues) {
 	switch vals.Error {
 	case ErrorPageNotFound:
 		if ep.NotFound != "" {

--- a/internal/schema/config/error_pages.go
+++ b/internal/schema/config/error_pages.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"html/template"
+	"log/slog"
 	"net/url"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rmorlok/authproxy/internal/apctx"
 )
 
 type ErrorPage string
@@ -71,7 +73,14 @@ func (ep *ErrorPages) UrlForError(error ErrorPage, publicBaseUrl string) string 
 	return parsedUrl.String()
 }
 
-func (ep *ErrorPages) RenderErrorOrRedirect(gctx *gin.Context, vals ErrorTemplateValues) {
+func (ep *ErrorPages) RenderErrorOrRedirect(gctx *gin.Context, vals ErrorTemplateValues, err error) {
+	if err != nil {
+		slog.Default().Error(err.Error(), "error", err)
+		if apctx.IsDebugMode(gctx.Request.Context()) {
+			gctx.Header("x-authproxy-debug", err.Error())
+		}
+	}
+
 	switch vals.Error {
 	case ErrorPageNotFound:
 		if ep.NotFound != "" {

--- a/internal/schema/config/error_pages_test.go
+++ b/internal/schema/config/error_pages_test.go
@@ -74,7 +74,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound}, nil)
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/404", w.Header().Get("Location"))
 
@@ -82,7 +82,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized}, nil)
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/401", w.Header().Get("Location"))
 
@@ -90,7 +90,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError}, nil)
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/500", w.Header().Get("Location"))
 
@@ -98,7 +98,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"}, nil)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Contains(t, w.Body.String(), "Error Occurred")
 	})
@@ -114,7 +114,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound}, nil)
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -122,7 +122,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized}, nil)
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -130,7 +130,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError}, nil)
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -138,7 +138,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"}, nil)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Contains(t, w.Body.String(), "Error Occurred")
 	})

--- a/internal/schema/config/error_pages_test.go
+++ b/internal/schema/config/error_pages_test.go
@@ -74,7 +74,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/404", w.Header().Get("Location"))
 
@@ -82,7 +82,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/401", w.Header().Get("Location"))
 
@@ -90,7 +90,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Equal(t, "https://example.com/500", w.Header().Get("Location"))
 
@@ -98,12 +98,12 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Contains(t, w.Body.String(), "Error Occurred")
 	})
 
-	// Note: The RenderRenderOrRedirect method has a bug where it returns early
+	// Note: The RenderErrorOrRedirect method has a bug where it returns early
 	// if the URL is not configured, without rendering the error page.
 	// This test verifies the current behavior, even though it's likely a bug.
 	t.Run("without configured URLs", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageNotFound})
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -122,7 +122,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageUnauthorized})
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -130,7 +130,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: ErrorPageInternalError})
 		assert.Equal(t, http.StatusOK, w.Code) // No status set because it returns early
 		assert.Empty(t, w.Body.String())       // No body because it returns early
 
@@ -138,7 +138,7 @@ func TestErrorPages_RenderRenderOrRedirect(t *testing.T) {
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
 		c.Request, _ = http.NewRequest("GET", "/", nil)
-		ep.RenderRenderOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
+		ep.RenderErrorOrRedirect(c, ErrorTemplateValues{Error: "unknown"})
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Contains(t, w.Body.String(), "Error Occurred")
 	})

--- a/internal/service/api/routes/README.md
+++ b/internal/service/api/routes/README.md
@@ -1,3 +1,0 @@
-# API Routes
-
-This package contains routes that are only present on the API service.

--- a/internal/service/public/routes/oauth2.go
+++ b/internal/service/public/routes/oauth2.go
@@ -39,7 +39,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 	if !ra.IsAuthenticated() {
 		logger.Warn("callback called without auth")
 		apgin.AddDebugHeader(gctx, "auth not present on context")
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error:       sconfig.ErrorPageUnauthorized,
 			Description: "Request is not part of an authenticated session.",
 		})
@@ -51,7 +51,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
 		gctx.Redirect(http.StatusFound, r.cfg.GetErrorPageUrl(sconfig.ErrorPageInternalError))
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -62,7 +62,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 		err = fmt.Errorf("failed to parse state param to UUID: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -73,7 +73,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 		err = fmt.Errorf("failed to get oauth2 state: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -85,7 +85,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 			err = fmt.Errorf("failed to end gin session: %w", err)
 			logger.Error(err.Error(), "error", err)
 			apgin.AddDebugHeaderError(gctx, err)
-			r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+			r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 				Error: sconfig.ErrorPageInternalError,
 			})
 			return
@@ -97,7 +97,7 @@ func (r *Oauth2Routes) callback(gctx *gin.Context) {
 		err = fmt.Errorf("failed to handle oauth2 callback: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -118,7 +118,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 	if !ra.IsAuthenticated() {
 		logger.Warn("redirect called without auth")
 		apgin.AddDebugHeader(gctx, "auth not present on context")
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -133,7 +133,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 			err = fmt.Errorf("failed to establish gin session: %w", err)
 			logger.Error(err.Error(), "error", err)
 			apgin.AddDebugHeaderError(gctx, err)
-			r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+			r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 				Error: sconfig.ErrorPageInternalError,
 			})
 			return
@@ -145,7 +145,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		err = fmt.Errorf("failed to bind redirect params: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -154,7 +154,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 	if req.StateId == "" {
 		logger.Error("state_id is required")
 		apgin.AddDebugHeader(gctx, "state_id is required")
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -165,7 +165,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		err = fmt.Errorf("failed to parse state_id: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -176,7 +176,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		err = fmt.Errorf("failed to get oauth2 state: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -187,7 +187,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		err = fmt.Errorf("failed to record cancel session after auth: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return
@@ -198,7 +198,7 @@ func (r *Oauth2Routes) redirect(gctx *gin.Context) {
 		err = fmt.Errorf("failed to generate oauth2 redirect url: %w", err)
 		logger.Error(err.Error(), "error", err)
 		apgin.AddDebugHeaderError(gctx, err)
-		r.cfg.GetRoot().ErrorPages.RenderRenderOrRedirect(gctx, sconfig.ErrorTemplateValues{
+		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
 		})
 		return

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/config"
 	common_routes "github.com/rmorlok/authproxy/internal/routes"
 	"github.com/rmorlok/authproxy/internal/service"
-	"github.com/rmorlok/authproxy/internal/service/public/routes"
 	"github.com/rmorlok/authproxy/internal/util"
 )
 
@@ -107,7 +106,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 	routesError := common_routes.NewErrorRoutes(dm.GetConfig())
 	routesError.Register(server)
 
-	routesOauth2 := routes.NewOauth2Routes(
+	routesOauth2 := common_routes.NewPublicOauth2Routes(
 		dm.GetConfig(),
 		authService,
 		dm.GetDatabase(),

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -109,6 +109,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 	routesOauth2 := common_routes.NewPublicOauth2Routes(
 		dm.GetConfig(),
 		authService,
+		&root.HostApplication,
 		dm.GetDatabase(),
 		dm.GetRedisClient(),
 		dm.GetCoreService(),


### PR DESCRIPTION
## Summary

- `/oauth2/callback` and `/oauth2/redirect` now require auth + `connections:create` and 302-redirect unauthenticated requests through the host application's session-initiate URL instead of returning 401/error — a lapsed session on a 3rd-party consent screen no longer dead-ends the user.
- Adds `AuthRedirectUrlGenerator` + `RequiredWithAuthRedirect` on the auth service, and `WithRedirectOnUnauthenticated` on `PermissionValidatorBuilder`, for any browser-initiated route that should redirect rather than 401 on unauth.
- Also rolls up prior branch work: renamed `renderErrorOrRedirect`, moved OAuth2 routes into `internal/routes/` alongside other shared routes with consistent error logging.

## Test plan

- [x] `go test ./internal/apauth/service/...` — new redirect middleware + builder tests pass
- [x] `go test ./internal/routes/...` — new public OAuth2 route tests (unauth redirect, forbidden, auth_token round-trip) pass
- [x] `go build ./...` — clean
- [x] Manual browser QA (Chrome DevTools): unauth `GET /oauth2/redirect?state_id=…` → 302 to `host_application.initiate_session_url?return_to=<original>`; unauth `GET /oauth2/callback?state=…&code=…` → same, with both `state` and `code` preserved in `return_to`

🤖 Generated with [Claude Code](https://claude.com/claude-code)