### PR TITLE
Cross-validate mustache references in connector definitions

### DIFF
--- a/internal/aptmpl/mustache.go
+++ b/internal/aptmpl/mustache.go
@@ -19,3 +19,43 @@ func ContainsMustache(s string) bool {
 	}
 	return false
 }
+
+// ExtractVariables parses the template and returns the de-duplicated list of variable
+// names referenced by it (including dotted paths like "cfg.tenant"). Section and inverted
+// section tags are included alongside variable tags. Returns an error if the template is
+// malformed.
+func ExtractVariables(template string) ([]string, error) {
+	if !ContainsMustache(template) {
+		return nil, nil
+	}
+
+	tmpl, err := mustache.ParseString(template)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+	collectTagNames(tmpl.Tags(), seen, &out)
+	return out, nil
+}
+
+func collectTagNames(tags []mustache.Tag, seen map[string]struct{}, out *[]string) {
+	for _, t := range tags {
+		switch t.Type() {
+		case mustache.Variable:
+			name := t.Name()
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				*out = append(*out, name)
+			}
+		case mustache.Section, mustache.InvertedSection:
+			name := t.Name()
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				*out = append(*out, name)
+			}
+			collectTagNames(t.Tags(), seen, out)
+		}
+	}
+}

--- a/internal/aptmpl/mustache_test.go
+++ b/internal/aptmpl/mustache_test.go
@@ -71,3 +71,58 @@ func TestContainsMustache(t *testing.T) {
 	assert.False(t, ContainsMustache("{not mustache}"))
 	assert.False(t, ContainsMustache("{ {spaced} }"))
 }
+
+func TestExtractVariables(t *testing.T) {
+	t.Run("plain string returns nil", func(t *testing.T) {
+		vars, err := ExtractVariables("https://example.com/api")
+		require.NoError(t, err)
+		assert.Nil(t, vars)
+	})
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		vars, err := ExtractVariables("")
+		require.NoError(t, err)
+		assert.Nil(t, vars)
+	})
+
+	t.Run("single variable", func(t *testing.T) {
+		vars, err := ExtractVariables("https://{{tenant}}.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tenant"}, vars)
+	})
+
+	t.Run("dotted path", func(t *testing.T) {
+		vars, err := ExtractVariables("https://{{cfg.tenant}}.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cfg.tenant"}, vars)
+	})
+
+	t.Run("multiple variables", func(t *testing.T) {
+		vars, err := ExtractVariables("{{cfg.tenant}}.{{cfg.region}}.example.com/{{labels.env}}")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"cfg.tenant", "cfg.region", "labels.env"}, vars)
+	})
+
+	t.Run("deduplicates repeated references", func(t *testing.T) {
+		vars, err := ExtractVariables("{{cfg.tenant}}.{{cfg.tenant}}.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cfg.tenant"}, vars)
+	})
+
+	t.Run("walks section tags", func(t *testing.T) {
+		vars, err := ExtractVariables("{{#cfg.flag}}{{cfg.tenant}}{{/cfg.flag}}")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"cfg.flag", "cfg.tenant"}, vars)
+	})
+
+	t.Run("walks inverted section tags", func(t *testing.T) {
+		vars, err := ExtractVariables("{{^cfg.flag}}{{cfg.fallback}}{{/cfg.flag}}")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"cfg.flag", "cfg.fallback"}, vars)
+	})
+
+	t.Run("malformed template returns error", func(t *testing.T) {
+		_, err := ExtractVariables("{{unclosed")
+		require.Error(t, err)
+	})
+}

