### PR TITLE
Handle annotations directly in UpsertActor (#115)

### DIFF
--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -44,6 +44,11 @@ func (a *Actor) GetNamespace() string {
 
 func (a *Actor) GetLabels() map[string]string { return a.Labels }
 
+// GetAnnotations always returns nil for JWT-derived actors. Annotations are
+// server-side metadata and do not propagate via JWT, so an upsert from a JWT
+// claim must not overwrite annotations on the stored actor.
+func (a *Actor) GetAnnotations() map[string]string { return nil }
+
 func CreateActor(data IActorData) *Actor {
 	if a, ok := data.(*Actor); ok {
 		return a

--- a/internal/apauth/tasks/actor_data.go
+++ b/internal/apauth/tasks/actor_data.go
@@ -37,6 +37,10 @@ func (a *configuredActorData) GetLabels() map[string]string {
 	return a.labels
 }
 
+func (a *configuredActorData) GetAnnotations() map[string]string {
+	return nil
+}
+
 func (a *configuredActorData) GetEncryptedKey() *encfield.EncryptedField {
 	return a.encryptedKey
 }

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -173,6 +173,13 @@ func (a *Actor) setFromData(d IActorData) {
 	a.Permissions = d.GetPermissions()
 	a.Labels = d.GetLabels()
 
+	// Annotations follow PATCH semantics: a nil map leaves existing annotations
+	// unchanged so server-side metadata is not wiped by callers (e.g. JWT auth)
+	// that don't carry annotations.
+	if annotations := d.GetAnnotations(); annotations != nil {
+		a.Annotations = annotations
+	}
+
 	// Handle extended fields via type assertion
 	if extended, ok := d.(IActorDataExtended); ok {
 		a.EncryptedKey = extended.GetEncryptedKey()
@@ -189,6 +196,19 @@ func (a *Actor) sameAsData(d IActorData) bool {
 	for k, v := range a.Labels {
 		if dv, ok := dLabels[k]; !ok || dv != v {
 			return false
+		}
+	}
+
+	// Compare annotations only when the caller provided them (matches the
+	// PATCH semantics in setFromData).
+	if dAnnotations := d.GetAnnotations(); dAnnotations != nil {
+		if len(a.Annotations) != len(dAnnotations) {
+			return false
+		}
+		for k, v := range a.Annotations {
+			if dv, ok := dAnnotations[k]; !ok || dv != v {
+				return false
+			}
 		}
 	}
 

--- a/internal/database/actor_test.go
+++ b/internal/database/actor_test.go
@@ -372,6 +372,94 @@ func TestActor(t *testing.T) {
 				require.Equal(t, id3, retrieved3.Id)
 				require.Equal(t, originalPerms3, retrieved3.Permissions)
 			})
+			t.Run("annotations", func(t *testing.T) {
+				t.Run("set on create", func(t *testing.T) {
+					setup(t)
+
+					actor, err := db.UpsertActor(ctx, &Actor{
+						Namespace:   "root",
+						ExternalId:  "annotated",
+						Annotations: Annotations{"env": "prod"},
+					})
+					require.NoError(t, err)
+
+					retrieved, err := db.GetActor(ctx, actor.Id)
+					require.NoError(t, err)
+					require.Equal(t, Annotations{"env": "prod"}, retrieved.Annotations)
+				})
+				t.Run("replace on update", func(t *testing.T) {
+					setup(t)
+
+					id := apid.New(apid.PrefixActor)
+					require.NoError(t, db.CreateActor(ctx, &Actor{
+						Id:          id,
+						Namespace:   "root",
+						ExternalId:  "to-replace",
+						Annotations: Annotations{"env": "dev", "team": "x"},
+					}))
+
+					updated, err := db.UpsertActor(ctx, &Actor{
+						Id:          id,
+						Namespace:   "root",
+						ExternalId:  "to-replace",
+						Annotations: Annotations{"env": "prod"},
+					})
+					require.NoError(t, err)
+					require.Equal(t, Annotations{"env": "prod"}, updated.Annotations)
+
+					retrieved, err := db.GetActor(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, Annotations{"env": "prod"}, retrieved.Annotations)
+				})
+				t.Run("nil annotations leave existing unchanged", func(t *testing.T) {
+					setup(t)
+
+					id := apid.New(apid.PrefixActor)
+					require.NoError(t, db.CreateActor(ctx, &Actor{
+						Id:          id,
+						Namespace:   "root",
+						ExternalId:  "preserve",
+						Annotations: Annotations{"env": "prod"},
+					}))
+
+					// Pass data with nil annotations - simulates JWT-derived actors
+					// where annotations should never be touched.
+					_, err := db.UpsertActor(ctx, &core.Actor{
+						Id:         id,
+						Namespace:  "root",
+						ExternalId: "preserve",
+					})
+					require.NoError(t, err)
+
+					retrieved, err := db.GetActor(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, Annotations{"env": "prod"}, retrieved.Annotations)
+				})
+				t.Run("empty map clears annotations", func(t *testing.T) {
+					setup(t)
+
+					id := apid.New(apid.PrefixActor)
+					require.NoError(t, db.CreateActor(ctx, &Actor{
+						Id:          id,
+						Namespace:   "root",
+						ExternalId:  "to-clear",
+						Annotations: Annotations{"env": "prod"},
+					}))
+
+					updated, err := db.UpsertActor(ctx, &Actor{
+						Id:          id,
+						Namespace:   "root",
+						ExternalId:  "to-clear",
+						Annotations: Annotations{},
+					})
+					require.NoError(t, err)
+					require.Empty(t, updated.Annotations)
+
+					retrieved, err := db.GetActor(ctx, id)
+					require.NoError(t, err)
+					require.Empty(t, retrieved.Annotations)
+				})
+			})
 		})
 	})
 	t.Run("List", func(t *testing.T) {

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -26,6 +26,10 @@ type IActorData interface {
 	GetPermissions() []aschema.Permission
 	GetNamespace() string
 	GetLabels() map[string]string
+	// GetAnnotations returns the annotations to apply on upsert. A nil return means
+	// annotations should be left unchanged on existing actors (PATCH semantics);
+	// a non-nil map (including empty) is treated as a full replacement.
+	GetAnnotations() map[string]string
 }
 
 // IActorDataExtended extends IActorData with additional fields for labels and encrypted key.

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -40,6 +40,20 @@ func (m *MockIActorData) EXPECT() *MockIActorDataMockRecorder {
 	return m.recorder
 }
 
+// GetAnnotations mocks base method.
+func (m *MockIActorData) GetAnnotations() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnnotations")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetAnnotations indicates an expected call of GetAnnotations.
+func (mr *MockIActorDataMockRecorder) GetAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockIActorData)(nil).GetAnnotations))
+}
+
 // GetExternalId mocks base method.
 func (m *MockIActorData) GetExternalId() string {
 	m.ctrl.T.Helper()
@@ -131,6 +145,20 @@ func NewMockIActorDataExtended(ctrl *gomock.Controller) *MockIActorDataExtended 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIActorDataExtended) EXPECT() *MockIActorDataExtendedMockRecorder {
 	return m.recorder
+}
+
+// GetAnnotations mocks base method.
+func (m *MockIActorDataExtended) GetAnnotations() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnnotations")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetAnnotations indicates an expected call of GetAnnotations.
+func (mr *MockIActorDataExtendedMockRecorder) GetAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockIActorDataExtended)(nil).GetAnnotations))
 }
 
 // GetEncryptedKey mocks base method.

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -644,22 +644,15 @@ func (r *ActorsRoutes) update(gctx *gin.Context) {
 		existingActor.Labels = req.Labels
 	}
 
