### PR TITLE
Add OAuth2 callback cross-namespace rejection tests (#167)

### DIFF
--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -596,26 +598,36 @@ func (env *IntegrationTestEnv) ForgeOAuth2CallbackURL(state, code string) string
 }
 
 // InitiateOAuth2Connection POSTs to /api/v1/connections/_initiate signed as
-// the default test actor and returns the new connection's ID and the redirect
-// URL. Tests that need to initiate as a specific actor (multi-actor scenarios)
-// should call InitiateOAuth2ConnectionAsActor directly.
+// the default test actor in the root namespace. Tests that need to initiate
+// as a specific actor (multi-actor scenarios) or in a child namespace
+// (multi-tenant scenarios) should call InitiateOAuth2ConnectionAsActor directly.
 func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToUrl string) (connectionID, redirectURL string) {
 	t.Helper()
-	return env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnToUrl, "test-actor")
+	return env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnToUrl, "test-actor", sconfig.RootNamespace)
 }
 
 // InitiateOAuth2ConnectionAsActor POSTs to /api/v1/connections/_initiate signed
-// for the named actor (external_id) and returns the new connection's ID and
-// the redirect URL pointing at the public service's /oauth2/redirect endpoint.
-// Works in both in-process (ApiGin) and real HTTP (ServerURL) modes.
-func (env *IntegrationTestEnv) InitiateOAuth2ConnectionAsActor(t *testing.T, connectorID apid.ID, returnToUrl, actorExternalID string) (connectionID, redirectURL string) {
+// for the named actor (external_id) in the given namespace and returns the new
+// connection's ID and the redirect URL pointing at the public service's
+// /oauth2/redirect endpoint. Works in both in-process (ApiGin) and real HTTP
+// (ServerURL) modes.
+//
+// Caller is responsible for ensuring the namespace exists (via env.Core.CreateNamespace
+// or its ancestors) when it is not the root namespace.
+func (env *IntegrationTestEnv) InitiateOAuth2ConnectionAsActor(t *testing.T, connectorID apid.ID, returnToUrl, actorExternalID, namespace string) (connectionID, redirectURL string) {
 	t.Helper()
 	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
 		"InitiateOAuth2ConnectionAsActor requires either in-process gin or a running HTTP server")
 
+	// Land the connection in the actor's namespace by default. Without
+	// IntoNamespace, the API places the connection in the connector's
+	// namespace (root), which doesn't reflect how a real multi-tenant
+	// deployment isolates tenants — and breaks state-vs-connection
+	// namespace checks the security tests rely on.
 	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
-		ConnectorId: connectorID,
-		ReturnToUrl: returnToUrl,
+		ConnectorId:   connectorID,
+		ReturnToUrl:   returnToUrl,
+		IntoNamespace: namespace,
 	})
 	require.NoError(t, err)
 
@@ -624,7 +636,7 @@ func (env *IntegrationTestEnv) InitiateOAuth2ConnectionAsActor(t *testing.T, con
 		http.MethodPost,
 		path,
 		body,
-		sconfig.RootNamespace,
+		namespace,
 		actorExternalID,
 		aschema.AllPermissions(),
 	)
@@ -689,12 +701,22 @@ func (env *IntegrationTestEnv) FollowOAuth2Redirect(t *testing.T, redirectURL st
 }
 
 // DeliverOAuth2Callback issues an in-process GET to the public service's
-// `/oauth2/callback` endpoint with the code+state the OAuth provider would
-// have redirected the user to. Returns the final Location header — typically
-// the test's return_to_url, possibly augmented with setup=pending.
+// `/oauth2/callback` endpoint signed as the default test actor in the root
+// namespace. Tests that need to deliver under a specific actor or in a child
+// namespace should call DeliverOAuth2CallbackAsActor directly.
 func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL string) string {
 	t.Helper()
-	require.NotNil(t, env.PublicGin, "DeliverOAuth2Callback requires SetupOptions.IncludePublic=true")
+	return env.DeliverOAuth2CallbackAsActor(t, callbackURL, "test-actor", sconfig.RootNamespace)
+}
+
+// DeliverOAuth2CallbackAsActor issues an in-process GET to the public service's
+// `/oauth2/callback` endpoint signed for the named actor (external_id) in the
+// given namespace, mirroring the JWT a real browser session for that actor
+// would carry. Returns the final Location header — typically the test's
+// return_to_url on success, or error_pages.internal_error on rejection.
+func (env *IntegrationTestEnv) DeliverOAuth2CallbackAsActor(t *testing.T, callbackURL, actorExternalID, namespace string) string {
+	t.Helper()
+	require.NotNil(t, env.PublicGin, "DeliverOAuth2CallbackAsActor requires SetupOptions.IncludePublic=true")
 
 	parsed, err := url.Parse(callbackURL)
 	require.NoError(t, err)
@@ -703,8 +725,8 @@ func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL s
 		http.MethodGet,
 		parsed.RequestURI(),
 		nil,
-		sconfig.RootNamespace,
-		"test-actor",
+		namespace,
+		actorExternalID,
 		aschema.AllPermissions(),
 	)
 	require.NoError(t, err)
@@ -716,6 +738,46 @@ func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL s
 	loc := w.Header().Get("Location")
 	require.NotEmpty(t, loc, "/oauth2/callback should set Location")
 	return loc
