### PR TITLE
Carry-forward labels — Step 2b: parent carry-forward on resource create (#201)

### DIFF
--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -393,7 +393,19 @@ func (s *service) CreateActor(ctx context.Context, a *Actor) error {
 			return fmt.Errorf("actor namespace does not exist: %w", ErrNamespaceDoesNotExist)
 		}
 
+		nsLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+			"path":       a.Namespace,
+			"deleted_at": nil,
+		})
+		if err != nil {
+			return err
+		}
+
 		cpy := *a
+		cpy.Labels = ApplyParentCarryForward(
+			cpy.Labels,
+			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
+		)
 		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
 		now := apctx.GetClock(ctx).Now()
 		cpy.CreatedAt = now
@@ -475,6 +487,17 @@ func (s *service) UpsertActor(ctx context.Context, d IActorData) (*Actor, error)
 				}
 				newActor.setFromData(d)
 				newActor.normalize()
+				nsLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+					"path":       newActor.Namespace,
+					"deleted_at": nil,
+				})
+				if err != nil {
+					return err
+				}
+				newActor.Labels = ApplyParentCarryForward(
+					newActor.Labels,
+					ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
+				)
 				newActor.Labels = InjectSelfImplicitLabels(newActor.Id, newActor.Namespace, newActor.Labels)
 				validationErr := newActor.validate()
 				if validationErr != nil {

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -200,32 +200,62 @@ func (s *service) CreateConnection(ctx context.Context, c *Connection) error {
 		return err
 	}
 
-	cpy := *c
-	cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
-	now := apctx.GetClock(ctx).Now()
-	cpy.CreatedAt = now
-	cpy.UpdatedAt = now
+	return s.transaction(func(tx *sql.Tx) error {
+		// Fetch parent labels for carry-forward materialization. Missing
+		// parents yield nil — the daily consistency checker reconciles any
+		// drift if the parent appears later.
+		cvLabels, err := s.fetchLabelsForCarryForward(ctx, tx, ConnectorVersionsTable, sq.Eq{
+			"id":         c.ConnectorId,
+			"version":    c.ConnectorVersion,
+			"deleted_at": nil,
+		})
+		if err != nil {
+			return err
+		}
+		nsLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+			"path":       c.Namespace,
+			"deleted_at": nil,
+		})
+		if err != nil {
+			return err
+		}
 
-	result, err := s.sq.
-		Insert(ConnectionsTable).
-		Columns(cpy.cols()...).
-		Values(cpy.values()...).
-		RunWith(s.db).
-		Exec()
-	if err != nil {
-		return err
-	}
+		cpy := *c
+		// Order: cv first, ns second so the connection's own namespace
+		// overrides the cv's namespace pass-through on apxy/ns/-/* keys.
+		// Then InjectSelfImplicitLabels writes apxy/cxn/-/* on top.
+		cpy.Labels = ApplyParentCarryForward(
+			cpy.Labels,
+			ParentCarryForward{Rt: ApidPrefixToLabelToken(apid.PrefixConnectorVersion), Labels: cvLabels},
+			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
+		)
+		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
 
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
+		now := apctx.GetClock(ctx).Now()
+		cpy.CreatedAt = now
+		cpy.UpdatedAt = now
 
-	if affected == 0 {
-		return errors.New("failed to create connection; no rows inserted")
-	}
+		result, err := s.sq.
+			Insert(ConnectionsTable).
+			Columns(cpy.cols()...).
+			Values(cpy.values()...).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return err
+		}
 
-	return nil
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+
+		if affected == 0 {
+			return errors.New("failed to create connection; no rows inserted")
+		}
+
+		return nil
+	})
 }
 
 func (s *service) GetConnection(ctx context.Context, id apid.ID) (*Connection, error) {

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -1114,4 +1114,123 @@ func TestConnections(t *testing.T) {
 		require.NotNil(t, c.EncryptedAt)
 		assert.True(t, c.EncryptedAt.Equal(now))
 	})
