### PR TITLE
Rate limits — Step 4: selector matching + bucket-key resolution

### DIFF
--- a/internal/database/label_selector.go
+++ b/internal/database/label_selector.go
@@ -132,6 +132,43 @@ func (s LabelSelector) String() string {
 	return strings.Join(parts, ",")
 }
 
+// Matches reports whether the supplied label map satisfies every requirement
+// in the selector. An empty / nil selector matches any input — same convention
+// the SQL-side uses (no requirements means no filter).
+//
+// This is the in-memory counterpart to ApplyToSqlBuilderWithProvider used by
+// the rate-limit evaluator (and any future runtime path that needs to match
+// label selectors against per-request snapshots).
+func (s LabelSelector) Matches(labels map[string]string) bool {
+	for _, r := range s {
+		v, present := labels[r.Key]
+		switch r.Operator {
+		case LabelOperatorEqual:
+			if !present || v != r.Value {
+				return false
+			}
+		case LabelOperatorNotEqual:
+			// Kubernetes-style: matches when the key is absent OR present with
+			// a different value. Mirrors the SQL predicate above.
+			if present && v == r.Value {
+				return false
+			}
+		case LabelOperatorExists:
+			if !present {
+				return false
+			}
+		case LabelOperatorNotExists:
+			if present {
+				return false
+			}
+		default:
+			// Unknown operator — fail closed.
+			return false
+		}
+	}
+	return true
+}
+
 func (s LabelSelector) ApplyToSqlBuilderWithProvider(q sq.SelectBuilder, labelsColumn string, provider config.DatabaseProvider) sq.SelectBuilder {
 	labelsExpr := labelsColumn
 	sqlitePathExpr := fmt.Sprintf("'$.\"' || ? || '\"'")

--- a/internal/database/label_selector_test.go
+++ b/internal/database/label_selector_test.go
@@ -173,3 +173,127 @@ func TestBuildLabelSelectorFromMap_Roundtrip(t *testing.T) {
 		assert.Equal(t, labels[req.Key], req.Value)
 	}
 }
+
+// TestLabelSelector_Matches covers the in-memory evaluator added for the
+// rate-limit runtime. Each case exercises one operator + a few of the
+// edge interactions that the SQL emitter covers via predicates.
+func TestLabelSelector_Matches(t *testing.T) {
+	cases := []struct {
+		name     string
+		selector LabelSelector
+		labels   map[string]string
+		want     bool
+	}{
+		{"empty selector matches anything", nil, map[string]string{"x": "y"}, true},
+		{"empty selector matches nil labels", nil, nil, true},
+		{
+			"= matches",
+			LabelSelector{{Key: "env", Operator: LabelOperatorEqual, Value: "prod"}},
+			map[string]string{"env": "prod"},
+			true,
+		},
+		{
+			"= rejects different value",
+			LabelSelector{{Key: "env", Operator: LabelOperatorEqual, Value: "prod"}},
+			map[string]string{"env": "staging"},
+			false,
+		},
+		{
+			"= rejects missing key",
+			LabelSelector{{Key: "env", Operator: LabelOperatorEqual, Value: "prod"}},
+			map[string]string{},
+			false,
+		},
+		{
+			"!= matches different value",
+			LabelSelector{{Key: "env", Operator: LabelOperatorNotEqual, Value: "prod"}},
+			map[string]string{"env": "staging"},
+			true,
+		},
+		{
+			"!= matches missing key",
+			LabelSelector{{Key: "env", Operator: LabelOperatorNotEqual, Value: "prod"}},
+			map[string]string{},
+			true,
+		},
+		{
+			"!= rejects same value",
+			LabelSelector{{Key: "env", Operator: LabelOperatorNotEqual, Value: "prod"}},
+			map[string]string{"env": "prod"},
+			false,
+		},
+		{
+			"exists matches present key",
+			LabelSelector{{Key: "team", Operator: LabelOperatorExists}},
+			map[string]string{"team": "platform"},
+			true,
+		},
+		{
+			"exists matches present key with empty value",
+			LabelSelector{{Key: "team", Operator: LabelOperatorExists}},
+			map[string]string{"team": ""},
+			true,
+		},
+		{
+			"exists rejects missing key",
+			LabelSelector{{Key: "team", Operator: LabelOperatorExists}},
+			map[string]string{},
+			false,
+		},
+		{
+			"!exists rejects present key",
+			LabelSelector{{Key: "debug", Operator: LabelOperatorNotExists}},
+			map[string]string{"debug": "true"},
+			false,
+		},
+		{
+			"!exists matches missing key",
+			LabelSelector{{Key: "debug", Operator: LabelOperatorNotExists}},
+			map[string]string{},
+			true,
+		},
+		{
+			"all clauses ANDed: all satisfied",
+			LabelSelector{
+				{Key: "env", Operator: LabelOperatorEqual, Value: "prod"},
+				{Key: "team", Operator: LabelOperatorExists},
+				{Key: "debug", Operator: LabelOperatorNotExists},
+			},
+			map[string]string{"env": "prod", "team": "platform"},
+			true,
+		},
+		{
+			"all clauses ANDed: one fails",
+			LabelSelector{
+				{Key: "env", Operator: LabelOperatorEqual, Value: "prod"},
+				{Key: "team", Operator: LabelOperatorExists},
+			},
+			map[string]string{"env": "prod"}, // team missing
+			false,
+		},
+		{
+			"unknown operator fails closed",
+			LabelSelector{{Key: "x", Operator: LabelOperator("bogus"), Value: "y"}},
+			map[string]string{"x": "y"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.selector.Matches(tc.labels))
+		})
+	}
+}
+
+// TestLabelSelector_Matches_RoundtripWithParser ensures Parse + Matches
+// give the same answer as authoring the LabelSelector by hand. Mirrors the
+// existing SQL roundtrip test.
+func TestLabelSelector_Matches_RoundtripWithParser(t *testing.T) {
+	parsed, err := ParseLabelSelector("env=prod,team,!debug")
+	assert.NoError(t, err)
+
+	assert.True(t, parsed.Matches(map[string]string{"env": "prod", "team": "platform"}))
+	assert.False(t, parsed.Matches(map[string]string{"env": "prod"}))
+	assert.False(t, parsed.Matches(map[string]string{"env": "prod", "team": "p", "debug": "1"}))
+}