+}
+
+// OAuth2StateForTest mirrors the unexported `state` struct in
+// internal/auth_methods/oauth2 (see state.go:24-34) so tests can construct
+// synthetic state envelopes that exercise validation paths the natural
+// _initiate flow can't reach (e.g., crafted namespace/actor mismatches
+// against the state-vs-caller and state-vs-connection checks).
+//
+// JSON tags must stay in sync with the production struct; if they drift,
+// the production decode will fail with errStateTampered.
+type OAuth2StateForTest struct {
+	Id                     apid.ID   `json:"id"`
+	Namespace              string    `json:"namespace"`
+	ActorId                apid.ID   `json:"actor_id"`
+	ConnectorId            apid.ID   `json:"connector_id"`
+	ConnectorVersion       uint64    `json:"connector_version"`
+	ConnectionId           apid.ID   `json:"connection_id"`
+	ReturnToUrl            string    `json:"return_to"`
+	CancelSessionAfterAuth bool      `json:"cancel_session_after_auth"`
+	ExpiresAt              time.Time `json:"expires_at"`
+}
+
+// WriteOAuth2StateForTest encrypts and stores a synthetic OAuth2 state
+// envelope in Redis at the production key `oauth2:state:<state.Id>`,
+// using env.DM's encrypt service so the envelope round-trips through the
+// same AEAD as a state minted by the real `_initiate` flow.
+//
+// Used by tests that need the production callback handler to read a state
+// envelope with hand-crafted fields (namespace_mismatch_actor,
+// namespace_mismatch_connection, etc.) — values the natural flow would
+// never produce.
+func (env *IntegrationTestEnv) WriteOAuth2StateForTest(t *testing.T, s OAuth2StateForTest, ttl time.Duration) {
+	t.Helper()
+	plaintext, err := json.Marshal(s)
+	require.NoError(t, err)
+	ctx := context.Background()
+	ef, err := env.DM.GetEncryptService().EncryptGlobal(ctx, plaintext)
+	require.NoError(t, err)
+	key := fmt.Sprintf("oauth2:state:%s", s.Id.String())
+	require.NoError(t, env.DM.GetRedisClient().Set(ctx, key, ef.ToInlineString(), ttl).Err())
 }
 
 // GetOAuth2Token reads the most recent OAuth2 token row stored for the

--- a/integration_tests/oauth2/callback_cross_namespace_test.go
+++ b/integration_tests/oauth2/callback_cross_namespace_test.go
@@ -19,30 +19,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCallbackRejection_ActorMismatch covers issue #167 case 5: an attacker
-// initiates an OAuth flow, completes the provider authorize step to mint a
-// code, and sends the resulting `/oauth2/callback?state=…&code=…` URL to a
-// different actor (the victim) — e.g., via a phishing link. When the victim's
-// browser follows the link, the public service identifies the victim from
-// their SESSION-ID cookie, but the state record carries the attacker's actor
-// id. State validation must reject with `actor_mismatch` and redirect to the
-// configured error page; no token must be exchanged or persisted.
+// TestCallbackRejection_CrossNamespace covers issue #167 case 6: a multi-tenant
+// AuthProxy deployment where two customer apps share the instance and use
+// child namespaces (`root.tenant-a`, `root.tenant-b`) to isolate their actors.
+// The same external_id can refer to two different users — one in each
+// namespace — because actor rows are scoped per-namespace.
 //
