### PR TITLE
Rate limits — Step 5: algorithms + Redis-backed counter store

### DIFF
--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,0 +1,106 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+// Decision is the result of a per-request rate-limit check. The
+// enforcement layer (#223) consumes this to decide whether to short-circuit
+// with a 429 (when !Allowed) or pass the request through (when Allowed).
+type Decision struct {
+	// Allowed reports whether the request may proceed. When the underlying
+	// Redis call fails, Allowed is true and FailedOpen is also true — see
+	// the comment on FailedOpen for the rationale.
+	Allowed bool
+
+	// RetryAfter is the suggested wait time before the next request from
+	// the same bucket would be permitted. Valid only when Allowed=false.
+	// Window algorithms return time-remaining-in-window; token bucket
+	// returns time-to-next-token.
+	RetryAfter time.Duration
+
+	// Remaining is the number of additional requests the bucket can serve
+	// in the current window / from the current token pool. Valid only
+	// when Allowed=true. -1 means "not computable cheaply" (e.g.
+	// approximate counter mode in sliding window).
+	Remaining int
+
+	// FailedOpen indicates that the underlying counter store (Redis) was
+	// unavailable and the limiter chose to allow the request rather than
+	// reject it. Rate limits are guardrails, not security boundaries; a
+	// Redis blip should not convert into a customer-visible outage.
+	// Callers should still log / metric this so chronic Redis failures
+	// remain visible.
+	FailedOpen bool
+}
+
+// Limiter is the per-rule runtime evaluator. The enforcement layer holds
+// one Limiter per cached RateLimit and calls Decide once per matched
+// request. Implementations are stateless beyond the Redis client + the
+// rule's parameters; cheap to construct, safe for concurrent use.
+type Limiter interface {
+	// Decide checks the counter for the given bucket and atomically either
+	// increments it (Allowed=true) or returns time-until-next-allowed
+	// (Allowed=false, RetryAfter set). See Decision for the failure-mode
+	// contract.
+	Decide(ctx context.Context, bucketKey BucketKey) (Decision, error)
+}
+
+// NewLimiter builds a Limiter for a RateLimit row. The algorithm variant
+// is taken from rl.Definition.Algorithm; exactly one variant is required
+// (schema validation enforces this at write time).
+func NewLimiter(rl *database.RateLimit, redis apredis.Client, logger *slog.Logger) (Limiter, error) {
+	if rl == nil {
+		return nil, fmt.Errorf("ratelimit: nil rate limit")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	algo := rl.Definition.Algorithm
+
+	switch {
+	case algo.FixedWindow != nil:
+		return newFixedWindowLimiter(rl.Id, *algo.FixedWindow, redis, logger), nil
+	case algo.SlidingWindow != nil:
+		return newSlidingWindowLimiter(rl.Id, *algo.SlidingWindow, redis, logger), nil
+	case algo.TokenBucket != nil:
+		return newTokenBucketLimiter(rl.Id, *algo.TokenBucket, redis, logger), nil
+	}
+	return nil, fmt.Errorf("ratelimit: rule %s has no algorithm variant set", rl.Id)
+}
+
+// limiterKeyPrefix returns the Redis key namespace shared by all
+// algorithm-specific Limiters. Sharded by (rule_id, bucket_key) — the
+// algorithm-specific suffix is appended by each Limiter.
+func limiterKeyPrefix(ruleID apid.ID, bucketKey BucketKey) string {
+	// Use a different second segment from the existing 429 round-tripper
+	// store so the two systems can't collide, even if a future bug ever
+	// tries to share keys.
+	return fmt.Sprintf("ratelimit:rule:%s:%s", string(ruleID), bucketKey.String())
+}
+
+// failOpen is the canonical fail-open construction used by every algorithm.
+// Centralised so the metric / log shape stays consistent across algorithms.
+func failOpen(logger *slog.Logger, ruleID apid.ID, err error) (Decision, error) {
+	logger.Warn("rate-limit counter store unavailable; failing open",
+		"rule_id", ruleID,
+		"error", err,
+	)
+	return Decision{Allowed: true, FailedOpen: true}, err
+}
+
+// Compile-time guards that the variant types implement the Limiter
+// interface — kept here because Go has no formal interface declaration.
+var (
+	_ Limiter = (*fixedWindowLimiter)(nil)
+	_ Limiter = (*slidingWindowLimiter)(nil)
+	_ Limiter = (*tokenBucketLimiter)(nil)
+)
+

--- a/internal/ratelimit/limiter_fixed_window.go
+++ b/internal/ratelimit/limiter_fixed_window.go
@@ -1,0 +1,133 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// fixedWindowScript atomically increments the counter for the current
+// window. The first request to land in a window establishes the TTL —
+// subsequent requests inherit it. Returns:
+//
+//	{1, remaining}            when allowed (count <= limit)
+//	{0, retry_after_ms}       when exceeded; retry_after = remaining ms
+//	                          in the current window (PTTL)
+//
+// The window key incorporates floor(now_ms/window_ms) so windows roll
+// without any explicit deletion — old keys expire on their own TTL.
+var fixedWindowScript = redis.NewScript(`
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('PEXPIRE', key, window_ms)
+end
+
+if count > limit then
+    local pttl = redis.call('PTTL', key)
+    if pttl < 0 then
+        -- TTL not set yet (race against an EXPIRE that hasn't landed):
+        -- fall back to the full window so callers don't see -1.
+        pttl = window_ms
+    end
+    return {0, pttl}
+end
+
+return {1, limit - count}
+`)
+
+type fixedWindowLimiter struct {
+	ruleID   apid.ID
+	limit    int
+	window   time.Duration
+	redis    apredis.Client
+	logger   *slog.Logger
+}
+
+func newFixedWindowLimiter(ruleID apid.ID, params rlschema.FixedWindow, r apredis.Client, logger *slog.Logger) *fixedWindowLimiter {
+	return &fixedWindowLimiter{
+		ruleID: ruleID,
+		limit:  params.Limit,
+		window: params.Window.Duration,
+		redis:  r,
+		logger: logger,
+	}
+}
+
+func (l *fixedWindowLimiter) Decide(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+	windowMs := l.window.Milliseconds()
+
+	// Bucket the current request to the floor(now / window) window. Old
+	// windows' keys self-expire, so we never need to clean them up.
+	windowID := now.UnixMilli() / windowMs
+	key := fmt.Sprintf("%s:fw:%d", limiterKeyPrefix(l.ruleID, bucketKey), windowID)
+
+	res, err := fixedWindowScript.Run(ctx, l.redis, []string{key}, l.limit, windowMs).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, retryOrRemainingMs, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	if allowed {
+		return Decision{Allowed: true, Remaining: retryOrRemainingMs}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(retryOrRemainingMs) * time.Millisecond,
+	}, nil
+}
+
+// parseDecisionResult unpacks the {allowed, value} pair returned by
+// every Lua script in this package. Centralised so the unmarshaling
+// edge cases (Redis returns int64 vs string depending on transport)
+// only need handling once.
+func parseDecisionResult(res interface{}) (bool, int, error) {
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 2 {
+		return false, 0, fmt.Errorf("unexpected lua result shape: %#v", res)
+	}
+	allowed, err := toInt(arr[0])
+	if err != nil {
+		return false, 0, fmt.Errorf("allowed: %w", err)
+	}
+	value, err := toInt(arr[1])
+	if err != nil {
+		return false, 0, fmt.Errorf("value: %w", err)
+	}
+	return allowed == 1, value, nil
+}
+
+// toInt coerces the Lua-side number into a Go int. The redis driver
+// returns Lua integers as int64 in modern versions, but older code paths
+// (and miniredis) sometimes deliver strings — handle both.
+func toInt(v interface{}) (int, error) {
+	switch x := v.(type) {
+	case int:
+		return x, nil
+	case int64:
+		return int(x), nil
+	case string:
+		n, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return int(n), nil
+	}
+	return 0, fmt.Errorf("not an int: %T", v)
+}

--- a/internal/ratelimit/limiter_sliding_window.go
+++ b/internal/ratelimit/limiter_sliding_window.go
@@ -1,0 +1,206 @@
+package ratelimit
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// slidingWindowLogScript: ZSET of (score=timestamp_ms, member=unique tag).
+// Eviction: ZREMRANGEBYSCORE clears entries older than (now - window).
+// Decision: ZCARD vs limit; if at/above the cap, find the oldest entry's
+// score and report (oldest + window) - now as the retry window.
+//
+// Returns:
+//
+//	{1, remaining}      allowed
+//	{0, retry_after_ms} rejected
+var slidingWindowLogScript = redis.NewScript(`
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local now_ms = tonumber(ARGV[2])
+local window_ms = tonumber(ARGV[3])
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now_ms - window_ms)
+local count = redis.call('ZCARD', key)
+
+if count >= limit then
+    local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+    local retry_ms = window_ms
+    if #oldest == 2 then
+        retry_ms = (tonumber(oldest[2]) + window_ms) - now_ms
+        if retry_ms < 1 then retry_ms = 1 end
+    end
+    return {0, retry_ms}
+end
+
+redis.call('ZADD', key, now_ms, member)
+-- Slack on the TTL so an entry never gets evicted before its window
+-- has fully passed; ZREMRANGEBYSCORE handles correctness.
+redis.call('PEXPIRE', key, window_ms + 1000)
+return {1, limit - count - 1}
+`)
+
+// slidingWindowCounterScript: weighted average of the current and
+// previous fixed windows. The previous window's contribution is scaled
+// by (window - elapsed_in_current) / window, modelling the request
+// distribution as uniform over the previous window.
+//
+// Returns:
+//
+//	{1, remaining_approx}   allowed (remaining is approximate)
+//	{0, retry_after_ms}     rejected; retry_after ~= time until prev
+//	                        fully ages out
+var slidingWindowCounterScript = redis.NewScript(`
+local key_curr = KEYS[1]
+local key_prev = KEYS[2]
+local limit = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+local elapsed_ms = tonumber(ARGV[3])
+
+local prev_count = tonumber(redis.call('GET', key_prev) or '0')
+local curr_count = tonumber(redis.call('GET', key_curr) or '0')
+
+-- Math here mirrors the standard sliding-window-counter approximation.
+-- elapsed_ms goes 0 -> window_ms; the previous window's weight starts
+-- at 1.0 (entire window still in the trailing slice) and linearly
+-- decays to 0.0.
+local prev_weight = (window_ms - elapsed_ms) / window_ms
+if prev_weight < 0 then prev_weight = 0 end
+
+local approx = curr_count + math.floor(prev_count * prev_weight)
+
+if approx >= limit then
+    local retry_ms = window_ms - elapsed_ms
+    if retry_ms < 1 then retry_ms = 1 end
+    return {0, retry_ms}
+end
+
+redis.call('INCR', key_curr)
+-- 2 * window_ms keeps the previous window around long enough for the
+-- next bucket's prev-lookup to find it.
+redis.call('PEXPIRE', key_curr, 2 * window_ms)
+
+local remaining = limit - approx - 1
+if remaining < 0 then remaining = 0 end
+return {1, remaining}
+`)
+
+type slidingWindowLimiter struct {
+	ruleID  apid.ID
+	limit   int
+	window  time.Duration
+	mode    rlschema.SlidingWindowMode
+	redis   apredis.Client
+	logger  *slog.Logger
+}
+
+func newSlidingWindowLimiter(ruleID apid.ID, params rlschema.SlidingWindow, r apredis.Client, logger *slog.Logger) *slidingWindowLimiter {
+	return &slidingWindowLimiter{
+		ruleID: ruleID,
+		limit:  params.Limit,
+		window: params.Window.Duration,
+		mode:   params.Mode,
+		redis:  r,
+		logger: logger,
+	}
+}
+
+func (l *slidingWindowLimiter) Decide(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+
+	switch l.mode {
+	case rlschema.SlidingWindowModeLog:
+		return l.decideLog(ctx, bucketKey, now)
+	case rlschema.SlidingWindowModeCounter:
+		return l.decideCounter(ctx, bucketKey, now)
+	}
+	// Schema validation should make this unreachable; treat as fail-open
+	// so a bad rule doesn't bring down the proxy.
+	return failOpen(l.logger, l.ruleID, fmt.Errorf("unknown sliding window mode %q", l.mode))
+}
+
+func (l *slidingWindowLimiter) decideLog(ctx context.Context, bucketKey BucketKey, now time.Time) (Decision, error) {
+	key := fmt.Sprintf("%s:swl", limiterKeyPrefix(l.ruleID, bucketKey))
+
+	// ZSET members must be unique to record multiple requests at the
+	// same timestamp. Random hex is plenty — a hash of the bucket key
+	// plus a counter would also work but adds complexity for no gain.
+	member, err := randomHex(8)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	windowMs := l.window.Milliseconds()
+	res, err := slidingWindowLogScript.Run(ctx, l.redis,
+		[]string{key},
+		l.limit, now.UnixMilli(), windowMs, member,
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+	if allowed {
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}
+
+func (l *slidingWindowLimiter) decideCounter(ctx context.Context, bucketKey BucketKey, now time.Time) (Decision, error) {
+	windowMs := l.window.Milliseconds()
+	windowID := now.UnixMilli() / windowMs
+	elapsedMs := now.UnixMilli() % windowMs
+
+	prefix := limiterKeyPrefix(l.ruleID, bucketKey)
+	keyCurr := fmt.Sprintf("%s:swc:%d", prefix, windowID)
+	keyPrev := fmt.Sprintf("%s:swc:%d", prefix, windowID-1)
+
+	res, err := slidingWindowCounterScript.Run(ctx, l.redis,
+		[]string{keyCurr, keyPrev},
+		l.limit, windowMs, elapsedMs,
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+	if allowed {
+		// Counter-mode remaining is approximate. The Decision contract
+		// allows -1 for "not computable cheaply"; we do have a number
+		// here so we report it, but consumers should treat it as a
+		// rough estimate not a precise budget.
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1,0 +1,503 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/stretchr/testify/require"
+	clock "k8s.io/utils/clock/testing"
+)
+
+// limiterEnv bundles the moving parts every limiter test needs:
+// a real apredis.Client backed by miniredis + a fake clock at a stable
+// epoch. Tests step the clock and FastForward miniredis in sync via
+// step() so TTL-driven behaviour matches what would happen against
+// real Redis.
+type limiterEnv struct {
+	rds    apredis.Client
+	server *miniredis.Miniredis
+	clock  *clock.FakeClock
+}
+
+func newLimiterEnv(t *testing.T) *limiterEnv {
+	t.Helper()
+	_, r, server := apredis.MustApplyTestConfigWithServer(nil)
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fc := clock.NewFakeClock(t0)
+	return &limiterEnv{rds: r, server: server, clock: fc}
+}
+
+func (e *limiterEnv) ctx() context.Context {
+	return apctx.NewBuilderBackground().WithClock(e.clock).Build()
+}
+
+// step advances both the fake Go clock and the miniredis server clock.
+// Keeping them in sync lets TTL-driven tests behave the same way they
+// would against real Redis.
+func (e *limiterEnv) step(d time.Duration) {
+	e.clock.Step(d)
+	e.server.FastForward(d)
+}
+
+func mkBucket() BucketKey {
+	return BucketKey{Components: []BucketKeyComponent{{Name: "actor", Value: "act_test"}}}
+}
+
+func mustNewLimiter(t *testing.T, env *limiterEnv, def rlschema.RateLimit) Limiter {
+	t.Helper()
+	rl := &database.RateLimit{
+		Id:         apid.New(apid.PrefixRateLimit),
+		Definition: def,
+	}
+	l, err := NewLimiter(rl, env.rds, aplog.NewNoopLogger())
+	require.NoError(t, err)
+	return l
+}
+
+// TestNewLimiter_DispatchesByVariant pins the algorithm-selection logic.
+func TestNewLimiter_DispatchesByVariant(t *testing.T) {
+	env := newLimiterEnv(t)
+	cases := []struct {
+		name string
+		def  rlschema.RateLimit
+	}{
+		{"fixed_window", rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 5},
+		}}},
+		{"sliding_window_log", rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 5, Mode: rlschema.SlidingWindowModeLog},
+		}}},
+		{"sliding_window_counter", rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 5, Mode: rlschema.SlidingWindowModeCounter},
+		}}},
+		{"token_bucket", rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			TokenBucket: &rlschema.TokenBucket{Capacity: 5, RefillRate: 1.0},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := mustNewLimiter(t, env, tc.def)
+			require.NotNil(t, l)
+		})
+	}
+}
+
+func TestNewLimiter_NoVariantSet(t *testing.T) {
+	env := newLimiterEnv(t)
+	rl := &database.RateLimit{
+		Id:         apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{},
+	}
+	_, err := NewLimiter(rl, env.rds, aplog.NewNoopLogger())
+	require.Error(t, err)
+}
+
+func TestNewLimiter_NilRateLimit(t *testing.T) {
+	env := newLimiterEnv(t)
+	_, err := NewLimiter(nil, env.rds, aplog.NewNoopLogger())
+	require.Error(t, err)
+}
+
+// --- Fixed window ---
+
+func TestFixedWindow_BelowLimitAllowed(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 3},
+	}})
+	for i := 0; i < 3; i++ {
+		d, err := l.Decide(env.ctx(), mkBucket())
+		require.NoError(t, err)
+		require.True(t, d.Allowed, "request %d should be allowed", i+1)
+		require.Equal(t, 3-(i+1), d.Remaining)
+	}
+}
+
+func TestFixedWindow_ExceedsLimitRejected(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 2},
+	}})
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+	require.LessOrEqual(t, d.RetryAfter, time.Minute)
+}
+
+func TestFixedWindow_WindowRollover(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 2},
+	}})
+	// Saturate the first window.
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// Cross the window boundary; the next request should be allowed.
+	env.step(time.Minute + time.Second)
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed, "should be allowed in the new window")
+}
+
+func TestFixedWindow_PerBucketIsolation(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 1},
+	}})
+	bucketA := BucketKey{Components: []BucketKeyComponent{{Name: "actor", Value: "a"}}}
+	bucketB := BucketKey{Components: []BucketKeyComponent{{Name: "actor", Value: "b"}}}
+
+	// Bucket A consumes its quota.
+	d, _ := l.Decide(env.ctx(), bucketA)
+	require.True(t, d.Allowed)
+	d, _ = l.Decide(env.ctx(), bucketA)
+	require.False(t, d.Allowed)
+
+	// Bucket B is unaffected.
+	d, _ = l.Decide(env.ctx(), bucketB)
+	require.True(t, d.Allowed)
+}
+
+// --- Sliding window: log mode ---
+
+func TestSlidingWindowLog_BasicAllowReject(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 2, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.True(t, d.Allowed)
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.True(t, d.Allowed)
+
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+}
+
+func TestSlidingWindowLog_OldEntriesEvicted(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 2, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+
+	// Two requests at t=0; saturate.
+	_, _ = l.Decide(env.ctx(), mkBucket())
+	_, _ = l.Decide(env.ctx(), mkBucket())
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// Step past the window; the trailing window now contains zero
+	// entries → next request is allowed.
+	env.step(time.Minute + time.Second)
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+}
+
+func TestSlidingWindowLog_RetryAfterShrinksAsTimePasses(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 1, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.True(t, d.Allowed)
+
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+	first := d.RetryAfter
+
+	env.step(30 * time.Second)
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+	require.Less(t, d.RetryAfter, first, "retry-after should shrink as time passes")
+}
+
+// --- Sliding window: counter mode ---
+
+func TestSlidingWindowCounter_BasicAllowReject(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 3, Mode: rlschema.SlidingWindowModeCounter,
+		},
+	}})
+
+	for i := 0; i < 3; i++ {
+		d, err := l.Decide(env.ctx(), mkBucket())
+		require.NoError(t, err)
+		require.True(t, d.Allowed, "request %d should be allowed", i+1)
+	}
+
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+}
+
+func TestSlidingWindowCounter_PreviousWindowDecays(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: 60 * time.Second}, Limit: 4, Mode: rlschema.SlidingWindowModeCounter,
+		},
+	}})
+
+	// Saturate window N at t=0.
+	for i := 0; i < 4; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+
+	// Step into the next window (t=60s). Approx count =
+	// new_count(0) + prev_count(4) * (window-elapsed=60)/60 = 4 → still rejected.
+	env.step(time.Minute)
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed, "boundary of next window: full prev-window weight, still saturated")
+
+	// Step half a window further (t=90s). Approx ≈ 0 + 4 * 30/60 = 2 → allowed.
+	env.step(30 * time.Second)
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed, "halfway through next window: prev contributes 2, allowed")
+}
+
+// --- Token bucket ---
+
+func TestTokenBucket_BurstThenLimit(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 3, RefillRate: 1.0},
+	}})
+
+	// Initial burst — capacity tokens available.
+	for i := 0; i < 3; i++ {
+		d, err := l.Decide(env.ctx(), mkBucket())
+		require.NoError(t, err)
+		require.True(t, d.Allowed, "burst slot %d", i+1)
+	}
+
+	// 4th call drains the bucket.
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+	require.GreaterOrEqual(t, d.RetryAfter, 900*time.Millisecond)
+	require.LessOrEqual(t, d.RetryAfter, 1100*time.Millisecond)
+}
+
+func TestTokenBucket_Refill(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 2, RefillRate: 2.0},
+	}})
+
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// 500ms at 2 tokens/sec = 1 full token.
+	env.step(500 * time.Millisecond)
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+
+	// Bucket should be empty again immediately.
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+}
+
+func TestTokenBucket_RefillCappedAtCapacity(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 5, RefillRate: 1.0},
+	}})
+
+	// Drain.
+	for i := 0; i < 5; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// Wait far longer than capacity/rate; bucket should re-fill to
+	// capacity, not beyond.
+	env.step(time.Hour)
+	for i := 0; i < 5; i++ {
+		d, err := l.Decide(env.ctx(), mkBucket())
+		require.NoError(t, err)
+		require.True(t, d.Allowed, "refill slot %d", i+1)
+	}
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed, "burst should be capped at Capacity, not unbounded")
+}
+
+func TestTokenBucket_FractionalRefillRate(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 1, RefillRate: 0.5},
+	}})
+
+	// Single token consumed.
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.True(t, d.Allowed)
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+	// Refill rate 0.5/s → 1 token in 2s.
+	require.GreaterOrEqual(t, d.RetryAfter, 1900*time.Millisecond)
+	require.LessOrEqual(t, d.RetryAfter, 2100*time.Millisecond)
+
+	env.step(2 * time.Second)
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+}
+
+// --- Fail-open ---
+
+// failingRedis is a minimal stub that satisfies apredis.Client by
+// embedding a real client and overriding the script entry point to
+// always error. We can't spin up a "broken" miniredis cleanly, so we
+// close the underlying server and let real call attempts fail.
+func newFailedRedis(t *testing.T) apredis.Client {
+	_, r, server := apredis.MustApplyTestConfigWithServer(nil)
+	server.Close() // subsequent commands should error
+	return r
+}
+
+func TestFixedWindow_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 1},
+		}},
+	}
+	l, err := NewLimiter(rl, r, aplog.NewNoopLogger())
+	require.NoError(t, err)
+
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.Error(t, err, "Redis-down decide should propagate the error")
+	require.True(t, d.Allowed, "fail-open: allow when Redis is unavailable")
+	require.True(t, d.FailedOpen)
+}
+
+func TestSlidingWindowLog_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{
+				Window: common.HumanDuration{Duration: time.Minute}, Limit: 1, Mode: rlschema.SlidingWindowModeLog,
+			},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+func TestSlidingWindowCounter_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{
+				Window: common.HumanDuration{Duration: time.Minute}, Limit: 1, Mode: rlschema.SlidingWindowModeCounter,
+			},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+func TestTokenBucket_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			TokenBucket: &rlschema.TokenBucket{Capacity: 1, RefillRate: 1.0},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Decide(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+// TestConcurrentDecidesUnderRace runs many goroutines hammering a single
+// rule + bucket to confirm the Lua scripts produce a consistent count
+// (no races, no double-allow). With limit=N over many goroutines, the
+// number of allowed decisions should be exactly N.
+func TestFixedWindow_ConcurrentDecides(t *testing.T) {
+	env := newLimiterEnv(t)
+	const limit = 50
+	const goroutines = 200
+
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Hour}, Limit: limit},
+	}})
+
+	var allowed int
+	var rejected int
+	allowedCh := make(chan bool, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			d, err := l.Decide(env.ctx(), mkBucket())
+			if err != nil {
+				allowedCh <- false
+				return
+			}
+			allowedCh <- d.Allowed
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		if <-allowedCh {
+			allowed++
+		} else {
+			rejected++
+		}
+	}
+	require.Equal(t, limit, allowed, "exactly Limit decisions should be Allowed under concurrent load")
+	require.Equal(t, goroutines-limit, rejected)
+}

