### PR TITLE
Carry-forward labels — Step 3: per-request label snapshot (#197)

### DIFF
--- a/internal/apauth/core/request_auth.go
+++ b/internal/apauth/core/request_auth.go
@@ -19,6 +19,21 @@ func GetAuthFromContext(ctx context.Context) *RequestAuth {
 	return NewUnauthenticatedRequestAuth()
 }
 
+// ActorFromContext returns the initiating actor on the request context, or
+// nil if the request is unauthenticated. Returning an interface (rather
+// than *Actor) avoids passing a typed-nil pointer through an interface
+// argument elsewhere — a common pitfall where the wrapped interface is
+// non-nil despite the underlying pointer being nil. Callers can pass the
+// result directly to anything expecting an actor-shaped interface (e.g.
+// httpf.F.ForActor) and the nil-actor case will short-circuit cleanly.
+func ActorFromContext(ctx context.Context) IActorData {
+	auth := GetAuthFromContext(ctx)
+	if !auth.IsAuthenticated() {
+		return nil
+	}
+	return auth.GetActor()
+}
+
 // RequestAuth contains authentication and authorization information for a request.
 //
 // It includes the authenticated actor (user/service) and optionally request-level

--- a/internal/apauth/core/request_auth_test.go
+++ b/internal/apauth/core/request_auth_test.go
@@ -1,12 +1,39 @@
 package core
 
 import (
+	"context"
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/stretchr/testify/require"
 )
+
+func TestActorFromContext(t *testing.T) {
+	t.Run("returns nil for context without auth", func(t *testing.T) {
+		require.Nil(t, ActorFromContext(context.Background()))
+	})
+
+	t.Run("returns nil for unauthenticated request auth", func(t *testing.T) {
+		ctx := NewUnauthenticatedRequestAuth().ContextWith(context.Background())
+		require.Nil(t, ActorFromContext(ctx))
+	})
+
+	t.Run("returns the actor when authenticated", func(t *testing.T) {
+		actor := &Actor{
+			Id:         apid.MustParse("act_test1234567890ab"),
+			ExternalId: "ext-1",
+			Namespace:  "root.foo",
+			Labels:     map[string]string{"team": "platform"},
+		}
+		ctx := NewAuthenticatedRequestAuth(actor).ContextWith(context.Background())
+
+		got := ActorFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, actor.Id, got.GetId())
+		require.Equal(t, "platform", got.GetLabels()["team"])
+	})
+}
 
 func TestRequestAuth_Allows(t *testing.T) {
 	tests := []struct {

--- a/internal/auth_methods/no_auth/proxy.go
+++ b/internal/auth_methods/no_auth/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httpf"
 )
@@ -12,6 +13,7 @@ func (n *noAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 	r := n.httpf.
 		ForRequestType(reqType).
 		ForConnection(n.c).
+		ForActor(actorFromContext(ctx)).
 		ForLabels(req.Labels).
 		New().
 		UseContext(ctx).
@@ -29,6 +31,19 @@ func (n *noAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 
 func (n *noAuthConnection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
 	return nil
+}
+
+// actorFromContext returns the initiating actor from request context as a
+// httpf.Actor, or nil if the request is unauthenticated. The explicit
+// authentication check avoids passing a typed-nil *apauthcore.Actor through
+// the httpf.Actor interface (which would defeat ForActor's nil-receiver
+// short-circuit).
+func actorFromContext(ctx context.Context) httpf.Actor {
+	auth := apauthcore.GetAuthFromContext(ctx)
+	if !auth.IsAuthenticated() {
+		return nil
+	}
+	return auth.GetActor()
 }
 
 var _ iface.Proxy = (*noAuthConnection)(nil)

--- a/internal/auth_methods/no_auth/proxy.go
+++ b/internal/auth_methods/no_auth/proxy.go
@@ -13,7 +13,7 @@ func (n *noAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 	r := n.httpf.
 		ForRequestType(reqType).
 		ForConnection(n.c).
-		ForActor(actorFromContext(ctx)).
+		ForActor(apauthcore.ActorFromContext(ctx)).
 		ForLabels(req.Labels).
 		New().
 		UseContext(ctx).
@@ -31,19 +31,6 @@ func (n *noAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 
 func (n *noAuthConnection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
 	return nil
-}
-
-// actorFromContext returns the initiating actor from request context as a
-// httpf.Actor, or nil if the request is unauthenticated. The explicit
-// authentication check avoids passing a typed-nil *apauthcore.Actor through
-// the httpf.Actor interface (which would defeat ForActor's nil-receiver
-// short-circuit).
-func actorFromContext(ctx context.Context) httpf.Actor {
-	auth := apauthcore.GetAuthFromContext(ctx)
-	if !auth.IsAuthenticated() {
-		return nil
-	}
-	return auth.GetActor()
 }
 
 var _ iface.Proxy = (*noAuthConnection)(nil)

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -14,19 +14,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/httpf"
 )
 
-// actorFromContext returns the initiating actor from request context as a
-// httpf.Actor, or nil if the request is unauthenticated. The explicit
-// authentication check avoids passing a typed-nil *apauthcore.Actor through
-// the httpf.Actor interface (which would defeat ForActor's nil-receiver
-// short-circuit).
-func actorFromContext(ctx context.Context) httpf.Actor {
-	auth := apauthcore.GetAuthFromContext(ctx)
-	if !auth.IsAuthenticated() {
-		return nil
-	}
-	return auth.GetActor()
-}
-
 type refreshMode int
 
 const (
@@ -151,7 +138,7 @@ func (o *oAuth2Connection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 	r := o.httpf.
 		ForRequestType(reqType).
 		ForConnection(o.connection).
-		ForActor(actorFromContext(ctx)).
+		ForActor(apauthcore.ActorFromContext(ctx)).
 		ForLabels(req.Labels).
 		New().
 		UseContext(ctx).

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -7,11 +7,25 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/rmorlok/authproxy/internal/httperr"
+	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
 )
+
+// actorFromContext returns the initiating actor from request context as a
+// httpf.Actor, or nil if the request is unauthenticated. The explicit
+// authentication check avoids passing a typed-nil *apauthcore.Actor through
+// the httpf.Actor interface (which would defeat ForActor's nil-receiver
+// short-circuit).
+func actorFromContext(ctx context.Context) httpf.Actor {
+	auth := apauthcore.GetAuthFromContext(ctx)
+	if !auth.IsAuthenticated() {
+		return nil
+	}
+	return auth.GetActor()
+}
 
 type refreshMode int
 
@@ -137,6 +151,7 @@ func (o *oAuth2Connection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 	r := o.httpf.
 		ForRequestType(reqType).
 		ForConnection(o.connection).
+		ForActor(actorFromContext(ctx)).
 		ForLabels(req.Labels).
 		New().
 		UseContext(ctx).

--- a/internal/core/iface/proxy_test.go
+++ b/internal/core/iface/proxy_test.go
@@ -71,6 +71,24 @@ func TestProxyRequest_Validate(t *testing.T) {
 			},
 			expectedError: "either body_raw or body_json is must be specified",
 		},
+		{
+			name: "valid user labels",
+			proxyRequest: ProxyRequest{
+				URL:    "http://example.com",
+				Method: http.MethodGet,
+				Labels: map[string]string{"purpose": "ad-hoc"},
+			},
+			expectedError: "",
+		},
+		{
+			name: "rejects apxy/ user labels",
+			proxyRequest: ProxyRequest{
+				URL:    "http://example.com",
+				Method: http.MethodGet,
+				Labels: map[string]string{"apxy/cxn/-/id": "cxn_test1234567890ab"},
+			},
+			expectedError: "reserved",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -3,10 +3,12 @@ package httpf
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"gopkg.in/h2non/gentleman.v2"
 	"gopkg.in/h2non/gentleman.v2/plugins/transport"
@@ -123,8 +125,14 @@ func (f *clientFactory) ForLabels(labels map[string]string) F {
 		}
 		ri.Labels = newLabels
 	}
-	// Request labels override connection labels
+	// Request labels override connection user labels — but apxy/ keys are
+	// system-managed and per-request input may not modify them.
+	// ProxyRequest.Validate already rejects apxy/ keys; this is
+	// defense-in-depth against internal callers that might bypass it.
 	for k, v := range labels {
+		if strings.HasPrefix(k, database.ApxyReservedPrefix) {
+			continue
+		}
 		ri.Labels[k] = v
 	}
 

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -1,11 +1,13 @@
 package httpf
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -107,6 +109,54 @@ func (f *clientFactory) ForConnection(c Connection) F {
 	}
 
 	return fp.ForRequestInfo(ri)
+}
+
+// ForActor attaches the initiating actor's identity and labels to the
+// request snapshot. The actor's user labels are re-keyed under
+// apxy/act/<k> and the apxy/act/-/id and apxy/act/-/ns self-implicit
+// labels are added. Other apxy/-prefixed entries on the actor (e.g.
+// apxy/ns/<k> from the actor's namespace) are NOT forwarded — those
+// describe the actor's own context and would collide with the
+// connection's namespace context, which the request is acting under.
+//
+// A nil actor (or one with a nil id) is a no-op, so this can be safely
+// called from background paths where no actor initiated the request.
+func (f *clientFactory) ForActor(actor Actor) F {
+	if actor == nil || actor.GetId().IsNil() {
+		return f
+	}
+
+	actorContribution := make(map[string]string)
+	actToken := database.ApidPrefixToLabelToken(apid.PrefixActor)
+	for k, v := range actor.GetLabels() {
+		if strings.HasPrefix(k, database.ApxyReservedPrefix) {
+			continue
+		}
+		actorContribution[fmt.Sprintf("%s%s/%s", database.ApxyReservedPrefix, actToken, k)] = v
+	}
+	for k, v := range database.BuildImplicitIdentifierLabels(actor.GetId(), actor.GetNamespace()) {
+		actorContribution[k] = v
+	}
+
+	if len(actorContribution) == 0 {
+		return f
+	}
+
+	ri := f.requestInfo
+	if ri.Labels == nil {
+		ri.Labels = make(map[string]string, len(actorContribution))
+	} else {
+		copied := make(map[string]string, len(ri.Labels)+len(actorContribution))
+		for k, v := range ri.Labels {
+			copied[k] = v
+		}
+		ri.Labels = copied
+	}
+	for k, v := range actorContribution {
+		ri.Labels[k] = v
+	}
+
+	return f.ForRequestInfo(ri)
 }
 
 func (f *clientFactory) ForLabels(labels map[string]string) F {

--- a/internal/httpf/factory_labels_test.go
+++ b/internal/httpf/factory_labels_test.go
@@ -1,0 +1,117 @@
+package httpf
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+// stubConnection is a minimal Connection implementation for testing the
+// label-snapshot semantics of the request-info factory.
+type stubConnection struct {
+	id        apid.ID
+	namespace string
+	cvID      apid.ID
+	cvVersion uint64
+	labels    map[string]string
+}
+
+func (s *stubConnection) GetId() apid.ID                  { return s.id }
+func (s *stubConnection) GetNamespace() string            { return s.namespace }
+func (s *stubConnection) GetConnectorId() apid.ID         { return s.cvID }
+func (s *stubConnection) GetConnectorVersion() uint64     { return s.cvVersion }
+func (s *stubConnection) GetLabels() map[string]string    { return s.labels }
+
+func newTestFactory() *clientFactory {
+	return &clientFactory{
+		requestInfo: RequestInfo{},
+	}
+}
+
+func TestForConnectionCopiesAllLabels(t *testing.T) {
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		cvID:      apid.MustParse("cxr_test1234567890ab"),
+		cvVersion: 1,
+		labels: map[string]string{
+			"team":             "platform",
+			"apxy/cxn/-/id":    "cxn_test1234567890ab",
+			"apxy/cxn/-/ns":    "root.foo",
+			"apxy/cxr/type":    "google_drive",
+			"apxy/ns/tier":     "pro",
+		},
+	}
+
+	f := newTestFactory().ForConnection(conn).(*clientFactory)
+	require.Equal(t, "platform", f.requestInfo.Labels["team"])
+	require.Equal(t, "cxn_test1234567890ab", f.requestInfo.Labels["apxy/cxn/-/id"])
+	require.Equal(t, "google_drive", f.requestInfo.Labels["apxy/cxr/type"])
+	require.Equal(t, "pro", f.requestInfo.Labels["apxy/ns/tier"])
+}
+
+func TestForLabelsDoesNotOverrideApxyKeys(t *testing.T) {
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		labels: map[string]string{
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+			"apxy/cxr/type": "google_drive",
+		},
+	}
+
+	// Per-request input attempts to overwrite an apxy/ key (defense-in-depth:
+	// ProxyRequest.Validate normally rejects this; the factory MUST NOT
+	// honor it even if a caller bypasses validation).
+	perRequest := map[string]string{
+		"purpose":       "some_feature",
+		"apxy/cxr/type": "evil-override",
+	}
+
+	f := newTestFactory().ForConnection(conn).ForLabels(perRequest).(*clientFactory)
+
+	require.Equal(t, "some_feature", f.requestInfo.Labels["purpose"], "user labels merge in")
+	require.Equal(t, "google_drive", f.requestInfo.Labels["apxy/cxr/type"], "apxy/ keys are NOT overridable from per-request input")
+}
+
+func TestForLabelsAddsUserLabelsAlongsideApxy(t *testing.T) {
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		labels: map[string]string{
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+			"team":          "platform",
+		},
+	}
+
+	f := newTestFactory().ForConnection(conn).ForLabels(map[string]string{
+		"purpose": "ad-hoc",
+		"env":     "prod",
+	}).(*clientFactory)
+
+	// Connection labels survive.
+	require.Equal(t, "platform", f.requestInfo.Labels["team"])
+	require.Equal(t, "cxn_test1234567890ab", f.requestInfo.Labels["apxy/cxn/-/id"])
+
+	// Per-request labels added.
+	require.Equal(t, "ad-hoc", f.requestInfo.Labels["purpose"])
+	require.Equal(t, "prod", f.requestInfo.Labels["env"])
+}
+
+func TestForLabelsUserOverridesConnectionUserLabel(t *testing.T) {
+	// User-portion overrides ARE allowed — only apxy/ keys are protected.
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		labels: map[string]string{
+			"team": "platform",
+		},
+	}
+
+	f := newTestFactory().ForConnection(conn).ForLabels(map[string]string{
+		"team": "marketplace",
+	}).(*clientFactory)
+
+	require.Equal(t, "marketplace", f.requestInfo.Labels["team"])
+}

--- a/internal/httpf/factory_labels_test.go
+++ b/internal/httpf/factory_labels_test.go
@@ -23,6 +23,17 @@ func (s *stubConnection) GetConnectorId() apid.ID         { return s.cvID }
 func (s *stubConnection) GetConnectorVersion() uint64     { return s.cvVersion }
 func (s *stubConnection) GetLabels() map[string]string    { return s.labels }
 
+// stubActor is a minimal Actor implementation for testing.
+type stubActor struct {
+	id        apid.ID
+	namespace string
+	labels    map[string]string
+}
+
+func (s *stubActor) GetId() apid.ID               { return s.id }
+func (s *stubActor) GetNamespace() string         { return s.namespace }
+func (s *stubActor) GetLabels() map[string]string { return s.labels }
+
 func newTestFactory() *clientFactory {
 	return &clientFactory{
 		requestInfo: RequestInfo{},
@@ -114,4 +125,105 @@ func TestForLabelsUserOverridesConnectionUserLabel(t *testing.T) {
 	}).(*clientFactory)
 
 	require.Equal(t, "marketplace", f.requestInfo.Labels["team"])
+}
+
+func TestForActorAddsActorLabels(t *testing.T) {
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		labels: map[string]string{
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+			"apxy/cxn/-/ns": "root.foo",
+			"apxy/ns/tier":  "pro",
+		},
+	}
+	actor := &stubActor{
+		id:        apid.MustParse("act_test1234567890ab"),
+		namespace: "root.bar",
+		labels: map[string]string{
+			"team":  "marketplace",
+			"role":  "admin",
+		},
+	}
+
+	f := newTestFactory().ForConnection(conn).ForActor(actor).(*clientFactory)
+
+	// Actor's user labels are re-keyed under apxy/act/<k>.
+	require.Equal(t, "marketplace", f.requestInfo.Labels["apxy/act/team"])
+	require.Equal(t, "admin", f.requestInfo.Labels["apxy/act/role"])
+
+	// Actor's self-implicit identifier labels are present.
+	require.Equal(t, "act_test1234567890ab", f.requestInfo.Labels["apxy/act/-/id"])
+	require.Equal(t, "root.bar", f.requestInfo.Labels["apxy/act/-/ns"])
+
+	// Connection's apxy/ labels survive — actor doesn't trample them.
+	require.Equal(t, "cxn_test1234567890ab", f.requestInfo.Labels["apxy/cxn/-/id"])
+	require.Equal(t, "root.foo", f.requestInfo.Labels["apxy/cxn/-/ns"])
+	require.Equal(t, "pro", f.requestInfo.Labels["apxy/ns/tier"])
+}
+
+func TestForActorDoesNotForwardActorApxyKeys(t *testing.T) {
+	// Even if the actor's labels contain apxy/ entries (e.g. read fresh
+	// from a stored actor row), only the user portion is re-keyed under
+	// apxy/act/<k>. The actor's own apxy/ns/* would otherwise collide
+	// with the connection's namespace context.
+	actor := &stubActor{
+		id:        apid.MustParse("act_test1234567890ab"),
+		namespace: "root.bar",
+		labels: map[string]string{
+			"team":          "marketplace",
+			"apxy/ns/tier":  "free",     // should NOT propagate
+			"apxy/act/-/id": "ignored",  // self-implicit comes from id, not from labels
+		},
+	}
+
+	f := newTestFactory().ForActor(actor).(*clientFactory)
+
+	require.Equal(t, "marketplace", f.requestInfo.Labels["apxy/act/team"])
+	require.Equal(t, "act_test1234567890ab", f.requestInfo.Labels["apxy/act/-/id"])
+	_, hasNs := f.requestInfo.Labels["apxy/ns/tier"]
+	require.False(t, hasNs, "actor's apxy/ns/* must not leak through to the request")
+}
+
+func TestForActorNilIsNoop(t *testing.T) {
+	f := newTestFactory()
+	require.Equal(t, f, f.ForActor(nil), "nil actor must be a no-op")
+
+	// And typed-nil pointer wrapped in interface — callers should not
+	// produce this (per actorFromContext helper) but be defensive: a
+	// nil-id actor short-circuits.
+	emptyActor := &stubActor{}
+	out := f.ForActor(emptyActor).(*clientFactory)
+	require.Empty(t, out.requestInfo.Labels)
+}
+
+func TestForActorAfterForLabelsApxyStillProtected(t *testing.T) {
+	// Order: connection → actor → per-request labels.
+	// Per-request labels with apxy/ are still filtered out by ForLabels
+	// (defense-in-depth).
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		labels: map[string]string{
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+		},
+	}
+	actor := &stubActor{
+		id:        apid.MustParse("act_test1234567890ab"),
+		namespace: "root.bar",
+	}
+
+	f := newTestFactory().
+		ForConnection(conn).
+		ForActor(actor).
+		ForLabels(map[string]string{
+			"purpose":       "ad-hoc",
+			"apxy/act/team": "evil-override",
+		}).(*clientFactory)
+
+	require.Equal(t, "ad-hoc", f.requestInfo.Labels["purpose"])
+	// apxy/act/team would have been set by actor (if user labels included it)
+	// or absent (as here). Either way, per-request input cannot insert it.
+	_, hasEvil := f.requestInfo.Labels["apxy/act/team"]
+	require.False(t, hasEvil)
 }

