### PR TITLE
Carry-forward labels — Step 4: daily consistency checker (#198)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2
 	github.com/bsm/redislock v0.9.4
+	github.com/cbroglie/mustache v1.4.0
+	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/gin-contrib/cors v1.7.6
@@ -46,6 +48,8 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	golang.org/x/crypto v0.47.0
+	golang.org/x/time v0.12.0
+	google.golang.org/api v0.247.0
 	gopkg.in/h2non/gentleman-mock.v2 v2.0.0
 	gopkg.in/h2non/gentleman.v2 v2.0.5
 	gopkg.in/h2non/gock.v1 v1.1.2
@@ -83,7 +87,6 @@ require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
-	github.com/cbroglie/mustache v1.4.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
@@ -91,7 +94,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
-	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
@@ -172,9 +174,7 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
-	google.golang.org/api v0.247.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLR
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=

--- a/internal/core/iface/encryption_key.go
+++ b/internal/core/iface/encryption_key.go
@@ -21,7 +21,7 @@ type EncryptionKey interface {
 
 type ListEncryptionKeysExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[EncryptionKey]
-	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[EncryptionKey]) error
 }
 
 type ListEncryptionKeysBuilder interface {

--- a/internal/core/iface/list_connections.go
+++ b/internal/core/iface/list_connections.go
@@ -9,7 +9,7 @@ import (
 
 type ListConnectionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connection]
-	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Connection]) error
 }
 
 type ListConnectionsBuilder interface {

--- a/internal/core/iface/list_connector_versions.go
+++ b/internal/core/iface/list_connector_versions.go
@@ -14,7 +14,7 @@ import (
 
 type ListConnectorVersionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[ConnectorVersion]
-	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[ConnectorVersion]) error
 }
 
 type ListConnectorVersionsBuilder interface {

--- a/internal/core/iface/list_connectors.go
+++ b/internal/core/iface/list_connectors.go
@@ -10,7 +10,7 @@ import (
 
 type ListConnectorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connector]
-	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Connector]) error
 }
 
 type ListConnectorsBuilder interface {

--- a/internal/core/iface/namespace.go
+++ b/internal/core/iface/namespace.go
@@ -25,7 +25,7 @@ type Namespace interface {
 
 type ListNamespacesExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Namespace]
-	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Namespace]) error
 }
 
 type ListNamespacesBuilder interface {

--- a/internal/core/service_connection_list.go
+++ b/internal/core/service_connection_list.go
@@ -83,7 +83,7 @@ func (l *listConnectionsWrapper) FetchPage(ctx context.Context) pagination.PageR
 	return l.convertPageResult(ctx, l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectionsWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connection]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectionsWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.Connection]) error {
 	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connection]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(ctx, result))
 	})

--- a/internal/core/service_connector_list.go
+++ b/internal/core/service_connector_list.go
@@ -53,7 +53,7 @@ func (l *listConnectorWrapper) FetchPage(ctx context.Context) pagination.PageRes
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectorWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Connector]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectorWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.Connector]) error {
 	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Connector]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})

--- a/internal/core/service_connector_version_list.go
+++ b/internal/core/service_connector_version_list.go
@@ -45,7 +45,7 @@ func (l *listConnectorVersionWrapper) FetchPage(ctx context.Context) pagination.
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listConnectorVersionWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectorVersionWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.ConnectorVersion]) error {
 	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.ConnectorVersion]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})

--- a/internal/core/service_encryption_key.go
+++ b/internal/core/service_encryption_key.go
@@ -187,7 +187,7 @@ func (l *listEncryptionKeyWrapper) FetchPage(ctx context.Context) pagination.Pag
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listEncryptionKeyWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listEncryptionKeyWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.EncryptionKey]) error {
 	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.EncryptionKey]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})

--- a/internal/core/service_namespace.go
+++ b/internal/core/service_namespace.go
@@ -239,7 +239,7 @@ func (l *listNamespaceWrapper) FetchPage(ctx context.Context) pagination.PageRes
 	return l.convertPageResult(l.executor().FetchPage(ctx))
 }
 
-func (l *listNamespaceWrapper) Enumerate(ctx context.Context, callback func(pagination.PageResult[iface.Namespace]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listNamespaceWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.Namespace]) error {
 	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.Namespace]) (keepGoing pagination.KeepGoing, err error) {
 		return callback(l.convertPageResult(result))
 	})

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -607,7 +607,7 @@ func (s *service) DeleteActor(ctx context.Context, id apid.ID) error {
 
 type ListActorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[*Actor]
-	Enumerate(context.Context, func(pagination.PageResult[*Actor]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[*Actor]) error
 }
 
 type ListActorsBuilder interface {
@@ -782,7 +782,7 @@ func (l *listActorsFilters) FetchPage(ctx context.Context) pagination.PageResult
 	return l.fetchPage(ctx)
 }
 
-func (l *listActorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[*Actor]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listActorsFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[*Actor]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -469,7 +469,7 @@ func IsValidConnectionOrderByField[T string | ConnectionOrderByField](field T) b
 
 type ListConnectionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connection]
-	Enumerate(context.Context, func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Connection]) error
 }
 
 type ListConnectionsBuilder interface {
@@ -689,7 +689,7 @@ func (l *listConnectionsFilters) FetchPage(ctx context.Context) pagination.PageR
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectionsFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[Connection]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/connector.go
+++ b/internal/database/connector.go
@@ -53,7 +53,7 @@ func IsValidConnectorOrderByField[T string | ConnectorOrderByField](field T) boo
 
 type ListConnectorsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Connector]
-	Enumerate(context.Context, func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Connector]) error
 }
 
 type ListConnectorsBuilder interface {
@@ -324,7 +324,7 @@ func (l *listConnectorsFilters) FetchPage(ctx context.Context) pagination.PageRe
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectorsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Connector]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectorsFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[Connector]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/connector_version.go
+++ b/internal/database/connector_version.go
@@ -721,7 +721,7 @@ func IsValidConnectorVersionOrderByField[T string | ConnectorVersionOrderByField
 
 type ListConnectorVersionsExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[ConnectorVersion]
-	Enumerate(context.Context, func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[ConnectorVersion]) error
 }
 
 type ListConnectorVersionsBuilder interface {
@@ -930,7 +930,7 @@ func (l *listConnectorVersionsFilters) FetchPage(ctx context.Context) pagination
 	return l.fetchPage(ctx)
 }
 
-func (l *listConnectorVersionsFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[ConnectorVersion]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listConnectorVersionsFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[ConnectorVersion]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -612,7 +612,7 @@ func (s *service) DeleteEncryptionKeyAnnotations(ctx context.Context, id apid.ID
 
 type ListEncryptionKeysExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[EncryptionKey]
-	Enumerate(context.Context, func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[EncryptionKey]) error
 }
 
 type ListEncryptionKeysBuilder interface {
@@ -787,7 +787,7 @@ func (l *listEncryptionKeysFilters) FetchPage(ctx context.Context) pagination.Pa
 	return l.fetchPage(ctx)
 }
 
-func (l *listEncryptionKeysFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[EncryptionKey]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listEncryptionKeysFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[EncryptionKey]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -9,6 +9,7 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
+	"golang.org/x/time/rate"
 )
 
 type DeletedHandling bool
@@ -243,14 +244,15 @@ type DB interface {
 	RefreshConnectionsForConnectorVersion(ctx context.Context, id apid.ID, version uint64) error
 
 	// ReconcileCarryForwardLabels walks every labelled resource in batches
-	// of `batchSize`, sleeps `interBatchDelay` between batches, and
-	// re-derives the materialized apxy/ portion of each row. Drift is
-	// rare under normal operation, but this method is the safety net for
-	// any propagation task that misfired or any data path that bypassed
-	// the carry-forward triggers. Intended to be invoked from a daily
-	// asynq cron task. Returns the total number of rows whose labels
-	// were corrected.
-	ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (corrected int64, err error)
+	// of `batchSize` and re-derives the materialized apxy/ portion of
+	// each row. The optional `limiter` is consulted before each row is
+	// processed, providing a per-row records/sec rate limit; nil means
+	// unlimited. Drift is rare under normal operation, but this method
+	// is the safety net for any propagation task that misfired or any
+	// data path that bypassed the carry-forward triggers. Intended to be
+	// invoked from a daily asynq cron task. Returns the total number of
+	// rows whose labels were corrected.
+	ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, limiter *rate.Limiter) (corrected int64, err error)
 
 	/*
 	 *  Nonces

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -242,6 +242,16 @@ type DB interface {
 	// draft versions; primary and active are immutable).
 	RefreshConnectionsForConnectorVersion(ctx context.Context, id apid.ID, version uint64) error
 
+	// ReconcileCarryForwardLabels walks every labelled resource in batches
+	// of `batchSize`, sleeps `interBatchDelay` between batches, and
+	// re-derives the materialized apxy/ portion of each row. Drift is
+	// rare under normal operation, but this method is the safety net for
+	// any propagation task that misfired or any data path that bypassed
+	// the carry-forward triggers. Intended to be invoked from a daily
+	// asynq cron task. Returns the total number of rows whose labels
+	// were corrected.
+	ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (corrected int64, err error)
+
 	/*
 	 *  Nonces
 	 */

--- a/internal/database/labels_propagate.go
+++ b/internal/database/labels_propagate.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 )
 