--- a/internal/schema/connectors/auth_oauth2.go
+++ b/internal/schema/connectors/auth_oauth2.go
@@ -1,6 +1,7 @@
 package connectors
 
 import (
+	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
@@ -17,6 +18,47 @@ type AuthOAuth2 struct {
 func (a *AuthOAuth2) GetType() AuthType {
 	return AuthTypeOAuth2
 }
+
+// ValidateMustacheReferences cross-checks every templated field on the OAuth2 auth
+// definition against the field-availability data in mctx. Authorization and Token
+// templates render during the auth phase and may only reference preconnect fields;
+// Revocation templates render after setup completes and may reference any cfg field.
+func (a *AuthOAuth2) ValidateMustacheReferences(vc *common.ValidationContext, mctx *MustacheValidationContext) error {
+	if a == nil || mctx == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+	preconnectFields := mctx.PreconnectFields
+	allConfigFields := mctx.AllConfigFields
+
+	checkMustacheTemplate(vc.PushField("authorization").PushField("endpoint"), a.Authorization.Endpoint, preconnectFields, "preconnect", result)
+	for k, v := range a.Authorization.QueryOverrides {
+		checkMustacheTemplate(vc.PushField("authorization").PushField("query_overrides").PushField(k), v, preconnectFields, "preconnect", result)
+	}
+
+	checkMustacheTemplate(vc.PushField("token").PushField("endpoint"), a.Token.Endpoint, preconnectFields, "preconnect", result)
+	for k, v := range a.Token.QueryOverrides {
+		checkMustacheTemplate(vc.PushField("token").PushField("query_overrides").PushField(k), v, preconnectFields, "preconnect", result)
+	}
+	for k, v := range a.Token.FormOverrides {
+		checkMustacheTemplate(vc.PushField("token").PushField("form_overrides").PushField(k), v, preconnectFields, "preconnect", result)
+	}
+
+	if a.Revocation != nil {
+		checkMustacheTemplate(vc.PushField("revocation").PushField("endpoint"), a.Revocation.Endpoint, allConfigFields, "setup flow", result)
+		for k, v := range a.Revocation.QueryOverrides {
+			checkMustacheTemplate(vc.PushField("revocation").PushField("query_overrides").PushField(k), v, allConfigFields, "setup flow", result)
+		}
+		for k, v := range a.Revocation.FormOverrides {
+			checkMustacheTemplate(vc.PushField("revocation").PushField("form_overrides").PushField(k), v, allConfigFields, "setup flow", result)
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+var _ MustacheValidator = (*AuthOAuth2)(nil)
 
 func (a *AuthOAuth2) Clone() AuthImpl {
 	if a == nil {

--- a/internal/schema/connectors/connector.go
+++ b/internal/schema/connectors/connector.go
@@ -144,6 +144,10 @@ func (c *Connector) Validate(vc *common.ValidationContext) error {
 		}
 	}
 
+	if err := c.validateMustacheReferences(vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	return result.ErrorOrNil()
 }
 

--- a/internal/schema/connectors/connectors_mustache_validation.go
+++ b/internal/schema/connectors/connectors_mustache_validation.go
@@ -1,0 +1,96 @@
+package connectors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/aptmpl"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// cfgPrefix is the mustache namespace for fields collected during setup flow forms
+// and stored on the connection as Configuration. References like {{cfg.tenant}} resolve
+// from this map at render time.
+const cfgPrefix = "cfg."
+
+// validateMustacheReferences orchestrates per-field mustache cross-validation across
+// the connector. It computes the cfg.X field sets available at each lifecycle point
+// and delegates to the validators that live next to the templated fields themselves
+// (AuthOAuth2.ValidateMustacheReferences, DataSourceProxyRequest.ValidateMustacheReferences).
+//
+// {{labels.X}} and {{annotations.X}} references are not validated since those are set
+// freely on each connection and are not constrained by the connector definition.
+func (c *Connector) validateMustacheReferences(vc *common.ValidationContext) error {
+	if c == nil || c.Auth == nil {
+		return nil
+	}
+
+	mctx := NewMustacheValidationContext(c.SetupFlow)
+	result := &multierror.Error{}
+
+	if v, ok := c.Auth.Inner().(MustacheValidator); ok {
+		if err := v.ValidateMustacheReferences(vc.PushField("auth"), mctx); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if c.SetupFlow != nil && c.SetupFlow.Configure != nil {
+		for stepIdx, step := range c.SetupFlow.Configure.Steps {
+			if len(step.DataSources) == 0 {
+				continue
+			}
+			stepVc := vc.PushField("setup_flow").PushField("configure").PushField("steps").PushIndex(stepIdx).PushField("data_sources")
+			for name, ds := range step.DataSources {
+				if err := ds.ProxyRequest.ValidateMustacheReferences(stepVc.PushField(name).PushField("proxy_request"), mctx, stepIdx); err != nil {
+					result = multierror.Append(result, err)
+				}
+			}
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+// checkMustacheTemplate parses the template, extracts cfg references, and reports any
+// missing fields against the provided available-set with the given scope description.
+// Used by the per-struct ValidateMustacheReferences methods.
+func checkMustacheTemplate(vc *common.ValidationContext, template string, available map[string]bool, scope string, result *multierror.Error) {
+	if template == "" {
+		return
+	}
+	vars, err := aptmpl.ExtractVariables(template)
+	if err != nil {
+		*result = *multierror.Append(result, vc.NewErrorf("invalid mustache template: %s", err.Error()))
+		return
+	}
+	for _, v := range vars {
+		if !strings.HasPrefix(v, cfgPrefix) {
+			continue
+		}
+		field := strings.TrimPrefix(v, cfgPrefix)
+		// Only validate the top-level field; nested paths like cfg.foo.bar still require
+		// "foo" to be declared by the setup flow.
+		root := field
+		if idx := strings.IndexByte(field, '.'); idx >= 0 {
+			root = field[:idx]
+		}
+		if root == "" {
+			*result = *multierror.Append(result, vc.NewErrorf("mustache reference %q has empty cfg field name", "{{"+v+"}}"))
+			continue
+		}
+		if !available[root] {
+			*result = *multierror.Append(result, vc.NewErrorf(
+				"mustache reference %q has no matching field in %s of the setup flow",
+				"{{"+v+"}}", scope,
+			))
+		}
+	}
+}
+
+func configureScopeLabel(stepIdx int) string {
+	if stepIdx == 0 {
+		return "preconnect"
+	}
+	return fmt.Sprintf("preconnect or configure steps before index %d", stepIdx)
+}

--- a/internal/schema/connectors/connectors_mustache_validation_test.go
+++ b/internal/schema/connectors/connectors_mustache_validation_test.go
@@ -1,0 +1,342 @@
+package connectors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newOAuthConnector(oauth *AuthOAuth2, sf *SetupFlow) *Connector {
+	return &Connector{
+		Labels:      map[string]string{"type": "test"},
+		DisplayName: "Test",
+		Description: "Test",
+		Auth:        &Auth{InnerVal: oauth},
+		SetupFlow:   sf,
+	}
+}
+
+func preconnectFlow(jsonSchema string) *SetupFlow {
+	return &SetupFlow{
+		Preconnect: &SetupFlowPhase{
+			Steps: []SetupFlowStep{
+				{
+					Id:         "preconnect-1",
+					JsonSchema: common.RawJSON(jsonSchema),
+				},
+			},
+		},
+	}
+}
+
+func configureFlow(jsonSchema string) *SetupFlow {
+	return &SetupFlow{
+		Configure: &SetupFlowPhase{
+			Steps: []SetupFlowStep{
+				{
+					Id:         "configure-1",
+					JsonSchema: common.RawJSON(jsonSchema),
+				},
+			},
+		},
+	}
+}
+
+func TestValidateMustacheReferences_OAuthAuthorization(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("authorization endpoint cfg ref present in preconnect", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://{{cfg.tenant}}.example.com/oauth/authorize",
+			},
+		}, preconnectFlow(`{"type":"object","properties":{"tenant":{"type":"string"}}}`))
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("authorization endpoint cfg ref missing entirely", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://{{cfg.tenant}}.example.com/oauth/authorize",
+			},
+		}, nil)
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth.authorization.endpoint")
+		assert.Contains(t, err.Error(), "{{cfg.tenant}}")
+		assert.Contains(t, err.Error(), "preconnect")
+	})
+
+	t.Run("authorization endpoint cfg ref defined only in configure errors", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://{{cfg.tenant}}.example.com/oauth/authorize",
+			},
+		}, configureFlow(`{"type":"object","properties":{"tenant":{"type":"string"}}}`))
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "{{cfg.tenant}}")
+		assert.Contains(t, err.Error(), "preconnect")
+	})
+
+	t.Run("authorization query overrides validated against preconnect", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://example.com/authorize",
+				QueryOverrides: map[string]string{
+					"resource": "https://{{cfg.tenant}}.example.com/api",
+				},
+			},
+		}, nil)
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth.authorization.query_overrides.resource")
+	})
+
+	t.Run("static endpoint with no setup flow is fine", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://example.com/authorize",
+			},
+		}, nil)
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("labels and annotations refs are not validated", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://{{labels.env}}.{{annotations.region}}.example.com/authorize",
+			},
+		}, nil)
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+}
+
+func TestValidateMustacheReferences_OAuthToken(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("token endpoint requires preconnect cfg", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Token: AuthOauth2Token{
+				Endpoint: "https://{{cfg.tenant}}.example.com/oauth/token",
+			},
+		}, configureFlow(`{"type":"object","properties":{"tenant":{"type":"string"}}}`))
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth.token.endpoint")
+	})
+
+	t.Run("token form overrides validated against preconnect", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Token: AuthOauth2Token{
+				Endpoint: "https://example.com/token",
+				FormOverrides: map[string]string{
+					"audience": "{{cfg.audience}}",
+				},
+			},
+		}, preconnectFlow(`{"type":"object","properties":{"audience":{"type":"string"}}}`))
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+}
+
+func TestValidateMustacheReferences_OAuthRevocation(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("revocation accepts cfg from configure step", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Revocation: &AuthOauth2Revocation{
+				Endpoint: "https://{{cfg.workspace}}.example.com/oauth/revoke",
+			},
+		}, configureFlow(`{"type":"object","properties":{"workspace":{"type":"string"}}}`))
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("revocation accepts cfg from preconnect", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Revocation: &AuthOauth2Revocation{
+				Endpoint: "https://{{cfg.tenant}}.example.com/oauth/revoke",
+			},
+		}, preconnectFlow(`{"type":"object","properties":{"tenant":{"type":"string"}}}`))
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("revocation rejects unknown cfg", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Revocation: &AuthOauth2Revocation{
+				Endpoint: "https://{{cfg.unknown}}.example.com/oauth/revoke",
+			},
+		}, preconnectFlow(`{"type":"object","properties":{"tenant":{"type":"string"}}}`))
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth.revocation.endpoint")
+		assert.Contains(t, err.Error(), "{{cfg.unknown}}")
+	})
+}
+
+func TestValidateMustacheReferences_DataSources(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("data source url uses preconnect field", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{Type: AuthTypeOAuth2}, &SetupFlow{
+			Preconnect: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{Id: "p1", JsonSchema: common.RawJSON(`{"type":"object","properties":{"tenant":{"type":"string"}}}`)},
+				},
+			},
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "c1",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						DataSources: map[string]DataSourceDef{
+							"workspaces": {
+								ProxyRequest: &DataSourceProxyRequest{
+									Method: "GET",
+									Url:    "https://{{cfg.tenant}}.example.com/workspaces",
+								},
+								Transform: "data.map(w => ({value: w.id, label: w.name}))",
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("data source can reference earlier configure step", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{Type: AuthTypeOAuth2}, &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{Id: "c1", JsonSchema: common.RawJSON(`{"type":"object","properties":{"workspace":{"type":"string"}}}`)},
+					{
+						Id:         "c2",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						DataSources: map[string]DataSourceDef{
+							"projects": {
+								ProxyRequest: &DataSourceProxyRequest{
+									Method: "GET",
+									Url:    "https://example.com/{{cfg.workspace}}/projects",
+								},
+								Transform: "data.map(p => ({value: p.id, label: p.name}))",
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+
+	t.Run("data source cannot reference field from same step", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{Type: AuthTypeOAuth2}, &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "c1",
+						JsonSchema: common.RawJSON(`{"type":"object","properties":{"workspace":{"type":"string"}}}`),
+						DataSources: map[string]DataSourceDef{
+							"projects": {
+								ProxyRequest: &DataSourceProxyRequest{
+									Method: "GET",
+									Url:    "https://example.com/{{cfg.workspace}}/projects",
+								},
+								Transform: "data.map(p => ({value: p.id, label: p.name}))",
+							},
+						},
+					},
+				},
+			},
+		})
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "data_sources.projects.proxy_request.url")
+		assert.Contains(t, err.Error(), "{{cfg.workspace}}")
+	})
+
+	t.Run("data source headers validated", func(t *testing.T) {
+		c := newOAuthConnector(&AuthOAuth2{Type: AuthTypeOAuth2}, &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "c1",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						DataSources: map[string]DataSourceDef{
+							"projects": {
+								ProxyRequest: &DataSourceProxyRequest{
+									Method: "GET",
+									Url:    "https://example.com/projects",
+									Headers: map[string]string{
+										"X-Tenant": "{{cfg.missing}}",
+									},
+								},
+								Transform: "data",
+							},
+						},
+					},
+				},
+			},
+		})
+		err := c.validateMustacheReferences(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "data_sources.projects.proxy_request.headers.X-Tenant")
+	})
+}
+
+func TestValidateMustacheReferences_NestedPath(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("nested cfg path resolves on root field", func(t *testing.T) {
+		// {{cfg.tenant.name}} requires "tenant" to be declared as a property; the nested
+		// "name" lookup is at runtime against whatever shape the property holds.
+		c := newOAuthConnector(&AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://{{cfg.tenant.name}}.example.com/oauth/authorize",
+			},
+		}, preconnectFlow(`{"type":"object","properties":{"tenant":{"type":"object"}}}`))
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+}
+
+func TestValidateMustacheReferences_NonOAuthSkipped(t *testing.T) {
+	vc := &common.ValidationContext{}
+
+	t.Run("api key connector with no data sources is skipped", func(t *testing.T) {
+		c := &Connector{
+			Labels:      map[string]string{"type": "api"},
+			DisplayName: "API",
+			Description: "API",
+			Auth:        &Auth{InnerVal: &AuthApiKey{Type: AuthTypeAPIKey}},
+		}
+		require.NoError(t, c.validateMustacheReferences(vc))
+	})
+}
+
+func TestConnectorValidate_MustacheRefsBubbleUp(t *testing.T) {
+	// Belt-and-suspenders: ensure the mustache validation actually runs from the
+	// public Validate entrypoint that route handlers call.
+	c := newOAuthConnector(&AuthOAuth2{
+		Type: AuthTypeOAuth2,
+		Authorization: AuthOauth2Authorization{
+			Endpoint: "https://{{cfg.tenant}}.example.com/oauth/authorize",
+		},
+	}, nil)
+	err := c.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "{{cfg.tenant}}"), "expected error to mention missing reference, got: %s", err.Error())
+}