--- a/internal/httpf/interface.go
+++ b/internal/httpf/interface.go
@@ -30,6 +30,18 @@ type Connection interface {
 	GetLabels() map[string]string
 }
 
+// Actor is the minimum surface needed to attach an actor's identity and
+// labels to an outgoing request. The full Actor type lives in apauth/core
+// (it carries permissions, session info, etc.) but for label-snapshot
+// purposes the request-info factory only needs the id, namespace, and
+// label set. A nil Actor (e.g. background token-refresh requests where no
+// actor initiated the call) is a valid input for ForActor.
+type Actor interface {
+	GetId() apid.ID
+	GetNamespace() string
+	GetLabels() map[string]string
+}
+
 //go:generate mockgen -source=./interface.go -destination=./mock/httpf.go -package=mock
 type F interface {
 	New() *gentleman.Client
@@ -37,5 +49,6 @@ type F interface {
 	ForRequestType(rt RequestType) F
 	ForConnectorVersion(cv ConnectorVersion) F
 	ForConnection(cv Connection) F
+	ForActor(actor Actor) F
 	ForLabels(labels map[string]string) F
 }

--- a/internal/httpf/mock/httpf.go
+++ b/internal/httpf/mock/httpf.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	apid "github.com/rmorlok/authproxy/internal/apid"
 	httpf "github.com/rmorlok/authproxy/internal/httpf"
+	connectors "github.com/rmorlok/authproxy/internal/schema/connectors"
 	gentleman "gopkg.in/h2non/gentleman.v2"
 )
 
