### PR TITLE
Emit structured oauth callback rejection events

### DIFF
--- a/internal/auth_methods/oauth2/callback_rejection.go
+++ b/internal/auth_methods/oauth2/callback_rejection.go
@@ -1,0 +1,136 @@
+package oauth2
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/apid"
+)
+
+// rejectionCategory identifies the class of failure that caused us to refuse
+// an OAuth2 callback. The category is the primary observability hook for
+// security operators investigating CSRF, replay, or cross-tenant probing —
+// alerts and dashboards key off these stable string values, so existing
+// values must not be renamed without updating downstream consumers.
+type rejectionCategory string
+
+const (
+	// rejectionMissingState — the callback URL had no `state` query
+	// parameter. Almost always a malformed request or a probe.
+	rejectionMissingState rejectionCategory = "missing_state"
+	// rejectionInvalidStateFormat — `state` was present but did not parse
+	// as an apid.ID. The value never reached Redis.
+	rejectionInvalidStateFormat rejectionCategory = "invalid_state_format"
+	// rejectionUnknownState — the parsed state id was not present in Redis.
+	// Covers both genuinely unknown ids and replays of states already
+	// consumed (we delete on success).
+	rejectionUnknownState rejectionCategory = "unknown_state"
+	// rejectionTamperedState — the Redis payload failed AEAD authentication
+	// on decrypt. The state envelope was modified outside this proxy.
+	rejectionTamperedState rejectionCategory = "tampered_state"
+	// rejectionStateLoadError — Redis or envelope parsing failed for a
+	// reason other than not-found or AEAD failure (e.g., transport error,
+	// malformed JSON after decrypt). Treated as a rejection because we
+	// cannot trust a state we cannot fully validate.
+	rejectionStateLoadError rejectionCategory = "state_load_error"
+	// rejectionStateInvalid — the decrypted state was missing required
+	// fields per state.IsValid (empty namespace, zero ids, etc.).
+	rejectionStateInvalid rejectionCategory = "state_invalid"
+	// rejectionExpiredState — the state's ExpiresAt is in the past.
+	rejectionExpiredState rejectionCategory = "expired_state"
+	// rejectionActorMismatch — the inbound actor's id does not match the
+	// actor id recorded on the state. A different user is attempting to
+	// complete someone else's flow.
+	rejectionActorMismatch rejectionCategory = "actor_mismatch"
+	// rejectionNamespaceMismatchActor — the inbound actor's namespace does
+	// not match the state's namespace. Cross-tenant probe via a stolen or
+	// guessed state id.
+	rejectionNamespaceMismatchActor rejectionCategory = "namespace_mismatch_actor"
+	// rejectionNamespaceMismatchConnection — the connection referenced by
+	// the state lives in a different namespace than the state itself.
+	// State was crafted against another tenant's connection id.
+	rejectionNamespaceMismatchConnection rejectionCategory = "namespace_mismatch_connection"
+	// rejectionConnectionNotFound — the connection id on the state has no
+	// matching record. Usually a deleted connection or a fabricated id.
+	rejectionConnectionNotFound rejectionCategory = "connection_not_found"
+	// rejectionConnectorTypeMismatch — the connection's connector is not
+	// configured for OAuth2 auth. The state was crafted against a
+	// non-OAuth2 connection.
+	rejectionConnectorTypeMismatch rejectionCategory = "connector_type_mismatch"
+)
+
+// rejectionAttrs carries the safe-to-log identifiers associated with a
+// rejected callback. All fields are optional; only the populated ones are
+// emitted, so callers can supply just what they have at the moment of
+// failure. apid.IDs are UUID-prefixed and opaque, so they're safe to log.
+// Never put secrets, tokens, or raw query strings here.
+type rejectionAttrs struct {
+	StateId      apid.ID
+	ActorId      apid.ID
+	ConnectionId apid.ID
+	Namespace    string
+	Err          error
+}
+
+// rejectionEventMessage is the single message string for every callback
+// rejection. Operators filter on this exact string when correlating events
+// across categories — keep it stable.
+const rejectionEventMessage = "oauth callback rejected"
+
+// emitCallbackRejection logs a structured "oauth callback rejected" event
+// at Warn. The category is the primary axis for downstream alerting; the
+// other attrs are populated only when the caller has them in hand. This
+// helper is the single entrypoint for rejection events so a future change
+// (sampling, metric emission, sink change) lives in one place.
+func emitCallbackRejection(ctx context.Context, logger *slog.Logger, category rejectionCategory, attrs rejectionAttrs) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	b := aplog.NewBuilder(logger).WithCtx(ctx)
+	if attrs.ConnectionId != apid.Nil {
+		b = b.WithConnectionId(attrs.ConnectionId)
+	}
+	if attrs.Namespace != "" {
+		b = b.WithNamespace(attrs.Namespace)
+	}
+
+	args := []any{slog.String("category", string(category))}
+	if attrs.StateId != apid.Nil {
+		args = append(args, slog.String("state_id", attrs.StateId.String()))
+	}
+	if attrs.ActorId != apid.Nil {
+		args = append(args, slog.String("actor_id", attrs.ActorId.String()))
+	}
+	if attrs.Err != nil {
+		args = append(args, slog.String("error", attrs.Err.Error()))
+	}
+
+	b.Build().WarnContext(ctx, rejectionEventMessage, args...)
+}
+
+// errStateNotFound and errStateTampered let callers of readStateFromRedis
+// distinguish "no such state" from "state was modified outside the proxy"
+// without inspecting error strings. Keeping these as sentinels (rather
+// than pushing rejection emission into readStateFromRedis itself) lets us
+// emit at the call site where ActorId is also in scope.
+var (
+	errStateNotFound = errors.New("oauth state not found")
+	errStateTampered = errors.New("oauth state failed integrity check")
+)
+
+// EmitMissingStateRejection is invoked by the public oauth2 callback route
+// when the inbound request has no `state` query parameter. The state id
+// hasn't been parsed yet, so attrs carries no identifiers.
+func EmitMissingStateRejection(ctx context.Context, logger *slog.Logger, err error) {
+	emitCallbackRejection(ctx, logger, rejectionMissingState, rejectionAttrs{Err: err})
+}
+
+// EmitInvalidStateFormatRejection is invoked by the public oauth2 callback
+// route when the `state` query parameter fails to parse as an apid.ID.
+// The raw value isn't logged because it's attacker-controlled.
+func EmitInvalidStateFormatRejection(ctx context.Context, logger *slog.Logger, err error) {
+	emitCallbackRejection(ctx, logger, rejectionInvalidStateFormat, rejectionAttrs{Err: err})
+}