+
+	t.Run("carry-forward labels from connector version and namespace on create", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		now := time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		// Set up parents: namespace with user labels, then a connector
+		// version inside it with its own user label.
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:   "root.tenant-a",
+			State:  NamespaceStateActive,
+			Labels: Labels{"tier": "pro"},
+		}))
+
+		connectorID := apid.New(apid.PrefixConnectorVersion)
+		require.NoError(t, db.UpsertConnectorVersion(ctx, &ConnectorVersion{
+			Id:                  connectorID,
+			Version:             1,
+			Namespace:           "root.tenant-a",
+			State:               ConnectorVersionStateDraft,
+			Labels:              Labels{"type": "google-drive"},
+			Hash:                "h",
+			EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("ekv_test000000000001"), Data: "d"},
+		}))
+
+		// Create a connection that points at the connector version above.
+		connID := apid.New(apid.PrefixConnection)
+		require.NoError(t, db.CreateConnection(ctx, &Connection{
+			Id:               connID,
+			Namespace:        "root.tenant-a",
+			ConnectorId:      connectorID,
+			ConnectorVersion: 1,
+			State:            ConnectionStateCreated,
+			Labels:           Labels{"subscription": "gold"},
+		}))
+
+		c, err := db.GetConnection(ctx, connID)
+		require.NoError(t, err)
+
+		// User labels survive.
+		assert.Equal(t, "gold", c.Labels["subscription"])
+
+		// Connection's own self-implicit labels.
+		assert.Equal(t, string(connID), c.Labels["apxy/cxn/-/id"])
+		assert.Equal(t, "root.tenant-a", c.Labels["apxy/cxn/-/ns"])
+
+		// Connector-version carry-forward: user labels re-keyed under apxy/cxr/
+		// plus the cv's self-implicit ids forwarded as-is.
+		assert.Equal(t, "google-drive", c.Labels["apxy/cxr/type"])
+		assert.Equal(t, string(connectorID), c.Labels["apxy/cxr/-/id"])
+		assert.Equal(t, "root.tenant-a", c.Labels["apxy/cxr/-/ns"])
+
+		// Namespace carry-forward: user label re-keyed under apxy/ns/, plus
+		// the ns self-implicit ids. The connection's own namespace
+		// (root.tenant-a) wins over the cv's pass-through (which also points
+		// at root.tenant-a here, so the value is the same; the ordering is
+		// covered by TestApplyParentCarryForward).
+		assert.Equal(t, "pro", c.Labels["apxy/ns/tier"])
+		assert.Equal(t, "root.tenant-a", c.Labels["apxy/ns/-/id"])
+		assert.Equal(t, "root.tenant-a", c.Labels["apxy/ns/-/ns"])
+	})
+
+	t.Run("selector queries hit materialized parent labels", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		now := time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:  "root.sel",
+			State: NamespaceStateActive,
+		}))
+
+		cvDrive := apid.New(apid.PrefixConnectorVersion)
+		require.NoError(t, db.UpsertConnectorVersion(ctx, &ConnectorVersion{
+			Id:                  cvDrive,
+			Version:             1,
+			Namespace:           "root.sel",
+			State:               ConnectorVersionStateDraft,
+			Labels:              Labels{"type": "google-drive"},
+			Hash:                "h",
+			EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("ekv_test000000000001"), Data: "d"},
+		}))
+		cvSlack := apid.New(apid.PrefixConnectorVersion)
+		require.NoError(t, db.UpsertConnectorVersion(ctx, &ConnectorVersion{
+			Id:                  cvSlack,
+			Version:             1,
+			Namespace:           "root.sel",
+			State:               ConnectorVersionStateDraft,
+			Labels:              Labels{"type": "slack"},
+			Hash:                "h2",
+			EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("ekv_test000000000002"), Data: "d"},
+		}))
+
+		driveConn := apid.New(apid.PrefixConnection)
+		require.NoError(t, db.CreateConnection(ctx, &Connection{
+			Id:               driveConn,
+			Namespace:        "root.sel",
+			ConnectorId:      cvDrive,
+			ConnectorVersion: 1,
+			State:            ConnectionStateCreated,
+		}))
+		require.NoError(t, db.CreateConnection(ctx, &Connection{
+			Id:               apid.New(apid.PrefixConnection),
+			Namespace:        "root.sel",
+			ConnectorId:      cvSlack,
+			ConnectorVersion: 1,
+			State:            ConnectionStateCreated,
+		}))
+
+		// Filter connections by the parent connector version's user label —
+		// works for free because Step 2b materializes the carry-forward into
+		// each connection's own labels column.
+		page := db.ListConnectionsBuilder().
+			ForLabelSelector("apxy/cxr/type=google-drive").
+			FetchPage(ctx)
+		require.NoError(t, page.Error)
+		require.Len(t, page.Results, 1)
+		assert.Equal(t, driveConn, page.Results[0].Id)
+	})
 }

--- a/internal/database/connector_version.go
+++ b/internal/database/connector_version.go
@@ -433,7 +433,19 @@ func (s *service) UpsertConnectorVersion(ctx context.Context, cv *ConnectorVersi
 				return errors.New("cannot insert connector version at non-sequential version")
 			}
 