--- a/internal/ratelimit/limiter_token_bucket.go
+++ b/internal/ratelimit/limiter_token_bucket.go
@@ -1,0 +1,125 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+)
+
+// tokenBucketScript implements the standard refill-then-consume token
+// bucket. State (tokens, last_refill_ms) is stored as a Redis hash so the
+// two fields move atomically. New buckets are created full (tokens =
+// capacity) so the first burst gets the full benefit of the bucket
+// rather than starting empty.
+//
+// Returns:
+//
+//	{1, remaining_tokens_floor}  allowed
+//	{0, retry_after_ms}          rejected; retry_after = ms until 1 token
+//	                             would be available
+//
+// The refill_per_sec ARGV is encoded as a string with %g formatting so
+// fractional rates (e.g. 0.5 tokens/sec) round-trip cleanly.
+var tokenBucketScript = redis.NewScript(`
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_per_sec = tonumber(ARGV[2])
+local now_ms = tonumber(ARGV[3])
+local idle_ttl_ms = tonumber(ARGV[4])
+
+local data = redis.call('HMGET', key, 'tokens', 'last_refill_ms')
+local tokens = tonumber(data[1])
+local last_refill_ms = tonumber(data[2])
+
+if tokens == nil or last_refill_ms == nil then
+    -- New bucket: start full so first-time callers get the configured
+    -- burst capacity rather than instantly hitting an empty pool.
+    tokens = capacity
+    last_refill_ms = now_ms
+else
+    local elapsed_ms = now_ms - last_refill_ms
+    if elapsed_ms < 0 then elapsed_ms = 0 end
+    local refill = (elapsed_ms / 1000.0) * refill_per_sec
+    tokens = math.min(capacity, tokens + refill)
+    last_refill_ms = now_ms
+end
+
+if tokens < 1 then
+    -- Not enough; calculate how many ms until 1 full token accrues at
+    -- the current refill rate. Persist updated state so we don't
+    -- recompute the same partial refill on the next call.
+    local needed = 1 - tokens
+    local wait_ms = math.ceil(needed / refill_per_sec * 1000)
+    if wait_ms < 1 then wait_ms = 1 end
+    redis.call('HSET', key, 'tokens', tostring(tokens), 'last_refill_ms', tostring(last_refill_ms))
+    redis.call('PEXPIRE', key, idle_ttl_ms)
+    return {0, wait_ms}
+end
+
+tokens = tokens - 1
+redis.call('HSET', key, 'tokens', tostring(tokens), 'last_refill_ms', tostring(last_refill_ms))
+redis.call('PEXPIRE', key, idle_ttl_ms)
+return {1, math.floor(tokens)}
+`)
+
+// tokenBucketIdleTTL is how long we keep a quiescent bucket before
+// letting Redis garbage-collect it. An hour is plenty for proxy traffic
+// patterns; a longer TTL just costs Redis memory.
+const tokenBucketIdleTTL = time.Hour
+
+type tokenBucketLimiter struct {
+	ruleID     apid.ID
+	capacity   int
+	refillRate float64
+	redis      apredis.Client
+	logger     *slog.Logger
+}
+
+func newTokenBucketLimiter(ruleID apid.ID, params rlschema.TokenBucket, r apredis.Client, logger *slog.Logger) *tokenBucketLimiter {
+	return &tokenBucketLimiter{
+		ruleID:     ruleID,
+		capacity:   params.Capacity,
+		refillRate: params.RefillRate,
+		redis:      r,
+		logger:     logger,
+	}
+}
+
+func (l *tokenBucketLimiter) Decide(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+	key := fmt.Sprintf("%s:tb", limiterKeyPrefix(l.ruleID, bucketKey))
+
+	// Format the refill rate as a Lua-parseable float; %g preserves
+	// precision for both integer and fractional values without trailing
+	// zeros (e.g. "1" / "0.5" / "1.5e-06").
+	rateStr := strconv.FormatFloat(l.refillRate, 'g', -1, 64)
+
+	res, err := tokenBucketScript.Run(ctx, l.redis,
+		[]string{key},
+		l.capacity, rateStr, now.UnixMilli(), tokenBucketIdleTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	if allowed {
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Closes #221. Fifth of the eight sub-issues under #3; builds on #217 (schema), #219 (cache), and #220 (matcher).

Implements the three rate-limit algorithms used by the proxy enforcement layer (#223) atop \`apredis.Client\`. Each algorithm runs its check-and-increment accounting in a single Lua script so the operation is atomic — both within a process under concurrent goroutines and across processes hitting the same Redis.

## What's in

**Public surface**
- \`Decision { Allowed, RetryAfter, Remaining, FailedOpen }\` — what the enforcement layer consumes per request.
- \`Limiter\` interface { \`Decide(ctx, BucketKey) Decision\` } — one per cached \`RateLimit\` row, safe for concurrent use.
- \`NewLimiter(rl, redis, logger)\` dispatches on which algorithm variant the rule has set.

**Per-algorithm**
- \`limiter_fixed_window.go\` — \`INCR\` + \`PEXPIRE\` on a windowed key. Old windows self-expire. \`RetryAfter\` = remaining ms in current window.
- \`limiter_sliding_window.go\` (log mode) — \`ZSET\` of (score=ts_ms, member=random tag); \`ZREMRANGEBYSCORE\` evicts old, \`ZCARD\` vs limit. On reject, oldest score gives exact retry-after.
- \`limiter_sliding_window.go\` (counter mode) — two adjacent fixed-window counters, weighted average approximating the trailing window. Cheaper than log mode at the cost of approximate accuracy.
- \`limiter_token_bucket.go\` — hash \`{tokens, last_refill_ms}\` with refill = elapsed_s × rate, capped at capacity. New buckets start full so first-time callers get the configured burst. Idle bucket TTL = 1 hour.

**Fail-open**
Every algorithm catches Redis errors and returns \`Decision{Allowed: true, FailedOpen: true}\` plus the underlying error for the caller to log/metric. Rate limits are guardrails, not security boundaries — a Redis blip should not produce customer-visible outages. Centralised in \`failOpen()\` so the warning shape stays consistent across algorithms.

## Notes for the reviewer

- **Atomicity vs. round-trips**: each algorithm uses one Lua script per Decide() call. Round-trips: 1. The token-bucket and sliding-window-counter scripts deliberately avoid \`WATCH/MULTI\` patterns since the script itself is atomic.
- **New-bucket initial state**: token buckets start full rather than empty. This matters for first-time callers — an empty-start design would punish them with an immediate reject the first time a rule fires for them. Tested in \`TestTokenBucket_BurstThenLimit\`.
- **Member uniqueness in sliding-window log**: each request adds a unique random hex tag so multiple requests at the same millisecond don't collapse into one ZSET member. Cheap; alternative would be a hash of bucket+counter but adds complexity.
- **\`Remaining\` semantics**: precise for fixed_window and token_bucket; approximate for sliding_window (counter mode). The \`Decision\` doc-comment notes \`-1\` is reserved for "not computable cheaply" if a future algorithm needs it.

## Test plan

- [x] \`go test ./internal/ratelimit/\` — 22 new sub-tests pass (66 total in the package now)
- [x] \`go test -race ./internal/ratelimit/\` — race-detector clean, including the concurrency test that runs 200 goroutines against a limit of 50 and asserts exactly 50 are allowed
- [x] \`go test ./...\` — full repo green
- [x] \`./scripts/preflight.sh\` — clean

## Out of scope (later sub-issues)

- Request-log 429 attribution + connector-limiter fix (#222)
- Proxy-path enforcement (#223 — \`Limiter\`'s consumer)
- Terraform \`authproxy_rate_limit\` resource (#224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)