### PR TITLE
Document per-clone port slots for authproxy0-9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,23 @@ AUTHPROXY_CONFIG=./dev_config/default.yaml
 ## Per-install port slot.
 ##
 ## Each AuthProxy clone on one machine (e.g. authproxy1, authproxy2,
-## authproxy3) needs its own ports so they don't collide. The convention
-## is to step the 10's digit per install:
+## ... authproxy9, authproxy0) needs its own ports so they don't
+## collide. The convention is to step the 10's digit per install.
+## For clone N the offset from defaults is (N-1)*10, with authproxy0
+## treated as the 10th slot (offset 90):
 ##
 ##   authproxy1: 808x / 8083 / 5173 / 5174   (defaults — leave unset)
 ##   authproxy2: 809x / 8093 / 5183 / 5184
 ##   authproxy3: 810x / 8103 / 5193 / 5194
+##   authproxy4: 811x / 8113 / 5203 / 5204
+##   authproxy5: 812x / 8123 / 5213 / 5214
+##   authproxy6: 813x / 8133 / 5223 / 5224
+##   authproxy7: 814x / 8143 / 5233 / 5234
+##   authproxy8: 815x / 8153 / 5243 / 5244
+##   authproxy9: 816x / 8163 / 5253 / 5254
+##   authproxy0: 817x / 8173 / 5263 / 5264
+##
+## Columns: PUBLIC,API,ADMIN_API (808x) / WORKER_HEALTH / MARKETPLACE_UI / ADMIN_UI.
 ##
 ## Override in your local .env (gitignored). Defaults below match the
 ## values baked into dev_config/default.yaml + the per-package vite


### PR DESCRIPTION
## Summary
- Extend the per-install port slot table in \`.env.example\` from clones 1-3 to cover all 10 single-digit clones (authproxy1-9 plus authproxy0 as the 10th slot).
- \`authproxy1\` keeps the existing defaults so a fresh clone still runs without overrides.
- Adds an explicit column legend so readers know which numbers map to PUBLIC/API/ADMIN_API/WORKER_HEALTH/MARKETPLACE_UI/ADMIN_UI.

## Test plan
- [ ] Visually confirm new slots match the (N-1)*10 offset pattern on the existing values for slots 1-3.
- [ ] Verify a clone that copies \`.env.example\` -> \`.env\` and uncomments slot N's overrides starts without port conflicts against another clone using slot M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)