-// See callback_actor_mismatch_test.md for the scenario specification, threat
-// model rationale, and sequence diagram.
-func TestCallbackRejection_ActorMismatch(t *testing.T) {
+// Threat: an attacker (alice in tenant-a) initiates a connection, drives the
+// provider's authorize step to mint a code, and sends the resulting callback
+// URL to a victim with the same external_id in a different tenant (bob in
+// tenant-b). When bob's browser follows the link, the public service
+// identifies bob from his SESSION-ID cookie. Because actor IDs are
+// independently allocated per (namespace, external_id), bob's actor id
+// differs from alice's — so state validation rejects with `actor_mismatch`
+// before reaching the namespace-specific defense-in-depth checks.
+//
+// The two `namespace_mismatch_*` categories are tested separately in
+// callback_namespace_mismatch_test.go via direct state-envelope injection.
+func TestCallbackRejection_CrossNamespace(t *testing.T) {
 	provider := helpers.NewOAuth2TestProvider(t)
 
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
-	attackerExternalID := "alice-attacker-" + suffix
-	victimExternalID := "bob-victim-" + suffix
-	clientKey := "actor-mismatch-client-" + suffix
-	clientSecret := "actor-mismatch-secret-" + suffix
+	tenantA := "root.tenant-a-" + suffix
+	tenantB := "root.tenant-b-" + suffix
+	// Same external_id in both tenants — the multi-tenant collision the
+	// test exercises. Each tenant's actor row gets its own actor_id.
+	sharedExternalID := "user-123-" + suffix
+	clientKey := "cross-ns-client-" + suffix
+	clientSecret := "cross-ns-secret-" + suffix
 	providerUserPassword := "p4ssw0rd-" + suffix
 	providerUserEmail := "alice-" + suffix + "@example.com"
 
 	connectorID := apid.New(apid.PrefixConnectorVersion)
-	connector := helpers.NewOAuth2Connector(connectorID, "actor-mismatch-test", provider, helpers.OAuth2ConnectorOptions{
+	connector := helpers.NewOAuth2Connector(connectorID, "cross-ns-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,
 		Scopes:       []string{"read"},
@@ -58,6 +67,12 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 		LogCapture:         logCapture,
 	})
 	defer env.Cleanup()
+
+	ctx := context.Background()
+	_, err := env.Core.CreateNamespace(ctx, tenantA, nil)
+	require.NoError(t, err)
+	_, err = env.Core.CreateNamespace(ctx, tenantB, nil)
+	require.NoError(t, err)
 
 	callbackURL := env.PublicOAuthCallbackURL()
 	registered := provider.CreateClient(helpers.CreateClientRequest{
@@ -76,20 +91,18 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 	})
 	require.NotEmpty(t, providerUser.ID)
 
-	// 1. Attacker initiates the connection. State stored in Redis with
-	//    ActorId = attacker. The connection row gets the attacker's actor.
+	// 1. Attacker initiates as alice in tenant-a. State stored with
+	//    Namespace=tenant-a, ActorId=<alice's tenant-a actor>.
 	returnTo := "https://example.com/return"
-	connID, redirectURL := env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnTo, attackerExternalID, sconfig.RootNamespace)
+	connID, redirectURL := env.InitiateOAuth2ConnectionAsActor(t, connectorID, returnTo, sharedExternalID, tenantA)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
 	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed state_id in redirect URL: %s", redirectURL)
+	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed state_id: %s", redirectURL)
 
 	// 2. Mint a code via the test provider's /test/authorize. The provider
-	//    doesn't care which proxy actor owns the state — it's validating
-	//    against its own client/user records — so the attacker can drive
-	//    this leg programmatically. The output is the exact callback URL
-	//    the provider would have produced after a real consent.
+	//    only validates against its own client/user records, so the
+	//    attacker can drive this leg programmatically.
 	authResp := provider.Authorize(helpers.AuthorizeRequest{
 		ClientID:    clientKey,
 		UserID:      providerUser.ID,
@@ -104,68 +117,65 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 	code := providerCallback.Query().Get("code")
 	require.NotEmpty(t, code, "provider should issue a code on approve; got %s", authResp.RedirectURL)
 
-	// 3. Victim's marketplace session: open chromedp, navigate to
-	//    /connectors?auth_token=<victim>. The SPA bootstrap calls
-	//    /session/_initiate, which exchanges the JWT for a SESSION-ID
-	//    cookie scoped to the victim. We wait for the Connect button as
-	//    the bootstrap-complete signal — same marker standard_flow_test
-	//    uses.
-	victimAuthToken, err := env.PublicAuthUtil.GenerateBearerToken(
-		context.Background(), victimExternalID, sconfig.RootNamespace, aschema.AllPermissions(),
+	// 3. Victim bob's marketplace session in tenant-b. Same external_id
+	//    as alice but a different namespace, so the auth middleware
+	//    materializes a separate actor row with a different actor_id.
+	bobAuthToken, err := env.PublicAuthUtil.GenerateBearerToken(
+		ctx, sharedExternalID, tenantB, aschema.AllPermissions(),
 	)
 	require.NoError(t, err)
 
 	browserCtx, _ := helpers.NewBrowser(t)
 
-	connectorsURL := env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(victimAuthToken)
+	connectorsURL := env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(bobAuthToken)
 	require.NoError(t, chromedp.Run(browserCtx,
 		chromedp.Navigate(connectorsURL),
 		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
 	))
 
-	// 4. Victim's browser follows the forged callback link. The browser
-	//    carries the victim's SESSION-ID cookie, so the public service
-	//    identifies the victim as the calling actor; state validation
-	//    detects ActorId mismatch and redirects to the error page.
+	// 4. Bob's browser follows the forged callback link. The browser
+	//    carries bob's SESSION-ID cookie, so the public service
+	//    identifies bob (tenant-b actor); state validation finds
+	//    s.ActorId (alice in tenant-a) != caller.Id (bob in tenant-b)
+	//    and rejects with actor_mismatch — the namespace-specific checks
+	//    never run because actor identity is checked first.
 	forgedURL := env.PublicURL + "/oauth2/callback?state=" + url.QueryEscape(stateID) + "&code=" + url.QueryEscape(code)
 	errorPageURL := env.Cfg.GetRoot().ErrorPages.InternalError
 	require.NotEmpty(t, errorPageURL, "test config must set error_pages.internal_error")
 
 	require.NoError(t, chromedp.Run(browserCtx,
 		chromedp.Navigate(forgedURL),
-		// example.com renders <h1>Example Domain</h1> reliably; we use
-		// it as a load signal after the proxy's 302.
 		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
 	))
 
 	var finalURL string
 	require.NoError(t, chromedp.Run(browserCtx, chromedp.Location(&finalURL)))
 	assert.Equalf(t, errorPageURL, finalURL,
-		"victim's browser should land on error_pages.internal_error after actor_mismatch rejection; got %q", finalURL)
+		"bob's browser should land on error_pages.internal_error after rejection; got %q", finalURL)
 
-	// 5. Exactly one rejection event with category=actor_mismatch, carrying
-	//    the state id. The actor_id field reflects the calling actor (the
-	//    victim) so SOC analysts see who was hit by the link.
+	// 5. Exactly one rejection event with category=actor_mismatch.
 	events := logCapture.RecordsWithMessage(t, rejectionEventMessage)
 	require.Lenf(t, events, 1, "expected exactly one rejection event; got %d (%v)", len(events), events)
-	assert.Equal(t, "actor_mismatch", events[0]["category"], "rejection category mismatch")
+	assert.Equal(t, "actor_mismatch", events[0]["category"],
+		"cross-namespace attack rejects on actor_mismatch first; namespace_mismatch_actor is defense-in-depth tested separately")
 	assert.Equal(t, stateID, events[0]["state_id"], "rejection event should record the state_id")
 
-	// 6. No token row was written.
-	require.Nil(t, env.GetOAuth2Token(t, connID), "no oauth2_token row should exist after actor_mismatch rejection")
+	// 6. No credentials attached to bob's tenant. alice's connection in
+	//    tenant-a still has no token; bob in tenant-b owns no connection
+	//    related to this flow.
+	require.Nil(t, env.GetOAuth2Token(t, connID), "no oauth2_token row should exist for the rejected callback")
 
-	// 7. Connection still in `created`, no setup_step transition.
 	conn := env.GetConnection(t, connID)
 	assert.Equal(t, database.ConnectionStateCreated, conn.State,
 		"connection state should remain `created` after a rejected callback")
 	assert.Nil(t, conn.SetupStep, "no setup_step should be recorded on a rejected callback")
 	assert.Nil(t, conn.SetupError, "no setup_error should be recorded on a rejected callback")
+	assert.Equal(t, tenantA, conn.Namespace, "connection still belongs to alice's tenant")
 
-	// 8. Provider observed zero /token calls — the token exchange path was
-	//    short-circuited by state validation.
+	// 7. Provider observed zero /token calls.
 	tokenReqs := provider.Requests(helpers.RequestsFilter{
 		Endpoint: helpers.EndpointToken,
 		ClientID: clientKey,
 	})
-	assert.Empty(t, tokenReqs, "provider must not have observed a /token call when actor_mismatch rejected")
+	assert.Empty(t, tokenReqs, "provider must not have observed a /token call when callback rejected")
 }

--- a/integration_tests/oauth2/callback_cross_namespace_test.md
+++ b/integration_tests/oauth2/callback_cross_namespace_test.md
@@ -1,0 +1,216 @@
+# OAuth2 Callback State Security — Cross-Namespace Cases
+
+Companion specification for `callback_cross_namespace_test.go` and
+`callback_namespace_mismatch_test.go`. Together they cover cases 6–7 of
+issue #167 — state validation when the calling actor and the state
+envelope disagree on namespace, and when the state envelope and the
+referenced connection disagree on namespace.
+
+The four direct-HTTP cases (1–4) live in `callback_state_security_test.go`.
+The cross-actor case (5) lives in `callback_actor_mismatch_test.go`.
+
+## Threat model
+
+The primary scenario is a multi-tenant AuthProxy deployment: a single
+instance manages connections for two customer apps, and each app uses
+a child namespace (`root.tenant-a`, `root.tenant-b`) to isolate its
+actors. Because actor rows are scoped per `(namespace, external_id)`,
+the **same external id can refer to two different users** — each
+tenant's "alice" is a distinct actor with a distinct `act_…` id.
+
+What can go wrong, ordered by validation:
+
+1. **Cross-tenant phishing (case 6 primary).** Alice in tenant-a
+   initiates a connection, mints a code, and sends the callback URL
+   to a victim with the same external id in tenant-b. The state
+   envelope carries alice's actor id; the victim's session carries
+   their own (different) actor id. State validation rejects with
+   `actor_mismatch` — the actor-id check fires before any
+   namespace-specific check.
+
+2. **Colliding actor ids across namespaces (case 6 defense-in-depth).**
+   Two AuthProxy instances share Redis and happen to allocate the
+   same actor id in different namespaces, or a state envelope is
+   constructed via a process that picks an actor id colliding with
+   the caller. The actor-id check passes, but `s.Namespace !=
+   actor.GetNamespace()` fires `namespace_mismatch_actor`. This is a
+   guard against the actor-id-uniqueness assumption breaking.
+
+3. **State pointing at a connection in the wrong tenant (case 7).**
+   A state envelope claims namespace X (matching the caller's), but
+   `state.ConnectionId` points at a connection that lives in
+   namespace Y. The actor-id and actor-namespace checks both pass,
+   but the connection-namespace check fires
+   `namespace_mismatch_connection`. This guards against the
+   connection being moved across namespaces, or a forged envelope
+   that picks a foreign connection id.
+
+## Validation order in production
+
+`internal/auth_methods/oauth2/state.go:191–242` runs these checks in
+sequence, returning on the first failure:
+
+1. `s.ActorId != actor.GetId()` → `actor_mismatch`
+2. `s.Namespace != actor.GetNamespace()` → `namespace_mismatch_actor`
+3. Load connection from DB
+4. `s.Namespace != connection.GetNamespace()` → `namespace_mismatch_connection`
+
+The earliest-failing check is the one that fires. Test 1 below
+exercises check 1 in a multi-tenant context; tests 2 and 3 exercise
+checks 2 and 4 by injecting synthetic state envelopes that bypass
+the earlier checks.
+
+## What is asserted
+
+For every test:
+
+- **Callback is rejected.** The 302 Location header / final browser
+  URL is the configured `error_pages.internal_error`.
+- **Exactly one `oauth callback rejected` log event** with the
+  expected `category` and the synthetic / real `state_id`.
+- **No `oauth2_tokens` row** is written for any connection involved.
+- **Connection state is unchanged.** `created`, no `setup_step`,
+  no `setup_error`.
+- **Provider observed zero `/token` calls.** The token exchange
+  path was short-circuited by state validation.
+
+## Test 1 — `TestCallbackRejection_CrossNamespace` (chromedp)
+
+Bug-bounty shape, multi-tenant flavor. Drives the victim leg through
+chromedp + the marketplace SPA bootstrap so the test mirrors the
+attacker-sends-link-to-victim delivery vector.
+
+| Step | Action |
+| ---- | ------ |
+| Setup | Create namespaces `root.tenant-a-<suffix>`, `root.tenant-b-<suffix>`. |
+| Attacker | Alice (external_id = `user-123-<suffix>`) initiates in tenant-a. State has `Namespace=tenant-a`, `ActorId=act_alice`. |
+| Provider | `/test/authorize` issues a code under alice's stateId. |
+| Victim | Bob (external_id = `user-123-<suffix>`, same as alice) bootstraps via `/connectors?auth_token=<bob>` in tenant-b. Browser holds `SESSION-ID` cookie scoped to bob. |
+| Forge | Browser navigates to the cross-tenant callback URL. |
+| Reject | Public service identifies bob (act_bob in tenant-b); `s.ActorId (act_alice) != act_bob` → `actor_mismatch`. |
+
+**Why chromedp:** the saved feedback (cross-actor / cross-tenant
+tests prefer chromedp) applies — this is the realistic delivery
+vector for the bug-bounty submission shape. Direct-HTTP would
+exercise the same `state.ActorId` check but wouldn't mirror how the
+attack actually shows up.
+
+## Test 2 — `TestCallbackRejection_NamespaceMismatchActor` (synthetic state, direct HTTP)
+
+Defense-in-depth check 2. Exists to verify the guard fires when
+`actor_mismatch` would have fired in real life — i.e., to prove
+the namespace boundary holds even if the actor-id-uniqueness
+assumption breaks.
+
+| Step | Action |
+| ---- | ------ |
+| Setup | Create namespace `root.tenant-a-<suffix>`. |
+| Real initiate | Alice initiates in tenant-a so a real connection row exists. |
+| Lookup | Read alice's actor id via `env.Db.GetActorByExternalId(ctx, tenant-a, alice)`. |
+| Inject | `env.WriteOAuth2StateForTest` at a fresh `forgedStateID` with `ActorId=alice.Id`, `ConnectionId=conn.Id`, but `Namespace="root.tenant-b-<suffix>"` (lie). |
+| Deliver | `env.DeliverOAuth2CallbackAsActor(callback, alice, tenant-a)`. |
+| Reject | `s.ActorId == caller.Id` ✓, `s.Namespace ("tenant-b") != caller.Namespace ("tenant-a")` → `namespace_mismatch_actor`. |
+
+**Why direct HTTP:** the scenario hinges on programmatic state
+injection — there is no realistic browser-driven path to land a
+state with a colliding actor id in a different namespace. Direct
+delivery via `DeliverOAuth2CallbackAsActor` exercises the same
+production handler chain.
+
+## Test 3 — `TestCallbackRejection_NamespaceMismatchConnection` (synthetic state, direct HTTP)
+
+Defense-in-depth check 4. Verifies the guard catches a state that
+agrees with its caller on namespace but points at a connection in a
+different tenant.
+
+| Step | Action |
+| ---- | ------ |
+| Setup | Create namespaces `root.tenant-a-<suffix>`, `root.tenant-b-<suffix>`. |
+| Bob's connection | Bob initiates in tenant-b so a real connection row exists in tenant-b. |
+| Materialize alice | Alice initiates a throwaway connection in tenant-a so her actor row exists; we discard the connection id. |
+| Inject | Synthetic state: `Namespace=tenant-a`, `ActorId=alice.Id`, `ConnectionId=bob.Conn.Id` (in tenant-b). |
+| Deliver | `env.DeliverOAuth2CallbackAsActor(callback, alice, tenant-a)`. |
+| Reject | `s.ActorId == caller.Id` ✓, `s.Namespace == caller.Namespace` ✓, connection lookup returns bob's connection in tenant-b, `s.Namespace ("tenant-a") != connection.Namespace ("tenant-b")` → `namespace_mismatch_connection`. |
+
+**Why bob's connection isn't modified:** the rejection happens
+before any token exchange, so neither alice nor bob accumulates a
+token row. The test asserts bob's connection state is unchanged —
+proves a forged callback can't taint a victim tenant's connection
+data even when the forgery names the victim's connection id.
+
+## Components
+
+| Lever                                                    | What it controls |
+| -------------------------------------------------------- | ---------------- |
+| `env.Core.CreateNamespace(ctx, "root.tenant-x-…", nil)`  | Pre-creates child namespaces for multi-tenant tests. |
+| `env.InitiateOAuth2ConnectionAsActor(t, …, namespace)`   | Initiates as a named actor in a named namespace; sets `IntoNamespace` so the connection lives in the actor's tenant. |
+| `env.PublicAuthUtil.GenerateBearerToken(ctx, ext, ns, perms)` | Mints a JWT for any namespace; used to bootstrap the chromedp marketplace session. |
+| `env.WriteOAuth2StateForTest(t, OAuth2StateForTest{…}, ttl)` | Encrypts a synthetic state envelope via `env.DM.GetEncryptService().EncryptGlobal` and writes it to Redis at `oauth2:state:<id>`. The shape of `OAuth2StateForTest` mirrors the unexported production `state` struct. |
+| `env.DeliverOAuth2CallbackAsActor(t, url, ext, ns)`      | Delivers the callback signed as a specific actor in a specific namespace; mirrors the JWT a real browser session would carry. |
+| `logCapture.RecordsWithMessage(t, rejectionEventMessage)` | Surfaces the structured rejection event for category assertions. |
+
+## Sequence — Test 1 (chromedp)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant ATK as Alice (tenant-a)
+    participant VIC as Bob's browser<br/>(chromedp, tenant-b)
+    participant PUB as Public service
+    participant API as API service
+    participant DB as Postgres
+    participant R as Redis
+    participant P as OAuth provider
+
+    T->>API: POST /api/v1/connections/_initiate (signed alice@tenant-a, IntoNamespace=tenant-a)
+    API->>R: write encrypted state<br/>(ActorId=act_alice, Namespace=tenant-a)
+    API->>DB: insert connection in tenant-a
+
+    T->>P: POST /test/authorize (decision=approve)
+    P-->>T: redirect URL with code + state_id
+
+    T->>VIC: navigate /connectors?auth_token=<bob@tenant-b>
+    VIC->>PUB: SPA bootstrap → SESSION-ID cookie for bob@tenant-b
+
+    T->>VIC: navigate /oauth2/callback?state=…&code=…
+    VIC->>PUB: GET /oauth2/callback (carries bob's cookie)
+    PUB->>R: GET state envelope
+    PUB->>PUB: s.ActorId(act_alice) ≠ caller(act_bob)
+    PUB-->>VIC: 302 → error_pages.internal_error
+```
+
+## Sequence — Tests 2 & 3 (synthetic injection)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant API as API service
+    participant DB as Postgres
+    participant R as Redis
+    participant E as Encrypt service<br/>(env.DM.GetEncryptService)
+    participant PUB as Public service
+
+    T->>API: POST /_initiate (real, materializes actor + connection)
+    API->>R: write real state envelope
+    API->>DB: insert actor row, connection row
+    T->>DB: GetActorByExternalId → caller's actor_id
+
+    T->>E: EncryptGlobal(JSON of synthetic state)
+    E-->>T: EncryptedField
+    T->>R: SET oauth2:state:<forgedStateID> = envelope
+
+    T->>PUB: GET /oauth2/callback?state=<forgedStateID>&code=fake (signed as caller)
+    PUB->>R: GET state envelope
+    PUB->>PUB: validation cascade fails at the targeted check
+    PUB-->>T: 302 → error_pages.internal_error
+```
+
+## Why pre-create namespaces
+
+`env.Db.CreateActor` and downstream operations require the namespace
+row to exist. The `_initiate` flow auto-creates ancestor paths for
+the connection's target namespace, but tests that directly exercise
+multi-namespace setup explicitly call `env.Core.CreateNamespace` to
+keep the wiring obvious in the test body.

--- a/integration_tests/oauth2/callback_namespace_mismatch_test.go
+++ b/integration_tests/oauth2/callback_namespace_mismatch_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCallbackRejection_NamespaceMismatchActor exercises the
+// `namespace_mismatch_actor` defense-in-depth check at
+// internal/auth_methods/oauth2/state.go:203-213. The check fires when the
+// caller's actor id matches the state's actor id but the namespaces differ
+// — a configuration that the natural _initiate flow can't produce because
+// actor ids are allocated per (namespace, external_id). The only realistic
+// way to land in this state is via a corrupted state envelope (e.g., a
+// secondary AuthProxy instance writing into the same Redis with a colliding
+// actor id), so the test injects a synthetic state envelope directly.
+//
+// The check guards against the scenario where two AuthProxy instances share
+// Redis and happen to allocate the same actor id in different namespaces.
+// Without this check, the actor-id check would pass and the namespace
+// boundary would silently fail.
+func TestCallbackRejection_NamespaceMismatchActor(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	tenantA := "root.tenant-a-" + suffix
+	lyingNamespace := "root.tenant-b-" + suffix
+	aliceExternalID := "alice-" + suffix
+	clientKey := "ns-mismatch-actor-client-" + suffix
+	clientSecret := "ns-mismatch-actor-secret-" + suffix
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "ns-mismatch-actor-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+
+	logCapture := helpers.NewLogCapture()
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+		LogCapture:    logCapture,
+	})
+	defer env.Cleanup()
+
+	ctx := context.Background()
+	_, err := env.Core.CreateNamespace(ctx, tenantA, nil)
+	require.NoError(t, err)
+
+	provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+
+	// Alice initiates a real connection in tenant-a so we have a valid
+	// connection row to point the synthetic state at, and so alice's
+	// actor row is materialized with an apid we can reference.
+	connID, _ := env.InitiateOAuth2ConnectionAsActor(t, connectorID, "https://example.com/return", aliceExternalID, tenantA)
+	alice, err := env.Db.GetActorByExternalId(ctx, tenantA, aliceExternalID)
+	require.NoError(t, err)
+	require.NotNil(t, alice)
+	conn := env.GetConnection(t, connID)
+
+	// Synthesize a fresh state envelope that lies about the namespace
+	// while keeping the actor id correct. The natural state for this
+	// connection (already in Redis at the real state_id from initiate)
+	// is left alone; the test delivers the forged envelope at a fresh
+	// state id so the assertion targets exactly the synthetic value.
+	forgedStateID := apid.New(apid.PrefixOauth2State)
+	env.WriteOAuth2StateForTest(t, helpers.OAuth2StateForTest{
+		Id:               forgedStateID,
+		Namespace:        lyingNamespace,
+		ActorId:          alice.Id,
+		ConnectorId:      conn.ConnectorId,
+		ConnectorVersion: conn.ConnectorVersion,
+		ConnectionId:     conn.Id,
+		ReturnToUrl:      "https://example.com/return",
+		ExpiresAt:        time.Now().Add(5 * time.Minute),
+	}, 5*time.Minute)
+
+	// Deliver the callback as alice in tenant-a. The actor-id check passes
+	// (alice signed her own JWT), but s.Namespace ("tenant-b") doesn't
+	// match the caller's namespace ("tenant-a") — fires
+	// `namespace_mismatch_actor` before the connection lookup runs.
+	loc := env.DeliverOAuth2CallbackAsActor(t,
+		env.ForgeOAuth2CallbackURL(forgedStateID.String(), "fake-code"),
+		aliceExternalID, tenantA,
+	)
+	errorPageURL := env.Cfg.GetRoot().ErrorPages.InternalError
+	require.NotEmpty(t, errorPageURL, "test config must set error_pages.internal_error")
+	assert.Equal(t, errorPageURL, loc, "callback should redirect to error page on rejection")
+
+	events := logCapture.RecordsWithMessage(t, rejectionEventMessage)
+	require.Lenf(t, events, 1, "expected exactly one rejection event; got %d (%v)", len(events), events)
+	assert.Equal(t, "namespace_mismatch_actor", events[0]["category"])
+	assert.Equal(t, forgedStateID.String(), events[0]["state_id"])
+
+	// Real connection from initiate should still have no token row — the
+	// rejected callback never reached the token exchange.
+	require.Nil(t, env.GetOAuth2Token(t, connID))
+	connAfter := env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateCreated, connAfter.State)
+
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientKey,
+	})
+	assert.Empty(t, tokenReqs, "provider must not have observed a /token call when rejected")
+}
+
+// TestCallbackRejection_NamespaceMismatchConnection exercises the
+// `namespace_mismatch_connection` defense-in-depth check at
+// internal/auth_methods/oauth2/state.go:232-242. The check fires when
+// state.Namespace and the *connection's* namespace disagree — even
+// after the caller-vs-state namespace check passes. A natural _initiate
+// always produces matching namespaces, so this also requires synthetic
+// state injection.
+//
+// Scenario: bob owns a connection in tenant-b. An attacker forges a state
+// envelope that points the connection_id at bob's connection but claims
+// the state belongs to alice in tenant-a, and delivers the callback as
+// alice. The actor-id and actor-namespace checks pass (alice signs her
+// own JWT into tenant-a, state claims tenant-a), but the connection
+// itself lives in tenant-b — the third check rejects.
+func TestCallbackRejection_NamespaceMismatchConnection(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	tenantA := "root.tenant-a-" + suffix
+	tenantB := "root.tenant-b-" + suffix
+	aliceExternalID := "alice-" + suffix
+	bobExternalID := "bob-" + suffix
+	clientKey := "ns-mismatch-conn-client-" + suffix
+	clientSecret := "ns-mismatch-conn-secret-" + suffix
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "ns-mismatch-conn-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+
+	logCapture := helpers.NewLogCapture()
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+		LogCapture:    logCapture,
+	})
+	defer env.Cleanup()
+
+	ctx := context.Background()
+	_, err := env.Core.CreateNamespace(ctx, tenantA, nil)
+	require.NoError(t, err)
+	_, err = env.Core.CreateNamespace(ctx, tenantB, nil)
+	require.NoError(t, err)
+
+	provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+
+	// Bob owns a connection in tenant-b. We'll point the synthetic state
+	// at this connection to make the connection-namespace check fail.
+	bobConnID, _ := env.InitiateOAuth2ConnectionAsActor(t, connectorID, "https://example.com/return", bobExternalID, tenantB)
+	bobConn := env.GetConnection(t, bobConnID)
+	require.Equal(t, tenantB, bobConn.Namespace, "bob's connection should live in tenant-b")
+
+	// Materialize alice's actor by initiating a throwaway connection in
+	// tenant-a (we don't reference this connection in the synthetic state;
+	// we only need alice's actor_id so the actor-id check passes).
+	_, _ = env.InitiateOAuth2ConnectionAsActor(t, connectorID, "https://example.com/return", aliceExternalID, tenantA)
+	alice, err := env.Db.GetActorByExternalId(ctx, tenantA, aliceExternalID)
+	require.NoError(t, err)
+
+	// Synthetic state: ActorId+Namespace agree with alice's caller
+	// identity, but ConnectionId points at bob's connection in tenant-b.
+	// The first two checks pass; the third (state.Namespace vs
+	// connection.Namespace) rejects.
+	forgedStateID := apid.New(apid.PrefixOauth2State)
+	env.WriteOAuth2StateForTest(t, helpers.OAuth2StateForTest{
+		Id:               forgedStateID,
+		Namespace:        tenantA,
+		ActorId:          alice.Id,
+		ConnectorId:      bobConn.ConnectorId,
+		ConnectorVersion: bobConn.ConnectorVersion,
+		ConnectionId:     bobConn.Id,
+		ReturnToUrl:      "https://example.com/return",
+		ExpiresAt:        time.Now().Add(5 * time.Minute),
+	}, 5*time.Minute)
+
+	loc := env.DeliverOAuth2CallbackAsActor(t,
+		env.ForgeOAuth2CallbackURL(forgedStateID.String(), "fake-code"),
+		aliceExternalID, tenantA,
+	)
+	errorPageURL := env.Cfg.GetRoot().ErrorPages.InternalError
+	require.NotEmpty(t, errorPageURL, "test config must set error_pages.internal_error")
+	assert.Equal(t, errorPageURL, loc, "callback should redirect to error page on rejection")
+
+	events := logCapture.RecordsWithMessage(t, rejectionEventMessage)
+	require.Lenf(t, events, 1, "expected exactly one rejection event; got %d (%v)", len(events), events)
+	assert.Equal(t, "namespace_mismatch_connection", events[0]["category"])
+	assert.Equal(t, forgedStateID.String(), events[0]["state_id"])
+
+	// Bob's connection in tenant-b must not be modified — the forged
+	// callback claimed alice's identity but bob's connection was not
+	// actually touched (no token attached, state still `created`).
+	require.Nil(t, env.GetOAuth2Token(t, bobConnID),
+		"bob's connection must not have a token attached after a rejected forgery")
+	bobConnAfter := env.GetConnection(t, bobConnID)
+	assert.Equal(t, database.ConnectionStateCreated, bobConnAfter.State,
+		"bob's connection state should remain `created`")
+	assert.Nil(t, bobConnAfter.SetupStep)
+	assert.Nil(t, bobConnAfter.SetupError)
+
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientKey,
+	})
+	assert.Empty(t, tokenReqs, "provider must not have observed a /token call when rejected")
+}


