### PR TITLE
Add OAuth2 callback cross-actor rejection integration test (#167)

### DIFF
--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -595,12 +595,23 @@ func (env *IntegrationTestEnv) ForgeOAuth2CallbackURL(state, code string) string
 	return base
 }
 
-// InitiateOAuth2Connection POSTs to /api/v1/connections/_initiate and returns
-// the new connection's ID and the redirect URL the user would be sent to. The
-// redirect URL points at the public service's /oauth2/redirect endpoint.
+// InitiateOAuth2Connection POSTs to /api/v1/connections/_initiate signed as
+// the default test actor and returns the new connection's ID and the redirect
+// URL. Tests that need to initiate as a specific actor (multi-actor scenarios)
+// should call InitiateOAuth2ConnectionAsActor directly.
 func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToUrl string) (connectionID, redirectURL string) {
 	t.Helper()
-	require.NotNil(t, env.ApiGin, "InitiateOAuth2Connection requires in-process gin (StartHTTPServer must be false)")
+	return env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnToUrl, "test-actor")
+}
+
+// InitiateOAuth2ConnectionAsActor POSTs to /api/v1/connections/_initiate signed
+// for the named actor (external_id) and returns the new connection's ID and
+// the redirect URL pointing at the public service's /oauth2/redirect endpoint.
+// Works in both in-process (ApiGin) and real HTTP (ServerURL) modes.
+func (env *IntegrationTestEnv) InitiateOAuth2ConnectionAsActor(t *testing.T, connectorID apid.ID, returnToUrl, actorExternalID string) (connectionID, redirectURL string) {
+	t.Helper()
+	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
+		"InitiateOAuth2ConnectionAsActor requires either in-process gin or a running HTTP server")
 
 	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
 		ConnectorId: connectorID,
@@ -608,18 +619,34 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 	})
 	require.NoError(t, err)
 
+	const path = "/api/v1/connections/_initiate"
 	req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
 		http.MethodPost,
-		"/api/v1/connections/_initiate",
+		path,
 		body,
 		sconfig.RootNamespace,
-		"test-actor",
+		actorExternalID,
 		aschema.AllPermissions(),
 	)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	env.ApiGin.ServeHTTP(w, req)
+	if env.ApiGin != nil {
+		env.ApiGin.ServeHTTP(w, req)
+	} else {
+		abs, err := url.Parse(env.ServerURL + path)
+		require.NoError(t, err)
+		req.URL = abs
+		req.Host = abs.Host
+		req.RequestURI = ""
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		w.Code = resp.StatusCode
+		if _, err := w.Body.ReadFrom(resp.Body); err != nil {
+			require.NoError(t, err)
+		}
+	}
 	require.Equalf(t, http.StatusOK, w.Code, "initiate failed: %s", w.Body.String())
 
 	var resp coreIface.ConnectionSetupRedirect

