### PR TITLE
Carry-forward labels — Step 1: grammar, validators, helpers (#195)

### DIFF
--- a/internal/core/iface/proxy.go
+++ b/internal/core/iface/proxy.go
@@ -69,7 +69,7 @@ func (r *ProxyRequest) Validate() error {
 	}
 
 	if r.Labels != nil {
-		if err := database.Labels(r.Labels).Validate(); err != nil {
+		if err := database.ValidateUserLabels(r.Labels); err != nil {
 			errors = append(errors, "invalid labels: "+err.Error())
 		}
 	}

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -796,7 +796,7 @@ func (s *service) PutActorLabels(ctx context.Context, id apid.ID, labels map[str
 		return s.GetActor(ctx, id)
 	}
 
-	if err := ValidateLabels(labels); err != nil {
+	if err := ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -992,6 +992,10 @@ func (s *service) DeleteActorLabels(ctx context.Context, id apid.ID, keys []stri
 
 	if len(keys) == 0 {
 		return s.GetActor(ctx, id)
+	}
+
+	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
 	var result *Actor

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -684,7 +684,7 @@ func (s *service) UpdateConnectionLabels(ctx context.Context, id apid.ID, labels
 	}
 
 	if labels != nil {
-		if err := ValidateLabels(labels); err != nil {
+		if err := ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -737,7 +737,7 @@ func (s *service) PutConnectionLabels(ctx context.Context, id apid.ID, labels ma
 		return s.GetConnection(ctx, id)
 	}
 
-	if err := ValidateLabels(labels); err != nil {
+	if err := ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -931,6 +931,10 @@ func (s *service) DeleteConnectionLabels(ctx context.Context, id apid.ID, keys [
 
 	if len(keys) == 0 {
 		return s.GetConnection(ctx, id)
+	}
+
+	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
 	var result *Connection

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -315,7 +315,7 @@ func (s *service) UpdateEncryptionKeyLabels(ctx context.Context, id apid.ID, lab
 	}
 
 	if labels != nil {
-		if err := ValidateLabels(labels); err != nil {
+		if err := ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -366,7 +366,7 @@ func (s *service) PutEncryptionKeyLabels(ctx context.Context, id apid.ID, labels
 		return s.GetEncryptionKey(ctx, id)
 	}
 
-	if err := ValidateLabels(labels); err != nil {
+	if err := ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -413,6 +413,10 @@ func (s *service) DeleteEncryptionKeyLabels(ctx context.Context, id apid.ID, key
 
 	if len(keys) == 0 {
 		return s.GetEncryptionKey(ctx, id)
+	}
+
+	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
 	var result *EncryptionKey

--- a/internal/database/labels.go
+++ b/internal/database/labels.go
@@ -14,6 +14,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
 )
 
 // Kubernetes-style label restrictions
@@ -26,6 +27,15 @@ const (
 
 	// LabelValueMaxLength is the maximum length for a label value
 	LabelValueMaxLength = 63
+
+	// ApxyReservedPrefix is the reserved label-key prefix for system-managed
+	// labels (implicit identifier labels and parent carry-forward labels).
+	// User-supplied label keys may not begin with this prefix.
+	ApxyReservedPrefix = "apxy/"
+
+	// ApxyImplicitSegment is the segment used inside apxy/ keys to mark an
+	// implicit identifier label, e.g. apxy/<rt>/-/id.
+	ApxyImplicitSegment = "-"
 )
 
 var (
@@ -45,6 +55,12 @@ var (
 	// - 0-63 characters (can be empty)
 	// - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
 	labelValueRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?)?$|^[a-zA-Z0-9]?$`)
+
+	// apxyPathSegmentRegex validates a single segment inside an apxy/ path.
+	// A segment is either a DNS-label-like token (alphanumeric start/end, may
+	// contain '-' in the middle) or the literal "-" sentinel used to mark
+	// implicit identifier labels (e.g. apxy/cxr/-/id).
+	apxyPathSegmentRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|-)$`)
 )
 
 // Labels is a map of key-value pairs following Kubernetes label restrictions.
@@ -92,13 +108,30 @@ func (l *Labels) Scan(value interface{}) error {
 	}
 }
 
-// ValidateLabelKey validates a single label key according to Kubernetes restrictions.
-// Format: [prefix/]name
-// - prefix (optional): valid DNS subdomain, max 253 characters
-// - name (required): 1-63 characters, must start/end with alphanumeric, may contain '-', '_', '.'
+// ValidateLabelKey validates a single label key.
+//
+// Two grammars are accepted:
+//
+//  1. Standard Kubernetes-style key: [prefix/]name
+//     - prefix (optional): valid DNS subdomain, max 253 characters
+//     - name (required): 1-63 characters, must start/end with alphanumeric,
+//     may contain '-', '_', '.'
+//
+//  2. Reserved apxy/ multi-segment key: apxy/<seg>(/<seg>)*/<name>
+//     - each <seg> is a DNS-label-like token or the literal "-" sentinel
+//     - <name> follows the standard name rule above
+//     - total prefix portion (everything before the final '/') still capped
+//     at LabelKeyPrefixMaxLength characters
+//
+// This function accepts apxy/ keys; user-input call sites should use
+// ValidateUserLabelKey to additionally reject the reserved namespace.
 func ValidateLabelKey(key string) error {
 	if key == "" {
 		return errors.New("label key cannot be empty")
+	}
+
+	if strings.HasPrefix(key, ApxyReservedPrefix) {
+		return validateApxyLabelKey(key)
 	}
 
 	var prefix, name string
@@ -138,6 +171,60 @@ func ValidateLabelKey(key string) error {
 	return nil
 }
 
+// validateApxyLabelKey validates a key already known to start with apxy/.
+// The grammar is apxy/<seg>(/<seg>)*/<name>.
+func validateApxyLabelKey(key string) error {
+	idx := strings.LastIndex(key, "/")
+	// idx must exist because the key starts with "apxy/"; the final '/'
+	// separates the (possibly multi-segment) prefix from the name.
+	prefix := key[:idx]
+	name := key[idx+1:]
+
+	if len(prefix) > LabelKeyPrefixMaxLength {
+		return fmt.Errorf("label key prefix exceeds maximum length of %d characters", LabelKeyPrefixMaxLength)
+	}
+
+	// Trim the leading "apxy" segment (we know it's there) and require at
+	// least one further segment before the name — apxy/<rt>/...
+	innerPath := strings.TrimPrefix(prefix, "apxy")
+	if innerPath == "" {
+		return errors.New("apxy/ label key requires at least one segment after apxy/")
+	}
+	// innerPath now starts with '/'.
+	innerSegments := strings.Split(innerPath[1:], "/")
+	for _, seg := range innerSegments {
+		if seg == "" {
+			return errors.New("apxy/ label key has empty path segment")
+		}
+		if !apxyPathSegmentRegex.MatchString(seg) {
+			return fmt.Errorf("apxy/ label key segment %q must be a DNS label or the '-' sentinel", seg)
+		}
+	}
+
+	if name == "" {
+		return errors.New("label key name cannot be empty")
+	}
+	if len(name) > LabelKeyNameMaxLength {
+		return fmt.Errorf("label key name exceeds maximum length of %d characters", LabelKeyNameMaxLength)
+	}
+	if !labelKeyNameRegex.MatchString(name) {
+		return fmt.Errorf("label key name %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", name)
+	}
+
+	return nil
+}
+
+// ValidateUserLabelKey validates a label key supplied directly by an end user.
+// In addition to the rules of ValidateLabelKey, it rejects any key in the
+// reserved apxy/ namespace — those keys are managed by the system and may not
+// be set, modified, or deleted through user-input endpoints.
+func ValidateUserLabelKey(key string) error {
+	if strings.HasPrefix(key, ApxyReservedPrefix) {
+		return fmt.Errorf("label key %q is in the reserved %q namespace and cannot be set by users", key, ApxyReservedPrefix)
+	}
+	return ValidateLabelKey(key)
+}
+
 // ValidateLabelValue validates a single label value according to Kubernetes restrictions.
 // - 0-63 characters (can be empty)
 // - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
@@ -153,7 +240,9 @@ func ValidateLabelValue(value string) error {
 	return nil
 }
 
-// ValidateLabels validates all labels in a map according to Kubernetes restrictions.
+// ValidateLabels validates all labels in a map according to Kubernetes
+// restrictions. apxy/-prefixed keys are accepted; this is the right validator
+// for system-managed writes (e.g. carry-forward materialization).
 func ValidateLabels(labels map[string]string) error {
 	var result *multierror.Error
 	for key, value := range labels {
@@ -165,6 +254,36 @@ func ValidateLabels(labels map[string]string) error {
 		}
 	}
 
+	return result.ErrorOrNil()
+}
+
+// ValidateUserLabels validates a labels map supplied by a user. It applies
+// the same key/value rules as ValidateLabels but rejects any key in the
+// reserved apxy/ namespace.
+func ValidateUserLabels(labels map[string]string) error {
+	var result *multierror.Error
+	for key, value := range labels {
+		if err := ValidateUserLabelKey(key); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
+		}
+		if err := ValidateLabelValue(value); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, err))
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+// ValidateUserLabelDeletionKeys validates a list of keys passed to a
+// user-facing label-deletion endpoint. Keys must be well-formed and must not
+// reference the reserved apxy/ namespace.
+func ValidateUserLabelDeletionKeys(keys []string) error {
+	var result *multierror.Error
+	for _, k := range keys {
+		if err := ValidateUserLabelKey(k); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", k, err))
+		}
+	}
 	return result.ErrorOrNil()
 }
 
@@ -343,4 +462,58 @@ func (s *service) updateLabelsInTableTx(ctx context.Context, tx *sql.Tx, table s
 	}
 
 	return now, nil
+}
+
+// ApidPrefixToLabelToken returns the label-key token associated with an apid
+// prefix. It strips the trailing underscore so e.g. "cxr_" becomes "cxr" and
+// "cxn_" becomes "cxn". Used to build apxy/ keys whose <rt> segment matches
+// the resource's id prefix.
+func ApidPrefixToLabelToken(p apid.Prefix) string {
+	return strings.TrimSuffix(string(p), "_")
+}
+
+// BuildImplicitIdentifierLabels returns the two implicit identifier labels
+// for a resource: apxy/<rt>/-/id and apxy/<rt>/-/ns, where <rt> is derived
+// from the resource's id prefix. The id and namespacePath are stored as
+// label values verbatim — callers must ensure they have already been
+// validated by their respective rules.
+func BuildImplicitIdentifierLabels(id apid.ID, namespacePath string) Labels {
+	if id.IsNil() {
+		return nil
+	}
+	rt := ApidPrefixToLabelToken(id.Prefix())
+	if rt == "" {
+		return nil
+	}
+	return Labels{
+		fmt.Sprintf("%s%s/%s/id", ApxyReservedPrefix, rt, ApxyImplicitSegment): string(id),
+		fmt.Sprintf("%s%s/%s/ns", ApxyReservedPrefix, rt, ApxyImplicitSegment): namespacePath,
+	}
+}
+
+// BuildCarriedLabels takes a parent's labels and returns the carry-forward
+// labels for a child of the parent.
+//
+//   - User labels on the parent (any key NOT starting with apxy/) are
+//     re-keyed under apxy/<parentRt>/<key>.
+//   - apxy/-prefixed labels on the parent are forwarded as-is so that
+//     ancestors further up the chain remain visible. The child is expected
+//     to merge its own self-implicit labels on top of this map (deeper
+//     overrides shallower).
+//
+// parentRt is the resource-type token of the parent (e.g. "cxr", "cxn",
+// "ns") — typically obtained via ApidPrefixToLabelToken.
+func BuildCarriedLabels(parentRt string, parentLabels Labels) Labels {
+	if parentRt == "" || len(parentLabels) == 0 {
+		return nil
+	}
+	out := make(Labels, len(parentLabels))
+	for k, v := range parentLabels {
+		if strings.HasPrefix(k, ApxyReservedPrefix) {
+			out[k] = v
+			continue
+		}
+		out[fmt.Sprintf("%s%s/%s", ApxyReservedPrefix, parentRt, k)] = v
+	}
+	return out
 }

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +71,97 @@ func TestLabels(t *testing.T) {
 					require.Error(t, err, "key %q should be invalid: %s", tc.key, tc.reason)
 				})
 			}
+		})
+
+		t.Run("apxy/ multi-segment keys", func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				validKeys := []string{
+					"apxy/cxr/-/id",
+					"apxy/cxr/-/ns",
+					"apxy/cxn/-/id",
+					"apxy/ns/-/id",
+					"apxy/cxr/type",
+					"apxy/cxr/my-key",
+					"apxy/cxr/my.key",
+					"apxy/cxr/my_key",
+					"apxy/ns/dog",
+					"apxy/cxr/cxn/userkey",
+				}
+				for _, key := range validKeys {
+					t.Run(key, func(t *testing.T) {
+						require.NoError(t, ValidateLabelKey(key), "key %q should be valid", key)
+					})
+				}
+			})
+
+			t.Run("invalid", func(t *testing.T) {
+				invalidKeys := []struct {
+					key    string
+					reason string
+				}{
+					{"apxy/", "no segments after apxy/"},
+					{"apxy//id", "empty intermediate segment"},
+					{"apxy/cxr//id", "empty intermediate segment in middle"},
+					{"apxy/cxr/", "empty name"},
+					{"apxy/cxr/-/", "empty name after sentinel"},
+					{"apxy/cx@r/id", "invalid character in segment"},
+					{"apxy/cxr/-/-bad", "name starts with hyphen"},
+				}
+				for _, tc := range invalidKeys {
+					t.Run(tc.reason, func(t *testing.T) {
+						err := ValidateLabelKey(tc.key)
+						require.Error(t, err, "key %q should be invalid: %s", tc.key, tc.reason)
+					})
+				}
+			})
+		})
+	})
+
+	t.Run("ValidateUserLabelKey", func(t *testing.T) {
+		t.Run("rejects apxy/ prefix", func(t *testing.T) {
+			err := ValidateUserLabelKey("apxy/cxr/type")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "reserved")
+		})
+
+		t.Run("accepts non-apxy keys", func(t *testing.T) {
+			require.NoError(t, ValidateUserLabelKey("my-key"))
+			require.NoError(t, ValidateUserLabelKey("example.com/key"))
+		})
+
+		t.Run("still rejects invalid keys", func(t *testing.T) {
+			require.Error(t, ValidateUserLabelKey("-bad"))
+			require.Error(t, ValidateUserLabelKey(""))
+		})
+	})
+
+	t.Run("ValidateUserLabels", func(t *testing.T) {
+		t.Run("rejects map containing apxy/ key", func(t *testing.T) {
+			err := ValidateUserLabels(map[string]string{
+				"good":         "ok",
+				"apxy/cxr/bad": "nope",
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "reserved")
+		})
+
+		t.Run("accepts pure user labels", func(t *testing.T) {
+			require.NoError(t, ValidateUserLabels(map[string]string{
+				"team": "platform",
+				"env":  "prod",
+			}))
+		})
+	})
+
+	t.Run("ValidateUserLabelDeletionKeys", func(t *testing.T) {
+		t.Run("rejects apxy/ keys", func(t *testing.T) {
+			err := ValidateUserLabelDeletionKeys([]string{"team", "apxy/cxr/type"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "reserved")
+		})
+
+		t.Run("accepts user keys", func(t *testing.T) {
+			require.NoError(t, ValidateUserLabelDeletionKeys([]string{"team", "env"}))
 		})
 	})
 
@@ -344,5 +436,78 @@ func TestLabels(t *testing.T) {
 		// Test nil labels
 		var nilLabels Labels
 		require.Nil(t, nilLabels.Copy())
+	})
+}
+
+func TestApidPrefixToLabelToken(t *testing.T) {
+	require.Equal(t, "cxr", ApidPrefixToLabelToken(apid.PrefixConnectorVersion))
+	require.Equal(t, "cxn", ApidPrefixToLabelToken(apid.PrefixConnection))
+	require.Equal(t, "act", ApidPrefixToLabelToken(apid.PrefixActor))
+	require.Equal(t, "ek", ApidPrefixToLabelToken(apid.PrefixEncryptionKey))
+	require.Equal(t, "", ApidPrefixToLabelToken(apid.Prefix("")))
+}
+
+func TestBuildImplicitIdentifierLabels(t *testing.T) {
+	t.Run("builds id and ns labels", func(t *testing.T) {
+		id := apid.MustParse("cxn_test1234567890ab")
+		labels := BuildImplicitIdentifierLabels(id, "root.foo.bar")
+		require.Equal(t, Labels{
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+			"apxy/cxn/-/ns": "root.foo.bar",
+		}, labels)
+		// Result must validate under the system rules.
+		require.NoError(t, labels.Validate())
+	})
+
+	t.Run("nil id returns nil", func(t *testing.T) {
+		require.Nil(t, BuildImplicitIdentifierLabels(apid.Nil, "/foo"))
+	})
+
+	t.Run("uses correct rt token per resource type", func(t *testing.T) {
+		labels := BuildImplicitIdentifierLabels(apid.MustParse("cxr_test1234567890ab"), "root")
+		_, ok := labels["apxy/cxr/-/id"]
+		require.True(t, ok)
+		_, ok = labels["apxy/cxr/-/ns"]
+		require.True(t, ok)
+	})
+}
+
+func TestBuildCarriedLabels(t *testing.T) {
+	t.Run("re-keys user labels under parent rt", func(t *testing.T) {
+		parent := Labels{
+			"type":    "google_drive",
+			"variant": "shared",
+		}
+		out := BuildCarriedLabels("cxr", parent)
+		require.Equal(t, Labels{
+			"apxy/cxr/type":    "google_drive",
+			"apxy/cxr/variant": "shared",
+		}, out)
+		require.NoError(t, out.Validate())
+	})
+
+	t.Run("forwards apxy/ keys as-is", func(t *testing.T) {
+		parent := Labels{
+			"pig":            "oink",
+			"apxy/ns/dog":    "woof",
+			"apxy/cxr/-/id":  "cxr_abc",
+			"apxy/cxr/-/ns":  "/foo",
+		}
+		out := BuildCarriedLabels("cxr", parent)
+		require.Equal(t, Labels{
+			"apxy/cxr/pig":  "oink",
+			"apxy/ns/dog":   "woof",
+			"apxy/cxr/-/id": "cxr_abc",
+			"apxy/cxr/-/ns": "/foo",
+		}, out)
+	})
+
+	t.Run("empty parent labels returns nil", func(t *testing.T) {
+		require.Nil(t, BuildCarriedLabels("cxr", nil))
+		require.Nil(t, BuildCarriedLabels("cxr", Labels{}))
+	})
+
+	t.Run("empty parent rt returns nil", func(t *testing.T) {
+		require.Nil(t, BuildCarriedLabels("", Labels{"type": "google_drive"}))
 	})
 }

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -703,7 +703,7 @@ func (s *service) UpdateNamespaceLabels(ctx context.Context, path string, labels
 	}
 
 	if labels != nil {
-		if err := ValidateLabels(labels); err != nil {
+		if err := ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -745,7 +745,7 @@ func (s *service) PutNamespaceLabels(ctx context.Context, path string, labels ma
 		return s.GetNamespace(ctx, path)
 	}
 
-	if err := ValidateLabels(labels); err != nil {
+	if err := ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -784,6 +784,10 @@ func (s *service) DeleteNamespaceLabels(ctx context.Context, path string, keys [
 
 	if len(keys) == 0 {
 		return s.GetNamespace(ctx, path)
+	}
+
+	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
 	var result *Namespace

--- a/internal/routes/key_value/labels.go
+++ b/internal/routes/key_value/labels.go
@@ -51,7 +51,7 @@ var Label = Kind{
 	PathSegment:   "labels",
 	ParamName:     "label",
 	Singular:      "label",
-	ValidateKey:   database.ValidateLabelKey,
+	ValidateKey:   database.ValidateUserLabelKey,
 	ValidateValue: database.ValidateLabelValue,
 	Get:           func(r Resource) map[string]string { return r.GetLabels() },
 }


### PR DESCRIPTION
Closes #195. First slice of #194 — foundation only, no runtime carry-forward yet.

## Summary
- Establishes the \`apxy/\` reserved label-key namespace and the supporting validation / helper primitives that #196, #197, #198 will build on.
- Extends \`ValidateLabelKey\` to accept multi-segment \`apxy/<seg>(/<seg>)*/<name>\` keys; the existing Kubernetes-style \`[prefix/]name\` grammar is unchanged for non-\`apxy/\` keys.
- Adds user-input validators (\`ValidateUserLabelKey\`, \`ValidateUserLabels\`, \`ValidateUserLabelDeletionKeys\`) that reject any key in the \`apxy/\` namespace, and switches every user-facing label endpoint to use them: connection / actor / namespace / encryption-key Put/Update/Delete + the \`key_value\` routes adapter + \`ProxyRequest.Validate\` (per-request labels).
- Adds three helpers that subsequent steps will call:
  - \`ApidPrefixToLabelToken(p apid.Prefix) string\` — \`cxr_\` → \`cxr\`.
  - \`BuildImplicitIdentifierLabels(id, ns) Labels\` → \`{apxy/<rt>/-/id, apxy/<rt>/-/ns}\`.
  - \`BuildCarriedLabels(parentRt, parentLabels) Labels\` — re-keys parent user labels under \`apxy/<parentRt>/<key>\` and forwards parent's \`apxy/\` keys as-is so ancestors stay visible.

## Out of scope
- Materializing carry-forward on resource create / upgrade / namespace move (#196).
- Per-request label snapshot (#197).
- Daily consistency checker (#198).

## Notes for review
- The \`apxy/\` grammar is intentionally restricted to that one prefix; other keys still use the original single-slash rule. See \`validateApxyLabelKey\` for the parsing.
- I noted a follow-up concern on #196: namespace paths can plausibly exceed the 63-char label-value cap, which will matter when materializing \`apxy/<rt>/-/ns\`. Three options outlined there — let's pick before Step 2.
- \`Labels.Validate()\` and the per-resource \`Validate()\` methods still call \`ValidateLabels\` (the system-mode validator) so already-stored \`apxy/\` keys validate cleanly on read, ahead of #196 starting to write them.

## Test plan
- [x] \`go test ./internal/database/\` — full package passes, including 19 new \`apxy/\` grammar cases and helper tests.
- [x] \`go test ./...\` — full repo passes; no regressions in routes, core, or proxy paths.
- [x] \`./scripts/preflight.sh\` — passes.
- [ ] Manual: hit \`PUT /<resource>/<id>/labels/apxy/cxr/foo\` and confirm a 4xx with a \"reserved\" error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)