### PR DESCRIPTION
## Summary

Closes the multi-tenant cases (6 + 7) from #167's OAuth callback state-security workstream.

- **TestCallbackRejection_CrossNamespace** (chromedp): primary threat — multi-tenant deployment where the same `external_id` exists in two child namespaces. Alice in tenant-a mints a code and sends the forged callback to bob (same external_id) in tenant-b. Per-namespace actor allocation gives them distinct actor ids, so state validation fires `actor_mismatch` first. Drives the victim leg through the marketplace SPA bootstrap so the test mirrors the realistic phishing delivery vector.
- **TestCallbackRejection_NamespaceMismatchActor** (synthetic state, direct HTTP): defense-in-depth check 2. Injects a state envelope with a colliding actor id across namespaces and verifies the `s.Namespace != actor.Namespace` guard fires `namespace_mismatch_actor`.
- **TestCallbackRejection_NamespaceMismatchConnection** (synthetic state, direct HTTP): defense-in-depth check 4. State envelope agrees with the caller on namespace but its `connection_id` points at a connection in a foreign tenant. Fires `namespace_mismatch_connection` after the connection load.

Validation order in production (`internal/auth_methods/oauth2/state.go:191-242`): `actor_mismatch` → `namespace_mismatch_actor` → connection load → `namespace_mismatch_connection`. The chromedp test exercises the first check in a multi-tenant context; the synthetic tests bypass the earlier checks to exercise the namespace-specific guards.