--- a/integration_tests/oauth2/callback_actor_mismatch_test.go
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCallbackRejection_ActorMismatch covers issue #167 case 5: an attacker
+// initiates an OAuth flow, completes the provider authorize step to mint a
+// code, and sends the resulting `/oauth2/callback?state=…&code=…` URL to a
+// different actor (the victim) — e.g., via a phishing link. When the victim's
+// browser follows the link, the public service identifies the victim from
+// their SESSION-ID cookie, but the state record carries the attacker's actor
+// id. State validation must reject with `actor_mismatch` and redirect to the
+// configured error page; no token must be exchanged or persisted.
+//
+// See callback_actor_mismatch_test.md for the scenario specification, threat
+// model rationale, and sequence diagram.
+func TestCallbackRejection_ActorMismatch(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	attackerExternalID := "alice-attacker-" + suffix
+	victimExternalID := "bob-victim-" + suffix
+	clientKey := "actor-mismatch-client-" + suffix
+	clientSecret := "actor-mismatch-secret-" + suffix
+	providerUserPassword := "p4ssw0rd-" + suffix
+	providerUserEmail := "alice-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "actor-mismatch-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+
+	logCapture := helpers.NewLogCapture()
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:            helpers.ServiceTypeAPI,
+		StartHTTPServer:    true,
+		IncludePublic:      true,
+		ServeMarketplaceUI: true,
+		Connectors:         []sconfig.Connector{connector},
+		LogCapture:         logCapture,
+	})
+	defer env.Cleanup()
+
+	callbackURL := env.PublicOAuthCallbackURL()
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             callbackURL,
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	providerUser := provider.CreateUser(helpers.CreateUserRequest{
+		Username: providerUserEmail,
+		Password: providerUserPassword,
+		Email:    providerUserEmail,
+	})
+	require.NotEmpty(t, providerUser.ID)
+
+	// 1. Attacker initiates the connection. State stored in Redis with
+	//    ActorId = attacker. The connection row gets the attacker's actor.
+	returnTo := "https://example.com/return"
+	connID, redirectURL := env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnTo, attackerExternalID)
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed state_id in redirect URL: %s", redirectURL)
+
+	// 2. Mint a code via the test provider's /test/authorize. The provider
+	//    doesn't care which proxy actor owns the state — it's validating
+	//    against its own client/user records — so the attacker can drive
+	//    this leg programmatically. The output is the exact callback URL
+	//    the provider would have produced after a real consent.
+	authResp := provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    clientKey,
+		UserID:      providerUser.ID,
+		RedirectURI: callbackURL,
+		Scope:       "read",
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	require.NotEmpty(t, authResp.RedirectURL)
+	providerCallback, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code := providerCallback.Query().Get("code")
+	require.NotEmpty(t, code, "provider should issue a code on approve; got %s", authResp.RedirectURL)
+
+	// 3. Victim's marketplace session: open chromedp, navigate to
+	//    /connectors?auth_token=<victim>. The SPA bootstrap calls
+	//    /session/_initiate, which exchanges the JWT for a SESSION-ID
+	//    cookie scoped to the victim. We wait for the Connect button as
+	//    the bootstrap-complete signal — same marker standard_flow_test
+	//    uses.
+	victimAuthToken, err := env.PublicAuthUtil.GenerateBearerToken(
+		context.Background(), victimExternalID, sconfig.RootNamespace, aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	browserCtx, _ := helpers.NewBrowser(t)
+
+	connectorsURL := env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(victimAuthToken)
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Navigate(connectorsURL),
+		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
+	))
+
+	// 4. Victim's browser follows the forged callback link. The browser
+	//    carries the victim's SESSION-ID cookie, so the public service
+	//    identifies the victim as the calling actor; state validation
+	//    detects ActorId mismatch and redirects to the error page.
+	forgedURL := env.PublicURL + "/oauth2/callback?state=" + url.QueryEscape(stateID) + "&code=" + url.QueryEscape(code)
+	errorPageURL := env.Cfg.GetRoot().ErrorPages.InternalError
+	require.NotEmpty(t, errorPageURL, "test config must set error_pages.internal_error")
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Navigate(forgedURL),
+		// example.com renders <h1>Example Domain</h1> reliably; we use
+		// it as a load signal after the proxy's 302.
+		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
+	))
+
+	var finalURL string
+	require.NoError(t, chromedp.Run(browserCtx, chromedp.Location(&finalURL)))
+	assert.Equalf(t, errorPageURL, finalURL,
+		"victim's browser should land on error_pages.internal_error after actor_mismatch rejection; got %q", finalURL)
+
+	// 5. Exactly one rejection event with category=actor_mismatch, carrying
+	//    the state id. The actor_id field reflects the calling actor (the
+	//    victim) so SOC analysts see who was hit by the link.
+	events := logCapture.RecordsWithMessage(t, rejectionEventMessage)
+	require.Lenf(t, events, 1, "expected exactly one rejection event; got %d (%v)", len(events), events)
+	assert.Equal(t, "actor_mismatch", events[0]["category"], "rejection category mismatch")
+	assert.Equal(t, stateID, events[0]["state_id"], "rejection event should record the state_id")
+
+	// 6. No token row was written.
+	require.Nil(t, env.GetOAuth2Token(t, connID), "no oauth2_token row should exist after actor_mismatch rejection")
+
+	// 7. Connection still in `created`, no setup_step transition.
+	conn := env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+		"connection state should remain `created` after a rejected callback")
+	assert.Nil(t, conn.SetupStep, "no setup_step should be recorded on a rejected callback")
+	assert.Nil(t, conn.SetupError, "no setup_error should be recorded on a rejected callback")
+
+	// 8. Provider observed zero /token calls — the token exchange path was
+	//    short-circuited by state validation.
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientKey,
+	})
+	assert.Empty(t, tokenReqs, "provider must not have observed a /token call when actor_mismatch rejected")
+}

