### PR TITLE
Add JSON/YAML serialization to cschema.SetupStep (#156)

### DIFF
--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 
@@ -249,7 +250,7 @@ type ConnectionJson struct {
 	Labels      map[string]string        `json:"labels,omitempty"`
 	Annotations map[string]string        `json:"annotations,omitempty"`
 	State       database.ConnectionState `json:"state"`
-	SetupStep   *string                  `json:"setup_step,omitempty"`
+	SetupStep   *cschema.SetupStep       `json:"setup_step,omitempty" swaggertype:"string"`
 	SetupError  *string                  `json:"setup_error,omitempty"`
 	Connector   ConnectorJson            `json:"connector"`
 	CreatedAt   time.Time                `json:"created_at"`
@@ -259,19 +260,13 @@ type ConnectionJson struct {
 func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
 	connector := ConnectorVersionToConnectorJson(conn.GetConnectorVersionEntity())
 
-	var setupStep *string
-	if s := conn.GetSetupStep(); s != nil {
-		str := s.String()
-		setupStep = &str
-	}
-
 	return ConnectionJson{
 		Id:          conn.GetId(),
 		Namespace:   conn.GetNamespace(),
 		Labels:      conn.GetLabels(),
 		Annotations: conn.GetAnnotations(),
 		State:       conn.GetState(),
-		SetupStep:   setupStep,
+		SetupStep:   conn.GetSetupStep(),
 		SetupError:  conn.GetSetupError(),
 		Connector:   connector,
 		CreatedAt:   conn.GetCreatedAt(),

--- a/internal/schema/connectors/setup_flow.go
+++ b/internal/schema/connectors/setup_flow.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -219,6 +220,77 @@ func (s *SetupStep) Scan(value interface{}) error {
 		str = string(v)
 	default:
 		return fmt.Errorf("cannot scan %T into SetupStep", value)
+	}
+
+	if str == "" {
+		*s = SetupStep{}
+		return nil
+	}
+
+	parsed, err := ParseSetupStep(str)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// MarshalJSON renders SetupStep as the canonical setup-step string. The zero
+// SetupStep marshals as JSON null so it round-trips cleanly with omitempty
+// pointer fields and database NULL.
+func (s SetupStep) MarshalJSON() ([]byte, error) {
+	if s.IsZero() {
+		return []byte("null"), nil
+	}
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON parses a SetupStep from a JSON string, accepting null and the
+// empty string as the zero SetupStep.
+func (s *SetupStep) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*s = SetupStep{}
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return fmt.Errorf("setup step must be a JSON string: %w", err)
+	}
+
+	if str == "" {
+		*s = SetupStep{}
+		return nil
+	}
+
+	parsed, err := ParseSetupStep(str)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// MarshalYAML renders SetupStep as the canonical setup-step string. The zero
+// SetupStep marshals as YAML null.
+func (s SetupStep) MarshalYAML() (interface{}, error) {
+	if s.IsZero() {
+		return nil, nil
+	}
+	return s.String(), nil
+}
+
+// UnmarshalYAML parses a SetupStep from a YAML scalar, accepting null and the
+// empty string as the zero SetupStep.
+func (s *SetupStep) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		*s = SetupStep{}
+		return nil
+	}
+
+	var str string
+	if err := value.Decode(&str); err != nil {
+		return fmt.Errorf("setup step must be a YAML string: %w", err)
 	}
 
 	if str == "" {

--- a/internal/schema/connectors/setup_flow_test.go
+++ b/internal/schema/connectors/setup_flow_test.go
@@ -501,6 +501,123 @@ func TestSetupStepZero(t *testing.T) {
 	assert.Equal(t, "", z.String())
 }
 
+func TestSetupStepJSONMarshal(t *testing.T) {
+	t.Run("indexed phase marshals as canonical string", func(t *testing.T) {
+		s := MustNewIndexedSetupStep(SetupPhaseConfigure, 2)
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.Equal(t, `"configure:2"`, string(b))
+	})
+
+	t.Run("singleton phase marshals as canonical string", func(t *testing.T) {
+		b, err := json.Marshal(SetupStepAuth)
+		require.NoError(t, err)
+		assert.Equal(t, `"auth"`, string(b))
+	})
+
+	t.Run("zero value marshals as null", func(t *testing.T) {
+		var z SetupStep
+		b, err := json.Marshal(z)
+		require.NoError(t, err)
+		assert.Equal(t, `null`, string(b))
+	})
+
+	t.Run("pointer to zero with omitempty is omitted", func(t *testing.T) {
+		type wrapper struct {
+			Step *SetupStep `json:"step,omitempty"`
+		}
+		b, err := json.Marshal(wrapper{Step: nil})
+		require.NoError(t, err)
+		assert.Equal(t, `{}`, string(b))
+	})
+
+	t.Run("pointer to non-zero marshals as string", func(t *testing.T) {
+		type wrapper struct {
+			Step *SetupStep `json:"step,omitempty"`
+		}
+		s := MustNewIndexedSetupStep(SetupPhasePreconnect, 0)
+		b, err := json.Marshal(wrapper{Step: &s})
+		require.NoError(t, err)
+		assert.Equal(t, `{"step":"preconnect:0"}`, string(b))
+	})
+}
+
+func TestSetupStepJSONUnmarshal(t *testing.T) {
+	cases := []string{"preconnect:0", "preconnect:7", "configure:0", "configure:2", "auth", "verify", "verify_failed", "auth_failed"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			input := []byte(`"` + c + `"`)
+			var s SetupStep
+			require.NoError(t, json.Unmarshal(input, &s))
+			assert.Equal(t, c, s.String())
+
+			// And round-trip
+			b, err := json.Marshal(s)
+			require.NoError(t, err)
+			assert.Equal(t, string(input), string(b))
+		})
+	}
+
+	t.Run("null produces zero", func(t *testing.T) {
+		var s SetupStep
+		require.NoError(t, json.Unmarshal([]byte(`null`), &s))
+		assert.True(t, s.IsZero())
+	})
+
+	t.Run("empty string produces zero", func(t *testing.T) {
+		var s SetupStep
+		require.NoError(t, json.Unmarshal([]byte(`""`), &s))
+		assert.True(t, s.IsZero())
+	})
+
+	t.Run("invalid string returns error", func(t *testing.T) {
+		var s SetupStep
+		err := json.Unmarshal([]byte(`"unknown:0"`), &s)
+		assert.Error(t, err)
+	})
+
+	t.Run("non-string value returns error", func(t *testing.T) {
+		var s SetupStep
+		err := json.Unmarshal([]byte(`123`), &s)
+		assert.Error(t, err)
+	})
+}
+
+func TestSetupStepYAMLRoundTrip(t *testing.T) {
+	cases := []string{"preconnect:0", "configure:2", "auth", "verify_failed"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			parsed, err := ParseSetupStep(c)
+			require.NoError(t, err)
+
+			out, err := yaml.Marshal(parsed)
+			require.NoError(t, err)
+
+			var back SetupStep
+			require.NoError(t, yaml.Unmarshal(out, &back))
+			assert.Equal(t, c, back.String())
+		})
+	}
+
+	t.Run("null yaml decodes to zero", func(t *testing.T) {
+		var s SetupStep
+		require.NoError(t, yaml.Unmarshal([]byte(`null`), &s))
+		assert.True(t, s.IsZero())
+	})
+
+	t.Run("empty string yaml decodes to zero", func(t *testing.T) {
+		var s SetupStep
+		require.NoError(t, yaml.Unmarshal([]byte(`""`), &s))
+		assert.True(t, s.IsZero())
+	})
+
+	t.Run("invalid string returns error", func(t *testing.T) {
+		var s SetupStep
+		err := yaml.Unmarshal([]byte(`unknown:0`), &s)
+		assert.Error(t, err)
+	})
+}
+
 func TestSetupStepPhaseHelpers(t *testing.T) {
 	assert.True(t, SetupPhasePreconnect.IsIndexed())
 	assert.True(t, SetupPhaseConfigure.IsIndexed())


### PR DESCRIPTION
## Summary
- Implement `json.Marshaler/Unmarshaler` and `yaml.Marshaler/Unmarshaler` on `cschema.SetupStep` so the typed value uses the canonical "phase[:index]" string at every boundary (DB, JSON, YAML).
- Switch `routes.ConnectionJson.SetupStep` from `*string` to `*cschema.SetupStep` and drop the manual stringify in `ConnectionToJson`. Wire format is unchanged thanks to `MarshalJSON`.

The zero `SetupStep` round-trips as JSON/YAML `null`, matching the existing database `NULL` behavior, so `omitempty` continues to drop the field for connections that aren't in setup.

Closes #156.

## Test plan
- [x] `./scripts/preflight.sh`
- [x] `go test ./...`
- [x] New tests cover JSON/YAML marshal, unmarshal, round-trip, null/empty handling, and rejection of invalid strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)