### PR TITLE
Add HashiCorp Vault integration test and full KV v2 version support

### DIFF
--- a/.github/workflows/vault-integration.yml
+++ b/.github/workflows/vault-integration.yml
@@ -1,0 +1,98 @@
+# schema: https://json.schemastore.org/github-workflow.json
+name: HashiCorp Vault Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  vault-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5433:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: authproxy_integration
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:latest
+        ports:
+          - 6380:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      clickhouse:
+        image: clickhouse/clickhouse-server:latest
+        ports:
+          - 8124:8123
+        env:
+          CLICKHOUSE_DB: authproxy
+          CLICKHOUSE_USER: authproxy
+          CLICKHOUSE_PASSWORD: authproxy
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Start MinIO
+      run: |
+        docker run -d --name minio -p 9003:9000 \
+          -e MINIO_ROOT_USER=minioadmin \
+          -e MINIO_ROOT_PASSWORD=minioadmin \
+          minio/minio:latest server /data
+        for i in $(seq 1 30); do
+          curl -sf http://localhost:9003/minio/health/live && break
+          sleep 1
+        done
+
+    - name: Create MinIO bucket
+      run: |
+        docker run --rm --network host \
+          -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
+          minio/mc mb --ignore-existing minio/authproxy-request-logs
+
+    - name: Start Vault (dev mode)
+      run: |
+        docker run -d --name vault -p 8200:8200 \
+          -e VAULT_DEV_ROOT_TOKEN_ID=dev-only-token \
+          -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
+          -e SKIP_SETCAP=true \
+          hashicorp/vault:latest server -dev
+        for i in $(seq 1 30); do
+          curl -sf http://localhost:8200/v1/sys/health && break
+          sleep 1
+        done
+
+    - name: HashiCorp Vault Integration Tests
+      working-directory: integration_tests
+      env:
+        AUTH_PROXY_TEST_DATABASE_PROVIDER: postgres
+        POSTGRES_TEST_HOST: localhost
+        POSTGRES_TEST_PORT: "5433"
+        POSTGRES_TEST_USER: postgres
+        POSTGRES_TEST_PASSWORD: postgres
+        POSTGRES_TEST_DATABASE: authproxy_integration
+        POSTGRES_TEST_OPTIONS: sslmode=disable
+        AUTH_PROXY_VAULT_TEST: "1"
+        VAULT_ADDR: http://127.0.0.1:8200
+        VAULT_TOKEN: dev-only-token
+      run: go test -tags "integration,vault" -v -timeout 10m ./encrypt/...

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -92,6 +92,36 @@ Notes:
 - For CI, provide `GCP_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS_JSON` (the full service account key JSON) as repository secrets. The GitHub Actions workflow writes the JSON to a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
 - The workflow runs only on pushes to `main` (and manual `workflow_dispatch`) to avoid exposing the GCP secrets to PRs from forks.
 