--- a/integration_tests/oauth2/callback_actor_mismatch_test.md
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.md
@@ -1,0 +1,143 @@
+# OAuth2 Callback State Security — Cross-Actor Case
+
+Companion specification for `callback_actor_mismatch_test.go`. Covers
+case 5 of #167: an attacker initiates a connection, drives the
+provider's authorize step to mint a code, and sends the resulting
+`/oauth2/callback?state=…&code=…` URL to a different actor (the
+victim). When the victim's browser follows the link, the public
+service identifies the victim from their `SESSION-ID` cookie, but the
+state record carries the attacker's actor id. State validation must
+reject with `actor_mismatch` and redirect to the configured error
+page; no token must be exchanged or persisted.
+
+The four direct-HTTP cases (1–4) live in
+`callback_state_security_test.go`. The cross-tenant + cross-connection
+cases (6–7) are PR 5.
+
+## Threat model
+
+The bug-bounty shape: an attacker partially completes an OAuth flow
+under their own session, then sends the *forged callback URL* to a
+victim — a phishing link, a chat message, an embedded image, anything
+that causes the victim's browser to issue a GET to the proxy's
+callback endpoint. The state envelope was minted under the attacker's
+actor id; the victim's browser carries the victim's session cookie.
+If the proxy did not bind state-to-actor, the callback would attach
+the attacker-controlled provider account to the victim's connection
+record — a confused-deputy compromise.
+
+## Why chromedp, not direct HTTP
+
+Cases 1–4 hinge on programmatic tampering with the callback URL or
+Redis envelope — values a real browser would never produce. Case 5
+hinges on *who's calling*: the attacker minted the state under their
+own actor id, but the request that delivers the code arrives carrying
+the victim's session credentials. That delivery vector is exactly
+what a phishing link looks like in the wild, and chromedp + the real
+marketplace bootstrap is the closest possible reproduction:
+
+- The victim's browser hits `/connectors?auth_token=<victim JWT>`.
+- The marketplace SPA calls `/api/v1/session/_initiate`, which mints
+  a `SESSION-ID` cookie scoped to the victim.
+- The browser then follows the forged callback URL. The cookie
+  travels with the request; the public service identifies the
+  caller as the victim.
+- State validation reads the envelope, finds the attacker's actor id
+  inside, compares against the calling actor (victim), and rejects.
+
+A direct-HTTP path with a JWT signed as the victim would exercise the
+same `state.ActorId` check — but it would not mirror the real-world
+delivery vector. The chromedp path is what bug-bounty submissions
+look like.
+
+## What is asserted
+
+- **Browser lands on the error page.** After the 302 from the proxy,
+  the final URL is `error_pages.internal_error` (configured to
+  `https://example.com/500.html` in the test config). We use the
+  `<h1>Example Domain</h1>` element as the load signal.
+- **Exactly one `oauth callback rejected` log event** with
+  `category=actor_mismatch` and `state_id` matching the minted state.
+  The `actor_id` field on the event reflects the *calling* actor
+  (the victim) so a SOC analyst can see who clicked the link.
+- **No `oauth2_tokens` row** exists for the connection.
+- **Connection state is unchanged** — still `created`, with `setup_step`
+  and `setup_error` both nil.
+- **Provider observed zero `/token` calls** for the test's client id.
+  The token exchange was short-circuited by state validation.
+
+## Components
+
+| Lever                                                       | What it controls |
+| ----------------------------------------------------------- | ---------------- |
+| `helpers.SetupOptions{StartHTTPServer: true, IncludePublic: true, ServeMarketplaceUI: true, LogCapture: …}` | Real HTTP server + marketplace static assets so chromedp can bootstrap a session. |
+| `env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnTo, "alice-attacker-…")` | Initiates the connection programmatically as the attacker — signs the request with a JWT carrying the attacker's external id. |
+| `provider.Authorize(...)` (`/test/authorize`)               | Mints the OAuth code without a browser. The provider doesn't care which proxy actor owns the state — it validates against its own client/user records — so the attacker can drive this leg programmatically. |
+| `env.PublicAuthUtil.GenerateBearerToken(ctx, "bob-victim-…", root, allPerms)` | Mints the JWT the victim's browser will present to the marketplace. |
+| chromedp navigation to `/connectors?auth_token=<victim JWT>` | Triggers the marketplace SPA's `_initiate` call, which sets the victim's `SESSION-ID` cookie. We wait on the `Connect` button as the bootstrap-complete signal. |
+| chromedp navigation to the forged `/oauth2/callback?state=…&code=…` | Delivers the callback under the victim's cookie. The public service identifies the victim; state validation detects the actor mismatch and 302s to the error page. |
+| `chromedp.Location(&finalURL)`                              | Reads the URL the browser landed on after the 302. |
+| `logCapture.RecordsWithMessage(t, rejectionEventMessage)`   | Surfaces the structured rejection event for assertions. |
+| `provider.Requests(EndpointToken, …)`                       | Confirms the token exchange path was never taken. |
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant ATK as Attacker (alice)
+    participant VIC as Victim browser<br/>(chromedp)
+    participant PUB as Public service<br/>(real HTTP)
+    participant API as API service<br/>(real HTTP)
+    participant DB as Postgres
+    participant R as Redis
+    participant P as OAuth provider<br/>(docker)
+
+    Note over T,P: Attacker leg — programmatic, runs as alice
+    T->>API: POST /api/v1/connections/_initiate<br/>(JWT signed as attacker)
+    API->>R: write encrypted state envelope<br/>(ActorId = attacker)
+    API->>DB: insert connection (created, attacker actor)
+    API-->>T: { redirect_url containing state_id }
+
+    T->>P: POST /test/authorize (client+user, decision=approve, state=state_id)
+    P-->>T: { redirect_url with code + state_id }
+
+    Note over T,P: Victim leg — driven by chromedp
+    T->>VIC: navigate /connectors?auth_token=<victim JWT>
+    VIC->>PUB: GET /connectors?auth_token=…
+    VIC->>PUB: POST /api/v1/session/_initiate (auto by SPA)
+    PUB-->>VIC: SESSION-ID cookie (scoped to victim)
+    VIC->>PUB: GET /api/v1/connectors?limit=… (SPA bootstrap)
+    PUB-->>VIC: render Connect button (bootstrap-complete signal)
+
+    Note over T,P: Forged link delivery
+    T->>VIC: navigate /oauth2/callback?state=…&code=…
+    VIC->>PUB: GET /oauth2/callback?state=…&code=…<br/>(carries victim's SESSION-ID cookie)
+    PUB->>R: GET state envelope
+    PUB->>PUB: state.ActorId(attacker) ≠ caller(victim)
+    PUB-->>VIC: 302 → error_pages.internal_error
+    VIC->>VIC: load https://example.com/500.html
+
+    Note over T,PUB: An "oauth callback rejected" event with
+    Note over T,PUB: category=actor_mismatch is in env.LogCapture.
+    Note over T,P: Provider observed no /token call.
+```
+
+## Why we don't pre-create alice / bob
+
+`NewSignedRequestForActorExternalId` signs the JWT with `claims.Actor`
+populated. The auth middleware on the receiving service treats this
+as a self-asserted actor and upserts on first sight, so the test does
+not need to pre-create either actor row.
+
+## Why we rely on `https://example.com/500.html` reachability
+
+The error page redirect's destination URL comes from the test
+config's `error_pages.internal_error`. We chose `example.com` because
+it is reliably reachable and renders a stable `<h1>Example Domain</h1>`
+that chromedp can wait on as a load signal. An alternative — running
+a local HTTP stub for the error page — would add machinery without
+strengthening any assertion. The test asserts the *final URL*, not
+the page content; the `<h1>` wait is just a deterministic page-loaded
+gate.


### PR DESCRIPTION
## Summary

- Adds `TestCallbackRejection_ActorMismatch` covering case 5 of #167: an attacker initiates a connection, mints a provider code under their own actor, and sends the forged callback URL to a victim whose browser carries a different session cookie. State validation must reject with `category=actor_mismatch`, redirect to the error page, and not exchange or persist a token.
- Drives the victim leg through chromedp + the real marketplace SPA bootstrap (auth_token → `/session/_initiate` → `SESSION-ID` cookie → forged `/oauth2/callback`) so the test mirrors the bug-bounty delivery vector — attacker sends a partially-authorized link to a victim — rather than just exercising the `state.ActorId` check via signed HTTP.
- Generalizes `InitiateOAuth2Connection` by extracting `InitiateOAuth2ConnectionAsActor`, which signs the JWT for a named external id and works in both in-process gin and real HTTP modes.
- Companion spec at `integration_tests/oauth2/callback_actor_mismatch_test.md` covers the threat model, why chromedp over direct HTTP, the assertion list, and a sequence diagram.

This is PR 4 of the #167 workstream. Cases 1–4 (direct-HTTP rejection) shipped in #215; cases 6–7 (cross-namespace, cross-connection) are the next PR.

## Test plan

- [x] `go test -tags integration -count=1 -v -run TestCallbackRejection_ActorMismatch ./oauth2/...` passes against the docker-compose stack
- [x] `./scripts/preflight.sh` passes
- [x] No regression in existing `TestCallbackRejection_*` cases or `TestStandardFlow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)