### PR TITLE
Rate limits — Step 2: admin-api and api CRUD endpoints

### DIFF
--- a/internal/core/iface/rate_limit.go
+++ b/internal/core/iface/rate_limit.go
@@ -1,0 +1,37 @@
+package iface
+
+import (
+	"context"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+// RateLimit is the core abstraction for a rate-limit resource.
+type RateLimit interface {
+	GetId() apid.ID
+	GetNamespace() string
+	GetDefinition() rlschema.RateLimit
+	GetLabels() map[string]string
+	GetAnnotations() map[string]string
+	GetCreatedAt() time.Time
+	GetUpdatedAt() time.Time
+}
+
+type ListRateLimitsExecutor interface {
+	FetchPage(context.Context) pagination.PageResult[RateLimit]
+	Enumerate(context.Context, pagination.EnumerateCallback[RateLimit]) error
+}
+
+type ListRateLimitsBuilder interface {
+	ListRateLimitsExecutor
+	Limit(int32) ListRateLimitsBuilder
+	ForNamespaceMatcher(matcher string) ListRateLimitsBuilder
+	ForNamespaceMatchers(matchers []string) ListRateLimitsBuilder
+	OrderBy(database.RateLimitOrderByField, pagination.OrderBy) ListRateLimitsBuilder
+	IncludeDeleted() ListRateLimitsBuilder
+	ForLabelSelector(selector string) ListRateLimitsBuilder
+}

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
 	"github.com/rmorlok/authproxy/internal/tasks"
 )
 