--- a/internal/schema/connectors/mustache_validator.go
+++ b/internal/schema/connectors/mustache_validator.go
@@ -1,0 +1,62 @@
+package connectors
+
+import (
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
+)
+
+// MustacheValidationContext carries the cfg.X field-availability data that
+// validators consult when cross-checking mustache references against a
+// connector's setup flow. Different lifecycle points have different scopes:
+//
+//   - Auth-phase templates (OAuth2 Authorization, Token) may only reference
+//     PreconnectFields.
+//   - Post-setup templates (OAuth2 Revocation) may reference AllConfigFields.
+//   - Data sources rendered during a configure step use ConfigureStepFields,
+//     which limits visibility to fields collected before that step runs.
+type MustacheValidationContext struct {
+	// PreconnectFields are the cfg fields populated by preconnect form steps.
+	// Empty map if the connector has no preconnect phase.
+	PreconnectFields map[string]bool
+
+	// AllConfigFields contains every cfg field declared anywhere in the setup
+	// flow (preconnect + every configure step). Empty map if there is no
+	// setup flow.
+	AllConfigFields map[string]bool
+
+	// setupFlow backs the step-relative ConfigureStepFields query.
+	setupFlow *SetupFlow
+}
+
+// NewMustacheValidationContext builds a context from a (possibly nil) setup flow,
+// pre-computing the auth-phase and post-setup field sets so validators can read
+// them without recomputation.
+func NewMustacheValidationContext(sf *SetupFlow) *MustacheValidationContext {
+	return &MustacheValidationContext{
+		PreconnectFields: sf.PreconnectFieldNames(),
+		AllConfigFields:  sf.AllConfigFieldNames(),
+		setupFlow:        sf,
+	}
+}
+
+// ConfigureStepFields returns the cfg fields available while a configure step
+// at the given index is being filled out — preconnect fields plus configure
+// steps with index < stepIdx.
+func (m *MustacheValidationContext) ConfigureStepFields(stepIdx int) map[string]bool {
+	if m == nil {
+		return nil
+	}
+	if m.setupFlow == nil {
+		return m.PreconnectFields
+	}
+	return util.UnionBoolMaps(m.PreconnectFields, m.setupFlow.ConfigureFieldNamesUpTo(stepIdx))
+}
+
+// MustacheValidator is implemented by a templated subtree of a connector
+// definition (e.g. an Auth implementation) that wants to cross-check its
+// mustache references against the connector's setup flow. The implementation
+// chooses the appropriate scope on the provided context for the lifecycle
+// phase in which its templates render.
+type MustacheValidator interface {
+	ValidateMustacheReferences(vc *common.ValidationContext, mctx *MustacheValidationContext) error
+}

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -11,6 +11,7 @@ import (
 	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // SetupFlow defines the multi-step setup flow for a connector. Customers define this in their
@@ -347,6 +348,69 @@ func extractSchemaPropertyNames(schema json.RawMessage) (map[string]bool, error)
 	return result, nil
 }
 
