### PR TITLE
Make Connection.SetupStep a typed cschema.SetupStep (#150)

### DIFF
--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
-	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // Connection is a wrapper for the lower level database equivalent that handles wiring up logic specified in this
@@ -86,7 +85,7 @@ func (c *connection) GetAnnotations() map[string]string {
 	return c.Annotations
 }
 
-func (c *connection) GetSetupStep() *string {
+func (c *connection) GetSetupStep() *cschema.SetupStep {
 	return c.SetupStep
 }
 
@@ -99,15 +98,10 @@ func (c *connection) Logger() *slog.Logger {
 }
 
 func (c *connection) SetSetupStep(ctx context.Context, setupStep *cschema.SetupStep) error {
-	var setupStepStr *string
-	if setupStep != nil {
-		setupStepStr = util.ToPtr(setupStep.String())
-	}
-
-	if err := c.s.db.SetConnectionSetupStep(ctx, c.Id, setupStepStr); err != nil {
+	if err := c.s.db.SetConnectionSetupStep(ctx, c.Id, setupStep); err != nil {
 		return err
 	}
-	c.SetupStep = setupStepStr
+	c.SetupStep = setupStep
 	return nil
 }
 

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -40,11 +40,11 @@ func TestConnectionGetSetupStep(t *testing.T) {
 
 	t.Run("returns the setup step value", func(t *testing.T) {
 		conn := newTestConnection(cschema.Connector{})
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 		result := conn.GetSetupStep()
 		require.NotNil(t, result)
-		assert.Equal(t, "preconnect:0", *result)
+		assert.Equal(t, "preconnect:0", result.String())
 	})
 }
 
@@ -57,13 +57,12 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		conn := newTestConnectionWithService(s)
 
 		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
-		stepStr := step.String()
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
 
 		err := conn.SetSetupStep(context.Background(), &step)
 		require.NoError(t, err)
 		require.NotNil(t, conn.SetupStep)
-		assert.Equal(t, "configure:1", *conn.SetupStep)
+		assert.Equal(t, "configure:1", conn.SetupStep.String())
 	})
 
 	t.Run("clears setup step when nil", func(t *testing.T) {
@@ -72,10 +71,10 @@ func TestConnectionSetSetupStep(t *testing.T) {
 
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
-		existing := "preconnect:0"
+		existing := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &existing
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 
 		err := conn.SetSetupStep(context.Background(), nil)
 		require.NoError(t, err)
@@ -90,8 +89,7 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		conn := newTestConnectionWithService(s)
 
 		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
-		stepStr := step.String()
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &stepStr).Return(database.ErrNotFound)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(database.ErrNotFound)
 
 		err := conn.SetSetupStep(context.Background(), &step)
 		assert.ErrorIs(t, err, database.ErrNotFound)

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -20,12 +20,7 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("connection has no active setup step")
 	}
 
-	parsed, err := cschema.ParseSetupStep(*setupStep)
-	if err != nil {
-		return nil, httperr.BadRequestf("invalid setup step: %s", err)
-	}
-
-	if parsed.Phase() != cschema.SetupPhaseConfigure {
+	if setupStep.Phase() != cschema.SetupPhaseConfigure {
 		return nil, httperr.BadRequest("data sources are only available during configure steps")
 	}
 
@@ -34,7 +29,7 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("connector has no setup flow")
 	}
 
-	step, _, err := connector.SetupFlow.GetStepBySetupStep(parsed)
+	step, _, err := connector.SetupFlow.GetStepBySetupStep(*setupStep)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get current step: %w", err))
 	}

--- a/internal/core/connection_data_source_test.go
+++ b/internal/core/connection_data_source_test.go
@@ -52,7 +52,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "some_source")
@@ -71,7 +71,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := "auth"
+		step := cschema.SetupStepAuth
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "some_source")
@@ -84,7 +84,7 @@ func TestGetDataSource(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, nil)
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "workspaces")
@@ -111,7 +111,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "nonexistent")
@@ -143,7 +143,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "workspaces")

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -22,7 +22,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		conn, db, ac := newTestConnectionWithSetupFlowAndAsynq(t, ctrl, &cschema.SetupFlow{})
 		conn.cv.GetDefinition().Probes = []cschema.Probe{{Id: "ping"}}
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerify.String())).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.SetupStepVerify)).Return(nil)
 		ac.EXPECT().
 			EnqueueContext(gomock.Any(), gomock.AssignableToTypeOf(&asynq.Task{}), asynq.Retention(10*time.Minute)).
 			Return(&asynq.TaskInfo{ID: "mock-task-id"}, nil)
