### PR TITLE
Add verify connection step with probes after auth (#141)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tmp
 node_modules
 
 dev_config/keys/tls
+
+.claude/scheduled_tasks.lock

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 func (o *oAuth2Connection) getPublicCallbackUrl() (string, error) {
@@ -111,25 +112,35 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 		return errorRedirectPage, fmt.Errorf("failed to create db token from response: %w", err)
 	}
 
-	// Check if the connector has configure steps to complete after auth
 	cv := o.connection.GetConnectorVersionEntity()
-	hasConfigure := cv != nil && cv.GetDefinition().SetupFlow.HasConfigure()
+	var connectorDef *cschema.Connector
+	if cv != nil {
+		connectorDef = cv.GetDefinition()
+	}
+	hasProbes := connectorDef != nil && len(connectorDef.Probes) > 0
+	hasConfigure := connectorDef != nil && connectorDef.SetupFlow.HasConfigure()
+
+	// If the connector has probes, run them in a background task before proceeding to configure.
+	if hasProbes {
+		verifyStep := cschema.SetupStepVerify
+		if err := o.connection.SetSetupStep(ctx, &verifyStep); err != nil {
+			return errorRedirectPage, fmt.Errorf("failed to set setup step to verify: %w", err)
+		}
+		if err := o.connectors.EnqueueVerifyConnection(ctx, o.connection.GetId()); err != nil {
+			return errorRedirectPage, fmt.Errorf("failed to enqueue verify connection task: %w", err)
+		}
+
+		// The UI will poll /_setup_step to observe verify outcome and transition to configure/ready/error.
+		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
+	}
+
+	// No probes — proceed with the existing post-auth branches.
 	if hasConfigure {
 		configureStep := "configure:0"
 		if err := o.connection.SetSetupStep(ctx, &configureStep); err != nil {
 			return errorRedirectPage, fmt.Errorf("failed to set setup step to configure:0: %w", err)
 		}
-
-		// Append setup=pending to return URL so the UI knows to show configure forms
-		returnUrl, err := url.Parse(o.state.ReturnToUrl)
-		if err != nil {
-			return o.state.ReturnToUrl, nil // Fall back to the raw URL if parsing fails
-		}
-		q := returnUrl.Query()
-		q.Set("setup", "pending")
-		q.Set("connection_id", string(o.connection.GetId()))
-		returnUrl.RawQuery = q.Encode()
-		return returnUrl.String(), nil
+		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
 	}
 
 	// No configure steps — clear setup step if it was set
@@ -140,4 +151,18 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 	}
 
 	return o.state.ReturnToUrl, nil
+}
+
+// appendSetupPendingToReturnUrl augments the return URL with query params that signal the UI
+// to poll for setup-step advancement. Falls back to the raw URL if parsing fails.
+func (o *oAuth2Connection) appendSetupPendingToReturnUrl(raw string) string {
+	returnUrl, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	q := returnUrl.Query()
+	q.Set("setup", "pending")
+	q.Set("connection_id", string(o.connection.GetId()))
+	returnUrl.RawQuery = q.Encode()
+	return returnUrl.String()
 }

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -32,23 +32,42 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 	errorRedirectPage := o.cfg.GetErrorPageUrl(config.ErrorPageInternalError)
 
 	if o.state == nil {
+		// We have no connection context to record against — fall back to the static error page.
 		return errorRedirectPage, errors.New("state is nil")
 	}
 
+	redirectUrl, err := o.exchangeCodeAndAdvance(ctx, query)
+	if err == nil {
+		return redirectUrl, nil
+	}
+
+	// Record the failure on the connection so it lands in the auth_failed terminal state. The
+	// user is sent back to the original return URL with the setup-pending annotation; the
+	// marketplace UI then sees auth_failed via the connection record and offers retry/cancel.
+	if recordErr := o.connection.HandleAuthFailed(ctx, err); recordErr != nil {
+		return errorRedirectPage, fmt.Errorf("failed to record auth failure (%v) after: %w", recordErr, err)
+	}
+	return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
+}
+
+// exchangeCodeAndAdvance performs the OAuth token exchange and post-auth state transition.
+// Errors returned from here are recorded by the caller as auth failures on the connection so
+// the user can retry via the standard failure flow.
+func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url.Values) (string, error) {
 	// Delete the state from Redis now that the callback is consuming it.
 	// This is the terminal step of the OAuth flow, so the state is no longer needed.
 	if err := deleteStateFromRedis(ctx, o.r, o.state.Id); err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to clean up oauth state: %w", err)
+		return "", fmt.Errorf("failed to clean up oauth state: %w", err)
 	}
 
 	code := query.Get("code")
 	if code == "" {
-		return errorRedirectPage, errors.New("no code in query")
+		return "", errors.New("no code in query")
 	}
 
 	callbackUrl, err := o.getPublicCallbackUrl()
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to get public callback url: %w", err)
+		return "", fmt.Errorf("failed to get public callback url: %w", err)
 	}
 
 	c := o.httpf.
@@ -59,17 +78,17 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 
 	clientId, err := o.auth.ClientId.GetValue(ctx)
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to get client id for connector: %w", err)
+		return "", fmt.Errorf("failed to get client id for connector: %w", err)
 	}
 
 	clientSecret, err := o.auth.ClientSecret.GetValue(ctx)
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to get client id for connector: %w", err)
+		return "", fmt.Errorf("failed to get client id for connector: %w", err)
 	}
 
 	tokenEndpoint, err := o.renderMustache(ctx, o.auth.Token.Endpoint)
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to render token endpoint template: %w", err)
+		return "", fmt.Errorf("failed to render token endpoint template: %w", err)
 	}
 
 	req := c.Request().
@@ -99,21 +118,21 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 		Send()
 
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to post to exchange authorization code for access token: %w", err)
+		return "", fmt.Errorf("failed to post to exchange authorization code for access token: %w", err)
 	}
 
 	if resp.StatusCode != 200 {
-		return errorRedirectPage, fmt.Errorf("received status code %d from exchange authorization code for access token", resp.StatusCode)
+		return "", fmt.Errorf("received status code %d from exchange authorization code for access token", resp.StatusCode)
 	}
 
 	_, err = o.createDbTokenFromResponse(ctx, resp, nil)
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to create db token from response: %w", err)
+		return "", fmt.Errorf("failed to create db token from response: %w", err)
 	}
 
 	outcome, err := o.connection.HandleCredentialsEstablished(ctx)
 	if err != nil {
-		return errorRedirectPage, fmt.Errorf("failed to handle post-auth state transition: %w", err)
+		return "", fmt.Errorf("failed to handle post-auth state transition: %w", err)
 	}
 
 	if outcome.SetupPending {

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
-	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 func (o *oAuth2Connection) getPublicCallbackUrl() (string, error) {
@@ -112,44 +111,14 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 		return errorRedirectPage, fmt.Errorf("failed to create db token from response: %w", err)
 	}
 
-	cv := o.connection.GetConnectorVersionEntity()
-	var connectorDef *cschema.Connector
-	if cv != nil {
-		connectorDef = cv.GetDefinition()
+	outcome, err := o.connection.HandleCredentialsEstablished(ctx)
+	if err != nil {
+		return errorRedirectPage, fmt.Errorf("failed to handle post-auth state transition: %w", err)
 	}
-	hasProbes := connectorDef != nil && len(connectorDef.Probes) > 0
-	hasConfigure := connectorDef != nil && connectorDef.SetupFlow.HasConfigure()
 
-	// If the connector has probes, run them in a background task before proceeding to configure.
-	if hasProbes {
-		verifyStep := cschema.SetupStepVerify
-		if err := o.connection.SetSetupStep(ctx, &verifyStep); err != nil {
-			return errorRedirectPage, fmt.Errorf("failed to set setup step to verify: %w", err)
-		}
-		if err := o.connectors.EnqueueVerifyConnection(ctx, o.connection.GetId()); err != nil {
-			return errorRedirectPage, fmt.Errorf("failed to enqueue verify connection task: %w", err)
-		}
-
-		// The UI will poll /_setup_step to observe verify outcome and transition to configure/ready/error.
+	if outcome.SetupPending {
 		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
 	}
-
-	// No probes — proceed with the existing post-auth branches.
-	if hasConfigure {
-		configureStep := "configure:0"
-		if err := o.connection.SetSetupStep(ctx, &configureStep); err != nil {
-			return errorRedirectPage, fmt.Errorf("failed to set setup step to configure:0: %w", err)
-		}
-		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
-	}
-
-	// No configure steps — clear setup step if it was set
-	if o.connection.GetSetupStep() != nil {
-		if err := o.connection.SetSetupStep(ctx, nil); err != nil {
-			return errorRedirectPage, fmt.Errorf("failed to clear setup step: %w", err)
-		}
-	}
-
 	return o.state.ReturnToUrl, nil
 }
 

--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // Connection is a wrapper for the lower level database equivalent that handles wiring up logic specified in this
@@ -96,11 +98,16 @@ func (c *connection) Logger() *slog.Logger {
 	return c.logger
 }
 
-func (c *connection) SetSetupStep(ctx context.Context, setupStep *string) error {
-	if err := c.s.db.SetConnectionSetupStep(ctx, c.Id, setupStep); err != nil {
+func (c *connection) SetSetupStep(ctx context.Context, setupStep *cschema.SetupStep) error {
+	var setupStepStr *string
+	if setupStep != nil {
+		setupStepStr = util.ToPtr(setupStep.String())
+	}
+
+	if err := c.s.db.SetConnectionSetupStep(ctx, c.Id, setupStepStr); err != nil {
 		return err
 	}
-	c.SetupStep = setupStep
+	c.SetupStep = setupStepStr
 	return nil
 }
 

--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -104,6 +104,18 @@ func (c *connection) SetSetupStep(ctx context.Context, setupStep *string) error 
 	return nil
 }
 
+func (c *connection) GetSetupError() *string {
+	return c.SetupError
+}
+
+func (c *connection) SetSetupError(ctx context.Context, setupError *string) error {
+	if err := c.s.db.SetConnectionSetupError(ctx, c.Id, setupError); err != nil {
+		return err
+	}
+	c.SetupError = setupError
+	return nil
+}
+
 func (c *connection) GetConfiguration(ctx context.Context) (map[string]any, error) {
 	if c.EncryptedConfiguration == nil || c.EncryptedConfiguration.IsZero() {
 		return nil, nil

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -56,10 +56,12 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step := "configure:1"
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
+		step, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
+		require.NoError(t, err)
+		stepStr := step.String()
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(nil)
 
-		err := conn.SetSetupStep(context.Background(), &step)
+		err = conn.SetSetupStep(context.Background(), &step)
 		require.NoError(t, err)
 		require.NotNil(t, conn.SetupStep)
 		assert.Equal(t, "configure:1", *conn.SetupStep)
@@ -88,10 +90,12 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step := "preconnect:0"
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(database.ErrNotFound)
+		step, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		require.NoError(t, err)
+		stepStr := step.String()
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(database.ErrNotFound)
 
-		err := conn.SetSetupStep(context.Background(), &step)
+		err = conn.SetSetupStep(context.Background(), &step)
 		assert.ErrorIs(t, err, database.ErrNotFound)
 		// Local state should not be updated on error
 		assert.Nil(t, conn.SetupStep)

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -56,12 +56,11 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
-		require.NoError(t, err)
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
 		stepStr := step.String()
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(nil)
 
-		err = conn.SetSetupStep(context.Background(), &step)
+		err := conn.SetSetupStep(context.Background(), &step)
 		require.NoError(t, err)
 		require.NotNil(t, conn.SetupStep)
 		assert.Equal(t, "configure:1", *conn.SetupStep)
@@ -90,12 +89,11 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
-		require.NoError(t, err)
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		stepStr := step.String()
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(database.ErrNotFound)
 
-		err = conn.SetSetupStep(context.Background(), &step)
+		err := conn.SetSetupStep(context.Background(), &step)
 		assert.ErrorIs(t, err, database.ErrNotFound)
 		// Local state should not be updated on error
 		assert.Nil(t, conn.SetupStep)

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -20,12 +20,12 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("connection has no active setup step")
 	}
 
-	phase, _, err := cschema.ParseSetupStep(*setupStep)
+	parsed, err := cschema.ParseSetupStep(*setupStep)
 	if err != nil {
 		return nil, httperr.BadRequestf("invalid setup step: %s", err)
 	}
 
-	if phase != "configure" {
+	if parsed.Phase() != cschema.SetupPhaseConfigure {
 		return nil, httperr.BadRequest("data sources are only available during configure steps")
 	}
 
@@ -34,7 +34,7 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("connector has no setup flow")
 	}
 
-	step, _, err := connector.SetupFlow.GetStepBySetupStep(*setupStep)
+	step, _, err := connector.SetupFlow.GetStepBySetupStep(parsed)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get current step: %w", err))
 	}

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -21,7 +21,7 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	if len(connectorDef.Probes) > 0 {
-		verifyStep := cschema.SetupStepVerify
+		verifyStep := cschema.SetupStepVerify.String()
 		if err := c.SetSetupStep(ctx, &verifyStep); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to verify: %w", err)
 		}
@@ -32,7 +32,11 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	if connectorDef.SetupFlow.HasConfigure() {
-		configureStep := "configure:0"
+		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		if err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to construct configure:0 setup step: %w", err)
+		}
+		configureStep := first.String()
 		if err := c.SetSetupStep(ctx, &configureStep); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to configure:0: %w", err)
 		}
@@ -57,7 +61,7 @@ func (c *connection) HandleAuthFailed(ctx context.Context, authErr error) error 
 		return fmt.Errorf("failed to record setup error after auth failure: %w", err)
 	}
 
-	failedStep := cschema.SetupStepAuthFailed
+	failedStep := cschema.SetupStepAuthFailed.String()
 	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
 		return fmt.Errorf("failed to set setup step to auth_failed: %w", err)
 	}

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -46,3 +46,20 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 	return iface.PostAuthOutcome{SetupPending: false}, nil
 }
+
+// HandleAuthFailed records an auth-phase failure on the connection so it lands in the same
+// retryable terminal state the verify phase uses. setup_error captures the message and
+// setup_step becomes auth_failed; the marketplace UI surfaces this via the standard failure
+// screen and offers retry/cancel via /connections/{id}/_retry.
+func (c *connection) HandleAuthFailed(ctx context.Context, authErr error) error {
+	msg := authErr.Error()
+	if err := c.SetSetupError(ctx, &msg); err != nil {
+		return fmt.Errorf("failed to record setup error after auth failure: %w", err)
+	}
+
+	failedStep := cschema.SetupStepAuthFailed
+	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
+		return fmt.Errorf("failed to set setup step to auth_failed: %w", err)
+	}
+	return nil
+}

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+// HandleCredentialsEstablished advances the connection to the next setup phase after an auth
+// method has stored valid credentials. The decision tree is the same regardless of how
+// credentials were acquired:
+//   - probes defined → enter verify phase and enqueue the verify task
+//   - else configure steps defined → enter configure:0
+//   - else → clear setup step (connection is effectively ready)
+func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.PostAuthOutcome, error) {
+	connectorDef := c.cv.GetDefinition()
+	if connectorDef == nil {
+		return iface.PostAuthOutcome{}, fmt.Errorf("connector definition is missing")
+	}
+
+	if len(connectorDef.Probes) > 0 {
+		verifyStep := cschema.SetupStepVerify
+		if err := c.SetSetupStep(ctx, &verifyStep); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to verify: %w", err)
+		}
+		if err := c.s.EnqueueVerifyConnection(ctx, c.GetId()); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to enqueue verify connection task: %w", err)
+		}
+		return iface.PostAuthOutcome{SetupPending: true}, nil
+	}
+
+	if connectorDef.SetupFlow.HasConfigure() {
+		configureStep := "configure:0"
+		if err := c.SetSetupStep(ctx, &configureStep); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to configure:0: %w", err)
+		}
+		return iface.PostAuthOutcome{SetupPending: true}, nil
+	}
+
+	if c.GetSetupStep() != nil {
+		if err := c.SetSetupStep(ctx, nil); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to clear setup step: %w", err)
+		}
+	}
+	return iface.PostAuthOutcome{SetupPending: false}, nil
+}

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -21,8 +21,7 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	if len(connectorDef.Probes) > 0 {
-		verifyStep := cschema.SetupStepVerify.String()
-		if err := c.SetSetupStep(ctx, &verifyStep); err != nil {
+		if err := c.SetSetupStep(ctx, &cschema.SetupStepVerify); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to verify: %w", err)
 		}
 		if err := c.s.EnqueueVerifyConnection(ctx, c.GetId()); err != nil {
@@ -36,8 +35,8 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 		if err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to construct configure:0 setup step: %w", err)
 		}
-		configureStep := first.String()
-		if err := c.SetSetupStep(ctx, &configureStep); err != nil {
+
+		if err := c.SetSetupStep(ctx, &first); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to configure:0: %w", err)
 		}
 		return iface.PostAuthOutcome{SetupPending: true}, nil
@@ -61,8 +60,7 @@ func (c *connection) HandleAuthFailed(ctx context.Context, authErr error) error 
 		return fmt.Errorf("failed to record setup error after auth failure: %w", err)
 	}
 
-	failedStep := cschema.SetupStepAuthFailed.String()
-	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
+	if err := c.SetSetupStep(ctx, &cschema.SetupStepAuthFailed); err != nil {
 		return fmt.Errorf("failed to set setup step to auth_failed: %w", err)
 	}
 	return nil

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
@@ -13,7 +14,7 @@ import (
 // credentials were acquired:
 //   - probes defined → enter verify phase and enqueue the verify task
 //   - else configure steps defined → enter configure:0
-//   - else → clear setup step (connection is effectively ready)
+//   - else → clear setup step and mark the connection ready
 func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.PostAuthOutcome, error) {
 	connectorDef := c.cv.GetDefinition()
 	if connectorDef == nil {
@@ -41,6 +42,11 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	if c.GetSetupStep() != nil {
 		if err := c.SetSetupStep(ctx, nil); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to clear setup step: %w", err)
+		}
+	}
+	if c.GetState() != database.ConnectionStateReady {
+		if err := c.SetState(ctx, database.ConnectionStateReady); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set connection ready: %w", err)
 		}
 	}
 	return iface.PostAuthOutcome{SetupPending: false}, nil

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -31,11 +31,7 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	if connectorDef.SetupFlow.HasConfigure() {
-		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
-		if err != nil {
-			return iface.PostAuthOutcome{}, fmt.Errorf("failed to construct configure:0 setup step: %w", err)
-		}
-
+		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		if err := c.SetSetupStep(ctx, &first); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to configure:0: %w", err)
 		}

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -21,7 +21,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		conn, db, ac := newTestConnectionWithSetupFlowAndAsynq(t, ctrl, &cschema.SetupFlow{})
 		conn.cv.GetDefinition().Probes = []cschema.Probe{{Id: "ping"}}
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerify)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerify.String())).Return(nil)
 		ac.EXPECT().
 			EnqueueContext(gomock.Any(), gomock.AssignableToTypeOf(&asynq.Task{}), asynq.Retention(10*time.Minute)).
 			Return(&asynq.TaskInfo{ID: "mock-task-id"}, nil)
