### PR TITLE
Update go-oauth2-server pin; restore semantic scope names

### DIFF
--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   #   https://github.com/rmorlok/go-oauth2-server/blob/main/docs/test_mode_api.md
   oauth-server:
     build:
-      context: https://github.com/rmorlok/go-oauth2-server.git#97552ba20cfb7c367b95db0b500c239a99c3d155
+      context: https://github.com/rmorlok/go-oauth2-server.git#eb379d96ba1b0aa6cb5ba5826f75a13c8da66d50
     ports:
       - "8086:8080"
     # Bypass the upstream docker-entrypoint.sh: it waits for postgres+etcd

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   #   https://github.com/rmorlok/go-oauth2-server/blob/main/docs/test_mode_api.md
   oauth-server:
     build:
-      context: https://github.com/rmorlok/go-oauth2-server.git#eb379d96ba1b0aa6cb5ba5826f75a13c8da66d50
+      context: https://github.com/rmorlok/go-oauth2-server.git#eb379d97292dc292f55d70fd58198efb51489828
     ports:
       - "8086:8080"
     # Bypass the upstream docker-entrypoint.sh: it waits for postgres+etcd

--- a/integration_tests/oauth2/scope_mismatch_test.go
+++ b/integration_tests/oauth2/scope_mismatch_test.go
@@ -187,24 +187,17 @@ func (s *scopeMismatchSetup) fetchConnectionScopes(t *testing.T, connectionID st
 
 func ptr(s string) *string { return &s }
 
-// TestScopeMismatch_RequiredMissing — the connector requires {read, email} but
+// TestScopeMismatch_RequiredMissing — the connector requires {read, write} but
 // the provider grants only {read}. The proxy must reject the token, record an
 // auth failure, and surface the missing required scope in setup_error. The
 // token row is still persisted so /scopes can show what was requested vs
 // granted (useful for debugging the failure).
 //
-// We use scope names that the test provider has pre-registered in its scopes
-// table (read, email) — see go-oauth2-server/testmode/seed.go. The provider's
-// login handler validates the requested scope against that table before
-// rendering the consent page, so unregistered scopes (e.g. "write") would
-// short-circuit the flow at login and never reach the divergence we want to
-// test.
-//
 // See scope_mismatch_test.md for the scenario specification.
 func TestScopeMismatch_RequiredMissing(t *testing.T) {
 	s := newScopeMismatchSetup(t, "scope-required-missing",
-		[]string{"read", "email"}, nil,
-		[]string{"read", "email"})
+		[]string{"read", "write"}, nil,
+		[]string{"read", "write"})
 
 	s.provider.Script(s.clientKey, helpers.EndpointToken, helpers.ScriptAction{
 		ScopeOverride: ptr("read"),
@@ -221,25 +214,24 @@ func TestScopeMismatch_RequiredMissing(t *testing.T) {
 	require.NotNilf(t, conn.SetupError, "auth-failed connection should have setup_error recorded")
 	assert.Containsf(t, *conn.SetupError, "required oauth2 scopes were not granted",
 		"setup_error should call out the missing required scopes; got %q", *conn.SetupError)
-	assert.Containsf(t, *conn.SetupError, "email",
+	assert.Containsf(t, *conn.SetupError, "write",
 		"setup_error should name the missing scope; got %q", *conn.SetupError)
 
 	token := s.env.GetOAuth2Token(t, connectionID)
 	require.NotNilf(t, token, "token row should be persisted even on required-missing so /scopes can show the divergence")
 	assert.Equal(t, "read", token.Scopes, "stored scopes should reflect what the provider returned")
-	assert.Equal(t, "read email", token.RequestedScopes,
+	assert.Equal(t, "read write", token.RequestedScopes,
 		"requested_scopes should preserve the original request from the connector")
 }
 
-// TestScopeMismatch_OptionalMissing — connector declares {read (req), email
+// TestScopeMismatch_OptionalMissing — connector declares {read (req), write
 // (opt)}, provider grants only {read}. Connection should land ready, and
 // callers can inspect the divergence through the /scopes endpoint to decide
-// which features to expose. See TestScopeMismatch_RequiredMissing for why we
-// use registered scope names like "email" rather than "write".
+// which features to expose.
 func TestScopeMismatch_OptionalMissing(t *testing.T) {
 	s := newScopeMismatchSetup(t, "scope-optional-missing",
-		[]string{"read"}, []string{"email"},
-		[]string{"read", "email"})
+		[]string{"read"}, []string{"write"},
+		[]string{"read", "write"})
 
 	s.provider.Script(s.clientKey, helpers.EndpointToken, helpers.ScriptAction{
 		ScopeOverride: ptr("read"),
@@ -254,25 +246,24 @@ func TestScopeMismatch_OptionalMissing(t *testing.T) {
 	token := s.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, token, "token must be persisted on the success path")
 	assert.Equal(t, "read", token.Scopes)
-	assert.Equal(t, "read email", token.RequestedScopes)
+	assert.Equal(t, "read write", token.RequestedScopes)
 
 	status, body := s.fetchConnectionScopes(t, connectionID)
 	require.Equal(t, http.StatusOK, status)
-	assert.ElementsMatch(t, []string{"read", "email"}, body["requested"])
+	assert.ElementsMatch(t, []string{"read", "write"}, body["requested"])
 	assert.ElementsMatch(t, []string{"read"}, body["granted"])
 }
 
-// TestScopeMismatch_AllScopesGranted — connector declares {read (req), email
+// TestScopeMismatch_AllScopesGranted — connector declares {read (req), write
 // (opt)} and the provider grants both. Connection ready and the granted set
-// equals the requested set as exposed via the /scopes endpoint. See
-// TestScopeMismatch_RequiredMissing for why we use registered scope names.
+// equals the requested set as exposed via the /scopes endpoint.
 func TestScopeMismatch_AllScopesGranted(t *testing.T) {
 	s := newScopeMismatchSetup(t, "scope-all-granted",
-		[]string{"read"}, []string{"email"},
-		[]string{"read", "email"})
+		[]string{"read"}, []string{"write"},
+		[]string{"read", "write"})
 
 	s.provider.Script(s.clientKey, helpers.EndpointToken, helpers.ScriptAction{
-		ScopeOverride: ptr("read email"),
+		ScopeOverride: ptr("read write"),
 	})
 
 	connectionID := s.driveApprovalAndGetConnectionId(t)
@@ -282,13 +273,13 @@ func TestScopeMismatch_AllScopesGranted(t *testing.T) {
 
 	token := s.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, token)
-	assert.Equal(t, "read email", token.Scopes)
-	assert.Equal(t, "read email", token.RequestedScopes)
+	assert.Equal(t, "read write", token.Scopes)
+	assert.Equal(t, "read write", token.RequestedScopes)
 
 	status, body := s.fetchConnectionScopes(t, connectionID)
 	require.Equal(t, http.StatusOK, status)
-	assert.ElementsMatch(t, []string{"read", "email"}, body["requested"])
-	assert.ElementsMatch(t, []string{"read", "email"}, body["granted"])
+	assert.ElementsMatch(t, []string{"read", "write"}, body["requested"])
+	assert.ElementsMatch(t, []string{"read", "write"}, body["granted"])
 }
 
 // TestScopeMismatch_ExtraGranted — connector declares {read} but the provider

--- a/integration_tests/oauth2/scope_mismatch_test.md
+++ b/integration_tests/oauth2/scope_mismatch_test.md
@@ -39,20 +39,18 @@ The file contains five flow tests (one per scope-shape case):
 
 | Test                                      | Connector declares                       | Token-endpoint script   | Connection state | Notable assertion                                  |
 | ----------------------------------------- | ---------------------------------------- | ----------------------- | ---------------- | -------------------------------------------------- |
-| `TestScopeMismatch_RequiredMissing`       | `read` (req), `email` (req)              | `scope=read`            | `auth_failed`    | `setup_error` calls out the missing required scope |
-| `TestScopeMismatch_OptionalMissing`       | `read` (req), `email` (opt)              | `scope=read`            | `ready`          | `/scopes` returns granted=`[read]`, requested=`[read, email]` |
-| `TestScopeMismatch_AllScopesGranted`      | `read` (req), `email` (opt)              | `scope=read email`      | `ready`          | granted set equals requested set                   |
+| `TestScopeMismatch_RequiredMissing`       | `read` (req), `write` (req)              | `scope=read`            | `auth_failed`    | `setup_error` calls out the missing required scope |
+| `TestScopeMismatch_OptionalMissing`       | `read` (req), `write` (opt)              | `scope=read`            | `ready`          | `/scopes` returns granted=`[read]`, requested=`[read, write]` |
+| `TestScopeMismatch_AllScopesGranted`      | `read` (req), `write` (opt)              | `scope=read write`      | `ready`          | granted set equals requested set                   |
 | `TestScopeMismatch_ExtraGranted`          | `read` (req)                             | `scope=read admin`      | `ready`          | `/scopes` granted=`[read, admin]`, requested=`[read]` |
 | `TestScopeMismatch_ProviderOmitsScope`    | `read` (req)                             | `scope=""` (RFC §5.1)   | `ready`          | granted falls back to requested                    |
 
-The scope names used in the connector declarations (`read`, `email`)
-are chosen because they're already in the test provider's seeded scopes
-table — the provider's login handler validates the requested scope
-against that table before showing the consent page, so unregistered
-scope names like `write` would short-circuit the flow at login. For the
-ExtraGranted case the unregistered `admin` is fine: the connector only
-declares `read`, so the proxy never sends `admin` to the authorize
-endpoint — it appears solely in the scripted token response.
+The connector declarations use scope names like `write` and `admin`
+that are not in the provider's default seeded scopes table. The
+`provider.CreateClient(Scope: …)` call in the test setup registers
+each requested scope with the provider's `oauth_scopes` table (added
+in go-oauth2-server #44), so the provider's login handler accepts the
+authorize request and renders the consent page.
 
 For the success cases, each test additionally hits
 `GET /api/v1/connections/{id}/scopes` over the real HTTP server and


### PR DESCRIPTION
## Summary

- Bump the `oauth-server` build context pin from `97552ba` to `eb379d9` to pick up rmorlok/go-oauth2-server#44 (per-test scope registration via `POST /test/clients`).
- Restore `write` (req/opt) in the three scope-mismatch tests that had been temporarily switched to `email` to work around the unregistered-scope login redirect. Comments and the spec table now match the original intent.
- Update the spec note: instead of explaining a workaround, point at the new behavior (the test setup's existing `provider.CreateClient(Scope: …)` call now registers each requested scope).

No production code changes; helpers/setup.go didn't need changes — the existing `Scope` field on `CreateClientRequest` is what the upstream PR wired up.

## Test plan

- [ ] CI integration job green on this branch
- [ ] All five `TestScopeMismatch_*` tests pass
- [ ] `TestStandardAuthorizationCodeFlow` and `TestUserDenialFlow` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)