--- a/internal/ratelimit/bucket_key.go
+++ b/internal/ratelimit/bucket_key.go
@@ -1,0 +1,138 @@
+package ratelimit
+
+import (
+	"strconv"
+	"strings"
+
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// BucketKey is the projection of a matched request into independent
+// counters. Components preserve the rule's dimension order so the
+// String() form is deterministic across calls and across processes —
+// callers can use it directly as a Redis sub-key.
+type BucketKey struct {
+	Components []BucketKeyComponent
+}
+
+// BucketKeyComponent pairs a dimension name with the value resolved from a
+// request context. Empty Value means the dimension was unresolved (e.g.
+// labels/<key> referenced a label not present on the request).
+type BucketKeyComponent struct {
+	Name  string
+	Value string
+}
+
+// IsGlobal reports whether the rule had an empty dimensions list — meaning
+// a single global counter for the entire rule rather than per-bucket ones.
+func (k BucketKey) IsGlobal() bool {
+	return len(k.Components) == 0
+}
+
+// String renders a stable, canonical string suitable for use as a Redis
+// sub-key. The format escapes the field separator ('|') and the
+// name-value separator ('=') in values to avoid collisions, e.g.
+//
+//	actor=act_abc|labels/team=alpha
+//
+// IsGlobal() keys render as "*".
+func (k BucketKey) String() string {
+	if k.IsGlobal() {
+		return "*"
+	}
+	var b strings.Builder
+	for i, c := range k.Components {
+		if i > 0 {
+			b.WriteByte('|')
+		}
+		b.WriteString(escapeBucketField(c.Name))
+		b.WriteByte('=')
+		b.WriteString(escapeBucketField(c.Value))
+	}
+	return b.String()
+}
+
+// escapeBucketField percent-encodes the two reserved separators so a
+// label value containing '|' or '=' never produces an ambiguous key.
+// Done by hand to keep the encoding minimal and stable; we don't want
+// the broader URL-encoding rules quietly changing the output if a value
+// happens to contain (e.g.) spaces or unicode.
+func escapeBucketField(s string) string {
+	if !strings.ContainsAny(s, "|=%") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '|':
+			b.WriteString("%7C")
+		case '=':
+			b.WriteString("%3D")
+		case '%':
+			b.WriteString("%25")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ResolveBucketKey computes the bucket key for ctx according to the rule's
+// bucket clause. An empty rule.Bucket.Dimensions list yields a global key
+// (IsGlobal()). Reserved dimension names resolve to request-context fields;
+// "labels/<key>" resolves to the request's per-call label snapshot. A
+// dimension referencing data not present on the request resolves to "" —
+// callers will see this as a distinct bucket from values that *are* present.
+func ResolveBucketKey(rule rlschema.RateLimit, ctx *RequestContext) BucketKey {
+	dims := rule.Bucket.Dimensions
+	if len(dims) == 0 {
+		return BucketKey{}
+	}
+	out := BucketKey{Components: make([]BucketKeyComponent, 0, len(dims))}
+	for _, d := range dims {
+		out.Components = append(out.Components, BucketKeyComponent{
+			Name:  d,
+			Value: resolveDimension(d, ctx),
+		})
+	}
+	return out
+}
+
+// resolveDimension returns the per-request value for a single dimension.
+// Empty string means "not present" — distinct from "explicitly empty" only
+// in semantics; downstream counters treat the resolved tuple as opaque.
+func resolveDimension(name string, ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	switch name {
+	case rlschema.DimensionActor:
+		return string(ctx.ActorID)
+	case rlschema.DimensionConnection:
+		return string(ctx.ConnectionID)
+	case rlschema.DimensionConnector:
+		return string(ctx.ConnectorID)
+	case rlschema.DimensionConnectorVersion:
+		// Render as decimal so two connectors with versions 1 and 11
+		// produce distinct buckets.
+		if ctx.ConnectorVersion == 0 {
+			return ""
+		}
+		return strconv.FormatUint(ctx.ConnectorVersion, 10)
+	case rlschema.DimensionNamespace:
+		return ctx.Namespace
+	case rlschema.DimensionMethod:
+		return ctx.Method
+	}
+	if strings.HasPrefix(name, rlschema.LabelDimensionPrefix) {
+		key := strings.TrimPrefix(name, rlschema.LabelDimensionPrefix)
+		if v, ok := ctx.Labels[key]; ok {
+			return v
+		}
+		return ""
+	}
+	// Unknown dimension — schema validation should prevent this. Render as
+	// empty so the resulting bucket key still serializes deterministically.
+	return ""
+}

--- a/internal/ratelimit/bucket_key_test.go
+++ b/internal/ratelimit/bucket_key_test.go
@@ -1,0 +1,149 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketKey_String_Global(t *testing.T) {
+	k := BucketKey{}
+	require.True(t, k.IsGlobal())
+	require.Equal(t, "*", k.String())
+}
+
+func TestBucketKey_String_Stable(t *testing.T) {
+	// Two identical inputs must produce the same string. Tests deterministic
+	// serialization across invocations — important because the string is
+	// used as a Redis sub-key.
+	k1 := BucketKey{Components: []BucketKeyComponent{
+		{Name: "actor", Value: "act_a"},
+		{Name: "labels/team", Value: "alpha"},
+	}}
+	k2 := BucketKey{Components: []BucketKeyComponent{
+		{Name: "actor", Value: "act_a"},
+		{Name: "labels/team", Value: "alpha"},
+	}}
+	require.Equal(t, k1.String(), k2.String())
+	require.Equal(t, "actor=act_a|labels/team=alpha", k1.String())
+}
+
+func TestBucketKey_String_OrderMatters(t *testing.T) {
+	// Component order is preserved as-is so two rules with the same
+	// dimension *set* but different *order* produce different keys
+	// (matching the rule's own dimension list, which is the source of
+	// truth).
+	k1 := BucketKey{Components: []BucketKeyComponent{
+		{Name: "actor", Value: "act_a"},
+		{Name: "namespace", Value: "root"},
+	}}
+	k2 := BucketKey{Components: []BucketKeyComponent{
+		{Name: "namespace", Value: "root"},
+		{Name: "actor", Value: "act_a"},
+	}}
+	require.NotEqual(t, k1.String(), k2.String())
+}
+
+func TestBucketKey_String_Escapes(t *testing.T) {
+	// Values containing the field/separator characters must be escaped so
+	// they don't produce ambiguous parses or collisions.
+	k := BucketKey{Components: []BucketKeyComponent{
+		{Name: "labels/raw", Value: "a|b=c%d"},
+	}}
+	require.Equal(t, "labels/raw=a%7Cb%3Dc%25d", k.String())
+}
+
+func TestResolveBucketKey_Empty(t *testing.T) {
+	// Empty dimensions list = single global bucket per rule.
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{}}
+	ctx := &RequestContext{ActorID: apid.ID("act_x")}
+	k := ResolveBucketKey(rule, ctx)
+	require.True(t, k.IsGlobal())
+}
+
+func TestResolveBucketKey_ReservedDimensions(t *testing.T) {
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{
+			rlschema.DimensionActor,
+			rlschema.DimensionConnection,
+			rlschema.DimensionConnector,
+			rlschema.DimensionConnectorVersion,
+			rlschema.DimensionNamespace,
+			rlschema.DimensionMethod,
+		},
+	}}
+	ctx := &RequestContext{
+		ActorID:          apid.ID("act_a"),
+		ConnectionID:     apid.ID("cxn_1"),
+		ConnectorID:      apid.ID("cxr_1"),
+		ConnectorVersion: 7,
+		Namespace:        "root.team-x",
+		Method:           "POST",
+	}
+	k := ResolveBucketKey(rule, ctx)
+	require.Equal(t,
+		"actor=act_a|connection=cxn_1|connector=cxr_1|connector_version=7|namespace=root.team-x|method=POST",
+		k.String(),
+	)
+}
+
+func TestResolveBucketKey_LabelDimensions(t *testing.T) {
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{"labels/team", "labels/region"},
+	}}
+	ctx := &RequestContext{Labels: map[string]string{
+		"team":   "alpha",
+		"region": "us-east",
+	}}
+	k := ResolveBucketKey(rule, ctx)
+	require.Equal(t, "labels/team=alpha|labels/region=us-east", k.String())
+}
+
+func TestResolveBucketKey_MissingValuesResolveEmpty(t *testing.T) {
+	// Missing reserved + missing label both resolve to "" — distinct
+	// from a present-but-empty value only in semantics. The downstream
+	// counter sees the resolved tuple as opaque.
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{
+			rlschema.DimensionActor,
+			"labels/missing",
+		},
+	}}
+	ctx := &RequestContext{} // nothing populated
+	k := ResolveBucketKey(rule, ctx)
+	require.Equal(t, "actor=|labels/missing=", k.String())
+}
+
+func TestResolveBucketKey_NilContext(t *testing.T) {
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{rlschema.DimensionActor},
+	}}
+	k := ResolveBucketKey(rule, nil)
+	require.Equal(t, "actor=", k.String())
+}
+
+func TestResolveBucketKey_ZeroConnectorVersionResolvesEmpty(t *testing.T) {
+	// 0 means "no connector version" (unset) — distinct from version 0,
+	// which is impossible per apid conventions. Render as "" so it
+	// doesn't bucket alongside other small versions.
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{rlschema.DimensionConnectorVersion},
+	}}
+	ctx := &RequestContext{ConnectorVersion: 0}
+	k := ResolveBucketKey(rule, ctx)
+	require.Equal(t, "connector_version=", k.String())
+}
+
+func TestResolveBucketKey_UnknownDimensionResolvesEmpty(t *testing.T) {
+	// Schema validation should prevent unknown dimensions; if one slips
+	// through we still render the key deterministically rather than
+	// panicking or producing a malformed string.
+	rule := rlschema.RateLimit{Bucket: rlschema.Bucket{
+		Dimensions: []string{"made_up_thing"},
+	}}
+	ctx := &RequestContext{}
+	k := ResolveBucketKey(rule, ctx)
+	require.Equal(t, "made_up_thing=", k.String())
+}