@@ -30,7 +30,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, outcome.SetupPending)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepVerify, *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerify.String(), *conn.GetSetupStep())
 	})
 
 	t.Run("enters configure:0 when connector has configure but no probes", func(t *testing.T) {
@@ -96,12 +96,12 @@ func TestHandleAuthFailed(t *testing.T) {
 				assert.Contains(t, *msg, "token exchange boom")
 				return nil
 			})
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepAuthFailed)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepAuthFailed.String())).Return(nil)
 
 		err := conn.HandleAuthFailed(context.Background(), errors.New("token exchange boom"))
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepAuthFailed, *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepAuthFailed.String(), *conn.GetSetupStep())
 		require.NotNil(t, conn.GetSetupError())
 		assert.Contains(t, *conn.GetSetupError(), "token exchange boom")
 	})

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/database"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		assert.Equal(t, "configure:0", *conn.GetSetupStep())
 	})
 
-	t.Run("clears setup step when connector has neither probes nor configure", func(t *testing.T) {
+	t.Run("clears setup step and marks ready when connector has neither probes nor configure", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -63,23 +64,28 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		conn.SetupStep = &authStep
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.False(t, outcome.SetupPending)
 		assert.Nil(t, conn.GetSetupStep())
+		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
 	})
 
-	t.Run("no-op when no setup step and no probes/configure", func(t *testing.T) {
+	t.Run("marks ready when no setup step and no probes/configure", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.False(t, outcome.SetupPending)
 		assert.Nil(t, conn.GetSetupStep())
+		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
 	})
 }
 

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -79,5 +80,29 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, outcome.SetupPending)
 		assert.Nil(t, conn.GetSetupStep())
