### PR TITLE
Fix token revocation logic

### DIFF
--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -165,6 +165,7 @@ connectors:
         endpoint: https://oauth2.googleapis.com/token
       revocation:
         endpoint: https://oauth2.googleapis.com/revoke
+        supported_tokens: refresh_token
       scopes:
         - id: https://www.googleapis.com/auth/drive.readonly
           reason: |
@@ -206,6 +207,7 @@ connectors:
         endpoint: https://oauth2.googleapis.com/token
       revocation:
         endpoint: https://oauth2.googleapis.com/revoke
+        supported_tokens: refresh_token
       scopes:
         - id: https://www.googleapis.com/auth/calendar.readonly
           reason: |
@@ -274,6 +276,7 @@ connectors:
         endpoint: https://oauth2.googleapis.com/token
       revocation:
         endpoint: https://oauth2.googleapis.com/revoke
+        supported_tokens: refresh_token
       scopes:
         - id: https://www.googleapis.com/auth/gmail.readonly
           reason: |

--- a/dev_config/docker.yaml
+++ b/dev_config/docker.yaml
@@ -116,6 +116,7 @@ connectors:
         endpoint: https://oauth2.googleapis.com/token
       revocation:
         endpoint: https://oauth2.googleapis.com/revoke
+        supported_tokens: refresh_token
       scopes:
         - id: https://www.googleapis.com/auth/drive.readonly
           reason: |

--- a/internal/auth_methods/oauth2/revocation.go
+++ b/internal/auth_methods/oauth2/revocation.go
@@ -60,11 +60,6 @@ func (o *oAuth2Connection) revokeRefreshToken(ctx context.Context, token *databa
 		return err
 	}
 
-	accessToken, err := o.encrypt.DecryptString(ctx, token.EncryptedAccessToken)
-	if err != nil {
-		return err
-	}
-
 	c := o.httpf.
 		ForRequestType(httpf.RequestTypeOAuth).
 		ForConnection(o.connection).