@@ -31,7 +31,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, outcome.SetupPending)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepVerify.String(), *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerify, *conn.GetSetupStep())
 	})
 
 	t.Run("enters configure:0 when connector has configure but no probes", func(t *testing.T) {
@@ -46,13 +46,13 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 			},
 		})
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.True(t, outcome.SetupPending)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, "configure:0", *conn.GetSetupStep())
+		assert.Equal(t, "configure:0", conn.GetSetupStep().String())
 	})
 
 	t.Run("clears setup step and marks ready when connector has neither probes nor configure", func(t *testing.T) {
@@ -60,10 +60,10 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		authStep := "auth"
+		authStep := cschema.SetupStepAuth
 		conn.SetupStep = &authStep
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
@@ -102,12 +102,12 @@ func TestHandleAuthFailed(t *testing.T) {
 				assert.Contains(t, *msg, "token exchange boom")
 				return nil
 			})
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepAuthFailed.String())).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.SetupStepAuthFailed)).Return(nil)
 
 		err := conn.HandleAuthFailed(context.Background(), errors.New("token exchange boom"))
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepAuthFailed.String(), *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepAuthFailed, *conn.GetSetupStep())
 		require.NotNil(t, conn.GetSetupError())
 		assert.Contains(t, *conn.GetSetupError(), "token exchange boom")
 	})

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -25,12 +25,12 @@ func TestOnVerifyPassed(t *testing.T) {
 			},
 		})
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, "configure:0", *conn.GetSetupStep())
+		assert.Equal(t, "configure:0", conn.GetSetupStep().String())
 	})
 
 	t.Run("clears setup step and marks ready when no further steps", func(t *testing.T) {
@@ -39,7 +39,7 @@ func TestOnVerifyPassed(t *testing.T) {
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
@@ -63,12 +63,12 @@ func TestOnVerifyFailed(t *testing.T) {
 				assert.Contains(t, *msg, "boom")
 				return nil
 			})
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr(cschema.SetupStepVerifyFailed.String())).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.SetupStepVerifyFailed)).Return(nil)
 
 		err := conn.onVerifyFailed(context.Background(), "ping", errors.New("boom"))
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, cschema.SetupStepVerifyFailed.String(), *conn.GetSetupStep())
+		assert.Equal(t, cschema.SetupStepVerifyFailed, *conn.GetSetupStep())
 		require.NotNil(t, conn.GetSetupError())
 		assert.Contains(t, *conn.GetSetupError(), "boom")
 	})

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -27,7 +27,7 @@ type Connection interface {
 	GetDeletedAt() *time.Time
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
-	GetSetupStep() *string
+	GetSetupStep() *cschema.SetupStep
 	GetSetupError() *string
 
 	/*

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -25,7 +25,7 @@ type Connection struct {
 	DeletedAt        *time.Time
 	Labels           map[string]string
 	Annotations      map[string]string
-	SetupStep        *string
+	SetupStep        *cschema.SetupStep
 	SetupError       *string
 	Configuration    map[string]any
 }
@@ -104,17 +104,12 @@ func (m *Connection) ProxyRequestRaw(
 	return nil
 }
 
-func (m *Connection) GetSetupStep() *string {
+func (m *Connection) GetSetupStep() *cschema.SetupStep {
 	return m.SetupStep
 }
 
 func (m *Connection) SetSetupStep(ctx context.Context, setupStep *cschema.SetupStep) error {
-	if setupStep == nil {
-		m.SetupStep = nil
-	} else {
-		s := setupStep.String()
-		m.SetupStep = &s
-	}
+	m.SetupStep = setupStep
 	return nil
 }
 
@@ -186,7 +181,7 @@ func (m *Connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 func (m *Connection) HandleAuthFailed(ctx context.Context, authErr error) error {
 	msg := authErr.Error()
 	m.SetupError = &msg
-	failedStep := "auth_failed"
+	failedStep := cschema.SetupStepAuthFailed
 	m.SetupStep = &failedStep
 	return nil
 }

--- a/internal/core/service_connection_abort_test.go
+++ b/internal/core/service_connection_abort_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupAbortTest(t *testing.T, ctrl *gomock.Controller, sf *cschema.SetupFlow, setupStep *string) (*connection, *mockDb.MockDB) {
+func setupAbortTest(t *testing.T, ctrl *gomock.Controller, sf *cschema.SetupFlow, setupStep *cschema.SetupStep) (*connection, *mockDb.MockDB) {
 	conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
 	conn.SetupStep = setupStep
 
@@ -50,7 +50,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Preconnect: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{
@@ -70,7 +70,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := "auth"
+		step := cschema.SetupStepAuth
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Preconnect: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{
@@ -90,7 +90,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Configure: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{

--- a/internal/core/service_connection_cancel_setup_test.go
+++ b/internal/core/service_connection_cancel_setup_test.go
@@ -22,12 +22,12 @@ func TestCancelSetup(t *testing.T) {
 			},
 		})
 		conn.State = database.ConnectionStateReady
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 		errMsg := "stale"
 		conn.SetupError = &errMsg
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
 
 		require.NoError(t, conn.CancelSetup(context.Background()))

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -74,7 +74,7 @@ func TestReconfigure(t *testing.T) {
 		})
 		conn.State = database.ConnectionStateReady
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestReconfigure(t *testing.T) {
 		})
 		conn.State = database.ConnectionStateReady
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("configure:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)
@@ -111,5 +111,9 @@ func TestReconfigure(t *testing.T) {
 }
 
 func ptrStr(s string) *string {
+	return &s
+}
+
+func ptrStep(s cschema.SetupStep) *cschema.SetupStep {
 	return &s
 }

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -21,11 +21,7 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	setupStep := conn.GetSetupStep()
-	if setupStep == nil {
-		return nil, httperr.BadRequest("connection is not in a retryable state")
-	}
-	parsed, err := cschema.ParseSetupStep(*setupStep)
-	if err != nil || !parsed.IsTerminalFailure() {
+	if setupStep == nil || !setupStep.IsTerminalFailure() {
 		return nil, httperr.BadRequest("connection is not in a retryable state")
 	}
 

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -25,7 +25,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
 
@@ -55,7 +55,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.SetupStepVerifyFailed.String()
+		step := cschema.SetupStepVerifyFailed
 		conn.SetupStep = &step
 		errMsg := "probe failed"
 		conn.SetupError = &errMsg
@@ -72,7 +72,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("preconnect:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0))).Return(nil)
 
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.SetupStepAuthFailed.String()
+		step := cschema.SetupStepAuthFailed
 		conn.SetupStep = &step
 		errMsg := "token exchange failed"
 		conn.SetupError = &errMsg
@@ -110,7 +110,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStr("preconnect:0")).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0))).Return(nil)
 
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -26,10 +26,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		return nil, httperr.BadRequest("connector has no setup flow")
 	}
 
-	currentSetupStep, err := cschema.ParseSetupStep(*setupStep)
-	if err != nil {
-		return nil, httperr.BadRequestf("invalid setup step: %s", err)
-	}
+	currentSetupStep := *setupStep
 
 	// Only preconnect and configure phases accept form submissions
 	if !currentSetupStep.Phase().IsIndexed() {
@@ -165,10 +162,7 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Ini
 		}, nil
 	}
 
-	parsed, err := cschema.ParseSetupStep(*setupStep)
-	if err != nil {
-		return nil, httperr.BadRequestf("invalid setup step: %s", err)
-	}
+	parsed := *setupStep
 
 	switch parsed.Phase() {
 	case cschema.SetupPhaseAuth:

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -97,7 +97,7 @@ func TestSubmitForm(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, nil)
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 
 		_, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -122,11 +122,11 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		nextStep := "preconnect:1"
+		nextStep := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 1)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &nextStep).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -156,7 +156,7 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
@@ -182,11 +182,11 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -225,12 +225,12 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		// First submit — sets config with tenant
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		nextStep := "configure:1"
+		nextStep := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &nextStep).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -242,7 +242,7 @@ func TestSubmitForm(t *testing.T) {
 
 		// Second submit — merges workspace into existing config
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
 
 		resp, err = conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -284,7 +284,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 			},
 		}
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
@@ -311,7 +311,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 				},
 			},
 		})
-		step := "auth"
+		step := cschema.SetupStepAuth
 		conn.SetupStep = &step
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
@@ -331,7 +331,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 			},
 		}
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := "configure:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
@@ -350,7 +350,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		step := cschema.SetupStepVerify.String()
+		step := cschema.SetupStepVerify
 		conn.SetupStep = &step
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
@@ -364,7 +364,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		step := cschema.SetupStepVerifyFailed.String()
+		step := cschema.SetupStepVerifyFailed
 		conn.SetupStep = &step
 		errMsg := `probe "ping" failed: 401 unauthorized`
 		conn.SetupError = &errMsg

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -63,13 +63,8 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 
 	// Guard against stale tasks: only run if the connection is still in verify phase.
 	setupStep := conn.GetSetupStep()
-	if setupStep == nil {
+	if setupStep == nil || !setupStep.Equals(cschema.SetupStepVerify) {
 		logger.Info("connection is no longer in verify phase; skipping", "setup_step", setupStep)
-		return nil
-	}
-	parsed, err := cschema.ParseSetupStep(*setupStep)
-	if err != nil || !parsed.Equals(cschema.SetupStepVerify) {
-		logger.Info("connection is no longer in verify phase; skipping", "setup_step", *setupStep)
 		return nil
 	}
 

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -60,7 +61,7 @@ type Connection struct {
 	Annotations             Annotations
 	EncryptedConfiguration  *encfield.EncryptedField
 	EncryptedAt             *time.Time
-	SetupStep               *string
+	SetupStep               *cschema.SetupStep
 	SetupError              *string
 	CreatedAt               time.Time
 	UpdatedAt               time.Time
@@ -304,7 +305,7 @@ func (s *service) SetConnectionState(ctx context.Context, id apid.ID, state Conn
 	return nil
 }
 
-func (s *service) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *string) error {
+func (s *service) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *cschema.SetupStep) error {
 	if id == apid.Nil {
 		return errors.New("connection id is required")
 	}

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/test_utils"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/assert"
@@ -939,16 +940,17 @@ func TestConnections(t *testing.T) {
 		newNow := time.Date(1955, time.November, 6, 6, 29, 0, 0, time.UTC)
 		ctx = apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(newNow)).Build()
 
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		err = db.SetConnectionSetupStep(ctx, u, &step)
 		require.NoError(t, err)
 
+		stepStr := step.String()
 		test_utils.AssertSql(t, rawDb, `
 			SELECT id, setup_step, updated_at FROM connections;
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				SetupStep: &step,
+				SetupStep: &stepStr,
 				UpdatedAt: newNow,
 			},
 		})
@@ -957,17 +959,17 @@ func TestConnections(t *testing.T) {
 		c, err = db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "preconnect:0", *c.SetupStep)
+		assert.Equal(t, "preconnect:0", c.SetupStep.String())
 
 		// Update to a different step
-		step2 := "configure:0"
+		step2 := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		err = db.SetConnectionSetupStep(ctx, u, &step2)
 		require.NoError(t, err)
 
 		c, err = db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "configure:0", *c.SetupStep)
+		assert.Equal(t, "configure:0", c.SetupStep.String())
 
 		// Clear setup step (set to nil)
 		err = db.SetConnectionSetupStep(ctx, u, nil)
@@ -983,7 +985,7 @@ func TestConnections(t *testing.T) {
 		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		err := db.SetConnectionSetupStep(ctx, apid.New(apid.PrefixConnection), &step)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
@@ -1006,7 +1008,7 @@ func TestConnections(t *testing.T) {
 		err = db.DeleteConnection(ctx, u)
 		require.NoError(t, err)
 
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		err = db.SetConnectionSetupStep(ctx, u, &step)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
@@ -1078,7 +1080,7 @@ func TestConnections(t *testing.T) {
 		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		step := "preconnect:0"
+		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
 		ef := encfield.EncryptedField{ID: "ekv_test1234", Data: "encrypted-config-data"}
 		u := apid.New(apid.PrefixConnection)
 		err := db.CreateConnection(ctx, &Connection{
@@ -1096,7 +1098,7 @@ func TestConnections(t *testing.T) {
 		c, err := db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "preconnect:0", *c.SetupStep)
+		assert.Equal(t, "preconnect:0", c.SetupStep.String())
 		require.NotNil(t, c.EncryptedConfiguration)
 		assert.Equal(t, apid.ID("ekv_test1234"), c.EncryptedConfiguration.ID)
 		assert.Equal(t, "encrypted-config-data", c.EncryptedConfiguration.Data)

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -112,7 +113,7 @@ type DB interface {
 	CreateConnection(ctx context.Context, c *Connection) error
 	DeleteConnection(ctx context.Context, id apid.ID) error
 	SetConnectionState(ctx context.Context, id apid.ID, state ConnectionState) error
-	SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *string) error
+	SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *cschema.SetupStep) error
 	SetConnectionSetupError(ctx context.Context, id apid.ID, setupError *string) error
 	SetConnectionEncryptedConfiguration(ctx context.Context, id apid.ID, encryptedConfig *encfield.EncryptedField) error
 	UpdateConnectionLabels(ctx context.Context, id apid.ID, labels map[string]string) (*Connection, error)

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -14,6 +14,7 @@ import (
 	database "github.com/rmorlok/authproxy/internal/database"
 	encfield "github.com/rmorlok/authproxy/internal/encfield"
 	auth "github.com/rmorlok/authproxy/internal/schema/auth"
+	connectors "github.com/rmorlok/authproxy/internal/schema/connectors"
 	pagination "github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -1408,7 +1409,7 @@ func (mr *MockDBMockRecorder) SetConnectionEncryptedConfiguration(ctx, id, encry
 }
 
 // SetConnectionSetupStep mocks base method.
-func (m *MockDB) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *string) error {
+func (m *MockDB) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *connectors.SetupStep) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConnectionSetupStep", ctx, id, setupStep)
 	ret0, _ := ret[0].(error)

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -259,13 +259,19 @@ type ConnectionJson struct {
 func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
 	connector := ConnectorVersionToConnectorJson(conn.GetConnectorVersionEntity())
 
+	var setupStep *string
+	if s := conn.GetSetupStep(); s != nil {
+		str := s.String()
+		setupStep = &str
+	}
+
 	return ConnectionJson{
 		Id:          conn.GetId(),
 		Namespace:   conn.GetNamespace(),
 		Labels:      conn.GetLabels(),
 		Annotations: conn.GetAnnotations(),
 		State:       conn.GetState(),
-		SetupStep:   conn.GetSetupStep(),
+		SetupStep:   setupStep,
 		SetupError:  conn.GetSetupError(),
 		Connector:   connector,
 		CreatedAt:   conn.GetCreatedAt(),

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -192,6 +193,46 @@ func (s SetupStep) Equals(other SetupStep) bool { return s == other }
 
 // IsTerminalFailure reports whether the step is in a terminal failure phase.
 func (s SetupStep) IsTerminalFailure() bool { return s.phase.IsTerminalFailure() }
+
+// Value implements driver.Valuer so SetupStep can be stored as a database column.
+// The zero SetupStep round-trips as SQL NULL.
+func (s SetupStep) Value() (driver.Value, error) {
+	if s.IsZero() {
+		return nil, nil
+	}
+	return s.String(), nil
+}
+
+// Scan implements sql.Scanner so SetupStep can be read from a database column.
+// NULL and empty values produce the zero SetupStep.
+func (s *SetupStep) Scan(value interface{}) error {
+	if value == nil {
+		*s = SetupStep{}
+		return nil
+	}
+
+	var str string
+	switch v := value.(type) {
+	case string:
+		str = v
+	case []byte:
+		str = string(v)
+	default:
+		return fmt.Errorf("cannot scan %T into SetupStep", value)
+	}
+
+	if str == "" {
+		*s = SetupStep{}
+		return nil
+	}
+
+	parsed, err := ParseSetupStep(str)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
 
 // ParseSetupStep parses a setup-step string into a SetupStep. Indexed forms must be
 // "phase:index" (e.g. "preconnect:0", "configure:3"); singleton phases ("auth", "verify",


### PR DESCRIPTION
## Summary
- Add `driver.Valuer` / `sql.Scanner` impls to `cschema.SetupStep` so it can be persisted directly as a SQL column.
- Change `database.Connection.SetupStep` from `*string` to `*cschema.SetupStep` and update the `SetConnectionSetupStep` interface (plus mocks) to match.
- Drop the ad-hoc `ParseSetupStep` calls in core (submit / data-source / retry / verify-task); the JSON wire format is preserved by converting to a string at the routes boundary in `ConnectionToJson`.

Closes #150.

## Test plan
- [x] `./scripts/preflight.sh`
- [x] `go test ./...` (full suite)
- [x] `go test ./internal/database/... ./internal/core/... ./internal/routes/... ./internal/schema/connectors/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)