### PR TITLE
Add /dev inspection route to admin and marketplace UIs

### DIFF
--- a/ui/admin/src/App.tsx
+++ b/ui/admin/src/App.tsx
@@ -5,9 +5,14 @@ import { RouterProvider } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { selectAuthStatus } from "./store";
 import { router } from './routes';
+import Dev from './pages/Dev';
 
 export default function App() {
     const authStatus = useSelector(selectAuthStatus);
+
+    if (import.meta.env.DEV && window.location.pathname === '/dev') {
+        return <Dev />;
+    }
 
     if(authStatus === 'checking' || authStatus === 'redirecting') {
         return (

--- a/ui/admin/src/main.tsx
+++ b/ui/admin/src/main.tsx
@@ -46,7 +46,11 @@ if ((window as any).AUTHPROXY_AUTH_TOKEN) {
 }
 
 // Trigger auth state to load as soon as the page loads.
-store.dispatch(initiateSessionAsync(params));
+// Skip auth in dev mode for the /dev inspection page so cookies/state can be inspected
+// without being redirected away.
+if (!(import.meta.env.DEV && window.location.pathname === '/dev')) {
+    store.dispatch(initiateSessionAsync(params));
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/ui/admin/src/pages/Dev.tsx
+++ b/ui/admin/src/pages/Dev.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+export default function Dev() {
+    return (
+        <Box sx={{ p: 4 }}>
+            <Typography component="h1" variant="h5" sx={{ mb: 2 }}>
+                Dev
+            </Typography>
+            <Typography variant="body1">
+                This page is available only in development mode and bypasses the auth flow.
+                Use the browser dev tools to inspect cookies, storage, and network state.
+            </Typography>
+        </Box>
+    );
+}

--- a/ui/marketplace/src/App.tsx
+++ b/ui/marketplace/src/App.tsx
@@ -6,10 +6,15 @@ import { selectAuthStatus } from "./store";
 import Layout from './components/Layout';
 import ConnectorList from './components/ConnectorList';
 import ConnectionList from './components/ConnectionList';
+import Dev from './components/Dev';
 import { Error } from "./Error";
 
 export default function App() {
     const authStatus = useSelector(selectAuthStatus);
+
+    if (import.meta.env.DEV && window.location.pathname === '/dev') {
+        return <Dev />;
+    }
 
     if(authStatus === 'checking' || authStatus === 'redirecting') {
         return (

--- a/ui/marketplace/src/components/Dev.tsx
+++ b/ui/marketplace/src/components/Dev.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const Dev: React.FC = () => {
+    return (
+        <Box sx={{ p: 4 }}>
+            <Typography component="h1" variant="h5" sx={{ mb: 2 }}>
+                Dev
+            </Typography>
+            <Typography variant="body1">
+                This page is available only in development mode and bypasses the auth flow.
+                Use the browser dev tools to inspect cookies, storage, and network state.
+            </Typography>
+        </Box>
+    );
+};
+
+export default Dev;

--- a/ui/marketplace/src/main.tsx
+++ b/ui/marketplace/src/main.tsx
@@ -29,7 +29,11 @@ if ((window as any).AUTHPROXY_AUTH_TOKEN) {
 }
 
 // Trigger auth state to load as soon as the page loads.
-store.dispatch(initiateSessionAsync(params));
+// Skip auth in dev mode for the /dev inspection page so cookies/state can be inspected
+// without being redirected away.
+if (!(import.meta.env.DEV && window.location.pathname === '/dev')) {
+    store.dispatch(initiateSessionAsync(params));
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>


### PR DESCRIPTION
## Summary
- Adds a dev-only `/dev` route to both the admin and marketplace UIs that renders a small static page.
- The route is gated on `import.meta.env.DEV` and bypasses the auth flow entirely (no `initiateSessionAsync` dispatch, no auth-status loading screen), so the browser dev console can be used to inspect cookies, storage, and network state without being redirected away.
- Production builds set `import.meta.env.DEV` to `false`, so the route is unreachable there and falls through to normal auth-gated routing.

## Test plan
- [ ] `yarn workspace @authproxy/admin dev`, navigate to `/dev`, confirm the static page renders without any auth redirect or session-init request.
- [ ] `yarn workspace @authproxy/marketplace dev`, navigate to `/dev`, confirm the same.
- [ ] Build each app for production and confirm `/dev` does not bypass auth (falls through to the normal auth flow / unauthorized error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)