--- a/internal/ratelimit/matcher.go
+++ b/internal/ratelimit/matcher.go
@@ -1,0 +1,150 @@
+package ratelimit
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// Match decides whether rule's selector matches ctx and, if so, computes
+// the bucket key. All selector clauses are ANDed: a request must satisfy
+// every non-empty clause for the rule to fire.
+//
+// Returns:
+//   - matched=true with a populated BucketKey when the rule applies.
+//   - matched=false with a zero BucketKey when the rule does not apply.
+//   - a non-nil error only for malformed rule data that escaped schema
+//     validation (e.g. an uncompilable regex). Callers should log + skip
+//     such rules — they shouldn't be able to reach the runtime.
+func Match(rule rlschema.RateLimit, ctx *RequestContext) (matched bool, key BucketKey, err error) {
+	if ctx == nil {
+		return false, BucketKey{}, nil
+	}
+
+	if !matchRequestType(rule.Selector.EffectiveRequestTypes(), ctx.Type) {
+		return false, BucketKey{}, nil
+	}
+
+	if !matchMethods(rule.Selector.Methods, ctx.Method) {
+		return false, BucketKey{}, nil
+	}
+
+	if rule.Selector.LabelSelector != "" {
+		ok, lerr := matchLabelSelector(rule.Selector.LabelSelector, ctx.Labels)
+		if lerr != nil {
+			return false, BucketKey{}, fmt.Errorf("label selector: %w", lerr)
+		}
+		if !ok {
+			return false, BucketKey{}, nil
+		}
+	}
+
+	if rule.Selector.PathMatch != nil {
+		var p string
+		if ctx.UpstreamURL != nil {
+			p = ctx.UpstreamURL.Path
+		}
+		ok, perr := matchPath(rule.Selector.PathMatch, p, ctx.UpstreamURL != nil)
+		if perr != nil {
+			return false, BucketKey{}, fmt.Errorf("path match: %w", perr)
+		}
+		if !ok {
+			return false, BucketKey{}, nil
+		}
+	}
+
+	return true, ResolveBucketKey(rule, ctx), nil
+}
+
+// matchRequestType returns true if ctxType is in the rule's allowed list.
+// allowed is the *effective* list — callers should pass
+// rule.Selector.EffectiveRequestTypes() so the default [proxy, probe] is
+// applied when the rule omits the field.
+func matchRequestType(allowed []common.RequestType, ctxType common.RequestType) bool {
+	if len(allowed) == 0 {
+		// Defensive: EffectiveRequestTypes never returns an empty slice
+		// because schema validation rejects an explicit empty list. If
+		// we ever see one, fail closed (don't match).
+		return false
+	}
+	for _, t := range allowed {
+		if t == ctxType {
+			return true
+		}
+	}
+	return false
+}
+
+// matchMethods returns true when the rule has no method restriction
+// (nil/empty list = any) or when the request's method is in the list.
+// Comparison is exact (the schema rejects lowercase verbs at validation
+// time, so a typo in either side fails to match here).
+func matchMethods(allowed []string, ctxMethod string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, m := range allowed {
+		if m == ctxMethod {
+			return true
+		}
+	}
+	return false
+}
+
+// matchLabelSelector parses + evaluates the rule's labelSelector against the
+// per-request label snapshot. Parsing happens on every call rather than
+// being cached — the enforcement layer can add caching later if profiling
+// shows it matters.
+func matchLabelSelector(selector string, labels map[string]string) (bool, error) {
+	parsed, err := database.ParseLabelSelector(selector)
+	if err != nil {
+		return false, err
+	}
+	return parsed.Matches(labels), nil
+}
+
+// matchPath evaluates the rule's PathMatch against the path component of
+// the resolved upstream URL. urlPresent=false means the request didn't
+// carry a URL — a rule with a pathMatch clause then fails the match (the
+// rule wants to filter on a path that doesn't exist).
+//
+// Glob semantics use Go's path.Match, where '*' does not cross '/' — same
+// behavior as filepath.Match for shell globs. For full doublestar
+// behaviour, callers can use kind=regex.
+func matchPath(pm *rlschema.PathMatch, p string, urlPresent bool) (bool, error) {
+	if pm == nil {
+		return true, nil
+	}
+	if !urlPresent {
+		return false, nil
+	}
+	switch pm.Kind {
+	case rlschema.PathMatchKindPrefix:
+		return strings.HasPrefix(p, pm.Value), nil
+	case rlschema.PathMatchKindGlob:
+		// path.Match returns ErrBadPattern for malformed globs. Schema
+		// validation doesn't yet round-trip the glob through path.Match,
+		// so propagate the error rather than silently failing closed.
+		ok, err := path.Match(pm.Value, p)
+		if err != nil {
+			return false, err
+		}
+		return ok, nil
+	case rlschema.PathMatchKindRegex:
+		// Compile-on-call. The schema validator already proved it
+		// compiles, so this is wasted work in steady state — fix when
+		// the enforcement layer has a place to cache compiled regexes.
+		re, err := regexp.Compile(pm.Value)
+		if err != nil {
+			return false, err
+		}
+		return re.MatchString(p), nil
+	default:
+		return false, fmt.Errorf("unknown path match kind %q", pm.Kind)
+	}
+}