+			nsLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+				"path":       cv.Namespace,
+				"deleted_at": nil,
+			})
+			if err != nil {
+				return err
+			}
+
 			cpy := *cv
+			cpy.Labels = ApplyParentCarryForward(
+				cpy.Labels,
+				ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
+			)
 			cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
 			now := apctx.GetClock(ctx).Now()
 			cpy.CreatedAt = now

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -190,31 +190,45 @@ func (s *service) CreateEncryptionKey(ctx context.Context, ek *EncryptionKey) er
 		return err
 	}
 
-	ek.Labels = InjectSelfImplicitLabels(ek.Id, ek.Namespace, ek.Labels)
-	now := apctx.GetClock(ctx).Now()
-	ek.CreatedAt = now
-	ek.UpdatedAt = now
+	return s.transaction(func(tx *sql.Tx) error {
+		nsLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+			"path":       ek.Namespace,
+			"deleted_at": nil,
+		})
+		if err != nil {
+			return err
+		}
 
-	dbResult, err := s.sq.
-		Insert(EncryptionKeysTable).
-		Columns(ek.cols()...).
-		Values(ek.values()...).
-		RunWith(s.db).
-		Exec()
-	if err != nil {
-		return fmt.Errorf("failed to create encryption key: %w", err)
-	}
+		ek.Labels = ApplyParentCarryForward(
+			ek.Labels,
+			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
+		)
+		ek.Labels = InjectSelfImplicitLabels(ek.Id, ek.Namespace, ek.Labels)
+		now := apctx.GetClock(ctx).Now()
+		ek.CreatedAt = now
+		ek.UpdatedAt = now
 
-	affected, err := dbResult.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to create encryption key: %w", err)
-	}
+		dbResult, err := s.sq.
+			Insert(EncryptionKeysTable).
+			Columns(ek.cols()...).
+			Values(ek.values()...).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return fmt.Errorf("failed to create encryption key: %w", err)
+		}
 
-	if affected == 0 {
-		return errors.New("failed to create encryption key; no rows inserted")
-	}
+		affected, err := dbResult.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to create encryption key: %w", err)
+		}
 