@@ -57,7 +59,7 @@ func (s *service) RefreshNamespaceLabelsCarryForward(ctx context.Context, nsPath
 		return err
 	}
 	for _, childPath := range childPaths {
-		if err := s.recomputeNamespaceLabelsTx(ctx, childPath); err != nil {
+		if _, err := s.recomputeNamespaceLabelsTx(ctx, childPath); err != nil {
 			return err
 		}
 		if err := s.RefreshNamespaceLabelsCarryForward(ctx, childPath); err != nil {
@@ -99,7 +101,7 @@ func (s *service) RefreshConnectionsForConnectorVersion(ctx context.Context, id 
 	}
 	rows.Close()
 	for _, connID := range ids {
-		if err := s.recomputeConnectionLabelsTx(ctx, connID); err != nil {
+		if _, err := s.recomputeConnectionLabelsTx(ctx, connID); err != nil {
 			return err
 		}
 	}
@@ -164,7 +166,7 @@ func (s *service) refreshConnectionsInNamespace(ctx context.Context, nsPath stri
 		return err
 	}
 	for _, id := range ids {
-		if err := s.recomputeConnectionLabelsTx(ctx, id); err != nil {
+		if _, err := s.recomputeConnectionLabelsTx(ctx, id); err != nil {
 			return err
 		}
 	}
@@ -177,7 +179,7 @@ func (s *service) refreshActorsInNamespace(ctx context.Context, nsPath string) e
 		return err
 	}
 	for _, id := range ids {
-		if err := s.recomputeActorLabelsTx(ctx, id); err != nil {
+		if _, err := s.recomputeActorLabelsTx(ctx, id); err != nil {
 			return err
 		}
 	}
@@ -190,7 +192,7 @@ func (s *service) refreshEncryptionKeysInNamespace(ctx context.Context, nsPath s
 		return err
 	}
 	for _, id := range ids {
-		if err := s.recomputeEncryptionKeyLabelsTx(ctx, id); err != nil {
+		if _, err := s.recomputeEncryptionKeyLabelsTx(ctx, id); err != nil {
 			return err
 		}
 	}
@@ -226,7 +228,7 @@ func (s *service) refreshConnectorVersionsInNamespace(ctx context.Context, nsPat
 	}
 	rows.Close()
 	for _, ref := range refs {
-		if err := s.recomputeConnectorVersionLabelsTx(ctx, ref.id, ref.version); err != nil {
+		if _, err := s.recomputeConnectorVersionLabelsTx(ctx, ref.id, ref.version); err != nil {
 			return err
 		}
 	}
@@ -235,9 +237,11 @@ func (s *service) refreshConnectorVersionsInNamespace(ctx context.Context, nsPat
 
 // recomputeConnectionLabelsTx opens a short transaction, re-derives the
 // connection's full labels from its current connector version + namespace +
-// own user labels, and persists the result.
-func (s *service) recomputeConnectionLabelsTx(ctx context.Context, id apid.ID) error {
-	return s.transaction(func(tx *sql.Tx) error {
+// own user labels, and persists the result if it differs. Returns true if
+// drift was detected and corrected.
+func (s *service) recomputeConnectionLabelsTx(ctx context.Context, id apid.ID) (bool, error) {
+	var corrected bool
+	err := s.transaction(func(tx *sql.Tx) error {
 		var conn Connection
 		err := s.sq.
 			Select(conn.cols()...).
@@ -278,14 +282,19 @@ func (s *service) recomputeConnectionLabelsTx(ctx context.Context, id apid.ID) e
 		)
 		newLabels = InjectSelfImplicitLabels(conn.Id, conn.Namespace, newLabels)
 
-		return s.writeRecomputedLabels(ctx, tx, ConnectionsTable, sq.Eq{"id": id, "deleted_at": nil}, newLabels)
+		var werr error
+		corrected, werr = s.writeRecomputedLabels(ctx, tx, ConnectionsTable, sq.Eq{"id": id, "deleted_at": nil}, conn.Labels, newLabels)
+		return werr
 	})
+	return corrected, err
 }
 
 // recomputeActorLabelsTx opens a short transaction and re-derives an
-// actor's full labels from its namespace and own user labels.
-func (s *service) recomputeActorLabelsTx(ctx context.Context, id apid.ID) error {
-	return s.transaction(func(tx *sql.Tx) error {
+// actor's full labels from its namespace and own user labels. Returns true
+// if drift was detected and corrected.
+func (s *service) recomputeActorLabelsTx(ctx context.Context, id apid.ID) (bool, error) {
+	var corrected bool
+	err := s.transaction(func(tx *sql.Tx) error {
 		var a Actor
 		err := s.sq.
 			Select(a.cols()...).
@@ -316,14 +325,19 @@ func (s *service) recomputeActorLabelsTx(ctx context.Context, id apid.ID) error 
 		)
 		newLabels = InjectSelfImplicitLabels(a.Id, a.Namespace, newLabels)
 
-		return s.writeRecomputedLabels(ctx, tx, ActorTable, sq.Eq{"id": id, "deleted_at": nil}, newLabels)
+		var werr error
+		corrected, werr = s.writeRecomputedLabels(ctx, tx, ActorTable, sq.Eq{"id": id, "deleted_at": nil}, a.Labels, newLabels)
+		return werr
 	})
+	return corrected, err
 }
 
 // recomputeEncryptionKeyLabelsTx opens a short transaction and re-derives
 // an encryption key's full labels from its namespace and own user labels.
-func (s *service) recomputeEncryptionKeyLabelsTx(ctx context.Context, id apid.ID) error {
-	return s.transaction(func(tx *sql.Tx) error {
+// Returns true if drift was detected and corrected.
+func (s *service) recomputeEncryptionKeyLabelsTx(ctx context.Context, id apid.ID) (bool, error) {
+	var corrected bool
+	err := s.transaction(func(tx *sql.Tx) error {
 		var ek EncryptionKey
 		err := s.sq.
 			Select(ek.cols()...).
@@ -354,15 +368,19 @@ func (s *service) recomputeEncryptionKeyLabelsTx(ctx context.Context, id apid.ID
 		)
 		newLabels = InjectSelfImplicitLabels(ek.Id, ek.Namespace, newLabels)
 
-		return s.writeRecomputedLabels(ctx, tx, EncryptionKeysTable, sq.Eq{"id": id, "deleted_at": nil}, newLabels)
+		var werr error
+		corrected, werr = s.writeRecomputedLabels(ctx, tx, EncryptionKeysTable, sq.Eq{"id": id, "deleted_at": nil}, ek.Labels, newLabels)
+		return werr
 	})
+	return corrected, err
 }
 
 // recomputeConnectorVersionLabelsTx opens a short transaction and
 // re-derives a connector version's full labels from its namespace and own
-// user labels.
-func (s *service) recomputeConnectorVersionLabelsTx(ctx context.Context, id apid.ID, version uint64) error {
-	return s.transaction(func(tx *sql.Tx) error {
+// user labels. Returns true if drift was detected and corrected.
+func (s *service) recomputeConnectorVersionLabelsTx(ctx context.Context, id apid.ID, version uint64) (bool, error) {
+	var corrected bool
+	err := s.transaction(func(tx *sql.Tx) error {
 		var cv ConnectorVersion
 		err := s.sq.
 			Select(cv.cols()...).
@@ -393,18 +411,23 @@ func (s *service) recomputeConnectorVersionLabelsTx(ctx context.Context, id apid
 		)
 		newLabels = InjectSelfImplicitLabels(cv.Id, cv.Namespace, newLabels)
 
-		return s.writeRecomputedLabels(ctx, tx, ConnectorVersionsTable, sq.Eq{
+		var werr error
+		corrected, werr = s.writeRecomputedLabels(ctx, tx, ConnectorVersionsTable, sq.Eq{
 			"id":         id,
 			"version":    version,
 			"deleted_at": nil,
-		}, newLabels)
+		}, cv.Labels, newLabels)
+		return werr
 	})
+	return corrected, err
 }
 
 // recomputeNamespaceLabelsTx opens a short transaction and re-derives a
 // namespace's full labels from its immediate parent and its own user labels.
-func (s *service) recomputeNamespaceLabelsTx(ctx context.Context, path string) error {
-	return s.transaction(func(tx *sql.Tx) error {
+// Returns true if drift was detected and corrected.
+func (s *service) recomputeNamespaceLabelsTx(ctx context.Context, path string) (bool, error) {
+	var corrected bool
+	err := s.transaction(func(tx *sql.Tx) error {
 		var ns Namespace
 		err := s.sq.
 			Select(ns.cols()...).
@@ -440,22 +463,197 @@ func (s *service) recomputeNamespaceLabelsTx(ctx context.Context, path string) e
 		)
 		newLabels = InjectNamespaceSelfImplicitLabels(ns.Path, newLabels)
 
-		return s.writeRecomputedLabels(ctx, tx, NamespacesTable, sq.Eq{"path": path, "deleted_at": nil}, newLabels)
+		var werr error
+		corrected, werr = s.writeRecomputedLabels(ctx, tx, NamespacesTable, sq.Eq{"path": path, "deleted_at": nil}, ns.Labels, newLabels)
+		return werr
 	})
+	return corrected, err
 }
 
-// writeRecomputedLabels persists a recomputed labels map to a row. Updates
-// the updated_at timestamp.
-func (s *service) writeRecomputedLabels(ctx context.Context, tx *sql.Tx, table string, where sq.Eq, labels Labels) error {
+// writeRecomputedLabels persists a recomputed labels map to a row when it
+// differs from the row's current labels. Returns true if a row was actually
+// updated (drift was detected and corrected). Used by both the propagation
+// tasks (which expect drift after a parent change) and the daily
+// reconciler (which mostly finds none).
+func (s *service) writeRecomputedLabels(ctx context.Context, tx *sql.Tx, table string, where sq.Eq, current, newLabels Labels) (bool, error) {
+	if labelsEqual(current, newLabels) {
+		return false, nil
+	}
 	_, err := s.sq.
 		Update(table).
-		Set("labels", labels).
+		Set("labels", newLabels).
 		Set("updated_at", apctx.GetClock(ctx).Now()).
 		Where(where).
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		return fmt.Errorf("failed to write recomputed labels in %s: %w", table, err)
+		return false, fmt.Errorf("failed to write recomputed labels in %s: %w", table, err)
 	}
-	return nil
+	return true, nil
+}
+
+// labelsEqual reports whether two label maps contain exactly the same
+// key/value pairs. nil and empty are treated as equal.
+func labelsEqual(a, b Labels) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// ReconcileCarryForwardLabels walks every labelled resource type in
+// batches and re-derives the materialized apxy/ portion of each row. Each
+// row's update runs in its own short transaction; rows whose computed
+// labels match the stored labels are not rewritten. Returns the total
+// number of rows corrected across all resource types.
+//
+// batchSize controls the page size for each list query. interBatchDelay
+// is slept between successive batches (within a resource type and between
+// resource types) to throttle DB load.
+func (s *service) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	if interBatchDelay < 0 {
+		interBatchDelay = 0
+	}
+
+	s.logger.Info("starting carry-forward labels reconciliation", "batch_size", batchSize, "inter_batch_delay", interBatchDelay.String())
+
+	var totalCorrected int64
+
+	steps := []struct {
+		name string
+		walk func(ctx context.Context, batchSize int32) (int64, error)
+	}{
+		// Top-down: namespaces first (so child resources see fresh
+		// parent labels in subsequent passes), then per-resource walks.
+		{name: "namespaces", walk: s.reconcileNamespaces},
+		{name: "connector_versions", walk: s.reconcileConnectorVersions},
+		{name: "connections", walk: s.reconcileConnections},
+		{name: "actors", walk: s.reconcileActors},
+		{name: "encryption_keys", walk: s.reconcileEncryptionKeys},
+	}
+
+	clk := apctx.GetClock(ctx)
+	for i, step := range steps {
+		corrected, err := step.walk(ctx, batchSize)
+		if err != nil {
+			s.logger.Error("carry-forward labels reconciliation failed", "step", step.name, "corrected_so_far", totalCorrected, "error", err)
+			return totalCorrected, fmt.Errorf("reconcile %s: %w", step.name, err)
+		}
+		totalCorrected += corrected
+		s.logger.Info("reconciled resource type", "step", step.name, "corrected", corrected)
+		if interBatchDelay > 0 && i < len(steps)-1 {
+			clk.Sleep(interBatchDelay)
+		}
+	}
+
+	s.logger.Info("carry-forward labels reconciliation complete", "total_corrected", totalCorrected)
+	return totalCorrected, nil
+}
+
+func (s *service) reconcileNamespaces(ctx context.Context, batchSize int32) (int64, error) {
+	var corrected int64
+	err := s.ListNamespacesBuilder().
+		Limit(batchSize).
+		Enumerate(ctx, func(pr pagination.PageResult[Namespace]) (pagination.KeepGoing, error) {
+			for _, ns := range pr.Results {
+				wasCorrected, err := s.recomputeNamespaceLabelsTx(ctx, ns.Path)
+				if err != nil {
+					return pagination.Stop, err
+				}
+				if wasCorrected {
+					corrected++
+					s.logger.Info("reconciled drifted carry-forward labels", "type", "namespace", "path", ns.Path)
+				}
+			}
+			return pagination.Continue, nil
+		})
+	return corrected, err
+}
+
+func (s *service) reconcileConnectorVersions(ctx context.Context, batchSize int32) (int64, error) {
+	var corrected int64
+	err := s.ListConnectorVersionsBuilder().
+		Limit(batchSize).
+		Enumerate(ctx, func(pr pagination.PageResult[ConnectorVersion]) (pagination.KeepGoing, error) {
+			for _, cv := range pr.Results {
+				wasCorrected, err := s.recomputeConnectorVersionLabelsTx(ctx, cv.Id, cv.Version)
+				if err != nil {
+					return pagination.Stop, err
+				}
+				if wasCorrected {
+					corrected++
+					s.logger.Info("reconciled drifted carry-forward labels", "type", "connector_version", "id", cv.Id, "version", cv.Version)
+				}
+			}
+			return pagination.Continue, nil
+		})
+	return corrected, err
+}
+
+func (s *service) reconcileConnections(ctx context.Context, batchSize int32) (int64, error) {
+	var corrected int64
+	err := s.ListConnectionsBuilder().
+		Limit(batchSize).
+		Enumerate(ctx, func(pr pagination.PageResult[Connection]) (pagination.KeepGoing, error) {
+			for _, conn := range pr.Results {
+				wasCorrected, err := s.recomputeConnectionLabelsTx(ctx, conn.Id)
+				if err != nil {
+					return pagination.Stop, err
+				}
+				if wasCorrected {
+					corrected++
+					s.logger.Info("reconciled drifted carry-forward labels", "type", "connection", "id", conn.Id)
+				}
+			}
+			return pagination.Continue, nil
+		})
+	return corrected, err
+}
+
+func (s *service) reconcileActors(ctx context.Context, batchSize int32) (int64, error) {
+	var corrected int64
+	err := s.ListActorsBuilder().
+		Limit(batchSize).
+		Enumerate(ctx, func(pr pagination.PageResult[*Actor]) (pagination.KeepGoing, error) {
+			for _, a := range pr.Results {
+				wasCorrected, err := s.recomputeActorLabelsTx(ctx, a.Id)
+				if err != nil {
+					return pagination.Stop, err
+				}
+				if wasCorrected {
+					corrected++
+					s.logger.Info("reconciled drifted carry-forward labels", "type", "actor", "id", a.Id)
+				}
+			}
+			return pagination.Continue, nil
+		})
+	return corrected, err
+}
+
+func (s *service) reconcileEncryptionKeys(ctx context.Context, batchSize int32) (int64, error) {
+	var corrected int64
+	err := s.ListEncryptionKeysBuilder().
+		Limit(batchSize).
+		Enumerate(ctx, func(pr pagination.PageResult[EncryptionKey]) (pagination.KeepGoing, error) {
+			for _, ek := range pr.Results {
+				wasCorrected, err := s.recomputeEncryptionKeyLabelsTx(ctx, ek.Id)
+				if err != nil {
+					return pagination.Stop, err
+				}
+				if wasCorrected {
+					corrected++
+					s.logger.Info("reconciled drifted carry-forward labels", "type", "encryption_key", "id", ek.Id)
+				}
+			}
+			return pagination.Continue, nil
+		})
+	return corrected, err
 }

--- a/internal/database/labels_propagate.go
+++ b/internal/database/labels_propagate.go
@@ -5,13 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/util/pagination"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+	"golang.org/x/time/rate"
 )
 
 // Carry-forward propagation
@@ -512,24 +512,22 @@ func labelsEqual(a, b Labels) bool {
 // labels match the stored labels are not rewritten. Returns the total
 // number of rows corrected across all resource types.
 //
-// batchSize controls the page size for each list query. interBatchDelay
-// is slept between successive batches (within a resource type and between
-// resource types) to throttle DB load.
-func (s *service) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (int64, error) {
+// batchSize controls the page size for each list query. limiter, when
+// non-nil, is consulted before processing each row — providing a per-row
+// records/sec rate limit so a daily sweep over a large fleet is bounded
+// even though page reads are cheap. A nil limiter means unlimited.
+func (s *service) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	if batchSize <= 0 {
 		batchSize = 100
 	}
-	if interBatchDelay < 0 {
-		interBatchDelay = 0
-	}
 
-	s.logger.Info("starting carry-forward labels reconciliation", "batch_size", batchSize, "inter_batch_delay", interBatchDelay.String())
+	s.logger.Info("starting carry-forward labels reconciliation", "batch_size", batchSize, "rate_limit", rateLimitLogValue(limiter))
 
 	var totalCorrected int64
 
 	steps := []struct {
 		name string
-		walk func(ctx context.Context, batchSize int32) (int64, error)
+		walk func(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error)
 	}{
 		// Top-down: namespaces first (so child resources see fresh
 		// parent labels in subsequent passes), then per-resource walks.
@@ -540,120 +538,123 @@ func (s *service) ReconcileCarryForwardLabels(ctx context.Context, batchSize int
 		{name: "encryption_keys", walk: s.reconcileEncryptionKeys},
 	}
 
-	clk := apctx.GetClock(ctx)
-	for i, step := range steps {
-		corrected, err := step.walk(ctx, batchSize)
+	for _, step := range steps {
+		corrected, err := step.walk(ctx, batchSize, limiter)
 		if err != nil {
 			s.logger.Error("carry-forward labels reconciliation failed", "step", step.name, "corrected_so_far", totalCorrected, "error", err)
 			return totalCorrected, fmt.Errorf("reconcile %s: %w", step.name, err)
 		}
 		totalCorrected += corrected
 		s.logger.Info("reconciled resource type", "step", step.name, "corrected", corrected)
-		if interBatchDelay > 0 && i < len(steps)-1 {
-			clk.Sleep(interBatchDelay)
-		}
 	}
 
 	s.logger.Info("carry-forward labels reconciliation complete", "total_corrected", totalCorrected)
 	return totalCorrected, nil
 }
 
-func (s *service) reconcileNamespaces(ctx context.Context, batchSize int32) (int64, error) {
+func rateLimitLogValue(limiter *rate.Limiter) string {
+	if limiter == nil {
+		return "unlimited"
+	}
+	return fmt.Sprintf("%v rps", limiter.Limit())
+}
+
+func (s *service) reconcileNamespaces(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	var corrected int64
-	err := s.ListNamespacesBuilder().
-		Limit(batchSize).
-		Enumerate(ctx, func(pr pagination.PageResult[Namespace]) (pagination.KeepGoing, error) {
-			for _, ns := range pr.Results {
-				wasCorrected, err := s.recomputeNamespaceLabelsTx(ctx, ns.Path)
-				if err != nil {
-					return pagination.Stop, err
-				}
-				if wasCorrected {
-					corrected++
-					s.logger.Info("reconciled drifted carry-forward labels", "type", "namespace", "path", ns.Path)
-				}
+	err := pagination.EnumerateThrottled(
+		ctx,
+		s.ListNamespacesBuilder().Limit(batchSize).Enumerate,
+		limiter,
+		func(ns Namespace) error {
+			wasCorrected, err := s.recomputeNamespaceLabelsTx(ctx, ns.Path)
+			if err != nil {
+				return err
 			}
-			return pagination.Continue, nil
+			if wasCorrected {
+				corrected++
+				s.logger.Info("reconciled drifted carry-forward labels", "type", "namespace", "path", ns.Path)
+			}
+			return nil
 		})
 	return corrected, err
 }
 
-func (s *service) reconcileConnectorVersions(ctx context.Context, batchSize int32) (int64, error) {
+func (s *service) reconcileConnectorVersions(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	var corrected int64
-	err := s.ListConnectorVersionsBuilder().
-		Limit(batchSize).
-		Enumerate(ctx, func(pr pagination.PageResult[ConnectorVersion]) (pagination.KeepGoing, error) {
-			for _, cv := range pr.Results {
-				wasCorrected, err := s.recomputeConnectorVersionLabelsTx(ctx, cv.Id, cv.Version)
-				if err != nil {
-					return pagination.Stop, err
-				}
-				if wasCorrected {
-					corrected++
-					s.logger.Info("reconciled drifted carry-forward labels", "type", "connector_version", "id", cv.Id, "version", cv.Version)
-				}
+	err := pagination.EnumerateThrottled(
+		ctx,
+		s.ListConnectorVersionsBuilder().Limit(batchSize).Enumerate,
+		limiter,
+		func(cv ConnectorVersion) error {
+			wasCorrected, err := s.recomputeConnectorVersionLabelsTx(ctx, cv.Id, cv.Version)
+			if err != nil {
+				return err
 			}
-			return pagination.Continue, nil
+			if wasCorrected {
+				corrected++
+				s.logger.Info("reconciled drifted carry-forward labels", "type", "connector_version", "id", cv.Id, "version", cv.Version)
+			}
+			return nil
 		})
 	return corrected, err
 }
 
-func (s *service) reconcileConnections(ctx context.Context, batchSize int32) (int64, error) {
+func (s *service) reconcileConnections(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	var corrected int64
-	err := s.ListConnectionsBuilder().
-		Limit(batchSize).
-		Enumerate(ctx, func(pr pagination.PageResult[Connection]) (pagination.KeepGoing, error) {
-			for _, conn := range pr.Results {
-				wasCorrected, err := s.recomputeConnectionLabelsTx(ctx, conn.Id)
-				if err != nil {
-					return pagination.Stop, err
-				}
-				if wasCorrected {
-					corrected++
-					s.logger.Info("reconciled drifted carry-forward labels", "type", "connection", "id", conn.Id)
-				}
+	err := pagination.EnumerateThrottled(
+		ctx,
+		s.ListConnectionsBuilder().Limit(batchSize).Enumerate,
+		limiter,
+		func(conn Connection) error {
+			wasCorrected, err := s.recomputeConnectionLabelsTx(ctx, conn.Id)
+			if err != nil {
+				return err
 			}
-			return pagination.Continue, nil
+			if wasCorrected {
+				corrected++
+				s.logger.Info("reconciled drifted carry-forward labels", "type", "connection", "id", conn.Id)
+			}
+			return nil
 		})
 	return corrected, err
 }
 
-func (s *service) reconcileActors(ctx context.Context, batchSize int32) (int64, error) {
+func (s *service) reconcileActors(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	var corrected int64
-	err := s.ListActorsBuilder().
-		Limit(batchSize).
-		Enumerate(ctx, func(pr pagination.PageResult[*Actor]) (pagination.KeepGoing, error) {
-			for _, a := range pr.Results {
-				wasCorrected, err := s.recomputeActorLabelsTx(ctx, a.Id)
-				if err != nil {
-					return pagination.Stop, err
-				}
-				if wasCorrected {
-					corrected++
-					s.logger.Info("reconciled drifted carry-forward labels", "type", "actor", "id", a.Id)
-				}
+	err := pagination.EnumerateThrottled(
+		ctx,
+		s.ListActorsBuilder().Limit(batchSize).Enumerate,
+		limiter,
+		func(a *Actor) error {
+			wasCorrected, err := s.recomputeActorLabelsTx(ctx, a.Id)
+			if err != nil {
+				return err
 			}
-			return pagination.Continue, nil
+			if wasCorrected {
+				corrected++
+				s.logger.Info("reconciled drifted carry-forward labels", "type", "actor", "id", a.Id)
+			}
+			return nil
 		})
 	return corrected, err
 }
 
-func (s *service) reconcileEncryptionKeys(ctx context.Context, batchSize int32) (int64, error) {
+func (s *service) reconcileEncryptionKeys(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	var corrected int64
-	err := s.ListEncryptionKeysBuilder().
-		Limit(batchSize).
-		Enumerate(ctx, func(pr pagination.PageResult[EncryptionKey]) (pagination.KeepGoing, error) {
-			for _, ek := range pr.Results {
-				wasCorrected, err := s.recomputeEncryptionKeyLabelsTx(ctx, ek.Id)
-				if err != nil {
-					return pagination.Stop, err
-				}
-				if wasCorrected {
-					corrected++
-					s.logger.Info("reconciled drifted carry-forward labels", "type", "encryption_key", "id", ek.Id)
-				}
+	err := pagination.EnumerateThrottled(
+		ctx,
+		s.ListEncryptionKeysBuilder().Limit(batchSize).Enumerate,
+		limiter,
+		func(ek EncryptionKey) error {
+			wasCorrected, err := s.recomputeEncryptionKeyLabelsTx(ctx, ek.Id)
+			if err != nil {
+				return err
 			}
-			return pagination.Continue, nil
+			if wasCorrected {
+				corrected++
+				s.logger.Info("reconciled drifted carry-forward labels", "type", "encryption_key", "id", ek.Id)
+			}
+			return nil
 		})
 	return corrected, err
 }

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -16,6 +16,7 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/schema/auth"
 	connectors "github.com/rmorlok/authproxy/internal/schema/connectors"
 	pagination "github.com/rmorlok/authproxy/internal/util/pagination"
+	rate "golang.org/x/time/rate"
 )
 
 // MockIActorData is a mock of IActorData interface.
@@ -1395,18 +1396,18 @@ func (mr *MockDBMockRecorder) PutNamespaceLabels(ctx, path, labels interface{}) 
 }
 
 // ReconcileCarryForwardLabels mocks base method.
-func (m *MockDB) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (int64, error) {
+func (m *MockDB) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, limiter *rate.Limiter) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReconcileCarryForwardLabels", ctx, batchSize, interBatchDelay)
+	ret := m.ctrl.Call(m, "ReconcileCarryForwardLabels", ctx, batchSize, limiter)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReconcileCarryForwardLabels indicates an expected call of ReconcileCarryForwardLabels.
-func (mr *MockDBMockRecorder) ReconcileCarryForwardLabels(ctx, batchSize, interBatchDelay interface{}) *gomock.Call {
+func (mr *MockDBMockRecorder) ReconcileCarryForwardLabels(ctx, batchSize, limiter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileCarryForwardLabels", reflect.TypeOf((*MockDB)(nil).ReconcileCarryForwardLabels), ctx, batchSize, interBatchDelay)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileCarryForwardLabels", reflect.TypeOf((*MockDB)(nil).ReconcileCarryForwardLabels), ctx, batchSize, limiter)
 }
 
 // RefreshConnectionsForConnectorVersion mocks base method.

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -1394,6 +1394,21 @@ func (mr *MockDBMockRecorder) PutNamespaceLabels(ctx, path, labels interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutNamespaceLabels", reflect.TypeOf((*MockDB)(nil).PutNamespaceLabels), ctx, path, labels)
 }
 
+// ReconcileCarryForwardLabels mocks base method.
+func (m *MockDB) ReconcileCarryForwardLabels(ctx context.Context, batchSize int32, interBatchDelay time.Duration) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileCarryForwardLabels", ctx, batchSize, interBatchDelay)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileCarryForwardLabels indicates an expected call of ReconcileCarryForwardLabels.
+func (mr *MockDBMockRecorder) ReconcileCarryForwardLabels(ctx, batchSize, interBatchDelay interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileCarryForwardLabels", reflect.TypeOf((*MockDB)(nil).ReconcileCarryForwardLabels), ctx, batchSize, interBatchDelay)
+}
+
 // RefreshConnectionsForConnectorVersion mocks base method.
 func (m *MockDB) RefreshConnectionsForConnectorVersion(ctx context.Context, id apid.ID, version uint64) error {
 	m.ctrl.T.Helper()

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -480,7 +480,7 @@ func (s *service) SetNamespaceState(ctx context.Context, path string, state Name
 
 type ListNamespacesExecutor interface {
 	FetchPage(context.Context) pagination.PageResult[Namespace]
-	Enumerate(context.Context, func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(context.Context, pagination.EnumerateCallback[Namespace]) error
 }
 
 type ListNamespacesBuilder interface {
@@ -697,7 +697,7 @@ func (l *listNamespacesFilters) FetchPage(ctx context.Context) pagination.PageRe
 	return l.fetchPage(ctx)
 }
 
-func (l *listNamespacesFilters) Enumerate(ctx context.Context, callback func(pagination.PageResult[Namespace]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *listNamespacesFilters) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[Namespace]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 	clock "k8s.io/utils/clock/testing"
 )
 
@@ -2217,9 +2219,9 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 
 		// First run may fix any pre-existing drift (e.g. on the auto-created
 		// root namespace from migrations). Drain it so we start clean.
-		_, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		_, err := db.ReconcileCarryForwardLabels(ctx, 100, nil)
 		require.NoError(t, err)
-		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), fixed, "second run should be a no-op once everything is materialized")
 
@@ -2229,7 +2231,7 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 			`{"apxy/cxr/type":"stale","apxy/cxn/-/id":"`+string(connID)+`","apxy/cxn/-/ns":"root.recon"}`, connID)
 		require.NoError(t, err)
 
-		fixed, err = db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		fixed, err = db.ReconcileCarryForwardLabels(ctx, 100, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), fixed, "exactly the drifted connection row should be corrected")
 
@@ -2252,11 +2254,36 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 		}))
 
 		// Drain any pre-existing drift on the auto-created root namespace.
-		_, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		_, err := db.ReconcileCarryForwardLabels(ctx, 100, nil)
 		require.NoError(t, err)
 
-		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), fixed)
+	})
+
+	t.Run("rate limiter is consulted before each row", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		now := time.Date(2024, time.March, 1, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		// Seed a few rows so the limiter is consulted multiple times.
+		for _, p := range []string{"root.rl1", "root.rl2", "root.rl3"} {
+			require.NoError(t, db.CreateNamespace(ctx, &Namespace{Path: p, State: NamespaceStateActive}))
+		}
+
+		// Build a no-burst limiter that forbids any waits — Wait blocks
+		// past the deadline so a context with a short deadline forces an
+		// error. Use a context with a deadline already in the past to
+		// guarantee the limiter rejects without needing real time.
+		limited := rate.NewLimiter(rate.Every(time.Hour), 1)
+		// Drain the burst so subsequent waits would block.
+		require.NoError(t, limited.Wait(context.Background()))
+
+		ctxWithDeadline, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+		defer cancel()
+
+		_, err := db.ReconcileCarryForwardLabels(ctxWithDeadline, 100, limited)
+		require.Error(t, err, "a tripped limiter should propagate its error from the reconciler")
 	})
 }

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -2185,3 +2185,78 @@ func TestConnectorVersionLabelChangePropagation(t *testing.T) {
 		require.Equal(t, "x", c.Labels["apxy/cxr/extra"])
 	})
 }
+
+func TestReconcileCarryForwardLabels(t *testing.T) {
+	t.Run("corrects drifted apxy labels and reports the count", func(t *testing.T) {
+		_, db, rawDb := MustApplyBlankTestDbConfigRaw(t, nil)
+		defer rawDb.Close()
+		now := time.Date(2024, time.March, 1, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		// Build a tree: namespace, cv, connection, ek, actor.
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path: "root.recon", State: NamespaceStateActive, Labels: Labels{"team": "platform"},
+		}))
+		cvID := apid.New(apid.PrefixConnectorVersion)
+		require.NoError(t, db.UpsertConnectorVersion(ctx, &ConnectorVersion{
+			Id: cvID, Version: 1, Namespace: "root.recon",
+			State: ConnectorVersionStateDraft, Labels: Labels{"type": "google-drive"},
+			Hash: "h", EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("ekv_test000000000001"), Data: "d"},
+		}))
+		connID := apid.New(apid.PrefixConnection)
+		require.NoError(t, db.CreateConnection(ctx, &Connection{
+			Id: connID, Namespace: "root.recon", ConnectorId: cvID, ConnectorVersion: 1,
+			State: ConnectionStateCreated,
+		}))
+		require.NoError(t, db.CreateEncryptionKey(ctx, &EncryptionKey{
+			Id: apid.New(apid.PrefixEncryptionKey), Namespace: "root.recon", State: EncryptionKeyStateActive,
+		}))
+		require.NoError(t, db.CreateActor(ctx, &Actor{
+			Id: apid.New(apid.PrefixActor), ExternalId: "act-recon", Namespace: "root.recon",
+		}))
+
+		// First run may fix any pre-existing drift (e.g. on the auto-created
+		// root namespace from migrations). Drain it so we start clean.
+		_, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		require.NoError(t, err)
+		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), fixed, "second run should be a no-op once everything is materialized")
+
+		// Corrupt the connection's labels by writing a stale apxy/cxr/type.
+		// Bypasses the DB write paths so the reconciler has work to do.
+		_, err = rawDb.ExecContext(ctx, `UPDATE connections SET labels = $1 WHERE id = $2`,
+			`{"apxy/cxr/type":"stale","apxy/cxn/-/id":"`+string(connID)+`","apxy/cxn/-/ns":"root.recon"}`, connID)
+		require.NoError(t, err)
+
+		fixed, err = db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), fixed, "exactly the drifted connection row should be corrected")
+
+		// Confirm the connection's apxy/cxr/type is back to what carry-forward dictates.
+		c, err := db.GetConnection(ctx, connID)
+		require.NoError(t, err)
+		require.Equal(t, "google-drive", c.Labels["apxy/cxr/type"])
+	})
+
+	t.Run("idempotent - subsequent runs after a clean pass find nothing", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		now := time.Date(2024, time.March, 1, 12, 0, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path: "root.idem", State: NamespaceStateActive, Labels: Labels{"team": "platform"},
+		}))
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path: "root.idem.child", State: NamespaceStateActive, Labels: Labels{"env": "prod"},
+		}))
+
+		// Drain any pre-existing drift on the auto-created root namespace.
+		_, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		require.NoError(t, err)
+
+		fixed, err := db.ReconcileCarryForwardLabels(ctx, 100, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), fixed)
+	})
+}

--- a/internal/database/tasks/task_reconcile_carry_forward_labels.go
+++ b/internal/database/tasks/task_reconcile_carry_forward_labels.go
@@ -2,19 +2,21 @@ package tasks
 
 import (
 	"context"
-	"time"
 
 	"github.com/hibiken/asynq"
+	"golang.org/x/time/rate"
 )
 
 const taskTypeReconcileCarryForwardLabels = "database:reconcile_carry_forward_labels"
 
 // Defaults for the reconciliation pass. Drift is rare under normal
-// operation, so a small per-resource page and a short pause between
-// resource types is enough throttling to keep DB load negligible.
+// operation, so the rate limit is set conservatively to keep DB load
+// negligible — even on a fleet of millions of rows the daily sweep
+// finishes within a handful of hours.
 const (
-	reconcileBatchSize       int32         = 100
-	reconcileInterBatchDelay time.Duration = 0
+	reconcileBatchSize        int32      = 100
+	reconcileRecordsPerSecond rate.Limit = 100
+	reconcileBurst            int        = 100
 )
 
 func newReconcileCarryForwardLabelsTask() *asynq.Task {
@@ -23,7 +25,8 @@ func newReconcileCarryForwardLabelsTask() *asynq.Task {
 
 func (th *taskHandler) reconcileCarryForwardLabels(ctx context.Context, _ *asynq.Task) error {
 	th.logger.Info("running carry-forward labels reconciliation task")
-	corrected, err := th.db.ReconcileCarryForwardLabels(ctx, reconcileBatchSize, reconcileInterBatchDelay)
+	limiter := rate.NewLimiter(reconcileRecordsPerSecond, reconcileBurst)
+	corrected, err := th.db.ReconcileCarryForwardLabels(ctx, reconcileBatchSize, limiter)
 	if err != nil {
 		th.logger.Error("carry-forward labels reconciliation failed", "corrected_so_far", corrected, "error", err)
 		return err

--- a/internal/database/tasks/task_reconcile_carry_forward_labels.go
+++ b/internal/database/tasks/task_reconcile_carry_forward_labels.go
@@ -1,0 +1,33 @@
+package tasks
+
+import (
+	"context"
+	"time"
+
+	"github.com/hibiken/asynq"
+)
+
+const taskTypeReconcileCarryForwardLabels = "database:reconcile_carry_forward_labels"
+
+// Defaults for the reconciliation pass. Drift is rare under normal
+// operation, so a small per-resource page and a short pause between
+// resource types is enough throttling to keep DB load negligible.
+const (
+	reconcileBatchSize       int32         = 100
+	reconcileInterBatchDelay time.Duration = 0
+)
+
+func newReconcileCarryForwardLabelsTask() *asynq.Task {
+	return asynq.NewTask(taskTypeReconcileCarryForwardLabels, nil)
+}
+
+func (th *taskHandler) reconcileCarryForwardLabels(ctx context.Context, _ *asynq.Task) error {
+	th.logger.Info("running carry-forward labels reconciliation task")
+	corrected, err := th.db.ReconcileCarryForwardLabels(ctx, reconcileBatchSize, reconcileInterBatchDelay)
+	if err != nil {
+		th.logger.Error("carry-forward labels reconciliation failed", "corrected_so_far", corrected, "error", err)
+		return err
+	}
+	th.logger.Info("carry-forward labels reconciliation complete", "corrected", corrected)
+	return nil
+}

--- a/internal/database/tasks/task_reconcile_carry_forward_labels_test.go
+++ b/internal/database/tasks/task_reconcile_carry_forward_labels_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	dbMock "github.com/rmorlok/authproxy/internal/database/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileCarryForwardLabelsTask(t *testing.T) {
+	t.Run("delegates to ReconcileCarryForwardLabels with defaults", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockDB := dbMock.NewMockDB(ctrl)
+		mockDB.EXPECT().
+			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, reconcileInterBatchDelay).
+			Return(int64(3), nil)
+
+		th := &taskHandler{db: mockDB, logger: aplog.NewNoopLogger()}
+		require.NoError(t, th.reconcileCarryForwardLabels(context.Background(), asynq.NewTask(taskTypeReconcileCarryForwardLabels, nil)))
+	})
+
+	t.Run("propagates DB errors so asynq retries", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockDB := dbMock.NewMockDB(ctrl)
+		dbErr := errors.New("transient")
+		mockDB.EXPECT().
+			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, reconcileInterBatchDelay).
+			Return(int64(0), dbErr)
+
+		th := &taskHandler{db: mockDB, logger: aplog.NewNoopLogger()}
+		err := th.reconcileCarryForwardLabels(context.Background(), asynq.NewTask(taskTypeReconcileCarryForwardLabels, nil))
+		require.ErrorIs(t, err, dbErr)
+	})
+}
+
+func TestNewReconcileCarryForwardLabelsTask(t *testing.T) {
+	task := newReconcileCarryForwardLabelsTask()
+	require.Equal(t, taskTypeReconcileCarryForwardLabels, task.Type())
+}

--- a/internal/database/tasks/task_reconcile_carry_forward_labels_test.go
+++ b/internal/database/tasks/task_reconcile_carry_forward_labels_test.go
@@ -10,14 +10,29 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	dbMock "github.com/rmorlok/authproxy/internal/database/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
+// rateLimiterMatcher matches any *rate.Limiter whose limit equals
+// reconcileRecordsPerSecond — the handler is expected to construct one
+// with the package-level defaults each invocation.
+type rateLimiterMatcher struct{}
+
+func (rateLimiterMatcher) Matches(x interface{}) bool {
+	l, ok := x.(*rate.Limiter)
+	if !ok {
+		return false
+	}
+	return l != nil && l.Limit() == reconcileRecordsPerSecond
+}
+func (rateLimiterMatcher) String() string { return "is *rate.Limiter at default rps" }
+
 func TestReconcileCarryForwardLabelsTask(t *testing.T) {
-	t.Run("delegates to ReconcileCarryForwardLabels with defaults", func(t *testing.T) {
+	t.Run("delegates to ReconcileCarryForwardLabels with default limiter", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockDB := dbMock.NewMockDB(ctrl)
 		mockDB.EXPECT().
-			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, reconcileInterBatchDelay).
+			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, rateLimiterMatcher{}).
 			Return(int64(3), nil)
 
 		th := &taskHandler{db: mockDB, logger: aplog.NewNoopLogger()}
@@ -29,7 +44,7 @@ func TestReconcileCarryForwardLabelsTask(t *testing.T) {
 		mockDB := dbMock.NewMockDB(ctrl)
 		dbErr := errors.New("transient")
 		mockDB.EXPECT().
-			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, reconcileInterBatchDelay).
+			ReconcileCarryForwardLabels(gomock.Any(), reconcileBatchSize, rateLimiterMatcher{}).
 			Return(int64(0), dbErr)
 
 		th := &taskHandler{db: mockDB, logger: aplog.NewNoopLogger()}

--- a/internal/database/tasks/tasks.go
+++ b/internal/database/tasks/tasks.go
@@ -40,6 +40,7 @@ func (th *taskHandler) RegisterTasks(mux *asynq.ServeMux) {
 	mux.HandleFunc(taskTypeCleanupStaleConnections, th.cleanupStaleConnections)
 	mux.HandleFunc(taskTypePropagateNamespaceLabels, th.propagateNamespaceLabels)
 	mux.HandleFunc(taskTypePropagateConnectorVersionLabels, th.propagateConnectorVersionLabels)
+	mux.HandleFunc(taskTypeReconcileCarryForwardLabels, th.reconcileCarryForwardLabels)
 }
 
 // GetCronTasks returns the cron task configurations for database maintenance.
@@ -65,6 +66,10 @@ func (th *taskHandler) GetCronTasks() []*asynq.PeriodicTaskConfig {
 		{
 			Cronspec: cleanupCronspec,
 			Task:     newCleanupStaleConnectionsTask(),
+		},
+		{
+			Cronspec: "@daily",
+			Task:     newReconcileCarryForwardLabelsTask(),
 		},
 	}
 }

--- a/internal/request_log/list.go
+++ b/internal/request_log/list.go
@@ -52,7 +52,7 @@ func IsValidOrderByField(field RequestOrderByField) bool {
 
 type ListRequestExecutor interface {
 	FetchPage(ctx context.Context) pagination.PageResult[*LogRecord]
-	Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing pagination.KeepGoing, err error)) error
+	Enumerate(ctx context.Context, callback pagination.EnumerateCallback[*LogRecord]) error
 }
 
 type ListRequestBuilder interface {

--- a/internal/request_log/mock/list.go
+++ b/internal/request_log/mock/list.go
@@ -143,7 +143,7 @@ func (l *MockListRequestBuilderExecutor) FetchPage(ctx context.Context) paginati
 	return l.ReturnResults
 }
 
-func (l *MockListRequestBuilderExecutor) Enumerate(ctx context.Context, callback func(pagination.PageResult[*request_log.LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *MockListRequestBuilderExecutor) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[*request_log.LogRecord]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -616,7 +616,7 @@ func (l *sqlListRequestsBuilder) FetchPage(ctx context.Context) pagination.PageR
 	}
 }
 
-func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback func(pagination.PageResult[*LogRecord]) (keepGoing pagination.KeepGoing, err error)) error {
+func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[*LogRecord]) error {
 	var err error
 	keepGoing := pagination.Continue
 	hasMore := true

--- a/internal/util/pagination/enumerate.go
+++ b/internal/util/pagination/enumerate.go
@@ -1,0 +1,14 @@
+package pagination
+
+import "context"
+
+// EnumerateCallback is the per-page callback shape passed to an
+// Enumerate-style iterator. It returns Continue to fetch the next page,
+// Stop to halt early, or an error to abort the iteration.
+type EnumerateCallback[T any] func(PageResult[T]) (keepGoing KeepGoing, err error)
+
+// EnumerateFunc is the shape of an Enumerate method on a list builder.
+// Builders' Enumerate methods can be passed as values of this type
+// directly via Go's method-value conversion, which lets generic helpers
+// like EnumerateThrottled accept them without exposing the builder.
+type EnumerateFunc[T any] func(context.Context, EnumerateCallback[T]) error

--- a/internal/util/pagination/enumerate_throttled.go
+++ b/internal/util/pagination/enumerate_throttled.go
@@ -6,12 +6,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// EnumerateFunc is the shape of an Enumerate method on a list builder. It
-// matches the existing pagination iteration contract (a callback that
-// receives one PageResult at a time) so any builder's Enumerate method
-// can be passed as a method value.
-type EnumerateFunc[T any] func(context.Context, func(PageResult[T]) (keepGoing KeepGoing, err error)) error
-
 // EnumerateThrottled walks every item produced by enumerate, calling
 // limiter.Wait(ctx) before invoking cb on each item. A nil limiter means
 // no throttling. Stops on the first error from cb or limiter.Wait.

--- a/internal/util/pagination/enumerate_throttled.go
+++ b/internal/util/pagination/enumerate_throttled.go
@@ -1,0 +1,43 @@
+package pagination
+
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+)
+
+// EnumerateFunc is the shape of an Enumerate method on a list builder. It
+// matches the existing pagination iteration contract (a callback that
+// receives one PageResult at a time) so any builder's Enumerate method
+// can be passed as a method value.
+type EnumerateFunc[T any] func(context.Context, func(PageResult[T]) (keepGoing KeepGoing, err error)) error
+
+// EnumerateThrottled walks every item produced by enumerate, calling
+// limiter.Wait(ctx) before invoking cb on each item. A nil limiter means
+// no throttling. Stops on the first error from cb or limiter.Wait.
+//
+// Use this for background sweeps over large tables where the work per row
+// is cheap and you want to bound throughput in records/sec rather than
+// pause between fixed-size batches. The rate-limit check happens per row,
+// not per page, so adjusting the page size doesn't change the throughput
+// guarantee.
+func EnumerateThrottled[T any](
+	ctx context.Context,
+	enumerate EnumerateFunc[T],
+	limiter *rate.Limiter,
+	cb func(T) error,
+) error {
+	return enumerate(ctx, func(pr PageResult[T]) (KeepGoing, error) {
+		for _, item := range pr.Results {
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					return Stop, err
+				}
+			}
+			if err := cb(item); err != nil {
+				return Stop, err
+			}
+		}
+		return Continue, nil
+	})
+}

--- a/internal/util/pagination/enumerate_throttled_test.go
+++ b/internal/util/pagination/enumerate_throttled_test.go
@@ -1,0 +1,79 @@
+package pagination
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// staticEnumerate produces all items in a single page, then stops.
+func staticEnumerate[T any](items []T) EnumerateFunc[T] {
+	return func(ctx context.Context, cb func(PageResult[T]) (KeepGoing, error)) error {
+		_, err := cb(PageResult[T]{Results: items})
+		return err
+	}
+}
+
+func TestEnumerateThrottledNilLimiter(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+	var seen []int
+	err := EnumerateThrottled(context.Background(), staticEnumerate(items), nil, func(v int) error {
+		seen = append(seen, v)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, items, seen)
+}
+
+func TestEnumerateThrottledStopsOnCallbackError(t *testing.T) {
+	items := []int{1, 2, 3}
+	stopErr := errors.New("stop")
+	var seen []int
+	err := EnumerateThrottled(context.Background(), staticEnumerate(items), nil, func(v int) error {
+		seen = append(seen, v)
+		if v == 2 {
+			return stopErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, stopErr)
+	require.Equal(t, []int{1, 2}, seen)
+}
+
+func TestEnumerateThrottledRespectsLimiter(t *testing.T) {
+	// 50 records/sec, burst of 1 — three items should take roughly two
+	// limiter intervals (~40ms) before the third callback runs.
+	limiter := rate.NewLimiter(50, 1)
+	items := []int{1, 2, 3}
+
+	start := time.Now()
+	err := EnumerateThrottled(context.Background(), staticEnumerate(items), limiter, func(int) error {
+		return nil
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	// Two waits at 50 rps = ~40ms minimum. Allow generous slack for CI noise.
+	require.GreaterOrEqual(t, elapsed, 30*time.Millisecond, "limiter should slow throughput")
+}
+
+func TestEnumerateThrottledStopsOnLimiterError(t *testing.T) {
+	// Burst of 1, very long interval. Drain the burst then run with a
+	// context already past its deadline so Wait fails immediately.
+	limiter := rate.NewLimiter(rate.Every(time.Hour), 1)
+	require.NoError(t, limiter.Wait(context.Background()))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	called := 0
+	err := EnumerateThrottled(ctx, staticEnumerate([]int{1, 2}), limiter, func(int) error {
+		called++
+		return nil
+	})
+	require.Error(t, err)
+	require.Equal(t, 0, called, "callback should not fire when the limiter rejects")
+}

--- a/internal/util/pagination/enumerate_throttled_test.go
+++ b/internal/util/pagination/enumerate_throttled_test.go
@@ -12,7 +12,7 @@ import (
 
 // staticEnumerate produces all items in a single page, then stops.
 func staticEnumerate[T any](items []T) EnumerateFunc[T] {
-	return func(ctx context.Context, cb func(PageResult[T]) (KeepGoing, error)) error {
+	return func(ctx context.Context, cb EnumerateCallback[T]) error {
 		_, err := cb(PageResult[T]{Results: items})
 		return err
 	}


### PR DESCRIPTION
Closes #198. Final piece of the carry-forward labels work in #194.

## Summary
Drift in the materialized \`apxy/\` portion of any labelled resource — from a missed propagation task, a deploy that wrote labels via a path that predates carry-forward materialization, or an unforeseen bug — is now caught and corrected by a daily asynq cron task. The reconciliation helpers also let the propagation tasks shipped earlier in #202 stop doing no-op writes when nothing actually changed.

## Scope

### Database layer
- \`writeRecomputedLabels\` now compares the recomputed labels against the row's current labels and skips the UPDATE when they're equal. Returns \`(corrected bool, err error)\`.
- Each \`recompute<Resource>LabelsTx\` helper threads that bool back to its caller. All five resource types (Connection, Actor, EncryptionKey, ConnectorVersion, Namespace) are covered.
- Add \`labelsEqual\` helper.
- Add \`ReconcileCarryForwardLabels(ctx, batchSize, interBatchDelay) (int64, error)\` on \`database.DB\`. Walks every labelled resource type (namespaces top-down, then connector versions, connections, actors, encryption keys), pages by \`batchSize\` via the existing \`Enumerate\` builders, and recomputes each row in its own short transaction. Sleeps \`interBatchDelay\` between resource types to throttle DB load. Logs a structured entry per drift fix and a summary at the end.

### Tasks layer
- \`internal/database/tasks/task_reconcile_carry_forward_labels.go\`: task type \`database:reconcile_carry_forward_labels\` with default \`batchSize=100\` and \`interBatchDelay=0\`. Handler delegates to \`db.ReconcileCarryForwardLabels\`.
- Registered as a \`@daily\` periodic task alongside the existing purge and cleanup periodics.

## Tests
- \`TestReconcileCarryForwardLabels\` in the database package:
  - **Drift-correction**: seed a connection, corrupt its labels via raw SQL to bypass the carry-forward materialization, run the reconciler, verify the count is 1 and the connection's \`apxy/cxr/type\` is restored.
  - **Idempotence**: a clean run after the first stable pass reports 0 corrected.
- \`TestReconcileCarryForwardLabelsTask\` in the tasks package: handler delegates to db with the right defaults and propagates errors so asynq retries.
- \`TestNewReconcileCarryForwardLabelsTask\`: the constructor returns a task with the expected type.

## What this closes for #194
With this PR, all five sub-issues are merged: foundation primitives (#195), self-implicit + endpoint preservation (#200), parent carry-forward on create (#201), background propagation on parent label change (#202), per-request snapshot (#197), and the daily safety-net reconciler here (#198).

## Test plan
- [x] \`go test ./internal/database/\` and \`./internal/database/tasks/\` — new and existing tests pass.
- [x] \`go test ./...\` — full repo passes; no cross-package regressions.
- [x] \`./scripts/preflight.sh\` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)