+// PreconnectFieldNames returns the union of top-level property names defined across
+// all preconnect steps' JSON schemas. These are the cfg fields available before the
+// auth flow runs. Steps with malformed JSON schemas are silently skipped — those are
+// caught by the per-step Validate.
+func (sf *SetupFlow) PreconnectFieldNames() map[string]bool {
+	result := make(map[string]bool)
+	if sf == nil || sf.Preconnect == nil {
+		return result
+	}
+	for i := range sf.Preconnect.Steps {
+		step := &sf.Preconnect.Steps[i]
+		if step.JsonSchema.IsEmpty() {
+			continue
+		}
+		names, err := extractSchemaPropertyNames(json.RawMessage(step.JsonSchema))
+		if err != nil {
+			continue
+		}
+		for k := range names {
+			result[k] = true
+		}
+	}
+	return result
+}
+
+// ConfigureFieldNamesUpTo returns the union of top-level property names defined by
+// configure steps with index < stepIndex. Used to determine which cfg fields are
+// available to a data source rendered while the user is filling out configure step N.
+// Pass len(steps) to get all configure fields.
+func (sf *SetupFlow) ConfigureFieldNamesUpTo(stepIndex int) map[string]bool {
+	result := make(map[string]bool)
+	if sf == nil || sf.Configure == nil {
+		return result
+	}
+	limit := stepIndex
+	if limit > len(sf.Configure.Steps) {
+		limit = len(sf.Configure.Steps)
+	}
+	for i := 0; i < limit; i++ {
+		step := &sf.Configure.Steps[i]
+		if step.JsonSchema.IsEmpty() {
+			continue
+		}
+		names, err := extractSchemaPropertyNames(json.RawMessage(step.JsonSchema))
+		if err != nil {
+			continue
+		}
+		for k := range names {
+			result[k] = true
+		}
+	}
+	return result
+}
+
+// AllConfigFieldNames returns the union of cfg fields available after the entire
+// setup flow completes (preconnect + all configure steps).
+func (sf *SetupFlow) AllConfigFieldNames() map[string]bool {
+	return util.UnionBoolMaps(
+		sf.PreconnectFieldNames(),
+		sf.ConfigureFieldNamesUpTo(1<<31-1),
+	)
+}
+
 // DataSourceDef defines how to fetch dynamic data for populating form fields.
 type DataSourceDef struct {
 	// ProxyRequest defines an HTTP request to make through the connection's authenticated proxy.
@@ -398,6 +462,31 @@ func (r *DataSourceProxyRequest) Validate(vc *common.ValidationContext) error {
 
 	if r.Url == "" {
 		result = multierror.Append(result, vc.NewErrorfForField("url", "url is required"))
+	}
+
+	return result.ErrorOrNil()
+}
+
+// ValidateMustacheReferences checks that every {{cfg.X}} reference in the URL and
+// header templates resolves against the cfg fields visible to a configure step at
+// the given index. Visibility = preconnect fields plus any prior configure step's
+// fields (the step's own fields are not yet committed when the data source runs).
+func (r *DataSourceProxyRequest) ValidateMustacheReferences(
+	vc *common.ValidationContext,
+	mctx *MustacheValidationContext,
+	stepIdx int,
+) error {
+	if r == nil || mctx == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+	available := mctx.ConfigureStepFields(stepIdx)
+	scopeLabel := configureScopeLabel(stepIdx)
+
+	checkMustacheTemplate(vc.PushField("url"), r.Url, available, scopeLabel, result)
+	for k, v := range r.Headers {
+		checkMustacheTemplate(vc.PushField("headers").PushField(k), v, available, scopeLabel, result)
 	}
 
 	return result.ErrorOrNil()

--- a/internal/util/union_bool_maps.go
+++ b/internal/util/union_bool_maps.go
@@ -1,0 +1,18 @@
+package util
+
+// UnionBoolMaps merges any number of map[K]bool inputs into a single map containing
+// every key that was present in any input, all set to true. Useful when bool maps
+// are being used as sets and a combined set is needed.
+func UnionBoolMaps[K comparable](maps ...map[K]bool) map[K]bool {
+	total := 0
+	for _, m := range maps {
+		total += len(m)
+	}
+	out := make(map[K]bool, total)
+	for _, m := range maps {
+		for k := range m {
+			out[k] = true
+		}
+	}
+	return out
+}

--- a/internal/util/union_bool_maps_test.go
+++ b/internal/util/union_bool_maps_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnionBoolMaps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no inputs returns empty map", func(t *testing.T) {
+		got := UnionBoolMaps[string]()
+		assert.Equal(t, map[string]bool{}, got)
+	})
+
+	t.Run("single map is copied", func(t *testing.T) {
+		in := map[string]bool{"a": true, "b": true}
+		got := UnionBoolMaps(in)
+		assert.Equal(t, in, got)
+		// Mutating the result must not affect the input.
+		got["c"] = true
+		assert.NotContains(t, in, "c")
+	})
+
+	t.Run("two disjoint maps", func(t *testing.T) {
+		got := UnionBoolMaps(
+			map[string]bool{"a": true},
+			map[string]bool{"b": true},
+		)
+		assert.Equal(t, map[string]bool{"a": true, "b": true}, got)
+	})
+
+	t.Run("overlapping keys deduplicate", func(t *testing.T) {
+		got := UnionBoolMaps(
+			map[string]bool{"a": true, "b": true},
+			map[string]bool{"b": true, "c": true},
+		)
+		assert.Equal(t, map[string]bool{"a": true, "b": true, "c": true}, got)
+	})
+
+	t.Run("false values are normalized to true", func(t *testing.T) {
+		got := UnionBoolMaps(map[string]bool{"a": false})
+		assert.Equal(t, map[string]bool{"a": true}, got)
+	})
+
+	t.Run("nil entries are skipped", func(t *testing.T) {
+		got := UnionBoolMaps[string](nil, map[string]bool{"a": true}, nil)
+		assert.Equal(t, map[string]bool{"a": true}, got)
+	})
+
+	t.Run("works with non-string key types", func(t *testing.T) {
+		got := UnionBoolMaps(
+			map[int]bool{1: true, 2: true},
+			map[int]bool{2: true, 3: true},
+		)
+		assert.Equal(t, map[int]bool{1: true, 2: true, 3: true}, got)
+	})
+
+	t.Run("variadic with three or more maps", func(t *testing.T) {
+		got := UnionBoolMaps(
+			map[string]bool{"a": true},
+			map[string]bool{"b": true},
+			map[string]bool{"c": true},
+			map[string]bool{"a": true, "d": true},
+		)
+		assert.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true}, got)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds phase-aware cross-validation for mustache `cfg.X` references in connector templated fields (OAuth2 Authorization/Token/Revocation endpoints + overrides, data source proxy requests). Misconfigured references now fail at upsert time instead of render time.
- Validation logic lives next to the templated fields via a new `MustacheValidator` interface and `MustacheValidationContext`, so new auth types can opt in without touching the orchestrator.
- Adds `aptmpl.ExtractVariables` for walking mustache templates and a generic `util.UnionBoolMaps` helper.

## Phase scopes
- OAuth2 Authorization, Token: preconnect fields only.
- OAuth2 Revocation: any cfg field declared in the setup flow.
- Data source proxy requests in configure step N: preconnect plus configure steps before N.
- `{{labels.X}}` and `{{annotations.X}}` are intentionally not validated since those are set freely per connection.

Closes #122

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/schema/connectors/... ./internal/util/... ./internal/aptmpl/...`
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)