### PR TITLE
Consolidate label/annotation handlers into shared adapter (#95)

### DIFF
--- a/internal/apauth/service/test_auth.go
+++ b/internal/apauth/service/test_auth.go
@@ -39,6 +39,22 @@ func TestAuthService(t *testing.T, serviceId sconfig.ServiceId, cfg config.C) (c
 	return TestAuthServiceWithDb(serviceId, cfg, db)
 }
 
+// NewResourcePermissionValidatorForTest constructs a ResourcePermissionValidator
+// suitable for unit tests that exercise handlers calling
+// MustGetValidatorFromGinContext / ValidateHttpStatusError without spinning up
+// the full auth service. Pass an authenticated *core.RequestAuth (typically
+// built from core.NewAuthenticatedRequestAuthWithPermissions) along with the
+// resource and verb the handler will check against.
+func NewResourcePermissionValidatorForTest(ra *core.RequestAuth, resource, verb string) *ResourcePermissionValidator {
+	return &ResourcePermissionValidator{
+		pvb: &PermissionValidatorBuilder{
+			resource: resource,
+			verbs:    []string{verb},
+		},
+		ra: ra,
+	}
+}
+
 func TestAuthServiceWithDb(serviceId sconfig.ServiceId, cfg config.C, db database.DB) (config.C, A, *AuthTestUtil) {
 	if cfg == nil {
 		cfg = config.FromRoot(&sconfig.Root{})

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -141,6 +141,14 @@ func (c *Connection) GetNamespace() string {
 	return c.Namespace
 }
 
+func (c *Connection) GetLabels() map[string]string {
+	return c.Labels
+}
+
+func (c *Connection) GetAnnotations() map[string]string {
+	return c.Annotations
+}
+
 func (c *Connection) Validate() error {
 	result := &multierror.Error{}
 

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -32,8 +32,8 @@ type ActorsRoutes struct {
 	httpf         httpf.F
 	encrypt       encrypt.E
 	logger        *slog.Logger
-	labelsAdapter labels.Adapter[apid.ID]
-	annotsAdapter labels.Adapter[apid.ID]
+	labelsAdapter key_value.Adapter[apid.ID]
+	annotsAdapter key_value.Adapter[apid.ID]
 }
 
 type ActorJson struct {
@@ -1043,7 +1043,7 @@ func NewActorsRoutes(
 		return id, nil
 	}
 
-	getActor := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+	getActor := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
 		actor, err := db.GetActor(ctx, id)
 		if err != nil {
 			return nil, err
@@ -1065,34 +1065,34 @@ func NewActorsRoutes(
 		ForVerb("update").
 		Build()
 
-	labelsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Label,
+	labelsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Label,
 		ResourceName: "actor",
 		PathPrefix:   "/actors/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseActorID,
 		Get:          getActor,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return db.PutActorLabels(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return db.DeleteActorLabels(ctx, id, keys)
 		},
 	}
 
-	annotsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Annotation,
+	annotsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Annotation,
 		ResourceName: "actor",
 		PathPrefix:   "/actors/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseActorID,
 		Get:          getActor,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return db.PutActorAnnotations(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return db.DeleteActorAnnotations(ctx, id, keys)
 		},
 	}

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -747,7 +747,7 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 }
 
 // Label and annotation handlers for actors delegate to a shared
-// generic adapter (see internal/routes/labels). The doc comments below
+// generic adapter (see internal/routes/key_value). The doc comments below
 // drive the OpenAPI spec; the bodies forward to the adapter.
 
 // @Summary		Get all labels for an actor

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -1,19 +1,21 @@
 package routes
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 
@@ -23,13 +25,15 @@ import (
 )
 
 type ActorsRoutes struct {
-	cfg     config.C
-	auth    auth.A
-	db      database.DB
-	r       apredis.Client
-	httpf   httpf.F
-	encrypt encrypt.E
-	logger  *slog.Logger
+	cfg           config.C
+	auth          auth.A
+	db            database.DB
+	r             apredis.Client
+	httpf         httpf.F
+	encrypt       encrypt.E
+	logger        *slog.Logger
+	labelsAdapter labels.Adapter[apid.ID]
+	annotsAdapter labels.Adapter[apid.ID]
 }
 
 type ActorJson struct {
@@ -52,24 +56,6 @@ type CreateActorRequestJson struct {
 type UpdateActorRequestJson struct {
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
-}
-
-type PutActorLabelRequestJson struct {
-	Value string `json:"value"`
-}
-
-type ActorLabelJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type PutActorAnnotationRequestJson struct {
-	Value string `json:"value"`
-}
-
-type ActorAnnotationJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
 }
 
 func DatabaseActorToJson(a *database.Actor) ActorJson {
@@ -760,10 +746,13 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(updatedActor))
 }
 
+// Label and annotation handlers for actors delegate to a shared
+// generic adapter (see internal/routes/labels). The doc comments below
+// drive the OpenAPI spec; the bodies forward to the adapter.
+
 // @Summary		Get all labels for an actor
 // @Description	Get all labels associated with a specific actor
 // @Tags			actors
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Actor UUID"
 // @Success		200	{object}	map[string]string
@@ -773,130 +762,22 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/labels [get]
-func (r *ActorsRoutes) getLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	labels := actor.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
+func (r *ActorsRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific label for an actor
 // @Description	Get a specific label value by key for an actor
 // @Tags			actors
-// @Accept			json
 // @Produce		json
 // @Param			id		path		string	true	"Actor UUID"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	ActorLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/labels/{label} [get]
-func (r *ActorsRoutes) getLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	labels := actor.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, r.logger, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ActorLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *ActorsRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for an actor
 // @Description	Set or update a specific label value by key for an actor
@@ -905,8 +786,8 @@ func (r *ActorsRoutes) getLabel(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string						true	"Actor UUID"
 // @Param			label	path		string						true	"Label key"
-// @Param			request	body		PutActorLabelRequestJson	true	"Label value"
-// @Success		200		{object}	ActorLabelJson
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -914,101 +795,11 @@ func (r *ActorsRoutes) getLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/labels/{label} [put]
-func (r *ActorsRoutes) putLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate label key
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid label key: %s", err.Error()), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutActorLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate label value
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid label value: %s", err.Error()), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing actor for authorization check
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	// Use transactional PutActorLabels to update
-	updatedActor, err := r.db.PutActorLabels(ctx, id, map[string]string{labelKey: req.Value})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ActorLabelJson{
-		Key:   labelKey,
-		Value: updatedActor.Labels[labelKey],
-	})
-}
+func (r *ActorsRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from an actor
 // @Description	Delete a specific label by key from an actor
 // @Tags			actors
-// @Accept			json
-// @Produce		json
 // @Param			id		path	string	true	"Actor UUID"
 // @Param			label	path	string	true	"Label key"
 // @Success		204		"No Content"
@@ -1018,78 +809,11 @@ func (r *ActorsRoutes) putLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/labels/{label} [delete]
-func (r *ActorsRoutes) deleteLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing actor for authorization check
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			// Actor doesn't exist, return 204 (idempotent delete)
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		// Actor doesn't exist, return 204 (idempotent delete)
-		gctx.Status(http.StatusNoContent)
-		val.MarkValidated()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	// Use transactional DeleteActorLabels to delete
-	_, err = r.db.DeleteActorLabels(ctx, id, []string{labelKey})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			// Actor was deleted between the check and the update, return 204
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ActorsRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all annotations for an actor
 // @Description	Get all annotations for an actor by ID
 // @Tags			actors
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Actor UUID"
 // @Success		200	{object}	map[string]string
@@ -1099,140 +823,32 @@ func (r *ActorsRoutes) deleteLabel(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/annotations [get]
-func (r *ActorsRoutes) getAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	annotations := actor.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
-}
+func (r *ActorsRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific annotation for an actor
 // @Description	Get a specific annotation value by key for an actor
 // @Tags			actors
-// @Accept			json
 // @Produce		json
 // @Param			id			path		string	true	"Actor UUID"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	ActorAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/annotations/{annotation} [get]
-func (r *ActorsRoutes) getAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	annotations := actor.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, r.logger, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ActorAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
-}
+func (r *ActorsRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
 
 // @Summary		Set an annotation for an actor
 // @Description	Set or update a specific annotation value by key for an actor
 // @Tags			actors
 // @Accept			json
 // @Produce		json
-// @Param			id			path		string							true	"Actor UUID"
-// @Param			annotation	path		string							true	"Annotation key"
-// @Param			request		body		PutActorAnnotationRequestJson	true	"Annotation value"
-// @Success		200			{object}	ActorAnnotationJson
+// @Param			id			path		string						true	"Actor UUID"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		403			{object}	ErrorResponse
@@ -1240,94 +856,11 @@ func (r *ActorsRoutes) getAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/annotations/{annotation} [put]
-func (r *ActorsRoutes) putAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate annotation key
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid annotation key: %s", err.Error()), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutActorAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing actor for authorization check
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	// Use transactional PutActorAnnotations to update
-	updatedActor, err := r.db.PutActorAnnotations(ctx, id, map[string]string{annotationKey: req.Value})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, r.logger, httperr.NotFound("actor not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ActorAnnotationJson{
-		Key:   annotationKey,
-		Value: updatedActor.Annotations[annotationKey],
-	})
-}
+func (r *ActorsRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete an annotation from an actor
 // @Description	Delete a specific annotation by key from an actor
 // @Tags			actors
-// @Accept			json
-// @Produce		json
 // @Param			id			path	string	true	"Actor UUID"
 // @Param			annotation	path	string	true	"Annotation key"
 // @Success		204			"No Content"
@@ -1337,73 +870,7 @@ func (r *ActorsRoutes) putAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id}/annotations/{annotation} [delete]
-func (r *ActorsRoutes) deleteAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, r.logger, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing actor for authorization check
-	actor, err := r.db.GetActor(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			// Actor doesn't exist, return 204 (idempotent delete)
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if actor == nil {
-		// Actor doesn't exist, return 204 (idempotent delete)
-		gctx.Status(http.StatusNoContent)
-		val.MarkValidated()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(actor); httpErr != nil {
-		apgin.WriteError(gctx, r.logger, httpErr)
-		return
-	}
-
-	// Use transactional DeleteActorAnnotations to delete
-	_, err = r.db.DeleteActorAnnotations(ctx, id, []string{annotationKey})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			// Actor was deleted between the check and the update, return 204
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ActorsRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
 
 func (r *ActorsRoutes) Register(g gin.IRouter) {
 	g.GET(
@@ -1565,13 +1032,80 @@ func NewActorsRoutes(
 	encrypt encrypt.E,
 	logger *slog.Logger,
 ) *ActorsRoutes {
+	parseActorID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
+		id, err := apid.Parse(gctx.Param("id"))
+		if err != nil {
+			return apid.Nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err))
+		}
+		if id == apid.Nil {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		return id, nil
+	}
+
+	getActor := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+		actor, err := db.GetActor(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if actor == nil {
+			return nil, nil
+		}
+		return actor, nil
+	}
+
+	authGet := authService.NewRequiredBuilder().
+		ForResource("actors").
+		ForIdField("id").
+		ForVerb("get").
+		Build()
+	authMutate := authService.NewRequiredBuilder().
+		ForResource("actors").
+		ForIdField("id").
+		ForVerb("update").
+		Build()
+
+	labelsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Label,
+		ResourceName: "actor",
+		PathPrefix:   "/actors/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseActorID,
+		Get:          getActor,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return db.PutActorLabels(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return db.DeleteActorLabels(ctx, id, keys)
+		},
+	}
+
+	annotsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Annotation,
+		ResourceName: "actor",
+		PathPrefix:   "/actors/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseActorID,
+		Get:          getActor,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return db.PutActorAnnotations(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return db.DeleteActorAnnotations(ctx, id, keys)
+		},
+	}
+
 	return &ActorsRoutes{
-		cfg:     cfg,
-		auth:    authService,
-		db:      db,
-		r:       r,
-		httpf:   httpf,
-		encrypt: encrypt,
-		logger:  logger,
+		cfg:           cfg,
+		auth:          authService,
+		db:            db,
+		r:             r,
+		httpf:         httpf,
+		encrypt:       encrypt,
+		logger:        logger,
+		labelsAdapter: labelsAdapter,
+		annotsAdapter: annotsAdapter,
 	}
 }

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
@@ -1194,7 +1195,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1284,7 +1285,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1317,7 +1318,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)
@@ -1592,7 +1593,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1669,7 +1670,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1697,7 +1698,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ActorAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -1195,7 +1195,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1285,7 +1285,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1318,7 +1318,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)
@@ -1593,7 +1593,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1670,7 +1670,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1698,7 +1698,7 @@ func TestActorsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -917,7 +917,7 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 }
 
 // Label and annotation handlers for connections delegate to a shared
-// generic adapter (see internal/routes/labels). The doc comments below
+// generic adapter (see internal/routes/key_value). The doc comments below
 // drive the OpenAPI spec; the bodies forward to the adapter.
 
 // @Summary		Get all labels for a connection

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"errors"
 
 	"github.com/gin-gonic/gin"
@@ -15,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 
@@ -24,14 +26,16 @@ import (
 )
 
 type ConnectionsRoutes struct {
-	cfg     config.C
-	auth    auth.A
-	core    coreIface.C
-	db      database.DB
-	r       apredis.Client
-	httpf   httpf.F
-	encrypt encrypt.E
-	oauthf  oauth2.Factory
+	cfg              config.C
+	auth             auth.A
+	core             coreIface.C
+	db               database.DB
+	r                apredis.Client
+	httpf            httpf.F
+	encrypt          encrypt.E
+	oauthf           oauth2.Factory
+	labelsAdapter    labels.Adapter[apid.ID]
+	annotsAdapter    labels.Adapter[apid.ID]
 }
 
 // @Summary		Initiate connection
@@ -832,24 +836,6 @@ type UpdateConnectionRequestJson struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-type PutConnectionLabelRequestJson struct {
-	Value string `json:"value"`
-}
-
-type ConnectionLabelJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type PutConnectionAnnotationRequestJson struct {
-	Value string `json:"value"`
-}
-
-type ConnectionAnnotationJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
 // @Summary		Update connection
 // @Description	Update a connection's labels
 // @Tags			connections
@@ -935,10 +921,13 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, ConnectionToJson(c))
 }
 
+// Label and annotation handlers for connections delegate to a shared
+// generic adapter (see internal/routes/labels). The doc comments below
+// drive the OpenAPI spec; the bodies forward to the adapter.
+
 // @Summary		Get all labels for a connection
 // @Description	Get all labels associated with a specific connection
 // @Tags			connections
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Connection UUID"
 // @Success		200	{object}	map[string]string
@@ -948,140 +937,32 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/labels [get]
-func (r *ConnectionsRoutes) getLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := c.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
+func (r *ConnectionsRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific label for a connection
 // @Description	Get a specific label value by key for a connection
 // @Tags			connections
-// @Accept			json
 // @Produce		json
 // @Param			id		path		string	true	"Connection UUID"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	SwaggerConnectionLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/labels/{label} [get]
-func (r *ConnectionsRoutes) getLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := c.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectionLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *ConnectionsRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for a connection
 // @Description	Set or update a specific label value by key for a connection
 // @Tags			connections
 // @Accept			json
 // @Produce		json
-// @Param			id		path		string								true	"Connection UUID"
-// @Param			label	path		string								true	"Label key"
-// @Param			request	body		SwaggerPutConnectionLabelRequest	true	"Label value"
-// @Success		200		{object}	SwaggerConnectionLabelJson
+// @Param			id		path		string						true	"Connection UUID"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -1089,97 +970,11 @@ func (r *ConnectionsRoutes) getLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/labels/{label} [put]
-func (r *ConnectionsRoutes) putLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectionLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	updatedConn, err := r.db.PutConnectionLabels(ctx, id, map[string]string{labelKey: req.Value})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectionLabelJson{
-		Key:   labelKey,
-		Value: updatedConn.Labels[labelKey],
-	})
-}
+func (r *ConnectionsRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from a connection
 // @Description	Delete a specific label by key from a connection
 // @Tags			connections
-// @Accept			json
-// @Produce		json
 // @Param			id		path	string	true	"Connection UUID"
 // @Param			label	path	string	true	"Label key"
 // @Success		204		"No Content"
@@ -1189,73 +984,11 @@ func (r *ConnectionsRoutes) putLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/labels/{label} [delete]
-func (r *ConnectionsRoutes) deleteLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		gctx.Status(http.StatusNoContent)
-		val.MarkValidated()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	_, err = r.db.DeleteConnectionLabels(ctx, id, []string{labelKey})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ConnectionsRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all annotations for a connection
 // @Description	Get all annotations associated with a specific connection
 // @Tags			connections
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Connection UUID"
 // @Success		200	{object}	map[string]string
@@ -1265,140 +998,32 @@ func (r *ConnectionsRoutes) deleteLabel(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/annotations [get]
-func (r *ConnectionsRoutes) getAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := c.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
-}
+func (r *ConnectionsRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific annotation for a connection
 // @Description	Get a specific annotation value by key for a connection
 // @Tags			connections
-// @Accept			json
 // @Produce		json
 // @Param			id			path		string	true	"Connection UUID"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	SwaggerConnectionAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/annotations/{annotation} [get]
-func (r *ConnectionsRoutes) getAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := c.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectionAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
-}
+func (r *ConnectionsRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
 
 // @Summary		Set an annotation for a connection
 // @Description	Set or update a specific annotation value by key for a connection
 // @Tags			connections
 // @Accept			json
 // @Produce		json
-// @Param			id			path		string									true	"Connection UUID"
-// @Param			annotation	path		string									true	"Annotation key"
-// @Param			request		body		SwaggerPutConnectionAnnotationRequest	true	"Annotation value"
-// @Success		200			{object}	SwaggerConnectionAnnotationJson
+// @Param			id			path		string						true	"Connection UUID"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		403			{object}	ErrorResponse
@@ -1406,91 +1031,11 @@ func (r *ConnectionsRoutes) getAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/annotations/{annotation} [put]
-func (r *ConnectionsRoutes) putAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectionAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	updatedConn, err := r.db.PutConnectionAnnotations(ctx, id, map[string]string{annotationKey: req.Value})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("connection not found"))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectionAnnotationJson{
-		Key:   annotationKey,
-		Value: updatedConn.Annotations[annotationKey],
-	})
-}
+func (r *ConnectionsRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete an annotation from a connection
 // @Description	Delete a specific annotation by key from a connection
 // @Tags			connections
-// @Accept			json
-// @Produce		json
 // @Param			id			path	string	true	"Connection UUID"
 // @Param			annotation	path	string	true	"Annotation key"
 // @Success		204			"No Content"
@@ -1500,68 +1045,7 @@ func (r *ConnectionsRoutes) putAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id}/annotations/{annotation} [delete]
-func (r *ConnectionsRoutes) deleteAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id, err := apid.Parse(gctx.Param("id"))
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if id == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c, err := r.core.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if c == nil {
-		gctx.Status(http.StatusNoContent)
-		val.MarkValidated()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	_, err = r.db.DeleteConnectionAnnotations(ctx, id, []string{annotationKey})
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ConnectionsRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
 
 func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 	g.POST(
@@ -1763,14 +1247,81 @@ func NewConnectionsRoutes(
 	encrypt encrypt.E,
 	logger *slog.Logger,
 ) *ConnectionsRoutes {
+	parseConnID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
+		id, err := apid.Parse(gctx.Param("id"))
+		if err != nil {
+			return apid.Nil, httperr.BadRequest("invalid id format", httperr.WithInternalErr(err))
+		}
+		if id == apid.Nil {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		return id, nil
+	}
+
+	getConn := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+		conn, err := c.GetConnection(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if conn == nil {
+			return nil, nil
+		}
+		return conn, nil
+	}
+
+	authGet := authService.NewRequiredBuilder().
+		ForResource("connections").
+		ForVerb("get").
+		ForIdField("id").
+		Build()
+	authMutate := authService.NewRequiredBuilder().
+		ForResource("connections").
+		ForVerb("update").
+		ForIdField("id").
+		Build()
+
+	labelsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Label,
+		ResourceName: "connection",
+		PathPrefix:   "/connections/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseConnID,
+		Get:          getConn,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return db.PutConnectionLabels(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return db.DeleteConnectionLabels(ctx, id, keys)
+		},
+	}
+
+	annotsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Annotation,
+		ResourceName: "connection",
+		PathPrefix:   "/connections/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseConnID,
+		Get:          getConn,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return db.PutConnectionAnnotations(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return db.DeleteConnectionAnnotations(ctx, id, keys)
+		},
+	}
+
 	return &ConnectionsRoutes{
-		cfg:     cfg,
-		auth:    authService,
-		core:    c,
-		db:      db,
-		r:       r,
-		httpf:   httpf,
-		encrypt: encrypt,
-		oauthf:  oauth2.NewFactory(cfg, db, r, c, httpf, encrypt, logger),
+		cfg:           cfg,
+		auth:          authService,
+		core:          c,
+		db:            db,
+		r:             r,
+		httpf:         httpf,
+		encrypt:       encrypt,
+		oauthf:        oauth2.NewFactory(cfg, db, r, c, httpf, encrypt, logger),
+		labelsAdapter: labelsAdapter,
+		annotsAdapter: annotsAdapter,
 	}
 }

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -27,16 +27,16 @@ import (
 )
 
 type ConnectionsRoutes struct {
-	cfg              config.C
-	auth             auth.A
-	core             coreIface.C
-	db               database.DB
-	r                apredis.Client
-	httpf            httpf.F
-	encrypt          encrypt.E
-	oauthf           oauth2.Factory
-	labelsAdapter    labels.Adapter[apid.ID]
-	annotsAdapter    labels.Adapter[apid.ID]
+	cfg           config.C
+	auth          auth.A
+	core          coreIface.C
+	db            database.DB
+	r             apredis.Client
+	httpf         httpf.F
+	encrypt       encrypt.E
+	oauthf        oauth2.Factory
+	labelsAdapter key_value.Adapter[apid.ID]
+	annotsAdapter key_value.Adapter[apid.ID]
 }
 
 // @Summary		Initiate connection