--- a/internal/auth_methods/oauth2/callback_rejection_test.go
+++ b/internal/auth_methods/oauth2/callback_rejection_test.go
@@ -1,0 +1,126 @@
+package oauth2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bufLogger returns a slog logger writing JSON records to an in-memory
+// buffer plus a parser that returns each emitted record as a map. Tests
+// use this to assert on category/field shape without coupling to text
+// formatting.
+func bufLogger(t *testing.T) (*slog.Logger, func() []map[string]any) {
+	t.Helper()
+	var (
+		mu  sync.Mutex
+		buf bytes.Buffer
+	)
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(h)
+	read := func() []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		records := []map[string]any{}
+		dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+		for dec.More() {
+			var rec map[string]any
+			if err := dec.Decode(&rec); err != nil {
+				t.Fatalf("decode log record: %v", err)
+			}
+			records = append(records, rec)
+		}
+		return records
+	}
+	return logger, read
+}
+
+// onlyRejection filters log records to just the "oauth callback rejected"
+// events. Other emissions (debug logging, etc.) are ignored so assertions
+// don't have to know about adjacent log lines.
+func onlyRejection(records []map[string]any) []map[string]any {
+	out := []map[string]any{}
+	for _, r := range records {
+		if r["msg"] == rejectionEventMessage {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestEmitCallbackRejection_PopulatesProvidedFieldsOnly(t *testing.T) {
+	logger, read := bufLogger(t)
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+
+	emitCallbackRejection(context.Background(), logger, rejectionUnknownState, rejectionAttrs{
+		StateId: stateId,
+		ActorId: actorId,
+		Err:     errors.New("not found"),
+	})
+
+	records := onlyRejection(read())
+	require.Len(t, records, 1)
+	r := records[0]
+	assert.Equal(t, "WARN", r["level"])
+	assert.Equal(t, string(rejectionUnknownState), r["category"])
+	assert.Equal(t, stateId.String(), r["state_id"])
+	assert.Equal(t, actorId.String(), r["actor_id"])
+	assert.Equal(t, "not found", r["error"])
+	// Connection id and namespace were not set, so they must not appear.
+	_, hasConn := r["connection_id"]
+	_, hasNs := r["namespace"]
+	assert.False(t, hasConn, "connection_id should be omitted when not provided")
+	assert.False(t, hasNs, "namespace should be omitted when not provided")
+}
+
+func TestEmitCallbackRejection_AllFieldsPresent(t *testing.T) {
+	logger, read := bufLogger(t)
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	connId := apid.New(apid.PrefixConnection)
+
+	emitCallbackRejection(context.Background(), logger, rejectionNamespaceMismatchActor, rejectionAttrs{
+		StateId:      stateId,
+		ActorId:      actorId,
+		ConnectionId: connId,
+		Namespace:    "root.tenant-a",
+		Err:          errors.New("namespace mismatch"),
+	})
+
+	records := onlyRejection(read())
+	require.Len(t, records, 1)
+	r := records[0]
+	assert.Equal(t, string(rejectionNamespaceMismatchActor), r["category"])
+	assert.Equal(t, connId.String(), r["connection_id"])
+	assert.Equal(t, "root.tenant-a", r["namespace"])
+}
+
+func TestEmitMissingStateRejection_RouteWrapper(t *testing.T) {
+	logger, read := bufLogger(t)
+	EmitMissingStateRejection(context.Background(), logger, errors.New("no state"))
+
+	records := onlyRejection(read())
+	require.Len(t, records, 1)
+	assert.Equal(t, string(rejectionMissingState), records[0]["category"])
+	// State id never parsed, so no state_id field should be emitted.
+	_, hasStateId := records[0]["state_id"]
+	assert.False(t, hasStateId)
+}
+
+func TestEmitInvalidStateFormatRejection_RouteWrapper(t *testing.T) {
+	logger, read := bufLogger(t)
+	EmitInvalidStateFormatRejection(context.Background(), logger, errors.New("bad format"))
+
+	records := onlyRejection(read())
+	require.Len(t, records, 1)
+	assert.Equal(t, string(rejectionInvalidStateFormat), records[0]["category"])
+}

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
@@ -58,12 +59,24 @@ func writeStateToRedis(ctx context.Context, r apredis.Client, e encrypt.E, s *st
 	return nil
 }
 
-// readStateFromRedis loads, decrypts, and unmarshals the state. A decrypt
-// failure (tampered ciphertext, wrong key, etc.) is reported as a generic
-// state error so callers don't leak the failure mode to clients.
+// readStateFromRedis loads, decrypts, and unmarshals the state.
+//
+// Errors are wrapped against package sentinels so callers can dispatch on
+// the failure shape without inspecting strings:
+//   - errStateNotFound: the state id has no record in Redis (genuinely
+//     unknown id, or a replay of an already-consumed state).
+//   - errStateTampered: decryption or post-decrypt JSON parsing failed,
+//     indicating the payload was modified outside this proxy.
+//
+// Any other error (Redis transport, envelope parse) is returned wrapped
+// without a sentinel and represents a system fault rather than a security
+// rejection.
 func readStateFromRedis(ctx context.Context, r apredis.Client, e encrypt.E, stateId apid.ID) (*state, error) {
 	raw, err := r.Get(ctx, getStateRedisKey(stateId)).Result()
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, fmt.Errorf("%w: id %s", errStateNotFound, stateId.String())
+		}
 		return nil, fmt.Errorf("failed to get oauth state from redis for id %s: %w", stateId.String(), err)
 	}
 	ef, err := encfield.ParseInlineString(raw)
@@ -72,11 +85,11 @@ func readStateFromRedis(ctx context.Context, r apredis.Client, e encrypt.E, stat
 	}
 	plaintext, err := e.Decrypt(ctx, ef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt oauth state for id %s: %w", stateId.String(), err)
+		return nil, fmt.Errorf("%w: failed to decrypt oauth state for id %s: %v", errStateTampered, stateId.String(), err)
 	}
 	var s state
 	if err := json.Unmarshal(plaintext, &s); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal oauth state for id %s: %w", stateId.String(), err)
+		return nil, fmt.Errorf("%w: failed to unmarshal oauth state for id %s: %v", errStateTampered, stateId.String(), err)
 	}
 	return &s, nil
 }
