### PR TITLE
Hide reconfigure button when connector has no configure steps

### DIFF
--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -31,6 +31,7 @@ type ConnectorJson struct {
 	Description   string                         `json:"description"`
 	StatusPageUrl string                         `json:"status_page_url,omitempty"`
 	Logo          string                         `json:"logo"`
+	HasConfigure  bool                           `json:"has_configure"`
 	Labels        map[string]string              `json:"labels,omitempty"`
 	Annotations   map[string]string              `json:"annotations,omitempty"`
 	CreatedAt     time.Time                      `json:"created_at"`
@@ -64,6 +65,7 @@ func ConnectorVersionToConnectorJson(cv connIface.ConnectorVersion) ConnectorJso
 		Description:   def.Description,
 		StatusPageUrl: def.StatusPageUrl,
 		Logo:          logo,
+		HasConfigure:  def.SetupFlow.HasConfigure(),
 		Labels:        cv.GetLabels(),
 		Annotations:   cv.GetAnnotations(),
 		CreatedAt:     cv.GetCreatedAt(),

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -162,6 +162,8 @@ type SwaggerConnectorJson struct {
 	StatusPageUrl string `json:"status_page_url,omitempty" example:"https://status.salesforce.com"`
 	// Logo URL
 	Logo string `json:"logo,omitempty" example:"https://example.com/logo.png"`
+	// Whether the connector defines configure setup steps (controls reconfigure availability)
+	HasConfigure bool `json:"has_configure" example:"false"`
 	// Labels assigned to the connector
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations assigned to the connector

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -7012,6 +7012,11 @@ const docTemplateadmin_api = `{
                     "type": "string",
                     "example": "Salesforce"
                 },
+                "has_configure": {
+                    "description": "Whether the connector defines configure setup steps (controls reconfigure availability)",
+                    "type": "boolean",
+                    "example": false
+                },
                 "highlight": {
                     "description": "Short highlight text",
                     "type": "string",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -7006,6 +7006,11 @@
                     "type": "string",
                     "example": "Salesforce"
                 },
+                "has_configure": {
+                    "description": "Whether the connector defines configure setup steps (controls reconfigure availability)",
+                    "type": "boolean",
+                    "example": false
+                },
                 "highlight": {
                     "description": "Short highlight text",
                     "type": "string",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -384,6 +384,11 @@ definitions:
         description: Display name
         example: Salesforce
         type: string
+      has_configure:
+        description: Whether the connector defines configure setup steps (controls
+          reconfigure availability)
+        example: false
+        type: boolean
       highlight:
         description: Short highlight text
         example: CRM platform

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -7012,6 +7012,11 @@ const docTemplateApi = `{
                     "type": "string",
                     "example": "Salesforce"
                 },
+                "has_configure": {
+                    "description": "Whether the connector defines configure setup steps (controls reconfigure availability)",
+                    "type": "boolean",
+                    "example": false
+                },
                 "highlight": {
                     "description": "Short highlight text",
                     "type": "string",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -7006,6 +7006,11 @@
                     "type": "string",
                     "example": "Salesforce"
                 },
+                "has_configure": {
+                    "description": "Whether the connector defines configure setup steps (controls reconfigure availability)",
+                    "type": "boolean",
+                    "example": false
+                },
                 "highlight": {
                     "description": "Short highlight text",
                     "type": "string",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -384,6 +384,11 @@ definitions:
         description: Display name
         example: Salesforce
         type: string
+      has_configure:
+        description: Whether the connector defines configure setup steps (controls
+          reconfigure availability)
+        example: false
+        type: boolean
       highlight:
         description: Short highlight text
         example: CRM platform

--- a/sdks/js/src/connectors.ts
+++ b/sdks/js/src/connectors.ts
@@ -24,6 +24,7 @@ export interface Connector {
     highlight?: string;
     status_page_url?: string;
     logo: string;
+    has_configure: boolean;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
     created_at: string;

--- a/ui/marketplace/src/components/ConnectionCard.tsx
+++ b/ui/marketplace/src/components/ConnectionCard.tsx
@@ -190,7 +190,7 @@ const ConnectionCard: React.FC<ConnectionCardProps> = ({ connection }) => {
 
       {canBeDisconnected(connection) && (
         <CardActions>
-          {connection.state === ConnectionState.READY && (
+          {connection.state === ConnectionState.READY && connector?.has_configure && (
             <Button
               size="small"
               startIcon={<SettingsIcon />}

--- a/ui/marketplace/src/tests/ConnectionCard.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionCard.test.tsx
@@ -50,6 +50,7 @@ describe('ConnectionCard', () => {
         description: 'Connect to your Google Calendar to manage events and appointments.',
         highlight: undefined,
         logo: 'https://example.com/google-calendar-logo.png',
+        has_configure: false,
         versions: 1,
         states: [ConnectorVersionState.ACTIVE],
         created_at: '2023-04-01T12:00:00Z',

--- a/ui/marketplace/src/tests/ConnectionList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionList.test.tsx
@@ -33,6 +33,7 @@ const connector: Connector = {
     description: 'Calendar app',
     highlight: undefined,
     logo: 'https://example.com/logo.png',
+    has_configure: false,
     versions: 1,
     states: [ConnectorVersionState.ACTIVE],
     created_at: '2023-04-01T12:00:00Z',

--- a/ui/marketplace/src/tests/ConnectorCard.test.tsx
+++ b/ui/marketplace/src/tests/ConnectorCard.test.tsx
@@ -15,6 +15,7 @@ describe('ConnectorCard', () => {
         description: 'Connect to your Google Calendar to manage events and appointments.',
         highlight: undefined,
         logo: 'https://example.com/google-calendar-logo.png',
+        has_configure: false,
         versions: 1,
         states: [ConnectorVersionState.ACTIVE],
         created_at: '2023-04-01T12:00:00Z',


### PR DESCRIPTION
## Summary
- Fixes #152: the marketplace Reconfigure button was shown on every ready connection, even when the connector had no `setup_flow.configure` steps to reconfigure.
- Adds `has_configure` to the connector API response (derived from `SetupFlow.HasConfigure()`) and gates the Reconfigure button on it in `ConnectionCard`.

Closes #152 

## Test plan
- [x] `go test ./internal/routes/... ./internal/core/...` passes.
- [x] Marketplace `ConnectionCard` / `ConnectorCard` test suites pass; updated fixtures include the new field.
- [x] `./scripts/preflight.sh` passes (swagger docs regenerated).
- [ ] Manual: load marketplace UI, verify ready connections for connectors without configure steps no longer show Reconfigure, and connectors with configure steps still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)