### PR TITLE
Rename InitiateConnectionResponse to ConnectionSetupResponse (#151)

### DIFF
--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -59,10 +59,10 @@ type Connection interface {
 		req *ProxyRequest,
 		w http.ResponseWriter,
 	) error
-	SubmitForm(ctx context.Context, req SubmitConnectionRequest) (InitiateConnectionResponse, error)
-	GetCurrentSetupStepResponse(ctx context.Context) (InitiateConnectionResponse, error)
+	SubmitForm(ctx context.Context, req SubmitConnectionRequest) (ConnectionSetupResponse, error)
+	GetCurrentSetupStepResponse(ctx context.Context) (ConnectionSetupResponse, error)
 	GetDataSource(ctx context.Context, sourceId string) ([]apjs.DataSourceOption, error)
-	Reconfigure(ctx context.Context) (InitiateConnectionResponse, error)
+	Reconfigure(ctx context.Context) (ConnectionSetupResponse, error)
 
 	// CancelSetup abandons an in-flight reconfigure on a ready connection by clearing
 	// its setup_step and setup_error. The connection remains ready and its previously

--- a/internal/core/iface/connection_initiate.go
+++ b/internal/core/iface/connection_initiate.go
@@ -48,97 +48,97 @@ func (icr *InitiateConnectionRequest) HasIntoNamespace() bool {
 	return icr.IntoNamespace != ""
 }
 
-type InitiateConnectionResponseType string
+type ConnectionSetupResponseType string
 
 const (
-	PreconnectionResponseTypeRedirect  InitiateConnectionResponseType = "redirect"
-	PreconnectionResponseTypeForm      InitiateConnectionResponseType = "form"
-	PreconnectionResponseTypeComplete  InitiateConnectionResponseType = "complete"
-	PreconnectionResponseTypeVerifying InitiateConnectionResponseType = "verifying"
-	PreconnectionResponseTypeError     InitiateConnectionResponseType = "error"
+	ConnectionSetupResponseTypeRedirect  ConnectionSetupResponseType = "redirect"
+	ConnectionSetupResponseTypeForm      ConnectionSetupResponseType = "form"
+	ConnectionSetupResponseTypeComplete  ConnectionSetupResponseType = "complete"
+	ConnectionSetupResponseTypeVerifying ConnectionSetupResponseType = "verifying"
+	ConnectionSetupResponseTypeError     ConnectionSetupResponseType = "error"
 )
 
-type InitiateConnectionResponse interface {
+type ConnectionSetupResponse interface {
 	GetId() apid.ID
-	GetType() InitiateConnectionResponseType
+	GetType() ConnectionSetupResponseType
 }
 
-type InitiateConnectionRedirect struct {
-	Id          apid.ID                        `json:"id"`
-	Type        InitiateConnectionResponseType `json:"type"`
-	RedirectUrl string                         `json:"redirect_url"`
+type ConnectionSetupRedirect struct {
+	Id          apid.ID                     `json:"id"`
+	Type        ConnectionSetupResponseType `json:"type"`
+	RedirectUrl string                      `json:"redirect_url"`
 }
 
-func (icr *InitiateConnectionRedirect) GetId() apid.ID {
+func (icr *ConnectionSetupRedirect) GetId() apid.ID {
 	return icr.Id
 }
 
-func (icr *InitiateConnectionRedirect) GetType() InitiateConnectionResponseType {
+func (icr *ConnectionSetupRedirect) GetType() ConnectionSetupResponseType {
 	return icr.Type
 }
 
-type InitiateConnectionForm struct {
-	Id              apid.ID                        `json:"id"`
-	Type            InitiateConnectionResponseType `json:"type"`
-	StepId          string                         `json:"step_id"`
-	StepTitle       string                         `json:"step_title,omitempty"`
-	StepDescription string                         `json:"step_description,omitempty"`
-	CurrentStep     int                            `json:"current_step"`
-	TotalSteps      int                            `json:"total_steps"`
-	JsonSchema      json.RawMessage                `json:"json_schema"`
-	UiSchema        json.RawMessage                `json:"ui_schema"`
+type ConnectionSetupForm struct {
+	Id              apid.ID                     `json:"id"`
+	Type            ConnectionSetupResponseType `json:"type"`
+	StepId          string                      `json:"step_id"`
+	StepTitle       string                      `json:"step_title,omitempty"`
+	StepDescription string                      `json:"step_description,omitempty"`
+	CurrentStep     int                         `json:"current_step"`
+	TotalSteps      int                         `json:"total_steps"`
+	JsonSchema      json.RawMessage             `json:"json_schema"`
+	UiSchema        json.RawMessage             `json:"ui_schema"`
 }
 
-func (icf *InitiateConnectionForm) GetId() apid.ID {
+func (icf *ConnectionSetupForm) GetId() apid.ID {
 	return icf.Id
 }
 
-func (icf *InitiateConnectionForm) GetType() InitiateConnectionResponseType {
+func (icf *ConnectionSetupForm) GetType() ConnectionSetupResponseType {
 	return icf.Type
 }
 
-type InitiateConnectionComplete struct {
-	Id   apid.ID                        `json:"id"`
-	Type InitiateConnectionResponseType `json:"type"`
+type ConnectionSetupComplete struct {
+	Id   apid.ID                     `json:"id"`
+	Type ConnectionSetupResponseType `json:"type"`
 }
 
-func (icc *InitiateConnectionComplete) GetId() apid.ID {
+func (icc *ConnectionSetupComplete) GetId() apid.ID {
 	return icc.Id
 }
 
-func (icc *InitiateConnectionComplete) GetType() InitiateConnectionResponseType {
+func (icc *ConnectionSetupComplete) GetType() ConnectionSetupResponseType {
 	return icc.Type
 }
 
-// InitiateConnectionVerifying indicates that probes are running in the background to verify
+// ConnectionSetupVerifying indicates that probes are running in the background to verify
 // the credentials obtained during auth. The UI should poll /_setup_step to observe the outcome.
-type InitiateConnectionVerifying struct {
-	Id   apid.ID                        `json:"id"`
-	Type InitiateConnectionResponseType `json:"type"`
+type ConnectionSetupVerifying struct {
+	Id   apid.ID                     `json:"id"`
+	Type ConnectionSetupResponseType `json:"type"`
 }
 
-func (icv *InitiateConnectionVerifying) GetId() apid.ID {
+func (icv *ConnectionSetupVerifying) GetId() apid.ID {
 	return icv.Id
 }
 
-func (icv *InitiateConnectionVerifying) GetType() InitiateConnectionResponseType {
+func (icv *ConnectionSetupVerifying) GetType() ConnectionSetupResponseType {
 	return icv.Type
 }
 
-// InitiateConnectionError is a terminal error response during setup, e.g. when probe verification
+// ConnectionSetupError is a terminal error response during setup, e.g. when probe verification
 // fails. The UI should show the error and offer retry (POST /_retry) or cancel (POST /_abort).
-type InitiateConnectionError struct {
-	Id       apid.ID                        `json:"id"`
-	Type     InitiateConnectionResponseType `json:"type"`
-	Error    string                         `json:"error"`
-	CanRetry bool                           `json:"can_retry"`
+type ConnectionSetupError struct {
+	Id       apid.ID                     `json:"id"`
+	Type     ConnectionSetupResponseType `json:"type"`
+	Error    string                      `json:"error"`
+	CanRetry bool                        `json:"can_retry"`
 }
 
-func (ice *InitiateConnectionError) GetId() apid.ID {
+func (ice *ConnectionSetupError) GetId() apid.ID {
 	return ice.Id
 }
 
-func (ice *InitiateConnectionError) GetType() InitiateConnectionResponseType {
+func (ice *ConnectionSetupError) GetType() ConnectionSetupResponseType {
 	return ice.Type
 }
 

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -99,7 +99,7 @@ type C interface {
 	// ListConnectionsFromCursor continues listing connections from a cursor to support pagination.
 	ListConnectionsFromCursor(ctx context.Context, cursor string) (ListConnectionsExecutor, error)
 
-	InitiateConnection(ctx context.Context, req InitiateConnectionRequest) (InitiateConnectionResponse, error)
+	InitiateConnection(ctx context.Context, req InitiateConnectionRequest) (ConnectionSetupResponse, error)
 
 	// EnqueueVerifyConnection enqueues a background task to run all probes for a connection as part of
 	// the verify step of the setup flow. The task advances the connection's setup step based on the outcome.
@@ -108,7 +108,7 @@ type C interface {
 	// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the user
 	// can try setup again — either restarting preconnect forms, or re-initiating OAuth if the connector
 	// has no preconnect steps. Returns the initial setup step response for the retry.
-	RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (InitiateConnectionResponse, error)
+	RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (ConnectionSetupResponse, error)
 
 	/*
 	 *

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -154,11 +154,11 @@ func (m *Connection) GetMustacheContext(ctx context.Context) (map[string]any, er
 	return data, nil
 }
 
-func (m *Connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionRequest) (iface.InitiateConnectionResponse, error) {
+func (m *Connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionRequest) (iface.ConnectionSetupResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (m *Connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.InitiateConnectionResponse, error) {
+func (m *Connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.ConnectionSetupResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -166,7 +166,7 @@ func (m *Connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (m *Connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionResponse, error) {
+func (m *Connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -23,7 +23,7 @@ import (
 
 // InitiateConnection starts the process of initiating the connection. This method provides auth validation as part of
 // the logic.
-func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConnectionRequest) (iface.InitiateConnectionResponse, error) {
+func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConnectionRequest) (iface.ConnectionSetupResponse, error) {
 	val := auth.MustGetValidatorFromContext(ctx)
 	if err := req.Validate(); err != nil {
 		val.MarkErrorReturn()
@@ -93,9 +93,9 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 		}
 
-		return &iface.InitiateConnectionForm{
+		return &iface.ConnectionSetupForm{
 			Id:              connection.GetId(),
-			Type:            iface.PreconnectionResponseTypeForm,
+			Type:            iface.ConnectionSetupResponseTypeForm,
 			StepId:          firstStep.Id,
 			StepTitle:       firstStep.Title,
 			StepDescription: firstStep.Description,
@@ -120,9 +120,9 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 		}
 
-		return &iface.InitiateConnectionRedirect{
+		return &iface.ConnectionSetupRedirect{
 			Id:          connection.GetId(),
-			Type:        iface.PreconnectionResponseTypeRedirect,
+			Type:        iface.ConnectionSetupResponseTypeRedirect,
 			RedirectUrl: url,
 		}, nil
 	}

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -12,7 +12,7 @@ import (
 // Reconfigure initiates a reconfiguration of a completed connection by resetting
 // its setup step to the first configure step. The connection must be in the ready
 // state and its connector must have configure steps defined.
-func (c *connection) Reconfigure(ctx context.Context) (iface.InitiateConnectionResponse, error) {
+func (c *connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResponse, error) {
 	if c.GetState() != database.ConnectionStateReady {
 		return nil, httperr.BadRequest("connection must be in ready state to reconfigure")
 	}

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -79,7 +79,7 @@ func TestReconfigure(t *testing.T) {
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
+		assert.Equal(t, iface.ConnectionSetupResponseTypeForm, resp.GetType())
 	})
 
 	t.Run("returns first configure step when preconnect steps also exist", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestReconfigure(t *testing.T) {
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
+		assert.Equal(t, iface.ConnectionSetupResponseTypeForm, resp.GetType())
 	})
 }
 

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -14,7 +14,7 @@ import (
 // error) and verify_failed (probe failure after auth) are retryable. If the connector has
 // preconnect steps, retry restarts from preconnect:0 so the user can correct any input that
 // led to the failure. Otherwise, retry re-initiates the auth flow from scratch.
-func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (iface.InitiateConnectionResponse, error) {
+func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnToUrl string) (iface.ConnectionSetupResponse, error) {
 	conn, err := s.getConnection(ctx, id)
 	if err != nil {
 		return nil, err

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -77,8 +77,8 @@ func TestRetryConnectionSetup(t *testing.T) {
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
-		form := resp.(*iface.InitiateConnectionForm)
+		assert.Equal(t, iface.ConnectionSetupResponseTypeForm, resp.GetType())
+		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "tenant", form.StepId)
 	})
 
@@ -115,8 +115,8 @@ func TestRetryConnectionSetup(t *testing.T) {
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeForm, resp.GetType())
-		form := resp.(*iface.InitiateConnectionForm)
+		assert.Equal(t, iface.ConnectionSetupResponseTypeForm, resp.GetType())
+		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "tenant", form.StepId)
 	})
 }

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -15,7 +15,7 @@ import (
 // SubmitForm handles form data submission for a connection setup flow step.
 // It merges the submitted data into the connection's configuration, advances to the next step,
 // and returns the appropriate response (next form, auth redirect, or complete).
-func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionRequest) (iface.InitiateConnectionResponse, error) {
+func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionRequest) (iface.ConnectionSetupResponse, error) {
 	setupStep := c.GetSetupStep()
 	if setupStep == nil {
 		return nil, httperr.BadRequest("connection has no active setup step")
@@ -75,9 +75,9 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to set connection state to ready: %w", err))
 		}
 
-		return &iface.InitiateConnectionComplete{
+		return &iface.ConnectionSetupComplete{
 			Id:   c.GetId(),
-			Type: iface.PreconnectionResponseTypeComplete,
+			Type: iface.ConnectionSetupResponseTypeComplete,
 		}, nil
 	}
 
@@ -91,7 +91,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 }
 
 // initiateAuthStep starts the OAuth flow after preconnect steps are complete.
-func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, connector *cschema.Connector) (iface.InitiateConnectionResponse, error) {
+func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, connector *cschema.Connector) (iface.ConnectionSetupResponse, error) {
 	if returnToUrl == "" {
 		return nil, httperr.BadRequest("return_to_url is required for auth step")
 	}
@@ -115,15 +115,15 @@ func (c *connection) initiateAuthStep(ctx context.Context, returnToUrl string, c
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to generate OAuth redirect URL: %w", err))
 	}
 
-	return &iface.InitiateConnectionRedirect{
+	return &iface.ConnectionSetupRedirect{
 		Id:          c.GetId(),
-		Type:        iface.PreconnectionResponseTypeRedirect,
+		Type:        iface.ConnectionSetupResponseTypeRedirect,
 		RedirectUrl: url,
 	}, nil
 }
 
 // buildFormResponse creates a form response for the given setup step.
-func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.SetupStep, sf *cschema.SetupFlow) (iface.InitiateConnectionResponse, error) {
+func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.SetupStep, sf *cschema.SetupFlow) (iface.ConnectionSetupResponse, error) {
 	step, globalIndex, err := sf.GetStepBySetupStep(setupStep)
 	if err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get step definition: %w", err))
@@ -133,9 +133,9 @@ func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.Se
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
 	}
 
-	return &iface.InitiateConnectionForm{
+	return &iface.ConnectionSetupForm{
 		Id:              c.GetId(),
-		Type:            iface.PreconnectionResponseTypeForm,
+		Type:            iface.ConnectionSetupResponseTypeForm,
 		StepId:          step.Id,
 		StepTitle:       step.Title,
 		StepDescription: step.Description,
@@ -148,20 +148,20 @@ func (c *connection) buildFormResponse(ctx context.Context, setupStep cschema.Se
 
 // GetCurrentSetupStepResponse returns the response for the current setup step,
 // allowing the UI to resume an interrupted flow.
-func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.InitiateConnectionResponse, error) {
+func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.ConnectionSetupResponse, error) {
 	setupStep := c.GetSetupStep()
 	if setupStep == nil {
-		return &iface.InitiateConnectionComplete{
+		return &iface.ConnectionSetupComplete{
 			Id:   c.GetId(),
-			Type: iface.PreconnectionResponseTypeComplete,
+			Type: iface.ConnectionSetupResponseTypeComplete,
 		}, nil
 	}
 
 	connector := c.cv.GetDefinition()
 	if connector.SetupFlow == nil {
-		return &iface.InitiateConnectionComplete{
+		return &iface.ConnectionSetupComplete{
 			Id:   c.GetId(),
-			Type: iface.PreconnectionResponseTypeComplete,
+			Type: iface.ConnectionSetupResponseTypeComplete,
 		}, nil
 	}
 
@@ -173,23 +173,23 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Ini
 	switch parsed.Phase() {
 	case cschema.SetupPhaseAuth:
 		// The connection is waiting for the OAuth callback — tell the UI
-		return &iface.InitiateConnectionRedirect{
+		return &iface.ConnectionSetupRedirect{
 			Id:   c.GetId(),
-			Type: iface.PreconnectionResponseTypeRedirect,
+			Type: iface.ConnectionSetupResponseTypeRedirect,
 		}, nil
 	case cschema.SetupPhaseVerify:
-		return &iface.InitiateConnectionVerifying{
+		return &iface.ConnectionSetupVerifying{
 			Id:   c.GetId(),
-			Type: iface.PreconnectionResponseTypeVerifying,
+			Type: iface.ConnectionSetupResponseTypeVerifying,
 		}, nil
 	case cschema.SetupPhaseVerifyFailed, cschema.SetupPhaseAuthFailed:
 		msg := ""
 		if e := c.GetSetupError(); e != nil {
 			msg = *e
 		}
-		return &iface.InitiateConnectionError{
+		return &iface.ConnectionSetupError{
 			Id:       c.GetId(),
-			Type:     iface.PreconnectionResponseTypeError,
+			Type:     iface.ConnectionSetupResponseTypeError,
 			Error:    msg,
 			CanRetry: true,
 		}, nil

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -134,9 +134,9 @@ func TestSubmitForm(t *testing.T) {
 			Data:   json.RawMessage(`{"tenant":"acme"}`),
 		})
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionForm{}, resp)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
 
-		form := resp.(*iface.InitiateConnectionForm)
+		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "region", form.StepId)
 		assert.Equal(t, "Region", form.StepTitle)
 		assert.Equal(t, 1, form.CurrentStep)
@@ -194,8 +194,8 @@ func TestSubmitForm(t *testing.T) {
 			Data:   json.RawMessage(`{"workspace_id":"ws-123"}`),
 		})
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionComplete{}, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeComplete, resp.GetType())
+		require.IsType(t, &iface.ConnectionSetupComplete{}, resp)
+		assert.Equal(t, iface.ConnectionSetupResponseTypeComplete, resp.GetType())
 	})
 
 	t.Run("merges data from multiple steps", func(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSubmitForm(t *testing.T) {
 			Data:   json.RawMessage(`{"tenant":"acme"}`),
 		})
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionForm{}, resp)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
 
 		// Second submit — merges workspace into existing config
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
@@ -250,7 +250,7 @@ func TestSubmitForm(t *testing.T) {
 			Data:   json.RawMessage(`{"workspace":"main"}`),
 		})
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionComplete{}, resp)
+		require.IsType(t, &iface.ConnectionSetupComplete{}, resp)
 
 		// Verify both values are in config
 		cfg, err := conn.GetConfiguration(context.Background())
@@ -269,7 +269,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		assert.Equal(t, iface.PreconnectionResponseTypeComplete, resp.GetType())
+		assert.Equal(t, iface.ConnectionSetupResponseTypeComplete, resp.GetType())
 	})
 
 	t.Run("returns form for preconnect step", func(t *testing.T) {
@@ -291,9 +291,9 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionForm{}, resp)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
 
-		form := resp.(*iface.InitiateConnectionForm)
+		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "tenant", form.StepId)
 		assert.Equal(t, "Enter Tenant", form.StepTitle)
 		assert.Equal(t, 0, form.CurrentStep)
@@ -316,7 +316,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		assert.Equal(t, iface.PreconnectionResponseTypeRedirect, resp.GetType())
+		assert.Equal(t, iface.ConnectionSetupResponseTypeRedirect, resp.GetType())
 	})
 
 	t.Run("returns form for configure step", func(t *testing.T) {
@@ -338,9 +338,9 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionForm{}, resp)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
 
-		form := resp.(*iface.InitiateConnectionForm)
+		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "workspace", form.StepId)
 		assert.Equal(t, "Select Workspace", form.StepTitle)
 	})
@@ -355,8 +355,8 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionVerifying{}, resp)
-		assert.Equal(t, iface.PreconnectionResponseTypeVerifying, resp.GetType())
+		require.IsType(t, &iface.ConnectionSetupVerifying{}, resp)
+		assert.Equal(t, iface.ConnectionSetupResponseTypeVerifying, resp.GetType())
 	})
 
 	t.Run("returns error for verify_failed step with setup_error populated", func(t *testing.T) {
@@ -371,8 +371,8 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)
-		require.IsType(t, &iface.InitiateConnectionError{}, resp)
-		errResp := resp.(*iface.InitiateConnectionError)
+		require.IsType(t, &iface.ConnectionSetupError{}, resp)
+		errResp := resp.(*iface.ConnectionSetupError)
 		assert.Equal(t, errMsg, errResp.Error)
 		assert.True(t, errResp.CanRetry)
 	})

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -40,7 +40,7 @@ type ConnectionsRoutes struct {
 // @Accept			json
 // @Produce		json
 // @Param			request	body		InitiateConnectionRequest	true	"Connection initiation request"
-// @Success		200		{object}	InitiateConnectionRedirect
+// @Success		200		{object}	ConnectionSetupRedirect
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
@@ -75,7 +75,7 @@ func (r *ConnectionsRoutes) initiate(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string					true	"Connection ID"
 // @Param			request	body		SubmitConnectionRequest	true	"Form submission data"
-// @Success		200		{object}	InitiateConnectionComplete
+// @Success		200		{object}	ConnectionSetupComplete
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		501		{object}	ErrorResponse
@@ -132,7 +132,7 @@ func (r *ConnectionsRoutes) submit(gctx *gin.Context) {
 // @Tags			connections
 // @Produce		json
 // @Param			id	path		string	true	"Connection ID"
-// @Success		200	{object}	InitiateConnectionComplete
+// @Success		200	{object}	ConnectionSetupComplete
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		404	{object}	ErrorResponse
@@ -572,7 +572,7 @@ func (r *ConnectionsRoutes) abort(gctx *gin.Context) {
 // @Tags			connections
 // @Produce		json
 // @Param			id	path		string	true	"Connection UUID"
-// @Success		200	{object}	InitiateConnectionForm
+// @Success		200	{object}	ConnectionSetupForm
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		404	{object}	ErrorResponse
@@ -685,7 +685,7 @@ type RetryConnectionRequest struct {
 // @Produce		json
 // @Param			id		path	string					true	"Connection UUID"
 // @Param			request	body	RetryConnectionRequest	true	"Retry request"
-// @Success		200	{object}	InitiateConnectionForm
+// @Success		200	{object}	ConnectionSetupForm
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		404	{object}	ErrorResponse

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -30,10 +30,10 @@ type InitiateConnectionRequest struct {
 	ReturnToUrl string `json:"return_to_url" example:"https://example.com/callback"`
 }
 
-// InitiateConnectionRedirect represents the response when a connection requires a redirect for OAuth.
+// ConnectionSetupRedirect represents the response when a connection requires a redirect for OAuth.
 //
-//	@Description	Redirect response for connection initiation
-type InitiateConnectionRedirect struct {
+//	@Description	Redirect response for connection setup
+type ConnectionSetupRedirect struct {
 	// Connection UUID
 	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
 	// Response type (always "redirect")
@@ -42,10 +42,10 @@ type InitiateConnectionRedirect struct {
 	RedirectUrl string `json:"redirect_url" example:"https://oauth.provider.com/authorize?..."`
 }
 
-// InitiateConnectionForm represents the response when a connection requires form input.
+// ConnectionSetupForm represents the response when a connection requires form input.
 //
-//	@Description	Form response for connection initiation
-type InitiateConnectionForm struct {
+//	@Description	Form response for connection setup
+type ConnectionSetupForm struct {
 	// Connection UUID
 	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
 	// Response type (always "form")
@@ -56,10 +56,10 @@ type InitiateConnectionForm struct {
 	UiSchema interface{} `json:"ui_schema"`
 }
 
-// InitiateConnectionComplete represents the response when a connection setup is complete.
+// ConnectionSetupComplete represents the response when a connection setup is complete.
 //
-//	@Description	Completion response for connection initiation
-type InitiateConnectionComplete struct {
+//	@Description	Completion response for connection setup
+type ConnectionSetupComplete struct {
 	// Connection UUID
 	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
 	// Response type (always "complete")

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1235,7 +1235,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionRedirect"
+                            "$ref": "#/definitions/routes.ConnectionSetupRedirect"
                         }
                     },
                     "400": {
@@ -1795,7 +1795,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1859,7 +1859,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1911,7 +1911,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -1975,7 +1975,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -6520,6 +6520,65 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "routes.ConnectionSetupComplete": {
+            "description": "Completion response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "type": {
+                    "description": "Response type (always \"complete\")",
+                    "type": "string",
+                    "example": "complete"
+                }
+            }
+        },
+        "routes.ConnectionSetupForm": {
+            "description": "Form response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "json_schema": {
+                    "description": "JSON Schema defining the form fields"
+                },
+                "type": {
+                    "description": "Response type (always \"form\")",
+                    "type": "string",
+                    "example": "form"
+                },
+                "ui_schema": {
+                    "description": "UI Schema for JSON Forms rendering"
+                }
+            }
+        },
+        "routes.ConnectionSetupRedirect": {
+            "description": "Redirect response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "redirect_url": {
+                    "description": "URL to redirect the user to",
+                    "type": "string",
+                    "example": "https://oauth.provider.com/authorize?..."
+                },
+                "type": {
+                    "description": "Response type (always \"redirect\")",
+                    "type": "string",
+                    "example": "redirect"
+                }
+            }
+        },
         "routes.ConnectorAnnotationJson": {
             "type": "object",
             "properties": {
@@ -6636,65 +6695,6 @@ const docTemplateadmin_api = `{
                 "stack_trace": {
                     "description": "Stack trace (only in debug mode)",
                     "type": "string"
-                }
-            }
-        },
-        "routes.InitiateConnectionComplete": {
-            "description": "Completion response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "type": {
-                    "description": "Response type (always \"complete\")",
-                    "type": "string",
-                    "example": "complete"
-                }
-            }
-        },
-        "routes.InitiateConnectionForm": {
-            "description": "Form response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "json_schema": {
-                    "description": "JSON Schema defining the form fields"
-                },
-                "type": {
-                    "description": "Response type (always \"form\")",
-                    "type": "string",
-                    "example": "form"
-                },
-                "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
-                }
-            }
-        },
-        "routes.InitiateConnectionRedirect": {
-            "description": "Redirect response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "redirect_url": {
-                    "description": "URL to redirect the user to",
-                    "type": "string",
-                    "example": "https://oauth.provider.com/authorize?..."
-                },
-                "type": {
-                    "description": "Response type (always \"redirect\")",
-                    "type": "string",
-                    "example": "redirect"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1229,7 +1229,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionRedirect"
+                            "$ref": "#/definitions/routes.ConnectionSetupRedirect"
                         }
                     },
                     "400": {
@@ -1789,7 +1789,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1853,7 +1853,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1905,7 +1905,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -1969,7 +1969,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -6514,6 +6514,65 @@
                 }
             }
         },
+        "routes.ConnectionSetupComplete": {
+            "description": "Completion response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "type": {
+                    "description": "Response type (always \"complete\")",
+                    "type": "string",
+                    "example": "complete"
+                }
+            }
+        },
+        "routes.ConnectionSetupForm": {
+            "description": "Form response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "json_schema": {
+                    "description": "JSON Schema defining the form fields"
+                },
+                "type": {
+                    "description": "Response type (always \"form\")",
+                    "type": "string",
+                    "example": "form"
+                },
+                "ui_schema": {
+                    "description": "UI Schema for JSON Forms rendering"
+                }
+            }
+        },
+        "routes.ConnectionSetupRedirect": {
+            "description": "Redirect response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "redirect_url": {
+                    "description": "URL to redirect the user to",
+                    "type": "string",
+                    "example": "https://oauth.provider.com/authorize?..."
+                },
+                "type": {
+                    "description": "Response type (always \"redirect\")",
+                    "type": "string",
+                    "example": "redirect"
+                }
+            }
+        },
         "routes.ConnectorAnnotationJson": {
             "type": "object",
             "properties": {
@@ -6630,65 +6689,6 @@
                 "stack_trace": {
                     "description": "Stack trace (only in debug mode)",
                     "type": "string"
-                }
-            }
-        },
-        "routes.InitiateConnectionComplete": {
-            "description": "Completion response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "type": {
-                    "description": "Response type (always \"complete\")",
-                    "type": "string",
-                    "example": "complete"
-                }
-            }
-        },
-        "routes.InitiateConnectionForm": {
-            "description": "Form response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "json_schema": {
-                    "description": "JSON Schema defining the form fields"
-                },
-                "type": {
-                    "description": "Response type (always \"form\")",
-                    "type": "string",
-                    "example": "form"
-                },
-                "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
-                }
-            }
-        },
-        "routes.InitiateConnectionRedirect": {
-            "description": "Redirect response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "redirect_url": {
-                    "description": "URL to redirect the user to",
-                    "type": "string",
-                    "example": "https://oauth.provider.com/authorize?..."
-                },
-                "type": {
-                    "description": "Response type (always \"redirect\")",
-                    "type": "string",
-                    "example": "redirect"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -37,6 +37,50 @@ definitions:
       value:
         type: string
     type: object
+  routes.ConnectionSetupComplete:
+    description: Completion response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      type:
+        description: Response type (always "complete")
+        example: complete
+        type: string
+    type: object
+  routes.ConnectionSetupForm:
+    description: Form response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      json_schema:
+        description: JSON Schema defining the form fields
+      type:
+        description: Response type (always "form")
+        example: form
+        type: string
+      ui_schema:
+        description: UI Schema for JSON Forms rendering
+    type: object
+  routes.ConnectionSetupRedirect:
+    description: Redirect response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      redirect_url:
+        description: URL to redirect the user to
+        example: https://oauth.provider.com/authorize?...
+        type: string
+      type:
+        description: Response type (always "redirect")
+        example: redirect
+        type: string
+    type: object
   routes.ConnectorAnnotationJson:
     properties:
       key:
@@ -115,50 +159,6 @@ definitions:
         type: string
       stack_trace:
         description: Stack trace (only in debug mode)
-        type: string
-    type: object
-  routes.InitiateConnectionComplete:
-    description: Completion response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      type:
-        description: Response type (always "complete")
-        example: complete
-        type: string
-    type: object
-  routes.InitiateConnectionForm:
-    description: Form response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      json_schema:
-        description: JSON Schema defining the form fields
-      type:
-        description: Response type (always "form")
-        example: form
-        type: string
-      ui_schema:
-        description: UI Schema for JSON Forms rendering
-    type: object
-  routes.InitiateConnectionRedirect:
-    description: Redirect response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      redirect_url:
-        description: URL to redirect the user to
-        example: https://oauth.provider.com/authorize?...
-        type: string
-      type:
-        description: Response type (always "redirect")
-        example: redirect
         type: string
     type: object
   routes.InitiateConnectionRequest:
@@ -1675,7 +1675,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionRedirect'
+            $ref: '#/definitions/routes.ConnectionSetupRedirect'
         "400":
           description: Bad Request
           schema:
@@ -2040,7 +2040,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionForm'
+            $ref: '#/definitions/routes.ConnectionSetupForm'
         "400":
           description: Bad Request
           schema:
@@ -2086,7 +2086,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionForm'
+            $ref: '#/definitions/routes.ConnectionSetupForm'
         "400":
           description: Bad Request
           schema:
@@ -2120,7 +2120,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionComplete'
+            $ref: '#/definitions/routes.ConnectionSetupComplete'
         "400":
           description: Bad Request
           schema:
@@ -2161,7 +2161,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionComplete'
+            $ref: '#/definitions/routes.ConnectionSetupComplete'
         "400":
           description: Bad Request
           schema:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1235,7 +1235,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionRedirect"
+                            "$ref": "#/definitions/routes.ConnectionSetupRedirect"
                         }
                     },
                     "400": {
@@ -1795,7 +1795,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1859,7 +1859,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1911,7 +1911,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -1975,7 +1975,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -6520,6 +6520,65 @@ const docTemplateApi = `{
                 }
             }
         },
+        "routes.ConnectionSetupComplete": {
+            "description": "Completion response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "type": {
+                    "description": "Response type (always \"complete\")",
+                    "type": "string",
+                    "example": "complete"
+                }
+            }
+        },
+        "routes.ConnectionSetupForm": {
+            "description": "Form response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "json_schema": {
+                    "description": "JSON Schema defining the form fields"
+                },
+                "type": {
+                    "description": "Response type (always \"form\")",
+                    "type": "string",
+                    "example": "form"
+                },
+                "ui_schema": {
+                    "description": "UI Schema for JSON Forms rendering"
+                }
+            }
+        },
+        "routes.ConnectionSetupRedirect": {
+            "description": "Redirect response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "redirect_url": {
+                    "description": "URL to redirect the user to",
+                    "type": "string",
+                    "example": "https://oauth.provider.com/authorize?..."
+                },
+                "type": {
+                    "description": "Response type (always \"redirect\")",
+                    "type": "string",
+                    "example": "redirect"
+                }
+            }
+        },
         "routes.ConnectorAnnotationJson": {
             "type": "object",
             "properties": {
@@ -6636,65 +6695,6 @@ const docTemplateApi = `{
                 "stack_trace": {
                     "description": "Stack trace (only in debug mode)",
                     "type": "string"
-                }
-            }
-        },
-        "routes.InitiateConnectionComplete": {
-            "description": "Completion response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "type": {
-                    "description": "Response type (always \"complete\")",
-                    "type": "string",
-                    "example": "complete"
-                }
-            }
-        },
-        "routes.InitiateConnectionForm": {
-            "description": "Form response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "json_schema": {
-                    "description": "JSON Schema defining the form fields"
-                },
-                "type": {
-                    "description": "Response type (always \"form\")",
-                    "type": "string",
-                    "example": "form"
-                },
-                "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
-                }
-            }
-        },
-        "routes.InitiateConnectionRedirect": {
-            "description": "Redirect response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "redirect_url": {
-                    "description": "URL to redirect the user to",
-                    "type": "string",
-                    "example": "https://oauth.provider.com/authorize?..."
-                },
-                "type": {
-                    "description": "Response type (always \"redirect\")",
-                    "type": "string",
-                    "example": "redirect"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1229,7 +1229,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionRedirect"
+                            "$ref": "#/definitions/routes.ConnectionSetupRedirect"
                         }
                     },
                     "400": {
@@ -1789,7 +1789,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1853,7 +1853,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionForm"
+                            "$ref": "#/definitions/routes.ConnectionSetupForm"
                         }
                     },
                     "400": {
@@ -1905,7 +1905,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -1969,7 +1969,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.InitiateConnectionComplete"
+                            "$ref": "#/definitions/routes.ConnectionSetupComplete"
                         }
                     },
                     "400": {
@@ -6514,6 +6514,65 @@
                 }
             }
         },
+        "routes.ConnectionSetupComplete": {
+            "description": "Completion response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "type": {
+                    "description": "Response type (always \"complete\")",
+                    "type": "string",
+                    "example": "complete"
+                }
+            }
+        },
+        "routes.ConnectionSetupForm": {
+            "description": "Form response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "json_schema": {
+                    "description": "JSON Schema defining the form fields"
+                },
+                "type": {
+                    "description": "Response type (always \"form\")",
+                    "type": "string",
+                    "example": "form"
+                },
+                "ui_schema": {
+                    "description": "UI Schema for JSON Forms rendering"
+                }
+            }
+        },
+        "routes.ConnectionSetupRedirect": {
+            "description": "Redirect response for connection setup",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Connection UUID",
+                    "type": "string",
+                    "example": "req_test550e8400abcde"
+                },
+                "redirect_url": {
+                    "description": "URL to redirect the user to",
+                    "type": "string",
+                    "example": "https://oauth.provider.com/authorize?..."
+                },
+                "type": {
+                    "description": "Response type (always \"redirect\")",
+                    "type": "string",
+                    "example": "redirect"
+                }
+            }
+        },
         "routes.ConnectorAnnotationJson": {
             "type": "object",
             "properties": {
@@ -6630,65 +6689,6 @@
                 "stack_trace": {
                     "description": "Stack trace (only in debug mode)",
                     "type": "string"
-                }
-            }
-        },
-        "routes.InitiateConnectionComplete": {
-            "description": "Completion response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "type": {
-                    "description": "Response type (always \"complete\")",
-                    "type": "string",
-                    "example": "complete"
-                }
-            }
-        },
-        "routes.InitiateConnectionForm": {
-            "description": "Form response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "json_schema": {
-                    "description": "JSON Schema defining the form fields"
-                },
-                "type": {
-                    "description": "Response type (always \"form\")",
-                    "type": "string",
-                    "example": "form"
-                },
-                "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
-                }
-            }
-        },
-        "routes.InitiateConnectionRedirect": {
-            "description": "Redirect response for connection initiation",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Connection UUID",
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "redirect_url": {
-                    "description": "URL to redirect the user to",
-                    "type": "string",
-                    "example": "https://oauth.provider.com/authorize?..."
-                },
-                "type": {
-                    "description": "Response type (always \"redirect\")",
-                    "type": "string",
-                    "example": "redirect"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -37,6 +37,50 @@ definitions:
       value:
         type: string
     type: object
+  routes.ConnectionSetupComplete:
+    description: Completion response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      type:
+        description: Response type (always "complete")
+        example: complete
+        type: string
+    type: object
+  routes.ConnectionSetupForm:
+    description: Form response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      json_schema:
+        description: JSON Schema defining the form fields
+      type:
+        description: Response type (always "form")
+        example: form
+        type: string
+      ui_schema:
+        description: UI Schema for JSON Forms rendering
+    type: object
+  routes.ConnectionSetupRedirect:
+    description: Redirect response for connection setup
+    properties:
+      id:
+        description: Connection UUID
+        example: req_test550e8400abcde
+        type: string
+      redirect_url:
+        description: URL to redirect the user to
+        example: https://oauth.provider.com/authorize?...
+        type: string
+      type:
+        description: Response type (always "redirect")
+        example: redirect
+        type: string
+    type: object
   routes.ConnectorAnnotationJson:
     properties:
       key:
@@ -115,50 +159,6 @@ definitions:
         type: string
       stack_trace:
         description: Stack trace (only in debug mode)
-        type: string
-    type: object
-  routes.InitiateConnectionComplete:
-    description: Completion response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      type:
-        description: Response type (always "complete")
-        example: complete
-        type: string
-    type: object
-  routes.InitiateConnectionForm:
-    description: Form response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      json_schema:
-        description: JSON Schema defining the form fields
-      type:
-        description: Response type (always "form")
-        example: form
-        type: string
-      ui_schema:
-        description: UI Schema for JSON Forms rendering
-    type: object
-  routes.InitiateConnectionRedirect:
-    description: Redirect response for connection initiation
-    properties:
-      id:
-        description: Connection UUID
-        example: req_test550e8400abcde
-        type: string
-      redirect_url:
-        description: URL to redirect the user to
-        example: https://oauth.provider.com/authorize?...
-        type: string
-      type:
-        description: Response type (always "redirect")
-        example: redirect
         type: string
     type: object
   routes.InitiateConnectionRequest:
@@ -1675,7 +1675,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionRedirect'
+            $ref: '#/definitions/routes.ConnectionSetupRedirect'
         "400":
           description: Bad Request
           schema:
@@ -2040,7 +2040,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionForm'
+            $ref: '#/definitions/routes.ConnectionSetupForm'
         "400":
           description: Bad Request
           schema:
@@ -2086,7 +2086,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionForm'
+            $ref: '#/definitions/routes.ConnectionSetupForm'
         "400":
           description: Bad Request
           schema:
@@ -2120,7 +2120,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionComplete'
+            $ref: '#/definitions/routes.ConnectionSetupComplete'
         "400":
           description: Bad Request
           schema:
@@ -2161,7 +2161,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.InitiateConnectionComplete'
+            $ref: '#/definitions/routes.ConnectionSetupComplete'
         "400":
           description: Bad Request
           schema:

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -61,7 +61,7 @@ export interface InitiateConnectionRequest {
     labels?: Record<string, string>;
 }
 
-export enum InitiateConnectionResponseType {
+export enum ConnectionSetupResponseType {
     REDIRECT = 'redirect',
     FORM = 'form',
     COMPLETE = 'complete',
@@ -69,18 +69,18 @@ export enum InitiateConnectionResponseType {
     ERROR = 'error',
 }
 
-export interface InitiateConnectionResponse {
+export interface ConnectionSetupResponse {
     id: string;
-    type: InitiateConnectionResponseType;
+    type: ConnectionSetupResponseType;
 }
 
-export interface InitiateConnectionRedirectResponse extends InitiateConnectionResponse {
-    type: InitiateConnectionResponseType.REDIRECT;
+export interface ConnectionSetupRedirectResponse extends ConnectionSetupResponse {
+    type: ConnectionSetupResponseType.REDIRECT;
     redirect_url: string;
 }
 
-export interface InitiateConnectionFormResponse extends InitiateConnectionResponse {
-    type: InitiateConnectionResponseType.FORM;
+export interface ConnectionSetupFormResponse extends ConnectionSetupResponse {
+    type: ConnectionSetupResponseType.FORM;
     step_id: string;
     step_title?: string;
     step_description?: string;
@@ -90,38 +90,38 @@ export interface InitiateConnectionFormResponse extends InitiateConnectionRespon
     ui_schema: Record<string, unknown>;
 }
 
-export interface InitiateConnectionCompleteResponse extends InitiateConnectionResponse {
-    type: InitiateConnectionResponseType.COMPLETE;
+export interface ConnectionSetupCompleteResponse extends ConnectionSetupResponse {
+    type: ConnectionSetupResponseType.COMPLETE;
 }
 
-export interface InitiateConnectionVerifyingResponse extends InitiateConnectionResponse {
-    type: InitiateConnectionResponseType.VERIFYING;
+export interface ConnectionSetupVerifyingResponse extends ConnectionSetupResponse {
+    type: ConnectionSetupResponseType.VERIFYING;
 }
 
-export interface InitiateConnectionErrorResponse extends InitiateConnectionResponse {
-    type: InitiateConnectionResponseType.ERROR;
+export interface ConnectionSetupErrorResponse extends ConnectionSetupResponse {
+    type: ConnectionSetupResponseType.ERROR;
     error: string;
     can_retry: boolean;
 }
 
-export function isRedirectResponse(response: InitiateConnectionResponse): response is InitiateConnectionRedirectResponse {
-    return response.type === InitiateConnectionResponseType.REDIRECT;
+export function isRedirectResponse(response: ConnectionSetupResponse): response is ConnectionSetupRedirectResponse {
+    return response.type === ConnectionSetupResponseType.REDIRECT;
 }
 
-export function isFormResponse(response: InitiateConnectionResponse): response is InitiateConnectionFormResponse {
-    return response.type === InitiateConnectionResponseType.FORM;
+export function isFormResponse(response: ConnectionSetupResponse): response is ConnectionSetupFormResponse {
+    return response.type === ConnectionSetupResponseType.FORM;
 }
 
-export function isCompleteResponse(response: InitiateConnectionResponse): response is InitiateConnectionCompleteResponse {
-    return response.type === InitiateConnectionResponseType.COMPLETE;
+export function isCompleteResponse(response: ConnectionSetupResponse): response is ConnectionSetupCompleteResponse {
+    return response.type === ConnectionSetupResponseType.COMPLETE;
 }
 
-export function isVerifyingResponse(response: InitiateConnectionResponse): response is InitiateConnectionVerifyingResponse {
-    return response.type === InitiateConnectionResponseType.VERIFYING;
+export function isVerifyingResponse(response: ConnectionSetupResponse): response is ConnectionSetupVerifyingResponse {
+    return response.type === ConnectionSetupResponseType.VERIFYING;
 }
 
-export function isErrorResponse(response: InitiateConnectionResponse): response is InitiateConnectionErrorResponse {
-    return response.type === InitiateConnectionResponseType.ERROR;
+export function isErrorResponse(response: ConnectionSetupResponse): response is ConnectionSetupErrorResponse {
+    return response.type === ConnectionSetupResponseType.ERROR;
 }
 
 export interface SubmitConnectionRequest {
@@ -190,7 +190,7 @@ export const initiateConnection = (
         labels,
     };
 
-    return client.post<InitiateConnectionResponse>(
+    return client.post<ConnectionSetupResponse>(
         '/api/v1/connections/_initiate',
         request
     );
@@ -202,7 +202,7 @@ export const initiateConnection = (
 export const submitConnection = (connectionId: string, stepId: string, data: unknown) => {
     const request: SubmitConnectionRequest = { step_id: stepId, data };
 
-    return client.post<InitiateConnectionResponse>(
+    return client.post<ConnectionSetupResponse>(
         `/api/v1/connections/${connectionId}/_submit`,
         request
     );
@@ -302,7 +302,7 @@ export const abortConnection = (id: string) => {
  * Get the current setup step for a connection
  */
 export const getSetupStep = (connectionId: string) => {
-    return client.get<InitiateConnectionResponse>(`/api/v1/connections/${connectionId}/_setup_step`);
+    return client.get<ConnectionSetupResponse>(`/api/v1/connections/${connectionId}/_setup_step`);
 };
 
 /**
@@ -316,7 +316,7 @@ export const getDataSource = (connectionId: string, sourceId: string) => {
  * Reconfigure a completed connection by restarting its configure phase
  */
 export const reconfigureConnection = (id: string) => {
-    return client.post<InitiateConnectionResponse>(`/api/v1/connections/${id}/_reconfigure`);
+    return client.post<ConnectionSetupResponse>(`/api/v1/connections/${id}/_reconfigure`);
 };
 
 /**
@@ -334,7 +334,7 @@ export const cancelSetupConnection = (id: string) => {
  */
 export const retryConnection = (id: string, returnToUrl?: string) => {
     const request: RetryConnectionRequest = { return_to_url: returnToUrl };
-    return client.post<InitiateConnectionResponse>(
+    return client.post<ConnectionSetupResponse>(
         `/api/v1/connections/${id}/_retry`,
         request
     );

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -5,8 +5,8 @@ import {
     connections,
     ConnectionState,
     DisconnectResponseJson,
-    InitiateConnectionFormResponse,
-    InitiateConnectionResponse,
+    ConnectionSetupFormResponse,
+    ConnectionSetupResponse,
     isErrorResponse,
     isFormResponse,
     isVerifyingResponse,
@@ -24,7 +24,7 @@ interface FormStep {
     uiSchema: Record<string, unknown>;
 }
 
-function formStepFromResponse(response: InitiateConnectionFormResponse): FormStep {
+function formStepFromResponse(response: ConnectionSetupFormResponse): FormStep {
     return {
         connectionId: response.id,
         stepId: response.step_id,
@@ -40,7 +40,7 @@ function formStepFromResponse(response: InitiateConnectionFormResponse): FormSte
 // applySetupResponse updates state based on a setup-step response. Verifying responses
 // set the polling marker; error responses populate verifyError; form responses populate
 // currentFormStep; redirect and complete clear the in-flight setup UI.
-function applySetupResponse(state: ConnectionsState, response: InitiateConnectionResponse): void {
+function applySetupResponse(state: ConnectionsState, response: ConnectionSetupResponse): void {
     if (isFormResponse(response)) {
         state.currentFormStep = formStepFromResponse(response);
         state.verifyingConnectionId = null;


### PR DESCRIPTION
## Summary
- Renames `InitiateConnectionResponse` (and its `Redirect`/`Form`/`Complete`/`Verifying`/`Error` variants) to `ConnectionSetup*` to reflect that this response is used throughout the setup flow, not just the initiate call. Closes #151.
- Renames the mis-prefixed `PreconnectionResponseType*` constants to `ConnectionSetupResponseType*` to match.
- Keeps `InitiateConnectionRequest` since it remains specific to the initiate call. Wire format (`type` JSON values like `"redirect"`, `"form"`, etc.) is unchanged.
- Mirrors the rename in the JS SDK (`sdks/js/src/connections.ts`) and updates the marketplace UI consumer. Regenerates swagger docs.

Resolves #151

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... ./internal/routes/...`
- [x] `yarn workspace @authproxy/api typecheck`
- [x] `yarn workspace @authproxy/marketplace typecheck`
- [x] `integration_tests` module resolves (`go list -mod=readonly ./...`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)