@@ -1253,7 +1253,7 @@ func NewConnectionsRoutes(
 		return id, nil
 	}
 
-	getConn := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+	getConn := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
 		conn, err := c.GetConnection(ctx, id)
 		if err != nil {
 			return nil, err
@@ -1275,34 +1275,34 @@ func NewConnectionsRoutes(
 		ForIdField("id").
 		Build()
 
-	labelsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Label,
+	labelsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Label,
 		ResourceName: "connection",
 		PathPrefix:   "/connections/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseConnID,
 		Get:          getConn,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return db.PutConnectionLabels(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return db.DeleteConnectionLabels(ctx, id, keys)
 		},
 	}
 
-	annotsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Annotation,
+	annotsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Annotation,
 		ResourceName: "connection",
 		PathPrefix:   "/connections/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseConnID,
 		Get:          getConn,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return db.PutConnectionAnnotations(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return db.DeleteConnectionAnnotations(ctx, id, keys)
 		},
 	}

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -802,7 +802,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -918,7 +918,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -946,7 +946,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -1425,7 +1425,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "note", resp.Key)
@@ -1524,7 +1524,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "note", resp.Key)

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
@@ -801,7 +802,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectionLabelJson
+			var resp labels.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -917,7 +918,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectionLabelJson
+			var resp labels.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -945,7 +946,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectionLabelJson
+			var resp labels.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "env", resp.Key)
@@ -1424,7 +1425,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectionAnnotationJson
+			var resp labels.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "note", resp.Key)
@@ -1523,7 +1524,7 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectionAnnotationJson
+			var resp labels.KeyValueJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "note", resp.Key)

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -164,10 +164,10 @@ type ConnectorsRoutes struct {
 	cfg                  config.C
 	connectors           connIface.C
 	authService          auth.A
-	labelsAdapter        labels.Adapter[apid.ID]
-	annotsAdapter        labels.Adapter[apid.ID]
-	versionLabelsAdapter labels.Adapter[connectorVersionID]
-	versionAnnotsAdapter labels.Adapter[connectorVersionID]
+	labelsAdapter        key_value.Adapter[apid.ID]
+	annotsAdapter        key_value.Adapter[apid.ID]
+	versionLabelsAdapter key_value.Adapter[connectorVersionID]
+	versionAnnotsAdapter key_value.Adapter[connectorVersionID]
 }
 
 // @Summary		Get connector
@@ -1061,7 +1061,9 @@ func (r *ConnectorsRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.Hand
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels [get]
-func (r *ConnectorsRoutes) getVersionLabels(gctx *gin.Context) { r.versionLabelsAdapter.HandleList(gctx) }
+func (r *ConnectorsRoutes) getVersionLabels(gctx *gin.Context) {
+	r.versionLabelsAdapter.HandleList(gctx)
+}
 
 // @Summary		Get a specific label for a connector version
 // @Description	Get a specific label value by key for a specific version of a connector
@@ -1116,7 +1118,9 @@ func (r *ConnectorsRoutes) putVersionLabel(gctx *gin.Context) { r.versionLabelsA
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels/{label} [delete]
-func (r *ConnectorsRoutes) deleteVersionLabel(gctx *gin.Context) { r.versionLabelsAdapter.HandleDelete(gctx) }
+func (r *ConnectorsRoutes) deleteVersionLabel(gctx *gin.Context) {
+	r.versionLabelsAdapter.HandleDelete(gctx)
+}
 
 type ForceConnectorVersionStateRequestJson struct {
 	State database.ConnectorVersionState `json:"state"`
@@ -1609,7 +1613,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return connectorVersionID{ConnectorID: id, Version: version}, nil
 	}
 
-	getConnector := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+	getConnector := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
 		result := c.ListConnectorsBuilder().
 			ForId(id).
 			Limit(1).
@@ -1623,7 +1627,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return result.Results[0], nil
 	}
 
-	getConnectorVersion := func(ctx context.Context, id connectorVersionID) (labels.Resource, error) {
+	getConnectorVersion := func(ctx context.Context, id connectorVersionID) (key_value.Resource, error) {
 		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1666,7 +1670,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		ForVerb("update").
 		Build()
 
-	putConnectorLabels := func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+	putConnectorLabels := func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1684,7 +1688,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), merged, draft.GetAnnotations())
 	}
 
-	deleteConnectorLabels := func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+	deleteConnectorLabels := func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1702,7 +1706,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), merged, draft.GetAnnotations())
 	}
 
-	putConnectorAnnotations := func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+	putConnectorAnnotations := func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1720,7 +1724,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), merged)
 	}
 
-	deleteConnectorAnnotations := func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+	deleteConnectorAnnotations := func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1738,7 +1742,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), merged)
 	}
 
-	putVersionLabels := func(ctx context.Context, id connectorVersionID, kv map[string]string) (labels.Resource, error) {
+	putVersionLabels := func(ctx context.Context, id connectorVersionID, kv map[string]string) (key_value.Resource, error) {
 		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1759,7 +1763,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), merged, cv.GetAnnotations())
 	}
 
-	deleteVersionLabels := func(ctx context.Context, id connectorVersionID, keys []string) (labels.Resource, error) {
+	deleteVersionLabels := func(ctx context.Context, id connectorVersionID, keys []string) (key_value.Resource, error) {
 		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1780,7 +1784,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), merged, cv.GetAnnotations())
 	}
 
-	putVersionAnnotations := func(ctx context.Context, id connectorVersionID, kv map[string]string) (labels.Resource, error) {
+	putVersionAnnotations := func(ctx context.Context, id connectorVersionID, kv map[string]string) (key_value.Resource, error) {
 		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1801,7 +1805,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), cv.GetLabels(), merged)
 	}
 
-	deleteVersionAnnotations := func(ctx context.Context, id connectorVersionID, keys []string) (labels.Resource, error) {
+	deleteVersionAnnotations := func(ctx context.Context, id connectorVersionID, keys []string) (key_value.Resource, error) {
 		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -1822,8 +1826,8 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), cv.GetLabels(), merged)
 	}
 
-	labelsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Label,
+	labelsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Label,
 		ResourceName: "connector",
 		PathPrefix:   "/connectors/:id",
 		AuthGet:      connectorAuthGet,
@@ -1834,8 +1838,8 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		Delete:       deleteConnectorLabels,
 	}
 
-	annotsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Annotation,
+	annotsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Annotation,
 		ResourceName: "connector",
 		PathPrefix:   "/connectors/:id",
 		AuthGet:      connectorAuthGet,
@@ -1846,8 +1850,8 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		Delete:       deleteConnectorAnnotations,
 	}
 