## Helpers added

- `helpers.OAuth2StateForTest` + `env.WriteOAuth2StateForTest`: encrypts a synthetic state envelope via `env.DM.GetEncryptService().EncryptGlobal` and writes it to Redis at `oauth2:state:<id>`. Mirrors the unexported production state struct's JSON tags so tests can construct envelopes without touching internal types.
- Namespace-aware `InitiateOAuth2ConnectionAsActor(t, connectorID, returnTo, externalID, namespace)`: passes `IntoNamespace` so the connection lands in the actor's tenant (matching realistic multi-tenant deployments). The previous `InitiateOAuth2Connection` is now a wrapper that pins to `RootNamespace`.
- Namespace-aware `DeliverOAuth2CallbackAsActor(t, url, externalID, namespace)`: signs the callback request as a specific actor in a specific namespace, matching the JWT a real browser session would carry. The previous `DeliverOAuth2Callback` is now a wrapper.

## Spec doc

`integration_tests/oauth2/callback_cross_namespace_test.md` documents the threat model (cross-tenant phishing as primary, colliding-actor-id and cross-connection as defense-in-depth), validation order, all three tests with detailed setup/inject/deliver/reject step tables, and mermaid sequence diagrams for both delivery shapes (chromedp + synthetic injection).

## Test plan

- [x] `go test ./integration_tests/oauth2 -tags=integration -run TestCallbackRejection_CrossNamespace` — PASS
- [x] `go test ./integration_tests/oauth2 -tags=integration -run TestCallbackRejection_NamespaceMismatchActor` — PASS
- [x] `go test ./integration_tests/oauth2 -tags=integration -run TestCallbackRejection_NamespaceMismatchConnection` — PASS
- [x] Existing `TestCallbackRejection_*` and `TestStandardFlow` tests still pass (no regressions from the helper signature changes)
- [x] `./scripts/preflight.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)