@@ -115,6 +116,43 @@ func (mr *MockGettableConnectorVersionMockRecorder) GetConnectorVersionEntity() 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorVersionEntity", reflect.TypeOf((*MockGettableConnectorVersion)(nil).GetConnectorVersionEntity))
 }
 
+// MockRateLimitConfigProvider is a mock of RateLimitConfigProvider interface.
+type MockRateLimitConfigProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockRateLimitConfigProviderMockRecorder
+}
+
+// MockRateLimitConfigProviderMockRecorder is the mock recorder for MockRateLimitConfigProvider.
+type MockRateLimitConfigProviderMockRecorder struct {
+	mock *MockRateLimitConfigProvider
+}
+
+// NewMockRateLimitConfigProvider creates a new mock instance.
+func NewMockRateLimitConfigProvider(ctrl *gomock.Controller) *MockRateLimitConfigProvider {
+	mock := &MockRateLimitConfigProvider{ctrl: ctrl}
+	mock.recorder = &MockRateLimitConfigProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRateLimitConfigProvider) EXPECT() *MockRateLimitConfigProviderMockRecorder {
+	return m.recorder
+}
+
+// GetRateLimitConfig mocks base method.
+func (m *MockRateLimitConfigProvider) GetRateLimitConfig() *connectors.RateLimiting {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRateLimitConfig")
+	ret0, _ := ret[0].(*connectors.RateLimiting)
+	return ret0
+}
+
+// GetRateLimitConfig indicates an expected call of GetRateLimitConfig.
+func (mr *MockRateLimitConfigProviderMockRecorder) GetRateLimitConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRateLimitConfig", reflect.TypeOf((*MockRateLimitConfigProvider)(nil).GetRateLimitConfig))
+}
+
 // MockConnection is a mock of Connection interface.
 type MockConnection struct {
 	ctrl     *gomock.Controller
@@ -208,6 +246,71 @@ func (mr *MockConnectionMockRecorder) GetNamespace() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockConnection)(nil).GetNamespace))
 }
 
