### PR TITLE
Use pagination.KeepGoing alias for all Enumerate methods (#80)

### DIFF
--- a/integration_tests/encrypt/helpers_test.go
+++ b/integration_tests/encrypt/helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,13 +24,13 @@ func randomBytes(t *testing.T, n int) []byte {
 }
 
 func runReencryptAll(ctx context.Context, env *helpers.IntegrationTestEnv) error {
-	return env.Db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []database.ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+	return env.Db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []database.ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 		var updates []database.ReEncryptedFieldUpdate
 
 		for _, target := range targets {
 			newEF, reencryptErr := env.DM.GetEncryptService().ReEncryptField(ctx, target.EncryptedFieldValue, target.TargetEncryptionKeyVersionId)
 			if reencryptErr != nil {
-				return true, reencryptErr
+				return false, reencryptErr
 			}
 
 			if newEF.ID == target.EncryptedFieldValue.ID {
@@ -47,10 +48,10 @@ func runReencryptAll(ctx context.Context, env *helpers.IntegrationTestEnv) error
 
 		if len(updates) > 0 {
 			if updateErr := env.Db.BatchUpdateReEncryptedFields(ctx, updates); updateErr != nil {
-				return true, updateErr
+				return false, updateErr
 			}
 		}
 
-		return false, nil
+		return true, nil
 	})
 }

--- a/integration_tests/encrypt/helpers_test.go
+++ b/integration_tests/encrypt/helpers_test.go
@@ -30,7 +30,7 @@ func runReencryptAll(ctx context.Context, env *helpers.IntegrationTestEnv) error
 		for _, target := range targets {
 			newEF, reencryptErr := env.DM.GetEncryptService().ReEncryptField(ctx, target.EncryptedFieldValue, target.TargetEncryptionKeyVersionId)
 			if reencryptErr != nil {
-				return false, reencryptErr
+				return pagination.Stop, reencryptErr
 			}
 
 			if newEF.ID == target.EncryptedFieldValue.ID {
@@ -48,10 +48,10 @@ func runReencryptAll(ctx context.Context, env *helpers.IntegrationTestEnv) error
 
 		if len(updates) > 0 {
 			if updateErr := env.Db.BatchUpdateReEncryptedFields(ctx, updates); updateErr != nil {
-				return false, updateErr
+				return pagination.Stop, updateErr
 			}
 		}
 
-		return true, nil
+		return pagination.Continue, nil
 	})
 }

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -131,11 +131,11 @@ func (s *service) syncConfiguredActors(ctx context.Context, actors []*sconfig.Co
 				if dbActor.Labels[LabelConfiguredActorSyncSource] == sourceLabel && !expectedExternalIds[dbActor.ExternalId] {
 					s.logger.Info("deleting stale configured actor", "external_id", dbActor.ExternalId)
 					if err := s.db.DeleteActor(ctx, dbActor.Id); err != nil {
-						return false, fmt.Errorf("failed to delete stale actor %s: %w", dbActor.ExternalId, err)
+						return pagination.Stop, fmt.Errorf("failed to delete stale actor %s: %w", dbActor.ExternalId, err)
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 
 	if err != nil {

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -125,7 +125,7 @@ func (s *service) syncConfiguredActors(ctx context.Context, actors []*sconfig.Co
 	// Delete stale actors (those with the sync label but not in current config)
 	err := s.db.ListActorsBuilder().
 		ForLabelSelector(LabelConfiguredActorSyncSource).
-		Enumerate(ctx, func(result pagination.PageResult[*database.Actor]) (keepGoing bool, err error) {
+		Enumerate(ctx, func(result pagination.PageResult[*database.Actor]) (keepGoing pagination.KeepGoing, err error) {
 			for _, dbActor := range result.Results {
 				// Only delete actors with matching source label that aren't in current config
 				if dbActor.Labels[LabelConfiguredActorSyncSource] == sourceLabel && !expectedExternalIds[dbActor.ExternalId] {

--- a/internal/auth_methods/oauth2/task_refresh_expiring_oauth_tokens.go
+++ b/internal/auth_methods/oauth2/task_refresh_expiring_oauth_tokens.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 const taskTypeRefreshExpiringOAuthTokens = "oauth2:refresh_expiring_oauth_tokens"
@@ -49,16 +50,16 @@ func (th *taskHandler) refreshExpiringOauth2Tokens(ctx context.Context, t *asynq
 	err := th.db.EnumerateOAuth2TokensExpiringWithin(
 		ctx,
 		refreshWithin,
-		func(tokensWithConnections []*database.OAuth2TokenWithConnection, lastPage bool) (stop bool, err error) {
+		func(tokensWithConnections []*database.OAuth2TokenWithConnection, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tokenWithConnection := range tokensWithConnections {
 				t, err := newRefreshOauth2TokenTask(tokenWithConnection.Token.ConnectionId)
 				if err != nil {
-					return true, err
+					return false, err
 				}
 
 				ti, err := th.asynq.EnqueueContext(ctx, t)
 				if err != nil {
-					return true, err
+					return false, err
 				}
 				logger.Debug(
 					"token refresh task enqueued for connection",
@@ -69,7 +70,7 @@ func (th *taskHandler) refreshExpiringOauth2Tokens(ctx context.Context, t *asynq
 				queuedForRefresh++
 			}
 
-			return false, nil
+			return true, nil
 		},
 	)
 

--- a/internal/auth_methods/oauth2/task_refresh_expiring_oauth_tokens.go
+++ b/internal/auth_methods/oauth2/task_refresh_expiring_oauth_tokens.go
@@ -54,12 +54,12 @@ func (th *taskHandler) refreshExpiringOauth2Tokens(ctx context.Context, t *asynq
 			for _, tokenWithConnection := range tokensWithConnections {
 				t, err := newRefreshOauth2TokenTask(tokenWithConnection.Token.ConnectionId)
 				if err != nil {
-					return false, err
+					return pagination.Stop, err
 				}
 
 				ti, err := th.asynq.EnqueueContext(ctx, t)
 				if err != nil {
-					return false, err
+					return pagination.Stop, err
 				}
 				logger.Debug(
 					"token refresh task enqueued for connection",
@@ -70,7 +70,7 @@ func (th *taskHandler) refreshExpiringOauth2Tokens(ctx context.Context, t *asynq
 				queuedForRefresh++
 			}
 
-			return true, nil
+			return pagination.Continue, nil
 		},
 	)
 

--- a/internal/core/iface/encryption_key.go
+++ b/internal/core/iface/encryption_key.go
@@ -21,7 +21,7 @@ type EncryptionKey interface {
 
 type ListEncryptionKeysExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[EncryptionKey]
-	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListEncryptionKeysBuilder interface {

--- a/internal/core/iface/list_connections.go
+++ b/internal/core/iface/list_connections.go
@@ -9,7 +9,7 @@ import (
 
 type ListConnectionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connection]
-	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectionsBuilder interface {

--- a/internal/core/iface/list_connector_versions.go
+++ b/internal/core/iface/list_connector_versions.go
@@ -14,7 +14,7 @@ import (
 
 type ListConnectorVersionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[ConnectorVersion]
-	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectorVersionsBuilder interface {

--- a/internal/core/iface/list_connectors.go
+++ b/internal/core/iface/list_connectors.go
@@ -10,7 +10,7 @@ import (
 
 type ListConnectorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connector]
-	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectorsBuilder interface {

--- a/internal/core/iface/namespace.go
+++ b/internal/core/iface/namespace.go
@@ -25,7 +25,7 @@ type Namespace interface {
 
 type ListNamespacesExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Namespace]
-	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListNamespacesBuilder interface {

--- a/internal/core/service_connection_list.go
+++ b/internal/core/service_connection_list.go
@@ -83,8 +83,8 @@ func (l *listConnectionsWrapper) FetchPage(ctx context.Context) pagination.PageR
 	return l.convertPageResult(ctx, l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectionsWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connection]) (keepGoing bool, err error)) error {
-	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connection]) (keepGoing bool, err error) {
+func (l *listConnectionsWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connection]) (keepGoing pagination.KeepGoing, err error)) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connection]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(ctx, result))
 	})
 }

--- a/internal/core/service_connector_list.go
+++ b/internal/core/service_connector_list.go
@@ -53,8 +53,8 @@ func (l *listConnectorWrapper) FetchPage(ctx context.Context) pagination.PageRes
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectorWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connector]) (keepGoing bool, err error)) error {
-	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing bool, err error) {
+func (l *listConnectorWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connector]) (keepGoing pagination.KeepGoing, err error)) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})
 }

--- a/internal/core/service_connector_version_list.go
+++ b/internal/core/service_connector_version_list.go
@@ -45,8 +45,8 @@ func (l *listConnectorVersionWrapper) FetchPage(ctx context.Context) pagination.
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectorVersionWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.ConnectorVersion]) (keepGoing bool, err error)) error {
-	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.ConnectorVersion]) (keepGoing bool, err error) {
+func (l *listConnectorVersionWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.ConnectorVersion]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})
 }

--- a/internal/core/service_encryption_key.go
+++ b/internal/core/service_encryption_key.go
@@ -187,8 +187,8 @@ func (l *listEncryptionKeyWrapper) FetchPage(ctx context.Context) pagination.Pag
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listEncryptionKeyWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.EncryptionKey]) (keepGoing bool, err error)) error {
-	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.EncryptionKey]) (keepGoing bool, err error) {
+func (l *listEncryptionKeyWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.EncryptionKey]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})
 }

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -363,7 +363,7 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 			Limit(100)
 
 		results := make([]database.Connector, 0)
