### PR TITLE
Allow create or update for connection setup-flow endpoints (#126)

### DIFF
--- a/internal/apauth/service/permission_validator.go
+++ b/internal/apauth/service/permission_validator.go
@@ -83,15 +83,22 @@ func (rpv *ResourcePermissionValidator) ContextWith(ctx context.Context) context
 
 // ValidateNamespaceResourceId validates that the actor has permission to perform the route's action on the specified
 // resource in the given namespace. A non-nil error implies the actor does not have access to the resource.
+//
+// When the route is configured with multiple verbs (ForVerbs), the action is allowed if any one
+// of the verbs is permitted (logical OR).
 func (rpv *ResourcePermissionValidator) ValidateNamespaceResourceId(ns, resourceId string) error {
 	rpv.hasBeenValidated = true
 
-	allowed, reason := rpv.ra.AllowsReason(ns, rpv.pvb.resource, rpv.pvb.verb, resourceId)
-	if !allowed {
-		return fmt.Errorf("permission denied: %s", reason)
+	var lastReason string
+	for _, verb := range rpv.pvb.verbs {
+		allowed, reason := rpv.ra.AllowsReason(ns, rpv.pvb.resource, verb, resourceId)
+		if allowed {
+			return nil
+		}
+		lastReason = reason
 	}
 
-	return nil
+	return fmt.Errorf("permission denied: %s", lastReason)
 }
 
 // ValidateNamespace validates that the actor has permission to perform the verb for the route in the specified
@@ -143,8 +150,20 @@ func (rpv *ResourcePermissionValidator) GetEffectiveNamespaceMatchers(queryMatch
 		return []string{aschema.NamespaceNoMatchSentinel} // No access if not authenticated
 	}
 
-	// Get the namespaces this actor can access for this resource/verb
-	allowedNamespaces := rpv.ra.GetNamespacesAllowed(rpv.pvb.resource, rpv.pvb.verb)
+	// Get the namespaces this actor can access for this resource and any of the configured verbs.
+	// When multiple verbs are configured, the result is the union of namespaces allowed for any
+	// single verb (logical OR).
+	var allowedNamespaces []string
+	seen := make(map[string]struct{})
+	for _, verb := range rpv.pvb.verbs {
+		for _, ns := range rpv.ra.GetNamespacesAllowed(rpv.pvb.resource, verb) {
+			if _, ok := seen[ns]; ok {
+				continue
+			}
+			seen[ns] = struct{}{}
+			allowedNamespaces = append(allowedNamespaces, ns)
+		}
+	}
 	if len(allowedNamespaces) == 0 {
 		return []string{} // Empty slice means no access
 	}
@@ -195,7 +214,7 @@ func (rpv *ResourcePermissionValidator) GetEffectiveNamespaceMatchers(queryMatch
 type PermissionValidatorBuilder struct {
 	s                   *service
 	resource            string
-	verb                string
+	verbs               []string
 	idField             string
 	namespace           string
 	namespaceQueryParam string
@@ -212,9 +231,17 @@ func (pb *PermissionValidatorBuilder) ForResource(resource string) *PermissionVa
 }
 
 // ForVerb sets the action being performed (e.g., "get", "list", "create", "delete").
-// This is required.
+// Either ForVerb or ForVerbs is required.
 func (pb *PermissionValidatorBuilder) ForVerb(verb string) *PermissionValidatorBuilder {
-	pb.verb = verb
+	pb.verbs = []string{verb}
+	return pb
+}
+
+// ForVerbs sets multiple actions, any of which may satisfy the permission check
+// (logical OR). Use this for endpoints that serve more than one activity — e.g.,
+// connection setup steps that participate in both create and update flows.
+func (pb *PermissionValidatorBuilder) ForVerbs(verbs ...string) *PermissionValidatorBuilder {
+	pb.verbs = verbs
 	return pb
 }
 
@@ -316,7 +343,7 @@ func (pb *PermissionValidatorBuilder) Build() gin.HandlerFunc {
 		panic("resource must be specified")
 	}
 
-	if pb.verb == "" {
+	if len(pb.verbs) == 0 {
 		panic("verb must be specified")
 	}
 
@@ -333,7 +360,19 @@ func (pb *PermissionValidatorBuilder) Build() gin.HandlerFunc {
 
 		applyValidatorToGinContext(gctx, validator)
 
-		return ra.AllowsReason(pb.getNamespace(gctx), pb.resource, pb.verb, pb.getResourceId(gctx))
+		ns := pb.getNamespace(gctx)
+		resourceId := pb.getResourceId(gctx)
+
+		var lastReason string
+		for _, verb := range pb.verbs {
+			allowed, r := ra.AllowsReason(ns, pb.resource, verb, resourceId)
+			if allowed {
+				return true, ""
+			}
+			lastReason = r
+		}
+
+		return false, lastReason
 	}
 
 	postValidator := func(gctx *gin.Context, ra *core.RequestAuth) {

--- a/internal/apauth/service/permission_validator_test.go
+++ b/internal/apauth/service/permission_validator_test.go
@@ -209,7 +209,7 @@ func TestResourcePermissionValidator_Validate(t *testing.T) {
 				}),
 				pvb: &PermissionValidatorBuilder{
 					resource:    tt.resource,
-					verb:        tt.verb,
+					verbs:       []string{tt.verb},
 					idExtractor: tt.idExtractor,
 				},
 			}
@@ -416,7 +416,7 @@ func TestGetEffectiveNamespaceMatchers(t *testing.T) {
 				ra: ra,
 				pvb: &PermissionValidatorBuilder{
 					resource: tt.resource,
-					verb:     tt.verb,
+					verbs:    []string{tt.verb},
 				},
 			}
 
@@ -428,6 +428,79 @@ func TestGetEffectiveNamespaceMatchers(t *testing.T) {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func TestGetEffectiveNamespaceMatchers_MultiVerb(t *testing.T) {
+	tests := []struct {
+		name         string
+		permissions  []aschema.Permission
+		verbs        []string
+		queryMatcher *string
+		expected     []string
+	}{
+		{
+			name: "union of namespaces across verbs",
+			permissions: []aschema.Permission{
+				{Namespace: "root.prod", Resources: []string{"connections"}, Verbs: []string{"create"}},
+				{Namespace: "root.staging", Resources: []string{"connections"}, Verbs: []string{"update"}},
+			},
+			verbs:    []string{"create", "update"},
+			expected: []string{"root.prod", "root.staging"},
+		},
+		{
+			name: "deduplicates namespaces granted by multiple verbs",
+			permissions: []aschema.Permission{
+				{Namespace: "root.prod", Resources: []string{"connections"}, Verbs: []string{"create", "update"}},
+			},
+			verbs:    []string{"create", "update"},
+			expected: []string{"root.prod"},
+		},
+		{
+			name: "single matching verb suffices",
+			permissions: []aschema.Permission{
+				{Namespace: "root.prod", Resources: []string{"connections"}, Verbs: []string{"create"}},
+			},
+			verbs:    []string{"create", "update"},
+			expected: []string{"root.prod"},
+		},
+		{
+			name: "no permissions for any verb returns empty",
+			permissions: []aschema.Permission{
+				{Namespace: "root.prod", Resources: []string{"connections"}, Verbs: []string{"get"}},
+			},
+			verbs:    []string{"create", "update"},
+			expected: []string{},
+		},
+		{
+			name: "query matcher intersects union",
+			permissions: []aschema.Permission{
+				{Namespace: "root.prod.**", Resources: []string{"connections"}, Verbs: []string{"create"}},
+				{Namespace: "root.staging.**", Resources: []string{"connections"}, Verbs: []string{"update"}},
+			},
+			verbs:        []string{"create", "update"},
+			queryMatcher: strPtr("root.prod.tenant1"),
+			expected:     []string{"root.prod.tenant1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ra := core.NewAuthenticatedRequestAuth(&core.Actor{
+				Permissions: tt.permissions,
+			})
+
+			validator := &ResourcePermissionValidator{
+				ra: ra,
+				pvb: &PermissionValidatorBuilder{
+					resource: "connections",
+					verbs:    tt.verbs,
+				},
+			}
+
+			result := validator.GetEffectiveNamespaceMatchers(tt.queryMatcher)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
 }
 
 // filterTestResource implements hasNamespace and hasId for testing FilterForValidatedResources
@@ -508,7 +581,7 @@ func TestFilterForValidatedResources(t *testing.T) {
 				ra: ra,
 				pvb: &PermissionValidatorBuilder{
 					resource: tt.resource,
-					verb:     tt.verb,
+					verbs:    []string{tt.verb},
 				},
 			}
 
@@ -758,6 +831,101 @@ func TestValidatorOnRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 
 			require.True(t, panicOccurred)
+		})
+	})
+
+	t.Run("ForVerbs accepts any matching verb", func(t *testing.T) {
+		fakeRouteThatValidates := func(gctx *gin.Context) {
+			fm := &fakeModel{
+				namespace: "root.test",
+				id:        apid.MustParse("cxr_test0000000000001"),
+			}
+
+			val := MustGetValidatorFromGinContext(gctx)
+			httpErr := val.ValidateHttpStatusError(fm)
+			if httpErr != nil {
+				apgin.WriteError(gctx, nil, httpErr)
+				return
+			}
+
+			gctx.PureJSON(200, gin.H{"status": "ok"})
+		}
+
+		register := func(g gin.IRouter, auth A) {
+			g.GET(
+				"/cats",
+				auth.NewRequiredBuilder().
+					ForResource("cats").
+					ForVerbs("meow", "purr").
+					Build(),
+				fakeRouteThatValidates,
+			)
+		}
+
+		tu := setup(t, register)
+
+		t.Run("allowed - first verb only", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/cats",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "cats", "meow"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+		})
+
+		t.Run("allowed - second verb only", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/cats",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "cats", "purr"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+		})
+
+		t.Run("forbidden - none of the verbs", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/cats",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "cats", "woof"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("forbidden - resource id mismatch even with verb", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/cats",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingleWithResourceIds("root.**", "cats", "meow", "cxr_test0000000000002"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
 		})
 	})
 }

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -1588,7 +1588,7 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 		"/connections/:id/_submit",
 		r.auth.NewRequiredBuilder().
 			ForResource("connections").
-			ForVerb("update").
+			ForVerbs("create", "update").
 			ForIdField("id").
 			Build(),
 		r.submit,
@@ -1597,7 +1597,7 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 		"/connections/:id/_setup_step",
 		r.auth.NewRequiredBuilder().
 			ForResource("connections").
-			ForVerb("get").
+			ForVerbs("create", "update").
 			ForIdField("id").
 			Build(),
 		r.getSetupStep,
@@ -1606,7 +1606,7 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 		"/connections/:id/_data_source/:source_id",
 		r.auth.NewRequiredBuilder().
 			ForResource("connections").
-			ForVerb("get").
+			ForVerbs("create", "update").
 			ForIdField("id").
 			Build(),
 		r.getDataSource,
@@ -1651,7 +1651,7 @@ func (r *ConnectionsRoutes) Register(g gin.IRouter) {
 		"/connections/:id/_retry",
 		r.auth.NewRequiredBuilder().
 			ForResource("connections").
-			ForVerb("create"). // should also be update
+			ForVerbs("create", "update").
 			ForIdField("id").
 			Build(),
 		r.retry,

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -1715,5 +1715,219 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusBadRequest, w.Code)
 		})