+## HashiCorp Vault Integration Test
+
+This test hits a running HashiCorp Vault server and is gated behind the `vault` build tag and an env flag. Unlike the AWS and GCP tests, Vault runs locally (in dev mode) both on developer machines and in CI — no external credentials required.
+
+Requirements:
+- A Vault server reachable at `VAULT_ADDR` with a token in `VAULT_TOKEN` that can read and write the `secret/` KV v2 mount.
+- `AUTH_PROXY_VAULT_TEST=1` set to opt in.
+
+The `docker-compose.yml` in this directory already includes a Vault dev-mode service with the root token `dev-only-token`. Bring it up with `docker compose up -d` and point the test at it:
+
+```bash
+cd integration_tests
+AUTH_PROXY_VAULT_TEST=1 \
+  VAULT_ADDR=http://127.0.0.1:8200 \
+  VAULT_TOKEN=dev-only-token \
+  go test -tags "integration,vault" -v ./encrypt/...
+```
+
+Or start Vault ad hoc:
+
+```bash
+docker run -d --name vault -p 8200:8200 --cap-add=IPC_LOCK \
+  -e VAULT_DEV_ROOT_TOKEN_ID=dev-only-token \
+  hashicorp/vault:latest server -dev
+```
+
+Notes:
+- The test writes a short-lived KV v2 secret at a unique path and deletes its metadata on cleanup.
+- CI uses `.github/workflows/vault-integration.yml`, which runs Vault as a dev-mode container inside the workflow. The workflow runs on pushes to `main` and on `workflow_dispatch`.
+
 ## Teardown
 
 ```bash

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -76,3 +76,21 @@ services:
       mc alias set minio http://minio:9000 minioadmin minioadmin &&
       mc mb --ignore-existing minio/authproxy-request-logs
       "
+
+  vault:
+    image: hashicorp/vault:latest
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: dev-only-token
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+      # Dev mode does not need mlock (and mlock via CAP_IPC_LOCK requires
+      # CAP_SETFCAP to install at runtime). Skip setcap so the entrypoint
+      # runs cleanly without extra privileges.
+      SKIP_SETCAP: "true"
+    command: server -dev
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8200/v1/sys/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10

--- a/integration_tests/encrypt/vault_test.go
+++ b/integration_tests/encrypt/vault_test.go
@@ -1,0 +1,171 @@
+//go:build integration && vault
+
+package encrypt_test
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	vaultTestEnv    = "AUTH_PROXY_VAULT_TEST"
+	vaultAddrEnv    = "VAULT_ADDR"
+	vaultTokenEnv   = "VAULT_TOKEN"
+	vaultKvMount    = "secret"
+	vaultValueField = "value"
+)
+
+func init() {
+	// Best-effort load of .env files walking up from the current working
+	// directory so the test is runnable locally regardless of where the
+	// user keeps their .env.
+	util.LoadDotEnv()
+}
+
+// TestVaultKeySyncAndReencrypt verifies that encryption keys stored in a
+// HashiCorp Vault KV v2 mount are correctly synced into the database, that
+// new KV v2 versions are picked up on re-sync, and that the re-encryption
+// pipeline rewrites data encrypted under a prior version to the new current
+// version.
+func TestVaultKeySyncAndReencrypt(t *testing.T) {
+	if os.Getenv(vaultTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", vaultTestEnv)
+	}
+
+	vaultAddr := os.Getenv(vaultAddrEnv)
+	if vaultAddr == "" {
+		t.Skipf("%s is not set", vaultAddrEnv)
+	}
+
+	vaultToken := os.Getenv(vaultTokenEnv)
+	if vaultToken == "" {
+		t.Skipf("%s is not set", vaultTokenEnv)
+	}
+
+	ctx := context.Background()
+	client := newVaultClient(t, vaultAddr, vaultToken)
+
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+
+	secretPath := fmt.Sprintf("authproxy-vault-test-%d", time.Now().UnixNano())
+
+	// Vault KV v2 stores string values, so we hex-encode 16 random bytes
+	// (32 ASCII chars) so the resulting []byte is a valid 32-byte AES-256 key.
+	keyV1 := hex.EncodeToString(randomBytes(t, 16))
+
+	_, err := client.KVv2(vaultKvMount).Put(ctx, secretPath, map[string]interface{}{
+		vaultValueField: keyV1,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = client.KVv2(vaultKvMount).DeleteMetadata(cleanupCtx, secretPath)
+	})
+
+	namespace := fmt.Sprintf("root.vault-test-%d", time.Now().UnixNano())
+	ekID := apid.New(apid.PrefixEncryptionKey)
+
+	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
+		Path:            namespace,
+		EncryptionKeyId: &ekID,
+	}))
+
+	keyData := sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataVault{
+			VaultAddress: vaultAddr,
+			VaultToken:   vaultToken,
+			VaultPath:    fmt.Sprintf("%s/data/%s", vaultKvMount, secretPath),
+			VaultKey:     vaultValueField,
+		},
+	}
+	keyDataJSON, err := json.Marshal(&keyData)
+	require.NoError(t, err)
+
+	encKeyData, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSON)
+	require.NoError(t, err)
+
+	require.NoError(t, env.Db.CreateEncryptionKey(ctx, &database.EncryptionKey{
+		Id:               ekID,
+		Namespace:        namespace,
+		EncryptedKeyData: &encKeyData,
+		State:            database.EncryptionKeyStateActive,
+	}))
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	currentV1, err := env.Db.GetCurrentEncryptionKeyVersionForNamespace(ctx, namespace)
+	require.NoError(t, err)
+	require.Equal(t, "1", currentV1.ProviderVersion)
+
+	plaintext := "vault-kv-test"
+	encrypted, err := env.DM.GetEncryptService().EncryptStringForNamespace(ctx, namespace, plaintext)
+	require.NoError(t, err)
+	require.Equal(t, currentV1.Id, encrypted.ID)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, env.Db.CreateActor(ctx, &database.Actor{
+		Id:           actorID,
+		Namespace:    namespace,
+		ExternalId:   "vault-test-actor",
+		EncryptedKey: &encrypted,
+	}))
+
+	// Rotate: write a new KV v2 version to the same path.
+	keyV2 := hex.EncodeToString(randomBytes(t, 16))
+	require.NotEqual(t, keyV1, keyV2)
+
+	_, err = client.KVv2(vaultKvMount).Put(ctx, secretPath, map[string]interface{}{
+		vaultValueField: keyV2,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	currentV2, err := env.Db.GetCurrentEncryptionKeyVersionForNamespace(ctx, namespace)
+	require.NoError(t, err)
+	require.NotEqual(t, currentV1.Id, currentV2.Id)
+	require.Equal(t, "2", currentV2.ProviderVersion)
+
+	require.NoError(t, runReencryptAll(ctx, env))
+
+	updated, err := env.Db.GetActor(ctx, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.EncryptedKey)
+	require.Equal(t, currentV2.Id, updated.EncryptedKey.ID)
+
+	decrypted, err := env.DM.GetEncryptService().DecryptString(ctx, *updated.EncryptedKey)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+}
+
+func newVaultClient(t *testing.T, addr, token string) *vault.Client {
+	t.Helper()
+
+	cfg := vault.DefaultConfig()
+	cfg.Address = addr
+
+	client, err := vault.NewClient(cfg)
+	require.NoError(t, err)
+
+	client.SetToken(token)
+	return client
+}

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
+	github.com/hashicorp/vault/api v1.22.0
 	github.com/rmorlok/authproxy v0.0.0-00010101000000-000000000000
 	github.com/rmorlok/authproxy/terraform/provider v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.11.1
@@ -127,7 +128,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
-	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hibiken/asynq v0.25.1 // indirect
 	github.com/invopop/jsonschema v0.12.0 // indirect

--- a/internal/schema/config/key_data_vault.go
+++ b/internal/schema/config/key_data_vault.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	vault "github.com/hashicorp/vault/api"
@@ -79,11 +82,112 @@ func (kv *KeyDataVault) fetchVersionInfo(ctx context.Context, version string) (K
 }
 
 func (kv *KeyDataVault) fetchListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
-	v, err := kv.fetchCurrentVersion(ctx)
+	metaPath := kv.metadataPath()
+	if metaPath == "" {
+		// Not a KV v2 path — fall back to reporting the single value the
+		// current-version read returns.
+		v, err := kv.fetchCurrentVersion(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return []KeyVersionInfo{v}, nil
+	}
+
+	client, err := kv.newClient()
 	if err != nil {
 		return nil, err
 	}
-	return []KeyVersionInfo{v}, nil
+
+	meta, err := client.Logical().Read(metaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vault metadata %s: %w", metaPath, err)
+	}
+
+	if meta == nil || meta.Data == nil {
+		// Path has no metadata yet (new secret) — fall back to current.
+		v, err := kv.fetchCurrentVersion(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return []KeyVersionInfo{v}, nil
+	}
+
+	currentVersion := vaultVersionNumberString(meta.Data["current_version"])
+
+	versionsMap, ok := meta.Data["versions"].(map[string]interface{})
+	if !ok || len(versionsMap) == 0 {
+		return nil, fmt.Errorf("no versions returned at vault metadata path %s", metaPath)
+	}
+
+	versionKeys := make([]string, 0, len(versionsMap))
+	for v := range versionsMap {
+		versionKeys = append(versionKeys, v)
+	}
+	// Sort numerically so callers see versions in a predictable (oldest → newest) order.
+	sort.Slice(versionKeys, func(i, j int) bool {
+		a, _ := strconv.Atoi(versionKeys[i])
+		b, _ := strconv.Atoi(versionKeys[j])
+		return a < b
+	})
+
+	infos := make([]KeyVersionInfo, 0, len(versionKeys))
+	for _, versionStr := range versionKeys {
+		if versionMap, ok := versionsMap[versionStr].(map[string]interface{}); ok {
+			if deletionTime, _ := versionMap["deletion_time"].(string); deletionTime != "" {
+				continue
+			}
+			if destroyed, _ := versionMap["destroyed"].(bool); destroyed {
+				continue
+			}
+		}
+
+		data, err := kv.fetchVersionFromVault(versionStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read vault version %s at %s: %w", versionStr, kv.VaultPath, err)
+		}
+
+		infos = append(infos, KeyVersionInfo{
+			Provider:        ProviderTypeHashicorpVault,
+			ProviderID:      kv.vaultProviderID(),
+			ProviderVersion: versionStr,
+			Data:            data,
+			IsCurrent:       versionStr == currentVersion,
+		})
+	}
+
+	if len(infos) == 0 {
+		return nil, fmt.Errorf("all versions at vault metadata path %s are deleted or destroyed", metaPath)
+	}
+
+	return infos, nil
+}
+
+// metadataPath returns the KV v2 metadata path corresponding to VaultPath,
+// or empty if VaultPath is not a KV v2 data path. It replaces the first
+// `/data/` segment with `/metadata/` (the standard KV v2 layout).
+func (kv *KeyDataVault) metadataPath() string {
+	const dataSegment = "/data/"
+	idx := strings.Index(kv.VaultPath, dataSegment)
+	if idx < 0 {
+		return ""
+	}
+	return kv.VaultPath[:idx] + "/metadata/" + kv.VaultPath[idx+len(dataSegment):]
+}
+
+// vaultVersionNumberString coerces a Vault version value (json.Number, float64,
+// int, or string) into a canonical string form.
+func vaultVersionNumberString(v interface{}) string {
+	switch x := v.(type) {
+	case json.Number:
+		return x.String()
+	case float64:
+		return fmt.Sprintf("%d", int64(x))
+	case int:
+		return fmt.Sprintf("%d", x)
+	case string:
+		return x
+	}
+	return ""
 }
 
 func (kv *KeyDataVault) GetCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
@@ -233,23 +337,7 @@ func extractVaultVersion(data map[string]interface{}) string {
 	if !ok {
 		return ""
 	}
-
-	version, ok := metadata["version"]
-	if !ok {
-		return ""
-	}
-
-	// Vault returns version as json.Number or float64 depending on how it's parsed
-	switch v := version.(type) {
-	case json.Number:
-		return v.String()
-	case float64:
-		return fmt.Sprintf("%d", int64(v))
-	case string:
-		return v
-	}
-
-	return ""
+	return vaultVersionNumberString(metadata["version"])
 }
 
 var _ KeyDataType = (*KeyDataVault)(nil)


### PR DESCRIPTION
## Summary
- Adds an integration test (`integration_tests/encrypt/vault_test.go`, build tag `integration && vault`) that runs against a real Vault server and mirrors the AWS/GCP tests from #132 and #142: write a key, sync, encrypt, rotate the KV v2 secret, re-sync, re-encrypt, and verify the actor's field is rewritten with the new key.
- Adds `.github/workflows/vault-integration.yml` which runs Vault in dev mode as a container step during CI. No external secrets required — unlike AWS/GCP, Vault runs fully locally.
- Adds a `vault` service to `integration_tests/docker-compose.yml` (dev mode, port 8200, fixed root token `dev-only-token`) so the test is runnable locally with just `docker compose up -d`.
- Fixes `KeyDataVault.ListVersions` to enumerate every live KV v2 version via the metadata endpoint. Previously only the current version was returned, which caused `syncKeyVersionsForKeyToDatabase` to delete the prior `EncryptionKeyVersion` row on rotation and silently invalidate any data encrypted under it. The re-encryption portion of the new test exercises this path end-to-end.

## Running locally
```bash
cd integration_tests
docker compose up -d
AUTH_PROXY_VAULT_TEST=1 \
  VAULT_ADDR=http://127.0.0.1:8200 \
  VAULT_TOKEN=dev-only-token \
  go test -tags "integration,vault" -v ./encrypt/...
```

## CI
Runs on `push` to `main` and on `workflow_dispatch` only (matches the AWS/GCP convention), though no external secrets are required for this one.

Closes #143.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/schema/config/...` (existing Vault key-data unit tests still pass)
- [x] `go vet -tags "integration,vault" ./encrypt/...` from `integration_tests/`
- [x] `go vet -tags "integration,aws" ./encrypt/...` (ensures shared helpers still compile)
- [x] `go vet -tags "integration,gcp" ./encrypt/...`
- [x] `./scripts/preflight.sh`
- [x] `go test -tags "integration,vault" -v ./encrypt/...` skips cleanly when `AUTH_PROXY_VAULT_TEST` is unset
- [x] Full `TestVaultKeySyncAndReencrypt` passes locally against the docker-compose Vault
- [ ] `HashiCorp Vault Integration Tests` CI job runs green on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)