-	// Use UpsertActor to update (handles labels, permissions, etc. but not annotations)
+	if req.Annotations != nil {
+		existingActor.Annotations = req.Annotations
+	}
+
 	updatedActor, err := r.db.UpsertActor(ctx, existingActor)
 	if err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
-	}
-
-	// Update annotations separately since UpsertActor doesn't handle them
-	if req.Annotations != nil {
-		updatedActor, err = r.db.UpdateActorAnnotations(ctx, updatedActor.Id, req.Annotations)
-		if err != nil {
-			apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
 	}
 
 	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(updatedActor))
@@ -753,22 +746,15 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 		existingActor.Labels = req.Labels
 	}
 
-	// Use UpsertActor to update (handles labels, permissions, etc. but not annotations)
+	if req.Annotations != nil {
+		existingActor.Annotations = req.Annotations
+	}
+
 	updatedActor, err := r.db.UpsertActor(ctx, existingActor)
 	if err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
-	}
-
-	// Update annotations separately since UpsertActor doesn't handle them
-	if req.Annotations != nil {
-		updatedActor, err = r.db.UpdateActorAnnotations(ctx, updatedActor.Id, req.Annotations)
-		if err != nil {
-			apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
 	}
 
 	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(updatedActor))


### PR DESCRIPTION
## Summary
- Add `GetAnnotations()` to `database.IActorData` with PATCH semantics (nil leaves annotations unchanged; a non-nil map — including empty — replaces them).
- Extend `Actor.setFromData` / `sameAsData` to honor those semantics so `UpsertActor` writes annotations in a single transaction.
- Drop the second `UpdateActorAnnotations` call from the actor PATCH route handlers (by id and by external id).
- `core.Actor` (JWT-derived) and `configuredActorData` (sync) return `nil` from `GetAnnotations()` so routine upserts can't wipe server-side metadata.

Fixes #115.

## Test plan
- [x] `go test ./internal/database/ -run TestActor` (covers new `set on create`, `replace on update`, `nil preserves`, `empty map clears` cases under `UpsertActor/updates_existing/annotations`)
- [x] `go test ./internal/routes/ -run TestActor`
- [x] `go test ./internal/apauth/...`
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)