+	})
+}
+
+func TestHandleAuthFailed(t *testing.T) {
+	t.Run("records error and moves to auth_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+
+		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ any, msg *string) error {
+				require.NotNil(t, msg)
+				assert.Contains(t, *msg, "token exchange boom")
+				return nil
+			})
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepAuthFailed)).Return(nil)
+
+		err := conn.HandleAuthFailed(context.Background(), errors.New("token exchange boom"))
+		require.NoError(t, err)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepAuthFailed, *conn.GetSetupStep())
+		require.NotNil(t, conn.GetSetupError())
+		assert.Contains(t, *conn.GetSetupError(), "token exchange boom")
 	})
 }

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCredentialsEstablished(t *testing.T) {
+	t.Run("enters verify and enqueues task when connector has probes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db, ac := newTestConnectionWithSetupFlowAndAsynq(t, ctrl, &cschema.SetupFlow{})
+		conn.cv.GetDefinition().Probes = []cschema.Probe{{Id: "ping"}}
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerify)).Return(nil)
+		ac.EXPECT().
+			EnqueueContext(gomock.Any(), gomock.AssignableToTypeOf(&asynq.Task{}), asynq.Retention(10*time.Minute)).
+			Return(&asynq.TaskInfo{ID: "mock-task-id"}, nil)
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.True(t, outcome.SetupPending)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerify, *conn.GetSetupStep())
+	})
+
+	t.Run("enters configure:0 when connector has configure but no probes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		})
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.True(t, outcome.SetupPending)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, "configure:0", *conn.GetSetupStep())
+	})
+
+	t.Run("clears setup step when connector has neither probes nor configure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		authStep := "auth"
+		conn.SetupStep = &authStep
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.False(t, outcome.SetupPending)
+		assert.Nil(t, conn.GetSetupStep())
+	})
+
+	t.Run("no-op when no setup step and no probes/configure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.False(t, outcome.SetupPending)
+		assert.Nil(t, conn.GetSetupStep())
+	})
+}

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+// onVerifyPassed advances the connection to the next setup step after all probes have run
+// successfully. If there are no remaining steps the connection is marked ready; otherwise
+// the next step (typically configure:0) is recorded.
+func (c *connection) onVerifyPassed(ctx context.Context) error {
+	connector := c.cv.GetDefinition()
+
+	var nextStep string
+	if connector != nil && connector.SetupFlow != nil {
+		var err error
+		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, connector.HasProbes())
+		if err != nil {
+			return fmt.Errorf("failed to determine next step after verify: %w", err)
+		}
+	}
+
+	if nextStep == "" {
+		if err := c.SetSetupStep(ctx, nil); err != nil {
+			return fmt.Errorf("failed to clear setup step after verify: %w", err)
+		}
+		if err := c.SetState(ctx, database.ConnectionStateReady); err != nil {
+			return fmt.Errorf("failed to set connection ready after verify: %w", err)
+		}
+		return nil
+	}
+
+	if err := c.SetSetupStep(ctx, &nextStep); err != nil {
+		return fmt.Errorf("failed to advance setup step after verify: %w", err)
+	}
+	return nil
+}
+
+// onVerifyFailed records a verify failure on the connection: revokes any credentials acquired
+// during auth so the user must re-authenticate on retry, populates setup_error with the probe
+// failure message, and moves setup_step to the verify_failed terminal pseudo-step.
+func (c *connection) onVerifyFailed(ctx context.Context, probeId string, invokeErr error) error {
+	for _, op := range c.getRevokeCredentialsOperations() {
+		if err := op(ctx); err != nil {
+			// Log and continue — we still want to record the failure state even if revoke fails.
+			c.logger.Error("failed to revoke credentials during verify failure", "error", err)
+		}
+	}
+
+	msg := fmt.Sprintf("probe %q failed: %s", probeId, invokeErr.Error())
+	if err := c.SetSetupError(ctx, &msg); err != nil {
+		return err
+	}
+
+	failedStep := cschema.SetupStepVerifyFailed
+	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -14,7 +14,7 @@ import (
 func (c *connection) onVerifyPassed(ctx context.Context) error {
 	connector := c.cv.GetDefinition()
 
-	var nextStep string
+	var nextStep cschema.SetupStep
 	if connector != nil && connector.SetupFlow != nil {
 		var err error
 		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, connector.HasProbes())
@@ -23,7 +23,7 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 		}
 	}
 
-	if nextStep == "" {
+	if nextStep.IsZero() {
 		if err := c.SetSetupStep(ctx, nil); err != nil {
 			return fmt.Errorf("failed to clear setup step after verify: %w", err)
 		}
@@ -33,7 +33,8 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 		return nil
 	}
 
-	if err := c.SetSetupStep(ctx, &nextStep); err != nil {
+	nextStr := nextStep.String()
+	if err := c.SetSetupStep(ctx, &nextStr); err != nil {
 		return fmt.Errorf("failed to advance setup step after verify: %w", err)
 	}
 	return nil
@@ -55,7 +56,7 @@ func (c *connection) onVerifyFailed(ctx context.Context, probeId string, invokeE
 		return err
 	}
 
-	failedStep := cschema.SetupStepVerifyFailed
+	failedStep := cschema.SetupStepVerifyFailed.String()
 	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
 		return err
 	}

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -33,8 +33,7 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 		return nil
 	}
 
-	nextStr := nextStep.String()
-	if err := c.SetSetupStep(ctx, &nextStr); err != nil {
+	if err := c.SetSetupStep(ctx, &nextStep); err != nil {
 		return fmt.Errorf("failed to advance setup step after verify: %w", err)
 	}
 	return nil
@@ -56,8 +55,7 @@ func (c *connection) onVerifyFailed(ctx context.Context, probeId string, invokeE
 		return err
 	}
 
-	failedStep := cschema.SetupStepVerifyFailed.String()
-	if err := c.SetSetupStep(ctx, &failedStep); err != nil {
+	if err := c.SetSetupStep(ctx, &cschema.SetupStepVerifyFailed); err != nil {
 		return err
 	}
 	return nil

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnVerifyPassed(t *testing.T) {
+	t.Run("advances to configure:0 when configure exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		})
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+
+		err := conn.onVerifyPassed(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, "configure:0", *conn.GetSetupStep())
+	})
+
+	t.Run("clears setup step and marks ready when no further steps", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+
+		err := conn.onVerifyPassed(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, conn.GetSetupStep())
+		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+	})
+}
+
+func TestOnVerifyFailed(t *testing.T) {
+	t.Run("records error and moves to verify_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+
+		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ any, msg *string) error {
+				require.NotNil(t, msg)
+				assert.Contains(t, *msg, `probe "ping" failed`)
+				assert.Contains(t, *msg, "boom")
+				return nil
+			})
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerifyFailed)).Return(nil)
+
+		err := conn.onVerifyFailed(context.Background(), "ping", errors.New("boom"))
+		require.NoError(t, err)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerifyFailed, *conn.GetSetupStep())
+		require.NotNil(t, conn.GetSetupError())
+		assert.Contains(t, *conn.GetSetupError(), "boom")
+	})
+}

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -63,12 +63,12 @@ func TestOnVerifyFailed(t *testing.T) {
 				assert.Contains(t, *msg, "boom")
 				return nil
 			})
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerifyFailed)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerifyFailed.String())).Return(nil)
 
 		err := conn.onVerifyFailed(context.Background(), "ping", errors.New("boom"))
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepVerifyFailed, *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerifyFailed.String(), *conn.GetSetupStep())
 		require.NotNil(t, conn.GetSetupError())
 		assert.Contains(t, *conn.GetSetupError(), "boom")
 	})

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -64,6 +64,11 @@ type Connection interface {
 	GetDataSource(ctx context.Context, sourceId string) ([]apjs.DataSourceOption, error)
 	Reconfigure(ctx context.Context) (InitiateConnectionResponse, error)
 
+	// CancelSetup abandons an in-flight reconfigure on a ready connection by clearing
+	// its setup_step and setup_error. The connection remains ready and its previously
+	// stored configuration continues to apply.
+	CancelSetup(ctx context.Context) error
+
 	// HandleCredentialsEstablished advances the connection to the next setup phase after an
 	// auth method has stored valid credentials. It transitions the connection to verify (and
 	// enqueues probes) when the connector has probes, otherwise to configure:0 when the

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 type Connection interface {
@@ -40,7 +41,7 @@ type Connection interface {
 	 */
 
 	SetState(ctx context.Context, state database.ConnectionState) error
-	SetSetupStep(ctx context.Context, setupStep *string) error
+	SetSetupStep(ctx context.Context, setupStep *cschema.SetupStep) error
 	SetSetupError(ctx context.Context, setupError *string) error
 	GetConfiguration(ctx context.Context) (map[string]any, error)
 	SetConfiguration(ctx context.Context, data map[string]any) error

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -27,6 +27,7 @@ type Connection interface {
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
 	GetSetupStep() *string
+	GetSetupError() *string
 
 	/*
 	 * Nested entities
@@ -40,6 +41,7 @@ type Connection interface {
 
 	SetState(ctx context.Context, state database.ConnectionState) error
 	SetSetupStep(ctx context.Context, setupStep *string) error
+	SetSetupError(ctx context.Context, setupError *string) error
 	GetConfiguration(ctx context.Context) (map[string]any, error)
 	SetConfiguration(ctx context.Context, data map[string]any) error
 	GetMustacheContext(ctx context.Context) (map[string]any, error)

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -70,6 +70,12 @@ type Connection interface {
 	// considered ready. Auth methods invoke this so post-auth state transitions stay
 	// independent of the credential exchange mechanism.
 	HandleCredentialsEstablished(ctx context.Context) (PostAuthOutcome, error)
+
+	// HandleAuthFailed records a failure during the auth phase (e.g. an OAuth token exchange
+	// error). It populates setup_error and moves setup_step to the auth_failed terminal
+	// pseudo-step so the user is left in a retryable state — the marketplace UI surfaces the
+	// error and offers retry/cancel via the connection retry endpoint.
+	HandleAuthFailed(ctx context.Context, authErr error) error
 }
 
 // PostAuthOutcome describes what happened after credentials were established. SetupPending

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -62,4 +62,20 @@ type Connection interface {
 	GetCurrentSetupStepResponse(ctx context.Context) (InitiateConnectionResponse, error)
 	GetDataSource(ctx context.Context, sourceId string) ([]apjs.DataSourceOption, error)
 	Reconfigure(ctx context.Context) (InitiateConnectionResponse, error)
+
+	// HandleCredentialsEstablished advances the connection to the next setup phase after an
+	// auth method has stored valid credentials. It transitions the connection to verify (and
+	// enqueues probes) when the connector has probes, otherwise to configure:0 when the
+	// connector has configure steps, otherwise it clears the setup step so the connection is
+	// considered ready. Auth methods invoke this so post-auth state transitions stay
+	// independent of the credential exchange mechanism.
+	HandleCredentialsEstablished(ctx context.Context) (PostAuthOutcome, error)
+}
+
+// PostAuthOutcome describes what happened after credentials were established. SetupPending
+// is true when the connection still has a setup step to complete (verify or configure);
+// auth methods use this to decide whether the user should be sent to a "setup pending" URL
+// or directly to the original return URL.
+type PostAuthOutcome struct {
+	SetupPending bool
 }

--- a/internal/core/iface/connection_initiate.go
+++ b/internal/core/iface/connection_initiate.go
@@ -51,9 +51,11 @@ func (icr *InitiateConnectionRequest) HasIntoNamespace() bool {
 type InitiateConnectionResponseType string
 
 const (
-	PreconnectionResponseTypeRedirect InitiateConnectionResponseType = "redirect"
-	PreconnectionResponseTypeForm     InitiateConnectionResponseType = "form"
-	PreconnectionResponseTypeComplete InitiateConnectionResponseType = "complete"
+	PreconnectionResponseTypeRedirect  InitiateConnectionResponseType = "redirect"
+	PreconnectionResponseTypeForm      InitiateConnectionResponseType = "form"
+	PreconnectionResponseTypeComplete  InitiateConnectionResponseType = "complete"
+	PreconnectionResponseTypeVerifying InitiateConnectionResponseType = "verifying"
+	PreconnectionResponseTypeError     InitiateConnectionResponseType = "error"
 )
 
 type InitiateConnectionResponse interface {
@@ -106,6 +108,38 @@ func (icc *InitiateConnectionComplete) GetId() apid.ID {
 
 func (icc *InitiateConnectionComplete) GetType() InitiateConnectionResponseType {
 	return icc.Type
+}
+
+// InitiateConnectionVerifying indicates that probes are running in the background to verify
+// the credentials obtained during auth. The UI should poll /_setup_step to observe the outcome.
+type InitiateConnectionVerifying struct {
+	Id   apid.ID                        `json:"id"`
+	Type InitiateConnectionResponseType `json:"type"`
+}
+
+func (icv *InitiateConnectionVerifying) GetId() apid.ID {
+	return icv.Id
+}
+
+func (icv *InitiateConnectionVerifying) GetType() InitiateConnectionResponseType {
+	return icv.Type
+}
+
+// InitiateConnectionError is a terminal error response during setup, e.g. when probe verification
+// fails. The UI should show the error and offer retry (POST /_retry) or cancel (POST /_abort).
+type InitiateConnectionError struct {
+	Id       apid.ID                        `json:"id"`
+	Type     InitiateConnectionResponseType `json:"type"`
+	Error    string                         `json:"error"`
+	CanRetry bool                           `json:"can_retry"`
+}
+
+func (ice *InitiateConnectionError) GetId() apid.ID {
+	return ice.Id
+}
+
+func (ice *InitiateConnectionError) GetType() InitiateConnectionResponseType {
+	return ice.Type
 }
 
 type SubmitConnectionRequest struct {

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -101,6 +101,15 @@ type C interface {
 
 	InitiateConnection(ctx context.Context, req InitiateConnectionRequest) (InitiateConnectionResponse, error)
 
+	// EnqueueVerifyConnection enqueues a background task to run all probes for a connection as part of
+	// the verify step of the setup flow. The task advances the connection's setup step based on the outcome.
+	EnqueueVerifyConnection(ctx context.Context, id apid.ID) error
+
+	// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the user
+	// can try setup again — either restarting preconnect forms, or re-initiating OAuth if the connector
+	// has no preconnect steps. Returns the initial setup step response for the retry.
+	RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (InitiateConnectionResponse, error)
+
 	/*
 	 *
 	 * Namespaces

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -168,6 +168,14 @@ func (m *Connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	return iface.PostAuthOutcome{SetupPending: false}, nil
 }
 
+func (m *Connection) HandleAuthFailed(ctx context.Context, authErr error) error {
+	msg := authErr.Error()
+	m.SetupError = &msg
+	failedStep := "auth_failed"
+	m.SetupStep = &failedStep
+	return nil
+}
+
 var _ iface.Connection = (*Connection)(nil)
 
 type ConnectionMatcher struct {

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 type Connection struct {
@@ -107,8 +108,13 @@ func (m *Connection) GetSetupStep() *string {
 	return m.SetupStep
 }
 
-func (m *Connection) SetSetupStep(ctx context.Context, setupStep *string) error {
-	m.SetupStep = setupStep
+func (m *Connection) SetSetupStep(ctx context.Context, setupStep *cschema.SetupStep) error {
+	if setupStep == nil {
+		m.SetupStep = nil
+	} else {
+		s := setupStep.String()
+		m.SetupStep = &s
+	}
 	return nil
 }
 

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -164,6 +164,10 @@ func (m *Connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionR
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *Connection) HandleCredentialsEstablished(ctx context.Context) (iface.PostAuthOutcome, error) {
+	return iface.PostAuthOutcome{SetupPending: false}, nil
+}
+
 var _ iface.Connection = (*Connection)(nil)
 
 type ConnectionMatcher struct {

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -25,6 +25,7 @@ type Connection struct {
 	Labels           map[string]string
 	Annotations      map[string]string
 	SetupStep        *string
+	SetupError       *string
 	Configuration    map[string]any
 }
 
@@ -108,6 +109,15 @@ func (m *Connection) GetSetupStep() *string {
 
 func (m *Connection) SetSetupStep(ctx context.Context, setupStep *string) error {
 	m.SetupStep = setupStep
+	return nil
+}
+
+func (m *Connection) GetSetupError() *string {
+	return m.SetupError
+}
+
+func (m *Connection) SetSetupError(ctx context.Context, setupError *string) error {
+	m.SetupError = setupError
 	return nil
 }
 

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -170,6 +170,15 @@ func (m *Connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionR
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *Connection) CancelSetup(ctx context.Context) error {
+	if m.State != database.ConnectionStateReady {
+		return fmt.Errorf("connection is not in a state that can cancel setup")
+	}
+	m.SetupStep = nil
+	m.SetupError = nil
+	return nil
+}
+
 func (m *Connection) HandleCredentialsEstablished(ctx context.Context) (iface.PostAuthOutcome, error) {
 	return iface.PostAuthOutcome{SetupPending: false}, nil
 }

--- a/internal/core/service_connection_cancel_setup.go
+++ b/internal/core/service_connection_cancel_setup.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"context"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+)
+
+// CancelSetup abandons an in-flight reconfigure on a ready connection by clearing
+// its setup_step and setup_error. The connection stays in the ready state so the
+// previously stored configuration continues to apply. Only valid when the connection
+// is already ready — abandoning setup mid-creation should use AbortConnection, which
+// also revokes credentials and removes the connection.
+func (c *connection) CancelSetup(ctx context.Context) error {
+	if c.GetState() != database.ConnectionStateReady {
+		return httperr.BadRequest("connection is not in a state that can cancel setup")
+	}
+
+	if c.GetSetupStep() == nil && c.GetSetupError() == nil {
+		return nil
+	}
+
+	if c.GetSetupStep() != nil {
+		if err := c.SetSetupStep(ctx, nil); err != nil {
+			return httperr.InternalServerError(httperr.WithInternalErrorf("failed to clear setup step: %w", err))
+		}
+	}
+	if c.GetSetupError() != nil {
+		if err := c.SetSetupError(ctx, nil); err != nil {
+			return httperr.InternalServerError(httperr.WithInternalErrorf("failed to clear setup error: %w", err))
+		}
+	}
+	return nil
+}

--- a/internal/core/service_connection_cancel_setup_test.go
+++ b/internal/core/service_connection_cancel_setup_test.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelSetup(t *testing.T) {
+	t.Run("clears setup_step and setup_error when state is ready", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{{Id: "x", JsonSchema: workspaceSchema}},
+			},
+		})
+		conn.State = database.ConnectionStateReady
+		step := "configure:0"
+		conn.SetupStep = &step
+		errMsg := "stale"
+		conn.SetupError = &errMsg
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+
+		require.NoError(t, conn.CancelSetup(context.Background()))
+		assert.Nil(t, conn.GetSetupStep())
+		assert.Nil(t, conn.GetSetupError())
+		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+	})
+
+	t.Run("no-op when ready and nothing to clear", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		conn.State = database.ConnectionStateReady
+
+		require.NoError(t, conn.CancelSetup(context.Background()))
+	})
+
+	t.Run("rejects when not ready", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		conn.State = database.ConnectionStateCreated
+
+		err := conn.CancelSetup(context.Background())
+		require.Error(t, err)
+	})
+}

--- a/internal/core/service_connection_disconnect_test.go
+++ b/internal/core/service_connection_disconnect_test.go
@@ -55,7 +55,7 @@ func TestDisconnectConnection(t *testing.T) {
 			EnqueueContext(gomock.Any(), taskMatcher, asynq.Retention(10*time.Minute)).
 			DoAndReturn(func(_ context.Context, task *asynq.Task, _ ...asynq.Option) (*asynq.TaskInfo, error) {
 				// Verify the task type
-				assert.Equal(t, "connectors:disconnect_connection", task.Type())
+				assert.Equal(t, "core:disconnect_connection", task.Type())
 
 				// Parse the payload to verify the connection ID
 				var payload struct {

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -92,8 +92,7 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 		}
-		setupStep := first.String()
-		if err := connection.SetSetupStep(ctx, &setupStep); err != nil {
+		if err := connection.SetSetupStep(ctx, &first); err != nil {
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 		}

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apauth/core"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
@@ -87,11 +87,7 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 	// If the connector has preconnect steps, return the first form instead of proceeding to auth
 	if connector.SetupFlow.HasPreconnect() {
 		firstStep := connector.SetupFlow.Preconnect.Steps[0]
-		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
-		if err != nil {
-			val.MarkErrorReturn()
-			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
-		}
+		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		if err := connection.SetSetupStep(ctx, &first); err != nil {
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 /*
@@ -86,7 +87,12 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 	// If the connector has preconnect steps, return the first form instead of proceeding to auth
 	if connector.SetupFlow.HasPreconnect() {
 		firstStep := connector.SetupFlow.Preconnect.Steps[0]
-		setupStep := "preconnect:0"
+		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		if err != nil {
+			val.MarkErrorReturn()
+			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
+		}
+		setupStep := first.String()
 		if err := connection.SetSetupStep(ctx, &setupStep); err != nil {
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -3,9 +3,10 @@ package core
 import (
 	"context"
 
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
 // Reconfigure initiates a reconfiguration of a completed connection by resetting
@@ -21,5 +22,9 @@ func (c *connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionR
 		return nil, httperr.BadRequest("connector has no configure steps to reconfigure")
 	}
 
-	return c.buildFormResponse(ctx, "configure:0", connector.SetupFlow)
+	first, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to construct configure:0 setup step: %w", err))
+	}
+	return c.buildFormResponse(ctx, first, connector.SetupFlow)
 }

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -22,9 +22,6 @@ func (c *connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionR
 		return nil, httperr.BadRequest("connector has no configure steps to reconfigure")
 	}
 
-	first, err := cschema.NewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
-	if err != nil {
-		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to construct configure:0 setup step: %w", err))
-	}
+	first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 	return c.buildFormResponse(ctx, first, connector.SetupFlow)
 }

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -40,10 +40,7 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	if connector.SetupFlow.HasPreconnect() {
-		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
-		if err != nil {
-			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to construct preconnect:0 setup step: %w", err))
-		}
+		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		return conn.buildFormResponse(ctx, first, connector.SetupFlow)
 	}
 

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -9,10 +9,11 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
-// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the
-// user can try setup again. If the connector has preconnect steps, the retry restarts from
-// preconnect:0 so the user can correct any input that led to invalid credentials. Otherwise,
-// retry re-initiates the OAuth flow from scratch.
+// RetryConnectionSetup resets a connection that is in a terminal failure state so the user
+// can try setup again. Both auth_failed (auth-phase failure such as an OAuth token-exchange
+// error) and verify_failed (probe failure after auth) are retryable. If the connector has
+// preconnect steps, retry restarts from preconnect:0 so the user can correct any input that
+// led to the failure. Otherwise, retry re-initiates the auth flow from scratch.
 func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (iface.InitiateConnectionResponse, error) {
 	conn, err := s.getConnection(ctx, id)
 	if err != nil {
@@ -20,7 +21,7 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	setupStep := conn.GetSetupStep()
-	if setupStep == nil || *setupStep != cschema.SetupStepVerifyFailed {
+	if setupStep == nil || (*setupStep != cschema.SetupStepVerifyFailed && *setupStep != cschema.SetupStepAuthFailed) {
 		return nil, httperr.BadRequest("connection is not in a retryable state")
 	}
 

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"context"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the
+// user can try setup again. If the connector has preconnect steps, the retry restarts from
+// preconnect:0 so the user can correct any input that led to invalid credentials. Otherwise,
+// retry re-initiates the OAuth flow from scratch.
+func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (iface.InitiateConnectionResponse, error) {
+	conn, err := s.getConnection(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	setupStep := conn.GetSetupStep()
+	if setupStep == nil || *setupStep != cschema.SetupStepVerifyFailed {
+		return nil, httperr.BadRequest("connection is not in a retryable state")
+	}
+
+	connector := conn.cv.GetDefinition()
+	if connector == nil {
+		return nil, httperr.InternalServerErrorMsg("connector definition is missing")
+	}
+
+	// Clear any prior error message — retry is a fresh attempt.
+	if err := conn.SetSetupError(ctx, nil); err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to clear setup error: %w", err))
+	}
+
+	if connector.SetupFlow.HasPreconnect() {
+		return conn.buildFormResponse(ctx, "preconnect:0", connector.SetupFlow)
+	}
+
+	// No preconnect to return to — re-initiate OAuth from scratch.
+	return conn.initiateAuthStep(ctx, returnToUrl, connector)
+}

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -21,7 +21,11 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	setupStep := conn.GetSetupStep()
-	if setupStep == nil || (*setupStep != cschema.SetupStepVerifyFailed && *setupStep != cschema.SetupStepAuthFailed) {
+	if setupStep == nil {
+		return nil, httperr.BadRequest("connection is not in a retryable state")
+	}
+	parsed, err := cschema.ParseSetupStep(*setupStep)
+	if err != nil || !parsed.IsTerminalFailure() {
 		return nil, httperr.BadRequest("connection is not in a retryable state")
 	}
 
@@ -36,7 +40,11 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	if connector.SetupFlow.HasPreconnect() {
-		return conn.buildFormResponse(ctx, "preconnect:0", connector.SetupFlow)
+		first, err := cschema.NewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		if err != nil {
+			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to construct preconnect:0 setup step: %w", err))
+		}
+		return conn.buildFormResponse(ctx, first, connector.SetupFlow)
 	}
 
 	// No preconnect to return to — re-initiate OAuth from scratch.

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRetryConnectionSetup(t *testing.T) {
-	t.Run("returns error when setup step is not verify_failed", func(t *testing.T) {
+	t.Run("returns error when setup step is not a failed terminal state", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -58,6 +58,44 @@ func TestRetryConnectionSetup(t *testing.T) {
 		step := cschema.SetupStepVerifyFailed
 		conn.SetupStep = &step
 		errMsg := "probe failed"
+		conn.SetupError = &errMsg
+		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
+
+		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
+		db.EXPECT().GetConnectorVersion(gomock.Any(), conn.cv.Id, conn.cv.Version).Return(&database.ConnectorVersion{
+			Id:                  conn.cv.Id,
+			Version:             conn.cv.Version,
+			Labels:              conn.cv.GetLabels(),
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                conn.cv.Hash,
+			EncryptedDefinition: conn.cv.EncryptedDefinition,
+		}, nil).AnyTimes()
+
+		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("preconnect:0")).Return(nil)
+
+		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
+		form := resp.(*iface.InitiateConnectionForm)
+		assert.Equal(t, "tenant", form.StepId)
+	})
+
+	t.Run("resets to preconnect:0 from auth_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Preconnect: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "tenant", Title: "Tenant", JsonSchema: tenantSchema},
+				},
+			},
+		})
+		step := cschema.SetupStepAuthFailed
+		conn.SetupStep = &step
+		errMsg := "token exchange failed"
 		conn.SetupError = &errMsg
 		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
 

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryConnectionSetup(t *testing.T) {
+	t.Run("returns error when setup step is not verify_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Preconnect: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "tenant", JsonSchema: tenantSchema},
+				},
+			},
+		})
+		step := "preconnect:0"
+		conn.SetupStep = &step
+		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
+
+		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
+		db.EXPECT().GetConnectorVersion(gomock.Any(), conn.cv.Id, conn.cv.Version).Return(&database.ConnectorVersion{
+			Id:                  conn.cv.Id,
+			Version:             conn.cv.Version,
+			Labels:              conn.cv.GetLabels(),
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                conn.cv.Hash,
+			EncryptedDefinition: conn.cv.EncryptedDefinition,
+		}, nil).AnyTimes()
+
+		_, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not in a retryable state")
+	})
+
+	t.Run("resets to preconnect:0 when connector has preconnect", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Preconnect: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "tenant", Title: "Tenant", JsonSchema: tenantSchema},
+				},
+			},
+		})
+		step := cschema.SetupStepVerifyFailed
+		conn.SetupStep = &step
+		errMsg := "probe failed"
+		conn.SetupError = &errMsg
+		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
+
+		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
+		db.EXPECT().GetConnectorVersion(gomock.Any(), conn.cv.Id, conn.cv.Version).Return(&database.ConnectorVersion{
+			Id:                  conn.cv.Id,
+			Version:             conn.cv.Version,
+			Labels:              conn.cv.GetLabels(),
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                conn.cv.Hash,
+			EncryptedDefinition: conn.cv.EncryptedDefinition,
+		}, nil).AnyTimes()
+
+		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("preconnect:0")).Return(nil)
+
+		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
+		form := resp.(*iface.InitiateConnectionForm)
+		assert.Equal(t, "tenant", form.StepId)
+	})
+}

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -55,7 +55,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.SetupStepVerifyFailed
+		step := cschema.SetupStepVerifyFailed.String()
 		conn.SetupStep = &step
 		errMsg := "probe failed"
 		conn.SetupError = &errMsg
@@ -93,7 +93,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.SetupStepAuthFailed
+		step := cschema.SetupStepAuthFailed.String()
 		conn.SetupStep = &step
 		errMsg := "token exchange failed"
 		conn.SetupError = &errMsg

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -59,7 +59,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 	}
 
 	// Determine the next step
-	nextStep, err := connector.SetupFlow.NextSetupStep(*setupStep, len(connector.Probes) > 0)
+	nextStep, err := connector.SetupFlow.NextSetupStep(*setupStep, connector.HasProbes())
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to determine next step: %w", err))
 	}

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -59,7 +59,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 	}
 
 	// Determine the next step
-	nextStep, err := connector.SetupFlow.NextSetupStep(*setupStep)
+	nextStep, err := connector.SetupFlow.NextSetupStep(*setupStep, len(connector.Probes) > 0)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to determine next step: %w", err))
 	}
@@ -176,6 +176,26 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Ini
 		return &iface.InitiateConnectionRedirect{
 			Id:   c.GetId(),
 			Type: iface.PreconnectionResponseTypeRedirect,
+		}, nil
+	}
+
+	if phase == cschema.SetupStepVerify {
+		return &iface.InitiateConnectionVerifying{
+			Id:   c.GetId(),
+			Type: iface.PreconnectionResponseTypeVerifying,
+		}, nil
+	}
+
+	if phase == cschema.SetupStepVerifyFailed {
+		msg := ""
+		if e := c.GetSetupError(); e != nil {
+			msg = *e
+		}
+		return &iface.InitiateConnectionError{
+			Id:       c.GetId(),
+			Type:     iface.PreconnectionResponseTypeError,
+			Error:    msg,
+			CanRetry: true,
 		}, nil
 	}
 

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -26,18 +26,18 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		return nil, httperr.BadRequest("connector has no setup flow")
 	}
 
-	phase, _, err := cschema.ParseSetupStep(*setupStep)
+	currentSetupStep, err := cschema.ParseSetupStep(*setupStep)
 	if err != nil {
 		return nil, httperr.BadRequestf("invalid setup step: %s", err)
 	}
 
 	// Only preconnect and configure phases accept form submissions
-	if phase != "preconnect" && phase != "configure" {
-		return nil, httperr.BadRequestf("cannot submit form for phase %q", phase)
+	if !currentSetupStep.Phase().IsIndexed() {
+		return nil, httperr.BadRequestf("cannot submit form for phase %q", currentSetupStep.Phase())
 	}
 
 	// Look up the current step definition
-	currentStep, _, err := connector.SetupFlow.GetStepBySetupStep(*setupStep)
+	currentStep, _, err := connector.SetupFlow.GetStepBySetupStep(currentSetupStep)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get current step: %w", err))
 	}
@@ -59,13 +59,13 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 	}
 
 	// Determine the next step
-	nextStep, err := connector.SetupFlow.NextSetupStep(*setupStep, connector.HasProbes())
+	nextStep, err := connector.SetupFlow.NextSetupStep(currentSetupStep, connector.HasProbes())
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to determine next step: %w", err))
 	}
 
 	// Handle each possible next step
-	if nextStep == "" {
+	if nextStep.IsZero() {
 		// Flow complete
 		if err := c.SetSetupStep(ctx, nil); err != nil {
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to clear setup step: %w", err))
@@ -81,7 +81,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		}, nil
 	}
 
-	if nextStep == "auth" {
+	if nextStep.Equals(cschema.SetupStepAuth) {
 		// Transition to auth phase — initiate OAuth flow
 		return c.initiateAuthStep(ctx, req.ReturnToUrl, connector)
 	}
@@ -104,7 +104,7 @@ func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, c
 		return nil, httperr.InternalServerErrorMsg("unsupported connector auth type for setup flow")
 	}
 
-	authStep := "auth"
+	authStep := cschema.SetupStepAuth.String()
 	if err := c.SetSetupStep(ctx, &authStep); err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to set setup step to auth: %w", err))
 	}
@@ -124,13 +124,14 @@ func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, c
 }
 
 // buildFormResponse creates a form response for the given setup step.
-func (c *connection) buildFormResponse(ctx context.Context, setupStep string, sf *cschema.SetupFlow) (iface.InitiateConnectionResponse, error) {
+func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.SetupStep, sf *cschema.SetupFlow) (iface.InitiateConnectionResponse, error) {
 	step, globalIndex, err := sf.GetStepBySetupStep(setupStep)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get step definition: %w", err))
 	}
 
-	if err := c.SetSetupStep(ctx, &setupStep); err != nil {
+	stepStr := setupStep.String()
+	if err := c.SetSetupStep(ctx, &stepStr); err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
 	}
 
@@ -166,27 +167,24 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Ini
 		}, nil
 	}
 
-	phase, _, err := cschema.ParseSetupStep(*setupStep)
+	parsed, err := cschema.ParseSetupStep(*setupStep)
 	if err != nil {
 		return nil, httperr.BadRequestf("invalid setup step: %s", err)
 	}
 
-	if phase == "auth" {
+	switch parsed.Phase() {
+	case cschema.SetupPhaseAuth:
 		// The connection is waiting for the OAuth callback — tell the UI
 		return &iface.InitiateConnectionRedirect{
 			Id:   c.GetId(),
 			Type: iface.PreconnectionResponseTypeRedirect,
 		}, nil
-	}
-
-	if phase == cschema.SetupStepVerify {
+	case cschema.SetupPhaseVerify:
 		return &iface.InitiateConnectionVerifying{
 			Id:   c.GetId(),
 			Type: iface.PreconnectionResponseTypeVerifying,
 		}, nil
-	}
-
-	if phase == cschema.SetupStepVerifyFailed {
+	case cschema.SetupPhaseVerifyFailed, cschema.SetupPhaseAuthFailed:
 		msg := ""
 		if e := c.GetSetupError(); e != nil {
 			msg = *e
@@ -199,5 +197,5 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Ini
 		}, nil
 	}
 
-	return c.buildFormResponse(ctx, *setupStep, connector.SetupFlow)
+	return c.buildFormResponse(ctx, parsed, connector.SetupFlow)
 }

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -104,8 +104,7 @@ func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, c
 		return nil, httperr.InternalServerErrorMsg("unsupported connector auth type for setup flow")
 	}
 
-	authStep := cschema.SetupStepAuth.String()
-	if err := c.SetSetupStep(ctx, &authStep); err != nil {
+	if err := c.SetSetupStep(ctx, &cschema.SetupStepAuth); err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to set setup step to auth: %w", err))
 	}
 
@@ -130,8 +129,7 @@ func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.Se
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get step definition: %w", err))
 	}
 
-	stepStr := setupStep.String()
-	if err := c.SetSetupStep(ctx, &stepStr); err != nil {
+	if err := c.SetSetupStep(ctx, &setupStep); err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
 	}
 

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -338,4 +338,36 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		assert.Equal(t, "workspace", form.StepId)
 		assert.Equal(t, "Select Workspace", form.StepTitle)
 	})
+
+	t.Run("returns verifying for verify step", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		step := cschema.SetupStepVerify
+		conn.SetupStep = &step
+
+		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
+		require.NoError(t, err)
+		require.IsType(t, &iface.InitiateConnectionVerifying{}, resp)
+		assert.Equal(t, iface.PreconnectionResponseTypeVerifying, resp.GetType())
+	})
+
+	t.Run("returns error for verify_failed step with setup_error populated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		step := cschema.SetupStepVerifyFailed
+		conn.SetupStep = &step
+		errMsg := `probe "ping" failed: 401 unauthorized`
+		conn.SetupError = &errMsg
+
+		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
+		require.NoError(t, err)
+		require.IsType(t, &iface.InitiateConnectionError{}, resp)
+		errResp := resp.(*iface.InitiateConnectionError)
+		assert.Equal(t, errMsg, errResp.Error)
+		assert.True(t, errResp.CanRetry)
+	})
 }

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -41,8 +42,13 @@ var workspaceSchema = common.RawJSON(`{
 }`)
 
 func newTestConnectionWithSetupFlow(t *testing.T, ctrl *gomock.Controller, sf *cschema.SetupFlow) (*connection, *mockDb.MockDB) {
+	conn, db, _ := newTestConnectionWithSetupFlowAndAsynq(t, ctrl, sf)
+	return conn, db
+}
+
+func newTestConnectionWithSetupFlowAndAsynq(t *testing.T, ctrl *gomock.Controller, sf *cschema.SetupFlow) (*connection, *mockDb.MockDB, *mockAsynq.MockClient) {
 	e := encrypt.NewFakeEncryptService(false)
-	s, db, _, _, _, _ := FullMockService(t, ctrl)
+	s, db, _, _, ac, _ := FullMockService(t, ctrl)
 	s.encrypt = e
 
 	connector := cschema.Connector{
@@ -62,7 +68,7 @@ func newTestConnectionWithSetupFlow(t *testing.T, ctrl *gomock.Controller, sf *c
 		logger: aplog.NewNoopLogger(),
 	}
 
-	return conn, db
+	return conn, db, ac
 }
 
 func TestSubmitForm(t *testing.T) {

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -350,7 +350,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		step := cschema.SetupStepVerify
+		step := cschema.SetupStepVerify.String()
 		conn.SetupStep = &step
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
@@ -364,7 +364,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		step := cschema.SetupStepVerifyFailed
+		step := cschema.SetupStepVerifyFailed.String()
 		conn.SetupStep = &step
 		errMsg := `probe "ping" failed: 401 unauthorized`
 		conn.SetupError = &errMsg

--- a/internal/core/service_tasks.go
+++ b/internal/core/service_tasks.go
@@ -14,6 +14,7 @@ func (s *service) RegisterTasks(mux *asynq.ServeMux) {
 	mux.HandleFunc(taskTypeMigrateConnectionsBetweenConnectorVersions, s.migrateConnectionsBetweenConnectorVersions)
 	mux.HandleFunc(taskTypeDisconnectConnection, s.disconnectConnection)
 	mux.HandleFunc(taskTypeProbe, s.runProbeForConnection)
+	mux.HandleFunc(taskTypeVerifyConnection, s.verifyConnection)
 }
 
 func (s *service) GetCronTasks() []*asynq.PeriodicTaskConfig {

--- a/internal/core/service_verify_connection.go
+++ b/internal/core/service_verify_connection.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apid"
+)
+
+// EnqueueVerifyConnection enqueues the verify_connection task for a connection. The task runs
+// all probes in the background and advances the connection's setup step based on the outcome.
+func (s *service) EnqueueVerifyConnection(ctx context.Context, id apid.ID) error {
+	if id == apid.Nil {
+		return errors.New("connection id is required")
+	}
+
+	t, err := newVerifyConnectionTask(id)
+	if err != nil {
+		return fmt.Errorf("failed to create verify connection task: %w", err)
+	}
+
+	if _, err := s.ac.EnqueueContext(ctx, t, asynq.Retention(10*time.Minute)); err != nil {
+		return fmt.Errorf("failed to enqueue verify connection task: %w", err)
+	}
+
+	s.logger.Info("verify connection task enqueued", "id", id)
+	return nil
+}

--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 )
 
-const taskTypeDisconnectConnection = "connectors:disconnect_connection"
+const taskTypeDisconnectConnection = "core:disconnect_connection"
 
 func newDisconnectConnectionTask(connectionId apid.ID) (*asynq.Task, error) {
 	payload, err := json.Marshal(disconnectConnectionTaskPayload{connectionId})

--- a/internal/core/task_migrate_connections_between_connector_versions.go
+++ b/internal/core/task_migrate_connections_between_connector_versions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 )
 
-const taskTypeMigrateConnectionsBetweenConnectorVersions = "connectors:migrate_connections_between_connector_versions"
+const taskTypeMigrateConnectionsBetweenConnectorVersions = "core:migrate_connections_between_connector_versions"
 
 func newMigrateConnectionsBetweenConnectorVersionsTask() (*asynq.Task, error) {
 	return asynq.NewTask(taskTypeMigrateConnectionsBetweenConnectorVersions, nil), nil

--- a/internal/core/task_probe.go
+++ b/internal/core/task_probe.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 )
 
-const taskTypeProbe = "connectors:probe"
+const taskTypeProbe = "core:probe"
 
 func newProbeTask(connectionId apid.ID, probeId string) (*asynq.Task, error) {
 	payload, err := json.Marshal(probeTaskPayload{ConnectionId: connectionId, ProbeId: probeId})

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -75,7 +75,7 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 			continue
 		}
 		logger.Error("probe failed during verify", "probe_id", probe.GetId(), "outcome", outcome, "error", invokeErr)
-		if failErr := s.markVerifyFailed(ctx, conn, probe.GetId(), invokeErr); failErr != nil {
+		if failErr := conn.onVerifyFailed(ctx, probe.GetId(), invokeErr); failErr != nil {
 			// Return the failErr so asynq retries — probe outcome is preserved for a later attempt.
 			return fmt.Errorf("failed to record verify failure: %w", failErr)
 		}
@@ -83,56 +83,5 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 	}
 
 	// All probes passed. Advance to the next step in the flow.
-	return s.advanceAfterVerify(ctx, conn)
-}
-
-func (s *service) advanceAfterVerify(ctx context.Context, conn *connection) error {
-	connector := conn.cv.GetDefinition()
-
-	var nextStep string
-	if connector != nil && connector.SetupFlow != nil {
-		var err error
-		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, connector.HasProbes())
-		if err != nil {
-			return fmt.Errorf("failed to determine next step after verify: %w", err)
-		}
-	}
-
-	if nextStep == "" {
-		if err := conn.SetSetupStep(ctx, nil); err != nil {
-			return fmt.Errorf("failed to clear setup step after verify: %w", err)
-		}
-		if err := conn.SetState(ctx, database.ConnectionStateReady); err != nil {
-			return fmt.Errorf("failed to set connection ready after verify: %w", err)
-		}
-		return nil
-	}
-
-	if err := conn.SetSetupStep(ctx, &nextStep); err != nil {
-		return fmt.Errorf("failed to advance setup step after verify: %w", err)
-	}
-	return nil
-}
-
-func (s *service) markVerifyFailed(ctx context.Context, conn *connection, probeId string, invokeErr error) error {
-	// Revoke whatever credentials we obtained during auth so they cannot be reused. Retry will
-	// reauthenticate from scratch.
-	revokeOps := conn.getRevokeCredentialsOperations()
-	for _, op := range revokeOps {
-		if err := op(ctx); err != nil {
-			// Log and continue — we still want to record the failure state even if revoke fails.
-			conn.logger.Error("failed to revoke credentials during verify failure", "error", err)
-		}
-	}
-
-	msg := fmt.Sprintf("probe %q failed: %s", probeId, invokeErr.Error())
-	if err := conn.SetSetupError(ctx, &msg); err != nil {
-		return err
-	}
-
-	failedStep := cschema.SetupStepVerifyFailed
-	if err := conn.SetSetupStep(ctx, &failedStep); err != nil {
-		return err
-	}
-	return nil
+	return conn.onVerifyPassed(ctx)
 }

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -63,8 +63,13 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 
 	// Guard against stale tasks: only run if the connection is still in verify phase.
 	setupStep := conn.GetSetupStep()
-	if setupStep == nil || *setupStep != cschema.SetupStepVerify {
+	if setupStep == nil {
 		logger.Info("connection is no longer in verify phase; skipping", "setup_step", setupStep)
+		return nil
+	}
+	parsed, err := cschema.ParseSetupStep(*setupStep)
+	if err != nil || !parsed.Equals(cschema.SetupStepVerify) {
+		logger.Info("connection is no longer in verify phase; skipping", "setup_step", *setupStep)
 		return nil
 	}
 

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -13,7 +13,7 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
-const taskTypeVerifyConnection = "connectors:verify_connection"
+const taskTypeVerifyConnection = "core:verify_connection"
 
 func newVerifyConnectionTask(connectionId apid.ID) (*asynq.Task, error) {
 	payload, err := json.Marshal(verifyConnectionTaskPayload{ConnectionId: connectionId})

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+const taskTypeVerifyConnection = "connectors:verify_connection"
+
+func newVerifyConnectionTask(connectionId apid.ID) (*asynq.Task, error) {
+	payload, err := json.Marshal(verifyConnectionTaskPayload{ConnectionId: connectionId})
+	if err != nil {
+		return nil, err
+	}
+	return asynq.NewTask(taskTypeVerifyConnection, payload), nil
+}
+
+type verifyConnectionTaskPayload struct {
+	ConnectionId apid.ID `json:"connection_id"`
+}
+
+// verifyConnection runs all probes for a connection and advances the setup flow based on the
+// outcome. On success, the connection moves forward to the next step (configure or ready). On
+// failure, credentials are revoked, setup_error is populated, and setup_step becomes
+// "verify_failed" — a terminal pseudo-step the UI surfaces to the user with retry/cancel options.
+func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
+	logger := aplog.NewBuilder(s.logger).
+		WithTask(t).
+		WithCtx(ctx).
+		Build()
+	logger.Info("verify connection task started")
+	defer logger.Info("verify connection task completed")
+
+	var p verifyConnectionTaskPayload
+	if err := json.Unmarshal(t.Payload(), &p); err != nil {
+		return fmt.Errorf("%s json.Unmarshal failed: %v: %w", taskTypeVerifyConnection, err, asynq.SkipRetry)
+	}
+
+	if p.ConnectionId == apid.Nil {
+		return fmt.Errorf("%s connection id not specified: %w", taskTypeVerifyConnection, asynq.SkipRetry)
+	}
+
+	logger = aplog.NewBuilder(logger).
+		WithConnectionId(p.ConnectionId).
+		Build()
+
+	conn, err := s.getConnection(ctx, p.ConnectionId)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			logger.Error("connection not found", "error", err)
+			return asynq.SkipRetry
+		}
+		return fmt.Errorf("failed to get connection for verify: %w", err)
+	}
+
+	// Guard against stale tasks: only run if the connection is still in verify phase.
+	setupStep := conn.GetSetupStep()
+	if setupStep == nil || *setupStep != cschema.SetupStepVerify {
+		logger.Info("connection is no longer in verify phase; skipping", "setup_step", setupStep)
+		return nil
+	}
+
+	probes := conn.GetProbes()
+	for _, probe := range probes {
+		outcome, invokeErr := probe.Invoke(ctx)
+		if invokeErr == nil {
+			continue
+		}
+		logger.Error("probe failed during verify", "probe_id", probe.GetId(), "outcome", outcome, "error", invokeErr)
+		if failErr := s.markVerifyFailed(ctx, conn, probe.GetId(), invokeErr); failErr != nil {
+			// Return the failErr so asynq retries — probe outcome is preserved for a later attempt.
+			return fmt.Errorf("failed to record verify failure: %w", failErr)
+		}
+		return asynq.SkipRetry
+	}
+
+	// All probes passed. Advance to the next step in the flow.
+	return s.advanceAfterVerify(ctx, conn)
+}
+
+func (s *service) advanceAfterVerify(ctx context.Context, conn *connection) error {
+	connector := conn.cv.GetDefinition()
+	hasProbes := connector != nil && len(connector.Probes) > 0
+
+	var nextStep string
+	if connector != nil && connector.SetupFlow != nil {
+		var err error
+		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, hasProbes)
+		if err != nil {
+			return fmt.Errorf("failed to determine next step after verify: %w", err)
+		}
+	}
+
+	if nextStep == "" {
+		if err := conn.SetSetupStep(ctx, nil); err != nil {
+			return fmt.Errorf("failed to clear setup step after verify: %w", err)
+		}
+		if err := conn.SetState(ctx, database.ConnectionStateReady); err != nil {
+			return fmt.Errorf("failed to set connection ready after verify: %w", err)
+		}
+		return nil
+	}
+
+	if err := conn.SetSetupStep(ctx, &nextStep); err != nil {
+		return fmt.Errorf("failed to advance setup step after verify: %w", err)
+	}
+	return nil
+}
+
+func (s *service) markVerifyFailed(ctx context.Context, conn *connection, probeId string, invokeErr error) error {
+	// Revoke whatever credentials we obtained during auth so they cannot be reused. Retry will
+	// reauthenticate from scratch.
+	revokeOps := conn.getRevokeCredentialsOperations()
+	for _, op := range revokeOps {
+		if err := op(ctx); err != nil {
+			// Log and continue — we still want to record the failure state even if revoke fails.
+			conn.logger.Error("failed to revoke credentials during verify failure", "error", err)
+		}
+	}
+
+	msg := fmt.Sprintf("probe %q failed: %s", probeId, invokeErr.Error())
+	if err := conn.SetSetupError(ctx, &msg); err != nil {
+		return err
+	}
+
+	failedStep := cschema.SetupStepVerifyFailed
+	if err := conn.SetSetupStep(ctx, &failedStep); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -88,12 +88,11 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 
 func (s *service) advanceAfterVerify(ctx context.Context, conn *connection) error {
 	connector := conn.cv.GetDefinition()
-	hasProbes := connector != nil && len(connector.Probes) > 0
 
 	var nextStep string
 	if connector != nil && connector.SetupFlow != nil {
 		var err error
-		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, hasProbes)
+		nextStep, err = connector.SetupFlow.NextSetupStep(cschema.SetupStepVerify, connector.HasProbes())
 		if err != nil {
 			return fmt.Errorf("failed to determine next step after verify: %w", err)
 		}

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -61,6 +61,7 @@ type Connection struct {
 	EncryptedConfiguration  *encfield.EncryptedField
 	EncryptedAt             *time.Time
 	SetupStep               *string
+	SetupError              *string
 	CreatedAt               time.Time
 	UpdatedAt               time.Time
 	DeletedAt               *time.Time
@@ -78,6 +79,7 @@ func (c *Connection) cols() []string {
 		"encrypted_configuration",
 		"encrypted_at",
 		"setup_step",
+		"setup_error",
 		"created_at",
 		"updated_at",
 		"deleted_at",
@@ -96,6 +98,7 @@ func (c *Connection) fields() []any {
 		&c.EncryptedConfiguration,
 		&c.EncryptedAt,
 		&c.SetupStep,
+		&c.SetupError,
 		&c.CreatedAt,
 		&c.UpdatedAt,
 		&c.DeletedAt,
@@ -114,6 +117,7 @@ func (c *Connection) values() []any {
 		c.EncryptedConfiguration,
 		c.EncryptedAt,
 		c.SetupStep,
+		c.SetupError,
 		c.CreatedAt,
 		c.UpdatedAt,
 		c.DeletedAt,
@@ -328,6 +332,39 @@ func (s *service) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupS
 
 	if affected > 1 {
 		return fmt.Errorf("multiple connections had setup step updated: %w", ErrViolation)
+	}
+
+	return nil
+}
+
+func (s *service) SetConnectionSetupError(ctx context.Context, id apid.ID, setupError *string) error {
+	if id == apid.Nil {
+		return errors.New("connection id is required")
+	}
+
+	now := apctx.GetClock(ctx).Now()
+	dbResult, err := s.sq.
+		Update(ConnectionsTable).
+		Set("updated_at", now).
+		Set("setup_error", setupError).
+		Where(sq.Eq{"id": id, "deleted_at": nil}).
+		RunWith(s.db).
+		Exec()
+	if err != nil {
+		return fmt.Errorf("failed to update connection setup error: %w", err)
+	}
+
+	affected, err := dbResult.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to update connection setup error: %w", err)
+	}
+
+	if affected == 0 {
+		return ErrNotFound
+	}
+
+	if affected > 1 {
+		return fmt.Errorf("multiple connections had setup error updated: %w", ErrViolation)
 	}
 
 	return nil

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -109,6 +109,7 @@ type DB interface {
 	DeleteConnection(ctx context.Context, id apid.ID) error
 	SetConnectionState(ctx context.Context, id apid.ID, state ConnectionState) error
 	SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *string) error
+	SetConnectionSetupError(ctx context.Context, id apid.ID, setupError *string) error
 	SetConnectionEncryptedConfiguration(ctx context.Context, id apid.ID, encryptedConfig *encfield.EncryptedField) error
 	UpdateConnectionLabels(ctx context.Context, id apid.ID, labels map[string]string) (*Connection, error)
 	PutConnectionLabels(ctx context.Context, id apid.ID, labels map[string]string) (*Connection, error)

--- a/internal/database/migrations/postgres/000002_add_connection_setup_error.down.sql
+++ b/internal/database/migrations/postgres/000002_add_connection_setup_error.down.sql
@@ -1,0 +1,1 @@
+alter table connections drop column setup_error;

--- a/internal/database/migrations/postgres/000002_add_connection_setup_error.up.sql
+++ b/internal/database/migrations/postgres/000002_add_connection_setup_error.up.sql
@@ -1,0 +1,1 @@
+alter table connections add column setup_error text;

--- a/internal/database/migrations/sqlite/000002_add_connection_setup_error.down.sql
+++ b/internal/database/migrations/sqlite/000002_add_connection_setup_error.down.sql
@@ -1,0 +1,1 @@
+alter table connections drop column setup_error;

--- a/internal/database/migrations/sqlite/000002_add_connection_setup_error.up.sql
+++ b/internal/database/migrations/sqlite/000002_add_connection_setup_error.up.sql
@@ -1,0 +1,1 @@
+alter table connections add column setup_error text;

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -1393,6 +1393,20 @@ func (mr *MockDBMockRecorder) SetConnectionSetupStep(ctx, id, setupStep interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionSetupStep", reflect.TypeOf((*MockDB)(nil).SetConnectionSetupStep), ctx, id, setupStep)
 }
 
+// SetConnectionSetupError mocks base method.
+func (m *MockDB) SetConnectionSetupError(ctx context.Context, id apid.ID, setupError *string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConnectionSetupError", ctx, id, setupError)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetConnectionSetupError indicates an expected call of SetConnectionSetupError.
+func (mr *MockDBMockRecorder) SetConnectionSetupError(ctx, id, setupError interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionSetupError", reflect.TypeOf((*MockDB)(nil).SetConnectionSetupError), ctx, id, setupError)
+}
+
 // SetConnectionState mocks base method.
 func (m *MockDB) SetConnectionState(ctx context.Context, id apid.ID, state database.ConnectionState) error {
 	m.ctrl.T.Helper()

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -626,7 +626,7 @@ type RetryConnectionRequest struct {
 }
 
 // @Summary		Retry connection setup
-// @Description	Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.
+// @Description	Retry a connection setup that ended in a terminal failure state. Applies to any setup-phase failure: an auth-phase failure such as an OAuth token-exchange error (auth_failed) or a probe failure during verify (verify_failed). Clears the recorded error and either returns to the first preconnect step (if the connector defines one, so the user can correct any input that led to the failure) or re-initiates the auth flow from scratch.
 // @Tags			connections
 // @Accept			json
 // @Produce		json

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -621,6 +621,59 @@ func (r *ConnectionsRoutes) reconfigure(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, resp)
 }
 
+// @Summary		Cancel in-flight setup
+// @Description	Abandon a reconfigure attempt on a ready connection by clearing setup_step and setup_error. The connection remains ready and its previously stored configuration continues to apply.
+// @Tags			connections
+// @Produce		json
+// @Param			id	path		string	true	"Connection UUID"
+// @Success		204
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/connections/{id}/_cancel_setup [post]
+func (r *ConnectionsRoutes) cancelSetup(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, err := apid.Parse(gctx.Param("id"))
+	if err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if id == apid.Nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	c, err := r.core.GetConnection(ctx, id)
+	if err != nil {
+		if errors.Is(err, coreIface.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
+		} else {
+			apgin.WriteErr(gctx, nil, err)
+		}
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	if err := c.CancelSetup(ctx); err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.Status(http.StatusNoContent)
+}
+
 type RetryConnectionRequest struct {
 	ReturnToUrl string `json:"return_to_url,omitempty"`
 }
@@ -1583,6 +1636,15 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 			ForIdField("id").
 			Build(),
 		r.reconfigure,
+	)
+	g.POST(
+		"/connections/:id/_cancel_setup",
+		r.auth.NewRequiredBuilder().
+			ForResource("connections").
+			ForVerb("update").
+			ForIdField("id").
+			Build(),
+		r.cancelSetup,
 	)
 	g.POST(
 		"/connections/:id/_retry",

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -1588,7 +1588,7 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 		"/connections/:id/_retry",
 		r.auth.NewRequiredBuilder().
 			ForResource("connections").
-			ForVerb("update").
+			ForVerb("create"). // should also be update
 			ForIdField("id").
 			Build(),
 		r.retry,

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -250,6 +250,7 @@ type ConnectionJson struct {
 	Annotations map[string]string        `json:"annotations,omitempty"`
 	State       database.ConnectionState `json:"state"`
 	SetupStep   *string                  `json:"setup_step,omitempty"`
+	SetupError  *string                  `json:"setup_error,omitempty"`
 	Connector   ConnectorJson            `json:"connector"`
 	CreatedAt   time.Time                `json:"created_at"`
 	UpdatedAt   time.Time                `json:"updated_at"`
@@ -265,6 +266,7 @@ func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
 		Annotations: conn.GetAnnotations(),
 		State:       conn.GetState(),
 		SetupStep:   conn.GetSetupStep(),
+		SetupError:  conn.GetSetupError(),
 		Connector:   connector,
 		CreatedAt:   conn.GetCreatedAt(),
 		UpdatedAt:   conn.GetUpdatedAt(),
@@ -610,6 +612,70 @@ func (r *ConnectionsRoutes) reconfigure(gctx *gin.Context) {
 	}
 
 	resp, err := c.Reconfigure(ctx)
+	if err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, resp)
+}
+
+type RetryConnectionRequest struct {
+	ReturnToUrl string `json:"return_to_url,omitempty"`
+}
+
+// @Summary		Retry connection setup
+// @Description	Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.
+// @Tags			connections
+// @Accept			json
+// @Produce		json
+// @Param			id		path	string					true	"Connection UUID"
+// @Param			request	body	RetryConnectionRequest	true	"Retry request"
+// @Success		200	{object}	InitiateConnectionForm
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/connections/{id}/_retry [post]
+func (r *ConnectionsRoutes) retry(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, err := apid.Parse(gctx.Param("id"))
+	if err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if id == apid.Nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	c, err := r.core.GetConnection(ctx, id)
+	if err != nil {
+		if errors.Is(err, coreIface.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
+		} else {
+			apgin.WriteErr(gctx, nil, err)
+		}
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	var req RetryConnectionRequest
+	// Body is optional — return_to_url is only needed when the connector has no preconnect steps.
+	_ = gctx.ShouldBindBodyWithJSON(&req)
+
+	resp, err := r.core.RetryConnectionSetup(ctx, id, req.ReturnToUrl)
 	if err != nil {
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
@@ -1517,6 +1583,15 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 			ForIdField("id").
 			Build(),
 		r.reconfigure,
+	)
+	g.POST(
+		"/connections/:id/_retry",
+		r.auth.NewRequiredBuilder().
+			ForResource("connections").
+			ForVerb("update").
+			ForIdField("id").
+			Build(),
+		r.retry,
 	)
 	g.PUT(
 		"/connections/:id/_force_state",

--- a/internal/schema/connectors/connector.go
+++ b/internal/schema/connectors/connector.go
@@ -210,6 +210,15 @@ func (c *Connector) HasNamespace() bool {
 	return c.Namespace != nil
 }
 
+// HasProbes returns true if the connector has one or more probes, false otherwise
+func (c *Connector) HasProbes() bool {
+	if c == nil {
+		return false
+	}
+
+	return len(c.Probes) > 0
+}
+
 // IsDraft returns true if the connector has an explicitly defined state and that state is draft.
 func (c *Connector) IsDraft() bool {
 	if c == nil {

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -77,132 +77,213 @@ func (sf *SetupFlow) TotalSteps() int {
 	return total
 }
 
-// GetStepBySetupStep returns the step definition and its 0-based global index for the given
-// setup step string (e.g. "preconnect:0", "configure:1").
-func (sf *SetupFlow) GetStepBySetupStep(setupStep string) (*SetupFlowStep, int, error) {
-	phase, index, err := ParseSetupStep(setupStep)
-	if err != nil {
-		return nil, 0, err
-	}
+// SetupStepPhase identifies which phase of the setup flow a step belongs to. The indexed
+// phases (preconnect, configure) carry an integer index in their canonical setup-step form;
+// the others are singleton pseudo-steps with no index.
+type SetupStepPhase string
 
-	switch phase {
-	case "preconnect":
-		if sf.Preconnect == nil || index >= len(sf.Preconnect.Steps) {
-			return nil, 0, fmt.Errorf("preconnect step index %d out of range", index)
-		}
-		return &sf.Preconnect.Steps[index], index, nil
-	case "configure":
-		if sf.Configure == nil || index >= len(sf.Configure.Steps) {
-			return nil, 0, fmt.Errorf("configure step index %d out of range", index)
-		}
-		globalIndex := index
-		if sf.Preconnect != nil {
-			globalIndex += len(sf.Preconnect.Steps)
-		}
-		return &sf.Configure.Steps[index], globalIndex, nil
-	default:
-		return nil, 0, fmt.Errorf("unknown phase %q", phase)
-	}
+const (
+	SetupPhasePreconnect   SetupStepPhase = "preconnect"
+	SetupPhaseAuth         SetupStepPhase = "auth"
+	SetupPhaseVerify       SetupStepPhase = "verify"
+	SetupPhaseConfigure    SetupStepPhase = "configure"
+	SetupPhaseVerifyFailed SetupStepPhase = "verify_failed"
+	SetupPhaseAuthFailed   SetupStepPhase = "auth_failed"
+)
+
+// String returns the underlying phase identifier.
+func (p SetupStepPhase) String() string { return string(p) }
+
+// IsIndexed reports whether the phase carries a 0-based step index in its canonical form
+// (preconnect, configure). Singleton pseudo-steps return false.
+func (p SetupStepPhase) IsIndexed() bool {
+	return p == SetupPhasePreconnect || p == SetupPhaseConfigure
 }
 
-// FirstSetupStep returns the setup step string for the first step in the flow.
-// Returns "preconnect:0" if preconnect steps exist, otherwise "configure:0".
-// Returns empty string if no steps exist.
-func (sf *SetupFlow) FirstSetupStep() string {
-	if sf == nil {
+// IsTerminalFailure reports whether the phase represents a terminal failure pseudo-step
+// (verify_failed, auth_failed). Connections in this phase are retryable via the retry endpoint.
+func (p SetupStepPhase) IsTerminalFailure() bool {
+	return p == SetupPhaseVerifyFailed || p == SetupPhaseAuthFailed
+}
+
+// IsValid reports whether p is one of the recognized phases.
+func (p SetupStepPhase) IsValid() bool {
+	switch p {
+	case SetupPhasePreconnect, SetupPhaseAuth, SetupPhaseVerify, SetupPhaseConfigure,
+		SetupPhaseVerifyFailed, SetupPhaseAuthFailed:
+		return true
+	}
+	return false
+}
+
+// SetupStep is a typed representation of a setup-flow step. It captures the phase and, for
+// indexed phases, the 0-based step index. The zero SetupStep is invalid; use ParseSetupStep,
+// NewSetupStep, or NewIndexedSetupStep to construct one.
+type SetupStep struct {
+	phase SetupStepPhase
+	index int
+}
+
+// NewSetupStep returns a SetupStep for a singleton (non-indexed) phase.
+// Returns an error if phase is indexed or unknown.
+func NewSetupStep(phase SetupStepPhase) (SetupStep, error) {
+	if !phase.IsValid() {
+		return SetupStep{}, fmt.Errorf("unknown setup phase %q", phase)
+	}
+	if phase.IsIndexed() {
+		return SetupStep{}, fmt.Errorf("phase %q is indexed; use NewIndexedSetupStep", phase)
+	}
+	return SetupStep{phase: phase}, nil
+}
+
+// NewIndexedSetupStep returns a SetupStep for an indexed phase (preconnect, configure).
+// Returns an error if phase is not indexed or index is negative.
+func NewIndexedSetupStep(phase SetupStepPhase, index int) (SetupStep, error) {
+	if !phase.IsIndexed() {
+		return SetupStep{}, fmt.Errorf("phase %q is not indexed", phase)
+	}
+	if index < 0 {
+		return SetupStep{}, fmt.Errorf("setup step index must be non-negative, got %d", index)
+	}
+	return SetupStep{phase: phase, index: index}, nil
+}
+
+// Predefined SetupSteps for the singleton phases.
+var (
+	SetupStepAuth         = SetupStep{phase: SetupPhaseAuth}
+	SetupStepVerify       = SetupStep{phase: SetupPhaseVerify}
+	SetupStepVerifyFailed = SetupStep{phase: SetupPhaseVerifyFailed}
+	SetupStepAuthFailed   = SetupStep{phase: SetupPhaseAuthFailed}
+)
+
+// Phase returns the step's phase.
+func (s SetupStep) Phase() SetupStepPhase { return s.phase }
+
+// Index returns the 0-based index for indexed phases. Returns 0 for singleton phases.
+func (s SetupStep) Index() int { return s.index }
+
+// String renders the canonical setup-step form: "phase:index" for indexed phases, "phase"
+// for singletons. The zero SetupStep returns "".
+func (s SetupStep) String() string {
+	if s.phase == "" {
 		return ""
 	}
-	if sf.HasPreconnect() {
-		return "preconnect:0"
+	if s.phase.IsIndexed() {
+		return fmt.Sprintf("%s:%d", s.phase, s.index)
 	}
-	if sf.HasConfigure() {
-		return "configure:0"
-	}
-	return ""
+	return string(s.phase)
 }
 
-// SetupStepVerify is the pseudo-step that indicates connection probes are running in the background
-// to verify credentials obtained during auth.
-const SetupStepVerify = "verify"
+// IsZero reports whether s is the zero SetupStep (no phase set).
+func (s SetupStep) IsZero() bool { return s.phase == "" }
 
-// SetupStepVerifyFailed is a terminal pseudo-step that indicates probe verification failed.
-// The connection's setup_error column holds the failure message. It is not part of the normal
-// linear flow; the UI surfaces an error screen with retry/cancel options.
-const SetupStepVerifyFailed = "verify_failed"
+// Equals reports whether s and other are identical.
+func (s SetupStep) Equals(other SetupStep) bool { return s == other }
 
-// SetupStepAuthFailed is a terminal pseudo-step that indicates the auth phase failed (e.g. an
-// OAuth token exchange returned an error). The connection's setup_error column holds the
-// failure message. Like verify_failed, it is outside the normal linear flow; the UI surfaces
-// an error screen with retry/cancel options.
-const SetupStepAuthFailed = "auth_failed"
+// IsTerminalFailure reports whether the step is in a terminal failure phase.
+func (s SetupStep) IsTerminalFailure() bool { return s.phase.IsTerminalFailure() }
 
-// NextSetupStep returns the next setup step after the given one, or empty string if done.
-// The auth phase is implicit between preconnect and configure phases. When the connector has
-// probes, a verify phase runs between auth and configure.
-func (sf *SetupFlow) NextSetupStep(current string, hasProbes bool) (string, error) {
-	phase, index, err := ParseSetupStep(current)
-	if err != nil {
-		return "", err
-	}
-
-	switch phase {
-	case "preconnect":
-		if sf.Preconnect != nil && index+1 < len(sf.Preconnect.Steps) {
-			return fmt.Sprintf("preconnect:%d", index+1), nil
-		}
-		// Preconnect done — next is auth
-		return "auth", nil
-	case "auth":
-		if hasProbes {
-			return SetupStepVerify, nil
-		}
-		if sf.HasConfigure() {
-			return "configure:0", nil
-		}
-		return "", nil // Complete
-	case SetupStepVerify:
-		if sf.HasConfigure() {
-			return "configure:0", nil
-		}
-		return "", nil // Complete
-	case "configure":
-		if sf.Configure != nil && index+1 < len(sf.Configure.Steps) {
-			return fmt.Sprintf("configure:%d", index+1), nil
-		}
-		return "", nil // Complete
-	default:
-		return "", fmt.Errorf("unknown phase %q", phase)
-	}
-}
-
-// ParseSetupStep parses a setup step string like "preconnect:0" into phase and index.
-// Singleton pseudo-steps "auth", "verify", "verify_failed", and "auth_failed" return (phase, 0, nil).
-func ParseSetupStep(setupStep string) (phase string, index int, err error) {
-	switch setupStep {
-	case "auth", SetupStepVerify, SetupStepVerifyFailed, SetupStepAuthFailed:
-		return setupStep, 0, nil
+// ParseSetupStep parses a setup-step string into a SetupStep. Indexed forms must be
+// "phase:index" (e.g. "preconnect:0", "configure:3"); singleton phases ("auth", "verify",
+// "verify_failed", "auth_failed") parse as a SetupStep with index 0.
+func ParseSetupStep(setupStep string) (SetupStep, error) {
+	phase := SetupStepPhase(setupStep)
+	if phase.IsValid() && !phase.IsIndexed() {
+		return SetupStep{phase: phase}, nil
 	}
 
 	parts := strings.SplitN(setupStep, ":", 2)
 	if len(parts) != 2 {
-		return "", 0, fmt.Errorf("invalid setup step format %q", setupStep)
+		return SetupStep{}, fmt.Errorf("invalid setup step format %q", setupStep)
 	}
 
-	phase = parts[0]
-	if phase != "preconnect" && phase != "configure" {
-		return "", 0, fmt.Errorf("invalid setup step phase %q", phase)
+	phase = SetupStepPhase(parts[0])
+	if !phase.IsIndexed() {
+		return SetupStep{}, fmt.Errorf("invalid setup step phase %q", phase)
 	}
 
-	index, err = strconv.Atoi(parts[1])
+	index, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid setup step index %q: %w", parts[1], err)
+		return SetupStep{}, fmt.Errorf("invalid setup step index %q: %w", parts[1], err)
 	}
 
 	if index < 0 {
-		return "", 0, fmt.Errorf("setup step index must be non-negative, got %d", index)
+		return SetupStep{}, fmt.Errorf("setup step index must be non-negative, got %d", index)
 	}
 
-	return phase, index, nil
+	return SetupStep{phase: phase, index: index}, nil
+}
+
+// GetStepBySetupStep returns the step definition and its 0-based global index for the given
+// setup step. Returns an error if step is not an indexed phase or its index is out of range.
+func (sf *SetupFlow) GetStepBySetupStep(step SetupStep) (*SetupFlowStep, int, error) {
+	switch step.phase {
+	case SetupPhasePreconnect:
+		if sf.Preconnect == nil || step.index >= len(sf.Preconnect.Steps) {
+			return nil, 0, fmt.Errorf("preconnect step index %d out of range", step.index)
+		}
+		return &sf.Preconnect.Steps[step.index], step.index, nil
+	case SetupPhaseConfigure:
+		if sf.Configure == nil || step.index >= len(sf.Configure.Steps) {
+			return nil, 0, fmt.Errorf("configure step index %d out of range", step.index)
+		}
+		globalIndex := step.index
+		if sf.Preconnect != nil {
+			globalIndex += len(sf.Preconnect.Steps)
+		}
+		return &sf.Configure.Steps[step.index], globalIndex, nil
+	default:
+		return nil, 0, fmt.Errorf("phase %q does not have indexed steps", step.phase)
+	}
+}
+
+// FirstSetupStep returns the first step in the flow. Returns the zero SetupStep when the
+// flow has no steps (caller should check IsZero).
+func (sf *SetupFlow) FirstSetupStep() SetupStep {
+	if sf == nil {
+		return SetupStep{}
+	}
+	if sf.HasPreconnect() {
+		return SetupStep{phase: SetupPhasePreconnect}
+	}
+	if sf.HasConfigure() {
+		return SetupStep{phase: SetupPhaseConfigure}
+	}
+	return SetupStep{}
+}
+
+// NextSetupStep returns the step that follows current. The auth phase is implicit between
+// preconnect and configure phases; when the connector has probes, a verify phase runs between
+// auth and configure. Returns the zero SetupStep (IsZero) when current is the final step.
+func (sf *SetupFlow) NextSetupStep(current SetupStep, hasProbes bool) (SetupStep, error) {
+	switch current.phase {
+	case SetupPhasePreconnect:
+		if sf.Preconnect != nil && current.index+1 < len(sf.Preconnect.Steps) {
+			return SetupStep{phase: SetupPhasePreconnect, index: current.index + 1}, nil
+		}
+		// Preconnect done — next is auth
+		return SetupStepAuth, nil
+	case SetupPhaseAuth:
+		if hasProbes {
+			return SetupStepVerify, nil
+		}
+		if sf.HasConfigure() {
+			return SetupStep{phase: SetupPhaseConfigure}, nil
+		}
+		return SetupStep{}, nil // Complete
+	case SetupPhaseVerify:
+		if sf.HasConfigure() {
+			return SetupStep{phase: SetupPhaseConfigure}, nil
+		}
+		return SetupStep{}, nil // Complete
+	case SetupPhaseConfigure:
+		if sf.Configure != nil && current.index+1 < len(sf.Configure.Steps) {
+			return SetupStep{phase: SetupPhaseConfigure, index: current.index + 1}, nil
+		}
+		return SetupStep{}, nil // Complete
+	default:
+		return SetupStep{}, fmt.Errorf("no successor defined for phase %q", current.phase)
+	}
 }
 
 // SetupFlowPhase is a sequential list of form steps within a phase (preconnect or configure).

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -130,6 +130,12 @@ const SetupStepVerify = "verify"
 // linear flow; the UI surfaces an error screen with retry/cancel options.
 const SetupStepVerifyFailed = "verify_failed"
 
+// SetupStepAuthFailed is a terminal pseudo-step that indicates the auth phase failed (e.g. an
+// OAuth token exchange returned an error). The connection's setup_error column holds the
+// failure message. Like verify_failed, it is outside the normal linear flow; the UI surfaces
+// an error screen with retry/cancel options.
+const SetupStepAuthFailed = "auth_failed"
+
 // NextSetupStep returns the next setup step after the given one, or empty string if done.
 // The auth phase is implicit between preconnect and configure phases. When the connector has
 // probes, a verify phase runs between auth and configure.
@@ -170,10 +176,10 @@ func (sf *SetupFlow) NextSetupStep(current string, hasProbes bool) (string, erro
 }
 
 // ParseSetupStep parses a setup step string like "preconnect:0" into phase and index.
-// Singleton pseudo-steps "auth", "verify", and "verify_failed" return (phase, 0, nil).
+// Singleton pseudo-steps "auth", "verify", "verify_failed", and "auth_failed" return (phase, 0, nil).
 func ParseSetupStep(setupStep string) (phase string, index int, err error) {
 	switch setupStep {
-	case "auth", SetupStepVerify, SetupStepVerifyFailed:
+	case "auth", SetupStepVerify, SetupStepVerifyFailed, SetupStepAuthFailed:
 		return setupStep, 0, nil
 	}
 

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -121,9 +121,19 @@ func (sf *SetupFlow) FirstSetupStep() string {
 	return ""
 }
 
+// SetupStepVerify is the pseudo-step that indicates connection probes are running in the background
+// to verify credentials obtained during auth.
+const SetupStepVerify = "verify"
+
+// SetupStepVerifyFailed is a terminal pseudo-step that indicates probe verification failed.
+// The connection's setup_error column holds the failure message. It is not part of the normal
+// linear flow; the UI surfaces an error screen with retry/cancel options.
+const SetupStepVerifyFailed = "verify_failed"
+
 // NextSetupStep returns the next setup step after the given one, or empty string if done.
-// The auth phase is implicit between preconnect and configure phases.
-func (sf *SetupFlow) NextSetupStep(current string) (string, error) {
+// The auth phase is implicit between preconnect and configure phases. When the connector has
+// probes, a verify phase runs between auth and configure.
+func (sf *SetupFlow) NextSetupStep(current string, hasProbes bool) (string, error) {
 	phase, index, err := ParseSetupStep(current)
 	if err != nil {
 		return "", err
@@ -137,6 +147,14 @@ func (sf *SetupFlow) NextSetupStep(current string) (string, error) {
 		// Preconnect done — next is auth
 		return "auth", nil
 	case "auth":
+		if hasProbes {
+			return SetupStepVerify, nil
+		}
+		if sf.HasConfigure() {
+			return "configure:0", nil
+		}
+		return "", nil // Complete
+	case SetupStepVerify:
 		if sf.HasConfigure() {
 			return "configure:0", nil
 		}
@@ -152,10 +170,11 @@ func (sf *SetupFlow) NextSetupStep(current string) (string, error) {
 }
 
 // ParseSetupStep parses a setup step string like "preconnect:0" into phase and index.
-// For "auth", returns ("auth", 0, nil).
+// Singleton pseudo-steps "auth", "verify", and "verify_failed" return (phase, 0, nil).
 func ParseSetupStep(setupStep string) (phase string, index int, err error) {
-	if setupStep == "auth" {
-		return "auth", 0, nil
+	switch setupStep {
+	case "auth", SetupStepVerify, SetupStepVerifyFailed:
+		return setupStep, 0, nil
 	}
 
 	parts := strings.SplitN(setupStep, ":", 2)

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -148,6 +148,15 @@ func NewIndexedSetupStep(phase SetupStepPhase, index int) (SetupStep, error) {
 	return SetupStep{phase: phase, index: index}, nil
 }
 
+// MustNewIndexedSetupStep is like NewIndexedSetupStep but panics on error.
+func MustNewIndexedSetupStep(phase SetupStepPhase, index int) SetupStep {
+	step, err := NewIndexedSetupStep(phase, index)
+	if err != nil {
+		panic(err)
+	}
+	return step
+}
+
 // Predefined SetupSteps for the singleton phases.
 var (
 	SetupStepAuth         = SetupStep{phase: SetupPhaseAuth}

--- a/internal/schema/connectors/setup_flow_test.go
+++ b/internal/schema/connectors/setup_flow_test.go
@@ -461,6 +461,40 @@ func TestSetupStepConstructors(t *testing.T) {
 	})
 }
 
+func TestMustNewIndexedSetupStep(t *testing.T) {
+	t.Run("returns step for valid indexed phase", func(t *testing.T) {
+		s := MustNewIndexedSetupStep(SetupPhaseConfigure, 0)
+		assert.Equal(t, SetupPhaseConfigure, s.Phase())
+		assert.Equal(t, 0, s.Index())
+		assert.Equal(t, "configure:0", s.String())
+	})
+
+	t.Run("returns step for preconnect with non-zero index", func(t *testing.T) {
+		s := MustNewIndexedSetupStep(SetupPhasePreconnect, 3)
+		assert.Equal(t, SetupPhasePreconnect, s.Phase())
+		assert.Equal(t, 3, s.Index())
+		assert.Equal(t, "preconnect:3", s.String())
+	})
+
+	t.Run("panics on singleton phase", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustNewIndexedSetupStep(SetupPhaseAuth, 0)
+		})
+	})
+
+	t.Run("panics on negative index", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustNewIndexedSetupStep(SetupPhasePreconnect, -1)
+		})
+	})
+
+	t.Run("panics on unknown phase", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustNewIndexedSetupStep(SetupStepPhase("nope"), 0)
+		})
+	})
+}
+
 func TestSetupStepZero(t *testing.T) {
 	var z SetupStep
 	assert.True(t, z.IsZero())

--- a/internal/schema/connectors/setup_flow_test.go
+++ b/internal/schema/connectors/setup_flow_test.go
@@ -349,45 +349,137 @@ func TestSetupFlowHelpers(t *testing.T) {
 
 func TestParseSetupStep(t *testing.T) {
 	t.Run("valid preconnect", func(t *testing.T) {
-		phase, index, err := ParseSetupStep("preconnect:0")
+		s, err := ParseSetupStep("preconnect:0")
 		require.NoError(t, err)
-		assert.Equal(t, "preconnect", phase)
-		assert.Equal(t, 0, index)
+		assert.Equal(t, SetupPhasePreconnect, s.Phase())
+		assert.Equal(t, 0, s.Index())
 	})
 
 	t.Run("valid configure with higher index", func(t *testing.T) {
-		phase, index, err := ParseSetupStep("configure:3")
+		s, err := ParseSetupStep("configure:3")
 		require.NoError(t, err)
-		assert.Equal(t, "configure", phase)
-		assert.Equal(t, 3, index)
+		assert.Equal(t, SetupPhaseConfigure, s.Phase())
+		assert.Equal(t, 3, s.Index())
 	})
 
 	t.Run("auth phase", func(t *testing.T) {
-		phase, index, err := ParseSetupStep("auth")
+		s, err := ParseSetupStep("auth")
 		require.NoError(t, err)
-		assert.Equal(t, "auth", phase)
-		assert.Equal(t, 0, index)
+		assert.Equal(t, SetupPhaseAuth, s.Phase())
+		assert.Equal(t, 0, s.Index())
+		assert.True(t, s.Equals(SetupStepAuth))
+	})
+
+	t.Run("verify phase", func(t *testing.T) {
+		s, err := ParseSetupStep("verify")
+		require.NoError(t, err)
+		assert.True(t, s.Equals(SetupStepVerify))
+	})
+
+	t.Run("verify_failed phase", func(t *testing.T) {
+		s, err := ParseSetupStep("verify_failed")
+		require.NoError(t, err)
+		assert.True(t, s.Equals(SetupStepVerifyFailed))
+		assert.True(t, s.IsTerminalFailure())
+	})
+
+	t.Run("auth_failed phase", func(t *testing.T) {
+		s, err := ParseSetupStep("auth_failed")
+		require.NoError(t, err)
+		assert.True(t, s.Equals(SetupStepAuthFailed))
+		assert.True(t, s.IsTerminalFailure())
 	})
 
 	t.Run("invalid format", func(t *testing.T) {
-		_, _, err := ParseSetupStep("bad")
+		_, err := ParseSetupStep("bad")
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid phase", func(t *testing.T) {
-		_, _, err := ParseSetupStep("unknown:0")
+		_, err := ParseSetupStep("unknown:0")
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid index", func(t *testing.T) {
-		_, _, err := ParseSetupStep("preconnect:abc")
+		_, err := ParseSetupStep("preconnect:abc")
 		assert.Error(t, err)
 	})
 
 	t.Run("negative index", func(t *testing.T) {
-		_, _, err := ParseSetupStep("preconnect:-1")
+		_, err := ParseSetupStep("preconnect:-1")
 		assert.Error(t, err)
 	})
+
+	t.Run("singleton with index suffix is rejected", func(t *testing.T) {
+		_, err := ParseSetupStep("auth:0")
+		assert.Error(t, err)
+	})
+}
+
+func TestSetupStepRoundTrip(t *testing.T) {
+	cases := []string{"preconnect:0", "preconnect:7", "configure:0", "configure:2", "auth", "verify", "verify_failed", "auth_failed"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			s, err := ParseSetupStep(c)
+			require.NoError(t, err)
+			assert.Equal(t, c, s.String())
+		})
+	}
+}
+
+func TestSetupStepConstructors(t *testing.T) {
+	t.Run("NewSetupStep accepts singleton phases", func(t *testing.T) {
+		s, err := NewSetupStep(SetupPhaseAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "auth", s.String())
+	})
+
+	t.Run("NewSetupStep rejects indexed phase", func(t *testing.T) {
+		_, err := NewSetupStep(SetupPhasePreconnect)
+		assert.Error(t, err)
+	})
+
+	t.Run("NewSetupStep rejects unknown phase", func(t *testing.T) {
+		_, err := NewSetupStep(SetupStepPhase("nope"))
+		assert.Error(t, err)
+	})
+
+	t.Run("NewIndexedSetupStep accepts indexed phase", func(t *testing.T) {
+		s, err := NewIndexedSetupStep(SetupPhaseConfigure, 4)
+		require.NoError(t, err)
+		assert.Equal(t, "configure:4", s.String())
+	})
+
+	t.Run("NewIndexedSetupStep rejects singleton phase", func(t *testing.T) {
+		_, err := NewIndexedSetupStep(SetupPhaseAuth, 0)
+		assert.Error(t, err)
+	})
+
+	t.Run("NewIndexedSetupStep rejects negative index", func(t *testing.T) {
+		_, err := NewIndexedSetupStep(SetupPhasePreconnect, -1)
+		assert.Error(t, err)
+	})
+}
+
+func TestSetupStepZero(t *testing.T) {
+	var z SetupStep
+	assert.True(t, z.IsZero())
+	assert.Equal(t, "", z.String())
+}
+
+func TestSetupStepPhaseHelpers(t *testing.T) {
+	assert.True(t, SetupPhasePreconnect.IsIndexed())
+	assert.True(t, SetupPhaseConfigure.IsIndexed())
+	assert.False(t, SetupPhaseAuth.IsIndexed())
+	assert.False(t, SetupPhaseVerify.IsIndexed())
+
+	assert.True(t, SetupPhaseVerifyFailed.IsTerminalFailure())
+	assert.True(t, SetupPhaseAuthFailed.IsTerminalFailure())
+	assert.False(t, SetupPhaseAuth.IsTerminalFailure())
+	assert.False(t, SetupPhasePreconnect.IsTerminalFailure())
+
+	assert.False(t, SetupStepPhase("garbage").IsValid())
+	assert.True(t, SetupPhaseAuth.IsValid())
 }
 
 func TestSetupFlowTotalSteps(t *testing.T) {
@@ -406,21 +498,21 @@ func TestSetupFlowTotalSteps(t *testing.T) {
 }
 
 func TestSetupFlowFirstSetupStep(t *testing.T) {
-	assert.Equal(t, "", (*SetupFlow)(nil).FirstSetupStep())
+	assert.True(t, (*SetupFlow)(nil).FirstSetupStep().IsZero())
 
 	t.Run("preconnect first", func(t *testing.T) {
 		sf := &SetupFlow{
 			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
 			Configure:  &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "b"}}},
 		}
-		assert.Equal(t, "preconnect:0", sf.FirstSetupStep())
+		assert.Equal(t, "preconnect:0", sf.FirstSetupStep().String())
 	})
 
 	t.Run("configure only", func(t *testing.T) {
 		sf := &SetupFlow{
 			Configure: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
 		}
-		assert.Equal(t, "configure:0", sf.FirstSetupStep())
+		assert.Equal(t, "configure:0", sf.FirstSetupStep().String())
 	})
 }
 
@@ -434,64 +526,71 @@ func TestSetupFlowNextSetupStep(t *testing.T) {
 		},
 	}
 
-	t.Run("preconnect:0 -> preconnect:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep("preconnect:0", false)
+	mustParse := func(t *testing.T, s string) SetupStep {
+		t.Helper()
+		v, err := ParseSetupStep(s)
 		require.NoError(t, err)
-		assert.Equal(t, "preconnect:1", next)
+		return v
+	}
+
+	t.Run("preconnect:0 -> preconnect:1", func(t *testing.T) {
+		next, err := sf.NextSetupStep(mustParse(t, "preconnect:0"), false)
+		require.NoError(t, err)
+		assert.Equal(t, "preconnect:1", next.String())
 	})
 
 	t.Run("preconnect:1 -> auth", func(t *testing.T) {
-		next, err := sf.NextSetupStep("preconnect:1", false)
+		next, err := sf.NextSetupStep(mustParse(t, "preconnect:1"), false)
 		require.NoError(t, err)
-		assert.Equal(t, "auth", next)
+		assert.True(t, next.Equals(SetupStepAuth))
 	})
 
 	t.Run("auth -> configure:0", func(t *testing.T) {
-		next, err := sf.NextSetupStep("auth", false)
+		next, err := sf.NextSetupStep(SetupStepAuth, false)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:0", next)
+		assert.Equal(t, "configure:0", next.String())
 	})
 
 	t.Run("auth -> verify when probes present", func(t *testing.T) {
-		next, err := sf.NextSetupStep("auth", true)
+		next, err := sf.NextSetupStep(SetupStepAuth, true)
 		require.NoError(t, err)
-		assert.Equal(t, "verify", next)
+		assert.True(t, next.Equals(SetupStepVerify))
 	})
 
 	t.Run("verify -> configure:0", func(t *testing.T) {
-		next, err := sf.NextSetupStep("verify", true)
+		next, err := sf.NextSetupStep(SetupStepVerify, true)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:0", next)
+		assert.Equal(t, "configure:0", next.String())
 	})
 
-	t.Run("verify with no configure -> empty (complete)", func(t *testing.T) {
+	t.Run("verify with no configure -> zero (complete)", func(t *testing.T) {
 		sfNoConfig := &SetupFlow{
 			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
 		}
-		next, err := sfNoConfig.NextSetupStep("verify", true)
+		next, err := sfNoConfig.NextSetupStep(SetupStepVerify, true)
 		require.NoError(t, err)
-		assert.Equal(t, "", next)
+		assert.True(t, next.IsZero())
 	})
 
 	t.Run("configure:0 -> configure:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep("configure:0", false)
+		next, err := sf.NextSetupStep(mustParse(t, "configure:0"), false)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:1", next)
+		assert.Equal(t, "configure:1", next.String())
 	})
 
-	t.Run("configure:1 -> empty (complete)", func(t *testing.T) {
-		next, err := sf.NextSetupStep("configure:1", false)
+	t.Run("configure:1 -> zero (complete)", func(t *testing.T) {
+		next, err := sf.NextSetupStep(mustParse(t, "configure:1"), false)
 		require.NoError(t, err)
-		assert.Equal(t, "", next)
+		assert.True(t, next.IsZero())
 	})
 
-	t.Run("auth with no configure -> empty (complete)", func(t *testing.T) {
+	t.Run("auth with no configure -> zero (complete)", func(t *testing.T) {
 		sfNoConfig := &SetupFlow{
 			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
 		}
-		next, err := sfNoConfig.NextSetupStep("auth", false)
+		next, err := sfNoConfig.NextSetupStep(SetupStepAuth, false)
 		require.NoError(t, err)
-		assert.Equal(t, "", next)
+		assert.True(t, next.IsZero())
 	})
 }
 
@@ -505,34 +604,41 @@ func TestSetupFlowGetStepBySetupStep(t *testing.T) {
 		},
 	}
 
+	mustParse := func(t *testing.T, s string) SetupStep {
+		t.Helper()
+		v, err := ParseSetupStep(s)
+		require.NoError(t, err)
+		return v
+	}
+
 	t.Run("preconnect:0", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep("preconnect:0")
+		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:0"))
 		require.NoError(t, err)
 		assert.Equal(t, "tenant", step.Id)
 		assert.Equal(t, 0, idx)
 	})
 
 	t.Run("preconnect:1", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep("preconnect:1")
+		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:1"))
 		require.NoError(t, err)
 		assert.Equal(t, "region", step.Id)
 		assert.Equal(t, 1, idx)
 	})
 
 	t.Run("configure:0 global index includes preconnect", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep("configure:0")
+		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "configure:0"))
 		require.NoError(t, err)
 		assert.Equal(t, "workspace", step.Id)
 		assert.Equal(t, 2, idx) // 2 preconnect steps before this
 	})
 
 	t.Run("out of range", func(t *testing.T) {
-		_, _, err := sf.GetStepBySetupStep("preconnect:5")
+		_, _, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:5"))
 		assert.Error(t, err)
 	})
 
-	t.Run("invalid step", func(t *testing.T) {
-		_, _, err := sf.GetStepBySetupStep("bad")
+	t.Run("rejects singleton phase", func(t *testing.T) {
+		_, _, err := sf.GetStepBySetupStep(SetupStepAuth)
 		assert.Error(t, err)
 	})
 }

--- a/internal/schema/connectors/setup_flow_test.go
+++ b/internal/schema/connectors/setup_flow_test.go
@@ -435,31 +435,52 @@ func TestSetupFlowNextSetupStep(t *testing.T) {
 	}
 
 	t.Run("preconnect:0 -> preconnect:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep("preconnect:0")
+		next, err := sf.NextSetupStep("preconnect:0", false)
 		require.NoError(t, err)
 		assert.Equal(t, "preconnect:1", next)
 	})
 
 	t.Run("preconnect:1 -> auth", func(t *testing.T) {
-		next, err := sf.NextSetupStep("preconnect:1")
+		next, err := sf.NextSetupStep("preconnect:1", false)
 		require.NoError(t, err)
 		assert.Equal(t, "auth", next)
 	})
 
 	t.Run("auth -> configure:0", func(t *testing.T) {
-		next, err := sf.NextSetupStep("auth")
+		next, err := sf.NextSetupStep("auth", false)
 		require.NoError(t, err)
 		assert.Equal(t, "configure:0", next)
 	})
 
+	t.Run("auth -> verify when probes present", func(t *testing.T) {
+		next, err := sf.NextSetupStep("auth", true)
+		require.NoError(t, err)
+		assert.Equal(t, "verify", next)
+	})
+
+	t.Run("verify -> configure:0", func(t *testing.T) {
+		next, err := sf.NextSetupStep("verify", true)
+		require.NoError(t, err)
+		assert.Equal(t, "configure:0", next)
+	})
+
+	t.Run("verify with no configure -> empty (complete)", func(t *testing.T) {
+		sfNoConfig := &SetupFlow{
+			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
+		}
+		next, err := sfNoConfig.NextSetupStep("verify", true)
+		require.NoError(t, err)
+		assert.Equal(t, "", next)
+	})
+
 	t.Run("configure:0 -> configure:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep("configure:0")
+		next, err := sf.NextSetupStep("configure:0", false)
 		require.NoError(t, err)
 		assert.Equal(t, "configure:1", next)
 	})
 
 	t.Run("configure:1 -> empty (complete)", func(t *testing.T) {
-		next, err := sf.NextSetupStep("configure:1")
+		next, err := sf.NextSetupStep("configure:1", false)
 		require.NoError(t, err)
 		assert.Equal(t, "", next)
 	})
@@ -468,7 +489,7 @@ func TestSetupFlowNextSetupStep(t *testing.T) {
 		sfNoConfig := &SetupFlow{
 			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
 		}
-		next, err := sfNoConfig.NextSetupStep("auth")
+		next, err := sfNoConfig.NextSetupStep("auth", false)
 		require.NoError(t, err)
 		assert.Equal(t, "", next)
 	})

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1777,7 +1777,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "description": "Retry a connection setup that ended in a terminal failure state. Applies to any setup-phase failure: an auth-phase failure such as an OAuth token-exchange error (auth_failed) or a probe failure during verify (verify_failed). Clears the recorded error and either returns to the first preconnect step (if the connector defines one, so the user can correct any input that led to the failure) or re-initiates the auth flow from scratch.",
                 "consumes": [
                     "application/json"
                 ],

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1443,6 +1443,55 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/connections/{id}/_cancel_setup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Abandon a reconfigure attempt on a ready connection by clearing setup_step and setup_error. The connection remains ready and its previously stored configuration continues to apply.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Cancel in-flight setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_data_source/{source_id}": {
             "get": {
                 "security": [

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1770,6 +1770,70 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/connections/{id}/_retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Retry connection setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Retry request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.RetryConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_setup_step": {
             "get": {
                 "security": [
@@ -6765,6 +6829,14 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.RetryConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "return_to_url": {
                     "type": "string"
                 }
             }

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1437,6 +1437,55 @@
                 }
             }
         },
+        "/connections/{id}/_cancel_setup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Abandon a reconfigure attempt on a ready connection by clearing setup_step and setup_error. The connection remains ready and its previously stored configuration continues to apply.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Cancel in-flight setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_data_source/{source_id}": {
             "get": {
                 "security": [

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1771,7 +1771,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "description": "Retry a connection setup that ended in a terminal failure state. Applies to any setup-phase failure: an auth-phase failure such as an OAuth token-exchange error (auth_failed) or a probe failure during verify (verify_failed). Clears the recorded error and either returns to the first preconnect step (if the connector defines one, so the user can correct any input that led to the failure) or re-initiates the auth flow from scratch.",
                 "consumes": [
                     "application/json"
                 ],

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1764,6 +1764,70 @@
                 }
             }
         },
+        "/connections/{id}/_retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Retry connection setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Retry request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.RetryConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_setup_step": {
             "get": {
                 "security": [
@@ -6759,6 +6823,14 @@
             "type": "object",
             "properties": {
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.RetryConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "return_to_url": {
                     "type": "string"
                 }
             }

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -289,6 +289,11 @@ definitions:
       value:
         type: string
     type: object
+  routes.RetryConnectionRequest:
+    properties:
+      return_to_url:
+        type: string
+    type: object
   routes.SubmitConnectionRequest:
     description: Form submission data
     properties:
@@ -2018,6 +2023,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Reconfigure connection
+      tags:
+      - connections
+  /connections/{id}/_retry:
+    post:
+      consumes:
+      - application/json
+      description: Retry a connection setup that failed during probe verification.
+        Clears the failure and either returns to the first preconnect step or re-initiates
+        OAuth.
+      parameters:
+      - description: Connection UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Retry request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.RetryConnectionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.InitiateConnectionForm'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Retry connection setup
       tags:
       - connections
   /connections/{id}/_setup_step:

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -1812,6 +1812,39 @@ paths:
       summary: Abort connection setup
       tags:
       - connections
+  /connections/{id}/_cancel_setup:
+    post:
+      description: Abandon a reconfigure attempt on a ready connection by clearing
+        setup_step and setup_error. The connection remains ready and its previously
+        stored configuration continues to apply.
+      parameters:
+      - description: Connection UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Cancel in-flight setup
+      tags:
+      - connections
   /connections/{id}/_data_source/{source_id}:
     get:
       description: Fetch dynamic options for a data source defined in the current

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -2029,9 +2029,12 @@ paths:
     post:
       consumes:
       - application/json
-      description: Retry a connection setup that failed during probe verification.
-        Clears the failure and either returns to the first preconnect step or re-initiates
-        OAuth.
+      description: 'Retry a connection setup that ended in a terminal failure state.
+        Applies to any setup-phase failure: an auth-phase failure such as an OAuth
+        token-exchange error (auth_failed) or a probe failure during verify (verify_failed).
+        Clears the recorded error and either returns to the first preconnect step
+        (if the connector defines one, so the user can correct any input that led
+        to the failure) or re-initiates the auth flow from scratch.'
       parameters:
       - description: Connection UUID
         in: path

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1770,6 +1770,70 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/connections/{id}/_retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Retry connection setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Retry request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.RetryConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_setup_step": {
             "get": {
                 "security": [
@@ -6765,6 +6829,14 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.RetryConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "return_to_url": {
                     "type": "string"
                 }
             }

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1443,6 +1443,55 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/connections/{id}/_cancel_setup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Abandon a reconfigure attempt on a ready connection by clearing setup_step and setup_error. The connection remains ready and its previously stored configuration continues to apply.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Cancel in-flight setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_data_source/{source_id}": {
             "get": {
                 "security": [

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1777,7 +1777,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "description": "Retry a connection setup that ended in a terminal failure state. Applies to any setup-phase failure: an auth-phase failure such as an OAuth token-exchange error (auth_failed) or a probe failure during verify (verify_failed). Clears the recorded error and either returns to the first preconnect step (if the connector defines one, so the user can correct any input that led to the failure) or re-initiates the auth flow from scratch.",
                 "consumes": [
                     "application/json"
                 ],

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1437,6 +1437,55 @@
                 }
             }
         },
+        "/connections/{id}/_cancel_setup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Abandon a reconfigure attempt on a ready connection by clearing setup_step and setup_error. The connection remains ready and its previously stored configuration continues to apply.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Cancel in-flight setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_data_source/{source_id}": {
             "get": {
                 "security": [

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1771,7 +1771,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "description": "Retry a connection setup that ended in a terminal failure state. Applies to any setup-phase failure: an auth-phase failure such as an OAuth token-exchange error (auth_failed) or a probe failure during verify (verify_failed). Clears the recorded error and either returns to the first preconnect step (if the connector defines one, so the user can correct any input that led to the failure) or re-initiates the auth flow from scratch.",
                 "consumes": [
                     "application/json"
                 ],

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1764,6 +1764,70 @@
                 }
             }
         },
+        "/connections/{id}/_retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a connection setup that failed during probe verification. Clears the failure and either returns to the first preconnect step or re-initiates OAuth.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Retry connection setup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Retry request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.RetryConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connections/{id}/_setup_step": {
             "get": {
                 "security": [
@@ -6759,6 +6823,14 @@
             "type": "object",
             "properties": {
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.RetryConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "return_to_url": {
                     "type": "string"
                 }
             }

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -289,6 +289,11 @@ definitions:
       value:
         type: string
     type: object
+  routes.RetryConnectionRequest:
+    properties:
+      return_to_url:
+        type: string
+    type: object
   routes.SubmitConnectionRequest:
     description: Form submission data
     properties:
@@ -2018,6 +2023,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Reconfigure connection
+      tags:
+      - connections
+  /connections/{id}/_retry:
+    post:
+      consumes:
+      - application/json
+      description: Retry a connection setup that failed during probe verification.
+        Clears the failure and either returns to the first preconnect step or re-initiates
+        OAuth.
+      parameters:
+      - description: Connection UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Retry request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.RetryConnectionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.InitiateConnectionForm'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Retry connection setup
       tags:
       - connections
   /connections/{id}/_setup_step:

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -1812,6 +1812,39 @@ paths:
       summary: Abort connection setup
       tags:
       - connections
+  /connections/{id}/_cancel_setup:
+    post:
+      description: Abandon a reconfigure attempt on a ready connection by clearing
+        setup_step and setup_error. The connection remains ready and its previously
+        stored configuration continues to apply.
+      parameters:
+      - description: Connection UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Cancel in-flight setup
+      tags:
+      - connections
   /connections/{id}/_data_source/{source_id}:
     get:
       description: Fetch dynamic options for a data source defined in the current

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -2029,9 +2029,12 @@ paths:
     post:
       consumes:
       - application/json
-      description: Retry a connection setup that failed during probe verification.
-        Clears the failure and either returns to the first preconnect step or re-initiates
-        OAuth.
+      description: 'Retry a connection setup that ended in a terminal failure state.
+        Applies to any setup-phase failure: an auth-phase failure such as an OAuth
+        token-exchange error (auth_failed) or a probe failure during verify (verify_failed).
+        Clears the recorded error and either returns to the first preconnect step
+        (if the connector defines one, so the user can correct any input that led
+        to the failure) or re-initiates the auth flow from scratch.'
       parameters:
       - description: Connection UUID
         in: path

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -320,6 +320,14 @@ export const reconfigureConnection = (id: string) => {
 };
 
 /**
+ * Cancel an in-flight reconfigure on a ready connection by clearing setup_step and setup_error.
+ * The connection remains ready and its previously stored configuration continues to apply.
+ */
+export const cancelSetupConnection = (id: string) => {
+    return client.post<void>(`/api/v1/connections/${id}/_cancel_setup`);
+};
+
+/**
  * Retry a connection that failed during probe verification. For connectors with preconnect steps,
  * returns to preconnect:0 so the user can correct inputs. For connectors without preconnect steps,
  * re-initiates OAuth (return_to_url is required in that case).
@@ -344,6 +352,7 @@ export const connections = {
     getSetupStep: getSetupStep,
     getDataSource: getDataSource,
     reconfigure: reconfigureConnection,
+    cancelSetup: cancelSetupConnection,
     retry: retryConnection,
     getLabels: getConnectionLabels,
     getLabel: getConnectionLabel,

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -40,6 +40,7 @@ export interface Connection {
     connector: Connector;
     state: ConnectionState;
     setup_step?: string;
+    setup_error?: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
     created_at: string;
@@ -64,6 +65,8 @@ export enum InitiateConnectionResponseType {
     REDIRECT = 'redirect',
     FORM = 'form',
     COMPLETE = 'complete',
+    VERIFYING = 'verifying',
+    ERROR = 'error',
 }
 
 export interface InitiateConnectionResponse {
@@ -91,6 +94,16 @@ export interface InitiateConnectionCompleteResponse extends InitiateConnectionRe
     type: InitiateConnectionResponseType.COMPLETE;
 }
 
+export interface InitiateConnectionVerifyingResponse extends InitiateConnectionResponse {
+    type: InitiateConnectionResponseType.VERIFYING;
+}
+
+export interface InitiateConnectionErrorResponse extends InitiateConnectionResponse {
+    type: InitiateConnectionResponseType.ERROR;
+    error: string;
+    can_retry: boolean;
+}
+
 export function isRedirectResponse(response: InitiateConnectionResponse): response is InitiateConnectionRedirectResponse {
     return response.type === InitiateConnectionResponseType.REDIRECT;
 }
@@ -103,9 +116,21 @@ export function isCompleteResponse(response: InitiateConnectionResponse): respon
     return response.type === InitiateConnectionResponseType.COMPLETE;
 }
 
+export function isVerifyingResponse(response: InitiateConnectionResponse): response is InitiateConnectionVerifyingResponse {
+    return response.type === InitiateConnectionResponseType.VERIFYING;
+}
+
+export function isErrorResponse(response: InitiateConnectionResponse): response is InitiateConnectionErrorResponse {
+    return response.type === InitiateConnectionResponseType.ERROR;
+}
+
 export interface SubmitConnectionRequest {
     step_id: string;
     data: unknown;
+}
+
+export interface RetryConnectionRequest {
+    return_to_url?: string;
 }
 
 export interface DataSourceOption {
@@ -294,6 +319,19 @@ export const reconfigureConnection = (id: string) => {
     return client.post<InitiateConnectionResponse>(`/api/v1/connections/${id}/_reconfigure`);
 };
 
+/**
+ * Retry a connection that failed during probe verification. For connectors with preconnect steps,
+ * returns to preconnect:0 so the user can correct inputs. For connectors without preconnect steps,
+ * re-initiates OAuth (return_to_url is required in that case).
+ */
+export const retryConnection = (id: string, returnToUrl?: string) => {
+    const request: RetryConnectionRequest = { return_to_url: returnToUrl };
+    return client.post<InitiateConnectionResponse>(
+        `/api/v1/connections/${id}/_retry`,
+        request
+    );
+};
+
 export const connections = {
     list: listConnections,
     get: getConnection,
@@ -306,6 +344,7 @@ export const connections = {
     getSetupStep: getSetupStep,
     getDataSource: getDataSource,
     reconfigure: reconfigureConnection,
+    retry: retryConnection,
     getLabels: getConnectionLabels,
     getLabel: getConnectionLabel,
     putLabel: putConnectionLabel,

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -13,7 +13,7 @@ import {
   DialogTitle,
   DialogContent,
 } from '@mui/material';
-import { isRedirectResponse } from '@authproxy/api';
+import { ConnectionState, isRedirectResponse } from '@authproxy/api';
 import {
   selectConnections,
   selectConnectionsStatus,
@@ -32,6 +32,7 @@ import {
   selectRetryingConnection,
   retryConnectionAsync,
   abortConnectionAsync,
+  cancelSetupConnectionAsync,
   clearVerifyState,
 } from '../store';
 import ConnectionCard, { ConnectionCardSkeleton } from './ConnectionCard';
@@ -110,8 +111,18 @@ const ConnectionList: React.FC = () => {
   }, [dispatch, currentFormStep]);
 
   const handleFormCancel = useCallback(() => {
+    const connectionId = currentFormStep?.connectionId;
+    const conn = connectionId
+      ? connections.find((c) => c.id === connectionId)
+      : undefined;
+    // If the connection is already ready, the form is from a reconfigure flow.
+    // Clearing the form step alone leaves setup_step=configure:0 on the server,
+    // so the dialog reappears on next load — call cancel_setup to clear it server-side.
+    if (conn && conn.state === ConnectionState.READY) {
+      dispatch(cancelSetupConnectionAsync(conn.id));
+    }
     dispatch(clearFormStep());
-  }, [dispatch]);
+  }, [dispatch, currentFormStep, connections]);
 
   const handleRetryVerify = useCallback(() => {
     if (!verifyError) return;

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -7,7 +7,9 @@ import {
   Alert,
   Box,
   Button,
+  CircularProgress,
   Dialog,
+  DialogActions,
   DialogTitle,
   DialogContent,
 } from '@mui/material';
@@ -25,6 +27,12 @@ import {
   submitConnectionFormAsync,
   getSetupStepAsync,
   clearFormStep,
+  selectVerifyingConnectionId,
+  selectVerifyError,
+  selectRetryingConnection,
+  retryConnectionAsync,
+  abortConnectionAsync,
+  clearVerifyState,
 } from '../store';
 import ConnectionCard, { ConnectionCardSkeleton } from './ConnectionCard';
 import ConnectionFormStep from './ConnectionFormStep';
@@ -45,6 +53,9 @@ const ConnectionList: React.FC = () => {
   const currentFormStep = useSelector(selectCurrentFormStep);
   const isSubmittingForm = useSelector(selectSubmittingForm);
   const formSubmitError = useSelector(selectFormSubmitError);
+  const verifyingConnectionId = useSelector(selectVerifyingConnectionId);
+  const verifyError = useSelector(selectVerifyError);
+  const isRetrying = useSelector(selectRetryingConnection);
 
   useEffect(() => {
     if (status === 'idle') {
@@ -71,6 +82,18 @@ const ConnectionList: React.FC = () => {
     }
   }, [searchParams, setSearchParams, dispatch]);
 
+  // Poll the setup-step endpoint while probes are running so the UI can advance to the
+  // next setup step (or surface a failure) as soon as the background task completes.
+  useEffect(() => {
+    if (!verifyingConnectionId) {
+      return;
+    }
+    const interval = window.setInterval(() => {
+      dispatch(getSetupStepAsync(verifyingConnectionId));
+    }, 2000);
+    return () => window.clearInterval(interval);
+  }, [verifyingConnectionId, dispatch]);
+
   const handleFormSubmit = useCallback((connectionId: string, data: unknown) => {
     const stepId = currentFormStep?.stepId ?? '';
     dispatch(submitConnectionFormAsync({ connectionId, stepId, data })).then((action) => {
@@ -89,6 +112,29 @@ const ConnectionList: React.FC = () => {
   const handleFormCancel = useCallback(() => {
     dispatch(clearFormStep());
   }, [dispatch]);
+
+  const handleRetryVerify = useCallback(() => {
+    if (!verifyError) return;
+    dispatch(retryConnectionAsync({
+      connectionId: verifyError.connectionId,
+      returnToUrl: window.location.href,
+    })).then((action) => {
+      if (action.meta.requestStatus === 'fulfilled') {
+        const response = action.payload as { type: string; redirect_url?: string };
+        if (response.type === 'redirect' && response.redirect_url) {
+          window.location.href = response.redirect_url;
+        }
+      }
+    });
+  }, [dispatch, verifyError]);
+
+  const handleCancelVerifyError = useCallback(() => {
+    if (!verifyError) return;
+    dispatch(abortConnectionAsync(verifyError.connectionId)).then(() => {
+      dispatch(clearVerifyState());
+      dispatch(fetchConnectionsAsync());
+    });
+  }, [dispatch, verifyError]);
 
   let content;
 
@@ -180,6 +226,42 @@ const ConnectionList: React.FC = () => {
             />
           )}
         </DialogContent>
+      </Dialog>
+
+      <Dialog open={verifyingConnectionId !== null} maxWidth="xs" fullWidth>
+        <DialogTitle>Verifying connection</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}>
+            <CircularProgress size={24} />
+            <Typography variant="body1">
+              Checking that your credentials work with the provider…
+            </Typography>
+          </Box>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={verifyError !== null} onClose={handleCancelVerifyError} maxWidth="sm" fullWidth>
+        <DialogTitle>Connection verification failed</DialogTitle>
+        <DialogContent>
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {verifyError?.message ?? 'Verification failed'}
+          </Alert>
+          <Typography variant="body2" color="text.secondary">
+            {verifyError?.canRetry
+              ? 'You can retry the setup or cancel to delete this connection.'
+              : 'Please cancel and try again from scratch.'}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelVerifyError} disabled={isRetrying}>
+            Cancel
+          </Button>
+          {verifyError?.canRetry && (
+            <Button onClick={handleRetryVerify} disabled={isRetrying} variant="contained">
+              {isRetrying ? 'Retrying…' : 'Retry'}
+            </Button>
+          )}
+        </DialogActions>
       </Dialog>
     </Container>
   );

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -6,7 +6,10 @@ import {
     ConnectionState,
     DisconnectResponseJson,
     InitiateConnectionFormResponse,
+    InitiateConnectionResponse,
+    isErrorResponse,
     isFormResponse,
+    isVerifyingResponse,
     ListConnectionsParams,
 } from '@authproxy/api';
 
@@ -34,6 +37,45 @@ function formStepFromResponse(response: InitiateConnectionFormResponse): FormSte
     };
 }
 
+// applySetupResponse updates state based on a setup-step response. Verifying responses
+// set the polling marker; error responses populate verifyError; form responses populate
+// currentFormStep; redirect and complete clear the in-flight setup UI.
+function applySetupResponse(state: ConnectionsState, response: InitiateConnectionResponse): void {
+    if (isFormResponse(response)) {
+        state.currentFormStep = formStepFromResponse(response);
+        state.verifyingConnectionId = null;
+        state.verifyError = null;
+        return;
+    }
+    if (isVerifyingResponse(response)) {
+        state.verifyingConnectionId = response.id;
+        state.currentFormStep = null;
+        state.verifyError = null;
+        return;
+    }
+    if (isErrorResponse(response)) {
+        state.verifyError = {
+            connectionId: response.id,
+            message: response.error,
+            canRetry: response.can_retry,
+        };
+        state.verifyingConnectionId = null;
+        state.currentFormStep = null;
+        return;
+    }
+
+    // Redirect or complete — clear in-flight UI.
+    state.currentFormStep = null;
+    state.verifyingConnectionId = null;
+    state.verifyError = null;
+}
+
+interface VerifyError {
+    connectionId: string;
+    message: string;
+    canRetry: boolean;
+}
+
 interface ConnectionsState {
     items: Connection[];
     status: 'idle' | 'loading' | 'succeeded' | 'failed';
@@ -46,6 +88,9 @@ interface ConnectionsState {
     currentFormStep: FormStep | null;
     submittingForm: boolean;
     formSubmitError: string | null;
+    verifyingConnectionId: string | null;
+    verifyError: VerifyError | null;
+    retryingConnection: boolean;
 }
 
 const initialState: ConnectionsState = {
@@ -60,6 +105,9 @@ const initialState: ConnectionsState = {
     currentFormStep: null,
     submittingForm: false,
     formSubmitError: null,
+    verifyingConnectionId: null,
+    verifyError: null,
+    retryingConnection: false,
 };
 
 export const fetchConnectionsAsync = createAsyncThunk(
@@ -125,6 +173,14 @@ export const reconfigureConnectionAsync = createAsyncThunk(
     }
 );
 
+export const retryConnectionAsync = createAsyncThunk(
+    'connections/retryConnection',
+    async ({connectionId, returnToUrl}: { connectionId: string, returnToUrl?: string }) => {
+        const response = await connections.retry(connectionId, returnToUrl);
+        return response.data;
+    }
+);
+
 export const disconnectConnectionAsync = createAsyncThunk(
     'connections/disconnectConnection',
     async (connectionId: string, _): Promise<DisconnectResponseJson> => {
@@ -148,6 +204,10 @@ export const connectionsSlice = createSlice({
             state.currentFormStep = null;
             state.formSubmitError = null;
         },
+        clearVerifyState: (state) => {
+            state.verifyingConnectionId = null;
+            state.verifyError = null;
+        },
     },
     extraReducers: (builder) => {
         builder
@@ -169,13 +229,12 @@ export const connectionsSlice = createSlice({
                 state.initiatingConnection = true;
                 state.initiationError = null;
                 state.currentFormStep = null;
+                state.verifyingConnectionId = null;
+                state.verifyError = null;
             })
             .addCase(initiateConnectionAsync.fulfilled, (state, action) => {
                 state.initiatingConnection = false;
-                const response = action.payload;
-                if (isFormResponse(response)) {
-                    state.currentFormStep = formStepFromResponse(response);
-                }
+                applySetupResponse(state, action.payload);
             })
             .addCase(initiateConnectionAsync.rejected, (state, action) => {
                 state.initiatingConnection = false;
@@ -189,12 +248,7 @@ export const connectionsSlice = createSlice({
             })
             .addCase(submitConnectionFormAsync.fulfilled, (state, action) => {
                 state.submittingForm = false;
-                const response = action.payload;
-                if (isFormResponse(response)) {
-                    state.currentFormStep = formStepFromResponse(response);
-                } else {
-                    state.currentFormStep = null;
-                }
+                applySetupResponse(state, action.payload);
             })
             .addCase(submitConnectionFormAsync.rejected, (state, action) => {
                 state.submittingForm = false;
@@ -204,15 +258,14 @@ export const connectionsSlice = createSlice({
             // Abort connection
             .addCase(abortConnectionAsync.fulfilled, (state, action) => {
                 state.currentFormStep = null;
+                state.verifyingConnectionId = null;
+                state.verifyError = null;
                 state.items = state.items.filter(conn => conn.id !== action.payload);
             })
 
-            // Get setup step (resume)
+            // Get setup step (resume / verify polling)
             .addCase(getSetupStepAsync.fulfilled, (state, action) => {
-                const response = action.payload;
-                if (isFormResponse(response)) {
-                    state.currentFormStep = formStepFromResponse(response);
-                }
+                applySetupResponse(state, action.payload);
             })
 
             // Reconfigure connection
@@ -222,14 +275,25 @@ export const connectionsSlice = createSlice({
             })
             .addCase(reconfigureConnectionAsync.fulfilled, (state, action) => {
                 state.initiatingConnection = false;
-                const response = action.payload;
-                if (isFormResponse(response)) {
-                    state.currentFormStep = formStepFromResponse(response);
-                }
+                applySetupResponse(state, action.payload);
             })
             .addCase(reconfigureConnectionAsync.rejected, (state, action) => {
                 state.initiatingConnection = false;
                 state.initiationError = action.error.message || 'Failed to reconfigure connection';
+            })
+
+            // Retry connection
+            .addCase(retryConnectionAsync.pending, (state) => {
+                state.retryingConnection = true;
+                state.verifyError = null;
+            })
+            .addCase(retryConnectionAsync.fulfilled, (state, action) => {
+                state.retryingConnection = false;
+                applySetupResponse(state, action.payload);
+            })
+            .addCase(retryConnectionAsync.rejected, (state, action) => {
+                state.retryingConnection = false;
+                state.initiationError = action.error.message || 'Failed to retry connection';
             })
 
             // Disconnect connection
@@ -254,7 +318,7 @@ export const connectionsSlice = createSlice({
     },
 });
 
-export const {clearInitiationError, clearDisconnectionError, clearFormStep} = connectionsSlice.actions;
+export const {clearInitiationError, clearDisconnectionError, clearFormStep, clearVerifyState} = connectionsSlice.actions;
 
 // Selectors
 export const selectConnections = (state: RootState) => state.connections.items;
@@ -269,6 +333,10 @@ export const selectCurrentTaskId = (state: RootState) => state.connections.curre
 export const selectCurrentFormStep = (state: RootState) => state.connections.currentFormStep;
 export const selectSubmittingForm = (state: RootState) => state.connections.submittingForm;
 export const selectFormSubmitError = (state: RootState) => state.connections.formSubmitError;
+
+export const selectVerifyingConnectionId = (state: RootState) => state.connections.verifyingConnectionId;
+export const selectVerifyError = (state: RootState) => state.connections.verifyError;
+export const selectRetryingConnection = (state: RootState) => state.connections.retryingConnection;
 
 // Helper selectors
 export const selectActiveConnections = (state: RootState) =>

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -157,6 +157,14 @@ export const abortConnectionAsync = createAsyncThunk(
     }
 );
 
+export const cancelSetupConnectionAsync = createAsyncThunk(
+    'connections/cancelSetupConnection',
+    async (connectionId: string) => {
+        await connections.cancelSetup(connectionId);
+        return connectionId;
+    }
+);
+
 export const getSetupStepAsync = createAsyncThunk(
     'connections/getSetupStep',
     async (connectionId: string) => {
@@ -261,6 +269,21 @@ export const connectionsSlice = createSlice({
                 state.verifyingConnectionId = null;
                 state.verifyError = null;
                 state.items = state.items.filter(conn => conn.id !== action.payload);
+            })
+
+            // Cancel setup (reconfigure abandonment on a ready connection)
+            .addCase(cancelSetupConnectionAsync.fulfilled, (state, action) => {
+                state.currentFormStep = null;
+                state.verifyingConnectionId = null;
+                state.verifyError = null;
+                const idx = state.items.findIndex(c => c.id === action.payload);
+                if (idx !== -1) {
+                    state.items[idx] = {
+                        ...state.items[idx],
+                        setup_step: undefined,
+                        setup_error: undefined,
+                    };
+                }
             })
 
             // Get setup step (resume / verify polling)

--- a/ui/marketplace/src/tests/ConnectionList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionList.test.tsx
@@ -50,21 +50,28 @@ const makeConnection = (overrides: Partial<Connection> = {}): Connection => ({
 });
 
 describe('ConnectionList', () => {
+    const baseConnectionsState = {
+        initiatingConnection: false,
+        initiationError: null,
+        disconnectingConnection: false,
+        disconnectionError: null,
+        currentTaskId: null,
+        currentFormStep: null,
+        submittingForm: false,
+        formSubmitError: null,
+        verifyingConnectionId: null,
+        verifyError: null,
+        retryingConnection: false,
+    };
+
     test('renders skeletons when loading', () => {
         const store = createStore({
             connectors: {items: [], status: 'succeeded', error: null},
             connections: {
+                ...baseConnectionsState,
                 items: [],
                 status: 'loading',
                 error: null,
-                initiatingConnection: false,
-                initiationError: null,
-                disconnectingConnection: false,
-                disconnectionError: null,
-                currentTaskId: null,
-                currentFormStep: null,
-                submittingForm: false,
-                formSubmitError: null,
             },
             toasts: {items: []},
         });
@@ -84,17 +91,10 @@ describe('ConnectionList', () => {
         const store = createStore({
             connectors: {items: [], status: 'succeeded', error: null},
             connections: {
+                ...baseConnectionsState,
                 items: [],
                 status: 'failed',
                 error: 'Failed to fetch connections',
-                initiatingConnection: false,
-                initiationError: null,
-                disconnectingConnection: false,
-                disconnectionError: null,
-                currentTaskId: null,
-                currentFormStep: null,
-                submittingForm: false,
-                formSubmitError: null,
             },
             toasts: {items: []},
         });
@@ -114,17 +114,10 @@ describe('ConnectionList', () => {
         const store = createStore({
             connectors: {items: [], status: 'succeeded', error: null},
             connections: {
+                ...baseConnectionsState,
                 items: [],
                 status: 'succeeded',
                 error: null,
-                initiatingConnection: false,
-                initiationError: null,
-                disconnectingConnection: false,
-                disconnectionError: null,
-                currentTaskId: null,
-                currentFormStep: null,
-                submittingForm: false,
-                formSubmitError: null,
             },
             toasts: {items: []},
         });
@@ -146,17 +139,10 @@ describe('ConnectionList', () => {
         const store = createStore({
             connectors: {items: [connector], status: 'succeeded', error: null},
             connections: {
+                ...baseConnectionsState,
                 items,
                 status: 'succeeded',
                 error: null,
-                initiatingConnection: false,
-                initiationError: null,
-                disconnectingConnection: false,
-                disconnectionError: null,
-                currentTaskId: null,
-                currentFormStep: null,
-                submittingForm: false,
-                formSubmitError: null,
             },
             toasts: {items: []},
         });


### PR DESCRIPTION
## Summary
- Adds a verify phase to the setup flow that runs connector probes against the 3rd party after authentication and before configure
- Introduces a `verify_failed` pseudo-step plus a `setup_error` column so failed probes surface a dedicated error screen with retry/cancel options
- Wires the new phase end-to-end: DB migration, schema, core service + iface, OAuth2 callback, JS SDK, marketplace UI (verifying spinner + error dialog), and a `/connections/{id}/_retry` endpoint

Closes #141

## Test plan
- [x] `go test ./...` passes for changed packages
- [x] `yarn workspace @authproxy/marketplace run test` — 12/12 pass
- [x] `./scripts/preflight.sh` passes (swagger up to date, integration_tests module clean)
- [ ] Manual: connector with probes → success path advances to configure (or ready)
- [ ] Manual: connector with probes → forced failure shows error dialog with retry/cancel
- [ ] Manual: retry after verify_failed restarts at preconnect:0 (or re-initiates auth when no preconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)