### PR TITLE
Bind OAuth2 state to namespace and encrypt Redis payload

### DIFF
--- a/internal/auth_methods/oauth2/oauth2.go
+++ b/internal/auth_methods/oauth2/oauth2.go
@@ -70,9 +70,8 @@ func (o *oAuth2Connection) RecordCancelSessionAfterAuth(ctx context.Context, sho
 	o.state.CancelSessionAfterAuth = shouldCancel
 	ttl := o.state.ExpiresAt.Sub(apctx.GetClock(ctx).Now())
 
-	result := o.r.Set(ctx, getStateRedisKey(o.state.Id), o.state, ttl)
-	if result.Err() != nil {
-		return fmt.Errorf("failed to set state in redis for session status for connection %s: %w", o.connection.GetId(), result.Err())
+	if err := writeStateToRedis(ctx, o.r, o.encrypt, o.state, ttl); err != nil {
+		return fmt.Errorf("failed to set state in redis for session status for connection %s: %w", o.connection.GetId(), err)
 	}
 
 	return nil

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -2,7 +2,6 @@ package oauth2
 
 import (
 	"context"
-	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/config"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -22,6 +22,7 @@ import (
 
 type state struct {
 	Id                     apid.ID   `json:"id"`
+	Namespace              string    `json:"namespace"`
 	ActorId                apid.ID   `json:"actor_id"`
 	ConnectorId            apid.ID   `json:"connector_id"`
 	ConnectorVersion       uint64    `json:"connector_version"`
@@ -31,20 +32,53 @@ type state struct {
 	ExpiresAt              time.Time `json:"expires_at"`
 }
 
-func (s *state) MarshalBinary() ([]byte, error) {
-	return json.Marshal(s)
-}
-
-func (s *state) UnmarshalBinary(data []byte) error {
-	return json.Unmarshal(data, s)
-}
-
-// Make sure we have implemented the interface correctly
-var _ encoding.BinaryMarshaler = (*state)(nil)
-var _ encoding.BinaryUnmarshaler = (*state)(nil)
-
 func (s *state) IsValid() bool {
 	return s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
+}
+
+// writeStateToRedis encrypts the state with the global key (AES-GCM AEAD)
+// and stores it under the state's Redis key. AEAD gives us both
+// confidentiality (the payload is unreadable in Redis) and integrity (a
+// payload mutated outside this proxy fails authentication on decrypt
+// rather than producing a forged state), closing the
+// tamper-via-redis-state attack vector.
+func writeStateToRedis(ctx context.Context, r apredis.Client, e encrypt.E, s *state, ttl time.Duration) error {
+	plaintext, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal oauth2 state: %w", err)
+	}
+	ef, err := e.EncryptGlobal(ctx, plaintext)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt oauth2 state: %w", err)
+	}
+	result := r.Set(ctx, getStateRedisKey(s.Id), ef.ToInlineString(), ttl)
+	if result.Err() != nil {
+		return fmt.Errorf("failed to set state in redis for state %s: %w", s.Id, result.Err())
+	}
+	return nil
+}
+
+// readStateFromRedis loads, decrypts, and unmarshals the state. A decrypt
+// failure (tampered ciphertext, wrong key, etc.) is reported as a generic
+// state error so callers don't leak the failure mode to clients.
+func readStateFromRedis(ctx context.Context, r apredis.Client, e encrypt.E, stateId apid.ID) (*state, error) {
+	raw, err := r.Get(ctx, getStateRedisKey(stateId)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth state from redis for id %s: %w", stateId.String(), err)
+	}
+	ef, err := encfield.ParseInlineString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse oauth state envelope for id %s: %w", stateId.String(), err)
+	}
+	plaintext, err := e.Decrypt(ctx, ef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt oauth state for id %s: %w", stateId.String(), err)
+	}
+	var s state
+	if err := json.Unmarshal(plaintext, &s); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal oauth state for id %s: %w", stateId.String(), err)
+	}
+	return &s, nil
 }
 
 func getStateRedisKey(u apid.ID) string {
@@ -58,6 +92,7 @@ func (o *oAuth2Connection) saveStateToRedis(ctx context.Context, actor IActorDat
 	ttl := o.cfg.GetRoot().Oauth.GetRoundTripTtlOrDefault()
 	s := &state{
 		Id:               stateId,
+		Namespace:        actor.GetNamespace(),
 		ActorId:          actor.GetId(),
 		ConnectorId:      o.connection.GetConnectorVersionEntity().GetId(),
 		ConnectorVersion: o.connection.GetConnectorVersionEntity().GetVersion(),
@@ -65,9 +100,8 @@ func (o *oAuth2Connection) saveStateToRedis(ctx context.Context, actor IActorDat
 		ExpiresAt:        time.Now().Add(ttl),
 		ReturnToUrl:      returnToUrl,
 	}
-	result := o.r.Set(ctx, getStateRedisKey(stateId), s, ttl)
-	if result.Err() != nil {
-		return fmt.Errorf("failed to set state in redis for connection %s: %w", o.connection.GetId(), result.Err())
+	if err := writeStateToRedis(ctx, o.r, o.encrypt, s, ttl); err != nil {
+		return fmt.Errorf("failed to set state in redis for connection %s: %w", o.connection.GetId(), err)
 	}
 
 	o.state = s
@@ -92,15 +126,9 @@ func getOAuth2State(
 		"actor_id", actor.GetId(),
 	)
 
-	result := r.Get(ctx, getStateRedisKey(stateId))
-
-	if result.Err() != nil {
-		return nil, fmt.Errorf("failed to get oauth state from redis for id %s: %w", stateId.String(), result.Err())
-	}
-
-	var s state
-	if err := result.Scan(&s); err != nil {
-		return nil, fmt.Errorf("failed to parse state from redis value: %w", err)
+	s, err := readStateFromRedis(ctx, r, encrypt, stateId)
+	if err != nil {
+		return nil, err
 	}
 
 	if !s.IsValid() {
@@ -115,6 +143,10 @@ func getOAuth2State(
 		return nil, fmt.Errorf("actor id %s does not match state actor id %s", actor.GetId(), s.ActorId)
 	}
 
+	if s.Namespace != actor.GetNamespace() {
+		return nil, fmt.Errorf("actor namespace %q does not match state namespace %q", actor.GetNamespace(), s.Namespace)
+	}
+
 	connection, err := core.GetConnection(ctx, s.ConnectionId)
 	if err != nil {
 		if errors.Is(err, coreIface.ErrNotFound) {
@@ -122,6 +154,10 @@ func getOAuth2State(
 		}
 
 		return nil, fmt.Errorf("failed to get connection %s for state %s: %w", s.ConnectionId.String(), stateId.String(), err)
+	}
+
+	if s.Namespace != connection.GetNamespace() {
+		return nil, fmt.Errorf("connection namespace %q does not match state namespace %q", connection.GetNamespace(), s.Namespace)
 	}
 
 	cv := connection.GetConnectorVersionEntity()
@@ -133,7 +169,7 @@ func getOAuth2State(
 	// TODO: add actor auth validation once connections get ownership
 
 	o := newOAuth2(cfg, db, r, core, encrypt, logger, httpf, connection)
-	o.state = &s
+	o.state = s
 
 	return o, nil
 }

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -33,7 +33,7 @@ type state struct {
 }
 
 func (s *state) IsValid() bool {
-	return s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
+	return s.Namespace != "" && s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
 }
 
 // writeStateToRedis encrypts the state with the global key (AES-GCM AEAD)

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -1,0 +1,206 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/config"
+	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stateTestActor is a minimal IActorData stub for state tests.
+type stateTestActor struct {
+	id        apid.ID
+	namespace string
+}
+
+func (a stateTestActor) GetId() apid.ID                      { return a.id }
+func (a stateTestActor) GetExternalId() string               { return "" }
+func (a stateTestActor) GetLabels() map[string]string        { return nil }
+func (a stateTestActor) GetPermissions() []aschema.Permission { return nil }
+func (a stateTestActor) GetNamespace() string                { return a.namespace }
+
+// stateTestCore is a minimal coreIface.C that only implements GetConnection.
+// Other method calls will nil-panic, making accidental coupling obvious.
+type stateTestCore struct {
+	coreIface.C
+	conn coreIface.Connection
+	err  error
+}
+
+func (c *stateTestCore) GetConnection(_ context.Context, _ apid.ID) (coreIface.Connection, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.conn, nil
+}
+
+func newStateTestEncrypt(t *testing.T) encrypt.E {
+	t.Helper()
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: sconfig.NewKeyDataRandomBytes(),
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	_, e := encrypt.NewTestEncryptService(cfg, db)
+	return e
+}
+
+func TestState_RoundTripPreservesNamespace(t *testing.T) {
+	ctx := context.Background()
+	_, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+
+	original := &state{
+		Id:           apid.New(apid.PrefixOauth2State),
+		Namespace:    "root.tenant-a",
+		ActorId:      apid.New(apid.PrefixActor),
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		ReturnToUrl:  "https://example.com/return",
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, original, time.Minute))
+
+	loaded, err := readStateFromRedis(ctx, r, e, original.Id)
+	require.NoError(t, err)
+	assert.Equal(t, original.Namespace, loaded.Namespace)
+	assert.Equal(t, original.ActorId, loaded.ActorId)
+	assert.Equal(t, original.ConnectionId, loaded.ConnectionId)
+}
+
+func TestState_RedisValueIsCiphertext(t *testing.T) {
+	ctx := context.Background()
+	_, r := apredis.MustApplyTestConfig(nil)
+	e := newStateTestEncrypt(t)
+
+	s := &state{
+		Id:           apid.New(apid.PrefixOauth2State),
+		Namespace:    "root.tenant-a",
+		ActorId:      apid.New(apid.PrefixActor),
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	raw, err := r.Get(ctx, getStateRedisKey(s.Id)).Result()
+	require.NoError(t, err)
+	// Sanity: the raw blob must NOT contain the namespace string in plaintext.
+	assert.NotContains(t, raw, s.Namespace, "namespace must not appear in cleartext in redis")
+	assert.NotContains(t, raw, s.ActorId.String(), "actor id must not appear in cleartext in redis")
+}
+
+func TestState_TamperedCiphertextFailsToDecrypt(t *testing.T) {
+	ctx := context.Background()
+	_, r := apredis.MustApplyTestConfig(nil)
+	e := newStateTestEncrypt(t)
+
+	s := &state{
+		Id:           apid.New(apid.PrefixOauth2State),
+		Namespace:    "root.tenant-a",
+		ActorId:      apid.New(apid.PrefixActor),
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	// Read the stored envelope, flip a byte in the ciphertext body, and write it back.
+	// AES-GCM is AEAD, so decryption must fail with an authentication error.
+	raw, err := r.Get(ctx, getStateRedisKey(s.Id)).Result()
+	require.NoError(t, err)
+
+	ef, err := encfield.ParseInlineString(raw)
+	require.NoError(t, err)
+
+	ciphertext, err := base64.StdEncoding.DecodeString(ef.Data)
+	require.NoError(t, err)
+	require.NotEmpty(t, ciphertext)
+	ciphertext[len(ciphertext)/2] ^= 0xff
+	tampered := encfield.EncryptedField{ID: ef.ID, Data: base64.StdEncoding.EncodeToString(ciphertext)}
+	require.NoError(t, r.Set(ctx, getStateRedisKey(s.Id), tampered.ToInlineString(), time.Minute).Err())
+
+	_, err = readStateFromRedis(ctx, r, e, s.Id)
+	require.Error(t, err, "tampered ciphertext must not decrypt")
+	assert.Contains(t, err.Error(), "decrypt")
+}
+
+func TestGetOAuth2State_RejectsNamespaceMismatchOnActor(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      actorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	// The state was created against tenant-a but the inbound actor claims tenant-b.
+	// Even with a matching actor id, the namespace check must reject.
+	actor := stateTestActor{id: actorId, namespace: "root.tenant-b"}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor namespace")
+}
+
+func TestGetOAuth2State_RejectsNamespaceMismatchOnConnection(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      actorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	// Actor namespace matches the state, but the connection on file is in a different
+	// namespace — likely because the state was crafted against another tenant's
+	// connection id. Reject before we reach the auth-method dispatch.
+	actor := stateTestActor{id: actorId, namespace: "root.tenant-a"}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection namespace")
+}
+
+// testWriter routes slog output through t.Log so it shows up under -v.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -140,6 +140,50 @@ func TestState_TamperedCiphertextFailsToDecrypt(t *testing.T) {
 	assert.Contains(t, err.Error(), "decrypt")
 }
 
+func TestState_IsValidRequiresNamespace(t *testing.T) {
+	base := state{
+		ActorId:      apid.New(apid.PrefixActor),
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute),
+	}
+
+	withNs := base
+	withNs.Namespace = "root.tenant-a"
+	require.True(t, withNs.IsValid(), "state with all fields populated must be valid")
+
+	withoutNs := base
+	require.False(t, withoutNs.IsValid(), "empty namespace must invalidate the state")
+}
+
+func TestGetOAuth2State_RejectsEmptyNamespaceInState(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	// A state forged or persisted without a namespace must not be accepted, even
+	// when the inbound actor's namespace happens to be empty too.
+	s := &state{
+		Id:           stateId,
+		Namespace:    "",
+		ActorId:      actorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	actor := stateTestActor{id: actorId, namespace: ""}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: ""}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+}
+
 func TestGetOAuth2State_RejectsNamespaceMismatchOnActor(t *testing.T) {
 	ctx := context.Background()
 	cfg, r := apredis.MustApplyTestConfig(nil)


### PR DESCRIPTION
## Summary
- Adds a `Namespace` field to the OAuth2 round-trip `state` and validates it on callback against both the inbound actor's namespace and the target connection's namespace, closing the cross-tenant replay/forgery vector.
- Replaces the plain-JSON Redis payload with an AES-GCM AEAD blob (encrypted via the global key, stored in `<ekv_id>:<base64>` form). Tampering with the Redis value now fails authentication on decrypt rather than producing a forged state — closes the manual-Redis-mutation attack vector.
- Routes `RecordCancelSessionAfterAuth` and `saveStateToRedis` through a single `writeStateToRedis` helper so the encrypted-write path is never bypassed.

This is PR 2 of the #167 workstream.

## Test plan
- [x] `go test ./internal/auth_methods/oauth2/...` — five new unit tests cover round-trip with namespace, ciphertext-not-plaintext, AEAD tamper rejection, actor-namespace mismatch, connection-namespace mismatch.
- [x] `go test ./...` — full suite passes.
- [x] `./scripts/preflight.sh` — passes.
- [ ] Integration tests on PR (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)