### PR TITLE
Fix login CORS failure; make ports env-driven for multi-clone dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,41 @@ AUTHPROXY_DEBUG_MODE=true
 AUTHPROXY_CONFIG=./dev_config/default.yaml
 
 ##
+## Per-install port slot.
+##
+## Each AuthProxy clone on one machine (e.g. authproxy1, authproxy2,
+## authproxy3) needs its own ports so they don't collide. The convention
+## is to step the 10's digit per install:
+##
+##   authproxy1: 808x / 8083 / 5173 / 5174   (defaults — leave unset)
+##   authproxy2: 809x / 8093 / 5183 / 5184
+##   authproxy3: 810x / 8103 / 5193 / 5194
+##
+## Override in your local .env (gitignored). Defaults below match the
+## values baked into dev_config/default.yaml + the per-package vite
+## config so a fresh clone runs with no overrides.
+##
+#AUTHPROXY_PUBLIC_PORT=8080
+#AUTHPROXY_API_PORT=8081
+#AUTHPROXY_ADMIN_API_PORT=8082
+#AUTHPROXY_WORKER_HEALTH_PORT=8083
+#AUTHPROXY_ADMIN_UI_PORT=5174
+#AUTHPROXY_MARKETPLACE_UI_PORT=5173
+
+##
+## URLs that embed the ports above. The server reads these so the CORS
+## allow list (the UI's origin) and the login redirect target match the
+## ports above. The Vite dev servers also forward any VITE_* values set
+## here into the bundle, overriding the per-package .env.development
+## defaults.
+##
+#AUTHPROXY_ADMIN_UI_BASE_URL=http://localhost:5174
+#AUTHPROXY_MARKETPLACE_BASE_URL=http://localhost:5173
+#AUTHPROXY_HOST_APP_INITIATE_SESSION_URL=http://127.0.0.1:8888/login-redirect
+#VITE_ADMIN_BASE_URL=https://127.0.0.1:8082
+#VITE_PUBLIC_BASE_URL=https://127.0.0.1:8080
+
+##
 ## Uncomment to run tests with postgres
 ##
 #AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres

--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -1,21 +1,31 @@
 # $schema: ../config/schema.json
 
 public:
-  port: 8080
+  port:
+    env_var: AUTHPROXY_PUBLIC_PORT
+    default: 8080
   cookie:
     same_site: none
   tls:
     auto_gen_path: ./dev_config/keys/tls/
 
 api:
-  port: 8081
+  port:
+    env_var: AUTHPROXY_API_PORT
+    default: 8081
 
 admin_api:
-  port: 8082
+  port:
+    env_var: AUTHPROXY_ADMIN_API_PORT
+    default: 8082
   ui:
     enabled: true
-    base_url: http://localhost:5174
-    initiate_session_url: http://127.0.0.1:8888/login-redirect
+    base_url:
+      env_var: AUTHPROXY_ADMIN_UI_BASE_URL
+      default: http://localhost:5174
+    initiate_session_url:
+      env_var: AUTHPROXY_HOST_APP_INITIATE_SESSION_URL
+      default: http://127.0.0.1:8888/login-redirect
   cookie:
     same_site: none
   tls:
@@ -23,18 +33,22 @@ admin_api:
 
 worker:
   health_check_port:
-    env_var: HEALTH_CHECK_PORT
+    env_var: AUTHPROXY_WORKER_HEALTH_PORT
     default: 8083
   cron_sync_interval: 1m
 
 tasks:
   default_retention: 24h
-  
+
 host_application:
-  initiate_session_url: http://127.0.0.1:8888/login-redirect
+  initiate_session_url:
+    env_var: AUTHPROXY_HOST_APP_INITIATE_SESSION_URL
+    default: http://127.0.0.1:8888/login-redirect
 
 marketplace:
-  base_url: http://localhost:5173
+  base_url:
+    env_var: AUTHPROXY_MARKETPLACE_BASE_URL
+    default: http://localhost:5173
 
 system_auth:
   jwt_signing_key:

--- a/internal/apgin/cors.go
+++ b/internal/apgin/cors.go
@@ -1,0 +1,46 @@
+package apgin
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+// NewCorsMiddleware wraps gin-contrib/cors with logging that surfaces
+// rejected origins. The underlying library aborts non-matching CORS
+// requests with a silent 403 (no body, no logging), which makes
+// "stuck on login" symptoms hard to diagnose — especially when the UI
+// is served from an unexpected port. When that happens, this wrapper
+// emits a single Warn line with the rejected origin and the configured
+// allow list so the mismatch is obvious in the server log.
+func NewCorsMiddleware(config cors.Config, logger *slog.Logger) gin.HandlerFunc {
+	corsHandler := cors.New(config)
+	allowed := append([]string(nil), config.AllowOrigins...)
+
+	if logger != nil {
+		logger.Info("CORS enabled",
+			"allowed_origins", allowed,
+			"allow_credentials", config.AllowCredentials,
+			"allow_all_origins", config.AllowAllOrigins,
+		)
+	}
+
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		corsHandler(c)
+		if logger == nil || origin == "" {
+			return
+		}
+		if c.IsAborted() && c.Writer.Status() == http.StatusForbidden {
+			logger.Warn("CORS: rejected request from origin",
+				"origin", origin,
+				"method", c.Request.Method,
+				"path", c.Request.URL.Path,
+				"allowed_origins", allowed,
+				"allow_all_origins", config.AllowAllOrigins,
+			)
+		}
+	}
+}