--- a/internal/ratelimit/matcher_test.go
+++ b/internal/ratelimit/matcher_test.go
@@ -1,0 +1,378 @@
+package ratelimit
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+// validRule returns a permissive rule that matches anything by default —
+// individual tests narrow it via the closure passed to mutate.
+func validRule(mutate func(*rlschema.RateLimit)) rlschema.RateLimit {
+	r := rlschema.RateLimit{
+		Selector: rlschema.Selector{}, // no clauses = match anything (subject to default request types)
+		Bucket:   rlschema.Bucket{},
+		Algorithm: rlschema.Algorithm{
+			TokenBucket: &rlschema.TokenBucket{Capacity: 1, RefillRate: 1},
+		},
+	}
+	if mutate != nil {
+		mutate(&r)
+	}
+	return r
+}
+
+func proxyCtx(mutate func(*RequestContext)) *RequestContext {
+	c := &RequestContext{Type: common.RequestTypeProxy, Method: "GET"}
+	if mutate != nil {
+		mutate(c)
+	}
+	return c
+}
+
+// --- Request-type matching ---
+
+func TestMatch_RequestType_DefaultAcceptsProxy(t *testing.T) {
+	matched, _, err := Match(validRule(nil), proxyCtx(func(c *RequestContext) { c.Type = common.RequestTypeProxy }))
+	require.NoError(t, err)
+	require.True(t, matched)
+}
+
+func TestMatch_RequestType_DefaultAcceptsProbe(t *testing.T) {
+	matched, _, err := Match(validRule(nil), proxyCtx(func(c *RequestContext) { c.Type = common.RequestTypeProbe }))
+	require.NoError(t, err)
+	require.True(t, matched)
+}
+
+func TestMatch_RequestType_DefaultRejectsOAuth(t *testing.T) {
+	// Default is [proxy, probe] — anything else is rejected unless the
+	// rule explicitly opts in via Selector.RequestTypes.
+	matched, _, err := Match(validRule(nil), proxyCtx(func(c *RequestContext) { c.Type = common.RequestTypeOAuth }))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_RequestType_ExplicitOptIn(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.RequestTypes = []common.RequestType{common.RequestTypeOAuth}
+	})
+	// Default proxy traffic now fails to match.
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) { c.Type = common.RequestTypeProxy }))
+	require.NoError(t, err)
+	require.False(t, matched)
+
+	// Opted-in oauth traffic matches.
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) { c.Type = common.RequestTypeOAuth }))
+	require.NoError(t, err)
+	require.True(t, matched)
+}
+
+// --- Method matching ---
+
+func TestMatch_Methods_EmptyMatchesAny(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) { r.Selector.Methods = nil })
+	for _, m := range []string{"GET", "POST", "DELETE"} {
+		matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) { c.Method = m }))
+		require.NoError(t, err)
+		require.True(t, matched, "method %s should match an unrestricted rule", m)
+	}
+}
+
+func TestMatch_Methods_FilterApplies(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.Methods = []string{"POST", "PATCH"}
+	})
+
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) { c.Method = "POST" }))
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) { c.Method = "GET" }))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+// --- LabelSelector matching ---
+
+func TestMatch_LabelSelector_Matches(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.LabelSelector = "env=prod,team"
+	})
+
+	// Both clauses satisfied.
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "prod", "team": "platform"}
+	}))
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	// Wrong env value.
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "staging", "team": "platform"}
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+
+	// Missing team.
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "prod"}
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_LabelSelector_NotEqualAndNotExists(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.LabelSelector = "env!=prod,!debug"
+	})
+
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "staging"}
+	}))
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	// debug present → !debug fails.
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "staging", "debug": "true"}
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+
+	// env=prod fails the != clause.
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.Labels = map[string]string{"env": "prod"}
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_LabelSelector_BadSyntaxReturnsError(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		// Empty key after the bang isn't a valid label selector.
+		r.Selector.LabelSelector = "!="
+	})
+	matched, _, err := Match(rule, proxyCtx(nil))
+	require.Error(t, err)
+	require.False(t, matched)
+}
+
+// --- PathMatch matching ---
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestMatch_PathMatch_Prefix(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindPrefix, Value: "/services/data/",
+		}
+	})
+
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/services/data/v50/sobjects/Account")
+	}))
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/v1/users")
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_PathMatch_Glob(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindGlob, Value: "/v1/users/*",
+		}
+	})
+
+	cases := []struct {
+		path  string
+		want  bool
+		label string
+	}{
+		{"/v1/users/abc", true, "single-segment match"},
+		{"/v1/users/", true, "trailing slash matches empty segment"},
+		{"/v1/users/abc/orders", false, "* does not cross /"},
+		{"/v1/admin/abc", false, "wrong prefix"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+				c.UpstreamURL = mustURL(t, "https://api.example.com"+tc.path)
+			}))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, matched, "path=%s", tc.path)
+		})
+	}
+}
+
+func TestMatch_PathMatch_Regex(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindRegex, Value: `^/v1/users/[0-9]+$`,
+		}
+	})
+
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/v1/users/42")
+	}))
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, _, err = Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/v1/users/forty-two")
+	}))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_PathMatch_NilURLFails(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindPrefix, Value: "/x",
+		}
+	})
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) { c.UpstreamURL = nil }))
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_PathMatch_BadRegexReturnsError(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindRegex, Value: "[unterminated",
+		}
+	})
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/x")
+	}))
+	require.Error(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_PathMatch_BadGlobReturnsError(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: rlschema.PathMatchKindGlob, Value: "[unterminated",
+		}
+	})
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/x")
+	}))
+	require.Error(t, err)
+	require.False(t, matched)
+}
+
+func TestMatch_PathMatch_UnknownKindReturnsError(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.PathMatch = &rlschema.PathMatch{
+			Kind: "exact", Value: "/x",
+		}
+	})
+	matched, _, err := Match(rule, proxyCtx(func(c *RequestContext) {
+		c.UpstreamURL = mustURL(t, "https://api.example.com/x")
+	}))
+	require.Error(t, err)
+	require.False(t, matched)
+}
+
+// --- AND combinations ---
+
+func TestMatch_AllClausesANDed(t *testing.T) {
+	// All four clauses populated; one failure short-circuits the whole match.
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector = rlschema.Selector{
+			LabelSelector: "team=platform",
+			Methods:       []string{"POST"},
+			PathMatch: &rlschema.PathMatch{
+				Kind: rlschema.PathMatchKindPrefix, Value: "/v1/",
+			},
+			RequestTypes: []common.RequestType{common.RequestTypeProxy},
+		}
+	})
+
+	allGood := proxyCtx(func(c *RequestContext) {
+		c.Method = "POST"
+		c.Labels = map[string]string{"team": "platform"}
+		c.UpstreamURL = mustURL(t, "https://api.example.com/v1/foo")
+	})
+	matched, _, err := Match(rule, allGood)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	cases := []struct {
+		name string
+		mut  func(*RequestContext)
+	}{
+		{"wrong method", func(c *RequestContext) { c.Method = "GET" }},
+		{"wrong label", func(c *RequestContext) { c.Labels = map[string]string{"team": "marketing"} }},
+		{"wrong path", func(c *RequestContext) {
+			c.UpstreamURL = mustURL(t, "https://api.example.com/v2/foo")
+		}},
+		{"wrong type", func(c *RequestContext) { c.Type = common.RequestTypeOAuth }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := proxyCtx(func(c *RequestContext) {
+				c.Method = "POST"
+				c.Labels = map[string]string{"team": "platform"}
+				c.UpstreamURL = mustURL(t, "https://api.example.com/v1/foo")
+				tc.mut(c)
+			})
+			matched, _, err := Match(rule, ctx)
+			require.NoError(t, err)
+			require.False(t, matched, "expected non-match when %s", tc.name)
+		})
+	}
+}
+
+// --- BucketKey on match ---
+
+func TestMatch_ReturnsBucketKey(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Bucket.Dimensions = []string{
+			rlschema.DimensionActor, "labels/team",
+		}
+	})
+	ctx := proxyCtx(func(c *RequestContext) {
+		c.ActorID = apid.ID("act_42")
+		c.Labels = map[string]string{"team": "alpha"}
+	})
+	matched, k, err := Match(rule, ctx)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.False(t, k.IsGlobal())
+	require.Equal(t, "actor=act_42|labels/team=alpha", k.String())
+}
+
+func TestMatch_NonMatchReturnsZeroBucketKey(t *testing.T) {
+	rule := validRule(func(r *rlschema.RateLimit) {
+		r.Selector.Methods = []string{"POST"}
+		r.Bucket.Dimensions = []string{rlschema.DimensionActor}
+	})
+	matched, k, err := Match(rule, proxyCtx(func(c *RequestContext) { c.Method = "GET" }))
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.True(t, k.IsGlobal(), "non-match should return a zero (global) BucketKey")
+}
+
+// --- Nil ctx is a no-match ---
+
+func TestMatch_NilContext(t *testing.T) {
+	matched, k, err := Match(validRule(nil), nil)
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.True(t, k.IsGlobal())
+}