+// MockActor is a mock of Actor interface.
+type MockActor struct {
+	ctrl     *gomock.Controller
+	recorder *MockActorMockRecorder
+}
+
+// MockActorMockRecorder is the mock recorder for MockActor.
+type MockActorMockRecorder struct {
+	mock *MockActor
+}
+
+// NewMockActor creates a new mock instance.
+func NewMockActor(ctrl *gomock.Controller) *MockActor {
+	mock := &MockActor{ctrl: ctrl}
+	mock.recorder = &MockActorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockActor) EXPECT() *MockActorMockRecorder {
+	return m.recorder
+}
+
+// GetId mocks base method.
+func (m *MockActor) GetId() apid.ID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetId")
+	ret0, _ := ret[0].(apid.ID)
+	return ret0
+}
+
+// GetId indicates an expected call of GetId.
+func (mr *MockActorMockRecorder) GetId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetId", reflect.TypeOf((*MockActor)(nil).GetId))
+}
+
+// GetLabels mocks base method.
+func (m *MockActor) GetLabels() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLabels")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetLabels indicates an expected call of GetLabels.
+func (mr *MockActorMockRecorder) GetLabels() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabels", reflect.TypeOf((*MockActor)(nil).GetLabels))
+}
+
+// GetNamespace mocks base method.
+func (m *MockActor) GetNamespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNamespace indicates an expected call of GetNamespace.
+func (mr *MockActorMockRecorder) GetNamespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockActor)(nil).GetNamespace))
+}
+
 // MockF is a mock of F interface.
 type MockF struct {
 	ctrl     *gomock.Controller
@@ -231,18 +334,18 @@ func (m *MockF) EXPECT() *MockFMockRecorder {
 	return m.recorder
 }
 
-// ForLabels mocks base method.
-func (m *MockF) ForLabels(labels map[string]string) httpf.F {
+// ForActor mocks base method.
+func (m *MockF) ForActor(actor httpf.Actor) httpf.F {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForLabels", labels)
+	ret := m.ctrl.Call(m, "ForActor", actor)
 	ret0, _ := ret[0].(httpf.F)
 	return ret0
 }
 
-// ForLabels indicates an expected call of ForLabels.
-func (mr *MockFMockRecorder) ForLabels(labels interface{}) *gomock.Call {
+// ForActor indicates an expected call of ForActor.
+func (mr *MockFMockRecorder) ForActor(actor interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForLabels", reflect.TypeOf((*MockF)(nil).ForLabels), labels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForActor", reflect.TypeOf((*MockF)(nil).ForActor), actor)
 }
 
 // ForConnection mocks base method.
@@ -271,6 +374,20 @@ func (m *MockF) ForConnectorVersion(cv httpf.ConnectorVersion) httpf.F {
 func (mr *MockFMockRecorder) ForConnectorVersion(cv interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForConnectorVersion", reflect.TypeOf((*MockF)(nil).ForConnectorVersion), cv)
+}
+
+// ForLabels mocks base method.
+func (m *MockF) ForLabels(labels map[string]string) httpf.F {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForLabels", labels)
+	ret0, _ := ret[0].(httpf.F)
+	return ret0
+}
+
+// ForLabels indicates an expected call of ForLabels.
+func (mr *MockFMockRecorder) ForLabels(labels interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForLabels", reflect.TypeOf((*MockF)(nil).ForLabels), labels)
 }
 
 // ForRequestInfo mocks base method.

--- a/internal/httpf/mock/setup.go
+++ b/internal/httpf/mock/setup.go
@@ -50,6 +50,12 @@ func NewFactoryWithMockingClient(ctrl *gomock.Controller) *MockF {
 
 	h.
 		EXPECT().
+		ForActor(gomock.Any()).
+		Return(h).
+		AnyTimes()
+
+	h.
+		EXPECT().
 		ForLabels(gomock.Any()).
 		Return(h).
 		AnyTimes()


### PR DESCRIPTION
Closes #197.

## Summary
After Step 2, a connection's `labels` column contains the full materialized set: user labels, `apxy/cxn/-/*` self-implicit, `apxy/cxr/*` carried from the connector version, and `apxy/ns/*` carried from the namespace. The request path was already wired to snapshot those onto the request via `httpf.ForConnection` → `SetLogRecordFieldsFromRequestInfo` → `LogRecord.Labels`. This PR closes three remaining gaps.

### 1. Per-request submission of `apxy/` keys is rejected
`ProxyRequest.Validate` already calls the user-input validator from #195, so `apxy/` keys in the request body never reach the proxy code path.

### 2. `apxy/` keys in per-request input never override system-managed labels
`httpf.ForLabels` now skips `apxy/`-prefixed keys when merging per-request labels onto the connection's snapshot. User-portion overrides still work — a request can override `team`, but not `apxy/cxr/type`.

### 3. The initiating actor's identity and labels are part of the snapshot
For actor-driven requests (proxy calls), the request now also carries the requester's identity and labels:
- New `httpf.Actor` interface plus `F.ForActor(actor)` method.
- The actor's user labels are re-keyed under `apxy/act/<k>`; `apxy/act/-/id` and `apxy/act/-/ns` self-implicit labels are added.
- Other `apxy/`-prefixed entries on the actor (e.g. `apxy/ns/*` from the actor's own namespace) are NOT forwarded — those describe the actor's context and would collide with the connection's namespace, which the request is acting under.
- `ForActor(nil)` is a no-op so background paths with no initiating actor (e.g. OAuth2 token refresh) skip the step cleanly.

Wired into `auth_methods/no_auth/proxy.go` and `auth_methods/oauth2/proxy.go`'s user-facing proxy calls. The OAuth2 token-refresh path intentionally does not call `ForActor` — it has no initiating actor.

## Scope
- `internal/httpf/interface.go` — add `Actor` interface and `ForActor` method on `F`.
- `internal/httpf/factory.go` — implement `ForActor`; tighten `ForLabels` to skip `apxy/` keys.
- `internal/httpf/mock/setup.go` — include `ForActor` in `AnyTimes` wiring.
- `internal/auth_methods/no_auth/proxy.go`, `internal/auth_methods/oauth2/proxy.go` — invoke `ForActor` with an `actorFromContext` helper that returns `nil` for unauthenticated requests (avoids typed-nil through the interface).
- `internal/core/iface/proxy.go` — reject `apxy/` keys in `ProxyRequest.Validate` (was already done in #195; covered by extended test here).

## Tests
- `internal/httpf/factory_labels_test.go`:
  - Connection labels (user + `apxy/`) land in `RequestInfo.Labels` via `ForConnection`.
  - Per-request `apxy/` overrides are silently dropped by `ForLabels`.
  - Per-request user labels add alongside the connection's `apxy/` labels.
  - User-portion overrides from per-request input still work.
  - Actor's user labels become `apxy/act/<k>` plus self-implicit `apxy/act/-/id`/`-/ns`.
  - Actor's `apxy/ns/*` does not leak through.
  - `ForActor(nil)` and nil-id actor short-circuit.
  - Per-request input can't inject `apxy/act/<k>` even after the actor step.
- `internal/core/iface/proxy_test.go`: extend `TestProxyRequest_Validate` with cases for valid user labels and rejected `apxy/` user labels.

## Historical-snapshot guarantee
`LogRecord` stores its own labels JSON column with no FK to the connection's labels. Once written, later changes to the connection's labels cannot retroactively rewrite a logged record — the data model already gives us the snapshot semantics for free.

## Test plan
- [x] `go test ./internal/httpf/` — new tests pass.
- [x] `go test ./internal/core/iface/` — extended validate test passes.
- [x] `go test ./...` — full repo passes; no cross-package regressions.
- [x] `./scripts/preflight.sh` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)