@@ -128,42 +141,118 @@ func getOAuth2State(
 
 	s, err := readStateFromRedis(ctx, r, encrypt, stateId)
 	if err != nil {
+		switch {
+		case errors.Is(err, errStateNotFound):
+			emitCallbackRejection(ctx, logger, rejectionUnknownState, rejectionAttrs{
+				StateId: stateId,
+				ActorId: actor.GetId(),
+				Err:     err,
+			})
+		case errors.Is(err, errStateTampered):
+			emitCallbackRejection(ctx, logger, rejectionTamperedState, rejectionAttrs{
+				StateId: stateId,
+				ActorId: actor.GetId(),
+				Err:     err,
+			})
+		default:
+			emitCallbackRejection(ctx, logger, rejectionStateLoadError, rejectionAttrs{
+				StateId: stateId,
+				ActorId: actor.GetId(),
+				Err:     err,
+			})
+		}
 		return nil, err
 	}
 
 	if !s.IsValid() {
-		return nil, fmt.Errorf("state %s is invalid", stateId.String())
+		err := fmt.Errorf("state %s is invalid", stateId.String())
+		emitCallbackRejection(ctx, logger, rejectionStateInvalid, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	if s.ExpiresAt.Before(apctx.GetClock(ctx).Now()) {
-		return nil, fmt.Errorf("state %s has expired", stateId.String())
+		err := fmt.Errorf("state %s has expired", stateId.String())
+		emitCallbackRejection(ctx, logger, rejectionExpiredState, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	if s.ActorId != actor.GetId() {
-		return nil, fmt.Errorf("actor id %s does not match state actor id %s", actor.GetId(), s.ActorId)
+		err := fmt.Errorf("actor id %s does not match state actor id %s", actor.GetId(), s.ActorId)
+		emitCallbackRejection(ctx, logger, rejectionActorMismatch, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	if s.Namespace != actor.GetNamespace() {
-		return nil, fmt.Errorf("actor namespace %q does not match state namespace %q", actor.GetNamespace(), s.Namespace)
+		err := fmt.Errorf("actor namespace %q does not match state namespace %q", actor.GetNamespace(), s.Namespace)
+		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchActor, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	connection, err := core.GetConnection(ctx, s.ConnectionId)
 	if err != nil {
 		if errors.Is(err, coreIface.ErrNotFound) {
-			return nil, fmt.Errorf("connection %s not found for state %s", s.ConnectionId.String(), stateId.String())
+			notFoundErr := fmt.Errorf("connection %s not found for state %s", s.ConnectionId.String(), stateId.String())
+			emitCallbackRejection(ctx, logger, rejectionConnectionNotFound, rejectionAttrs{
+				StateId:      stateId,
+				ActorId:      actor.GetId(),
+				ConnectionId: s.ConnectionId,
+				Namespace:    s.Namespace,
+				Err:          notFoundErr,
+			})
+			return nil, notFoundErr
 		}
 
 		return nil, fmt.Errorf("failed to get connection %s for state %s: %w", s.ConnectionId.String(), stateId.String(), err)
 	}
 
 	if s.Namespace != connection.GetNamespace() {
-		return nil, fmt.Errorf("connection namespace %q does not match state namespace %q", connection.GetNamespace(), s.Namespace)
+		err := fmt.Errorf("connection namespace %q does not match state namespace %q", connection.GetNamespace(), s.Namespace)
+		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchConnection, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	cv := connection.GetConnectorVersionEntity()
 	connector := cv.GetDefinition()
 	if connector.Auth.GetType() != sconfig.AuthTypeOAuth2 {
-		return nil, fmt.Errorf("connector %s is not an oauth2 connector", s.ConnectorId)
+		err := fmt.Errorf("connector %s is not an oauth2 connector", s.ConnectorId)
+		emitCallbackRejection(ctx, logger, rejectionConnectorTypeMismatch, rejectionAttrs{
+			StateId:      stateId,
+			ActorId:      actor.GetId(),
+			ConnectionId: s.ConnectionId,
+			Namespace:    s.Namespace,
+			Err:          err,
+		})
+		return nil, err
 	}
 
 	// TODO: add actor auth validation once connections get ownership

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -248,3 +248,150 @@ func (w testWriter) Write(p []byte) (int, error) {
 	w.t.Log(string(p))
 	return len(p), nil
 }
+
+func TestGetOAuth2State_EmitsRejectionEvent_UnknownState(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger, read := bufLogger(t)
+
+	// State is never written, so the Redis lookup misses.
+	stateId := apid.New(apid.PrefixOauth2State)
+	actor := stateTestActor{id: apid.New(apid.PrefixActor), namespace: "root.tenant-a"}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, &stateTestCore{}, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+
+	events := onlyRejection(read())
+	require.Len(t, events, 1)
+	assert.Equal(t, string(rejectionUnknownState), events[0]["category"])
+	assert.Equal(t, stateId.String(), events[0]["state_id"])
+	assert.Equal(t, actor.id.String(), events[0]["actor_id"])
+}
+
+func TestGetOAuth2State_EmitsRejectionEvent_TamperedState(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := newStateTestEncrypt(t)
+	logger, read := bufLogger(t)
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actor := stateTestActor{id: apid.New(apid.PrefixActor), namespace: "root.tenant-a"}
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      actor.id,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	// Flip a byte in the ciphertext so AEAD authentication fails on read.
+	raw, err := r.Get(ctx, getStateRedisKey(stateId)).Result()
+	require.NoError(t, err)
+	ef, err := encfield.ParseInlineString(raw)
+	require.NoError(t, err)
+	ciphertext, err := base64.StdEncoding.DecodeString(ef.Data)
+	require.NoError(t, err)
+	ciphertext[len(ciphertext)/2] ^= 0xff
+	tampered := encfield.EncryptedField{ID: ef.ID, Data: base64.StdEncoding.EncodeToString(ciphertext)}
+	require.NoError(t, r.Set(ctx, getStateRedisKey(stateId), tampered.ToInlineString(), time.Minute).Err())
+
+	_, err = getOAuth2State(ctx, cfg, nil, r, &stateTestCore{}, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+
+	events := onlyRejection(read())
+	require.Len(t, events, 1)
+	assert.Equal(t, string(rejectionTamperedState), events[0]["category"])
+}
+
+func TestGetOAuth2State_EmitsRejectionEvent_ActorMismatch(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger, read := bufLogger(t)
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	stateActorId := apid.New(apid.PrefixActor)
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      stateActorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	// Inbound actor differs from the actor recorded on the state.
+	actor := stateTestActor{id: apid.New(apid.PrefixActor), namespace: "root.tenant-a"}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-a"}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+
+	events := onlyRejection(read())
+	require.Len(t, events, 1)
+	assert.Equal(t, string(rejectionActorMismatch), events[0]["category"])
+	assert.Equal(t, stateId.String(), events[0]["state_id"])
+}
+
+func TestGetOAuth2State_EmitsRejectionEvent_NamespaceMismatchActor(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger, read := bufLogger(t)
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      actorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	actor := stateTestActor{id: actorId, namespace: "root.tenant-b"}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+
+	events := onlyRejection(read())
+	require.Len(t, events, 1)
+	assert.Equal(t, string(rejectionNamespaceMismatchActor), events[0]["category"])
+	assert.Equal(t, "root.tenant-a", events[0]["namespace"])
+}
+
+func TestGetOAuth2State_EmitsRejectionEvent_NamespaceMismatchConnection(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger, read := bufLogger(t)
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	s := &state{
+		Id:           stateId,
+		Namespace:    "root.tenant-a",
+		ActorId:      actorId,
+		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
+		ConnectionId: apid.New(apid.PrefixConnection),
+		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	actor := stateTestActor{id: actorId, namespace: "root.tenant-a"}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+
+	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.Error(t, err)
+
+	events := onlyRejection(read())
+	require.Len(t, events, 1)
+	assert.Equal(t, string(rejectionNamespaceMismatchConnection), events[0]["category"])
+}

--- a/internal/routes/public_oauth2.go
+++ b/internal/routes/public_oauth2.go
@@ -39,17 +39,21 @@ func (r *PublicOauth2Routes) callback(gctx *gin.Context) {
 	auth.MustGetValidatorFromGinContext(gctx).MarkValidated()
 
 	if gctx.Query("state") == "" {
+		err := errors.New("failed to bind state param")
+		oauth2.EmitMissingStateRejection(ctx, r.logger, err)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		}, errors.New("failed to bind state param"))
+		}, err)
 		return
 	}
 
 	stateUUID, err := apid.Parse(gctx.Query("state"))
 	if err != nil {
+		wrapped := fmt.Errorf("failed to parse state param to UUID: %w", err)
+		oauth2.EmitInvalidStateFormatRejection(ctx, r.logger, wrapped)
 		r.cfg.GetRoot().ErrorPages.RenderErrorOrRedirect(gctx, sconfig.ErrorTemplateValues{
 			Error: sconfig.ErrorPageInternalError,
-		}, fmt.Errorf("failed to parse state param to UUID: %w", err))
+		}, wrapped)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Introduces a single structured slog event (`oauth callback rejected`) carrying a stable `category` attribute for every OAuth2 callback rejection path.
- Adds `errStateNotFound` / `errStateTampered` sentinels to `readStateFromRedis` so `getOAuth2State` can dispatch to the right category by `errors.Is` instead of error-string inspection.
- Wires the route-level rejections (missing state, unparseable state) through two narrow exported helpers since they happen before a state id exists.

Categories: `missing_state`, `invalid_state_format`, `unknown_state`, `tampered_state`, `state_load_error`, `state_invalid`, `expired_state`, `actor_mismatch`, `namespace_mismatch_actor`, `namespace_mismatch_connection`, `connection_not_found`, `connector_type_mismatch`. These string values are now part of the contract — downstream alerts and integration tests in #167 will key off them.

Part of #167. PR 1 of the rejection observability workstream — the integration tests in subsequent PRs assert on these events.

## Test plan

- [x] `go test ./internal/auth_methods/oauth2/...` passes (new helper-level tests + new tests asserting the category emerging from `getOAuth2State` for unknown / tampered / actor mismatch / both namespace mismatches).
- [x] `go test ./internal/routes/...` passes.
- [x] `go test ./internal/...` green across the tree.
- [x] `./scripts/preflight.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)