@@ -196,6 +197,48 @@ type C interface {
 
 	// ListEncryptionKeysFromCursor continues listing encryption keys from a cursor to support pagination.
 	ListEncryptionKeysFromCursor(ctx context.Context, cursor string) (ListEncryptionKeysExecutor, error)
+
+	/*
+	 *
+	 * Rate Limits
+	 *
+	 */
+
+	// GetRateLimit returns a rate limit by ID.
+	GetRateLimit(ctx context.Context, id apid.ID) (RateLimit, error)
+
+	// CreateRateLimit creates a new rate-limit resource. Definition is validated before insert.
+	CreateRateLimit(ctx context.Context, namespace string, def rlschema.RateLimit, labels, annotations map[string]string) (RateLimit, error)
+
+	// UpdateRateLimitDefinition replaces a rate limit's definition payload.
+	UpdateRateLimitDefinition(ctx context.Context, id apid.ID, def rlschema.RateLimit) (RateLimit, error)
+
+	// DeleteRateLimit soft deletes a rate limit.
+	DeleteRateLimit(ctx context.Context, id apid.ID) error
+
+	// UpdateRateLimitLabels replaces all user labels on a rate limit.
+	UpdateRateLimitLabels(ctx context.Context, id apid.ID, labels map[string]string) (RateLimit, error)
+
+	// PutRateLimitLabels merges the supplied labels into the existing set.
+	PutRateLimitLabels(ctx context.Context, id apid.ID, labels map[string]string) (RateLimit, error)
+
+	// DeleteRateLimitLabels removes the specified user-label keys.
+	DeleteRateLimitLabels(ctx context.Context, id apid.ID, keys []string) (RateLimit, error)
+
+	// UpdateRateLimitAnnotations replaces all annotations on a rate limit.
+	UpdateRateLimitAnnotations(ctx context.Context, id apid.ID, annotations map[string]string) (RateLimit, error)
+
+	// PutRateLimitAnnotations merges the supplied annotations into the existing set.
+	PutRateLimitAnnotations(ctx context.Context, id apid.ID, annotations map[string]string) (RateLimit, error)
+
+	// DeleteRateLimitAnnotations removes the specified annotation keys.
+	DeleteRateLimitAnnotations(ctx context.Context, id apid.ID, keys []string) (RateLimit, error)
+
+	// ListRateLimitsBuilder returns a builder for listing rate limits.
+	ListRateLimitsBuilder() ListRateLimitsBuilder
+
+	// ListRateLimitsFromCursor continues listing rate limits from a cursor.
+	ListRateLimitsFromCursor(ctx context.Context, cursor string) (ListRateLimitsExecutor, error)
 
 	/*
 	 *

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// RateLimit is the core abstraction wrapping a database.RateLimit.
+type RateLimit struct {
+	database.RateLimit
+
+	s      *service
+	logger *slog.Logger
+}
+
+func wrapRateLimit(rl database.RateLimit, s *service) *RateLimit {
+	return &RateLimit{
+		RateLimit: rl,
+		s:         s,
+		logger: aplog.NewBuilder(s.logger).
+			WithNamespace(rl.Namespace).
+			Build(),
+	}
+}
+
+func (r *RateLimit) GetId() apid.ID                   { return r.Id }
+func (r *RateLimit) GetNamespace() string             { return r.Namespace }
+func (r *RateLimit) GetDefinition() rlschema.RateLimit { return r.Definition }
+func (r *RateLimit) GetLabels() map[string]string     { return r.Labels }
+func (r *RateLimit) GetAnnotations() map[string]string { return r.Annotations }
+func (r *RateLimit) GetCreatedAt() time.Time          { return r.CreatedAt }
+func (r *RateLimit) GetUpdatedAt() time.Time          { return r.UpdatedAt }
+func (r *RateLimit) Logger() *slog.Logger             { return r.logger }
+
+var _ iface.RateLimit = (*RateLimit)(nil)
+var _ aplog.HasLogger = (*RateLimit)(nil)

--- a/internal/core/service_rate_limit.go
+++ b/internal/core/service_rate_limit.go
@@ -1,0 +1,207 @@
+package core
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+func (s *service) GetRateLimit(ctx context.Context, id apid.ID) (iface.RateLimit, error) {
+	rl, err := s.db.GetRateLimit(ctx, id)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) CreateRateLimit(ctx context.Context, namespace string, def rlschema.RateLimit, labels, annotations map[string]string) (iface.RateLimit, error) {
+	rl := &database.RateLimit{
+		Id:          apid.New(apid.PrefixRateLimit),
+		Namespace:   namespace,
+		Definition:  def,
+		Labels:      database.Labels(labels),
+		Annotations: database.Annotations(annotations),
+	}
+
+	if err := s.db.CreateRateLimit(ctx, rl); err != nil {
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) UpdateRateLimitDefinition(ctx context.Context, id apid.ID, def rlschema.RateLimit) (iface.RateLimit, error) {
+	rl, err := s.db.UpdateRateLimitDefinition(ctx, id, def)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) DeleteRateLimit(ctx context.Context, id apid.ID) error {
+	if err := s.db.DeleteRateLimit(ctx, id); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *service) UpdateRateLimitLabels(ctx context.Context, id apid.ID, labels map[string]string) (iface.RateLimit, error) {
+	rl, err := s.db.UpdateRateLimitLabels(ctx, id, labels)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) PutRateLimitLabels(ctx context.Context, id apid.ID, labels map[string]string) (iface.RateLimit, error) {
+	rl, err := s.db.PutRateLimitLabels(ctx, id, labels)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) DeleteRateLimitLabels(ctx context.Context, id apid.ID, keys []string) (iface.RateLimit, error) {
+	rl, err := s.db.DeleteRateLimitLabels(ctx, id, keys)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) UpdateRateLimitAnnotations(ctx context.Context, id apid.ID, annotations map[string]string) (iface.RateLimit, error) {
+	rl, err := s.db.UpdateRateLimitAnnotations(ctx, id, annotations)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) PutRateLimitAnnotations(ctx context.Context, id apid.ID, annotations map[string]string) (iface.RateLimit, error) {
+	rl, err := s.db.PutRateLimitAnnotations(ctx, id, annotations)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) DeleteRateLimitAnnotations(ctx context.Context, id apid.ID, keys []string) (iface.RateLimit, error) {
+	rl, err := s.db.DeleteRateLimitAnnotations(ctx, id, keys)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+type listRateLimitsWrapper struct {
+	l database.ListRateLimitsBuilder
+	e database.ListRateLimitsExecutor
+	s *service
+}
+
+func (l *listRateLimitsWrapper) convertPageResult(result pagination.PageResult[database.RateLimit]) pagination.PageResult[iface.RateLimit] {
+	if result.Error != nil {
+		return pagination.PageResult[iface.RateLimit]{Error: result.Error}
+	}
+
+	out := make([]iface.RateLimit, 0, len(result.Results))
+	for _, r := range result.Results {
+		out = append(out, wrapRateLimit(r, l.s))
+	}
+
+	return pagination.PageResult[iface.RateLimit]{
+		Results: out,
+		Error:   result.Error,
+		HasMore: result.HasMore,
+		Cursor:  result.Cursor,
+	}
+}
+
+func (l *listRateLimitsWrapper) executor() database.ListRateLimitsExecutor {
+	if l.e != nil {
+		return l.e
+	}
+	return l.l
+}
+
+func (l *listRateLimitsWrapper) FetchPage(ctx context.Context) pagination.PageResult[iface.RateLimit] {
+	return l.convertPageResult(l.executor().FetchPage(ctx))
+}
+
+func (l *listRateLimitsWrapper) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[iface.RateLimit]) error {
+	return l.executor().Enumerate(ctx, func(result pagination.PageResult[database.RateLimit]) (keepGoing pagination.KeepGoing, err error) {
+		return callback(l.convertPageResult(result))
+	})
+}
+
+func (l *listRateLimitsWrapper) Limit(lim int32) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.Limit(lim), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) ForNamespaceMatcher(matcher string) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.ForNamespaceMatcher(matcher), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) ForNamespaceMatchers(matchers []string) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.ForNamespaceMatchers(matchers), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) OrderBy(f database.RateLimitOrderByField, o pagination.OrderBy) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.OrderBy(f, o), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) IncludeDeleted() iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.IncludeDeleted(), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) ForLabelSelector(selector string) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.ForLabelSelector(selector), s: l.s}
+}
+
+func (s *service) ListRateLimitsBuilder() iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{
+		l: s.db.ListRateLimitsBuilder(),
+		s: s,
+	}
+}
+
+func (s *service) ListRateLimitsFromCursor(ctx context.Context, cursor string) (iface.ListRateLimitsExecutor, error) {
+	e, err := s.db.ListRateLimitsFromCursor(ctx, cursor)
+	if err != nil {
+		return nil, err
+	}
+	return &listRateLimitsWrapper{e: e, s: s}, nil
+}
+
+var _ iface.ListRateLimitsBuilder = (*listRateLimitsWrapper)(nil)

--- a/internal/routes/rate_limits.go
+++ b/internal/routes/rate_limits.go
@@ -1,0 +1,787 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/core"
+	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/routes/key_value"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+type RateLimitJson struct {
+	Id          apid.ID            `json:"id"`
+	Namespace   string             `json:"namespace"`
+	Definition  rlschema.RateLimit `json:"definition"`
+	Labels      map[string]string  `json:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty"`
+	CreatedAt   time.Time          `json:"created_at"`
+	UpdatedAt   time.Time          `json:"updated_at"`
+}
+
+type CreateRateLimitRequestJson struct {
+	Namespace   string             `json:"namespace"`
+	Definition  rlschema.RateLimit `json:"definition"`
+	Labels      map[string]string  `json:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty"`
+}
+
+type UpdateRateLimitRequestJson struct {
+	Definition  *rlschema.RateLimit `json:"definition,omitempty"`
+	Labels      *map[string]string  `json:"labels,omitempty"`
+	Annotations *map[string]string  `json:"annotations,omitempty"`
+}
+
+type ListRateLimitsRequestQueryParams struct {
+	Cursor        *string `form:"cursor"`
+	LimitVal      *int32  `form:"limit"`
+	NamespaceVal  *string `form:"namespace"`
+	LabelSelector *string `form:"label_selector"`
+	OrderByVal    *string `form:"order_by"`
+}
+
+type ListRateLimitsResponseJson struct {
+	Items  []RateLimitJson `json:"items"`
+	Cursor string          `json:"cursor,omitempty"`
+}
+
+func RateLimitToJson(r coreIface.RateLimit) RateLimitJson {
+	return RateLimitJson{
+		Id:          r.GetId(),
+		Namespace:   r.GetNamespace(),
+		Definition:  r.GetDefinition(),
+		Labels:      r.GetLabels(),
+		Annotations: r.GetAnnotations(),
+		CreatedAt:   r.GetCreatedAt(),
+		UpdatedAt:   r.GetUpdatedAt(),
+	}
+}
+
+type RateLimitsRoutes struct {
+	cfg           config.C
+	core          coreIface.C
+	authService   auth.A
+	labelsAdapter key_value.Adapter[apid.ID]
+	annotsAdapter key_value.Adapter[apid.ID]
+}
+
+// @Summary		Get rate limit
+// @Description	Get a specific rate limit by ID
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			id	path		string	true	"Rate limit ID"
+// @Success		200		{object}	SwaggerRateLimitJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id} [get]
+func (r *RateLimitsRoutes) get(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id := apid.ID(gctx.Param("id"))
+	if id.IsNil() {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	rl, err := r.core.GetRateLimit(ctx, id)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("rate limit '%s' not found", id), httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(rl); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+}
+
+// @Summary		Create rate limit
+// @Description	Create a new rate limit resource
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			request	body		CreateRateLimitRequestJson	true	"Rate limit creation request"
+// @Success		200		{object}	SwaggerRateLimitJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits [post]
+func (r *RateLimitsRoutes) create(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	var req CreateRateLimitRequestJson
+	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if req.Namespace == "" {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("namespace is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if err := val.ValidateNamespace(req.Namespace); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if err := req.Definition.Validate(); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid definition: %s", err.Error()))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if req.Labels != nil {
+		if err := database.ValidateUserLabels(req.Labels); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	if req.Annotations != nil {
+		if err := database.Annotations(req.Annotations).Validate(); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	rl, err := r.core.CreateRateLimit(ctx, req.Namespace, req.Definition, req.Labels, req.Annotations)
+	if err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+}
+
+// @Summary		List rate limits
+// @Description	List rate limits with optional filtering and pagination
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			cursor			query		string	false	"Pagination cursor"
+// @Param			limit			query		integer	false	"Maximum number of results to return"
+// @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			label_selector	query		string	false	"Filter by label selector"
+// @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:desc')"
+// @Success		200				{object}	SwaggerListRateLimitsResponse
+// @Failure		400				{object}	ErrorResponse
+// @Failure		401				{object}	ErrorResponse
+// @Failure		500				{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits [get]
+func (r *RateLimitsRoutes) list(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	var req ListRateLimitsRequestQueryParams
+	if err := gctx.ShouldBindQuery(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	var err error
+	var ex coreIface.ListRateLimitsExecutor
+
+	if req.Cursor != nil {
+		ex, err = r.core.ListRateLimitsFromCursor(ctx, *req.Cursor)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("failed to list rate limits from cursor", httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+	} else {
+		b := r.core.ListRateLimitsBuilder()
+
+		if req.LimitVal != nil {
+			b = b.Limit(*req.LimitVal)
+		}
+
+		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.LabelSelector != nil {
+			b = b.ForLabelSelector(*req.LabelSelector)
+		}
+
+		if req.OrderByVal != nil {
+			field, order, err := pagination.SplitOrderByParam[database.RateLimitOrderByField](*req.OrderByVal)
+			if err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+				val.MarkErrorReturn()
+				return
+			}
+
+			if !database.IsValidRateLimitOrderByField(field) {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid sort field '%s'", field))
+				val.MarkErrorReturn()
+				return
+			}
+
+			b.OrderBy(field, order)
+		}
+
+		ex = b
+	}
+
+	result := ex.FetchPage(ctx)
+	if result.Error != nil {
+		apgin.WriteErr(gctx, nil, result.Error)
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, ListRateLimitsResponseJson{
+		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), RateLimitToJson),
+		Cursor: result.Cursor,
+	})
+}
+
+// @Summary		Update rate limit
+// @Description	Update a rate limit's definition, labels, or annotations
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string							true	"Rate limit ID"
+// @Param			request	body		UpdateRateLimitRequestJson		true	"Update request"
+// @Success		200		{object}	SwaggerRateLimitJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id} [patch]
+func (r *RateLimitsRoutes) update(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id := apid.ID(gctx.Param("id"))
+	if id.IsNil() {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	var req UpdateRateLimitRequestJson
+	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if req.Definition != nil {
+		if err := req.Definition.Validate(); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid definition: %s", err.Error()))
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	if req.Labels != nil {
+		if err := database.ValidateUserLabels(*req.Labels); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	if req.Annotations != nil {
+		if err := database.Annotations(*req.Annotations).Validate(); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	rl, err := r.core.GetRateLimit(ctx, id)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("rate limit '%s' not found", id), httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(rl); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	if req.Definition != nil {
+		if _, err := r.core.UpdateRateLimitDefinition(ctx, id, *req.Definition); err != nil {
+			r.handleMutateError(gctx, val, id, err)
+			return
+		}
+	}
+
+	if req.Labels != nil {
+		if _, err := r.core.UpdateRateLimitLabels(ctx, id, *req.Labels); err != nil {
+			r.handleMutateError(gctx, val, id, err)
+			return
+		}
+	}
+
+	if req.Annotations != nil {
+		if _, err := r.core.UpdateRateLimitAnnotations(ctx, id, *req.Annotations); err != nil {
+			r.handleMutateError(gctx, val, id, err)
+			return
+		}
+	}
+
+	rl, err = r.core.GetRateLimit(ctx, id)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("rate limit '%s' not found", id), httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+}
+
+func (r *RateLimitsRoutes) handleMutateError(gctx *gin.Context, val *auth.ResourcePermissionValidator, id apid.ID, err error) {
+	if errors.Is(err, core.ErrNotFound) {
+		apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("rate limit '%s' not found", id), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+	apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+	val.MarkErrorReturn()
+}
+
+// @Summary		Delete rate limit
+// @Description	Soft delete a rate limit
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			id	path	string	true	"Rate limit ID"
+// @Success		204		"No Content"
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id} [delete]
+func (r *RateLimitsRoutes) delete(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	id := apid.ID(gctx.Param("id"))
+	if id.IsNil() {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	rl, err := r.core.GetRateLimit(ctx, id)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			gctx.Status(http.StatusNoContent)
+			val.MarkValidated()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(rl); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	if err := r.core.DeleteRateLimit(ctx, id); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			gctx.Status(http.StatusNoContent)
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.Status(http.StatusNoContent)
+}
+
+// Label and annotation handlers delegate to the shared key_value adapter.
+
+// @Summary		Get all labels for a rate limit
+// @Description	Get all labels associated with a specific rate limit
+// @Tags			rate_limits
+// @Produce		json
+// @Param			id	path		string	true	"Rate limit ID"
+// @Success		200	{object}	map[string]string
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Failure		500	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/labels [get]
+func (r *RateLimitsRoutes) getLabels(gctx *gin.Context) { r.labelsAdapter.HandleList(gctx) }
+
+// @Summary		Get a specific label for a rate limit
+// @Description	Get a specific label value by key for a rate limit
+// @Tags			rate_limits
+// @Produce		json
+// @Param			id		path		string	true	"Rate limit ID"
+// @Param			label	path		string	true	"Label key"
+// @Success		200		{object}	SwaggerKeyValueJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/labels/{label} [get]
+func (r *RateLimitsRoutes) getLabel(gctx *gin.Context) { r.labelsAdapter.HandleGet(gctx) }
+
+// @Summary		Set a label for a rate limit
+// @Description	Set or update a specific label value by key for a rate limit
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string						true	"Rate limit ID"
+// @Param			label	path		string						true	"Label key"
+// @Param			request	body		SwaggerPutKeyValueRequest	true	"Label value"
+// @Success		200		{object}	SwaggerKeyValueJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/labels/{label} [put]
+func (r *RateLimitsRoutes) putLabel(gctx *gin.Context) { r.labelsAdapter.HandlePut(gctx) }
+
+// @Summary		Delete a label from a rate limit
+// @Description	Delete a specific label by key from a rate limit
+// @Tags			rate_limits
+// @Param			id		path	string	true	"Rate limit ID"
+// @Param			label	path	string	true	"Label key"
+// @Success		204		"No Content"
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/labels/{label} [delete]
+func (r *RateLimitsRoutes) deleteLabel(gctx *gin.Context) { r.labelsAdapter.HandleDelete(gctx) }
+
+// @Summary		Get all annotations for a rate limit
+// @Description	Get all annotations associated with a specific rate limit
+// @Tags			rate_limits
+// @Produce		json
+// @Param			id	path		string	true	"Rate limit ID"
+// @Success		200	{object}	map[string]string
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Failure		500	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/annotations [get]
+func (r *RateLimitsRoutes) getAnnotations(gctx *gin.Context) { r.annotsAdapter.HandleList(gctx) }
+
+// @Summary		Get a specific annotation for a rate limit
+// @Description	Get a specific annotation value by key for a rate limit
+// @Tags			rate_limits
+// @Produce		json
+// @Param			id			path		string	true	"Rate limit ID"
+// @Param			annotation	path		string	true	"Annotation key"
+// @Success		200			{object}	SwaggerKeyValueJson
+// @Failure		400			{object}	ErrorResponse
+// @Failure		401			{object}	ErrorResponse
+// @Failure		404			{object}	ErrorResponse
+// @Failure		500			{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/annotations/{annotation} [get]
+func (r *RateLimitsRoutes) getAnnotation(gctx *gin.Context) { r.annotsAdapter.HandleGet(gctx) }
+
+// @Summary		Set an annotation for a rate limit
+// @Description	Set or update a specific annotation value by key for a rate limit
+// @Tags			rate_limits
+// @Accept			json
+// @Produce		json
+// @Param			id			path		string						true	"Rate limit ID"
+// @Param			annotation	path		string						true	"Annotation key"
+// @Param			request		body		SwaggerPutKeyValueRequest	true	"Annotation value"
+// @Success		200			{object}	SwaggerKeyValueJson
+// @Failure		400			{object}	ErrorResponse
+// @Failure		401			{object}	ErrorResponse
+// @Failure		403			{object}	ErrorResponse
+// @Failure		404			{object}	ErrorResponse
+// @Failure		500			{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/annotations/{annotation} [put]
+func (r *RateLimitsRoutes) putAnnotation(gctx *gin.Context) { r.annotsAdapter.HandlePut(gctx) }
+
+// @Summary		Delete an annotation from a rate limit
+// @Description	Delete a specific annotation by key from a rate limit
+// @Tags			rate_limits
+// @Param			id			path	string	true	"Rate limit ID"
+// @Param			annotation	path	string	true	"Annotation key"
+// @Success		204			"No Content"
+// @Failure		400			{object}	ErrorResponse
+// @Failure		401			{object}	ErrorResponse
+// @Failure		403			{object}	ErrorResponse
+// @Failure		500			{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/rate-limits/{id}/annotations/{annotation} [delete]
+func (r *RateLimitsRoutes) deleteAnnotation(gctx *gin.Context) {
+	r.annotsAdapter.HandleDelete(gctx)
+}
+
+func (r *RateLimitsRoutes) Register(g gin.IRouter) {
+	idExtractor := func(rl interface{}) string {
+		return string(rl.(coreIface.RateLimit).GetId())
+	}
+
+	g.GET(
+		"/rate-limits",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdExtractor(idExtractor).
+			ForVerb("list").
+			Build(),
+		r.list,
+	)
+	g.POST(
+		"/rate-limits",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdExtractor(idExtractor).
+			ForVerb("create").
+			Build(),
+		r.create,
+	)
+	g.GET(
+		"/rate-limits/:id",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("get").
+			Build(),
+		r.get,
+	)
+	g.PATCH(
+		"/rate-limits/:id",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("update").
+			Build(),
+		r.update,
+	)
+	g.DELETE(
+		"/rate-limits/:id",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("delete").
+			Build(),
+		r.delete,
+	)
+	g.GET(
+		"/rate-limits/:id/labels",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("get").
+			Build(),
+		r.getLabels,
+	)
+	g.GET(
+		"/rate-limits/:id/labels/:label",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("get").
+			Build(),
+		r.getLabel,
+	)
+	g.PUT(
+		"/rate-limits/:id/labels/:label",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("update").
+			Build(),
+		r.putLabel,
+	)
+	g.DELETE(
+		"/rate-limits/:id/labels/:label",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("update").
+			Build(),
+		r.deleteLabel,
+	)
+	g.GET(
+		"/rate-limits/:id/annotations",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("get").
+			Build(),
+		r.getAnnotations,
+	)
+	g.GET(
+		"/rate-limits/:id/annotations/:annotation",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("get").
+			Build(),
+		r.getAnnotation,
+	)
+	g.PUT(
+		"/rate-limits/:id/annotations/:annotation",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("update").
+			Build(),
+		r.putAnnotation,
+	)
+	g.DELETE(
+		"/rate-limits/:id/annotations/:annotation",
+		r.authService.NewRequiredBuilder().
+			ForResource("rate_limits").
+			ForIdField("id").
+			ForIdExtractor(idExtractor).
+			ForVerb("update").
+			Build(),
+		r.deleteAnnotation,
+	)
+}
+
+func NewRateLimitsRoutes(cfg config.C, authService auth.A, c coreIface.C) *RateLimitsRoutes {
+	parseRateLimitID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
+		id := apid.ID(gctx.Param("id"))
+		if id.IsNil() {
+			return apid.Nil, httperr.BadRequest("id is required")
+		}
+		return id, nil
+	}
+
+	getRateLimit := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
+		rl, err := c.GetRateLimit(ctx, id)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, database.ErrNotFound
+			}
+			return nil, err
+		}
+		if rl == nil {
+			return nil, nil
+		}
+		return rl, nil
+	}
+
+	idExtractor := func(rl interface{}) string {
+		return string(rl.(coreIface.RateLimit).GetId())
+	}
+
+	authGet := authService.NewRequiredBuilder().
+		ForResource("rate_limits").
+		ForIdField("id").
+		ForIdExtractor(idExtractor).
+		ForVerb("get").
+		Build()
+	authMutate := authService.NewRequiredBuilder().
+		ForResource("rate_limits").
+		ForIdField("id").
+		ForIdExtractor(idExtractor).
+		ForVerb("update").
+		Build()
+
+	labelsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Label,
+		ResourceName: "rate limit",
+		PathPrefix:   "/rate-limits/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseRateLimitID,
+		Get:          getRateLimit,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
+			return c.PutRateLimitLabels(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
+			return c.DeleteRateLimitLabels(ctx, id, keys)
+		},
+	}
+
+	annotsAdapter := key_value.Adapter[apid.ID]{
+		Kind:         key_value.Annotation,
+		ResourceName: "rate limit",
+		PathPrefix:   "/rate-limits/:id",
+		AuthGet:      authGet,
+		AuthMutate:   authMutate,
+		ParseID:      parseRateLimitID,
+		Get:          getRateLimit,
+		Put: func(ctx context.Context, id apid.ID, kv map[string]string) (key_value.Resource, error) {
+			return c.PutRateLimitAnnotations(ctx, id, kv)
+		},
+		Delete: func(ctx context.Context, id apid.ID, keys []string) (key_value.Resource, error) {
+			return c.DeleteRateLimitAnnotations(ctx, id, keys)
+		},
+	}
+
+	return &RateLimitsRoutes{
+		cfg:           cfg,
+		authService:   authService,
+		core:          c,
+		labelsAdapter: labelsAdapter,
+		annotsAdapter: annotsAdapter,
+	}
+}

--- a/internal/routes/rate_limits_test.go
+++ b/internal/routes/rate_limits_test.go
@@ -1,0 +1,628 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	asynqmock "github.com/rmorlok/authproxy/internal/apasynq/mock"
+	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	apredismock "github.com/rmorlok/authproxy/internal/apredis/mock"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/core"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimits(t *testing.T) {
+	type TestSetup struct {
+		Gin      *gin.Engine
+		Cfg      config.C
+		AuthUtil *auth2.AuthTestUtil
+		Db       database.DB
+	}
+
+	setup := func(t *testing.T) (*TestSetup, func()) {
+		cfg := config.FromRoot(&sconfig.Root{
+			Connectors: &sconfig.Connectors{LoadFromList: []sconfig.Connector{}},
+		})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+		cfg, rds := apredis.MustApplyTestConfig(cfg)
+		cfg, auth, authUtil := auth2.TestAuthServiceWithDb(sconfig.ServiceIdApi, cfg, db)
+		h := httpf2.CreateFactory(cfg, rds, nil, aplog.NewNoopLogger())
+		cfg, e := encrypt.NewTestEncryptService(cfg, db)
+		ctrl := gomock.NewController(t)
+		ac := asynqmock.NewMockClient(ctrl)
+		rs := apredismock.NewMockClient(ctrl)
+
+		c := core.NewCoreService(cfg, db, e, rs, h, ac, test_utils.NewTestLogger())
+		require.NoError(t, c.Migrate(context.Background()))
+		rlr := NewRateLimitsRoutes(cfg, auth, c)
+		r := apgin.ForTest(nil)
+		rlr.Register(r)
+
+		return &TestSetup{
+				Gin:      r,
+				Cfg:      cfg,
+				AuthUtil: authUtil,
+				Db:       db,
+			}, func() {
+				ctrl.Finish()
+			}
+	}
+
+	// validDef returns a JSON-serialisable rate-limit definition that passes
+	// schema validation. Use map[string]interface{} so the test crafts the
+	// wire format directly rather than relying on Go struct marshaling.
+	validDef := func() map[string]interface{} {
+		return map[string]interface{}{
+			"selector": map[string]interface{}{
+				"methods":       []string{"GET"},
+				"request_types": []string{"proxy"},
+			},
+			"bucket": map[string]interface{}{
+				"dimensions": []string{"actor"},
+			},
+			"algorithm": map[string]interface{}{
+				"token_bucket": map[string]interface{}{
+					"capacity":    60,
+					"refill_rate": 1.0,
+				},
+			},
+		}
+	}
+
+	createRateLimit := func(t *testing.T, tu *TestSetup, namespace string, labels map[string]string) RateLimitJson {
+		body := map[string]interface{}{
+			"namespace":  namespace,
+			"definition": validDef(),
+		}
+		if labels != nil {
+			body["labels"] = labels
+		}
+		jsonBody, _ := json.Marshal(body)
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPost,
+			"/rate-limits",
+			bytes.NewReader(jsonBody),
+			"root",
+			"some-actor",
+			aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "create body: %s", w.Body.String())
+
+		var resp RateLimitJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		return resp
+	}
+
+	t.Run("get rate limit", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		created := createRateLimit(t, tu, "root", map[string]string{"env": "test"})
+
+		t.Run("unauthorized", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/rate-limits/%s", created.Id), nil)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+
+		t.Run("forbidden wrong verb", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				fmt.Sprintf("/rate-limits/%s", created.Id),
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "rate_limits", "create"), // Wrong verb
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			fakeId := apid.New(apid.PrefixRateLimit)
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				fmt.Sprintf("/rate-limits/%s", fakeId),
+				nil,
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNotFound, w.Code)
+		})
+
+		t.Run("valid", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				fmt.Sprintf("/rate-limits/%s", created.Id),
+				nil,
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp RateLimitJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Equal(t, created.Id, resp.Id)
+			require.Equal(t, "root", resp.Namespace)
+			require.Equal(t, "test", resp.Labels["env"])
+			require.NotNil(t, resp.Definition.Algorithm.TokenBucket)
+			require.Equal(t, 60, resp.Definition.Algorithm.TokenBucket.Capacity)
+		})
+	})
+
+	t.Run("create rate limit", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		t.Run("unauthorized", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"namespace": "root", "definition": validDef()})
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodPost, "/rate-limits", bytes.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+
+		t.Run("forbidden wrong verb", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"namespace": "root", "definition": validDef()})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/rate-limits",
+				bytes.NewReader(body),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "rate_limits", "list"),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("missing namespace", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"definition": validDef()})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("forbidden namespace not allowed", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"namespace": "root.restricted", "definition": validDef()})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor",
+				aschema.PermissionsSingle("root.other.**", "rate_limits", "create"))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("invalid definition - empty algorithm", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{
+				"namespace": "root",
+				"definition": map[string]interface{}{
+					"selector":  map[string]interface{}{},
+					"bucket":    map[string]interface{}{},
+					"algorithm": map[string]interface{}{},
+				},
+			})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "exactly one of")
+		})
+
+		t.Run("invalid definition - request_types empty list", func(t *testing.T) {
+			def := validDef()
+			def["selector"].(map[string]interface{})["request_types"] = []string{}
+			body, _ := json.Marshal(map[string]interface{}{"namespace": "root", "definition": def})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("invalid labels - reserved apxy/ prefix", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{
+				"namespace":  "root",
+				"definition": validDef(),
+				"labels":     map[string]string{"apxy/foo": "bar"},
+			})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "labels")
+		})
+
+		t.Run("valid with labels and annotations", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{
+				"namespace":   "root",
+				"definition":  validDef(),
+				"labels":      map[string]string{"env": "prod", "team": "platform"},
+				"annotations": map[string]string{"description": "throttle"},
+			})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp RateLimitJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.True(t, resp.Id.HasPrefix(apid.PrefixRateLimit))
+			require.Equal(t, "prod", resp.Labels["env"])
+			require.Equal(t, "platform", resp.Labels["team"])
+			require.Equal(t, "throttle", resp.Annotations["description"])
+			// Implicit identifier labels are present.
+			require.Equal(t, string(resp.Id), resp.Labels["apxy/rl/-/id"])
+		})
+	})
+
+	t.Run("update rate limit", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		created := createRateLimit(t, tu, "root", map[string]string{"env": "test"})
+
+		t.Run("update definition", func(t *testing.T) {
+			newDef := validDef()
+			newDef["mode"] = "observe"
+			body, _ := json.Marshal(map[string]interface{}{"definition": newDef})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPatch, fmt.Sprintf("/rate-limits/%s", created.Id), bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp RateLimitJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Equal(t, rlschema.ModeObserve, resp.Definition.Mode)
+		})
+
+		t.Run("update with invalid definition", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{
+				"definition": map[string]interface{}{
+					"selector":  map[string]interface{}{},
+					"bucket":    map[string]interface{}{},
+					"algorithm": map[string]interface{}{},
+				},
+			})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPatch, fmt.Sprintf("/rate-limits/%s", created.Id), bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("update labels (full replace)", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"labels": map[string]string{"region": "us-east"}})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPatch, fmt.Sprintf("/rate-limits/%s", created.Id), bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp RateLimitJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			// PATCH with labels = full user-label replace.
+			require.Equal(t, "us-east", resp.Labels["region"])
+			_, hadEnv := resp.Labels["env"]
+			require.False(t, hadEnv, "old env label should be replaced")
+			// apxy/* survive replace.
+			require.Equal(t, string(created.Id), resp.Labels["apxy/rl/-/id"])
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]interface{}{"labels": map[string]string{"env": "test"}})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPatch, fmt.Sprintf("/rate-limits/%s", apid.New(apid.PrefixRateLimit)),
+				bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNotFound, w.Code)
+		})
+	})
+
+	t.Run("delete rate limit", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		created := createRateLimit(t, tu, "root", nil)
+
+		t.Run("forbidden wrong verb", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodDelete, fmt.Sprintf("/rate-limits/%s", created.Id), nil,
+				"root", "some-actor",
+				aschema.PermissionsSingle("root.**", "rate_limits", "get"))
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("valid", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodDelete, fmt.Sprintf("/rate-limits/%s", created.Id), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNoContent, w.Code)
+
+			// Subsequent get returns 404.
+			w = httptest.NewRecorder()
+			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, fmt.Sprintf("/rate-limits/%s", created.Id), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNotFound, w.Code)
+		})
+
+		t.Run("delete already-deleted returns 204", func(t *testing.T) {
+			// The encryption-keys delete returns 204 even when the row is
+			// already gone; rate limits should match.
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodDelete, fmt.Sprintf("/rate-limits/%s", apid.New(apid.PrefixRateLimit)), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNoContent, w.Code)
+		})
+	})
+
+	t.Run("list rate limits", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		// Seed: 3 in root, 2 in root (one with team=alpha, one with team=beta).
+		_ = createRateLimit(t, tu, "root", map[string]string{"team": "alpha"})
+		_ = createRateLimit(t, tu, "root", map[string]string{"team": "beta"})
+		_ = createRateLimit(t, tu, "root", nil)
+
+		t.Run("list all", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits", nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListRateLimitsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 3)
+		})
+
+		t.Run("filter by namespace", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits?namespace=root", nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListRateLimitsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 3)
+		})
+
+		t.Run("filter by namespace - none match", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits?namespace=root.nope", nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListRateLimitsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Empty(t, resp.Items)
+		})
+
+		t.Run("filter by label_selector", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits?label_selector=team%3Dalpha", nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp ListRateLimitsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 1)
+			require.Equal(t, "alpha", resp.Items[0].Labels["team"])
+		})
+
+		t.Run("invalid order_by", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits?order_by=banana%3Aasc", nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	})
+
+	t.Run("label sub-resources", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		created := createRateLimit(t, tu, "root", map[string]string{"env": "test"})
+
+		t.Run("get all labels", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, fmt.Sprintf("/rate-limits/%s/labels", created.Id), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var labels map[string]string
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &labels))
+			require.Equal(t, "test", labels["env"])
+		})
+
+		t.Run("put one label", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]string{"value": "us-east"})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPut, fmt.Sprintf("/rate-limits/%s/labels/region", created.Id),
+				bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			// Re-read to confirm.
+			rl, err := tu.Db.GetRateLimit(context.Background(), created.Id)
+			require.NoError(t, err)
+			require.Equal(t, "us-east", rl.Labels["region"])
+		})
+
+		t.Run("delete one label", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodDelete, fmt.Sprintf("/rate-limits/%s/labels/env", created.Id), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+
+			rl, err := tu.Db.GetRateLimit(context.Background(), created.Id)
+			require.NoError(t, err)
+			_, exists := rl.Labels["env"]
+			require.False(t, exists)
+		})
+	})
+
+	t.Run("annotation sub-resources", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		created := createRateLimit(t, tu, "root", nil)
+
+		t.Run("put one annotation", func(t *testing.T) {
+			body, _ := json.Marshal(map[string]string{"value": "platform@example.com"})
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPut, fmt.Sprintf("/rate-limits/%s/annotations/owner", created.Id),
+				bytes.NewReader(body),
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			rl, err := tu.Db.GetRateLimit(context.Background(), created.Id)
+			require.NoError(t, err)
+			require.Equal(t, "platform@example.com", rl.Annotations["owner"])
+		})
+
+		t.Run("get all annotations", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, fmt.Sprintf("/rate-limits/%s/annotations", created.Id), nil,
+				"root", "some-actor", aschema.AllPermissions())
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var annots map[string]string
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &annots))
+			require.Equal(t, "platform@example.com", annots["owner"])
+		})
+	})
+}
+
+// Compile-time guards: the schema package's request_type constants are the
+// canonical source the routes reference. Touching these here ensures import
+// hygiene if the package or constants are renamed.
+var (
+	_ = common.RequestTypeProxy
+	_ = rlschema.ModeEnforce
+	_ time.Time
+)

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -332,6 +332,36 @@ type SwaggerListEncryptionKeysResponse struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
+// SwaggerRateLimitJson is a simplified rate-limit model for swagger documentation.
+//
+//	@Description	Rate limit configuration
+type SwaggerRateLimitJson struct {
+	// Rate limit ID
+	Id apid.ID `swaggertype:"string" json:"id" example:"rl_test550e8400abcde"`
+	// Namespace path
+	Namespace string `json:"namespace" example:"acme"`
+	// JSON-serialised definition (mode, selector, bucket, algorithm)
+	Definition map[string]interface{} `json:"definition"`
+	// Labels assigned to the rate limit
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations assigned to the rate limit
+	Annotations map[string]string `json:"annotations,omitempty"`
+	// Creation timestamp
+	CreatedAt time.Time `json:"created_at"`
+	// Last update timestamp
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// SwaggerListRateLimitsResponse is the response for list rate limits.
+//
+//	@Description	Paginated list of rate limits
+type SwaggerListRateLimitsResponse struct {
+	// List of rate limits
+	Items []SwaggerRateLimitJson `json:"items"`
+	// Pagination cursor for next page
+	Cursor string `json:"cursor,omitempty"`
+}
+
 // SwaggerListRequestsResponse is the response for list request logs
 //
 //	@Description	Paginated list of request log entries

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -151,6 +151,11 @@ func GetGinServer(
 		authService,
 		dm.GetCoreService(),
 	)
+	routesRateLimits := common_routes.NewRateLimitsRoutes(
+		dm.GetConfig(),
+		authService,
+		dm.GetCoreService(),
+	)
 	routesTaskMonitoring := common_routes.NewTaskMonitoringRoutes(
 		dm.GetConfig(),
 		authService,
@@ -164,6 +169,7 @@ func GetGinServer(
 	routesConnections.Register(api)
 	routesNamespaces.Register(api)
 	routesEncryptionKeys.Register(api)
+	routesRateLimits.Register(api)
 	routesRequestLog.Register(api)
 	routesActors.Register(api)
 	routesTaskMonitoring.Register(api)

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -6093,6 +6093,846 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/rate-limits": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List rate limits with optional filtering and pagination",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "List rate limits",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label selector",
+                        "name": "label_selector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (e.g., 'created_at:desc')",
+                        "name": "order_by",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerListRateLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new rate limit resource",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Create rate limit",
+                "parameters": [
+                    {
+                        "description": "Rate limit creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific rate limit by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft delete a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a rate limit's definition, labels, or annotations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Update rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all annotations associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all annotations for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations/{annotation}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific annotation value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific annotation value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set an annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Annotation value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific annotation by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete an annotation from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all labels associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all labels for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels/{label}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific label value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific label value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set a label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Label value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific label by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete a label from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/request-log": {
             "get": {
                 "security": [
@@ -6458,6 +7298,9 @@ const docTemplateadmin_api = `{
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
+        "github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit": {
+            "type": "object"
+        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6631,6 +7474,9 @@ const docTemplateadmin_api = `{
                     "type": "string"
                 }
             }
+        },
+        "routes.CreateRateLimitRequestJson": {
+            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -7233,6 +8079,23 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "routes.SwaggerListRateLimitsResponse": {
+            "description": "Paginated list of rate limits",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "Pagination cursor for next page",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "List of rate limits",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                    }
+                }
+            }
+        },
         "routes.SwaggerListRequestsResponse": {
             "description": "Paginated list of request log entries",
             "type": "object",
@@ -7300,6 +8163,49 @@ const docTemplateadmin_api = `{
                     "description": "Value to set",
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.SwaggerRateLimitJson": {
+            "description": "Rate limit configuration",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "id": {
+                    "description": "Rate limit ID",
+                    "type": "string",
+                    "example": "rl_test550e8400abcde"
+                },
+                "labels": {
+                    "description": "Labels assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "description": "Namespace path",
+                    "type": "string",
+                    "example": "acme"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
                 }
             }
         },
@@ -7497,6 +8403,26 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "routes.UpdateRateLimitRequestJson": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -6087,6 +6087,846 @@
                 }
             }
         },
+        "/rate-limits": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List rate limits with optional filtering and pagination",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "List rate limits",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label selector",
+                        "name": "label_selector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (e.g., 'created_at:desc')",
+                        "name": "order_by",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerListRateLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new rate limit resource",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Create rate limit",
+                "parameters": [
+                    {
+                        "description": "Rate limit creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific rate limit by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft delete a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a rate limit's definition, labels, or annotations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Update rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all annotations associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all annotations for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations/{annotation}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific annotation value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific annotation value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set an annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Annotation value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific annotation by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete an annotation from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all labels associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all labels for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels/{label}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific label value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific label value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set a label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Label value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific label by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete a label from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/request-log": {
             "get": {
                 "security": [
@@ -6452,6 +7292,9 @@
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
+        "github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit": {
+            "type": "object"
+        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6625,6 +7468,9 @@
                     "type": "string"
                 }
             }
+        },
+        "routes.CreateRateLimitRequestJson": {
+            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -7227,6 +8073,23 @@
                 }
             }
         },
+        "routes.SwaggerListRateLimitsResponse": {
+            "description": "Paginated list of rate limits",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "Pagination cursor for next page",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "List of rate limits",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                    }
+                }
+            }
+        },
         "routes.SwaggerListRequestsResponse": {
             "description": "Paginated list of request log entries",
             "type": "object",
@@ -7294,6 +8157,49 @@
                     "description": "Value to set",
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.SwaggerRateLimitJson": {
+            "description": "Rate limit configuration",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "id": {
+                    "description": "Rate limit ID",
+                    "type": "string",
+                    "example": "rl_test550e8400abcde"
+                },
+                "labels": {
+                    "description": "Labels assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "description": "Namespace path",
+                    "type": "string",
+                    "example": "acme"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
                 }
             }
         },
@@ -7491,6 +8397,26 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "routes.UpdateRateLimitRequestJson": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -2,6 +2,8 @@ basePath: /api/v1
 definitions:
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
     type: object
+  github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit:
+    type: object
   routes.ActorJson:
     properties:
       annotations:
@@ -120,6 +122,8 @@ definitions:
         type: object
       path:
         type: string
+    type: object
+  routes.CreateRateLimitRequestJson:
     type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
@@ -561,6 +565,18 @@ definitions:
           $ref: '#/definitions/routes.SwaggerNamespaceJson'
         type: array
     type: object
+  routes.SwaggerListRateLimitsResponse:
+    description: Paginated list of rate limits
+    properties:
+      cursor:
+        description: Pagination cursor for next page
+        type: string
+      items:
+        description: List of rate limits
+        items:
+          $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        type: array
+    type: object
   routes.SwaggerListRequestsResponse:
     description: Paginated list of request log entries
     properties:
@@ -610,6 +626,38 @@ definitions:
       value:
         description: Value to set
         example: production
+        type: string
+    type: object
+  routes.SwaggerRateLimitJson:
+    description: Rate limit configuration
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        description: Annotations assigned to the rate limit
+        type: object
+      created_at:
+        description: Creation timestamp
+        type: string
+      definition:
+        additionalProperties: true
+        description: JSON-serialised definition (mode, selector, bucket, algorithm)
+        type: object
+      id:
+        description: Rate limit ID
+        example: rl_test550e8400abcde
+        type: string
+      labels:
+        additionalProperties:
+          type: string
+        description: Labels assigned to the rate limit
+        type: object
+      namespace:
+        description: Namespace path
+        example: acme
+        type: string
+      updated_at:
+        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerRequestLogEntry:
@@ -752,6 +800,19 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+  routes.UpdateRateLimitRequestJson:
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit'
       labels:
         additionalProperties:
           type: string
@@ -4718,6 +4779,548 @@ paths:
       summary: Set a label for a namespace
       tags:
       - namespaces
+  /rate-limits:
+    get:
+      consumes:
+      - application/json
+      description: List rate limits with optional filtering and pagination
+      parameters:
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Maximum number of results to return
+        in: query
+        name: limit
+        type: integer
+      - description: Filter by namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Filter by label selector
+        in: query
+        name: label_selector
+        type: string
+      - description: Order by field (e.g., 'created_at:desc')
+        in: query
+        name: order_by
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerListRateLimitsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List rate limits
+      tags:
+      - rate_limits
+    post:
+      consumes:
+      - application/json
+      description: Create a new rate limit resource
+      parameters:
+      - description: Rate limit creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.CreateRateLimitRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Create rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Soft delete a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete rate limit
+      tags:
+      - rate_limits
+    get:
+      consumes:
+      - application/json
+      description: Get a specific rate limit by ID
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get rate limit
+      tags:
+      - rate_limits
+    patch:
+      consumes:
+      - application/json
+      description: Update a rate limit's definition, labels, or annotations
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.UpdateRateLimitRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/annotations:
+    get:
+      description: Get all annotations associated with a specific rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all annotations for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/annotations/{annotation}:
+    delete:
+      description: Delete a specific annotation by key from a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete an annotation from a rate limit
+      tags:
+      - rate_limits
+    get:
+      description: Get a specific annotation value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a specific annotation for a rate limit
+      tags:
+      - rate_limits
+    put:
+      consumes:
+      - application/json
+      description: Set or update a specific annotation value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      - description: Annotation value
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set an annotation for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/labels:
+    get:
+      description: Get all labels associated with a specific rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all labels for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/labels/{label}:
+    delete:
+      description: Delete a specific label by key from a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a label from a rate limit
+      tags:
+      - rate_limits
+    get:
+      description: Get a specific label value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a specific label for a rate limit
+      tags:
+      - rate_limits
+    put:
+      consumes:
+      - application/json
+      description: Set or update a specific label value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      - description: Label value
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set a label for a rate limit
+      tags:
+      - rate_limits
   /request-log:
     get:
       consumes:

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -139,6 +139,11 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		dm.GetEncryptService(),
 		logger,
 	)
+	routesRateLimits := common_routes.NewRateLimitsRoutes(
+		dm.GetConfig(),
+		authService,
+		dm.GetCoreService(),
+	)
 
 	api := server.Group("/api/v1")
 
@@ -149,6 +154,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 	routesTasks.Register(api)
 	routesRequestLog.Register(api)
 	routesActors.Register(api)
+	routesRateLimits.Register(api)
 
 	return service.GetServerAndHealthChecker(server, healthChecker)
 }

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -6093,6 +6093,846 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/rate-limits": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List rate limits with optional filtering and pagination",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "List rate limits",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label selector",
+                        "name": "label_selector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (e.g., 'created_at:desc')",
+                        "name": "order_by",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerListRateLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new rate limit resource",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Create rate limit",
+                "parameters": [
+                    {
+                        "description": "Rate limit creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific rate limit by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft delete a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a rate limit's definition, labels, or annotations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Update rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all annotations associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all annotations for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations/{annotation}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific annotation value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific annotation value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set an annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Annotation value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific annotation by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete an annotation from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all labels associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all labels for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels/{label}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific label value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific label value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set a label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Label value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific label by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete a label from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/request-log": {
             "get": {
                 "security": [
@@ -6458,6 +7298,9 @@ const docTemplateApi = `{
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
+        "github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit": {
+            "type": "object"
+        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6631,6 +7474,9 @@ const docTemplateApi = `{
                     "type": "string"
                 }
             }
+        },
+        "routes.CreateRateLimitRequestJson": {
+            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -7233,6 +8079,23 @@ const docTemplateApi = `{
                 }
             }
         },
+        "routes.SwaggerListRateLimitsResponse": {
+            "description": "Paginated list of rate limits",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "Pagination cursor for next page",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "List of rate limits",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                    }
+                }
+            }
+        },
         "routes.SwaggerListRequestsResponse": {
             "description": "Paginated list of request log entries",
             "type": "object",
@@ -7300,6 +8163,49 @@ const docTemplateApi = `{
                     "description": "Value to set",
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.SwaggerRateLimitJson": {
+            "description": "Rate limit configuration",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "id": {
+                    "description": "Rate limit ID",
+                    "type": "string",
+                    "example": "rl_test550e8400abcde"
+                },
+                "labels": {
+                    "description": "Labels assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "description": "Namespace path",
+                    "type": "string",
+                    "example": "acme"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
                 }
             }
         },
@@ -7497,6 +8403,26 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "routes.UpdateRateLimitRequestJson": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -6087,6 +6087,846 @@
                 }
             }
         },
+        "/rate-limits": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List rate limits with optional filtering and pagination",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "List rate limits",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by namespace",
+                        "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label selector",
+                        "name": "label_selector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order by field (e.g., 'created_at:desc')",
+                        "name": "order_by",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerListRateLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new rate limit resource",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Create rate limit",
+                "parameters": [
+                    {
+                        "description": "Rate limit creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific rate limit by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft delete a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a rate limit's definition, labels, or annotations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Update rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all annotations associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all annotations for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/annotations/{annotation}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific annotation value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific annotation value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set an annotation for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Annotation value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific annotation by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete an annotation from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Annotation key",
+                        "name": "annotation",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all labels associated with a specific rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get all labels for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/rate-limits/{id}/labels/{label}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a specific label value by key for a rate limit",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Get a specific label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Set or update a specific label value by key for a rate limit",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Set a label for a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Label value",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerPutKeyValueRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.SwaggerKeyValueJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific label by key from a rate limit",
+                "tags": [
+                    "rate_limits"
+                ],
+                "summary": "Delete a label from a rate limit",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rate limit ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Label key",
+                        "name": "label",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/request-log": {
             "get": {
                 "security": [
@@ -6452,6 +7292,9 @@
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
             "type": "object"
         },
+        "github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit": {
+            "type": "object"
+        },
         "routes.ActorJson": {
             "type": "object",
             "properties": {
@@ -6625,6 +7468,9 @@
                     "type": "string"
                 }
             }
+        },
+        "routes.CreateRateLimitRequestJson": {
+            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -7227,6 +8073,23 @@
                 }
             }
         },
+        "routes.SwaggerListRateLimitsResponse": {
+            "description": "Paginated list of rate limits",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "Pagination cursor for next page",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "List of rate limits",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
+                    }
+                }
+            }
+        },
         "routes.SwaggerListRequestsResponse": {
             "description": "Paginated list of request log entries",
             "type": "object",
@@ -7294,6 +8157,49 @@
                     "description": "Value to set",
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.SwaggerRateLimitJson": {
+            "description": "Rate limit configuration",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "description": "Creation timestamp",
+                    "type": "string"
+                },
+                "definition": {
+                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "id": {
+                    "description": "Rate limit ID",
+                    "type": "string",
+                    "example": "rl_test550e8400abcde"
+                },
+                "labels": {
+                    "description": "Labels assigned to the rate limit",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "description": "Namespace path",
+                    "type": "string",
+                    "example": "acme"
+                },
+                "updated_at": {
+                    "description": "Last update timestamp",
+                    "type": "string"
                 }
             }
         },
@@ -7491,6 +8397,26 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "routes.UpdateRateLimitRequestJson": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -2,6 +2,8 @@ basePath: /api/v1
 definitions:
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
     type: object
+  github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit:
+    type: object
   routes.ActorJson:
     properties:
       annotations:
@@ -120,6 +122,8 @@ definitions:
         type: object
       path:
         type: string
+    type: object
+  routes.CreateRateLimitRequestJson:
     type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
@@ -561,6 +565,18 @@ definitions:
           $ref: '#/definitions/routes.SwaggerNamespaceJson'
         type: array
     type: object
+  routes.SwaggerListRateLimitsResponse:
+    description: Paginated list of rate limits
+    properties:
+      cursor:
+        description: Pagination cursor for next page
+        type: string
+      items:
+        description: List of rate limits
+        items:
+          $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        type: array
+    type: object
   routes.SwaggerListRequestsResponse:
     description: Paginated list of request log entries
     properties:
@@ -610,6 +626,38 @@ definitions:
       value:
         description: Value to set
         example: production
+        type: string
+    type: object
+  routes.SwaggerRateLimitJson:
+    description: Rate limit configuration
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        description: Annotations assigned to the rate limit
+        type: object
+      created_at:
+        description: Creation timestamp
+        type: string
+      definition:
+        additionalProperties: true
+        description: JSON-serialised definition (mode, selector, bucket, algorithm)
+        type: object
+      id:
+        description: Rate limit ID
+        example: rl_test550e8400abcde
+        type: string
+      labels:
+        additionalProperties:
+          type: string
+        description: Labels assigned to the rate limit
+        type: object
+      namespace:
+        description: Namespace path
+        example: acme
+        type: string
+      updated_at:
+        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerRequestLogEntry:
@@ -752,6 +800,19 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+  routes.UpdateRateLimitRequestJson:
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_rate_limit.RateLimit'
       labels:
         additionalProperties:
           type: string
@@ -4718,6 +4779,548 @@ paths:
       summary: Set a label for a namespace
       tags:
       - namespaces
+  /rate-limits:
+    get:
+      consumes:
+      - application/json
+      description: List rate limits with optional filtering and pagination
+      parameters:
+      - description: Pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Maximum number of results to return
+        in: query
+        name: limit
+        type: integer
+      - description: Filter by namespace
+        in: query
+        name: namespace
+        type: string
+      - description: Filter by label selector
+        in: query
+        name: label_selector
+        type: string
+      - description: Order by field (e.g., 'created_at:desc')
+        in: query
+        name: order_by
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerListRateLimitsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List rate limits
+      tags:
+      - rate_limits
+    post:
+      consumes:
+      - application/json
+      description: Create a new rate limit resource
+      parameters:
+      - description: Rate limit creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.CreateRateLimitRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Create rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Soft delete a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete rate limit
+      tags:
+      - rate_limits
+    get:
+      consumes:
+      - application/json
+      description: Get a specific rate limit by ID
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get rate limit
+      tags:
+      - rate_limits
+    patch:
+      consumes:
+      - application/json
+      description: Update a rate limit's definition, labels, or annotations
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.UpdateRateLimitRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/annotations:
+    get:
+      description: Get all annotations associated with a specific rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all annotations for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/annotations/{annotation}:
+    delete:
+      description: Delete a specific annotation by key from a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete an annotation from a rate limit
+      tags:
+      - rate_limits
+    get:
+      description: Get a specific annotation value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a specific annotation for a rate limit
+      tags:
+      - rate_limits
+    put:
+      consumes:
+      - application/json
+      description: Set or update a specific annotation value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Annotation key
+        in: path
+        name: annotation
+        required: true
+        type: string
+      - description: Annotation value
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set an annotation for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/labels:
+    get:
+      description: Get all labels associated with a specific rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get all labels for a rate limit
+      tags:
+      - rate_limits
+  /rate-limits/{id}/labels/{label}:
+    delete:
+      description: Delete a specific label by key from a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a label from a rate limit
+      tags:
+      - rate_limits
+    get:
+      description: Get a specific label value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get a specific label for a rate limit
+      tags:
+      - rate_limits
+    put:
+      consumes:
+      - application/json
+      description: Set or update a specific label value by key for a rate limit
+      parameters:
+      - description: Rate limit ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Label key
+        in: path
+        name: label
+        required: true
+        type: string
+      - description: Label value
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.SwaggerPutKeyValueRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.SwaggerKeyValueJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Set a label for a rate limit
+      tags:
+      - rate_limits
   /request-log:
     get:
       consumes:


### PR DESCRIPTION
## Summary

Closes #218. Second of the eight sub-issues under #3 (rate limit support); builds on #217 (schema and DB foundation, merged).

Wires up the admin-api endpoints for the `RateLimit` resource — full CRUD plus the standard label/annotation sub-resources via the shared `key_value.Adapter`. Encryption keys were the closest template (namespace-scoped, ID-keyed, mutable, same label/annotation surface).

## What's in

**Core layer**
- `internal/core/iface/rate_limit.go` — `RateLimit` interface + list builder/executor.
- `internal/core/iface/service.go` — 12 new methods on `C` (CRUD + label/annotation mutators + list builder/cursor).
- `internal/core/rate_limit.go` — concrete wrapper around `database.RateLimit`.
- `internal/core/service_rate_limit.go` — service methods + a paginated list wrapper mirroring `listEncryptionKeyWrapper`.

**Routes**
- `internal/routes/rate_limits.go`:
  - `GET    /rate-limits` (with `namespace_matcher` + `label_selector` + `order_by` + cursor pagination)
  - `POST   /rate-limits`
  - `GET    /rate-limits/:id`
  - `PATCH  /rate-limits/:id` (definition / labels / annotations all optional)
  - `DELETE /rate-limits/:id`
  - `GET/PUT/DELETE /rate-limits/:id/labels[/:label]`
  - `GET/PUT/DELETE /rate-limits/:id/annotations[/:annotation]`
- `internal/routes/swagger_models.go` — `SwaggerRateLimitJson` + `SwaggerListRateLimitsResponse`.
- `internal/service/admin_api/server.go` — register the routes.

**Validation surface in the create/update handlers**
- Rejects missing namespace.
- `val.ValidateNamespace(req.Namespace)` for permission scoping.
- `req.Definition.Validate()` runs the schema package's full rule set (selector clauses, bucket dimensions, exactly-one algorithm, request_types non-empty if explicit).
- `database.ValidateUserLabels` rejects `apxy/`-prefixed labels.
- `database.Annotations.Validate` enforces the size cap.

## Path naming

Used `/rate-limits` (kebab-case) to match the existing convention (`/encryption-keys`, `/connectors`, `/namespaces`). The issue spec wrote `/rate_limits`, but I followed the established style — flagging in case you'd prefer the underscore form.

## Test plan

- [x] `go test ./internal/routes/... -run TestRateLimits` — 30 sub-tests passing
- [x] `go test ./...` — full repo green
- [x] `./scripts/preflight.sh` — swagger up to date, integration_tests module ok

## Out of scope (later sub-issues)

- Background sync to proxy nodes (#219)
- Selector / bucket evaluation engine (#220)
- Algorithms + Redis counter store (#221)
- Request-log 429 attribution + connector-limiter fix (#222)
- Proxy-path enforcement (#223)
- Terraform `authproxy_rate_limit` resource (#224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)