-	versionLabelsAdapter := labels.Adapter[connectorVersionID]{
-		Kind:         labels.Label,
+	versionLabelsAdapter := key_value.Adapter[connectorVersionID]{
+		Kind:         key_value.Label,
 		ResourceName: "connector version",
 		PathPrefix:   "/connectors/:id/versions/:version",
 		AuthGet:      versionAuthGet,
@@ -1858,8 +1862,8 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		Delete:       deleteVersionLabels,
 	}
 
-	versionAnnotsAdapter := labels.Adapter[connectorVersionID]{
-		Kind:         labels.Annotation,
+	versionAnnotsAdapter := key_value.Adapter[connectorVersionID]{
+		Kind:         key_value.Annotation,
 		ResourceName: "connector version",
 		PathPrefix:   "/connectors/:id/versions/:version",
 		AuthGet:      versionAuthGet,

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -16,7 +16,7 @@ import (
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -10,11 +11,12 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -151,32 +153,21 @@ type CreateConnectorVersionRequestJson struct {
 	Annotations *map[string]string `json:"annotations,omitempty"`
 }
 
-// ConnectorLabelJson is a single label key-value pair for a connector
-type ConnectorLabelJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-// PutConnectorLabelRequestJson is the request body for PUT /connectors/:id/labels/:label
-type PutConnectorLabelRequestJson struct {
-	Value string `json:"value"`
-}
-
-// ConnectorAnnotationJson is a single annotation key-value pair for a connector
-type ConnectorAnnotationJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-// PutConnectorAnnotationRequestJson is the request body for PUT /connectors/:id/annotations/:annotation
-type PutConnectorAnnotationRequestJson struct {
-	Value string `json:"value"`
+// connectorVersionID is the composite identifier used by the version-level
+// label/annotation adapters.
+type connectorVersionID struct {
+	ConnectorID apid.ID
+	Version     uint64
 }
 
 type ConnectorsRoutes struct {
-	cfg         config.C
-	connectors  connIface.C
-	authService auth.A
+	cfg                  config.C
+	connectors           connIface.C
+	authService          auth.A
+	labelsAdapter        labels.Adapter[apid.ID]
+	annotsAdapter        labels.Adapter[apid.ID]
+	versionLabelsAdapter labels.Adapter[connectorVersionID]
+	versionAnnotsAdapter labels.Adapter[connectorVersionID]
 }
 
 // @Summary		Get connector
@@ -1004,62 +995,7 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/labels [get]
-func (r *ConnectorsRoutes) getLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	result := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if result.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(result.Error)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if len(result.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c := result.Results[0]
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := c.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
+func (r *ConnectorsRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific label for a connector
 // @Description	Get a specific label value by key for the primary version of a connector
@@ -1068,92 +1004,24 @@ func (r *ConnectorsRoutes) getLabels(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string	true	"Connector UUID"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	SwaggerConnectorLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/labels/{label} [get]
-func (r *ConnectorsRoutes) getLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	result := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if result.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(result.Error)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if len(result.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c := result.Results[0]
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := c.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *ConnectorsRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for a connector
 // @Description	Set or update a specific label on a connector's draft version, creating one if needed
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
-// @Param			id		path		string								true	"Connector UUID"
-// @Param			label	path		string								true	"Label key"
-// @Param			request	body		SwaggerPutConnectorLabelRequest		true	"Label value"
-// @Success		200		{object}	SwaggerConnectorLabelJson
+// @Param			id		path		string						true	"Connector UUID"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -1161,91 +1029,7 @@ func (r *ConnectorsRoutes) getLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/labels/{label} [put]
-func (r *ConnectorsRoutes) putLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectorLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(draft); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := make(map[string]string)
-	for k, v := range draft.GetLabels() {
-		labels[k] = v
-	}
-	labels[labelKey] = req.Value
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, draft.GetVersion(), draft.GetDefinition(), labels, draft.GetAnnotations())
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorLabelJson{
-		Key:   labelKey,
-		Value: req.Value,
-	})
-}
+func (r *ConnectorsRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from a connector
 // @Description	Delete a specific label from a connector's draft version, creating one if needed
@@ -1261,69 +1045,7 @@ func (r *ConnectorsRoutes) putLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/labels/{label} [delete]
-func (r *ConnectorsRoutes) deleteLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(draft); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := make(map[string]string)
-	for k, v := range draft.GetLabels() {
-		labels[k] = v
-	}
-	delete(labels, labelKey)
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, draft.GetVersion(), draft.GetDefinition(), labels, draft.GetAnnotations())
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ConnectorsRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all labels for a connector version
 // @Description	Get all labels associated with a specific version of a connector
@@ -1339,68 +1061,7 @@ func (r *ConnectorsRoutes) deleteLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels [get]
-func (r *ConnectorsRoutes) getVersionLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	cv, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(cv); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := cv.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
+func (r *ConnectorsRoutes) getVersionLabels(gctx *gin.Context) { r.versionLabelsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific label for a connector version
 // @Description	Get a specific label value by key for a specific version of a connector
@@ -1410,99 +1071,25 @@ func (r *ConnectorsRoutes) getVersionLabels(gctx *gin.Context) {
 // @Param			id		path		string	true	"Connector UUID"
 // @Param			version	path		integer	true	"Version number"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	SwaggerConnectorLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels/{label} [get]
-func (r *ConnectorsRoutes) getVersionLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	cv, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(cv); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := cv.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *ConnectorsRoutes) getVersionLabel(gctx *gin.Context) { r.versionLabelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for a connector version
 // @Description	Set or update a specific label on a specific draft version of a connector
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
-// @Param			id		path		string								true	"Connector UUID"
-// @Param			version	path		integer								true	"Version number"
-// @Param			label	path		string								true	"Label key"
-// @Param			request	body		SwaggerPutConnectorLabelRequest		true	"Label value"
-// @Success		200		{object}	SwaggerConnectorLabelJson
+// @Param			id		path		string						true	"Connector UUID"
+// @Param			version	path		integer						true	"Version number"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -1511,111 +1098,7 @@ func (r *ConnectorsRoutes) getVersionLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels/{label} [put]
-func (r *ConnectorsRoutes) putVersionLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectorLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	if existing.GetState() != database.ConnectorVersionStateDraft {
-		apgin.WriteError(gctx, nil, httperr.Conflictf("connector version '%s:%d' is not a draft", connectorId, version))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labels := make(map[string]string)
-	for k, v := range existing.GetLabels() {
-		labels[k] = v
-	}
-	labels[labelKey] = req.Value
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, version, existing.GetDefinition(), labels, existing.GetAnnotations())
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorLabelJson{
-		Key:   labelKey,
-		Value: req.Value,
-	})
-}
+func (r *ConnectorsRoutes) putVersionLabel(gctx *gin.Context) { r.versionLabelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from a connector version
 // @Description	Delete a specific label from a specific draft version of a connector
@@ -1633,89 +1116,7 @@ func (r *ConnectorsRoutes) putVersionLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/labels/{label} [delete]
-func (r *ConnectorsRoutes) deleteVersionLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	if existing.GetState() != database.ConnectorVersionStateDraft {
-		apgin.WriteError(gctx, nil, httperr.Conflictf("connector version '%s:%d' is not a draft", connectorId, version))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labels := make(map[string]string)
-	for k, v := range existing.GetLabels() {
-		labels[k] = v
-	}
-	delete(labels, labelKey)
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, version, existing.GetDefinition(), labels, existing.GetAnnotations())
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ConnectorsRoutes) deleteVersionLabel(gctx *gin.Context) { r.versionLabelsAdapter.HandleDelete(gctx) }
 
 type ForceConnectorVersionStateRequestJson struct {
 	State database.ConnectorVersionState `json:"state"`
@@ -1841,62 +1242,7 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 // @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/annotations [get]
-func (r *ConnectorsRoutes) getAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	result := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if result.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(result.Error)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if len(result.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c := result.Results[0]
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := c.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
-}
+func (r *ConnectorsRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific annotation for a connector
 // @Description	Get a specific annotation value by key for a connector
@@ -1905,92 +1251,24 @@ func (r *ConnectorsRoutes) getAnnotations(gctx *gin.Context) {
 // @Produce		json
 // @Param			id			path		string	true	"Connector UUID"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	ConnectorAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/annotations/{annotation} [get]
-func (r *ConnectorsRoutes) getAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	result := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if result.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(result.Error)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if len(result.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c := result.Results[0]
-
-	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := c.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
-}
+func (r *ConnectorsRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
 
 // @Summary		Set an annotation for a connector
 // @Description	Set or update a specific annotation value by key for a connector's draft version, creating one if needed
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
-// @Param			id			path		string								true	"Connector UUID"
-// @Param			annotation	path		string								true	"Annotation key"
-// @Param			request		body		PutConnectorAnnotationRequestJson	true	"Annotation value"
-// @Success		200			{object}	ConnectorAnnotationJson
+// @Param			id			path		string						true	"Connector UUID"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		403			{object}	ErrorResponse
@@ -1998,86 +1276,7 @@ func (r *ConnectorsRoutes) getAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/annotations/{annotation} [put]
-func (r *ConnectorsRoutes) putAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate annotation key (same rules as label keys)
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectorAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(draft); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := make(map[string]string)
-	for k, v := range draft.GetAnnotations() {
-		annotations[k] = v
-	}
-	annotations[annotationKey] = req.Value
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), annotations)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorAnnotationJson{
-		Key:   annotationKey,
-		Value: req.Value,
-	})
-}
+func (r *ConnectorsRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete an annotation from a connector
 // @Description	Delete a specific annotation from a connector's draft version, creating one if needed
@@ -2093,69 +1292,7 @@ func (r *ConnectorsRoutes) putAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id}/annotations/{annotation} [delete]
-func (r *ConnectorsRoutes) deleteAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(draft); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := make(map[string]string)
-	for k, v := range draft.GetAnnotations() {
-		annotations[k] = v
-	}
-	delete(annotations, annotationKey)
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), annotations)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *ConnectorsRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all annotations for a connector version
 // @Description	Get all annotations associated with a specific version of a connector
@@ -2172,66 +1309,7 @@ func (r *ConnectorsRoutes) deleteAnnotation(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/annotations [get]
 func (r *ConnectorsRoutes) getVersionAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := existing.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
+	r.versionAnnotsAdapter.HandleList(gctx)
 }
 
 // @Summary		Get a specific annotation for a connector version
@@ -2242,7 +1320,7 @@ func (r *ConnectorsRoutes) getVersionAnnotations(gctx *gin.Context) {
 // @Param			id			path		string	true	"Connector UUID"
 // @Param			version		path		integer	true	"Version number"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	ConnectorAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
@@ -2250,79 +1328,7 @@ func (r *ConnectorsRoutes) getVersionAnnotations(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/annotations/{annotation} [get]
 func (r *ConnectorsRoutes) getVersionAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := existing.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
+	r.versionAnnotsAdapter.HandleGet(gctx)
 }
 
 // @Summary		Set an annotation for a connector version
@@ -2330,11 +1336,11 @@ func (r *ConnectorsRoutes) getVersionAnnotation(gctx *gin.Context) {
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
-// @Param			id			path		string								true	"Connector UUID"
-// @Param			version		path		integer								true	"Version number"
-// @Param			annotation	path		string								true	"Annotation key"
-// @Param			request		body		PutConnectorAnnotationRequestJson	true	"Annotation value"
-// @Success		200			{object}	ConnectorAnnotationJson
+// @Param			id			path		string						true	"Connector UUID"
+// @Param			version		path		integer						true	"Version number"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		403			{object}	ErrorResponse
@@ -2344,103 +1350,7 @@ func (r *ConnectorsRoutes) getVersionAnnotation(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/annotations/{annotation} [put]
 func (r *ConnectorsRoutes) putVersionAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutConnectorAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector version '%s:%d' not found", connectorId, version))
-			val.MarkErrorReturn()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	if existing.GetState() != database.ConnectorVersionStateDraft {
-		apgin.WriteError(gctx, nil, httperr.Conflictf("connector version '%s:%d' is not a draft", connectorId, version))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotations := make(map[string]string)
-	for k, v := range existing.GetAnnotations() {
-		annotations[k] = v
-	}
-	annotations[annotationKey] = req.Value
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, version, existing.GetDefinition(), existing.GetLabels(), annotations)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, ConnectorAnnotationJson{
-		Key:   annotationKey,
-		Value: req.Value,
-	})
+	r.versionAnnotsAdapter.HandlePut(gctx)
 }
 
 // @Summary		Delete an annotation from a connector version
@@ -2460,87 +1370,7 @@ func (r *ConnectorsRoutes) putVersionAnnotation(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/connectors/{id}/versions/{version}/annotations/{annotation} [delete]
 func (r *ConnectorsRoutes) deleteVersionAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(existing); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	if existing.GetState() != database.ConnectorVersionStateDraft {
-		apgin.WriteError(gctx, nil, httperr.Conflictf("connector version '%s:%d' is not a draft", connectorId, version))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotations := make(map[string]string)
-	for k, v := range existing.GetAnnotations() {
-		annotations[k] = v
-	}
-	delete(annotations, annotationKey)
-
-	_, err = r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, version, existing.GetDefinition(), existing.GetLabels(), annotations)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
+	r.versionAnnotsAdapter.HandleDelete(gctx)
 }
 
 func (r *ConnectorsRoutes) Register(g gin.IRouter) {
@@ -2748,9 +1578,305 @@ func (r *ConnectorsRoutes) Register(g gin.IRouter) {
 }
 
 func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *ConnectorsRoutes {
+	parseConnectorID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
+		idStr := gctx.Param("id")
+		if idStr == "" {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		id, err := apid.Parse(idStr)
+		if err != nil {
+			return apid.Nil, httperr.BadRequest("invalid id format")
+		}
+		if id == apid.Nil {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		return id, nil
+	}
+
+	parseConnectorVersionID := func(gctx *gin.Context) (connectorVersionID, *httperr.Error) {
+		id, herr := parseConnectorID(gctx)
+		if herr != nil {
+			return connectorVersionID{}, herr
+		}
+		versionStr := gctx.Param("version")
+		if versionStr == "" {
+			return connectorVersionID{}, httperr.BadRequest("version is required")
+		}
+		version, err := strconv.ParseUint(versionStr, 10, 64)
+		if err != nil {
+			return connectorVersionID{}, httperr.BadRequest("failed to parse version as an integer")
+		}
+		return connectorVersionID{ConnectorID: id, Version: version}, nil
+	}
+
+	getConnector := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+		result := c.ListConnectorsBuilder().
+			ForId(id).
+			Limit(1).
+			FetchPage(ctx)
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		if len(result.Results) == 0 {
+			return nil, database.ErrNotFound
+		}
+		return result.Results[0], nil
+	}
+
+	getConnectorVersion := func(ctx context.Context, id connectorVersionID) (labels.Resource, error) {
+		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if cv == nil {
+			return nil, nil
+		}
+		return cv, nil
+	}
+
+	connectorIDExtractor := func(v interface{}) string {
+		return string(v.(connIface.ConnectorVersion).GetId())
+	}
+
+	connectorAuthGet := authService.NewRequiredBuilder().
+		ForResource("connectors").
+		ForIdField("id").
+		ForIdExtractor(connectorIDExtractor).
+		ForVerb("get").
+		Build()
+	connectorAuthMutate := authService.NewRequiredBuilder().
+		ForResource("connectors").
+		ForIdField("id").
+		ForIdExtractor(connectorIDExtractor).
+		ForVerb("update").
+		Build()
+	versionAuthGet := authService.NewRequiredBuilder().
+		ForResource("connectors").
+		ForIdField("id").
+		ForIdExtractor(connectorIDExtractor).
+		ForVerb("list/versions").
+		Build()
+	versionAuthMutate := authService.NewRequiredBuilder().
+		ForResource("connectors").
+		ForIdField("id").
+		ForIdExtractor(connectorIDExtractor).
+		ForVerb("update").
+		Build()
+
+	putConnectorLabels := func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		merged := make(map[string]string)
+		for k, v := range draft.GetLabels() {
+			merged[k] = v
+		}
+		for k, v := range kv {
+			merged[k] = v
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), merged, draft.GetAnnotations())
+	}
+
+	deleteConnectorLabels := func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		merged := make(map[string]string)
+		for k, v := range draft.GetLabels() {
+			merged[k] = v
+		}
+		for _, k := range keys {
+			delete(merged, k)
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), merged, draft.GetAnnotations())
+	}
+
+	putConnectorAnnotations := func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		merged := make(map[string]string)
+		for k, v := range draft.GetAnnotations() {
+			merged[k] = v
+		}
+		for k, v := range kv {
+			merged[k] = v
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), merged)
+	}
+
+	deleteConnectorAnnotations := func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		draft, err := c.GetOrCreateDraftConnectorVersion(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		merged := make(map[string]string)
+		for k, v := range draft.GetAnnotations() {
+			merged[k] = v
+		}
+		for _, k := range keys {
+			delete(merged, k)
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id, draft.GetVersion(), draft.GetDefinition(), draft.GetLabels(), merged)
+	}
+
+	putVersionLabels := func(ctx context.Context, id connectorVersionID, kv map[string]string) (labels.Resource, error) {
+		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if cv.GetState() != database.ConnectorVersionStateDraft {
+			return nil, httperr.Conflictf("connector version '%s:%d' is not a draft", id.ConnectorID, id.Version)
+		}
+		merged := make(map[string]string)
+		for k, v := range cv.GetLabels() {
+			merged[k] = v
+		}
+		for k, v := range kv {
+			merged[k] = v
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), merged, cv.GetAnnotations())
+	}
+
+	deleteVersionLabels := func(ctx context.Context, id connectorVersionID, keys []string) (labels.Resource, error) {
+		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if cv.GetState() != database.ConnectorVersionStateDraft {
+			return nil, httperr.Conflictf("connector version '%s:%d' is not a draft", id.ConnectorID, id.Version)
+		}
+		merged := make(map[string]string)
+		for k, v := range cv.GetLabels() {
+			merged[k] = v
+		}
+		for _, k := range keys {
+			delete(merged, k)
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), merged, cv.GetAnnotations())
+	}
+
+	putVersionAnnotations := func(ctx context.Context, id connectorVersionID, kv map[string]string) (labels.Resource, error) {
+		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if cv.GetState() != database.ConnectorVersionStateDraft {
+			return nil, httperr.Conflictf("connector version '%s:%d' is not a draft", id.ConnectorID, id.Version)
+		}
+		merged := make(map[string]string)
+		for k, v := range cv.GetAnnotations() {
+			merged[k] = v
+		}
+		for k, v := range kv {
+			merged[k] = v
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), cv.GetLabels(), merged)
+	}
+
+	deleteVersionAnnotations := func(ctx context.Context, id connectorVersionID, keys []string) (labels.Resource, error) {
+		cv, err := c.GetConnectorVersion(ctx, id.ConnectorID, id.Version)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if cv.GetState() != database.ConnectorVersionStateDraft {
+			return nil, httperr.Conflictf("connector version '%s:%d' is not a draft", id.ConnectorID, id.Version)
+		}
+		merged := make(map[string]string)
+		for k, v := range cv.GetAnnotations() {
+			merged[k] = v
+		}
+		for _, k := range keys {
+			delete(merged, k)
+		}
+		return c.UpdateDraftConnectorVersion(ctx, id.ConnectorID, id.Version, cv.GetDefinition(), cv.GetLabels(), merged)
+	}
+
+	labelsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Label,
+		ResourceName: "connector",
+		PathPrefix:   "/connectors/:id",
+		AuthGet:      connectorAuthGet,
+		AuthMutate:   connectorAuthMutate,
+		ParseID:      parseConnectorID,
+		Get:          getConnector,
+		Put:          putConnectorLabels,
+		Delete:       deleteConnectorLabels,
+	}
+
+	annotsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Annotation,
+		ResourceName: "connector",
+		PathPrefix:   "/connectors/:id",
+		AuthGet:      connectorAuthGet,
+		AuthMutate:   connectorAuthMutate,
+		ParseID:      parseConnectorID,
+		Get:          getConnector,
+		Put:          putConnectorAnnotations,
+		Delete:       deleteConnectorAnnotations,
+	}
+
+	versionLabelsAdapter := labels.Adapter[connectorVersionID]{
+		Kind:         labels.Label,
+		ResourceName: "connector version",
+		PathPrefix:   "/connectors/:id/versions/:version",
+		AuthGet:      versionAuthGet,
+		AuthMutate:   versionAuthMutate,
+		ParseID:      parseConnectorVersionID,
+		Get:          getConnectorVersion,
+		Put:          putVersionLabels,
+		Delete:       deleteVersionLabels,
+	}
+
+	versionAnnotsAdapter := labels.Adapter[connectorVersionID]{
+		Kind:         labels.Annotation,
+		ResourceName: "connector version",
+		PathPrefix:   "/connectors/:id/versions/:version",
+		AuthGet:      versionAuthGet,
+		AuthMutate:   versionAuthMutate,
+		ParseID:      parseConnectorVersionID,
+		Get:          getConnectorVersion,
+		Put:          putVersionAnnotations,
+		Delete:       deleteVersionAnnotations,
+	}
+
 	return &ConnectorsRoutes{
-		cfg:         cfg,
-		authService: authService,
-		connectors:  c,
+		cfg:                  cfg,
+		authService:          authService,
+		connectors:           c,
+		labelsAdapter:        labelsAdapter,
+		annotsAdapter:        annotsAdapter,
+		versionLabelsAdapter: versionLabelsAdapter,
+		versionAnnotsAdapter: versionAnnotsAdapter,
 	}
 }

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
@@ -1151,7 +1152,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorLabelJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "type", resp.Key)
@@ -1179,7 +1180,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put label", func(t *testing.T) {
 			t.Run("bad uuid", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorLabelRequestJson{Value: "val"}
+				body := labels.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1199,7 +1200,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("invalid key", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorLabelRequestJson{Value: "val"}
+				body := labels.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1219,7 +1220,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("not found", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorLabelRequestJson{Value: "val"}
+				body := labels.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1239,7 +1240,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("valid - creates draft and sets label", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorLabelRequestJson{Value: "production"}
+				body := labels.PutKeyValueRequestJson{Value: "production"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1256,7 +1257,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorLabelJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1402,7 +1403,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorLabelJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "type", resp.Key)
@@ -1430,7 +1431,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put version label", func(t *testing.T) {
 			t.Run("conflict - not a draft", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorLabelRequestJson{Value: "val"}
+				body := labels.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1471,7 +1472,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put a label on the draft version
-				body := PutConnectorLabelRequestJson{Value: "staging"}
+				body := labels.PutKeyValueRequestJson{Value: "staging"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1488,7 +1489,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorLabelJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1794,7 +1795,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorAnnotationJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "my-annotation", resp.Key)
@@ -1822,7 +1823,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put annotation", func(t *testing.T) {
 			t.Run("valid", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorAnnotationRequestJson{Value: "production"}
+				body := labels.PutKeyValueRequestJson{Value: "production"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1839,7 +1840,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorAnnotationJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1848,7 +1849,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("valid - creates draft and sets annotation", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := PutConnectorAnnotationRequestJson{Value: "my-description"}
+				body := labels.PutKeyValueRequestJson{Value: "my-description"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1865,7 +1866,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorAnnotationJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "description", resp.Key)
@@ -1897,7 +1898,7 @@ func TestConnectors(t *testing.T) {
 				tu := setup(t, nil)
 
 				// First put an annotation
-				body := PutConnectorAnnotationRequestJson{Value: "to-delete"}
+				body := labels.PutKeyValueRequestJson{Value: "to-delete"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1933,7 +1934,7 @@ func TestConnectors(t *testing.T) {
 				tu := setup(t, nil)
 
 				// First put an annotation so it exists (this creates draft version 2)
-				body := PutConnectorAnnotationRequestJson{Value: "will-be-removed"}
+				body := labels.PutKeyValueRequestJson{Value: "will-be-removed"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2038,7 +2039,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft
-				body := PutConnectorAnnotationRequestJson{Value: "draft-value"}
+				body := labels.PutKeyValueRequestJson{Value: "draft-value"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2069,7 +2070,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorAnnotationJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "info", resp.Key)
@@ -2118,7 +2119,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft version
-				body := PutConnectorAnnotationRequestJson{Value: "staging"}
+				body := labels.PutKeyValueRequestJson{Value: "staging"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2135,7 +2136,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorAnnotationJson
+				var resp labels.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -2167,7 +2168,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft
-				body := PutConnectorAnnotationRequestJson{Value: "to-delete"}
+				body := labels.PutKeyValueRequestJson{Value: "to-delete"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -1152,7 +1152,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "type", resp.Key)
@@ -1180,7 +1180,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put label", func(t *testing.T) {
 			t.Run("bad uuid", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "val"}
+				body := key_value.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1200,7 +1200,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("invalid key", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "val"}
+				body := key_value.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1220,7 +1220,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("not found", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "val"}
+				body := key_value.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1240,7 +1240,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("valid - creates draft and sets label", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "production"}
+				body := key_value.PutKeyValueRequestJson{Value: "production"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1257,7 +1257,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1403,7 +1403,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "type", resp.Key)
@@ -1431,7 +1431,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put version label", func(t *testing.T) {
 			t.Run("conflict - not a draft", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "val"}
+				body := key_value.PutKeyValueRequestJson{Value: "val"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1472,7 +1472,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put a label on the draft version
-				body := labels.PutKeyValueRequestJson{Value: "staging"}
+				body := key_value.PutKeyValueRequestJson{Value: "staging"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1489,7 +1489,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1795,7 +1795,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "my-annotation", resp.Key)
@@ -1823,7 +1823,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("put annotation", func(t *testing.T) {
 			t.Run("valid", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "production"}
+				body := key_value.PutKeyValueRequestJson{Value: "production"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1840,7 +1840,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -1849,7 +1849,7 @@ func TestConnectors(t *testing.T) {
 
 			t.Run("valid - creates draft and sets annotation", func(t *testing.T) {
 				tu := setup(t, nil)
-				body := labels.PutKeyValueRequestJson{Value: "my-description"}
+				body := key_value.PutKeyValueRequestJson{Value: "my-description"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1866,7 +1866,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "description", resp.Key)
@@ -1898,7 +1898,7 @@ func TestConnectors(t *testing.T) {
 				tu := setup(t, nil)
 
 				// First put an annotation
-				body := labels.PutKeyValueRequestJson{Value: "to-delete"}
+				body := key_value.PutKeyValueRequestJson{Value: "to-delete"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1934,7 +1934,7 @@ func TestConnectors(t *testing.T) {
 				tu := setup(t, nil)
 
 				// First put an annotation so it exists (this creates draft version 2)
-				body := labels.PutKeyValueRequestJson{Value: "will-be-removed"}
+				body := key_value.PutKeyValueRequestJson{Value: "will-be-removed"}
 				jsonBody, _ := json.Marshal(body)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2039,7 +2039,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft
-				body := labels.PutKeyValueRequestJson{Value: "draft-value"}
+				body := key_value.PutKeyValueRequestJson{Value: "draft-value"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2070,7 +2070,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "info", resp.Key)
@@ -2119,7 +2119,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft version
-				body := labels.PutKeyValueRequestJson{Value: "staging"}
+				body := key_value.PutKeyValueRequestJson{Value: "staging"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2136,7 +2136,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp labels.KeyValueJson
+				var resp key_value.KeyValueJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Equal(t, "env", resp.Key)
@@ -2168,7 +2168,7 @@ func TestConnectors(t *testing.T) {
 				draftVersion := createResp.Version
 
 				// Put an annotation on the draft
-				body := labels.PutKeyValueRequestJson{Value: "to-delete"}
+				body := key_value.PutKeyValueRequestJson{Value: "to-delete"}
 				jsonBody, _ := json.Marshal(body)
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"

--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -16,7 +16,7 @@ import (
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"

--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -33,10 +33,10 @@ type EncryptionKeyJson struct {
 }
 
 type CreateEncryptionKeyRequestJson struct {
-	Namespace   string            `json:"namespace"`
+	Namespace   string             `json:"namespace"`
 	KeyData     *cfgschema.KeyData `json:"key_data,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string  `json:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty"`
 }
 
 type UpdateEncryptionKeyRequestJson struct {
@@ -75,8 +75,8 @@ type EncryptionKeysRoutes struct {
 	cfg           config.C
 	core          coreIface.C
 	authService   auth.A
-	labelsAdapter labels.Adapter[apid.ID]
-	annotsAdapter labels.Adapter[apid.ID]
+	labelsAdapter key_value.Adapter[apid.ID]
+	annotsAdapter key_value.Adapter[apid.ID]
 }
 
 // @Summary		Get encryption key
@@ -598,7 +598,9 @@ func (r *EncryptionKeysRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapte
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/annotations/{annotation} [delete]
-func (r *EncryptionKeysRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
+func (r *EncryptionKeysRoutes) deleteAnnotation(gctx *gin.Context) {
+	r.annotsAdapter.HandleDelete(gctx)
+}
 
 func (r *EncryptionKeysRoutes) Register(g gin.IRouter) {
 	g.GET(
@@ -740,7 +742,7 @@ func NewEncryptionKeysRoutes(cfg config.C, authService auth.A, c coreIface.C) *E
 		return id, nil
 	}
 
-	getEncryptionKey := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+	getEncryptionKey := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
 		ek, err := c.GetEncryptionKey(ctx, id)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -769,34 +771,34 @@ func NewEncryptionKeysRoutes(cfg config.C, authService auth.A, c coreIface.C) *E
 		ForVerb("update").
 		Build()
 
-	labelsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Label,
+	labelsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Label,
 		ResourceName: "encryption key",
 		PathPrefix:   "/encryption-keys/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseEncryptionKeyID,
 		Get:          getEncryptionKey,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return c.PutEncryptionKeyLabels(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return c.DeleteEncryptionKeyLabels(ctx, id, keys)
 		},
 	}
 
-	annotsAdapter := labels.Adapter[apid.ID]{
-		Kind:         labels.Annotation,
+	annotsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Annotation,
 		ResourceName: "encryption key",
 		PathPrefix:   "/encryption-keys/:id",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseEncryptionKeyID,
 		Get:          getEncryptionKey,
-		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
 			return c.PutEncryptionKeyAnnotations(ctx, id, kv)
 		},
-		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
 			return c.DeleteEncryptionKeyAnnotations(ctx, id, keys)
 		},
 	}

--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -475,7 +475,7 @@ func (r *EncryptionKeysRoutes) delete(gctx *gin.Context) {
 }
 
 // Label and annotation handlers for encryption keys delegate to a shared
-// generic adapter (see internal/routes/labels). The doc comments below
+// generic adapter (see internal/routes/key_value). The doc comments below
 // drive the OpenAPI spec; the bodies forward to the adapter.
 
 // @Summary		Get all labels for an encryption key

--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -1,20 +1,22 @@
 package routes
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/rmorlok/authproxy/internal/apgin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -57,24 +59,6 @@ type ListEncryptionKeysResponseJson struct {
 	Cursor string              `json:"cursor,omitempty"`
 }
 
-type PutEncryptionKeyLabelRequestJson struct {
-	Value string `json:"value"`
-}
-
-type EncryptionKeyLabelJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type PutEncryptionKeyAnnotationRequestJson struct {
-	Value string `json:"value"`
-}
-
-type EncryptionKeyAnnotationJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
 func EncryptionKeyToJson(ek coreIface.EncryptionKey) EncryptionKeyJson {
 	return EncryptionKeyJson{
 		Id:          ek.GetId(),
@@ -88,9 +72,11 @@ func EncryptionKeyToJson(ek coreIface.EncryptionKey) EncryptionKeyJson {
 }
 
 type EncryptionKeysRoutes struct {
-	cfg         config.C
-	core        coreIface.C
-	authService auth.A
+	cfg           config.C
+	core          coreIface.C
+	authService   auth.A
+	labelsAdapter labels.Adapter[apid.ID]
+	annotsAdapter labels.Adapter[apid.ID]
 }
 
 // @Summary		Get encryption key
@@ -488,551 +474,131 @@ func (r *EncryptionKeysRoutes) delete(gctx *gin.Context) {
 	gctx.Status(http.StatusNoContent)
 }
 
+// Label and annotation handlers for encryption keys delegate to a shared
+// generic adapter (see internal/routes/labels). The doc comments below
+// drive the OpenAPI spec; the bodies forward to the adapter.
+
 // @Summary		Get all labels for an encryption key
 // @Description	Get all labels associated with a specific encryption key
 // @Tags			encryption_keys
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Encryption key ID"
-// @Success		200		{object}	map[string]string
-// @Failure		400		{object}	ErrorResponse
-// @Failure		401		{object}	ErrorResponse
-// @Failure		404		{object}	ErrorResponse
-// @Failure		500		{object}	ErrorResponse
+// @Success		200	{object}	map[string]string
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/labels [get]
-func (r *EncryptionKeysRoutes) getLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := ek.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
+func (r *EncryptionKeysRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific label for an encryption key
 // @Description	Get a specific label value by key for an encryption key
 // @Tags			encryption_keys
-// @Accept			json
 // @Produce		json
 // @Param			id		path		string	true	"Encryption key ID"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	EncryptionKeyLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/labels/{label} [get]
-func (r *EncryptionKeysRoutes) getLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := ek.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, EncryptionKeyLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *EncryptionKeysRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for an encryption key
 // @Description	Set or update a specific label value by key for an encryption key
 // @Tags			encryption_keys
 // @Accept			json
 // @Produce		json
-// @Param			id		path		string								true	"Encryption key ID"
-// @Param			label	path		string								true	"Label key"
-// @Param			request	body		PutEncryptionKeyLabelRequestJson	true	"Label value"
-// @Success		200		{object}	EncryptionKeyLabelJson
+// @Param			id		path		string						true	"Encryption key ID"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/labels/{label} [put]
-func (r *EncryptionKeysRoutes) putLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutEncryptionKeyLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get existing key for authorization check
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	updatedEk, err := r.core.PutEncryptionKeyLabels(ctx, id, map[string]string{labelKey: req.Value})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, EncryptionKeyLabelJson{
-		Key:   labelKey,
-		Value: updatedEk.GetLabels()[labelKey],
-	})
-}
+func (r *EncryptionKeysRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from an encryption key
 // @Description	Delete a specific label by key from an encryption key
 // @Tags			encryption_keys
-// @Accept			json
-// @Produce		json
 // @Param			id		path	string	true	"Encryption key ID"
 // @Param			label	path	string	true	"Label key"
 // @Success		204		"No Content"
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/labels/{label} [delete]
-func (r *EncryptionKeysRoutes) deleteLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get existing key for authorization check
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	_, err = r.core.DeleteEncryptionKeyLabels(ctx, id, []string{labelKey})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *EncryptionKeysRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all annotations for an encryption key
 // @Description	Get all annotations associated with a specific encryption key
 // @Tags			encryption_keys
-// @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Encryption key ID"
-// @Success		200		{object}	map[string]string
-// @Failure		400		{object}	ErrorResponse
-// @Failure		401		{object}	ErrorResponse
-// @Failure		404		{object}	ErrorResponse
-// @Failure		500		{object}	ErrorResponse
+// @Success		200	{object}	map[string]string
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Failure		500	{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/annotations [get]
-func (r *EncryptionKeysRoutes) getAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := ek.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
-}
+func (r *EncryptionKeysRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific annotation for an encryption key
 // @Description	Get a specific annotation value by key for an encryption key
 // @Tags			encryption_keys
-// @Accept			json
 // @Produce		json
 // @Param			id			path		string	true	"Encryption key ID"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	SwaggerEncryptionKeyAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/annotations/{annotation} [get]
-func (r *EncryptionKeysRoutes) getAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := ek.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, EncryptionKeyAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
-}
+func (r *EncryptionKeysRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
 
 // @Summary		Set an annotation for an encryption key
 // @Description	Set or update a specific annotation value by key for an encryption key
 // @Tags			encryption_keys
 // @Accept			json
 // @Produce		json
-// @Param			id			path		string										true	"Encryption key ID"
-// @Param			annotation	path		string										true	"Annotation key"
-// @Param			request		body		SwaggerPutEncryptionKeyAnnotationRequest	true	"Annotation value"
-// @Success		200			{object}	SwaggerEncryptionKeyAnnotationJson
+// @Param			id			path		string						true	"Encryption key ID"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
+// @Failure		403			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/annotations/{annotation} [put]
-func (r *EncryptionKeysRoutes) putAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutEncryptionKeyAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.ValidateAnnotationValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get existing key for authorization check
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	updatedEk, err := r.core.PutEncryptionKeyAnnotations(ctx, id, map[string]string{annotationKey: req.Value})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, EncryptionKeyAnnotationJson{
-		Key:   annotationKey,
-		Value: updatedEk.GetAnnotations()[annotationKey],
-	})
-}
+func (r *EncryptionKeysRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete an annotation from an encryption key
 // @Description	Delete a specific annotation by key from an encryption key
 // @Tags			encryption_keys
-// @Accept			json
-// @Produce		json
 // @Param			id			path	string	true	"Encryption key ID"
 // @Param			annotation	path	string	true	"Annotation key"
 // @Success		204			"No Content"
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
+// @Failure		403			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/encryption-keys/{id}/annotations/{annotation} [delete]
-func (r *EncryptionKeysRoutes) deleteAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	id := apid.ID(gctx.Param("id"))
-
-	if id.IsNil() {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get existing key for authorization check
-	ek, err := r.core.GetEncryptionKey(ctx, id)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	_, err = r.core.DeleteEncryptionKeyAnnotations(ctx, id, []string{annotationKey})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *EncryptionKeysRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
 
 func (r *EncryptionKeysRoutes) Register(g gin.IRouter) {
 	g.GET(
@@ -1166,9 +732,80 @@ func (r *EncryptionKeysRoutes) Register(g gin.IRouter) {
 }
 
 func NewEncryptionKeysRoutes(cfg config.C, authService auth.A, c coreIface.C) *EncryptionKeysRoutes {
+	parseEncryptionKeyID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
+		id := apid.ID(gctx.Param("id"))
+		if id.IsNil() {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		return id, nil
+	}
+
+	getEncryptionKey := func(ctx context.Context, id apid.ID) (labels.Resource, error) {
+		ek, err := c.GetEncryptionKey(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if ek == nil {
+			return nil, nil
+		}
+		return ek, nil
+	}
+
+	idExtractor := func(ek interface{}) string { return string(ek.(coreIface.EncryptionKey).GetId()) }
+
+	authGet := authService.NewRequiredBuilder().
+		ForResource("encryption_keys").
+		ForIdField("id").
+		ForIdExtractor(idExtractor).
+		ForVerb("get").
+		Build()
+	authMutate := authService.NewRequiredBuilder().
+		ForResource("encryption_keys").
+		ForIdField("id").
+		ForIdExtractor(idExtractor).
+		ForVerb("update").
+		Build()
+
+	labelsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Label,
+		ResourceName: "encryption key",
+		PathPrefix:   "/encryption-keys/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseEncryptionKeyID,
+		Get:          getEncryptionKey,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return c.PutEncryptionKeyLabels(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return c.DeleteEncryptionKeyLabels(ctx, id, keys)
+		},
+	}
+
+	annotsAdapter := labels.Adapter[apid.ID]{
+		Kind:         labels.Annotation,
+		ResourceName: "encryption key",
+		PathPrefix:   "/encryption-keys/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseEncryptionKeyID,
+		Get:          getEncryptionKey,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (labels.Resource, error) {
+			return c.PutEncryptionKeyAnnotations(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (labels.Resource, error) {
+			return c.DeleteEncryptionKeyAnnotations(ctx, id, keys)
+		},
+	}
+
 	return &EncryptionKeysRoutes{
-		cfg:         cfg,
-		authService: authService,
-		core:        c,
+		cfg:           cfg,
+		authService:   authService,
+		core:          c,
+		labelsAdapter: labelsAdapter,
+		annotsAdapter: annotsAdapter,
 	}
 }

--- a/internal/routes/encryption_keys_test.go
+++ b/internal/routes/encryption_keys_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"

--- a/internal/routes/encryption_keys_test.go
+++ b/internal/routes/encryption_keys_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
@@ -938,7 +939,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1034,7 +1035,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1062,7 +1063,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1441,7 +1442,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "staging key", resp.Value)
@@ -1537,7 +1538,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "primary encryption key", resp.Value)
@@ -1565,7 +1566,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp EncryptionKeyAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "updated description", resp.Value)

--- a/internal/routes/encryption_keys_test.go
+++ b/internal/routes/encryption_keys_test.go
@@ -18,7 +18,6 @@ import (
 	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apgin"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/apredis"
@@ -27,6 +26,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
@@ -939,7 +939,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1035,7 +1035,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1063,7 +1063,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1442,7 +1442,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "staging key", resp.Value)
@@ -1538,7 +1538,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "primary encryption key", resp.Value)
@@ -1566,7 +1566,7 @@ func TestEncryptionKeys(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "description", resp.Key)
 			require.Equal(t, "updated description", resp.Value)

--- a/internal/routes/key_value/adapter.go
+++ b/internal/routes/key_value/adapter.go
@@ -3,6 +3,7 @@ package key_value
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -52,6 +53,10 @@ type Adapter[ID any] struct {
 
 	// Delete removes the supplied keys from the resource.
 	Delete func(ctx context.Context, id ID, keys []string) (Resource, error)
+
+	// Logger is the optional logger forwarded to apgin.WriteError when the
+	// adapter writes error responses. May be nil.
+	Logger *slog.Logger
 }
 
 // Register adds the four endpoints for this kind to the router.
@@ -66,19 +71,26 @@ func (a Adapter[ID]) Register(g gin.IRouter) {
 }
 
 // fetchAndAuthorize loads the resource and runs the permission
-// validator. Returns the resource on success. On failure it has already
-// written the error response and returns a nil resource.
+// validator.
 //
-// notFoundStatus controls whether a missing resource produces a 404
-// (returnNotFound=true) or 204 (returnNotFound=false, used by DELETE
-// for idempotent semantics).
-func (a Adapter[ID]) fetchAndAuthorize(gctx *gin.Context, id ID, val *auth.ResourcePermissionValidator, returnNotFound bool) (Resource, bool) {
+// On success it returns (resource, true) and the caller continues
+// handling the request.
+//
+// On failure it returns (nil, false) and has already written the
+// terminal HTTP response (error body or 204) and updated the validator
+// state. The caller MUST return immediately without writing anything
+// further to gctx.
+//
+// returnNotFound selects the response when the resource is missing:
+//   - true: 404 Not Found (used by GET and PUT)
+//   - false: 204 No Content (used by DELETE for idempotent semantics)
+func (a Adapter[ID]) fetchAndAuthorize(gctx *gin.Context, id ID, val *auth.ResourcePermissionValidator, returnNotFound bool) (resource Resource, ok bool) {
 	ctx := gctx.Request.Context()
 	r, err := a.Get(ctx, id)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			if returnNotFound {
-				apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+				apgin.WriteError(gctx, a.Logger, httperr.NotFoundf("%s not found", a.ResourceName))
 				val.MarkErrorReturn()
 			} else {
 				gctx.Status(http.StatusNoContent)
@@ -86,14 +98,14 @@ func (a Adapter[ID]) fetchAndAuthorize(gctx *gin.Context, id ID, val *auth.Resou
 			}
 			return nil, false
 		}
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		apgin.WriteError(gctx, a.Logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return nil, false
 	}
 
 	if r == nil {
 		if returnNotFound {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+			apgin.WriteError(gctx, a.Logger, httperr.NotFoundf("%s not found", a.ResourceName))
 			val.MarkErrorReturn()
 		} else {
 			gctx.Status(http.StatusNoContent)
@@ -103,7 +115,7 @@ func (a Adapter[ID]) fetchAndAuthorize(gctx *gin.Context, id ID, val *auth.Resou
 	}
 
 	if httpErr := val.ValidateHttpStatusError(r); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
+		apgin.WriteError(gctx, a.Logger, httpErr)
 		return nil, false
 	}
 
@@ -117,7 +129,7 @@ func (a Adapter[ID]) HandleList(gctx *gin.Context) {
 
 	id, herr := a.ParseID(gctx)
 	if herr != nil {
-		apgin.WriteError(gctx, nil, herr)
+		apgin.WriteError(gctx, a.Logger, herr)
 		val.MarkErrorReturn()
 		return
 	}
@@ -141,14 +153,14 @@ func (a Adapter[ID]) HandleGet(gctx *gin.Context) {
 
 	id, herr := a.ParseID(gctx)
 	if herr != nil {
-		apgin.WriteError(gctx, nil, herr)
+		apgin.WriteError(gctx, a.Logger, herr)
 		val.MarkErrorReturn()
 		return
 	}
 
 	key := gctx.Param(a.Kind.ParamName)
 	if key == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequestf("%s key is required", a.Kind.Singular))
 		val.MarkErrorReturn()
 		return
 	}
@@ -160,7 +172,7 @@ func (a Adapter[ID]) HandleGet(gctx *gin.Context) {
 
 	value, exists := a.Kind.Get(r)[key]
 	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("%s '%s' not found", a.Kind.Singular, key))
+		apgin.WriteError(gctx, a.Logger, httperr.NotFoundf("%s '%s' not found", a.Kind.Singular, key))
 		val.MarkErrorReturn()
 		return
 	}
@@ -176,33 +188,33 @@ func (a Adapter[ID]) HandlePut(gctx *gin.Context) {
 
 	id, herr := a.ParseID(gctx)
 	if herr != nil {
-		apgin.WriteError(gctx, nil, herr)
+		apgin.WriteError(gctx, a.Logger, herr)
 		val.MarkErrorReturn()
 		return
 	}
 
 	key := gctx.Param(a.Kind.ParamName)
 	if key == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequestf("%s key is required", a.Kind.Singular))
 		val.MarkErrorReturn()
 		return
 	}
 
 	if err := a.Kind.ValidateKey(key); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid %s key: %s", a.Kind.Singular, err.Error()))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequestf("invalid %s key: %s", a.Kind.Singular, err.Error()))
 		val.MarkErrorReturn()
 		return
 	}
 
 	var req PutKeyValueRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
 	}
 
 	if err := a.Kind.ValidateValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid %s value: %s", a.Kind.Singular, err.Error()))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequestf("invalid %s value: %s", a.Kind.Singular, err.Error()))
 		val.MarkErrorReturn()
 		return
 	}
@@ -214,11 +226,11 @@ func (a Adapter[ID]) HandlePut(gctx *gin.Context) {
 	updated, err := a.Put(ctx, id, map[string]string{key: req.Value})
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+			apgin.WriteError(gctx, a.Logger, httperr.NotFoundf("%s not found", a.ResourceName))
 			val.MarkErrorReturn()
 			return
 		}
-		apgin.WriteErr(gctx, nil, err)
+		apgin.WriteErr(gctx, a.Logger, err)
 		val.MarkErrorReturn()
 		return
 	}
@@ -238,14 +250,14 @@ func (a Adapter[ID]) HandleDelete(gctx *gin.Context) {
 
 	id, herr := a.ParseID(gctx)
 	if herr != nil {
-		apgin.WriteError(gctx, nil, herr)
+		apgin.WriteError(gctx, a.Logger, herr)
 		val.MarkErrorReturn()
 		return
 	}
 
 	key := gctx.Param(a.Kind.ParamName)
 	if key == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		apgin.WriteError(gctx, a.Logger, httperr.BadRequestf("%s key is required", a.Kind.Singular))
 		val.MarkErrorReturn()
 		return
 	}
@@ -259,7 +271,7 @@ func (a Adapter[ID]) HandleDelete(gctx *gin.Context) {
 			gctx.Status(http.StatusNoContent)
 			return
 		}
-		apgin.WriteErr(gctx, nil, err)
+		apgin.WriteErr(gctx, a.Logger, err)
 		val.MarkErrorReturn()
 		return
 	}

--- a/internal/routes/key_value/adapter.go
+++ b/internal/routes/key_value/adapter.go
@@ -1,4 +1,4 @@
-package labels
+package key_value
 
 import (
 	"context"
@@ -33,6 +33,7 @@ type Adapter[ID any] struct {
 
 	// AuthGet is the auth middleware for read endpoints (GET).
 	AuthGet gin.HandlerFunc
+
 	// AuthMutate is the auth middleware for write endpoints (PUT/DELETE).
 	AuthMutate gin.HandlerFunc
 

--- a/internal/routes/key_value/adapter_test.go
+++ b/internal/routes/key_value/adapter_test.go
@@ -1,0 +1,417 @@
+package key_value
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResource is a minimal Resource that also satisfies the auth
+// validator's runtime expectations (GetNamespace + GetId).
+type fakeResource struct {
+	id          apid.ID
+	namespace   string
+	labels      map[string]string
+	annotations map[string]string
+}
+
+func (f *fakeResource) GetId() apid.ID                   { return f.id }
+func (f *fakeResource) GetNamespace() string             { return f.namespace }
+func (f *fakeResource) GetLabels() map[string]string     { return f.labels }
+func (f *fakeResource) GetAnnotations() map[string]string {
+	return f.annotations
+}
+
+// store is an in-memory, mutex-guarded backing store for the adapter
+// closures.
+type store struct {
+	mu        sync.Mutex
+	resources map[apid.ID]*fakeResource
+}
+
+func newStore() *store {
+	return &store{resources: make(map[apid.ID]*fakeResource)}
+}
+
+func (s *store) put(r *fakeResource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resources[r.id] = r
+}
+
+func (s *store) get(id apid.ID) (*fakeResource, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.resources[id]
+	if !ok {
+		return nil, database.ErrNotFound
+	}
+	return r, nil
+}
+
+// permissiveAuth installs a ResourcePermissionValidator with wildcard
+// permissions onto the gin context so handlers can call
+// MustGetValidatorFromGinContext.
+func permissiveAuth() gin.HandlerFunc {
+	return func(gctx *gin.Context) {
+		ra := authcore.NewAuthenticatedRequestAuth(&authcore.Actor{
+			Id:          apid.New(apid.PrefixActor),
+			ExternalId:  "test-actor",
+			Namespace:   "root",
+			Permissions: aschema.AllPermissions(),
+		})
+
+		val := auth.NewResourcePermissionValidatorForTest(ra, "fakes", "edit")
+		ctx := val.ContextWith(gctx.Request.Context())
+		gctx.Request = gctx.Request.WithContext(ctx)
+		gctx.Next()
+	}
+}
+
+func parseFakeID(gctx *gin.Context) (apid.ID, *httperr.Error) {
+	raw := gctx.Param("id")
+	id, err := apid.Parse(raw)
+	if err != nil {
+		return apid.Nil, httperr.BadRequestf("invalid id: %s", err.Error())
+	}
+	return id, nil
+}
+
+type adapterFixture struct {
+	store   *store
+	engine  *gin.Engine
+	adapter Adapter[apid.ID]
+}
+
+func newAdapterFixture(t *testing.T, kind Kind) *adapterFixture {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	s := newStore()
+
+	a := Adapter[apid.ID]{
+		Kind:         kind,
+		ResourceName: "fake",
+		PathPrefix:   "/fakes/:id",
+		AuthGet:      permissiveAuth(),
+		AuthMutate:   permissiveAuth(),
+		ParseID:      parseFakeID,
+		Get: func(_ context.Context, id apid.ID) (Resource, error) {
+			r, err := s.get(id)
+			if err != nil {
+				return nil, err
+			}
+			return r, nil
+		},
+		Put: func(_ context.Context, id apid.ID, kv map[string]string) (Resource, error) {
+			r, err := s.get(id)
+			if err != nil {
+				return nil, err
+			}
+			target := kind.Get(r)
+			if target == nil {
+				target = make(map[string]string)
+				if kind.PathSegment == "labels" {
+					r.labels = target
+				} else {
+					r.annotations = target
+				}
+			}
+			for k, v := range kv {
+				target[k] = v
+			}
+			return r, nil
+		},
+		Delete: func(_ context.Context, id apid.ID, keys []string) (Resource, error) {
+			r, err := s.get(id)
+			if err != nil {
+				return nil, err
+			}
+			target := kind.Get(r)
+			for _, k := range keys {
+				delete(target, k)
+			}
+			return r, nil
+		},
+	}
+
+	engine := apgin.ForTest(nil)
+	a.Register(engine)
+
+	return &adapterFixture{store: s, engine: engine, adapter: a}
+}
+
+func (f *adapterFixture) do(method, path string, body io.Reader) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	f.engine.ServeHTTP(w, req)
+	return w
+}
+
+func newFake(id apid.ID) *fakeResource {
+	return &fakeResource{
+		id:          id,
+		namespace:   "root",
+		labels:      map[string]string{},
+		annotations: map[string]string{},
+	}
+}
+
+func TestAdapter_Register_RoutesEachVerb(t *testing.T) {
+	f := newAdapterFixture(t, Label)
+
+	got := make(map[string]bool)
+	for _, ri := range f.engine.Routes() {
+		got[ri.Method+" "+ri.Path] = true
+	}
+
+	for _, want := range []string{
+		"GET /fakes/:id/labels",
+		"GET /fakes/:id/labels/:label",
+		"PUT /fakes/:id/labels/:label",
+		"DELETE /fakes/:id/labels/:label",
+	} {
+		assert.True(t, got[want], "expected route %q to be registered", want)
+	}
+}
+
+func TestAdapter_HandleList(t *testing.T) {
+	t.Run("returns labels map", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		r := newFake(id)
+		r.labels["env"] = "prod"
+		r.labels["team"] = "core"
+		f.store.put(r)
+
+		w := f.do(http.MethodGet, "/fakes/"+string(id)+"/labels", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.Equal(t, map[string]string{"env": "prod", "team": "core"}, got)
+	})
+
+	t.Run("returns empty map when nil", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		r := newFake(id)
+		r.labels = nil
+		f.store.put(r)
+
+		w := f.do(http.MethodGet, "/fakes/"+string(id)+"/labels", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.JSONEq(t, `{}`, w.Body.String())
+	})
+
+	t.Run("404 when resource missing", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		w := f.do(http.MethodGet, "/fakes/"+string(apid.New(apid.PrefixActor))+"/labels", nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "fake not found")
+	})
+
+	t.Run("annotations route works on Annotation kind", func(t *testing.T) {
+		f := newAdapterFixture(t, Annotation)
+		id := apid.New(apid.PrefixActor)
+		r := newFake(id)
+		r.annotations["note"] = "hello"
+		f.store.put(r)
+
+		w := f.do(http.MethodGet, "/fakes/"+string(id)+"/annotations", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.JSONEq(t, `{"note":"hello"}`, w.Body.String())
+	})
+}
+
+func TestAdapter_HandleGet(t *testing.T) {
+	t.Run("returns key/value pair", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		r := newFake(id)
+		r.labels["env"] = "prod"
+		f.store.put(r)
+
+		w := f.do(http.MethodGet, "/fakes/"+string(id)+"/labels/env", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var got KeyValueJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.Equal(t, KeyValueJson{Key: "env", Value: "prod"}, got)
+	})
+
+	t.Run("404 when key missing", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodGet, "/fakes/"+string(id)+"/labels/missing", nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "label 'missing' not found")
+	})
+
+	t.Run("404 when resource missing", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		w := f.do(http.MethodGet, "/fakes/"+string(apid.New(apid.PrefixActor))+"/labels/env", nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestAdapter_HandlePut(t *testing.T) {
+	t.Run("upserts value and returns it", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodPut, "/fakes/"+string(id)+"/labels/env",
+			strings.NewReader(`{"value":"prod"}`))
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var got KeyValueJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.Equal(t, KeyValueJson{Key: "env", Value: "prod"}, got)
+
+		stored, _ := f.store.get(id)
+		assert.Equal(t, "prod", stored.labels["env"])
+	})
+
+	t.Run("400 when key invalid", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodPut, "/fakes/"+string(id)+"/labels/-bad",
+			strings.NewReader(`{"value":"prod"}`))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid label key")
+	})
+
+	t.Run("400 when value invalid", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodPut, "/fakes/"+string(id)+"/labels/env",
+			strings.NewReader(`{"value":"!!!"}`))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid label value")
+	})
+
+	t.Run("400 when body malformed", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodPut, "/fakes/"+string(id)+"/labels/env",
+			strings.NewReader(`not-json`))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("404 when resource missing", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		w := f.do(http.MethodPut, "/fakes/"+string(apid.New(apid.PrefixActor))+"/labels/env",
+			strings.NewReader(`{"value":"prod"}`))
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("annotation kind allows arbitrary value", func(t *testing.T) {
+		f := newAdapterFixture(t, Annotation)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		// Annotation values are unrestricted; this would fail the label
+		// regex but must succeed for annotations.
+		w := f.do(http.MethodPut, "/fakes/"+string(id)+"/annotations/note",
+			strings.NewReader(`{"value":"any value with spaces and !!!"}`))
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("propagates Conflict from Put closure", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		s := newStore()
+		id := apid.New(apid.PrefixActor)
+		s.put(newFake(id))
+
+		a := Adapter[apid.ID]{
+			Kind:         Label,
+			ResourceName: "fake",
+			PathPrefix:   "/fakes/:id",
+			AuthGet:      permissiveAuth(),
+			AuthMutate:   permissiveAuth(),
+			ParseID:      parseFakeID,
+			Get: func(_ context.Context, id apid.ID) (Resource, error) {
+				r, err := s.get(id)
+				if err != nil {
+					return nil, err
+				}
+				return r, nil
+			},
+			Put: func(_ context.Context, _ apid.ID, _ map[string]string) (Resource, error) {
+				return nil, httperr.Conflictf("draft locked")
+			},
+			Delete: func(_ context.Context, _ apid.ID, _ []string) (Resource, error) {
+				return nil, errors.New("unused")
+			},
+		}
+		engine := apgin.ForTest(nil)
+		a.Register(engine)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, httptest.NewRequest(http.MethodPut,
+			"/fakes/"+string(id)+"/labels/env",
+			strings.NewReader(`{"value":"prod"}`)))
+		require.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "draft locked")
+	})
+}
+
+func TestAdapter_HandleDelete(t *testing.T) {
+	t.Run("removes key and returns 204", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		r := newFake(id)
+		r.labels["env"] = "prod"
+		f.store.put(r)
+
+		w := f.do(http.MethodDelete, "/fakes/"+string(id)+"/labels/env", nil)
+		require.Equal(t, http.StatusNoContent, w.Code)
+
+		stored, _ := f.store.get(id)
+		_, exists := stored.labels["env"]
+		assert.False(t, exists)
+	})
+
+	t.Run("idempotent: 204 when resource missing", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		w := f.do(http.MethodDelete, "/fakes/"+string(apid.New(apid.PrefixActor))+"/labels/env", nil)
+		require.Equal(t, http.StatusNoContent, w.Code)
+	})
+
+	t.Run("204 when key absent on existing resource", func(t *testing.T) {
+		f := newAdapterFixture(t, Label)
+		id := apid.New(apid.PrefixActor)
+		f.store.put(newFake(id))
+
+		w := f.do(http.MethodDelete, "/fakes/"+string(id)+"/labels/never-set", nil)
+		require.Equal(t, http.StatusNoContent, w.Code)
+	})
+}

--- a/internal/routes/key_value/labels.go
+++ b/internal/routes/key_value/labels.go
@@ -1,4 +1,4 @@
-// Package labels provides a generic adapter for exposing the standard
+// Package key_value provides a generic adapter for exposing the standard
 // labels and annotations endpoints on resources that store key/value
 // metadata in a uniform way:
 //
@@ -9,7 +9,7 @@
 //
 // Each resource provides an Adapter wired to its own ID type, fetcher,
 // and persistence functions; the handler implementations live here once.
-package labels
+package key_value
 
 import (
 	"github.com/rmorlok/authproxy/internal/database"

--- a/internal/routes/labels/adapter.go
+++ b/internal/routes/labels/adapter.go
@@ -1,0 +1,267 @@
+package labels
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+)
+
+// Adapter wires the generic label/annotation handlers to a specific
+// resource type. ID is the resource's identifier type (e.g. apid.ID,
+// string, or a struct for composite keys).
+type Adapter[ID any] struct {
+	// Kind selects between Label and Annotation behavior.
+	Kind Kind
+
+	// ResourceName is the singular resource name used in error messages
+	// (e.g. "connection", "namespace").
+	ResourceName string
+
+	// PathPrefix is the gin path prefix that identifies a single
+	// resource, including any path parameters.
+	// Examples:
+	//   "/connections/:id"
+	//   "/namespaces/:path"
+	//   "/connectors/:id/versions/:version"
+	PathPrefix string
+
+	// AuthGet is the auth middleware for read endpoints (GET).
+	AuthGet gin.HandlerFunc
+	// AuthMutate is the auth middleware for write endpoints (PUT/DELETE).
+	AuthMutate gin.HandlerFunc
+
+	// ParseID extracts and validates the resource identifier from the
+	// gin context. Returns a non-nil *httperr.Error to terminate the
+	// request with that error response.
+	ParseID func(*gin.Context) (ID, *httperr.Error)
+
+	// Get fetches the resource for read endpoints and for auth
+	// validation on write endpoints. Should return database.ErrNotFound
+	// when the resource is missing.
+	Get func(ctx context.Context, id ID) (Resource, error)
+
+	// Put adds or updates the supplied keys on the resource.
+	Put func(ctx context.Context, id ID, kv map[string]string) (Resource, error)
+
+	// Delete removes the supplied keys from the resource.
+	Delete func(ctx context.Context, id ID, keys []string) (Resource, error)
+}
+
+// Register adds the four endpoints for this kind to the router.
+func (a Adapter[ID]) Register(g gin.IRouter) {
+	listPath := a.PathPrefix + "/" + a.Kind.PathSegment
+	itemPath := listPath + "/:" + a.Kind.ParamName
+
+	g.GET(listPath, a.AuthGet, a.HandleList)
+	g.GET(itemPath, a.AuthGet, a.HandleGet)
+	g.PUT(itemPath, a.AuthMutate, a.HandlePut)
+	g.DELETE(itemPath, a.AuthMutate, a.HandleDelete)
+}
+
+// fetchAndAuthorize loads the resource and runs the permission
+// validator. Returns the resource on success. On failure it has already
+// written the error response and returns a nil resource.
+//
+// notFoundStatus controls whether a missing resource produces a 404
+// (returnNotFound=true) or 204 (returnNotFound=false, used by DELETE
+// for idempotent semantics).
+func (a Adapter[ID]) fetchAndAuthorize(gctx *gin.Context, id ID, val *auth.ResourcePermissionValidator, returnNotFound bool) (Resource, bool) {
+	ctx := gctx.Request.Context()
+	r, err := a.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			if returnNotFound {
+				apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+				val.MarkErrorReturn()
+			} else {
+				gctx.Status(http.StatusNoContent)
+				val.MarkValidated()
+			}
+			return nil, false
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return nil, false
+	}
+
+	if r == nil {
+		if returnNotFound {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+			val.MarkErrorReturn()
+		} else {
+			gctx.Status(http.StatusNoContent)
+			val.MarkValidated()
+		}
+		return nil, false
+	}
+
+	if httpErr := val.ValidateHttpStatusError(r); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return nil, false
+	}
+
+	return r, true
+}
+
+// HandleList serves GET /<resource>/<id>/<segment> — returns all
+// labels (or annotations) for the resource as a flat key/value map.
+func (a Adapter[ID]) HandleList(gctx *gin.Context) {
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, herr := a.ParseID(gctx)
+	if herr != nil {
+		apgin.WriteError(gctx, nil, herr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	r, ok := a.fetchAndAuthorize(gctx, id, val, true)
+	if !ok {
+		return
+	}
+
+	values := a.Kind.Get(r)
+	if values == nil {
+		values = make(map[string]string)
+	}
+	gctx.PureJSON(http.StatusOK, values)
+}
+
+// HandleGet serves GET /<resource>/<id>/<segment>/<key> — returns the
+// single key/value pair, or 404 if the key is not set.
+func (a Adapter[ID]) HandleGet(gctx *gin.Context) {
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, herr := a.ParseID(gctx)
+	if herr != nil {
+		apgin.WriteError(gctx, nil, herr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	key := gctx.Param(a.Kind.ParamName)
+	if key == "" {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		val.MarkErrorReturn()
+		return
+	}
+
+	r, ok := a.fetchAndAuthorize(gctx, id, val, true)
+	if !ok {
+		return
+	}
+
+	value, exists := a.Kind.Get(r)[key]
+	if !exists {
+		apgin.WriteError(gctx, nil, httperr.NotFoundf("%s '%s' not found", a.Kind.Singular, key))
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, KeyValueJson{Key: key, Value: value})
+}
+
+// HandlePut serves PUT /<resource>/<id>/<segment>/<key> — adds or
+// updates the value for a single key.
+func (a Adapter[ID]) HandlePut(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, herr := a.ParseID(gctx)
+	if herr != nil {
+		apgin.WriteError(gctx, nil, herr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	key := gctx.Param(a.Kind.ParamName)
+	if key == "" {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if err := a.Kind.ValidateKey(key); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid %s key: %s", a.Kind.Singular, err.Error()))
+		val.MarkErrorReturn()
+		return
+	}
+
+	var req PutKeyValueRequestJson
+	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if err := a.Kind.ValidateValue(req.Value); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid %s value: %s", a.Kind.Singular, err.Error()))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if _, ok := a.fetchAndAuthorize(gctx, id, val, true); !ok {
+		return
+	}
+
+	updated, err := a.Put(ctx, id, map[string]string{key: req.Value})
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("%s not found", a.ResourceName))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, KeyValueJson{
+		Key:   key,
+		Value: a.Kind.Get(updated)[key],
+	})
+}
+
+// HandleDelete serves DELETE /<resource>/<id>/<segment>/<key> —
+// removes the key. Returns 204 on success or when the resource does
+// not exist (idempotent).
+func (a Adapter[ID]) HandleDelete(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id, herr := a.ParseID(gctx)
+	if herr != nil {
+		apgin.WriteError(gctx, nil, herr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	key := gctx.Param(a.Kind.ParamName)
+	if key == "" {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("%s key is required", a.Kind.Singular))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if _, ok := a.fetchAndAuthorize(gctx, id, val, false); !ok {
+		return
+	}
+
+	if _, err := a.Delete(ctx, id, []string{key}); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			gctx.Status(http.StatusNoContent)
+			return
+		}
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.Status(http.StatusNoContent)
+}

--- a/internal/routes/labels/labels.go
+++ b/internal/routes/labels/labels.go
@@ -1,0 +1,80 @@
+// Package labels provides a generic adapter for exposing the standard
+// labels and annotations endpoints on resources that store key/value
+// metadata in a uniform way:
+//
+//	GET    /<resource>/<id>/<segment>            list all
+//	GET    /<resource>/<id>/<segment>/<key>      get one
+//	PUT    /<resource>/<id>/<segment>/<key>      set one
+//	DELETE /<resource>/<id>/<segment>/<key>      delete one
+//
+// Each resource provides an Adapter wired to its own ID type, fetcher,
+// and persistence functions; the handler implementations live here once.
+package labels
+
+import (
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+// Resource is the minimal contract a fetched resource must satisfy so the
+// adapter can read its labels and annotations. Resources are also passed
+// through to the auth validator, which uses runtime type assertions to
+// extract namespace and id, so the concrete type must additionally
+// satisfy the validator's expectations (typically GetNamespace() string
+// and GetId() apid.ID, or a custom id extractor configured on the auth
+// builder).
+type Resource interface {
+	GetLabels() map[string]string
+	GetAnnotations() map[string]string
+}
+
+// Kind captures the differences between labels and annotations that the
+// generic adapter needs to vary on: URL segment naming, validation
+// rules, and which accessor returns the relevant map.
+type Kind struct {
+	// PathSegment is the URL segment ("labels" or "annotations").
+	PathSegment string
+	// ParamName is the gin path-parameter name for the key
+	// ("label" or "annotation").
+	ParamName string
+	// Singular is the noun used in error messages ("label" or "annotation").
+	Singular string
+	// ValidateKey validates a single key.
+	ValidateKey func(string) error
+	// ValidateValue validates a single value.
+	ValidateValue func(string) error
+	// Get returns the relevant map from a Resource.
+	Get func(Resource) map[string]string
+}
+
+// Label is the Kind for labels.
+var Label = Kind{
+	PathSegment:   "labels",
+	ParamName:     "label",
+	Singular:      "label",
+	ValidateKey:   database.ValidateLabelKey,
+	ValidateValue: database.ValidateLabelValue,
+	Get:           func(r Resource) map[string]string { return r.GetLabels() },
+}
+
+// Annotation is the Kind for annotations.
+var Annotation = Kind{
+	PathSegment:   "annotations",
+	ParamName:     "annotation",
+	Singular:      "annotation",
+	ValidateKey:   database.ValidateAnnotationKey,
+	ValidateValue: database.ValidateAnnotationValue,
+	Get:           func(r Resource) map[string]string { return r.GetAnnotations() },
+}
+
+// KeyValueJson is a single key/value pair returned by the get-one and
+// put endpoints for both labels and annotations.
+type KeyValueJson struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// PutKeyValueRequestJson is the request body for PUT
+// /<resource>/<id>/labels/<key> and the annotation equivalent.
+type PutKeyValueRequestJson struct {
+	Value string `json:"value"`
+}

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -80,8 +80,8 @@ type NamespacesRoutes struct {
 	cfg           config.C
 	core          coreIface.C
 	authService   auth.A
-	labelsAdapter labels.Adapter[string]
-	annotsAdapter labels.Adapter[string]
+	labelsAdapter key_value.Adapter[string]
+	annotsAdapter key_value.Adapter[string]
 }
 
 // @Summary		Get namespace
@@ -422,7 +422,6 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/labels [get]
 func (r *NamespacesRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
-
 
 // @Summary		Get a specific label for a namespace
 // @Description	Get a specific label value by key for a namespace
@@ -855,7 +854,7 @@ func NewNamespacesRoutes(cfg config.C, authService auth.A, c coreIface.C) *Names
 		return path, nil
 	}
 
-	getNamespace := func(ctx context.Context, path string) (labels.Resource, error) {
+	getNamespace := func(ctx context.Context, path string) (key_value.Resource, error) {
 		ns, err := c.GetNamespace(ctx, path)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
@@ -884,34 +883,34 @@ func NewNamespacesRoutes(cfg config.C, authService auth.A, c coreIface.C) *Names
 		ForVerb("update").
 		Build()
 
-	labelsAdapter := labels.Adapter[string]{
-		Kind:         labels.Label,
+	labelsAdapter := key_value.Adapter[string]{
+		Kind:         key_value.Label,
 		ResourceName: "namespace",
 		PathPrefix:   "/namespaces/:path",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseNamespaceID,
 		Get:          getNamespace,
-		Put: func(ctx context.Context, path string, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, path string, kv map[string]string) (key_value.Resource, error) {
 			return c.PutNamespaceLabels(ctx, path, kv)
 		},
-		Delete: func(ctx context.Context, path string, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, path string, keys []string) (key_value.Resource, error) {
 			return c.DeleteNamespaceLabels(ctx, path, keys)
 		},
 	}
 
-	annotsAdapter := labels.Adapter[string]{
-		Kind:         labels.Annotation,
+	annotsAdapter := key_value.Adapter[string]{
+		Kind:         key_value.Annotation,
 		ResourceName: "namespace",
 		PathPrefix:   "/namespaces/:path",
 		AuthGet:      authGet,
 		AuthMutate:   authMutate,
 		ParseID:      parseNamespaceID,
 		Get:          getNamespace,
-		Put: func(ctx context.Context, path string, kv map[string]string) (labels.Resource, error) {
+		Put: func(ctx context.Context, path string, kv map[string]string) (key_value.Resource, error) {
 			return c.PutNamespaceAnnotations(ctx, path, kv)
 		},
-		Delete: func(ctx context.Context, path string, keys []string) (labels.Resource, error) {
+		Delete: func(ctx context.Context, path string, keys []string) (key_value.Resource, error) {
 			return c.DeleteNamespaceAnnotations(ctx, path, keys)
 		},
 	}

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -406,7 +406,7 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 }
 
 // Label and annotation handlers for namespaces delegate to a shared
-// generic adapter (see internal/routes/labels). The doc comments below
+// generic adapter (see internal/routes/key_value). The doc comments below
 // drive the OpenAPI spec; the bodies forward to the adapter.
 
 // @Summary		Get all labels for a namespace

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -1,20 +1,21 @@
 package routes
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"time"
 
-	"fmt"
-
 	"github.com/gin-gonic/gin"
-	"github.com/rmorlok/authproxy/internal/apgin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 
@@ -40,24 +41,6 @@ type CreateNamespaceRequestJson struct {
 type UpdateNamespaceRequestJson struct {
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
-}
-
-type PutNamespaceLabelRequestJson struct {
-	Value string `json:"value"`
-}
-
-type NamespaceLabelJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type PutNamespaceAnnotationRequestJson struct {
-	Value string `json:"value"`
-}
-
-type NamespaceAnnotationJson struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
 }
 
 func NamespaceToJson(ns coreIface.Namespace) NamespaceJson {
@@ -94,9 +77,11 @@ type ListNamespacesResponseJson struct {
 }
 
 type NamespacesRoutes struct {
-	cfg         config.C
-	core        coreIface.C
-	authService auth.A
+	cfg           config.C
+	core          coreIface.C
+	authService   auth.A
+	labelsAdapter labels.Adapter[string]
+	annotsAdapter labels.Adapter[string]
 }
 
 // @Summary		Get namespace
@@ -420,10 +405,13 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, NamespaceToJson(ns))
 }
 
+// Label and annotation handlers for namespaces delegate to a shared
+// generic adapter (see internal/routes/labels). The doc comments below
+// drive the OpenAPI spec; the bodies forward to the adapter.
+
 // @Summary		Get all labels for a namespace
 // @Description	Get all labels associated with a specific namespace
 // @Tags			namespaces
-// @Accept			json
 // @Produce		json
 // @Param			path	path		string	true	"Namespace path"
 // @Success		200		{object}	map[string]string
@@ -433,118 +421,33 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/labels [get]
-func (r *NamespacesRoutes) getLabels(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
+func (r *NamespacesRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
 
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := ns.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, labels)
-}
 
 // @Summary		Get a specific label for a namespace
 // @Description	Get a specific label value by key for a namespace
 // @Tags			namespaces
-// @Accept			json
 // @Produce		json
 // @Param			path	path		string	true	"Namespace path"
 // @Param			label	path		string	true	"Label key"
-// @Success		200		{object}	NamespaceLabelJson
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/labels/{label} [get]
-func (r *NamespacesRoutes) getLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	labels := ns.GetLabels()
-	value, exists := labels[labelKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("label '%s' not found", labelKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, NamespaceLabelJson{
-		Key:   labelKey,
-		Value: value,
-	})
-}
+func (r *NamespacesRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
 
 // @Summary		Set a label for a namespace
 // @Description	Set or update a specific label value by key for a namespace
 // @Tags			namespaces
 // @Accept			json
 // @Produce		json
-// @Param			path	path		string							true	"Namespace path"
-// @Param			label	path		string							true	"Label key"
-// @Param			request	body		PutNamespaceLabelRequestJson	true	"Label value"
-// @Success		200		{object}	NamespaceLabelJson
+// @Param			path	path		string						true	"Namespace path"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -552,90 +455,11 @@ func (r *NamespacesRoutes) getLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/labels/{label} [put]
-func (r *NamespacesRoutes) putLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate label key
-	if err := database.ValidateLabelKey(labelKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutNamespaceLabelRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate label value
-	if err := database.ValidateLabelValue(req.Value); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid label value: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing namespace for authorization check
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	// Use transactional PutNamespaceLabels to update
-	updatedNs, err := r.core.PutNamespaceLabels(ctx, path, map[string]string{labelKey: req.Value})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, NamespaceLabelJson{
-		Key:   labelKey,
-		Value: updatedNs.GetLabels()[labelKey],
-	})
-}
+func (r *NamespacesRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete a label from a namespace
 // @Description	Delete a specific label by key from a namespace
 // @Tags			namespaces
-// @Accept			json
-// @Produce		json
 // @Param			path	path	string	true	"Namespace path"
 // @Param			label	path	string	true	"Label key"
 // @Success		204		"No Content"
@@ -645,66 +469,11 @@ func (r *NamespacesRoutes) putLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/labels/{label} [delete]
-func (r *NamespacesRoutes) deleteLabel(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	labelKey := gctx.Param("label")
-	if labelKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("label key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing namespace for authorization check
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			// Namespace doesn't exist, return 204 (idempotent delete)
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	// Use transactional DeleteNamespaceLabels to delete
-	_, err = r.core.DeleteNamespaceLabels(ctx, path, []string{labelKey})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			// Namespace was deleted between the check and the update, return 204
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *NamespacesRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
 
 // @Summary		Get all annotations for a namespace
 // @Description	Get all annotations associated with a specific namespace
 // @Tags			namespaces
-// @Accept			json
 // @Produce		json
 // @Param			path	path		string	true	"Namespace path"
 // @Success		200		{object}	map[string]string
@@ -714,118 +483,32 @@ func (r *NamespacesRoutes) deleteLabel(gctx *gin.Context) {
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/annotations [get]
-func (r *NamespacesRoutes) getAnnotations(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := ns.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	gctx.PureJSON(http.StatusOK, annotations)
-}
+func (r *NamespacesRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
 
 // @Summary		Get a specific annotation for a namespace
 // @Description	Get a specific annotation value by key for a namespace
 // @Tags			namespaces
-// @Accept			json
 // @Produce		json
 // @Param			path		path		string	true	"Namespace path"
 // @Param			annotation	path		string	true	"Annotation key"
-// @Success		200			{object}	SwaggerNamespaceAnnotationJson
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		404			{object}	ErrorResponse
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/annotations/{annotation} [get]
-func (r *NamespacesRoutes) getAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	annotations := ns.GetAnnotations()
-	value, exists := annotations[annotationKey]
-	if !exists {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("annotation '%s' not found", annotationKey))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, NamespaceAnnotationJson{
-		Key:   annotationKey,
-		Value: value,
-	})
-}
+func (r *NamespacesRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
 
 // @Summary		Set an annotation for a namespace
 // @Description	Set or update a specific annotation value by key for a namespace
 // @Tags			namespaces
 // @Accept			json
 // @Produce		json
-// @Param			path		path		string									true	"Namespace path"
-// @Param			annotation	path		string									true	"Annotation key"
-// @Param			request		body		SwaggerPutNamespaceAnnotationRequest	true	"Annotation value"
-// @Success		200			{object}	SwaggerNamespaceAnnotationJson
+// @Param			path		path		string						true	"Namespace path"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
 // @Failure		400			{object}	ErrorResponse
 // @Failure		401			{object}	ErrorResponse
 // @Failure		403			{object}	ErrorResponse
@@ -833,83 +516,11 @@ func (r *NamespacesRoutes) getAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/annotations/{annotation} [put]
-func (r *NamespacesRoutes) putAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Validate annotation key
-	if err := database.ValidateAnnotationKey(annotationKey); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotation key: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var req PutNamespaceAnnotationRequestJson
-	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing namespace for authorization check
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	// Use transactional PutNamespaceAnnotations to update
-	updatedNs, err := r.core.PutNamespaceAnnotations(ctx, path, map[string]string{annotationKey: req.Value})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("namespace '%s' not found", path), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.PureJSON(http.StatusOK, NamespaceAnnotationJson{
-		Key:   annotationKey,
-		Value: updatedNs.GetAnnotations()[annotationKey],
-	})
-}
+func (r *NamespacesRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
 
 // @Summary		Delete an annotation from a namespace
 // @Description	Delete a specific annotation by key from a namespace
 // @Tags			namespaces
-// @Accept			json
-// @Produce		json
 // @Param			path		path	string	true	"Namespace path"
 // @Param			annotation	path	string	true	"Annotation key"
 // @Success		204			"No Content"
@@ -919,61 +530,7 @@ func (r *NamespacesRoutes) putAnnotation(gctx *gin.Context) {
 // @Failure		500			{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/namespaces/{path}/annotations/{annotation} [delete]
-func (r *NamespacesRoutes) deleteAnnotation(gctx *gin.Context) {
-	ctx := gctx.Request.Context()
-	val := auth.MustGetValidatorFromGinContext(gctx)
-
-	path := gctx.Param("path")
-
-	if path == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("path is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	annotationKey := gctx.Param("annotation")
-	if annotationKey == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("annotation key is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	// Get the existing namespace for authorization check
-	ns, err := r.core.GetNamespace(ctx, path)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			// Namespace doesn't exist, return 204 (idempotent delete)
-			gctx.Status(http.StatusNoContent)
-			val.MarkValidated()
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if httpErr := val.ValidateHttpStatusError(ns); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	// Use transactional DeleteNamespaceAnnotations to delete
-	_, err = r.core.DeleteNamespaceAnnotations(ctx, path, []string{annotationKey})
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			// Namespace was deleted between the check and the update, return 204
-			gctx.Status(http.StatusNoContent)
-			return
-		}
-
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	gctx.Status(http.StatusNoContent)
-}
+func (r *NamespacesRoutes) deleteAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleDelete(gctx) }
 
 type SetNamespaceEncryptionKeyRequestJson struct {
 	EncryptionKeyId string `json:"encryption_key_id"`
@@ -1290,9 +847,80 @@ func (r *NamespacesRoutes) Register(g gin.IRouter) {
 }
 
 func NewNamespacesRoutes(cfg config.C, authService auth.A, c coreIface.C) *NamespacesRoutes {
+	parseNamespaceID := func(gctx *gin.Context) (string, *httperr.Error) {
+		path := gctx.Param("path")
+		if path == "" {
+			return "", httperr.BadRequest("path is required")
+		}
+		return path, nil
+	}
+
+	getNamespace := func(ctx context.Context, path string) (labels.Resource, error) {
+		ns, err := c.GetNamespace(ctx, path)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if ns == nil {
+			return nil, nil
+		}
+		return ns, nil
+	}
+
+	idExtractor := func(ns interface{}) string { return ns.(coreIface.Namespace).GetPath() }
+
+	authGet := authService.NewRequiredBuilder().
+		ForResource("namespaces").
+		ForIdField("path").
+		ForIdExtractor(idExtractor).
+		ForVerb("get").
+		Build()
+	authMutate := authService.NewRequiredBuilder().
+		ForResource("namespaces").
+		ForIdField("path").
+		ForIdExtractor(idExtractor).
+		ForVerb("update").
+		Build()
+
+	labelsAdapter := labels.Adapter[string]{
+		Kind:         labels.Label,
+		ResourceName: "namespace",
+		PathPrefix:   "/namespaces/:path",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseNamespaceID,
+		Get:          getNamespace,
+		Put: func(ctx context.Context, path string, kv map[string]string) (labels.Resource, error) {
+			return c.PutNamespaceLabels(ctx, path, kv)
+		},
+		Delete: func(ctx context.Context, path string, keys []string) (labels.Resource, error) {
+			return c.DeleteNamespaceLabels(ctx, path, keys)
+		},
+	}
+
+	annotsAdapter := labels.Adapter[string]{
+		Kind:         labels.Annotation,
+		ResourceName: "namespace",
+		PathPrefix:   "/namespaces/:path",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseNamespaceID,
+		Get:          getNamespace,
+		Put: func(ctx context.Context, path string, kv map[string]string) (labels.Resource, error) {
+			return c.PutNamespaceAnnotations(ctx, path, kv)
+		},
+		Delete: func(ctx context.Context, path string, keys []string) (labels.Resource, error) {
+			return c.DeleteNamespaceAnnotations(ctx, path, keys)
+		},
+	}
+
 	return &NamespacesRoutes{
-		cfg:         cfg,
-		authService: authService,
-		core:        c,
+		cfg:           cfg,
+		authService:   authService,
+		core:          c,
+		labelsAdapter: labelsAdapter,
+		annotsAdapter: annotsAdapter,
 	}
 }

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -15,7 +15,7 @@ import (
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/routes/labels"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -862,7 +862,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -961,7 +961,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -996,7 +996,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)
@@ -1438,7 +1438,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1537,7 +1537,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1572,7 +1572,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp labels.KeyValueJson
+			var resp key_value.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/routes/labels"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
@@ -861,7 +862,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -960,7 +961,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -995,7 +996,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceLabelJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)
@@ -1437,7 +1438,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "staging", resp.Value)
@@ -1536,7 +1537,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "env", resp.Key)
 			require.Equal(t, "production", resp.Value)
@@ -1571,7 +1572,7 @@ func TestNamespaces(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp NamespaceAnnotationJson
+			var resp labels.KeyValueJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "version", resp.Key)
 			require.Equal(t, "v2", resp.Value)

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -408,110 +408,22 @@ type SwaggerUpdateConnectionRequest struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// SwaggerPutConnectionLabelRequest is the request to set a single label on a connection
+// SwaggerKeyValueJson is a single key-value pair, used by both label
+// and annotation endpoints across all resource types.
 //
-//	@Description	Request to set a label value
-type SwaggerPutConnectionLabelRequest struct {
-	// Label value
-	Value string `json:"value" example:"production"`
-}
-
-// SwaggerConnectionLabelJson is a single label key-value pair
-//
-//	@Description	Connection label key-value pair
-type SwaggerConnectionLabelJson struct {
-	// Label key
+//	@Description	Key-value pair (label or annotation)
+type SwaggerKeyValueJson struct {
+	// Key
 	Key string `json:"key" example:"env"`
-	// Label value
+	// Value
 	Value string `json:"value" example:"production"`
 }
 
-// SwaggerConnectionAnnotationJson is a single connection annotation key-value pair
+// SwaggerPutKeyValueRequest is the body for PUT label/annotation
+// endpoints across all resource types.
 //
-//	@Description	Connection annotation key-value pair
-type SwaggerConnectionAnnotationJson struct {
-	// Annotation key
-	Key string `json:"key" example:"description"`
-	// Annotation value
-	Value string `json:"value" example:"Primary production connection"`
-}
-
-// SwaggerPutConnectionAnnotationRequest is the request to set a single annotation on a connection
-//
-//	@Description	Request to set an annotation value
-type SwaggerPutConnectionAnnotationRequest struct {
-	// Annotation value
-	Value string `json:"value" example:"Primary production connection"`
-}
-
-// SwaggerNamespaceAnnotationJson is a single namespace annotation key-value pair
-//
-//	@Description	Namespace annotation key-value pair
-type SwaggerNamespaceAnnotationJson struct {
-	// Annotation key
-	Key string `json:"key" example:"description"`
-	// Annotation value
-	Value string `json:"value" example:"Production namespace"`
-}
-
-// SwaggerPutNamespaceAnnotationRequest is the request to set a single annotation on a namespace
-//
-//	@Description	Request to set a namespace annotation value
-type SwaggerPutNamespaceAnnotationRequest struct {
-	// Annotation value
-	Value string `json:"value" example:"Production namespace"`
-}
-
-// SwaggerEncryptionKeyAnnotationJson is a single encryption key annotation key-value pair
-//
-//	@Description	Encryption key annotation key-value pair
-type SwaggerEncryptionKeyAnnotationJson struct {
-	// Annotation key
-	Key string `json:"key" example:"description"`
-	// Annotation value
-	Value string `json:"value" example:"Primary encryption key"`
-}
-
-// SwaggerPutEncryptionKeyAnnotationRequest is the request to set a single annotation on an encryption key
-//
-//	@Description	Request to set an encryption key annotation value
-type SwaggerPutEncryptionKeyAnnotationRequest struct {
-	// Annotation value
-	Value string `json:"value" example:"Primary encryption key"`
-}
-
-// SwaggerConnectorAnnotationJson is a single connector annotation key-value pair
-//
-//	@Description	Connector annotation key-value pair
-type SwaggerConnectorAnnotationJson struct {
-	// Annotation key
-	Key string `json:"key" example:"description"`
-	// Annotation value
-	Value string `json:"value" example:"Salesforce CRM connector"`
-}
-
-// SwaggerPutConnectorAnnotationRequest is the request to set a single annotation on a connector
-//
-//	@Description	Request to set a connector annotation value
-type SwaggerPutConnectorAnnotationRequest struct {
-	// Annotation value
-	Value string `json:"value" example:"Salesforce CRM connector"`
-}
-
-// SwaggerPutConnectorLabelRequest is the request to set a single label on a connector
-//
-//	@Description	Request to set a connector label value
-type SwaggerPutConnectorLabelRequest struct {
-	// Label value
-	Value string `json:"value" example:"production"`
-}
-
-// SwaggerConnectorLabelJson is a single connector label key-value pair
-//
-//	@Description	Connector label key-value pair
-type SwaggerConnectorLabelJson struct {
-	// Label key
-	Key string `json:"key" example:"env"`
-	// Label value
+//	@Description	Request to set a label or annotation value
+type SwaggerPutKeyValueRequest struct {
+	// Value to set
 	Value string `json:"value" example:"production"`
 }

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -574,9 +574,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all annotations for an actor by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -638,9 +635,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -668,7 +662,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -735,7 +729,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -743,7 +737,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -785,12 +779,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -850,9 +838,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -914,9 +899,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific label value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -944,7 +926,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1011,7 +993,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -1019,7 +1001,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1061,12 +1043,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific label by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -2007,9 +1983,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2071,9 +2044,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2101,7 +2071,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2168,7 +2138,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2176,7 +2146,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2218,12 +2188,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2283,9 +2247,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2347,9 +2308,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific label value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2377,7 +2335,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2444,7 +2402,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2452,7 +2410,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2494,12 +2452,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific label by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2933,7 +2885,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3000,7 +2952,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3008,7 +2960,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3209,7 +3161,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3276,7 +3228,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3284,7 +3236,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3907,7 +3859,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3981,7 +3933,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3989,7 +3941,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4223,7 +4175,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4297,7 +4249,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4305,7 +4257,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4749,9 +4701,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4813,9 +4762,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4843,7 +4789,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4910,7 +4856,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4918,7 +4864,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4929,6 +4875,12 @@ const docTemplateadmin_api = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -4954,12 +4906,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -4996,6 +4942,12 @@ const docTemplateadmin_api = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5013,9 +4965,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5077,9 +5026,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific label value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5107,7 +5053,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5174,7 +5120,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutEncryptionKeyLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5182,7 +5128,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5193,6 +5139,12 @@ const docTemplateadmin_api = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5218,12 +5170,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific label by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -5256,6 +5202,12 @@ const docTemplateadmin_api = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5557,9 +5509,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5621,9 +5570,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5651,7 +5597,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5718,7 +5664,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutNamespaceAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5726,7 +5672,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5768,12 +5714,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -5833,9 +5773,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5897,9 +5834,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Get a specific label value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5927,7 +5861,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5994,7 +5928,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutNamespaceLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -6002,7 +5936,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -6044,12 +5978,6 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Delete a specific label by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -6466,17 +6394,6 @@ const docTemplateadmin_api = `{
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
-        "routes.ActorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6505,17 +6422,6 @@ const docTemplateadmin_api = `{
                     "type": "string"
                 },
                 "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.ActorLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
                     "type": "string"
                 }
             }
@@ -6576,17 +6482,6 @@ const docTemplateadmin_api = `{
                     "description": "Response type (always \"redirect\")",
                     "type": "string",
                     "example": "redirect"
-                }
-            }
-        },
-        "routes.ConnectorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
                 }
             }
         },
@@ -6672,17 +6567,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.EncryptionKeyLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ErrorResponse": {
             "description": "Standardized error response",
             "type": "object",
@@ -6763,17 +6647,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.NamespaceLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ProxyRequest": {
             "description": "Request to proxy an HTTP request through a connection",
             "type": "object",
@@ -6842,46 +6715,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.PutActorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutActorLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutConnectorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutEncryptionKeyLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutNamespaceLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.RetryConnectionRequest": {
             "type": "object",
             "properties": {
@@ -6896,22 +6729,6 @@ const docTemplateadmin_api = `{
             "properties": {
                 "data": {
                     "description": "Form data matching the JSON Schema provided in the form response"
-                }
-            }
-        },
-        "routes.SwaggerConnectionAnnotationJson": {
-            "description": "Connection annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
                 }
             }
         },
@@ -6968,22 +6785,6 @@ const docTemplateadmin_api = `{
                 "updated_at": {
                     "description": "Last update timestamp",
                     "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerConnectionLabelJson": {
-            "description": "Connection label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7062,22 +6863,6 @@ const docTemplateadmin_api = `{
                     "description": "Connector version number",
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "routes.SwaggerConnectorLabelJson": {
-            "description": "Connector label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7201,22 +6986,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.SwaggerEncryptionKeyAnnotationJson": {
-            "description": "Encryption key annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
         "routes.SwaggerEncryptionKeyJson": {
             "description": "Encryption key configuration",
             "type": "object",
@@ -7279,6 +7048,22 @@ const docTemplateadmin_api = `{
                     "description": "Target state (pending, connected, disconnecting, disconnected, error)",
                     "type": "string",
                     "example": "connected"
+                }
+            }
+        },
+        "routes.SwaggerKeyValueJson": {
+            "description": "Key-value pair (label or annotation)",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key",
+                    "type": "string",
+                    "example": "env"
+                },
+                "value": {
+                    "description": "Value",
+                    "type": "string",
+                    "example": "production"
                 }
             }
         },
@@ -7388,22 +7173,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.SwaggerNamespaceAnnotationJson": {
-            "description": "Namespace annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
-                }
-            }
-        },
         "routes.SwaggerNamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7442,58 +7211,14 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.SwaggerPutConnectionAnnotationRequest": {
-            "description": "Request to set an annotation value",
+        "routes.SwaggerPutKeyValueRequest": {
+            "description": "Request to set a label or annotation value",
             "type": "object",
             "properties": {
                 "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectionLabelRequest": {
-            "description": "Request to set a label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
+                    "description": "Value to set",
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectorLabelRequest": {
-            "description": "Request to set a connector label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutEncryptionKeyAnnotationRequest": {
-            "description": "Request to set an encryption key annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
-        "routes.SwaggerPutNamespaceAnnotationRequest": {
-            "description": "Request to set a namespace annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -568,9 +568,6 @@
                     }
                 ],
                 "description": "Get all annotations for an actor by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -632,9 +629,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -662,7 +656,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -729,7 +723,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -737,7 +731,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -779,12 +773,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -844,9 +832,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -908,9 +893,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -938,7 +920,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1005,7 +987,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -1013,7 +995,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1055,12 +1037,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -2001,9 +1977,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2065,9 +2038,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2095,7 +2065,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2162,7 +2132,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2170,7 +2140,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2212,12 +2182,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2277,9 +2241,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2341,9 +2302,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2371,7 +2329,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2438,7 +2396,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2446,7 +2404,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2488,12 +2446,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2927,7 +2879,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2994,7 +2946,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3002,7 +2954,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3203,7 +3155,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3270,7 +3222,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3278,7 +3230,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3901,7 +3853,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3975,7 +3927,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3983,7 +3935,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4217,7 +4169,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4291,7 +4243,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4299,7 +4251,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4743,9 +4695,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4807,9 +4756,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4837,7 +4783,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4904,7 +4850,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4912,7 +4858,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4923,6 +4869,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -4948,12 +4900,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -4990,6 +4936,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5007,9 +4959,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5071,9 +5020,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5101,7 +5047,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5168,7 +5114,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutEncryptionKeyLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5176,7 +5122,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5187,6 +5133,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5212,12 +5164,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -5250,6 +5196,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5551,9 +5503,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5615,9 +5564,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5645,7 +5591,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5712,7 +5658,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutNamespaceAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5720,7 +5666,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5762,12 +5708,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -5827,9 +5767,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5891,9 +5828,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5921,7 +5855,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5988,7 +5922,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutNamespaceLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5996,7 +5930,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -6038,12 +5972,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -6460,17 +6388,6 @@
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
-        "routes.ActorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6499,17 +6416,6 @@
                     "type": "string"
                 },
                 "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.ActorLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
                     "type": "string"
                 }
             }
@@ -6570,17 +6476,6 @@
                     "description": "Response type (always \"redirect\")",
                     "type": "string",
                     "example": "redirect"
-                }
-            }
-        },
-        "routes.ConnectorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
                 }
             }
         },
@@ -6666,17 +6561,6 @@
                 }
             }
         },
-        "routes.EncryptionKeyLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ErrorResponse": {
             "description": "Standardized error response",
             "type": "object",
@@ -6757,17 +6641,6 @@
                 }
             }
         },
-        "routes.NamespaceLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ProxyRequest": {
             "description": "Request to proxy an HTTP request through a connection",
             "type": "object",
@@ -6836,46 +6709,6 @@
                 }
             }
         },
-        "routes.PutActorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutActorLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutConnectorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutEncryptionKeyLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutNamespaceLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.RetryConnectionRequest": {
             "type": "object",
             "properties": {
@@ -6890,22 +6723,6 @@
             "properties": {
                 "data": {
                     "description": "Form data matching the JSON Schema provided in the form response"
-                }
-            }
-        },
-        "routes.SwaggerConnectionAnnotationJson": {
-            "description": "Connection annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
                 }
             }
         },
@@ -6962,22 +6779,6 @@
                 "updated_at": {
                     "description": "Last update timestamp",
                     "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerConnectionLabelJson": {
-            "description": "Connection label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7056,22 +6857,6 @@
                     "description": "Connector version number",
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "routes.SwaggerConnectorLabelJson": {
-            "description": "Connector label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7195,22 +6980,6 @@
                 }
             }
         },
-        "routes.SwaggerEncryptionKeyAnnotationJson": {
-            "description": "Encryption key annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
         "routes.SwaggerEncryptionKeyJson": {
             "description": "Encryption key configuration",
             "type": "object",
@@ -7273,6 +7042,22 @@
                     "description": "Target state (pending, connected, disconnecting, disconnected, error)",
                     "type": "string",
                     "example": "connected"
+                }
+            }
+        },
+        "routes.SwaggerKeyValueJson": {
+            "description": "Key-value pair (label or annotation)",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key",
+                    "type": "string",
+                    "example": "env"
+                },
+                "value": {
+                    "description": "Value",
+                    "type": "string",
+                    "example": "production"
                 }
             }
         },
@@ -7382,22 +7167,6 @@
                 }
             }
         },
-        "routes.SwaggerNamespaceAnnotationJson": {
-            "description": "Namespace annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
-                }
-            }
-        },
         "routes.SwaggerNamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7436,58 +7205,14 @@
                 }
             }
         },
-        "routes.SwaggerPutConnectionAnnotationRequest": {
-            "description": "Request to set an annotation value",
+        "routes.SwaggerPutKeyValueRequest": {
+            "description": "Request to set a label or annotation value",
             "type": "object",
             "properties": {
                 "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectionLabelRequest": {
-            "description": "Request to set a label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
+                    "description": "Value to set",
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectorLabelRequest": {
-            "description": "Request to set a connector label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutEncryptionKeyAnnotationRequest": {
-            "description": "Request to set an encryption key annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
-        "routes.SwaggerPutNamespaceAnnotationRequest": {
-            "description": "Request to set a namespace annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -2,13 +2,6 @@ basePath: /api/v1
 definitions:
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
     type: object
-  routes.ActorAnnotationJson:
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-    type: object
   routes.ActorJson:
     properties:
       annotations:
@@ -28,13 +21,6 @@ definitions:
       namespace:
         type: string
       updated_at:
-        type: string
-    type: object
-  routes.ActorLabelJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.ConnectionSetupComplete:
@@ -79,13 +65,6 @@ definitions:
       type:
         description: Response type (always "redirect")
         example: redirect
-        type: string
-    type: object
-  routes.ConnectorAnnotationJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.CreateActorRequestJson:
@@ -141,13 +120,6 @@ definitions:
       value:
         description: Option value
         example: ws-123
-        type: string
-    type: object
-  routes.EncryptionKeyLabelJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.ErrorResponse:
@@ -207,13 +179,6 @@ definitions:
           $ref: '#/definitions/routes.ActorJson'
         type: array
     type: object
-  routes.NamespaceLabelJson:
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-    type: object
   routes.ProxyRequest:
     description: Request to proxy an HTTP request through a connection
     properties:
@@ -264,31 +229,6 @@ definitions:
         example: 200
         type: integer
     type: object
-  routes.PutActorAnnotationRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutActorLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutConnectorAnnotationRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutEncryptionKeyLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutNamespaceLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
   routes.RetryConnectionRequest:
     properties:
       return_to_url:
@@ -299,18 +239,6 @@ definitions:
     properties:
       data:
         description: Form data matching the JSON Schema provided in the form response
-    type: object
-  routes.SwaggerConnectionAnnotationJson:
-    description: Connection annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Primary production connection
-        type: string
     type: object
   routes.SwaggerConnectionJson:
     description: Connection to an external service
@@ -351,18 +279,6 @@ definitions:
         type: string
       updated_at:
         description: Last update timestamp
-        type: string
-    type: object
-  routes.SwaggerConnectionLabelJson:
-    description: Connection label key-value pair
-    properties:
-      key:
-        description: Label key
-        example: env
-        type: string
-      value:
-        description: Label value
-        example: production
         type: string
     type: object
   routes.SwaggerConnectorJson:
@@ -425,18 +341,6 @@ definitions:
         description: Connector version number
         example: 1
         type: integer
-    type: object
-  routes.SwaggerConnectorLabelJson:
-    description: Connector label key-value pair
-    properties:
-      key:
-        description: Label key
-        example: env
-        type: string
-      value:
-        description: Label value
-        example: production
-        type: string
     type: object
   routes.SwaggerConnectorVersionJson:
     description: Detailed connector version information
@@ -525,18 +429,6 @@ definitions:
         description: Task ID for tracking the disconnect operation
         type: string
     type: object
-  routes.SwaggerEncryptionKeyAnnotationJson:
-    description: Encryption key annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Primary encryption key
-        type: string
-    type: object
   routes.SwaggerEncryptionKeyJson:
     description: Encryption key configuration
     properties:
@@ -584,6 +476,18 @@ definitions:
         description: Target state (pending, connected, disconnecting, disconnected,
           error)
         example: connected
+        type: string
+    type: object
+  routes.SwaggerKeyValueJson:
+    description: Key-value pair (label or annotation)
+    properties:
+      key:
+        description: Key
+        example: env
+        type: string
+      value:
+        description: Value
+        example: production
         type: string
     type: object
   routes.SwaggerListConnectionResponse:
@@ -661,18 +565,6 @@ definitions:
         description: Total count of matching records (if requested)
         type: integer
     type: object
-  routes.SwaggerNamespaceAnnotationJson:
-    description: Namespace annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Production namespace
-        type: string
-    type: object
   routes.SwaggerNamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -701,44 +593,12 @@ definitions:
         description: Last update timestamp
         type: string
     type: object
-  routes.SwaggerPutConnectionAnnotationRequest:
-    description: Request to set an annotation value
+  routes.SwaggerPutKeyValueRequest:
+    description: Request to set a label or annotation value
     properties:
       value:
-        description: Annotation value
-        example: Primary production connection
-        type: string
-    type: object
-  routes.SwaggerPutConnectionLabelRequest:
-    description: Request to set a label value
-    properties:
-      value:
-        description: Label value
+        description: Value to set
         example: production
-        type: string
-    type: object
-  routes.SwaggerPutConnectorLabelRequest:
-    description: Request to set a connector label value
-    properties:
-      value:
-        description: Label value
-        example: production
-        type: string
-    type: object
-  routes.SwaggerPutEncryptionKeyAnnotationRequest:
-    description: Request to set an encryption key annotation value
-    properties:
-      value:
-        description: Annotation value
-        example: Primary encryption key
-        type: string
-    type: object
-  routes.SwaggerPutNamespaceAnnotationRequest:
-    description: Request to set a namespace annotation value
-    properties:
-      value:
-        description: Annotation value
-        example: Production namespace
         type: string
     type: object
   routes.SwaggerRequestLogEntry:
@@ -1117,8 +977,6 @@ paths:
       - actors
   /actors/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations for an actor by ID
       parameters:
       - description: Actor UUID
@@ -1158,8 +1016,6 @@ paths:
       - actors
   /actors/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from an actor
       parameters:
       - description: Actor UUID
@@ -1172,8 +1028,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -1199,8 +1053,6 @@ paths:
       tags:
       - actors
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for an actor
       parameters:
       - description: Actor UUID
@@ -1219,7 +1071,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1261,14 +1113,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutActorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1296,8 +1148,6 @@ paths:
       - actors
   /actors/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific actor
       parameters:
       - description: Actor UUID
@@ -1337,8 +1187,6 @@ paths:
       - actors
   /actors/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from an actor
       parameters:
       - description: Actor UUID
@@ -1351,8 +1199,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -1378,8 +1224,6 @@ paths:
       tags:
       - actors
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for an actor
       parameters:
       - description: Actor UUID
@@ -1398,7 +1242,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1440,14 +1284,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutActorLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2186,8 +2030,6 @@ paths:
       - connections
   /connections/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific connection
       parameters:
       - description: Connection UUID
@@ -2227,8 +2069,6 @@ paths:
       - connections
   /connections/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from a connection
       parameters:
       - description: Connection UUID
@@ -2241,8 +2081,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -2268,8 +2106,6 @@ paths:
       tags:
       - connections
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for a connection
       parameters:
       - description: Connection UUID
@@ -2288,7 +2124,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2330,14 +2166,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectionAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2365,8 +2201,6 @@ paths:
       - connections
   /connections/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific connection
       parameters:
       - description: Connection UUID
@@ -2406,8 +2240,6 @@ paths:
       - connections
   /connections/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from a connection
       parameters:
       - description: Connection UUID
@@ -2420,8 +2252,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -2447,8 +2277,6 @@ paths:
       tags:
       - connections
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for a connection
       parameters:
       - description: Connection UUID
@@ -2467,7 +2295,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2509,14 +2337,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectionLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2827,7 +2655,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2870,14 +2698,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutConnectorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3009,7 +2837,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3052,14 +2880,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectorLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3475,7 +3303,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3523,14 +3351,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutConnectorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3683,7 +3511,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3731,14 +3559,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectorLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3974,8 +3802,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific encryption key
       parameters:
       - description: Encryption key ID
@@ -4015,8 +3841,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from an encryption key
       parameters:
       - description: Encryption key ID
@@ -4029,8 +3853,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4040,6 +3862,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4052,8 +3878,6 @@ paths:
       tags:
       - encryption_keys
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for an encryption key
       parameters:
       - description: Encryption key ID
@@ -4072,7 +3896,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerEncryptionKeyAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4115,20 +3939,24 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerEncryptionKeyAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
@@ -4146,8 +3974,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific encryption key
       parameters:
       - description: Encryption key ID
@@ -4187,8 +4013,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from an encryption key
       parameters:
       - description: Encryption key ID
@@ -4201,8 +4025,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4212,6 +4034,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4224,8 +4050,6 @@ paths:
       tags:
       - encryption_keys
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for an encryption key
       parameters:
       - description: Encryption key ID
@@ -4244,7 +4068,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.EncryptionKeyLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4286,20 +4110,24 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutEncryptionKeyLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.EncryptionKeyLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
@@ -4497,8 +4325,6 @@ paths:
       - namespaces
   /namespaces/{path}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific namespace
       parameters:
       - description: Namespace path
@@ -4538,8 +4364,6 @@ paths:
       - namespaces
   /namespaces/{path}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from a namespace
       parameters:
       - description: Namespace path
@@ -4552,8 +4376,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4579,8 +4401,6 @@ paths:
       tags:
       - namespaces
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for a namespace
       parameters:
       - description: Namespace path
@@ -4599,7 +4419,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerNamespaceAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4641,14 +4461,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutNamespaceAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerNamespaceAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4676,8 +4496,6 @@ paths:
       - namespaces
   /namespaces/{path}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific namespace
       parameters:
       - description: Namespace path
@@ -4717,8 +4535,6 @@ paths:
       - namespaces
   /namespaces/{path}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from a namespace
       parameters:
       - description: Namespace path
@@ -4731,8 +4547,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4758,8 +4572,6 @@ paths:
       tags:
       - namespaces
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for a namespace
       parameters:
       - description: Namespace path
@@ -4778,7 +4590,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.NamespaceLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4820,14 +4632,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutNamespaceLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.NamespaceLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -574,9 +574,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all annotations for an actor by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -638,9 +635,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -668,7 +662,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -735,7 +729,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -743,7 +737,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -785,12 +779,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -850,9 +838,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -914,9 +899,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific label value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -944,7 +926,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1011,7 +993,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -1019,7 +1001,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1061,12 +1043,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific label by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -2007,9 +1983,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2071,9 +2044,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2101,7 +2071,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2168,7 +2138,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2176,7 +2146,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2218,12 +2188,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2283,9 +2247,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2347,9 +2308,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific label value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2377,7 +2335,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2444,7 +2402,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2452,7 +2410,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2494,12 +2452,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific label by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2933,7 +2885,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3000,7 +2952,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3008,7 +2960,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3209,7 +3161,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3276,7 +3228,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3284,7 +3236,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3907,7 +3859,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3981,7 +3933,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3989,7 +3941,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4223,7 +4175,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4297,7 +4249,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4305,7 +4257,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4749,9 +4701,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4813,9 +4762,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4843,7 +4789,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4910,7 +4856,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4918,7 +4864,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4929,6 +4875,12 @@ const docTemplateApi = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -4954,12 +4906,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -4996,6 +4942,12 @@ const docTemplateApi = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5013,9 +4965,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5077,9 +5026,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific label value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5107,7 +5053,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5174,7 +5120,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutEncryptionKeyLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5182,7 +5128,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5193,6 +5139,12 @@ const docTemplateApi = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5218,12 +5170,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific label by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -5256,6 +5202,12 @@ const docTemplateApi = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5557,9 +5509,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all annotations associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5621,9 +5570,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific annotation value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5651,7 +5597,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5718,7 +5664,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutNamespaceAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5726,7 +5672,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5768,12 +5714,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific annotation by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -5833,9 +5773,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get all labels associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5897,9 +5834,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Get a specific label value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5927,7 +5861,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5994,7 +5928,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutNamespaceLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -6002,7 +5936,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -6044,12 +5978,6 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Delete a specific label by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -6466,17 +6394,6 @@ const docTemplateApi = `{
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
-        "routes.ActorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6505,17 +6422,6 @@ const docTemplateApi = `{
                     "type": "string"
                 },
                 "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.ActorLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
                     "type": "string"
                 }
             }
@@ -6576,17 +6482,6 @@ const docTemplateApi = `{
                     "description": "Response type (always \"redirect\")",
                     "type": "string",
                     "example": "redirect"
-                }
-            }
-        },
-        "routes.ConnectorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
                 }
             }
         },
@@ -6672,17 +6567,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.EncryptionKeyLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ErrorResponse": {
             "description": "Standardized error response",
             "type": "object",
@@ -6763,17 +6647,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.NamespaceLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ProxyRequest": {
             "description": "Request to proxy an HTTP request through a connection",
             "type": "object",
@@ -6842,46 +6715,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.PutActorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutActorLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutConnectorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutEncryptionKeyLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutNamespaceLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.RetryConnectionRequest": {
             "type": "object",
             "properties": {
@@ -6896,22 +6729,6 @@ const docTemplateApi = `{
             "properties": {
                 "data": {
                     "description": "Form data matching the JSON Schema provided in the form response"
-                }
-            }
-        },
-        "routes.SwaggerConnectionAnnotationJson": {
-            "description": "Connection annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
                 }
             }
         },
@@ -6968,22 +6785,6 @@ const docTemplateApi = `{
                 "updated_at": {
                     "description": "Last update timestamp",
                     "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerConnectionLabelJson": {
-            "description": "Connection label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7062,22 +6863,6 @@ const docTemplateApi = `{
                     "description": "Connector version number",
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "routes.SwaggerConnectorLabelJson": {
-            "description": "Connector label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7201,22 +6986,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.SwaggerEncryptionKeyAnnotationJson": {
-            "description": "Encryption key annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
         "routes.SwaggerEncryptionKeyJson": {
             "description": "Encryption key configuration",
             "type": "object",
@@ -7279,6 +7048,22 @@ const docTemplateApi = `{
                     "description": "Target state (pending, connected, disconnecting, disconnected, error)",
                     "type": "string",
                     "example": "connected"
+                }
+            }
+        },
+        "routes.SwaggerKeyValueJson": {
+            "description": "Key-value pair (label or annotation)",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key",
+                    "type": "string",
+                    "example": "env"
+                },
+                "value": {
+                    "description": "Value",
+                    "type": "string",
+                    "example": "production"
                 }
             }
         },
@@ -7388,22 +7173,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.SwaggerNamespaceAnnotationJson": {
-            "description": "Namespace annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
-                }
-            }
-        },
         "routes.SwaggerNamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7442,58 +7211,14 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.SwaggerPutConnectionAnnotationRequest": {
-            "description": "Request to set an annotation value",
+        "routes.SwaggerPutKeyValueRequest": {
+            "description": "Request to set a label or annotation value",
             "type": "object",
             "properties": {
                 "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectionLabelRequest": {
-            "description": "Request to set a label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
+                    "description": "Value to set",
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectorLabelRequest": {
-            "description": "Request to set a connector label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutEncryptionKeyAnnotationRequest": {
-            "description": "Request to set an encryption key annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
-        "routes.SwaggerPutNamespaceAnnotationRequest": {
-            "description": "Request to set a namespace annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -568,9 +568,6 @@
                     }
                 ],
                 "description": "Get all annotations for an actor by ID",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -632,9 +629,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -662,7 +656,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -729,7 +723,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -737,7 +731,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -779,12 +773,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -844,9 +832,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -908,9 +893,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for an actor",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -938,7 +920,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1005,7 +987,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutActorLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -1013,7 +995,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ActorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -1055,12 +1037,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from an actor",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "actors"
                 ],
@@ -2001,9 +1977,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2065,9 +2038,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2095,7 +2065,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2162,7 +2132,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2170,7 +2140,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2212,12 +2182,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2277,9 +2241,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2341,9 +2302,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for a connection",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2371,7 +2329,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2438,7 +2396,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectionLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -2446,7 +2404,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectionLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2488,12 +2446,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from a connection",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "connections"
                 ],
@@ -2927,7 +2879,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -2994,7 +2946,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3002,7 +2954,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3203,7 +3155,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3270,7 +3222,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3278,7 +3230,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3901,7 +3853,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -3975,7 +3927,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutConnectorAnnotationRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -3983,7 +3935,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4217,7 +4169,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4291,7 +4243,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutConnectorLabelRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4299,7 +4251,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerConnectorLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4743,9 +4695,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4807,9 +4756,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -4837,7 +4783,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4904,7 +4850,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -4912,7 +4858,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerEncryptionKeyAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -4923,6 +4869,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -4948,12 +4900,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -4990,6 +4936,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5007,9 +4959,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5071,9 +5020,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5101,7 +5047,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5168,7 +5114,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutEncryptionKeyLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5176,7 +5122,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.EncryptionKeyLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5187,6 +5133,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5212,12 +5164,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from an encryption key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "encryption_keys"
                 ],
@@ -5250,6 +5196,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5551,9 +5503,6 @@
                     }
                 ],
                 "description": "Get all annotations associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5615,9 +5564,6 @@
                     }
                 ],
                 "description": "Get a specific annotation value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5645,7 +5591,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5712,7 +5658,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerPutNamespaceAnnotationRequest"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5720,7 +5666,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.SwaggerNamespaceAnnotationJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5762,12 +5708,6 @@
                     }
                 ],
                 "description": "Delete a specific annotation by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -5827,9 +5767,6 @@
                     }
                 ],
                 "description": "Get all labels associated with a specific namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5891,9 +5828,6 @@
                     }
                 ],
                 "description": "Get a specific label value by key for a namespace",
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
@@ -5921,7 +5855,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -5988,7 +5922,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.PutNamespaceLabelRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
                         }
                     }
                 ],
@@ -5996,7 +5930,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.NamespaceLabelJson"
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
                         }
                     },
                     "400": {
@@ -6038,12 +5972,6 @@
                     }
                 ],
                 "description": "Delete a specific label by key from a namespace",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "namespaces"
                 ],
@@ -6460,17 +6388,6 @@
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
-        "routes.ActorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6499,17 +6416,6 @@
                     "type": "string"
                 },
                 "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.ActorLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
                     "type": "string"
                 }
             }
@@ -6570,17 +6476,6 @@
                     "description": "Response type (always \"redirect\")",
                     "type": "string",
                     "example": "redirect"
-                }
-            }
-        },
-        "routes.ConnectorAnnotationJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
                 }
             }
         },
@@ -6666,17 +6561,6 @@
                 }
             }
         },
-        "routes.EncryptionKeyLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ErrorResponse": {
             "description": "Standardized error response",
             "type": "object",
@@ -6757,17 +6641,6 @@
                 }
             }
         },
-        "routes.NamespaceLabelJson": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.ProxyRequest": {
             "description": "Request to proxy an HTTP request through a connection",
             "type": "object",
@@ -6836,46 +6709,6 @@
                 }
             }
         },
-        "routes.PutActorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutActorLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutConnectorAnnotationRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutEncryptionKeyLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.PutNamespaceLabelRequestJson": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.RetryConnectionRequest": {
             "type": "object",
             "properties": {
@@ -6890,22 +6723,6 @@
             "properties": {
                 "data": {
                     "description": "Form data matching the JSON Schema provided in the form response"
-                }
-            }
-        },
-        "routes.SwaggerConnectionAnnotationJson": {
-            "description": "Connection annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
                 }
             }
         },
@@ -6962,22 +6779,6 @@
                 "updated_at": {
                     "description": "Last update timestamp",
                     "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerConnectionLabelJson": {
-            "description": "Connection label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7056,22 +6857,6 @@
                     "description": "Connector version number",
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "routes.SwaggerConnectorLabelJson": {
-            "description": "Connector label key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Label key",
-                    "type": "string",
-                    "example": "env"
-                },
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
                 }
             }
         },
@@ -7195,22 +6980,6 @@
                 }
             }
         },
-        "routes.SwaggerEncryptionKeyAnnotationJson": {
-            "description": "Encryption key annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
         "routes.SwaggerEncryptionKeyJson": {
             "description": "Encryption key configuration",
             "type": "object",
@@ -7273,6 +7042,22 @@
                     "description": "Target state (pending, connected, disconnecting, disconnected, error)",
                     "type": "string",
                     "example": "connected"
+                }
+            }
+        },
+        "routes.SwaggerKeyValueJson": {
+            "description": "Key-value pair (label or annotation)",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key",
+                    "type": "string",
+                    "example": "env"
+                },
+                "value": {
+                    "description": "Value",
+                    "type": "string",
+                    "example": "production"
                 }
             }
         },
@@ -7382,22 +7167,6 @@
                 }
             }
         },
-        "routes.SwaggerNamespaceAnnotationJson": {
-            "description": "Namespace annotation key-value pair",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Annotation key",
-                    "type": "string",
-                    "example": "description"
-                },
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
-                }
-            }
-        },
         "routes.SwaggerNamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7436,58 +7205,14 @@
                 }
             }
         },
-        "routes.SwaggerPutConnectionAnnotationRequest": {
-            "description": "Request to set an annotation value",
+        "routes.SwaggerPutKeyValueRequest": {
+            "description": "Request to set a label or annotation value",
             "type": "object",
             "properties": {
                 "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary production connection"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectionLabelRequest": {
-            "description": "Request to set a label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
+                    "description": "Value to set",
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutConnectorLabelRequest": {
-            "description": "Request to set a connector label value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Label value",
-                    "type": "string",
-                    "example": "production"
-                }
-            }
-        },
-        "routes.SwaggerPutEncryptionKeyAnnotationRequest": {
-            "description": "Request to set an encryption key annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Primary encryption key"
-                }
-            }
-        },
-        "routes.SwaggerPutNamespaceAnnotationRequest": {
-            "description": "Request to set a namespace annotation value",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "Annotation value",
-                    "type": "string",
-                    "example": "Production namespace"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -2,13 +2,6 @@ basePath: /api/v1
 definitions:
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
     type: object
-  routes.ActorAnnotationJson:
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-    type: object
   routes.ActorJson:
     properties:
       annotations:
@@ -28,13 +21,6 @@ definitions:
       namespace:
         type: string
       updated_at:
-        type: string
-    type: object
-  routes.ActorLabelJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.ConnectionSetupComplete:
@@ -79,13 +65,6 @@ definitions:
       type:
         description: Response type (always "redirect")
         example: redirect
-        type: string
-    type: object
-  routes.ConnectorAnnotationJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.CreateActorRequestJson:
@@ -141,13 +120,6 @@ definitions:
       value:
         description: Option value
         example: ws-123
-        type: string
-    type: object
-  routes.EncryptionKeyLabelJson:
-    properties:
-      key:
-        type: string
-      value:
         type: string
     type: object
   routes.ErrorResponse:
@@ -207,13 +179,6 @@ definitions:
           $ref: '#/definitions/routes.ActorJson'
         type: array
     type: object
-  routes.NamespaceLabelJson:
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-    type: object
   routes.ProxyRequest:
     description: Request to proxy an HTTP request through a connection
     properties:
@@ -264,31 +229,6 @@ definitions:
         example: 200
         type: integer
     type: object
-  routes.PutActorAnnotationRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutActorLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutConnectorAnnotationRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutEncryptionKeyLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
-  routes.PutNamespaceLabelRequestJson:
-    properties:
-      value:
-        type: string
-    type: object
   routes.RetryConnectionRequest:
     properties:
       return_to_url:
@@ -299,18 +239,6 @@ definitions:
     properties:
       data:
         description: Form data matching the JSON Schema provided in the form response
-    type: object
-  routes.SwaggerConnectionAnnotationJson:
-    description: Connection annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Primary production connection
-        type: string
     type: object
   routes.SwaggerConnectionJson:
     description: Connection to an external service
@@ -351,18 +279,6 @@ definitions:
         type: string
       updated_at:
         description: Last update timestamp
-        type: string
-    type: object
-  routes.SwaggerConnectionLabelJson:
-    description: Connection label key-value pair
-    properties:
-      key:
-        description: Label key
-        example: env
-        type: string
-      value:
-        description: Label value
-        example: production
         type: string
     type: object
   routes.SwaggerConnectorJson:
@@ -425,18 +341,6 @@ definitions:
         description: Connector version number
         example: 1
         type: integer
-    type: object
-  routes.SwaggerConnectorLabelJson:
-    description: Connector label key-value pair
-    properties:
-      key:
-        description: Label key
-        example: env
-        type: string
-      value:
-        description: Label value
-        example: production
-        type: string
     type: object
   routes.SwaggerConnectorVersionJson:
     description: Detailed connector version information
@@ -525,18 +429,6 @@ definitions:
         description: Task ID for tracking the disconnect operation
         type: string
     type: object
-  routes.SwaggerEncryptionKeyAnnotationJson:
-    description: Encryption key annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Primary encryption key
-        type: string
-    type: object
   routes.SwaggerEncryptionKeyJson:
     description: Encryption key configuration
     properties:
@@ -584,6 +476,18 @@ definitions:
         description: Target state (pending, connected, disconnecting, disconnected,
           error)
         example: connected
+        type: string
+    type: object
+  routes.SwaggerKeyValueJson:
+    description: Key-value pair (label or annotation)
+    properties:
+      key:
+        description: Key
+        example: env
+        type: string
+      value:
+        description: Value
+        example: production
         type: string
     type: object
   routes.SwaggerListConnectionResponse:
@@ -661,18 +565,6 @@ definitions:
         description: Total count of matching records (if requested)
         type: integer
     type: object
-  routes.SwaggerNamespaceAnnotationJson:
-    description: Namespace annotation key-value pair
-    properties:
-      key:
-        description: Annotation key
-        example: description
-        type: string
-      value:
-        description: Annotation value
-        example: Production namespace
-        type: string
-    type: object
   routes.SwaggerNamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -701,44 +593,12 @@ definitions:
         description: Last update timestamp
         type: string
     type: object
-  routes.SwaggerPutConnectionAnnotationRequest:
-    description: Request to set an annotation value
+  routes.SwaggerPutKeyValueRequest:
+    description: Request to set a label or annotation value
     properties:
       value:
-        description: Annotation value
-        example: Primary production connection
-        type: string
-    type: object
-  routes.SwaggerPutConnectionLabelRequest:
-    description: Request to set a label value
-    properties:
-      value:
-        description: Label value
+        description: Value to set
         example: production
-        type: string
-    type: object
-  routes.SwaggerPutConnectorLabelRequest:
-    description: Request to set a connector label value
-    properties:
-      value:
-        description: Label value
-        example: production
-        type: string
-    type: object
-  routes.SwaggerPutEncryptionKeyAnnotationRequest:
-    description: Request to set an encryption key annotation value
-    properties:
-      value:
-        description: Annotation value
-        example: Primary encryption key
-        type: string
-    type: object
-  routes.SwaggerPutNamespaceAnnotationRequest:
-    description: Request to set a namespace annotation value
-    properties:
-      value:
-        description: Annotation value
-        example: Production namespace
         type: string
     type: object
   routes.SwaggerRequestLogEntry:
@@ -1117,8 +977,6 @@ paths:
       - actors
   /actors/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations for an actor by ID
       parameters:
       - description: Actor UUID
@@ -1158,8 +1016,6 @@ paths:
       - actors
   /actors/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from an actor
       parameters:
       - description: Actor UUID
@@ -1172,8 +1028,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -1199,8 +1053,6 @@ paths:
       tags:
       - actors
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for an actor
       parameters:
       - description: Actor UUID
@@ -1219,7 +1071,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1261,14 +1113,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutActorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1296,8 +1148,6 @@ paths:
       - actors
   /actors/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific actor
       parameters:
       - description: Actor UUID
@@ -1337,8 +1187,6 @@ paths:
       - actors
   /actors/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from an actor
       parameters:
       - description: Actor UUID
@@ -1351,8 +1199,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -1378,8 +1224,6 @@ paths:
       tags:
       - actors
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for an actor
       parameters:
       - description: Actor UUID
@@ -1398,7 +1242,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -1440,14 +1284,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutActorLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ActorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2186,8 +2030,6 @@ paths:
       - connections
   /connections/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific connection
       parameters:
       - description: Connection UUID
@@ -2227,8 +2069,6 @@ paths:
       - connections
   /connections/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from a connection
       parameters:
       - description: Connection UUID
@@ -2241,8 +2081,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -2268,8 +2106,6 @@ paths:
       tags:
       - connections
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for a connection
       parameters:
       - description: Connection UUID
@@ -2288,7 +2124,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2330,14 +2166,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectionAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2365,8 +2201,6 @@ paths:
       - connections
   /connections/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific connection
       parameters:
       - description: Connection UUID
@@ -2406,8 +2240,6 @@ paths:
       - connections
   /connections/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from a connection
       parameters:
       - description: Connection UUID
@@ -2420,8 +2252,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -2447,8 +2277,6 @@ paths:
       tags:
       - connections
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for a connection
       parameters:
       - description: Connection UUID
@@ -2467,7 +2295,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2509,14 +2337,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectionLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectionLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2827,7 +2655,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -2870,14 +2698,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutConnectorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3009,7 +2837,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3052,14 +2880,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectorLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3475,7 +3303,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3523,14 +3351,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutConnectorAnnotationRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3683,7 +3511,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3731,14 +3559,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutConnectorLabelRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerConnectorLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -3974,8 +3802,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific encryption key
       parameters:
       - description: Encryption key ID
@@ -4015,8 +3841,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from an encryption key
       parameters:
       - description: Encryption key ID
@@ -4029,8 +3853,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4040,6 +3862,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4052,8 +3878,6 @@ paths:
       tags:
       - encryption_keys
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for an encryption key
       parameters:
       - description: Encryption key ID
@@ -4072,7 +3896,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerEncryptionKeyAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4115,20 +3939,24 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutEncryptionKeyAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerEncryptionKeyAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
@@ -4146,8 +3974,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific encryption key
       parameters:
       - description: Encryption key ID
@@ -4187,8 +4013,6 @@ paths:
       - encryption_keys
   /encryption-keys/{id}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from an encryption key
       parameters:
       - description: Encryption key ID
@@ -4201,8 +4025,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4212,6 +4034,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4224,8 +4050,6 @@ paths:
       tags:
       - encryption_keys
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for an encryption key
       parameters:
       - description: Encryption key ID
@@ -4244,7 +4068,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.EncryptionKeyLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4286,20 +4110,24 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutEncryptionKeyLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.EncryptionKeyLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
@@ -4497,8 +4325,6 @@ paths:
       - namespaces
   /namespaces/{path}/annotations:
     get:
-      consumes:
-      - application/json
       description: Get all annotations associated with a specific namespace
       parameters:
       - description: Namespace path
@@ -4538,8 +4364,6 @@ paths:
       - namespaces
   /namespaces/{path}/annotations/{annotation}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific annotation by key from a namespace
       parameters:
       - description: Namespace path
@@ -4552,8 +4376,6 @@ paths:
         name: annotation
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4579,8 +4401,6 @@ paths:
       tags:
       - namespaces
     get:
-      consumes:
-      - application/json
       description: Get a specific annotation value by key for a namespace
       parameters:
       - description: Namespace path
@@ -4599,7 +4419,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerNamespaceAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4641,14 +4461,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.SwaggerPutNamespaceAnnotationRequest'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.SwaggerNamespaceAnnotationJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4676,8 +4496,6 @@ paths:
       - namespaces
   /namespaces/{path}/labels:
     get:
-      consumes:
-      - application/json
       description: Get all labels associated with a specific namespace
       parameters:
       - description: Namespace path
@@ -4717,8 +4535,6 @@ paths:
       - namespaces
   /namespaces/{path}/labels/{label}:
     delete:
-      consumes:
-      - application/json
       description: Delete a specific label by key from a namespace
       parameters:
       - description: Namespace path
@@ -4731,8 +4547,6 @@ paths:
         name: label
         required: true
         type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
@@ -4758,8 +4572,6 @@ paths:
       tags:
       - namespaces
     get:
-      consumes:
-      - application/json
       description: Get a specific label value by key for a namespace
       parameters:
       - description: Namespace path
@@ -4778,7 +4590,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.NamespaceLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:
@@ -4820,14 +4632,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.PutNamespaceLabelRequestJson'
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.NamespaceLabelJson'
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
         "400":
           description: Bad Request
           schema:


### PR DESCRIPTION
## Summary
- Introduces `internal/routes/labels`, a generic `Adapter[ID any]` that owns the parsing, auth-validation, and key/value handling for the four standard label/annotation endpoints (`GET list`, `GET one`, `PUT`, `DELETE`)
- Migrates actors, connections, connectors, encryption keys, and namespaces off their per-resource handler copies onto the shared adapter — wiring resource-specific `Get`/`Put`/`Delete` closures and matching auth verbs
- For connectors, four adapters cover the connector-level and version-level paths for both labels and annotations; version-level mutations preserve the draft-state Conflict semantics inside the closure
- Replaces the per-resource Swagger types with a shared `SwaggerKeyValueJson` and `SwaggerPutKeyValueRequest`; regenerates the OpenAPI docs

Net change: 1,805 insertions / 5,533 deletions across 20 files. Closes #95.

## Test plan
- [x] `go test ./...` passes
- [x] `./scripts/preflight.sh` (Swagger regen, integration_tests module check) passes after committing the regenerated docs
- [ ] Sanity-check label/annotation endpoints in the running admin/api services for at least one resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)