+
+		// _submit accepts either "create" or "update" so the same endpoint serves both
+		// initial setup (driven by a create-only actor) and reconfigure (update-only actor).
+		t.Run("forbidden with unrelated verb", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+connId.String()+"/_submit",
+				util.JsonToReader(map[string]interface{}{
+					"data": map[string]interface{}{"key": "value"},
+				}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("create-only actor passes auth", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+connId.String()+"/_submit",
+				util.JsonToReader(map[string]interface{}{
+					"data": map[string]interface{}{"key": "value"},
+				}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "create"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			// Auth allowed (would otherwise be 403); request still 400 since no active setup step.
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("update-only actor passes auth", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+connId.String()+"/_submit",
+				util.JsonToReader(map[string]interface{}{
+					"data": map[string]interface{}{"key": "value"},
+				}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "update"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	})
+
+	t.Run("get setup step", func(t *testing.T) {
+		tu, done := setup(t, nil)
+		defer done()
+
+		connId := apid.New(apid.PrefixConnection)
+		err := tu.Db.CreateConnection(context.Background(), &database.Connection{
+			Id:               connId,
+			Namespace:        sconfig.RootNamespace,
+			ConnectorId:      connectorId,
+			ConnectorVersion: connectorVersion,
+			State:            database.ConnectionStateCreated,
+		})
+		require.NoError(t, err)
+
+		// _setup_step is part of the setup flow, so it accepts create or update —
+		// not get, since reading the in-progress setup state is gated on the same
+		// activity that produces it.
+		for _, verb := range []string{"create", "update"} {
+			t.Run(verb+"-only actor passes auth", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodGet,
+					"/connections/"+connId.String()+"/_setup_step",
+					nil,
+					"root",
+					"some-actor",
+					aschema.PermissionsSingle("root.**", "connections", verb),
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.NotEqual(t, http.StatusForbidden, w.Code)
+				require.NotEqual(t, http.StatusUnauthorized, w.Code)
+			})
+		}
+
+		t.Run("forbidden with get-only", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/connections/"+connId.String()+"/_setup_step",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "get"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+	})
+
+	t.Run("get data source", func(t *testing.T) {
+		tu, done := setup(t, nil)
+		defer done()
+
+		connId := apid.New(apid.PrefixConnection)
+		err := tu.Db.CreateConnection(context.Background(), &database.Connection{
+			Id:               connId,
+			Namespace:        sconfig.RootNamespace,
+			ConnectorId:      connectorId,
+			ConnectorVersion: connectorVersion,
+			State:            database.ConnectionStateCreated,
+		})
+		require.NoError(t, err)
+
+		// _data_source serves dynamic options for the active setup step, so it accepts
+		// create or update — not get.
+		for _, verb := range []string{"create", "update"} {
+			t.Run(verb+"-only actor passes auth", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodGet,
+					"/connections/"+connId.String()+"/_data_source/some-source",
+					nil,
+					"root",
+					"some-actor",
+					aschema.PermissionsSingle("root.**", "connections", verb),
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.NotEqual(t, http.StatusForbidden, w.Code)
+				require.NotEqual(t, http.StatusUnauthorized, w.Code)
+			})
+		}
+
+		t.Run("forbidden with get-only", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/connections/"+connId.String()+"/_data_source/some-source",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "get"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+	})
+
+	t.Run("retry connection setup", func(t *testing.T) {
+		tu, done := setup(t, nil)
+		defer done()
+
+		connId := apid.New(apid.PrefixConnection)
+		err := tu.Db.CreateConnection(context.Background(), &database.Connection{
+			Id:               connId,
+			Namespace:        sconfig.RootNamespace,
+			ConnectorId:      connectorId,
+			ConnectorVersion: connectorVersion,
+			State:            database.ConnectionStateCreated,
+		})
+		require.NoError(t, err)
+
+		// _retry accepts create or update so it serves both the initial-setup retry path
+		// and a reconfigure retry.
+		for _, verb := range []string{"create", "update"} {
+			t.Run(verb+"-only actor passes auth", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodPost,
+					"/connections/"+connId.String()+"/_retry",
+					nil,
+					"root",
+					"some-actor",
+					aschema.PermissionsSingle("root.**", "connections", verb),
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.NotEqual(t, http.StatusForbidden, w.Code)
+				require.NotEqual(t, http.StatusUnauthorized, w.Code)
+			})
+		}
+
+		t.Run("forbidden with unrelated verb", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+connId.String()+"/_retry",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "get"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
 	})
 }


### PR DESCRIPTION
## Summary
- Add `ForVerbs(...)` to the permission validator with logical-OR semantics (any one matching verb allows the action). `ForVerb` is preserved as a thin wrapper, so existing call sites don't change.
- Update the connection setup-flow routes so `create` or `update` permission satisfies them: `_submit`, `_setup_step`, `_data_source`, `_retry`. Drops the "should also be update" TODO on `_retry`.
- `GetEffectiveNamespaceMatchers` now returns the union (deduped) of allowed namespaces across the configured verbs.

Fixes #126.

## Test plan
- [x] `go test ./internal/apauth/... ./internal/routes/...` — passes.
- [x] `./scripts/preflight.sh` — passes.
- [x] New unit tests cover `ForVerbs` allow/deny paths and the multi-verb namespace union.
- [x] New route tests confirm create-only and update-only actors clear auth on `_submit`/`_setup_step`/`_data_source`/`_retry`, and that `get`/`list`-only actors are forbidden where they should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)