@@ -80,10 +75,9 @@ func (o *oAuth2Connection) revokeRefreshToken(ctx context.Context, token *databa
 		Method("POST").
 		URL(revocationEndpoint).
 		Type("application/x-www-form-urlencoded").
-		AddHeader("accept", "application/json").
-		SetHeader("Authorization", "Bearer "+accessToken)
+		AddHeader("accept", "application/json")
 
-	for k, v := range o.auth.Token.QueryOverrides {
+	for k, v := range o.auth.Revocation.QueryOverrides {
 		req = req.SetQuery(k, v)
 	}
 
@@ -147,10 +141,9 @@ func (o *oAuth2Connection) revokeAccessToken(ctx context.Context, token *databas
 		Method("POST").
 		URL(revocationEndpoint).
 		Type("application/x-www-form-urlencoded").
-		AddHeader("accept", "application/json").
-		SetHeader("Authorization", "Bearer "+accessToken)
+		AddHeader("accept", "application/json")
 
-	for k, v := range o.auth.Token.QueryOverrides {
+	for k, v := range o.auth.Revocation.QueryOverrides {
 		req = req.SetQuery(k, v)
 	}
 

--- a/internal/auth_methods/oauth2/revocation_test.go
+++ b/internal/auth_methods/oauth2/revocation_test.go
@@ -2,6 +2,8 @@ package oauth2
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -16,7 +18,19 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/stretchr/testify/require"
 	genmock "gopkg.in/h2non/gentleman-mock.v2"
+	gock "gopkg.in/h2non/gock.v1"
 )
+
+// noAuthorizationHeader is a gock matcher that fails if the request includes
+// an Authorization header. RFC 7009 token revocation does not use Bearer
+// authorization on the token itself, and Google's revoke endpoint rejects
+// requests that include one.
+func noAuthorizationHeader(req *http.Request, _ *gock.Request) (bool, error) {
+	if v := req.Header.Get("Authorization"); v != "" {
+		return false, fmt.Errorf("revoke request must not include Authorization header, got %q", v)
+	}
+	return true, nil
+}
 
 func TestSupportsRevokeRefreshToken(t *testing.T) {
 	o2 := oAuth2Connection{}
@@ -88,6 +102,7 @@ func TestRevokeRefreshToken(t *testing.T) {
 			New("http://example.com").
 			Post("/revoke").
 			MatchType("application/x-www-form-urlencoded").
+			AddMatcher(noAuthorizationHeader).
 			BodyString("token=some-refresh-token&token_type_hint=refresh_token").
 			Reply(200)
 
@@ -95,7 +110,39 @@ func TestRevokeRefreshToken(t *testing.T) {
 			New("http://example.com").
 			Post("/revoke").
 			MatchType("application/x-www-form-urlencoded").
+			AddMatcher(noAuthorizationHeader).
 			BodyString("token=some-access-token&token_type_hint=access_token").
+			Reply(200)
+
+		err := o2.RevokeTokens(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("only revokes refresh token when supported_tokens=refresh_token", func(t *testing.T) {
+		o2, db, encrypt, ctrl := setupWithMocks(t)
+		defer ctrl.Finish()
+
+		supported := cschema.AuthOAuth2RevocationSupportedTypeRefreshToken
+		o2.auth.Revocation.SupportedTokens = &supported
+
+		MockOAuthTokenForConnection(context.Background(), db, encrypt, database.OAuth2Token{
+			Id:                    tokenId,
+			ConnectionId:          connectionId,
+			EncryptedAccessToken:  encfield.EncryptedField{ID: "ekv_test", Data: "some-access-token"},
+			EncryptedRefreshToken: encfield.EncryptedField{ID: "ekv_test", Data: "some-refresh-token"},
+		})
+
+		db.
+			EXPECT().
+			DeleteOAuth2Token(gomock.Any(), tokenId).
+			Return(nil)
+
+		genmock.
+			New("http://example.com").
+			Post("/revoke").
+			MatchType("application/x-www-form-urlencoded").
+			AddMatcher(noAuthorizationHeader).
+			BodyString("token=some-refresh-token&token_type_hint=refresh_token").
 			Reply(200)
 
 		err := o2.RevokeTokens(context.Background())

--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -4,14 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/database"
 )
 
 const taskTypeDisconnectConnection = "core:disconnect_connection"
+
+// maxRevokeAttempts caps the number of times a revoke operation is retried
+// inside a single disconnect task invocation. After exhausting attempts, the
+// disconnect proceeds so a connection cannot get stuck in `disconnecting`
+// because a 3rd-party revoke endpoint is misbehaving.
+const maxRevokeAttempts = 3
 
 func newDisconnectConnectionTask(connectionId apid.ID) (*asynq.Task, error) {
 	payload, err := json.Marshal(disconnectConnectionTaskPayload{connectionId})
@@ -50,11 +58,35 @@ func (s *service) disconnectConnection(ctx context.Context, t *asynq.Task) error
 	revokeOps := conn.getRevokeCredentialsOperations()
 	if len(revokeOps) > 0 {
 		logger.Info("revoking credentials")
+		clk := apctx.GetClock(ctx)
 		for _, op := range revokeOps {
-			err = op(ctx)
-			if err != nil {
-				logger.Error("failed to revoke credentials", "error", err)
-				return fmt.Errorf("failed to revoke credentials: %w", err)
+			var lastErr error
+			for attempt := 1; attempt <= maxRevokeAttempts; attempt++ {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				lastErr = op(ctx)
+				if lastErr == nil {
+					break
+				}
+				logger.Warn(
+					"revoke attempt failed",
+					"error", lastErr,
+					"attempt", attempt,
+					"max_attempts", maxRevokeAttempts,
+				)
+				if attempt < maxRevokeAttempts {
+					clk.Sleep(time.Duration(attempt) * time.Second)
+				}
+			}
+			if lastErr != nil {
+				// Proceed with the rest of the disconnect so the connection
+				// does not stay stuck in `disconnecting` forever.
+				logger.Error(
+					"revocation failed after max attempts; proceeding with disconnect",
+					"error", lastErr,
+					"attempts", maxRevokeAttempts,
+				)
 			}
 		}
 	}

--- a/internal/core/task_disconnect_connection_test.go
+++ b/internal/core/task_disconnect_connection_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/rmorlok/authproxy/internal/apasynq"
 	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
+	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	mockOauth2 "github.com/rmorlok/authproxy/internal/auth_methods/oauth2/mock"
 	"github.com/rmorlok/authproxy/internal/core/mock"
 	"github.com/rmorlok/authproxy/internal/database"
 	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
@@ -17,6 +20,7 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	tclock "k8s.io/utils/clock/testing"
 )
 
 func TestTaskDisconnectConnection(t *testing.T) {
@@ -88,6 +92,55 @@ func TestTaskDisconnectConnection(t *testing.T) {
 		err = svc.disconnectConnection(ctx, task)
 		assert.Error(t, err)
 		assert.True(t, apasynq.IsRetriable(err))
+	})
+
+	t.Run("retries revocation up to 3 times then proceeds with disconnect", func(t *testing.T) {
+		oauthConnector := &cschema.Connector{
+			Id:          apid.New(apid.PrefixConnectorVersion),
+			Version:     1,
+			DisplayName: "OAuth Connector",
+			Auth: &cschema.Auth{InnerVal: &cschema.AuthOAuth2{
+				Type: cschema.AuthTypeOAuth2,
+				Revocation: &cschema.AuthOauth2Revocation{
+					Endpoint: "https://example.com/revoke",
+				},
+			}},
+		}
+
+		svc, dbMock, _, e, ctrl := setupWithMocks(t)
+		defer ctrl.Finish()
+
+		// Skip lazy init of the real OAuth2 factory by pre-populating the mock.
+		o2Factory := mockOauth2.NewMockFactory(ctrl)
+		o2Conn := mockOauth2.NewMockOAuth2Connection(ctrl)
+		svc.o2Factory = o2Factory
+		svc.o2FactoryOnce.Do(func() {})
+
+		o2Factory.EXPECT().NewOAuth2(gomock.Any()).Return(o2Conn).AnyTimes()
+		o2Conn.EXPECT().SupportsRevokeTokens().Return(true).AnyTimes()
+		o2Conn.EXPECT().RevokeTokens(gomock.Any()).Return(errors.New("3rd party 400")).Times(maxRevokeAttempts)
+
+		mock.MockConnectionRetrieval(context.Background(), dbMock, e, connectionId, oauthConnector)
+
+		dbMock.
+			EXPECT().
+			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnected).
+			Return(nil)
+
+		dbMock.
+			EXPECT().
+			DeleteConnection(gomock.Any(), connectionId).
+			Return(nil)
+
+		task, err := newDisconnectConnectionTask(connectionId)
+		require.NoError(t, err)
+
+		// Use a fake clock so the inter-attempt sleeps return immediately.
+		fakeClk := tclock.NewFakeClock(time.Now())
+		retryCtx := apctx.WithClock(ctx, fakeClk)
+
+		err = svc.disconnectConnection(retryCtx, task)
+		assert.NoError(t, err, "disconnect should succeed even when revocation fails")
 	})
 
 	t.Run("is retriable on database delete error", func(t *testing.T) {


### PR DESCRIPTION
  Bug fixes (internal/auth_methods/oauth2/revocation.go)
  - Removed bogus Authorization: Bearer <accessToken> header from both revokeRefreshToken and revokeAccessToken — Google's revoke endpoint and RFC 7009 don't expect it, and that was the cause of the 400.
  - Fixed o.auth.Token.QueryOverrides → o.auth.Revocation.QueryOverrides (copy-paste bug).

  Config (dev_config/default.yaml, dev_config/docker.yaml)
  - Added supported_tokens: refresh_token to Google Drive / Calendar / Gmail revocation blocks. Google revokes the related access token automatically, so calling revoke twice would fail on the second call.

  Test hardening (internal/auth_methods/oauth2/revocation_test.go)
  - Added a gock matcher that fails if any Authorization header is sent on the revoke request.
  - Added a sub-test for the supported_tokens=refresh_token path.

  Disconnect retry behavior (internal/core/task_disconnect_connection.go)
  - Each revoke operation is now retried up to 3 times with linear backoff (1s, 2s) using the context clock.
  - After 3 failures, the failure is logged at error level and the disconnect proceeds (SetState + DeleteConnection). A misbehaving 3rd-party revoke endpoint can no longer trap a connection in disconnecting.
  - Added a test verifying the retry-then-proceed behavior.

Closes #8