--- a/internal/schema/common/integer_value_env_var.go
+++ b/internal/schema/common/integer_value_env_var.go
@@ -13,8 +13,10 @@ type IntegerValueEnvVar struct {
 }
 
 func (kev *IntegerValueEnvVar) HasValue(ctx context.Context) bool {
-	val, present := os.LookupEnv(kev.EnvVar)
-	return present && len(val) > 0
+	if val, present := os.LookupEnv(kev.EnvVar); present && len(val) > 0 {
+		return true
+	}
+	return kev.Default != nil
 }
 
 func (kev *IntegerValueEnvVar) GetValue(ctx context.Context) (int64, error) {

--- a/internal/schema/common/string_value_env_var.go
+++ b/internal/schema/common/string_value_env_var.go
@@ -12,8 +12,10 @@ type StringValueEnvVar struct {
 }
 
 func (kev *StringValueEnvVar) HasValue(ctx context.Context) bool {
-	val, present := os.LookupEnv(kev.EnvVar)
-	return present && len(val) > 0
+	if val, present := os.LookupEnv(kev.EnvVar); present && len(val) > 0 {
+		return true
+	}
+	return kev.Default != nil && len(*kev.Default) > 0
 }
 
 func (kev *StringValueEnvVar) GetValue(ctx context.Context) (string, error) {

--- a/internal/schema/config/host_application.go
+++ b/internal/schema/config/host_application.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"github.com/rmorlok/authproxy/internal/schema/common"
-
+	"context"
 	"net/url"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
 type HostApplication struct {
@@ -13,7 +14,7 @@ type HostApplication struct {
 	// When redirecting to `redirect_url`, the host application should append an `auth_token` query param with a signed
 	// JWT for authenticating the user. This JWT should use a nonce and expiration to protect against session
 	// hijacking
-	InitiateSessionUrl string `json:"initiate_session_url" yaml:"initiate_session_url"`
+	InitiateSessionUrl *StringValue `json:"initiate_session_url" yaml:"initiate_session_url"`
 }
 
 func (ha *HostApplication) Validate(vc *common.ValidationContext) error {
@@ -21,7 +22,7 @@ func (ha *HostApplication) Validate(vc *common.ValidationContext) error {
 		return vc.NewError("host_application must be specified")
 	}
 
-	if ha.InitiateSessionUrl == "" {
+	if ha.InitiateSessionUrl == nil || !ha.InitiateSessionUrl.HasValue(context.Background()) {
 		return vc.NewError("initiate_session_url must be specified")
 	}
 
@@ -29,9 +30,14 @@ func (ha *HostApplication) Validate(vc *common.ValidationContext) error {
 }
 
 func (ha *HostApplication) GetInitiateSessionUrl(returnTo string) string {
-	u, err := url.Parse(ha.InitiateSessionUrl)
+	raw := ""
+	if ha.InitiateSessionUrl != nil {
+		raw, _ = ha.InitiateSessionUrl.GetValue(context.Background())
+	}
+
+	u, err := url.Parse(raw)
 	if err != nil {
-		return ha.InitiateSessionUrl
+		return raw
 	}
 
 	q := u.Query()

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -267,7 +267,7 @@
     "HostApplication": {
       "properties": {
         "initiate_session_url": {
-          "type": "string"
+          "$ref": "../common/schema.json#/$defs/StringValue"
         }
       },
       "additionalProperties": false,
@@ -530,7 +530,7 @@
           "$ref": "../common/schema.json#/$defs/StringValue"
         },
         "initiate_session_url": {
-          "type": "string"
+          "$ref": "../common/schema.json#/$defs/StringValue"
         }
       },
       "additionalProperties": false,

--- a/internal/schema/config/service_admin_api.go
+++ b/internal/schema/config/service_admin_api.go
@@ -149,13 +149,18 @@ type ServiceAdminUi struct {
 	// When redirecting to `redirect_url`, the host application should append an `auth_token` query param with a signed
 	// JWT for authenticating the user. This JWT should use a nonce and expiration to protect against session
 	// hijacking
-	InitiateSessionUrl string `json:"initiate_session_url" yaml:"initiate_session_url"`
+	InitiateSessionUrl *StringValue `json:"initiate_session_url" yaml:"initiate_session_url"`
 }
 
 func (s *ServiceAdminUi) GetInitiateSessionUrl(returnTo string) string {
-	u, err := url.Parse(s.InitiateSessionUrl)
+	raw := ""
+	if s.InitiateSessionUrl != nil {
+		raw, _ = s.InitiateSessionUrl.GetValue(context.Background())
+	}
+
+	u, err := url.Parse(raw)
 	if err != nil {
-		return s.InitiateSessionUrl
+		return raw
 	}
 
 	q := u.Query()

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -60,8 +60,7 @@ func GetGinServer(
 
 	corsConfig := GetCorsConfig(dm.GetConfig())
 	if corsConfig != nil {
-		logger.Info("Enabling CORS")
-		server.Use(cors.New(*corsConfig))
+		server.Use(apgin.NewCorsMiddleware(*corsConfig, logger))
 	}
 
 	// Swagger documentation endpoint

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
@@ -38,8 +37,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 
 	corsConfig := root.Api.CorsVal.ToGinCorsConfig(nil)
 	if corsConfig != nil {
-		logger.Info("Enabling CORS")
-		server.Use(cors.New(*corsConfig))
+		server.Use(apgin.NewCorsMiddleware(*corsConfig, logger))
 	}
 
 	// Swagger documentation endpoint

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -66,8 +66,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 
 	corsConfig := GetCorsConfig(dm.GetConfig())
 	if corsConfig != nil {
-		logger.Info("Enabling CORS")
-		server.Use(cors.New(*corsConfig))
+		server.Use(apgin.NewCorsMiddleware(*corsConfig, logger))
 	}
 
 	if service.StaticVal != nil {

--- a/sdks/js/src/client.ts
+++ b/sdks/js/src/client.ts
@@ -31,6 +31,49 @@ const shouldIncludeXsrfToken = (config: any): boolean => {
   return true;
 };
 
+// Resolve the full request URL from an axios config, joining baseURL + url
+// the same way axios does, so log lines show what the browser actually sent.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const resolveRequestUrl = (config: any): string => {
+  const url: string = config?.url ?? '';
+  const baseURL: string = config?.baseURL ?? '';
+  if (!url) return baseURL;
+  if (/^https?:\/\//i.test(url) || !baseURL) return url;
+  return baseURL.replace(/\/+$/, '') + (url.startsWith('/') ? url : '/' + url);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const logRequestError = (error: any): void => {
+  if (typeof console === 'undefined') return;
+  const config = error?.config ?? {};
+  const method = (config.method ?? 'request').toString().toUpperCase();
+  const url = resolveRequestUrl(config);
+  const status = error?.response?.status;
+  const data = error?.response?.data;
+  const pageOrigin =
+    typeof window !== 'undefined' && window.location ? window.location.origin : '(non-browser)';
+
+  if (status) {
+    console.error(
+      `[AuthProxy SDK] ${method} ${url} failed: HTTP ${status}`,
+      { status, data, pageOrigin },
+    );
+    return;
+  }
+
+  // No response received — most commonly a CORS preflight rejection or the
+  // server being unreachable. The browser does not expose CORS errors to
+  // JS, so we have to infer; log enough to make the cause obvious.
+  console.error(
+    `[AuthProxy SDK] ${method} ${url} failed with no response. ` +
+      `This is usually a CORS rejection (the server returned no Access-Control-Allow-Origin ` +
+      `for page origin ${pageOrigin}) or the server being unreachable. ` +
+      `Check that the server's CORS allow list includes ${pageOrigin}, and that ` +
+      `the configured baseURL (${config.baseURL ?? '(unset)'}) is reachable.`,
+    { error },
+  );
+};
+
 // Wire up interceptors to an axios instance
 function attachInterceptors(instance: AxiosInstance) {
   // Response interceptor to extract XSRF tokens
@@ -45,6 +88,7 @@ function attachInterceptors(instance: AxiosInstance) {
       // Also check for XSRF tokens in error responses
       const token = extractXsrfToken(error?.response?.headers ?? {});
       if (token) xsrfToken = token;
+      logRequestError(error);
       return Promise.reject(error);
     }
   );
@@ -106,6 +150,15 @@ export function configureClient(opts: AuthProxyClientOptions = {}) {
   // Create new instance and attach interceptors
   client = axios.create(config);
   attachInterceptors(client);
+
+  if (typeof console !== 'undefined') {
+    const pageOrigin =
+      typeof window !== 'undefined' && window.location ? window.location.origin : '(non-browser)';
+    console.info(
+      `[AuthProxy SDK] client configured: baseURL=${baseURL ?? '(unset)'}, ` +
+        `withCredentials=${withCredentials}, page origin=${pageOrigin}`,
+    );
+  }
 }
 
 // Export function to manually set XSRF token (useful for testing or manual token management)

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 5174",
+    "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "preview": "vite preview",

--- a/ui/admin/src/store/sessionSlice.ts
+++ b/ui/admin/src/store/sessionSlice.ts
@@ -33,16 +33,22 @@ export const initiateSessionAsync = createAsyncThunk<
             if (isInitiateSessionSuccessResponse(response.data)) {
                 return response.data;
             } else {
+                console.warn('[AuthProxy admin] session initiate returned a redirect', response.data);
                 return rejectWithValue(response.data);
             }
         } catch (error: any) {
-            // Handle unexpected errors
+            // Handle unexpected errors. The SDK already logged the underlying
+            // request failure; here we just record what we're going to do next.
             if (error.response?.data && !isInitiateSessionSuccessResponse(error.response.data)) {
+                console.warn('[AuthProxy admin] session initiate failed; using server-provided redirect', error.response.data);
                 return rejectWithValue(error.response.data);
             }
 
-            // Default error response
-            return rejectWithValue({ redirect_url: new URL('error', import.meta.env.VITE_ADMIN_BASE_URL).toString() });
+            const fallback = new URL('error', import.meta.env.VITE_ADMIN_BASE_URL).toString();
+            console.error(
+                `[AuthProxy admin] session initiate failed with no usable response; falling back to ${fallback}`,
+            );
+            return rejectWithValue({ redirect_url: fallback });
         }
     }
 );
@@ -73,8 +79,10 @@ export const sessionSlice = createSlice({
             .addCase(initiateSessionAsync.rejected, (state, action) => {
                 state.status = 'unauthenticated';
                 state.actor_id = null;
+                const target = action.payload?.redirect_url || import.meta.env.VITE_ADMIN_BASE_URL + '/error';
+                console.warn(`[AuthProxy admin] not authenticated; redirecting to ${target}`);
                 setTimeout(() => {
-                    window.location.href = action.payload?.redirect_url || import.meta.env.VITE_ADMIN_BASE_URL + '/error';
+                    window.location.href = target;
                 }, 0);
         });
     },

--- a/ui/admin/vite.config.ts
+++ b/ui/admin/vite.config.ts
@@ -1,16 +1,38 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = resolve(__dirname, '../..');
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: [
-      { find: '@authproxy/api', replacement: resolve(__dirname, '../../sdks/js/src') },
-    ],
-  },
+export default defineConfig(({ mode }) => {
+  // Per-package .env.* files are auto-loaded by Vite as defaults that travel
+  // with the repo. The monorepo-root .env is gitignored and is where each
+  // local clone (e.g. authproxy1, authproxy2, authproxy3 on one machine)
+  // sets its own port slot. Vite's own env-loading lets process.env beat
+  // .env files, so seeding process.env from the root .env up front makes
+  // root values override the per-package defaults without changing envDir.
+  const rootEnv = loadEnv(mode, monorepoRoot, '');
+  for (const [k, v] of Object.entries(rootEnv)) {
+    process.env[k] = v;
+  }
+
+  const port = Number(process.env.AUTHPROXY_ADMIN_UI_PORT) || 5174;
+
+  return {
+    plugins: [react()],
+    // strictPort makes a port collision fail loudly instead of silently
+    // shifting onto another install's slot — see the multi-clone setup above.
+    server: {
+      port,
+      strictPort: true,
+    },
+    resolve: {
+      alias: [
+        { find: '@authproxy/api', replacement: resolve(__dirname, '../../sdks/js/src') },
+      ],
+    },
+  };
 });

--- a/ui/marketplace/src/store/sessionSlice.ts
+++ b/ui/marketplace/src/store/sessionSlice.ts
@@ -33,16 +33,22 @@ export const initiateSessionAsync = createAsyncThunk<
             if (isInitiateSessionSuccessResponse(response.data)) {
                 return response.data;
             } else {
+                console.warn('[AuthProxy marketplace] session initiate returned a redirect', response.data);
                 return rejectWithValue(response.data);
             }
         } catch (error: any) {
-            // Handle unexpected errors
+            // Handle unexpected errors. The SDK already logged the underlying
+            // request failure; here we just record what we're going to do next.
             if (error.response?.data && !isInitiateSessionSuccessResponse(error.response.data)) {
+                console.warn('[AuthProxy marketplace] session initiate failed; using server-provided redirect', error.response.data);
                 return rejectWithValue(error.response.data);
             }
 
-            // Default error response
-            return rejectWithValue({ redirect_url: new URL('/error', import.meta.env.VITE_PUBLIC_BASE_URL).toString() });
+            const fallback = new URL('/error', import.meta.env.VITE_PUBLIC_BASE_URL).toString();
+            console.error(
+                `[AuthProxy marketplace] session initiate failed with no usable response; falling back to ${fallback}`,
+            );
+            return rejectWithValue({ redirect_url: fallback });
         }
     }
 );
@@ -73,8 +79,10 @@ export const sessionSlice = createSlice({
             .addCase(initiateSessionAsync.rejected, (state, action) => {
                 state.status = 'unauthenticated';
                 state.actor_id = null;
+                const target = action.payload?.redirect_url || import.meta.env.VITE_PUBLIC_BASE_URL + '/error';
+                console.warn(`[AuthProxy marketplace] not authenticated; redirecting to ${target}`);
                 setTimeout(() => {
-                    window.location.href = action.payload?.redirect_url || import.meta.env.VITE_PUBLIC_BASE_URL + '/error';
+                    window.location.href = target;
                 }, 0);
         });
     },

--- a/ui/marketplace/vite.config.ts
+++ b/ui/marketplace/vite.config.ts
@@ -1,22 +1,44 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = resolve(__dirname, '../..');
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: [
-      { find: '@authproxy/api', replacement: resolve(__dirname, '../../sdks/js/src') },
-    ],
-  },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/tests/setup.ts'],
-    css: true,
-  },
+export default defineConfig(({ mode }) => {
+  // Per-package .env.* files are auto-loaded by Vite as defaults that travel
+  // with the repo. The monorepo-root .env is gitignored and is where each
+  // local clone (e.g. authproxy1, authproxy2, authproxy3 on one machine)
+  // sets its own port slot. Vite's own env-loading lets process.env beat
+  // .env files, so seeding process.env from the root .env up front makes
+  // root values override the per-package defaults without changing envDir.
+  const rootEnv = loadEnv(mode, monorepoRoot, '');
+  for (const [k, v] of Object.entries(rootEnv)) {
+    process.env[k] = v;
+  }
+
+  const port = Number(process.env.AUTHPROXY_MARKETPLACE_UI_PORT) || 5173;
+
+  return {
+    plugins: [react()],
+    // strictPort makes a port collision fail loudly instead of silently
+    // shifting onto another install's slot — see the multi-clone setup above.
+    server: {
+      port,
+      strictPort: true,
+    },
+    resolve: {
+      alias: [
+        { find: '@authproxy/api', replacement: resolve(__dirname, '../../sdks/js/src') },
+      ],
+    },
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./src/tests/setup.ts'],
+      css: true,
+    },
+  };
 });


### PR DESCRIPTION
## Summary

Both the admin and marketplace UIs were getting stuck in a failed-login state. Root cause: when a Vite default port was occupied at startup, Vite silently auto-incremented onto another port, so requests went out from an origin (`localhost:5174` for what was actually marketplace, `localhost:5175` for admin) that the server's CORS allow list didn't recognize. The preflight `OPTIONS` returned 403 with no body and no log line, and the UI redirected to a `/error` route that doesn't exist on the public/admin services — making the failure mode opaque from both ends.

The fix has three parts:

- **The bug:** Vite configs now use `strictPort: true`, so a port conflict fails loudly instead of silently relocating.
- **Multi-clone friendly config:** ports and the URLs that embed them are now driven by env vars from the monorepo-root `.env` (gitignored). Each clone (`authproxy1`, `authproxy2`, …) can claim its own port slot using a 10's-digit convention documented in `.env.example`. Defaults preserve the existing behavior, so a fresh clone runs unchanged.
- **Diagnostics so this doesn't repeat:** server-side CORS rejection now produces a clear log line, and the SDK client logs configured baseURL + a CORS-aware error message when a request fails.

### Detailed changes

**Bug / Vite**
- `ui/{admin,marketplace}/vite.config.ts` — `loadEnv()` reads the monorepo-root `.env` and seeds `process.env`, letting root values override per-package `.env.development` defaults. Port comes from `AUTHPROXY_ADMIN_UI_PORT` / `AUTHPROXY_MARKETPLACE_UI_PORT` with the original defaults; `strictPort: true`.
- `ui/admin/package.json` — drop hardcoded `--port 5174` (vite.config drives it now).

**Config**
- `dev_config/default.yaml` — `public.port`, `api.port`, `admin_api.port`, `worker.health_check_port`, `admin_api.ui.base_url`, `admin_api.ui.initiate_session_url`, `host_application.initiate_session_url`, and `marketplace.base_url` all use the `{ env_var: …, default: … }` form.
- `internal/schema/config/{host_application,service_admin_api}.go` + `schema.json` — `initiate_session_url` upgraded from plain `string` to `StringValue` so it accepts the same `env_var/default` form as the URLs around it.
- `internal/schema/common/{string,integer}_value_env_var.go` — `HasValue` now also returns true when only `Default` is set, matching what `GetValue` actually returns. Pre-existing inconsistency that the new env-var-with-default usage exposed.

**Diagnostics**
- `internal/apgin/cors.go` (new) — `NewCorsMiddleware` wraps `gin-contrib/cors`, logs the allow list at startup, and emits a `Warn` line with the rejected origin + allow list whenever the underlying middleware aborts with 403. Wired into all three services (`admin_api`, `api`, `public`).
- `sdks/js/src/client.ts` — `configureClient` logs `[AuthProxy SDK] client configured: baseURL=…, page origin=…`; failed responses log status / response body on HTTP errors and a CORS-aware "no response" message on network failures.
- `ui/{admin,marketplace}/src/store/sessionSlice.ts` — log on each branch of the rejected/redirect path so the redirect target is visible before navigation.

**Docs**
- `.env.example` — documents `AUTHPROXY_*_PORT`, `AUTHPROXY_*_BASE_URL`, `AUTHPROXY_HOST_APP_INITIATE_SESSION_URL`, `VITE_ADMIN_BASE_URL`, `VITE_PUBLIC_BASE_URL` with the per-install 10's-digit convention.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/schema/... ./internal/config/... ./internal/apgin/... ./internal/service/... ./internal/apauth/... ./internal/routes/...` passes
- [x] `yarn typecheck` passes for `@authproxy/admin` and `@authproxy/marketplace`
- [x] `go run ./cmd/server routes --config=./dev_config/default.yaml` parses and prints routes; new `CORS enabled` log line shows allow list
- [x] Login works end-to-end on admin (`localhost:5174` → `8082`) and marketplace (`localhost:5173` → `8080`) — `_initiate` returns 200, namespaces / connections load
- [x] `strictPort` correctly fails the second admin instance with `Port 5174 is already in use` instead of silently shifting
- [x] Setting `AUTHPROXY_ADMIN_UI_PORT=5188` + `VITE_ADMIN_BASE_URL=…` in monorepo-root `.env` boots admin on 5188 with the overridden URL in the bundle
- [ ] Reviewer: fresh clone with no overrides should still run unchanged
- [ ] Reviewer: confirm second clone (`authproxy2`) running on 809x ports works alongside this one on 808x

🤖 Generated with [Claude Code](https://claude.com/claude-code)