-		err := b.Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing bool, err error) {
+		err := b.Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing pagination.KeepGoing, err error) {
 			results = append(results, result.Results...)
 			return true, nil
 		})

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -365,7 +365,7 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 		results := make([]database.Connector, 0)
 		err := b.Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing pagination.KeepGoing, err error) {
 			results = append(results, result.Results...)
-			return true, nil
+			return pagination.Continue, nil
 		})
 		if err != nil {
 			return fmt.Errorf("failed to check for existing connector for precheck: %w", err)

--- a/internal/core/service_namespace.go
+++ b/internal/core/service_namespace.go
@@ -219,8 +219,8 @@ func (l *listNamespaceWrapper) FetchPage(ctx context.Context) pagination.PageRes
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listNamespaceWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Namespace]) (keepGoing bool, err error)) error {
-	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Namespace]) (keepGoing bool, err error) {
+func (l *listNamespaceWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Namespace]) (keepGoing pagination.KeepGoing, err error)) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Namespace]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})
 }

--- a/internal/core/service_tasks.go
+++ b/internal/core/service_tasks.go
@@ -33,7 +33,7 @@ func (s *service) GetCronTasks() []*asynq.PeriodicTaskConfig {
 		}).
 		Enumerate(
 			context.Background(),
-			func(pr pagination.PageResult[database.Connection]) (keepGoing bool, err error) {
+			func(pr pagination.PageResult[database.Connection]) (keepGoing pagination.KeepGoing, err error) {
 				for _, dbConn := range pr.Results {
 					logger := aplog.NewBuilder(s.logger).
 						WithConnectionId(dbConn.Id).
@@ -62,7 +62,7 @@ func (s *service) GetCronTasks() []*asynq.PeriodicTaskConfig {
 					}
 				}
 
-				return true, nil
+				return pagination.Continue, nil
 			},
 		)
 

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -576,7 +576,7 @@ func (s *service) DeleteActor(ctx context.Context, id apid.ID) error {
 
 type ListActorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[*Actor]
-	Enumerate(context.Context, func(pagination.PageResult[*Actor]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[*Actor]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListActorsBuilder interface {
@@ -751,7 +751,7 @@ func (l *listActorsFilters) FetchPage(ctx context.Context) pagination.PageResult
 	return l.fetchPage(ctx)
 }
 
-func (l *listActorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[*Actor]) (keepGoing bool, err error)) error {
+func (l *listActorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[*Actor]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -753,10 +753,10 @@ func (l *listActorsFilters) FetchPage(ctx context.Context) pagination.PageResult
 
 func (l *listActorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[*Actor]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/database/actor_test.go
+++ b/internal/database/actor_test.go
@@ -515,7 +515,7 @@ func TestActor(t *testing.T) {
 		t.Run("reverse order", func(t *testing.T) {
 			var allResults []*Actor
 			q := db.ListActorsBuilder().Limit(7).OrderBy(ActorOrderByCreatedAt, pagination.OrderByDesc)
-			err := q.Enumerate(ctx, func(result pagination.PageResult[*Actor]) (bool, error) {
+			err := q.Enumerate(ctx, func(result pagination.PageResult[*Actor]) (pagination.KeepGoing, error) {
 				allResults = append(allResults, result.Results...)
 				return true, nil
 			})

--- a/internal/database/actor_test.go
+++ b/internal/database/actor_test.go
@@ -517,7 +517,7 @@ func TestActor(t *testing.T) {
 			q := db.ListActorsBuilder().Limit(7).OrderBy(ActorOrderByCreatedAt, pagination.OrderByDesc)
 			err := q.Enumerate(ctx, func(result pagination.PageResult[*Actor]) (pagination.KeepGoing, error) {
 				allResults = append(allResults, result.Results...)
-				return true, nil
+				return pagination.Continue, nil
 			})
 
 			require.NoError(t, err)

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -430,7 +430,7 @@ func IsValidConnectionOrderByField[T string | ConnectionOrderByField](field T) b
 
 type ListConnectionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connection]
-	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectionsBuilder interface {
@@ -650,7 +650,7 @@ func (l *listConnectionsFilters) FetchPage(ctx context.Context) pagination.PageR
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connection]) (keepGoing bool, err error)) error {
+func (l *listConnectionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -652,10 +652,10 @@ func (l *listConnectionsFilters) FetchPage(ctx context.Context) pagination.PageR
 
 func (l *listConnectionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -383,7 +383,7 @@ func TestConnections(t *testing.T) {
 				OrderBy(ConnectionOrderByCreatedAt, pagination.OrderByDesc)
 			err := q.Enumerate(ctx, func(result pagination.PageResult[Connection]) (pagination.KeepGoing, error) {
 				allResults = append(allResults, result.Results...)
-				return true, nil
+				return pagination.Continue, nil
 			})
 
 			assert.NoError(t, err)
@@ -864,7 +864,7 @@ func TestConnections(t *testing.T) {
 				WithDeletedHandling(DeletedHandlingInclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
-					return true, nil
+					return pagination.Continue, nil
 				})
 			assert.NoError(t, err)
 			assert.Equal(t, 203, total)
@@ -876,7 +876,7 @@ func TestConnections(t *testing.T) {
 				WithDeletedHandling(DeletedHandlingExclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
-					return true, nil
+					return pagination.Continue, nil
 				})
 			assert.NoError(t, err)
 			assert.Equal(t, 202, total)
@@ -889,7 +889,7 @@ func TestConnections(t *testing.T) {
 				WithDeletedHandling(DeletedHandlingExclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
-					return true, nil
+					return pagination.Continue, nil
 				})
 			assert.NoError(t, err)
 			assert.Equal(t, 201, total)
@@ -902,7 +902,7 @@ func TestConnections(t *testing.T) {
 				WithDeletedHandling(DeletedHandlingExclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
-					return false, nil
+					return pagination.Stop, nil
 				})
 			assert.NoError(t, err)
 			assert.Equal(t, 100, total)

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -381,7 +381,7 @@ func TestConnections(t *testing.T) {
 				ListConnectionsBuilder().
 				Limit(7).
 				OrderBy(ConnectionOrderByCreatedAt, pagination.OrderByDesc)
-			err := q.Enumerate(ctx, func(result pagination.PageResult[Connection]) (bool, error) {
+			err := q.Enumerate(ctx, func(result pagination.PageResult[Connection]) (pagination.KeepGoing, error) {
 				allResults = append(allResults, result.Results...)
 				return true, nil
 			})
@@ -862,7 +862,7 @@ func TestConnections(t *testing.T) {
 			err := db.
 				ListConnectionsBuilder().
 				WithDeletedHandling(DeletedHandlingInclude).
-				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing bool, err error) {
+				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
 					return true, nil
 				})
@@ -874,7 +874,7 @@ func TestConnections(t *testing.T) {
 			err := db.
 				ListConnectionsBuilder().
 				WithDeletedHandling(DeletedHandlingExclude).
-				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing bool, err error) {
+				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
 					return true, nil
 				})
@@ -887,7 +887,7 @@ func TestConnections(t *testing.T) {
 				ListConnectionsBuilder().
 				ForStates([]ConnectionState{ConnectionStateCreated, ConnectionStateReady}).
 				WithDeletedHandling(DeletedHandlingExclude).
-				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing bool, err error) {
+				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
 					return true, nil
 				})
@@ -900,7 +900,7 @@ func TestConnections(t *testing.T) {
 				ListConnectionsBuilder().
 				ForStates([]ConnectionState{ConnectionStateReady}).
 				WithDeletedHandling(DeletedHandlingExclude).
-				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing bool, err error) {
+				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
 					return false, nil
 				})

--- a/internal/database/connector.go
+++ b/internal/database/connector.go
@@ -53,7 +53,7 @@ func IsValidConnectorOrderByField[T string | ConnectorOrderByField](field T) boo
 
 type ListConnectorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connector]
-	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectorsBuilder interface {
@@ -324,7 +324,7 @@ func (l *listConnectorsFilters) FetchPage(ctx context.Context) pagination.PageRe
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connector]) (keepGoing bool, err error)) error {
+func (l *listConnectorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/database/connector.go
+++ b/internal/database/connector.go
@@ -326,10 +326,10 @@ func (l *listConnectorsFilters) FetchPage(ctx context.Context) pagination.PageRe
 
 func (l *listConnectorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/database/connector_version.go
+++ b/internal/database/connector_version.go
@@ -694,7 +694,7 @@ func IsValidConnectorVersionOrderByField[T string | ConnectorVersionOrderByField
 
 type ListConnectorVersionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[ConnectorVersion]
-	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListConnectorVersionsBuilder interface {
@@ -903,7 +903,7 @@ func (l *listConnectorVersionsFilters) FetchPage(ctx context.Context) pagination
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectorVersionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[ConnectorVersion]) (keepGoing bool, err error)) error {
+func (l *listConnectorVersionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/database/connector_version.go
+++ b/internal/database/connector_version.go
@@ -905,10 +905,10 @@ func (l *listConnectorVersionsFilters) FetchPage(ctx context.Context) pagination
 
 func (l *listConnectorVersionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -770,10 +770,10 @@ func (l *listEncryptionKeysFilters) FetchPage(ctx context.Context) pagination.Pa
 
 func (l *listEncryptionKeysFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -593,7 +593,7 @@ func (s *service) DeleteEncryptionKeyAnnotations(ctx context.Context, id apid.ID
 
 type ListEncryptionKeysExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[EncryptionKey]
-	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListEncryptionKeysBuilder interface {
@@ -768,7 +768,7 @@ func (l *listEncryptionKeysFilters) FetchPage(ctx context.Context) pagination.Pa
 	return l.fetchPage(ctx)
 }
 
-func (l *listEncryptionKeysFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[EncryptionKey]) (keepGoing bool, err error)) error {
+func (l *listEncryptionKeysFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true
@@ -809,11 +809,11 @@ func (s *service) ListEncryptionKeysFromCursor(ctx context.Context, cursor strin
 // key-version mappings into memory, builds this tree, then invokes the callback once per depth level
 // starting at depth 0 (the root). Keys whose parent cannot be resolved — because their
 // EncryptedKeyData.ID references a missing or deleted encryption key version — are collected and
-// returned as orphans. Return stop=true from the callback to halt the walk early; orphans are still
-// returned in that case.
+// returned as orphans. Return keepGoing=false from the callback to halt the walk early; orphans are
+// still returned in that case.
 func (s *service) EnumerateEncryptionKeysInDependencyOrder(
 	ctx context.Context,
-	callback func(keys []*EncryptionKey, depth int) (stop bool, err error),
+	callback func(keys []*EncryptionKey, depth int) (keepGoing pagination.KeepGoing, err error),
 ) ([]*EncryptionKey, error) {
 	// Load all non-deleted encryption keys
 	rows, err := s.sq.
@@ -894,11 +894,11 @@ func (s *service) EnumerateEncryptionKeysInDependencyOrder(
 	depth := 0
 
 	for len(currentLevel) > 0 {
-		stop, err := callback(currentLevel, depth)
+		keepGoing, err := callback(currentLevel, depth)
 		if err != nil {
 			return orphans, err
 		}
-		if stop {
+		if !keepGoing {
 			return orphans, nil
 		}
 

--- a/internal/database/encryption_key_test.go
+++ b/internal/database/encryption_key_test.go
@@ -291,7 +291,7 @@ func TestEncryptionKey(t *testing.T) {
 				ids   []apid.ID
 				depth int
 			}{ids, depth})
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -384,7 +384,7 @@ func TestEncryptionKey(t *testing.T) {
 				ids[k.Id] = true
 			}
 			levels = append(levels, level{ids, depth})
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -440,7 +440,7 @@ func TestEncryptionKey(t *testing.T) {
 		callCount := 0
 		_, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			callCount++
-			return false, nil // stop immediately after first level
+			return pagination.Stop, nil // stop immediately after first level
 		})
 		require.NoError(t, err)
 		require.Equal(t, 1, callCount)
@@ -482,7 +482,7 @@ func TestEncryptionKey(t *testing.T) {
 			for _, k := range keys {
 				allIDs = append(allIDs, k.Id)
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -512,7 +512,7 @@ func TestEncryptionKey(t *testing.T) {
 			for _, k := range keys {
 				allIDs = append(allIDs, k.Id)
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		// Only root in the walk; orphan is not walked

--- a/internal/database/encryption_key_test.go
+++ b/internal/database/encryption_key_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -281,7 +282,7 @@ func TestEncryptionKey(t *testing.T) {
 			depth int
 		}
 
-		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (bool, error) {
+		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			var ids []apid.ID
 			for _, k := range keys {
 				ids = append(ids, k.Id)
@@ -290,7 +291,7 @@ func TestEncryptionKey(t *testing.T) {
 				ids   []apid.ID
 				depth int
 			}{ids, depth})
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -377,13 +378,13 @@ func TestEncryptionKey(t *testing.T) {
 		}
 		var levels []level
 
-		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (bool, error) {
+		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			ids := make(map[apid.ID]bool)
 			for _, k := range keys {
 				ids[k.Id] = true
 			}
 			levels = append(levels, level{ids, depth})
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -408,7 +409,7 @@ func TestEncryptionKey(t *testing.T) {
 	})
 
 	t.Run("EnumerateInDependencyOrder/early_stop", func(t *testing.T) {
-		// Verify that returning stop=true halts after that level.
+		// Verify that returning keepGoing=false halts after that level.
 		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
@@ -437,9 +438,9 @@ func TestEncryptionKey(t *testing.T) {
 		require.NoError(t, db.CreateEncryptionKey(ctx, child))
 
 		callCount := 0
-		_, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (bool, error) {
+		_, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			callCount++
-			return true, nil // stop immediately after first level
+			return false, nil // stop immediately after first level
 		})
 		require.NoError(t, err)
 		require.Equal(t, 1, callCount)
@@ -477,11 +478,11 @@ func TestEncryptionKey(t *testing.T) {
 		require.NoError(t, db.DeleteEncryptionKey(ctx, child.Id))
 
 		var allIDs []apid.ID
-		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (bool, error) {
+		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			for _, k := range keys {
 				allIDs = append(allIDs, k.Id)
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, orphans)
@@ -507,11 +508,11 @@ func TestEncryptionKey(t *testing.T) {
 		require.NoError(t, db.CreateEncryptionKey(ctx, orphan))
 
 		var allIDs []apid.ID
-		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (bool, error) {
+		orphans, err := db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*EncryptionKey, depth int) (pagination.KeepGoing, error) {
 			for _, k := range keys {
 				allIDs = append(allIDs, k.Id)
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		// Only root in the walk; orphan is not walked

--- a/internal/database/encryption_key_version.go
+++ b/internal/database/encryption_key_version.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 const EncryptionKeyVersionsTable = "encryption_key_versions"
@@ -392,7 +393,7 @@ func (s *service) SetEncryptionKeyVersionCurrentFlag(ctx context.Context, id api
 func (s *service) EnumerateEncryptionKeyVersionsForKey(
 	ctx context.Context,
 	ekId apid.ID,
-	callback func(ekvs []*EncryptionKeyVersion, lastPage bool) (stop bool, err error),
+	callback func(ekvs []*EncryptionKeyVersion, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 ) error {
 	const pageSize = 100
 	offset := uint64(0)
@@ -430,12 +431,12 @@ func (s *service) EnumerateEncryptionKeyVersionsForKey(
 			results = results[:pageSize]
 		}
 
-		stop, err := callback(results, lastPage)
+		keepGoing, err := callback(results, lastPage)
 		if err != nil {
 			return err
 		}
 
-		if stop || lastPage {
+		if !keepGoing || lastPage {
 			break
 		}
 

--- a/internal/database/encryption_key_version.go
+++ b/internal/database/encryption_key_version.go
@@ -436,7 +436,7 @@ func (s *service) EnumerateEncryptionKeyVersionsForKey(
 			return err
 		}
 
-		if !keepGoing || lastPage {
+		if keepGoing == pagination.Stop || lastPage {
 			break
 		}
 

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -67,7 +67,7 @@ type DB interface {
 	ListNamespacesFromCursor(ctx context.Context, cursor string) (ListNamespacesExecutor, error)
 	EnumerateNamespaceEncryptionTargets(
 		ctx context.Context,
-		callback func(targets []NamespaceEncryptionTarget, lastPage bool) (updates []NamespaceTargetEncryptionKeyVersionUpdate, stop bool, err error),
+		callback func(targets []NamespaceEncryptionTarget, lastPage bool) (updates []NamespaceTargetEncryptionKeyVersionUpdate, keepGoing pagination.KeepGoing, err error),
 	) error
 
 	/*
@@ -147,7 +147,7 @@ type DB interface {
 	EnumerateOAuth2TokensExpiringWithin(
 		ctx context.Context,
 		duration time.Duration,
-		callback func(tokens []*OAuth2TokenWithConnection, lastPage bool) (stop bool, err error),
+		callback func(tokens []*OAuth2TokenWithConnection, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 	) error
 
 	/*
@@ -174,7 +174,7 @@ type DB interface {
 	// Returns a slice of orphaned keys whose parent encryption key version could not be resolved.
 	EnumerateEncryptionKeysInDependencyOrder(
 		ctx context.Context,
-		callback func(keys []*EncryptionKey, depth int) (stop bool, err error),
+		callback func(keys []*EncryptionKey, depth int) (keepGoing pagination.KeepGoing, err error),
 	) ([]*EncryptionKey, error)
 
 	/*
@@ -200,7 +200,7 @@ type DB interface {
 	EnumerateEncryptionKeyVersionsForKey(
 		ctx context.Context,
 		ekId apid.ID,
-		callback func(ekvs []*EncryptionKeyVersion, lastPage bool) (stop bool, err error),
+		callback func(ekvs []*EncryptionKeyVersion, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 	) error
 
 	/*
@@ -211,7 +211,7 @@ type DB interface {
 	// finding rows whose encrypted field EKV ID does not match the namespace's target EKV ID.
 	EnumerateFieldsRequiringReEncryption(
 		ctx context.Context,
-		callback func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error),
+		callback func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 	) error
 
 	// BatchUpdateReEncryptedFields updates encrypted field values after re-encryption,

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -657,7 +657,7 @@ func (mr *MockDBMockRecorder) EnsureNamespaceByPath(ctx, path interface{}) *gomo
 }
 
 // EnumerateEncryptionKeyVersionsForKey mocks base method.
-func (m *MockDB) EnumerateEncryptionKeyVersionsForKey(ctx context.Context, ekId apid.ID, callback func([]*database.EncryptionKeyVersion, bool) (bool, error)) error {
+func (m *MockDB) EnumerateEncryptionKeyVersionsForKey(ctx context.Context, ekId apid.ID, callback func([]*database.EncryptionKeyVersion, bool) (pagination.KeepGoing, error)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnumerateEncryptionKeyVersionsForKey", ctx, ekId, callback)
 	ret0, _ := ret[0].(error)
@@ -671,7 +671,7 @@ func (mr *MockDBMockRecorder) EnumerateEncryptionKeyVersionsForKey(ctx, ekId, ca
 }
 
 // EnumerateEncryptionKeysInDependencyOrder mocks base method.
-func (m *MockDB) EnumerateEncryptionKeysInDependencyOrder(ctx context.Context, callback func([]*database.EncryptionKey, int) (bool, error)) ([]*database.EncryptionKey, error) {
+func (m *MockDB) EnumerateEncryptionKeysInDependencyOrder(ctx context.Context, callback func([]*database.EncryptionKey, int) (pagination.KeepGoing, error)) ([]*database.EncryptionKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnumerateEncryptionKeysInDependencyOrder", ctx, callback)
 	ret0, _ := ret[0].([]*database.EncryptionKey)
@@ -686,7 +686,7 @@ func (mr *MockDBMockRecorder) EnumerateEncryptionKeysInDependencyOrder(ctx, call
 }
 
 // EnumerateFieldsRequiringReEncryption mocks base method.
-func (m *MockDB) EnumerateFieldsRequiringReEncryption(ctx context.Context, callback func([]database.ReEncryptionTarget, bool) (bool, error)) error {
+func (m *MockDB) EnumerateFieldsRequiringReEncryption(ctx context.Context, callback func([]database.ReEncryptionTarget, bool) (pagination.KeepGoing, error)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnumerateFieldsRequiringReEncryption", ctx, callback)
 	ret0, _ := ret[0].(error)
@@ -700,7 +700,7 @@ func (mr *MockDBMockRecorder) EnumerateFieldsRequiringReEncryption(ctx, callback
 }
 
 // EnumerateNamespaceEncryptionTargets mocks base method.
-func (m *MockDB) EnumerateNamespaceEncryptionTargets(ctx context.Context, callback func([]database.NamespaceEncryptionTarget, bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error)) error {
+func (m *MockDB) EnumerateNamespaceEncryptionTargets(ctx context.Context, callback func([]database.NamespaceEncryptionTarget, bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnumerateNamespaceEncryptionTargets", ctx, callback)
 	ret0, _ := ret[0].(error)
@@ -714,7 +714,7 @@ func (mr *MockDBMockRecorder) EnumerateNamespaceEncryptionTargets(ctx, callback 
 }
 
 // EnumerateOAuth2TokensExpiringWithin mocks base method.
-func (m *MockDB) EnumerateOAuth2TokensExpiringWithin(ctx context.Context, duration time.Duration, callback func([]*database.OAuth2TokenWithConnection, bool) (bool, error)) error {
+func (m *MockDB) EnumerateOAuth2TokensExpiringWithin(ctx context.Context, duration time.Duration, callback func([]*database.OAuth2TokenWithConnection, bool) (pagination.KeepGoing, error)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnumerateOAuth2TokensExpiringWithin", ctx, duration, callback)
 	ret0, _ := ret[0].(error)
@@ -1408,20 +1408,6 @@ func (mr *MockDBMockRecorder) SetConnectionEncryptedConfiguration(ctx, id, encry
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionEncryptedConfiguration", reflect.TypeOf((*MockDB)(nil).SetConnectionEncryptedConfiguration), ctx, id, encryptedConfig)
 }
 
-// SetConnectionSetupStep mocks base method.
-func (m *MockDB) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *connectors.SetupStep) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConnectionSetupStep", ctx, id, setupStep)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetConnectionSetupStep indicates an expected call of SetConnectionSetupStep.
-func (mr *MockDBMockRecorder) SetConnectionSetupStep(ctx, id, setupStep interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionSetupStep", reflect.TypeOf((*MockDB)(nil).SetConnectionSetupStep), ctx, id, setupStep)
-}
-
 // SetConnectionSetupError mocks base method.
 func (m *MockDB) SetConnectionSetupError(ctx context.Context, id apid.ID, setupError *string) error {
 	m.ctrl.T.Helper()
@@ -1434,6 +1420,20 @@ func (m *MockDB) SetConnectionSetupError(ctx context.Context, id apid.ID, setupE
 func (mr *MockDBMockRecorder) SetConnectionSetupError(ctx, id, setupError interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionSetupError", reflect.TypeOf((*MockDB)(nil).SetConnectionSetupError), ctx, id, setupError)
+}
+
+// SetConnectionSetupStep mocks base method.
+func (m *MockDB) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupStep *connectors.SetupStep) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConnectionSetupStep", ctx, id, setupStep)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetConnectionSetupStep indicates an expected call of SetConnectionSetupStep.
+func (mr *MockDBMockRecorder) SetConnectionSetupStep(ctx, id, setupStep interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectionSetupStep", reflect.TypeOf((*MockDB)(nil).SetConnectionSetupStep), ctx, id, setupStep)
 }
 
 // SetConnectionState mocks base method.

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -679,10 +679,10 @@ func (l *listNamespacesFilters) FetchPage(ctx context.Context) pagination.PageRe
 
 func (l *listNamespacesFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 
@@ -1002,7 +1002,7 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 			}
 		}
 
-		if !keepGoing || lastPage {
+		if keepGoing == pagination.Stop || lastPage {
 			break
 		}
 

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -460,7 +460,7 @@ func (s *service) SetNamespaceState(ctx context.Context, path string, state Name
 
 type ListNamespacesExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Namespace]
-	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing bool, err error)) error
+	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListNamespacesBuilder interface {
@@ -677,7 +677,7 @@ func (l *listNamespacesFilters) FetchPage(ctx context.Context) pagination.PageRe
 	return l.fetchPage(ctx)
 }
 
-func (l *listNamespacesFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Namespace]) (keepGoing bool, err error)) error {
+func (l *listNamespacesFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true
@@ -944,7 +944,7 @@ type NamespaceTargetEncryptionKeyVersionUpdate struct {
 
 func (s *service) EnumerateNamespaceEncryptionTargets(
 	ctx context.Context,
-	callback func(targets []NamespaceEncryptionTarget, lastPage bool) (updates []NamespaceTargetEncryptionKeyVersionUpdate, stop bool, err error),
+	callback func(targets []NamespaceEncryptionTarget, lastPage bool) (updates []NamespaceTargetEncryptionKeyVersionUpdate, keepGoing pagination.KeepGoing, err error),
 ) error {
 	const pageSize = 100
 	offset := uint64(0)
@@ -979,7 +979,7 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 			results = results[:pageSize]
 		}
 
-		updates, stop, err := callback(results, lastPage)
+		updates, keepGoing, err := callback(results, lastPage)
 		if err != nil {
 			return err
 		}
@@ -1002,7 +1002,7 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 			}
 		}
 
-		if stop || lastPage {
+		if !keepGoing || lastPage {
 			break
 		}
 

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -167,7 +167,7 @@ INSERT INTO namespaces
 		count := 0
 		err = db.
 			ListNamespacesBuilder().
-			Enumerate(ctx, func(page pagination.PageResult[Namespace]) (bool, error) {
+			Enumerate(ctx, func(page pagination.PageResult[Namespace]) (pagination.KeepGoing, error) {
 				count += len(page.Results)
 				return true, nil
 			})
@@ -1619,9 +1619,9 @@ INSERT INTO namespaces
 
 			var collected []NamespaceEncryptionTarget
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					collected = append(collected, targets...)
-					return nil, false, nil
+					return nil, true, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1670,7 +1670,7 @@ INSERT INTO namespaces
 			require.NoError(t, err)
 
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					var updates []NamespaceTargetEncryptionKeyVersionUpdate
 					for _, t := range targets {
 						if t.EncryptionKeyId != nil {
@@ -1680,7 +1680,7 @@ INSERT INTO namespaces
 							})
 						}
 					}
-					return updates, false, nil
+					return updates, true, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1727,9 +1727,9 @@ INSERT INTO namespaces
 
 			callCount := 0
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					callCount++
-					return nil, true, nil // stop immediately
+					return nil, false, nil // stop immediately
 				},
 			)
 			require.NoError(t, err)
@@ -1753,8 +1753,8 @@ INSERT INTO namespaces
 
 			expectedErr := fmt.Errorf("test error")
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
-					return nil, false, expectedErr
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
+					return nil, true, expectedErr
 				},
 			)
 			require.ErrorIs(t, err, expectedErr)
@@ -1770,11 +1770,11 @@ INSERT INTO namespaces
 
 			callCount := 0
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					callCount++
 					require.Empty(t, targets)
 					require.True(t, lastPage)
-					return nil, false, nil
+					return nil, true, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1801,9 +1801,9 @@ INSERT INTO namespaces
 
 			var lastPageValues []bool
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
-				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					lastPageValues = append(lastPageValues, lastPage)
-					return nil, false, nil
+					return nil, true, nil
 				},
 			)
 			require.NoError(t, err)

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -169,7 +169,7 @@ INSERT INTO namespaces
 			ListNamespacesBuilder().
 			Enumerate(ctx, func(page pagination.PageResult[Namespace]) (pagination.KeepGoing, error) {
 				count += len(page.Results)
-				return true, nil
+				return pagination.Continue, nil
 			})
 		require.NoError(t, err)
 		require.Equal(t, count, 8)
@@ -1621,7 +1621,7 @@ INSERT INTO namespaces
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
 				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					collected = append(collected, targets...)
-					return nil, true, nil
+					return nil, pagination.Continue, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1680,7 +1680,7 @@ INSERT INTO namespaces
 							})
 						}
 					}
-					return updates, true, nil
+					return updates, pagination.Continue, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1729,7 +1729,7 @@ INSERT INTO namespaces
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
 				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					callCount++
-					return nil, false, nil // stop immediately
+					return nil, pagination.Stop, nil // stop immediately
 				},
 			)
 			require.NoError(t, err)
@@ -1754,7 +1754,7 @@ INSERT INTO namespaces
 			expectedErr := fmt.Errorf("test error")
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
 				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
-					return nil, true, expectedErr
+					return nil, pagination.Stop, expectedErr
 				},
 			)
 			require.ErrorIs(t, err, expectedErr)
@@ -1774,7 +1774,7 @@ INSERT INTO namespaces
 					callCount++
 					require.Empty(t, targets)
 					require.True(t, lastPage)
-					return nil, true, nil
+					return nil, pagination.Continue, nil
 				},
 			)
 			require.NoError(t, err)
@@ -1803,7 +1803,7 @@ INSERT INTO namespaces
 			err = db.EnumerateNamespaceEncryptionTargets(ctx,
 				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 					lastPageValues = append(lastPageValues, lastPage)
-					return nil, true, nil
+					return nil, pagination.Continue, nil
 				},
 			)
 			require.NoError(t, err)

--- a/internal/database/oauth2_token.go
+++ b/internal/database/oauth2_token.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 func init() {
@@ -307,7 +308,7 @@ type OAuth2TokenWithConnection struct {
 func (s *service) EnumerateOAuth2TokensExpiringWithin(
 	ctx context.Context,
 	duration time.Duration,
-	callback func(tokens []*OAuth2TokenWithConnection, lastPage bool) (stop bool, err error),
+	callback func(tokens []*OAuth2TokenWithConnection, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 ) error {
 	const pageSize = 100
 	now := apctx.GetClock(ctx).Now()
@@ -356,12 +357,12 @@ func (s *service) EnumerateOAuth2TokensExpiringWithin(
 			results = results[:pageSize]
 		}
 
-		stop, err := callback(results, lastPage)
+		keepGoing, err := callback(results, lastPage)
 		if err != nil {
 			return err
 		}
 
-		if stop || lastPage {
+		if !keepGoing || lastPage {
 			break
 		}
 

--- a/internal/database/oauth2_token.go
+++ b/internal/database/oauth2_token.go
@@ -362,7 +362,7 @@ func (s *service) EnumerateOAuth2TokensExpiringWithin(
 			return err
 		}
 
-		if !keepGoing || lastPage {
+		if keepGoing == pagination.Stop || lastPage {
 			break
 		}
 

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -592,12 +593,12 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 				}
 
 				count := 0
-				err = db.EnumerateOAuth2TokensExpiringWithin(ctx, tc.duration, func(tokens []*OAuth2TokenWithConnection, lastPage bool) (bool, error) {
+				err = db.EnumerateOAuth2TokensExpiringWithin(ctx, tc.duration, func(tokens []*OAuth2TokenWithConnection, lastPage bool) (pagination.KeepGoing, error) {
 					if tc.callbackError {
-						return true, fmt.Errorf("callback error")
+						return false, fmt.Errorf("callback error")
 					}
 					count += len(tokens)
-					return false, nil
+					return true, nil
 				})
 
 				if tc.callbackError {

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -595,10 +595,10 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 				count := 0
 				err = db.EnumerateOAuth2TokensExpiringWithin(ctx, tc.duration, func(tokens []*OAuth2TokenWithConnection, lastPage bool) (pagination.KeepGoing, error) {
 					if tc.callbackError {
-						return false, fmt.Errorf("callback error")
+						return pagination.Stop, fmt.Errorf("callback error")
 					}
 					count += len(tokens)
-					return true, nil
+					return pagination.Continue, nil
 				})
 
 				if tc.callbackError {

--- a/internal/database/reencrypt_registry.go
+++ b/internal/database/reencrypt_registry.go
@@ -162,7 +162,7 @@ func (s *service) EnumerateFieldsRequiringReEncryption(
 				return err
 			}
 
-			if !keepGoing || lastPageForTable {
+			if keepGoing == pagination.Stop || lastPageForTable {
 				break
 			}
 

--- a/internal/database/reencrypt_registry.go
+++ b/internal/database/reencrypt_registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 // EncryptedFieldRegistration declares which columns on a table contain encrypted fields
@@ -133,7 +134,7 @@ type ReEncryptedFieldUpdate struct {
 
 func (s *service) EnumerateFieldsRequiringReEncryption(
 	ctx context.Context,
-	callback func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error),
+	callback func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error),
 ) error {
 	regs := GetEncryptedFieldRegistrations()
 	if len(regs) == 0 {
@@ -156,12 +157,12 @@ func (s *service) EnumerateFieldsRequiringReEncryption(
 			lastPageForTable := totalRows <= pageSize
 			isLastPage := isLastReg && lastPageForTable
 
-			stop, err := callback(targets, isLastPage)
+			keepGoing, err := callback(targets, isLastPage)
 			if err != nil {
 				return err
 			}
 
-			if stop || lastPageForTable {
+			if !keepGoing || lastPageForTable {
 				break
 			}
 

--- a/internal/database/reencrypt_registry_test.go
+++ b/internal/database/reencrypt_registry_test.go
@@ -55,7 +55,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		var allTargets []ReEncryptionTarget
 		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			allTargets = append(allTargets, targets...)
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "actor at target EKV should not appear")
@@ -146,7 +146,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, tokenTargets, 1, "only the mismatched field should appear")
@@ -187,7 +187,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, tokenTargets, 2, "both mismatched fields should appear")
@@ -235,7 +235,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.True(t, found, "oauth2 token should resolve namespace via connections JOIN")
@@ -274,7 +274,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, cvTargets, 1)
@@ -309,7 +309,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "actor with NULL encrypted_key should not appear")
@@ -371,7 +371,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		var allTargets []ReEncryptionTarget
 		err := db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			allTargets = append(allTargets, targets...)
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, allTargets)
@@ -404,7 +404,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "namespace with NULL target should not produce targets")

--- a/internal/database/reencrypt_registry_test.go
+++ b/internal/database/reencrypt_registry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -52,9 +53,9 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var allTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			allTargets = append(allTargets, targets...)
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 
@@ -95,7 +96,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var actorTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == ActorTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == actorId {
@@ -103,7 +104,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "actor at target EKV should not appear")
@@ -137,7 +138,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var tokenTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == OAuth2TokensTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == token.Id {
@@ -145,7 +146,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, tokenTargets, 1, "only the mismatched field should appear")
@@ -178,7 +179,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var tokenTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == OAuth2TokensTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == token.Id {
@@ -186,7 +187,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, tokenTargets, 2, "both mismatched fields should appear")
@@ -225,7 +226,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var found bool
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == OAuth2TokensTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == token.Id {
@@ -234,7 +235,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.True(t, found, "oauth2 token should resolve namespace via connections JOIN")
@@ -265,7 +266,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var cvTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == ConnectorVersionsTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == cvId {
@@ -273,7 +274,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Len(t, cvTargets, 1)
@@ -300,7 +301,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var actorTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == ActorTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == actorId {
@@ -308,7 +309,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "actor with NULL encrypted_key should not appear")
@@ -368,9 +369,9 @@ func TestReEncryptRegistry(t *testing.T) {
 
 		// No target EKV set on any namespace, so nothing should be returned
 		var allTargets []ReEncryptionTarget
-		err := db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err := db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			allTargets = append(allTargets, targets...)
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, allTargets)
@@ -395,7 +396,7 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		var actorTargets []ReEncryptionTarget
-		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+		err = db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 			for _, tgt := range targets {
 				if tgt.Table == ActorTable {
 					if id, ok := tgt.PrimaryKeyValues[0].(string); ok && apid.ID(id) == actorId {
@@ -403,7 +404,7 @@ func TestReEncryptRegistry(t *testing.T) {
 					}
 				}
 			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Empty(t, actorTargets, "namespace with NULL target should not produce targets")

--- a/internal/database/tasks/task_cleanup_stale_connections.go
+++ b/internal/database/tasks/task_cleanup_stale_connections.go
@@ -39,7 +39,7 @@ func (th *taskHandler) cleanupStaleConnections(ctx context.Context, t *asynq.Tas
 
 				cleaned++
 			}
-			return true, nil
+			return pagination.Continue, nil
 		})
 
 	if err != nil {

--- a/internal/database/tasks/task_cleanup_stale_connections.go
+++ b/internal/database/tasks/task_cleanup_stale_connections.go
@@ -23,7 +23,7 @@ func (th *taskHandler) cleanupStaleConnections(ctx context.Context, t *asynq.Tas
 		ForStates([]database.ConnectionState{database.ConnectionStateCreated}).
 		WithSetupStepNotNull().
 		UpdatedBefore(cutoff).
-		Enumerate(ctx, func(pr pagination.PageResult[database.Connection]) (bool, error) {
+		Enumerate(ctx, func(pr pagination.PageResult[database.Connection]) (pagination.KeepGoing, error) {
 			for _, conn := range pr.Results {
 				th.logger.Info("cleaning up stale connection", "id", conn.Id, "updated_at", conn.UpdatedAt)
 

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -191,12 +191,12 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 						}
 					}
 
-					return true, nil
+					return pagination.Continue, nil
 				},
 			)
 		}
 
-		return true, nil
+		return pagination.Continue, nil
 	})
 
 	if err != nil {
@@ -211,7 +211,7 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 			}
 		}
 
-		return true, nil
+		return pagination.Continue, nil
 	})
 
 	if err != nil {

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -130,7 +130,7 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 		}
 	}()
 
-	_, err := s.db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*database.EncryptionKey, _ int) (stop bool, err error) {
+	_, err := s.db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*database.EncryptionKey, _ int) (keepGoing pagination.KeepGoing, err error) {
 		for _, key := range keys {
 			var keyData *sconfig.KeyData
 			if key.Id == globalEncryptionKeyID {
@@ -171,7 +171,7 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 			// in the database will be ignored as it is the database sync that defines when new versions become
 			// available.
 			_ = s.db.EnumerateEncryptionKeyVersionsForKey(ctx, key.Id,
-				func(ekvs []*database.EncryptionKeyVersion, lastPage bool) (stop bool, err error) {
+				func(ekvs []*database.EncryptionKeyVersion, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 					for _, ekv := range ekvs {
 						if ekv.IsCurrent {
 							newEkToEkvCurrentVersionCache[ekv.EncryptionKeyId] = ekv.Id
@@ -191,12 +191,12 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 						}
 					}
 
-					return false, nil
+					return true, nil
 				},
 			)
 		}
 
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *service) syncKeysFromDbToMemory(ctx context.Context) error {
 	}
 
 	// Identify all the keys used for the namespaces
-	err = s.db.ListNamespacesBuilder().Enumerate(ctx, func(pr pagination.PageResult[database.Namespace]) (keepGoing bool, err error) {
+	err = s.db.ListNamespacesBuilder().Enumerate(ctx, func(pr pagination.PageResult[database.Namespace]) (keepGoing pagination.KeepGoing, err error) {
 		for _, ns := range pr.Results {
 			if ns.EncryptionKeyId != nil {
 				newNamespaceToEkCache[ns.Path] = *ns.EncryptionKeyId

--- a/internal/encrypt/task_reencrypt.go
+++ b/internal/encrypt/task_reencrypt.go
@@ -65,7 +65,7 @@ func (h *EncryptServiceTaskHandler) handleReencryptAll(ctx context.Context, task
 			}
 		}
 
-		return true, nil
+		return pagination.Continue, nil
 	})
 
 	if err != nil {

--- a/internal/encrypt/task_reencrypt.go
+++ b/internal/encrypt/task_reencrypt.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 const (
@@ -25,7 +26,7 @@ func (h *EncryptServiceTaskHandler) handleReencryptAll(ctx context.Context, task
 
 	var totalProcessed, totalSkipped, totalErrors int
 
-	err := h.db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []database.ReEncryptionTarget, lastPage bool) (stop bool, err error) {
+	err := h.db.EnumerateFieldsRequiringReEncryption(ctx, func(targets []database.ReEncryptionTarget, lastPage bool) (keepGoing pagination.KeepGoing, err error) {
 		var updates []database.ReEncryptedFieldUpdate
 
 		for _, target := range targets {
@@ -64,7 +65,7 @@ func (h *EncryptServiceTaskHandler) handleReencryptAll(ctx context.Context, task
 			}
 		}
 
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -226,7 +226,7 @@ func syncKeysVersionsToDatabase(
 			}
 		}
 
-		return true, nil
+		return pagination.Continue, nil
 	})
 
 	if err != nil {
@@ -294,7 +294,7 @@ func syncKeysVersionsToDatabase(
 				}
 			}
 
-			return updates, true, nil
+			return updates, pagination.Continue, nil
 		},
 	)
 	if err != nil {

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 const (
@@ -185,7 +186,7 @@ func syncKeysVersionsToDatabase(
 
 	var result *multierror.Error
 
-	_, err = db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*database.EncryptionKey, _ int) (stop bool, err error) {
+	_, err = db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*database.EncryptionKey, _ int) (keepGoing pagination.KeepGoing, err error) {
 		for _, key := range keys {
 			if key.EncryptedKeyData == nil {
 				// Global key already synced
@@ -225,7 +226,7 @@ func syncKeysVersionsToDatabase(
 			}
 		}
 
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {
@@ -238,7 +239,7 @@ func syncKeysVersionsToDatabase(
 	effectiveEKV := make(map[string]apid.ID)
 
 	err = db.EnumerateNamespaceEncryptionTargets(ctx,
-		func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+		func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 			var updates []database.NamespaceTargetEncryptionKeyVersionUpdate
 
 			for _, target := range targets {
@@ -293,7 +294,7 @@ func syncKeysVersionsToDatabase(
 				}
 			}
 
-			return updates, false, nil
+			return updates, true, nil
 		},
 	)
 	if err != nil {

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -597,9 +598,9 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		// Verify the namespace got the correct target
 		var collected []database.NamespaceEncryptionTarget
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
-			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, false, nil
+				return nil, true, nil
 			},
 		)
 		require.NoError(t, err)
@@ -677,9 +678,9 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		// Verify child inherited from parent
 		var collected []database.NamespaceEncryptionTarget
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
-			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, false, nil
+				return nil, true, nil
 			},
 		)
 		require.NoError(t, err)
@@ -731,9 +732,9 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		// Verify namespace uses global key version
 		var collected []database.NamespaceEncryptionTarget
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
-			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, false, nil
+				return nil, true, nil
 			},
 		)
 		require.NoError(t, err)
@@ -775,9 +776,9 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		// Capture state after first sync
 		var firstCollected []database.NamespaceEncryptionTarget
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
-			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				firstCollected = append(firstCollected, targets...)
-				return nil, false, nil
+				return nil, true, nil
 			},
 		)
 		require.NoError(t, err)
@@ -788,9 +789,9 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 
 		var secondCollected []database.NamespaceEncryptionTarget
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
-			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, bool, error) {
+			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				secondCollected = append(secondCollected, targets...)
-				return nil, false, nil
+				return nil, true, nil
 			},
 		)
 		require.NoError(t, err)

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -600,7 +600,7 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
 			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, true, nil
+				return nil, pagination.Continue, nil
 			},
 		)
 		require.NoError(t, err)
@@ -680,7 +680,7 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
 			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, true, nil
+				return nil, pagination.Continue, nil
 			},
 		)
 		require.NoError(t, err)
@@ -734,7 +734,7 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
 			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				collected = append(collected, targets...)
-				return nil, true, nil
+				return nil, pagination.Continue, nil
 			},
 		)
 		require.NoError(t, err)
@@ -778,7 +778,7 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
 			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				firstCollected = append(firstCollected, targets...)
-				return nil, true, nil
+				return nil, pagination.Continue, nil
 			},
 		)
 		require.NoError(t, err)
@@ -791,7 +791,7 @@ func TestSyncKeysVersionsToDatabase(t *testing.T) {
 		err = db.EnumerateNamespaceEncryptionTargets(ctx,
 			func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
 				secondCollected = append(secondCollected, targets...)
-				return nil, true, nil
+				return nil, pagination.Continue, nil
 			},
 		)
 		require.NoError(t, err)

--- a/internal/request_log/list.go
+++ b/internal/request_log/list.go
@@ -52,7 +52,7 @@ func IsValidOrderByField(field RequestOrderByField) bool {
 
 type ListRequestExecutor interface {
 	FetchPage(ctx context.Context) pagination.PageResult[*LogRecord]
-	Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing bool, err error)) error
+	Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing pagination.KeepGoing, err error)) error
 }
 
 type ListRequestBuilder interface {

--- a/internal/request_log/mock/list.go
+++ b/internal/request_log/mock/list.go
@@ -145,10 +145,10 @@ func (l *MockListRequestBuilderExecutor) FetchPage(ctx context.Context) paginati
 
 func (l *MockListRequestBuilderExecutor) Enumerate(ctx context.Context, callback func(pagination.PageResult[*request_log.LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/request_log/mock/list.go
+++ b/internal/request_log/mock/list.go
@@ -143,7 +143,7 @@ func (l *MockListRequestBuilderExecutor) FetchPage(ctx context.Context) paginati
 	return l.ReturnResults
 }
 
-func (l *MockListRequestBuilderExecutor) Enumerate(ctx context.Context, callback func(pagination.PageResult[*request_log.LogRecord]) (keepGoing bool, err error)) error {
+func (l *MockListRequestBuilderExecutor) Enumerate(ctx context.Context, callback func(pagination.PageResult[*request_log.LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -618,10 +618,10 @@ func (l *sqlListRequestsBuilder) FetchPage(ctx context.Context) pagination.PageR
 
 func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
-	keepGoing := true
+	keepGoing := pagination.Continue
 	hasMore := true
 
-	for err == nil && hasMore && keepGoing {
+	for err == nil && hasMore && bool(keepGoing) {
 		result := l.FetchPage(ctx)
 		hasMore = result.HasMore
 

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -616,7 +616,7 @@ func (l *sqlListRequestsBuilder) FetchPage(ctx context.Context) pagination.PageR
 	}
 }
 
-func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing bool, err error)) error {
+func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
 	var err error
 	keepGoing := true
 	hasMore := true

--- a/internal/util/pagination/keep_going.go
+++ b/internal/util/pagination/keep_going.go
@@ -1,0 +1,16 @@
+package pagination
+
+// KeepGoing is the bool returned by Enumerate-style callbacks to control iteration.
+// Return true to continue to the next page; return false to stop early.
+//
+// Using this named type (instead of a bare bool) gives Enumerate callbacks across
+// the codebase a consistent semantic: true means "keep going."
+type KeepGoing = bool
+
+const (
+	// Continue tells an Enumerate-style iterator to fetch the next page.
+	Continue KeepGoing = true
+
+	// Stop tells an Enumerate-style iterator to halt before the next page.
+	Stop KeepGoing = false
+)

--- a/internal/util/pagination/keep_going.go
+++ b/internal/util/pagination/keep_going.go
@@ -1,11 +1,11 @@
 package pagination
 
 // KeepGoing is the bool returned by Enumerate-style callbacks to control iteration.
-// Return true to continue to the next page; return false to stop early.
+// Return Continue to fetch the next page; return Stop to halt early.
 //
-// Using this named type (instead of a bare bool) gives Enumerate callbacks across
-// the codebase a consistent semantic: true means "keep going."
-type KeepGoing = bool
+// Defined as a named type (not an alias) so callbacks must return the exported
+// constants — bare true/false won't compile, which keeps intent explicit.
+type KeepGoing bool
 
 const (
 	// Continue tells an Enumerate-style iterator to fetch the next page.


### PR DESCRIPTION
## Summary
- Introduces `pagination.KeepGoing = bool` type alias (with `Continue`/`Stop` constants) so all Enumerate callbacks use a consistent, self-documenting return type.
- Applies the alias across every Enumerate method in the database, core, request log, and list-builder layers (interfaces, implementations, mocks, and callers).
- Flips the semantic of DB Enumerate methods that previously used an inverted "stop" return so the convention is unified: return `true` to keep going, `false` to stop.

Closes #80.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)