--- a/internal/ratelimit/request_context.go
+++ b/internal/ratelimit/request_context.go
@@ -1,0 +1,50 @@
+package ratelimit
+
+import (
+	"net/url"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// RequestContext is the per-request input to rate-limit evaluation. The
+// proxy enforcement layer (#223) populates this from httpf.RequestInfo plus
+// the resolved upstream URL and the actor identified by the auth layer.
+//
+// Construction is intentionally explicit (rather than wrapping
+// httpf.RequestInfo) so the evaluator stays low in the import graph and is
+// trivially constructible in tests.
+type RequestContext struct {
+	// Type identifies what kind of traffic this request represents. Compared
+	// against the rule's Selector.RequestTypes (default [proxy, probe] when
+	// the rule omits the field).
+	Type common.RequestType
+
+	// Method is the HTTP verb (canonical upper-case form, e.g. "GET").
+	Method string
+
+	// UpstreamURL is the *final* URL being sent to the 3rd party, after any
+	// connector-level templating/rewriting. PathMatch evaluates against
+	// UpstreamURL.Path. May be nil if the rule's PathMatch clause is empty.
+	UpstreamURL *url.URL
+
+	// Namespace is the namespace path the request is being made in.
+	Namespace string
+
+	// ActorID is the actor that owns the connection / initiated the call.
+	// Empty for system / unauthenticated traffic — bucket dimensions
+	// referencing "actor" resolve to "" in that case.
+	ActorID apid.ID
+
+	// ConnectionID, ConnectorID, ConnectorVersion identify the connection
+	// being proxied through (where applicable). Zero values for traffic
+	// that doesn't traverse a connection.
+	ConnectionID     apid.ID
+	ConnectorID      apid.ID
+	ConnectorVersion uint64
+
+	// Labels is the per-request label snapshot the labelSelector clause is
+	// evaluated against. Carry-forward / system labels are expected to
+	// already be merged in by the caller.
+	Labels map[string]string
+}


### PR DESCRIPTION
## Summary

Closes #220. Fourth of the eight sub-issues under #3; builds on #217 (schema/DB) and #219 (cache).

Pure-function evaluation layer the proxy enforcement (#223) will call into. Given a \`RateLimit\` rule and a request context, decides whether the rule matches and computes the bucket key. No Redis, no algorithms, no enforcement here.

## What's in

**`internal/ratelimit/request_context.go`**
\`RequestContext\` carries the per-request fields the matcher needs (type, method, upstream URL, namespace, actor/connection/connector ids, label snapshot). Constructed explicitly by the enforcement layer rather than wrapping \`httpf.RequestInfo\` so the evaluator stays low in the import graph and is trivially constructible in tests.

**`internal/ratelimit/bucket_key.go`**
\`BucketKey\` + \`BucketKeyComponent\` + a stable \`String()\` canonical serialization used as a Redis sub-key. Reserved separators (\`|\`, \`=\`, \`%\`) are percent-encoded in values to avoid collisions. Empty dimensions list yields \`IsGlobal()=true\`, serialized as \`*\`.

**`internal/ratelimit/matcher.go`**
\`Match(rule, ctx)\` returns \`(matched, BucketKey, err)\`. All four selector clauses (request type, methods, label selector, path match) are ANDed; default \`[proxy, probe]\` is applied via \`Selector.EffectiveRequestTypes()\`; pathMatch evaluates against the upstream URL's path with prefix / glob (\`path.Match\` — \`*\` doesn't cross \`/\`) / regex semantics. \`ResolveBucketKey(rule, ctx)\` projects the matched request into the rule's dimension tuple — reserved names map to \`RequestContext\` fields; \`labels/<key>\` reads from \`ctx.Labels\`. Returns errors only for malformed rule data that escaped schema validation; callers log + skip.

**`internal/database/label_selector.go`**
Added \`LabelSelector.Matches(labels)\` — the in-memory counterpart to the existing SQL emitter. Mirrors the same operator semantics (\`=\`, \`!=\`, exists, \`!exists\`), with \`!=\`-on-missing-key matching per the Kubernetes convention the SQL predicate already uses.

## Notes on intent

- **Path matching syntax**: I used \`path.Match\` (Go stdlib) for the \`glob\` kind, which means \`*\` doesn't cross \`/\` — the typical shell-glob semantics. For doublestar-style matching, callers can use \`kind: regex\`. Tests pin this behaviour.
- **Caching**: regex compiled per call. The schema validator already proved it compiles; in steady state this is wasted work. The enforcement layer (#223) is the natural place for a compiled-regex cache once we know what its hot path looks like.
- **Errors vs panics**: invalid rule data (bad regex, bad glob, bad label selector) returns an error rather than panicking. Schema validation should prevent these from reaching the runtime, but defending against malformed data in flight is cheaper than a goroutine crash.
- **Empty values in bucket keys**: a missing reserved field or a missing label resolves to \`""\` rather than dropping the dimension. This means \`actor=|labels/team=alpha\` is a valid bucket distinct from \`actor=act_x|labels/team=alpha\` — counters for unauthenticated traffic don't collide with authenticated traffic.

## Test plan

- [x] \`go test ./internal/ratelimit/ ./internal/database/\` — 30 + 16 new tests passing
- [x] \`go test -race ./internal/ratelimit/ ./internal/database/\` — race-detector clean
- [x] \`go test ./...\` — full repo green
- [x] \`./scripts/preflight.sh\` — clean

## Out of scope (later sub-issues)

- Algorithms + Redis counter store (#221)
- Request-log 429 attribution + connector-limiter fix (#222)
- Proxy-path enforcement (#223 — \`Match\`'s consumer)
- Terraform \`authproxy_rate_limit\` resource (#224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)