-	return nil
+		if affected == 0 {
+			return errors.New("failed to create encryption key; no rows inserted")
+		}
+
+		return nil
+	})
 }
 
 func (s *service) UpdateEncryptionKey(ctx context.Context, id apid.ID, updates map[string]interface{}) (*EncryptionKey, error) {

--- a/internal/database/labels.go
+++ b/internal/database/labels.go
@@ -670,6 +670,43 @@ func MergeApxyAndUserLabels(user, apxy Labels) Labels {
 	return out
 }
 
+// ParentCarryForward bundles a parent's resource-type token with the
+// parent's stored labels for use with ApplyParentCarryForward.
+type ParentCarryForward struct {
+	Rt     string
+	Labels Labels
+}
+
+// ApplyParentCarryForward composes a child resource's labels from the
+// parents listed and the user-supplied labels. For each parent it calls
+// BuildCarriedLabels(parent.Rt, parent.Labels) and merges the result; the
+// user's own labels are merged last among non-self entries (they cannot
+// collide with apxy/ keys because user input cannot reference the apxy/
+// namespace). Parents are applied in order, so a later parent's apxy/
+// pass-through overrides an earlier parent's — list parents from most
+// distant to most direct so the most direct ancestor wins on conflicts
+// (deeper-overrides-shallower).
+//
+// Callers should follow with InjectSelfImplicitLabels (or
+// InjectNamespaceSelfImplicitLabels for path-keyed namespaces) so the
+// child's own self-implicit labels override any same-keyed pass-through
+// from a parent.
+func ApplyParentCarryForward(userLabels Labels, parents ...ParentCarryForward) Labels {
+	out := make(Labels)
+	for _, p := range parents {
+		for k, v := range BuildCarriedLabels(p.Rt, p.Labels) {
+			out[k] = v
+		}
+	}
+	for k, v := range userLabels {
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // BuildCarriedLabels takes a parent's labels and returns the carry-forward
 // labels for a child of the parent.
 //
@@ -695,4 +732,27 @@ func BuildCarriedLabels(parentRt string, parentLabels Labels) Labels {
 		out[fmt.Sprintf("%s%s/%s", ApxyReservedPrefix, parentRt, k)] = v
 	}
 	return out
+}
+
+// fetchLabelsForCarryForward returns the labels column for a row identified
+// by `where` in `table`, or nil if the row does not exist. Parent rows are
+// expected for carry-forward materialization but are not strictly required —
+// a missing parent simply yields no carry-forward and the daily consistency
+// checker can reconcile later if the parent appears.
+func (s *service) fetchLabelsForCarryForward(ctx context.Context, runner sq.BaseRunner, table string, where sq.Eq) (Labels, error) {
+	var labels Labels
+	err := s.sq.
+		Select("labels").
+		From(table).
+		Where(where).
+		RunWith(runner).
+		QueryRow().
+		Scan(&labels)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return labels, nil
 }

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -611,3 +611,49 @@ func TestInjectNamespaceSelfImplicitLabels(t *testing.T) {
 	require.Equal(t, "root.foo.bar", out["apxy/ns/-/ns"])
 	require.Equal(t, "oink", out["pig"])
 }
+
+func TestApplyParentCarryForward(t *testing.T) {
+	t.Run("merges user labels with parent carry-forward", func(t *testing.T) {
+		parent := Labels{
+			"type":          "google_drive",
+			"apxy/ns/-/id":  "root",
+			"apxy/ns/-/ns":  "root",
+			"apxy/ns/dog":   "woof",
+		}
+		out := ApplyParentCarryForward(
+			Labels{"subscription_level": "pro"},
+			ParentCarryForward{Rt: "cxr", Labels: parent},
+		)
+		require.Equal(t, "pro", out["subscription_level"])
+		require.Equal(t, "google_drive", out["apxy/cxr/type"])
+		require.Equal(t, "root", out["apxy/ns/-/id"])
+		require.Equal(t, "woof", out["apxy/ns/dog"])
+	})
+
+	t.Run("later parent overrides earlier on apxy/ collisions", func(t *testing.T) {
+		// Two parents both forwarding apxy/ns/-/ns. The "more direct" parent
+		// (listed last) wins.
+		cv := Labels{"apxy/ns/-/id": "root", "apxy/ns/-/ns": "root"}
+		ns := Labels{"apxy/ns/-/id": "root.foo", "apxy/ns/-/ns": "root.foo"}
+		out := ApplyParentCarryForward(
+			nil,
+			ParentCarryForward{Rt: "cxr", Labels: cv},
+			ParentCarryForward{Rt: "ns", Labels: ns},
+		)
+		require.Equal(t, "root.foo", out["apxy/ns/-/id"])
+		require.Equal(t, "root.foo", out["apxy/ns/-/ns"])
+	})
+
+	t.Run("returns nil when nothing to apply", func(t *testing.T) {
+		require.Nil(t, ApplyParentCarryForward(nil))
+		require.Nil(t, ApplyParentCarryForward(nil, ParentCarryForward{Rt: "cxr", Labels: nil}))
+	})
+
+	t.Run("user labels survive when no parent labels", func(t *testing.T) {
+		out := ApplyParentCarryForward(
+			Labels{"team": "platform"},
+			ParentCarryForward{Rt: "cxr", Labels: nil},
+		)
+		require.Equal(t, Labels{"team": "platform"}, out)
+	})
+}

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -265,6 +265,24 @@ func (s *service) createNamespace(ctx context.Context, tx *sql.Tx, ns *Namespace
 	// Update the state so that we are always bound by the parent namespace state
 	ns.State = state
 
+	// Materialize parent-namespace carry-forward. Each ancestor namespace
+	// already stored its own ancestor chain at create time, so it suffices
+	// to pull labels from the immediate parent and re-key its user portion
+	// under apxy/ns/<k> while forwarding apxy/ entries as-is.
+	if len(prefixes) > 1 {
+		parentPath := prefixes[len(prefixes)-2]
+		parentLabels, err := s.fetchLabelsForCarryForward(ctx, tx, NamespacesTable, sq.Eq{
+			"path":       parentPath,
+			"deleted_at": nil,
+		})
+		if err != nil {
+			return err
+		}
+		ns.Labels = ApplyParentCarryForward(
+			ns.Labels,
+			ParentCarryForward{Rt: NamespaceLabelToken, Labels: parentLabels},
+		)
+	}
 	ns.Labels = InjectNamespaceSelfImplicitLabels(ns.Path, ns.Labels)
 
 	now := apctx.GetClock(ctx).Now()

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1858,6 +1858,49 @@ INSERT INTO namespaces
 			require.Equal(t, "root.n2", pr.Results[0].Path)
 		})
 	})
+
+	t.Run("CarryForwardOnCreate", func(t *testing.T) {
+		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
+		now := time.Date(2023, 10, 15, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		// Parent: root.foo with two user labels.
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:   "root.foo",
+			State:  NamespaceStateActive,
+			Labels: Labels{"dog": "woof", "cat": "meow"},
+		}))
+
+		// Child: root.foo.bar with one new user label. It should carry
+		// forward dog and cat from the parent under apxy/ns/, plus its own
+		// pig user label, plus the apxy/ns/-/* self-implicit pointing at
+		// root.foo.bar (which overrides any pass-through of root.foo's
+		// self-implicit on the same keys).
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:   "root.foo.bar",
+			State:  NamespaceStateActive,
+			Labels: Labels{"pig": "oink"},
+		}))
+
+		bar, err := db.GetNamespace(ctx, "root.foo.bar")
+		require.NoError(t, err)
+
+		// Own user label.
+		require.Equal(t, "oink", bar.Labels["pig"])
+
+		// Parent user labels carried forward under apxy/ns/.
+		require.Equal(t, "woof", bar.Labels["apxy/ns/dog"])
+		require.Equal(t, "meow", bar.Labels["apxy/ns/cat"])
+
+		// Child's own self-implicit wins over the parent's pass-through.
+		require.Equal(t, "root.foo.bar", bar.Labels["apxy/ns/-/id"])
+		require.Equal(t, "root.foo.bar", bar.Labels["apxy/ns/-/ns"])
+
+		// And the parent's user labels did NOT silently leak into the
+		// child's user portion.
+		_, hasDog := bar.Labels["dog"]
+		require.False(t, hasDog)
+	})
 }
 
 func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {


### PR DESCRIPTION
Closes #201. Second slice of #196's split.

## Summary
Every newly-created labelled resource now persists its parents' carry-forward into its own \`labels\` column, in addition to the self-implicit labels added in #200.

### What lands here
- **Helpers in \`labels.go\`:** \`ParentCarryForward\` struct + \`ApplyParentCarryForward(userLabels, parents...)\`. Composes a child's labels from an ordered list of parents — user labels re-keyed under \`apxy/<parentRt>/<key>\`, \`apxy/\` entries forwarded as-is. Later parents override earlier ones on \`apxy/\` collisions, so callers list parents most-distant-first and the most direct ancestor wins (deeper-overrides-shallower).
- **Service helper \`fetchLabelsForCarryForward\`:** returns a row's \`labels\` column or nil if the row is absent. Missing parents yield no carry-forward; the daily consistency checker (#198) reconciles later. This matches the existing semantics where \`CreateConnection\` etc. don't strictly require the parent row to exist.
- **Wired into all five create paths** inside their transactions:
  - \`CreateConnection\`: parents = ConnectorVersion + Namespace, ordered so the connection's own namespace wins on \`apxy/ns/-/*\` collisions.
  - \`UpsertConnectorVersion\` (insert path): parent = Namespace.
  - \`CreateActor\` and \`UpsertActor\` (insert path): parent = Namespace.
  - \`CreateEncryptionKey\`: parent = Namespace.
  - \`createNamespace\`: parent = immediate ancestor namespace from \`SplitNamespacePathToPrefixes\`. Each ancestor already stored its own chain at create time, so pulling from the immediate parent yields the full chain via deeper-overrides-shallower merging.

## Tests
- \`TestApplyParentCarryForward\` — helper unit tests including parent ordering and \`apxy/\` pass-through.
- \`TestConnections/carry-forward_labels_from_connector_version_and_namespace_on_create\` — end-to-end: a connection in \`root.tenant-a\` with a connector version having user label \`{type: google-drive}\` and a namespace having \`{tier: pro}\` ends up with all the expected \`apxy/cxr/...\`, \`apxy/ns/...\`, \`apxy/cxn/-/...\` keys plus its own user label.
- \`TestConnections/selector_queries_hit_materialized_parent_labels\` — \`apxy/cxr/type=google-drive\` selector returns the right connection. Falls out for free since carry-forward is materialized into the child's own \`labels\` column; no selector code changes needed.
- \`TestNamespaces/CarryForwardOnCreate\` — parent-namespace inheritance: \`root.foo\` user labels \`{dog, cat}\` become \`apxy/ns/dog\`, \`apxy/ns/cat\` on child \`root.foo.bar\`; child's \`apxy/ns/-/id\` and \`apxy/ns/-/ns\` override the parent's pass-through.

## Out of scope (lands in #202)
- Triggers: connection upgrade to a new connector version, namespace move, parent user-label change propagation.

## Test plan
- [x] \`go test ./internal/database/\` — new tests pass.
- [x] \`go test ./...\` — full repo passes; no cross-package regressions.
- [x] \`./scripts/preflight.sh\` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)