### PR TITLE
Add OAuth2 token-exchange retry policy and tests (#168)

### DIFF
--- a/integration_tests/oauth2/callback_token_exchange_retry_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.go
@@ -1,0 +1,259 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenExchangeRetryRig is the per-test fixture for the transient
+// retry/5xx cases. Mirrors tokenExchangeFailureRig (PR B) but each test
+// expects the proxy to make multiple /token calls before settling on a
+// final outcome — success after a retried failure, or auth_failed after
+// the retry budget is exhausted.
+type tokenExchangeRetryRig struct {
+	provider     *helpers.OAuth2TestProvider
+	env          *helpers.IntegrationTestEnv
+	logCapture   *helpers.LogCapture
+	clientKey    string
+	userID       string
+	connectorID  apid.ID
+	scopes       []string
+	returnToURL  string
+	errorPageURL string
+}
+
+func newTokenExchangeRetryRig(t *testing.T, name string) *tokenExchangeRetryRig {
+	t.Helper()
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := name + "-client-" + suffix
+	clientSecret := name + "-secret-" + suffix
+	userPassword := "p4ssw0rd-" + suffix
+	userEmail := name + "-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+
+	logCapture := helpers.NewLogCapture()
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+		LogCapture:    logCapture,
+	})
+	t.Cleanup(env.Cleanup)
+
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: userPassword,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	return &tokenExchangeRetryRig{
+		provider:     provider,
+		env:          env,
+		logCapture:   logCapture,
+		clientKey:    clientKey,
+		userID:       user.ID,
+		connectorID:  connectorID,
+		scopes:       []string{"read"},
+		returnToURL:  "https://example.com/return",
+		errorPageURL: env.Cfg.GetRoot().ErrorPages.InternalError,
+	}
+}
+
+func (r *tokenExchangeRetryRig) initiateAndMintCode(t *testing.T) (connectionID, stateID, code string) {
+	t.Helper()
+	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID = parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+
+	authResp := r.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    r.clientKey,
+		UserID:      r.userID,
+		RedirectURI: r.env.PublicOAuthCallbackURL(),
+		Scope:       strings.Join(r.scopes, " "),
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	require.NotEmpty(t, authResp.RedirectURL)
+	pc, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code = pc.Query().Get("code")
+	require.NotEmptyf(t, code, "provider should issue a code on approve; got %s", authResp.RedirectURL)
+	return connID, stateID, code
+}
+
+func (r *tokenExchangeRetryRig) tokenCallCount() int {
+	return len(r.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: r.clientKey,
+	}))
+}
+
+// TestTokenExchange_TransientRetrySucceeds — provider returns 503 on the
+// first two /token calls, succeeds on the third. The proxy's retry
+// budget (3 attempts) is exactly enough to ride through the transient
+// outage. Asserts the connection ends up in the success state, with a
+// real token row, and no rejection event is emitted — the eventual
+// success means there was no failure to alert on, even though the
+// provider was unhealthy for two attempts.
+func TestTokenExchange_TransientRetrySucceeds(t *testing.T) {
+	rig := newTokenExchangeRetryRig(t, "te-retry-success")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+
+	// FailCount=2 means the next two /token calls return this scripted
+	// 503; the third call falls through to default behavior (a real
+	// access_token grant). The proxy's max-attempts=3 budget means we
+	// arrive at the success on the final allowed try.
+	rig.provider.Script(rig.clientKey, helpers.EndpointToken, helpers.ScriptAction{
+		Status:    503,
+		Body:      `{"error":"temporarily_unavailable"}`,
+		FailCount: 2,
+	})
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, code))
+
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"successful retry should land on return_to_url; got %q", loc)
+
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateReady, conn.State,
+		"retried success must transition the connection to ready")
+	assert.Nil(t, conn.SetupStep, "successful retry must not record an auth_failed setup_step")
+	assert.Nil(t, conn.SetupError, "successful retry must not record a setup_error")
+
+	require.NotNil(t, rig.env.GetOAuth2Token(t, connID),
+		"retried success must persist the access token from the third attempt")
+
+	// Most important assertion: 3 /token calls observed, proving the
+	// retry loop actually retried twice. If the proxy gave up after
+	// the first 503, this would be 1.
+	assert.Equal(t, 3, rig.tokenCallCount(),
+		"expected 3 /token calls (2 retried 503s + 1 success)")
+
+	// Successful retry must not emit a token-exchange-failed event —
+	// alert dashboards key on this message string and a noisy emit on
+	// every transient blip would render them useless. Per-retry Warn
+	// log lines are fine; the structured failure event is the one to
+	// keep clean.
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage),
+		"successful retry must not emit a token-exchange-failed event")
+}
+
+// TestTokenExchange_TransientRetryExhausted — provider returns 503 on
+// every /token call. The proxy retries until the budget is exhausted,
+// then settles into auth_failed. The single failure event records the
+// final attempt count so dashboards can see "we tried 3 times and gave
+// up" without parsing log lines.
+func TestTokenExchange_TransientRetryExhausted(t *testing.T) {
+	rig := newTokenExchangeRetryRig(t, "te-retry-exhausted")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+
+	// FailCount=10 is well past the proxy's retry budget — we expect
+	// the proxy to make exactly tokenExchangeMaxAttempts (=3) calls
+	// before giving up. The remaining 7 scripted 503s sit unconsumed
+	// in the queue and don't affect the outcome.
+	rig.provider.Script(rig.clientKey, helpers.EndpointToken, helpers.ScriptAction{
+		Status:    503,
+		Body:      `{"error":"temporarily_unavailable"}`,
+		FailCount: 10,
+	})
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, code))
+
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"exhausted retry should still 302 to return_to_url with setup=pending so the UI re-renders; got %q", loc)
+	parsed, err := url.Parse(loc)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", parsed.Query().Get("setup"))
+	assert.Equal(t, connID, parsed.Query().Get("connection_id"))
+
+	events := rig.logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)
+	require.Lenf(t, events, 1, "exhausted retry should emit exactly one failure event; got %d (%v)", len(events), events)
+	assert.Equal(t, "provider_5xx", events[0]["category"])
+	assert.Equal(t, stateID, events[0]["state_id"])
+	assert.Equal(t, float64(503), events[0]["provider_status_code"])
+	// attempts records the budget exhaustion so the alert can distinguish
+	// this from a single non-retryable failure.
+	assert.Equal(t, float64(3), events[0]["attempts"],
+		"failure event should record attempts=tokenExchangeMaxAttempts on exhaustion")
+
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID))
+
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateCreated, conn.State)
+	require.NotNil(t, conn.SetupStep)
+	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
+		"exhausted retry should land in auth_failed; got %q", conn.SetupStep.String())
+	require.NotNil(t, conn.SetupError)
+	assert.Containsf(t, *conn.SetupError, "received status code 503",
+		"setup_error should mention the 503; got %q", *conn.SetupError)
+
+	assert.Equal(t, 3, rig.tokenCallCount(),
+		"proxy should make exactly tokenExchangeMaxAttempts (=3) /token calls before giving up")
+}
+
+// TestTokenExchange_5xxVariants_AllRetried — sanity check that the
+// retry policy is keyed on the 5xx range, not on a specific status
+// code. Issue #168 lists 500/502/503/504 as the transient failure
+// status codes; the proxy classifies any of them as provider_5xx and
+// retries. We exercise 504 specifically because gateway-timeout
+// responses can otherwise look indistinguishable from an unreachable
+// upstream — they are still 5xx and should still retry.
+func TestTokenExchange_5xxVariants_AllRetried(t *testing.T) {
+	rig := newTokenExchangeRetryRig(t, "te-retry-504")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+
+	rig.provider.Script(rig.clientKey, helpers.EndpointToken, helpers.ScriptAction{
+		Status:    504,
+		Body:      `{"error":"gateway_timeout"}`,
+		FailCount: 10,
+	})
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"504 exhaustion should still redirect to return_to_url; got %q", loc)
+
+	events := rig.logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)
+	require.Lenf(t, events, 1, "504 exhaustion should emit exactly one failure event; got %d", len(events))
+	assert.Equal(t, "provider_5xx", events[0]["category"],
+		"504 should classify as provider_5xx, same as 503")
+	assert.Equal(t, float64(504), events[0]["provider_status_code"])
+	assert.Equal(t, float64(3), events[0]["attempts"],
+		"504 must be retried like any other 5xx — attempts should hit max")
+
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID))
+	assert.Equal(t, 3, rig.tokenCallCount())
+}
+

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.md
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.md
@@ -1,0 +1,167 @@
+# OAuth2 Callback Token-Exchange Retry / 5xx Cases
+
+Companion specification for `callback_token_exchange_retry_test.go`.
+Covers the transient retry leg of issue #168 — the proxy POSTs to the
+provider's `/token` endpoint, the provider responds with a 5xx, and the
+proxy retries up to a small bounded budget before either succeeding or
+giving up. The non-retryable rejection cases (4xx + malformed 200) live
+in `callback_token_exchange_failure_test.go` (PR B).
+
+## What the retry policy is, and why
+
+Source: `internal/auth_methods/oauth2/callback.go:26-38`.
+
+```
+tokenExchangeMaxAttempts = 3                       // 1 try + 2 retries
+tokenExchangeBackoffStep = 200 * time.Millisecond  // linear: 200ms, 400ms
+```
+
+- **3 attempts.** A single bad pod or a quick rolling restart on the
+  provider should not surface as a user-visible auth failure. Three
+  attempts is enough headroom to ride that out without stretching a
+  hard outage into a multi-second wait that the user notices.
+- **5xx + transport errors only.** 4xx is the provider classifying the
+  request as malformed or unauthorized. Resubmitting the same
+  authorization code would only burn the code and produce
+  `invalid_grant` on the second call — observably worse than the
+  original failure.
+- **Linear backoff.** 200ms before retry 1, 400ms before retry 2.
+  Short enough that a user staring at the marketplace post-consent
+  doesn't notice; long enough that a node-local failover has time to
+  settle.
+- **Hardcoded.** No connector-level knob. If different connectors need
+  different budgets, the constants become a config field — but only
+  when there's evidence that they do.
+
+The policy is not RFC-mandated. It exists because the token-exchange
+leg is a fixed window (the authorization code lifetime, typically
+~60s) and a single transport blip during that window otherwise
+propagates straight to the user as auth_failed.
+
+## What is asserted
+
+For every retry case:
+
+- **Attempt count is the load-bearing assertion.** Each test pins the
+  number of `/token` calls observed via `provider.Requests(...)`. A
+  retry policy that silently regressed to "no retry" would still pass
+  most other assertions; the call count is what catches that.
+- **Connection lands in the correct terminal state.** Successful retry
+  → `state=ready`, no `setup_step`, no `setup_error`, real token row
+  persisted. Exhausted retry → `state=created`,
+  `setup_step=auth_failed`, `setup_error` containing the provider
+  status code.
+- **Exactly one structured failure event on exhaustion, none on
+  success.** The structured `oauth token exchange failed` event is
+  what dashboards key on; emitting it for every transient blip would
+  render the alert useless. Per-retry Warn log lines (separate
+  message string `"oauth token exchange transient failure;
+  retrying"`) are fine — only the rejection event must remain
+  one-per-final-failure.
+- **`attempts` field on the failure event records exhaustion.** Set to
+  `tokenExchangeMaxAttempts` on the exhausted-retry path so dashboards
+  can distinguish "we tried 3 times and gave up" from a single
+  non-retryable failure. The PR B 4xx tests don't pin the field — it's
+  populated there too, but the assertion belongs in PR C where the
+  value is the point of the test.
+- **302 to `return_to_url?setup=pending&connection_id=<id>` even on
+  exhaustion.** Same as the PR B failure path — the user must land
+  somewhere recoverable, the marketplace UI re-renders the connection
+  in `auth_failed`, and the user can retry/cancel.
+
+## Test plan
+
+| Test | Scripted token endpoint response | Expected outcome | Issue #168 case(s) covered |
+| ---- | -------------------------------- | ---------------- | -------------------------- |
+| `TestTokenExchange_TransientRetrySucceeds` | `503 {"error":"temporarily_unavailable"}` × 2, then default success | `state=ready`, token persisted, **3** `/token` calls, **no** failure event | Transient outage that resolves within budget |
+| `TestTokenExchange_TransientRetryExhausted` | `503 {"error":"temporarily_unavailable"}` × 10 (only first 3 consumed) | `state=created`, `setup_step=auth_failed`, **3** `/token` calls, single failure event with `category=provider_5xx`, `attempts=3`, `provider_status_code=503` | Sustained 5xx outage exceeding budget |
+| `TestTokenExchange_5xxVariants_AllRetried` | `504 {"error":"gateway_timeout"}` × 10 | Same shape as exhausted with `provider_status_code=504` | Retry policy keyed on 5xx range, not specific code |
+
+### Why `FailCount` instead of fixed-count scripts
+
+`provider.Script(...)` accepts a `FailCount` field that returns the
+scripted response that many times before falling through to default
+behavior. The success case uses `FailCount: 2` paired with
+`tokenExchangeMaxAttempts = 3` so the third attempt naturally hits the
+default (real access_token grant) — proving end-to-end that the proxy
+made it through the failures and consumed a real success without us
+having to script the success body explicitly.
+
+The exhausted/504 cases use `FailCount: 10` instead of a tight match
+to the budget. If `tokenExchangeMaxAttempts` ever increases, the
+assertion `tokenCallCount() == 3` is what fails — not the script
+running out of responses on the wrong attempt and producing a
+confusing error.
+
+## Why direct HTTP, not chromedp
+
+Same rationale as PR B: the user-flow leg (Connect → login → consent)
+is irrelevant to these cases — the failure mode is purely server-side
+at the token endpoint. Each test:
+
+1. Calls `env.InitiateOAuth2Connection(t, …)` to materialize a real
+   state envelope in Redis and a real connection row.
+2. Calls `provider.Authorize(...)` (`/test/authorize`) to mint a real
+   `code` without booting a browser.
+3. Calls `provider.Script(clientKey, EndpointToken, ScriptAction{…})`
+   to enqueue the desired token-endpoint response (with `FailCount`).
+4. Calls `env.DeliverOAuth2Callback(t, …)` to deliver the callback
+   in-process via `env.PublicGin`, exercising the retry loop end to
+   end.
+
+## What is *not* covered here
+
+- **Transport-error retries.** The retry policy retries on transport
+  errors (DNS, dial, TLS, read timeout) as well as 5xx, but the
+  scripted provider can only synthesize HTTP responses. Transport
+  errors are exercised by the unit tests in
+  `internal/auth_methods/oauth2/token_exchange_failure_test.go`.
+- **Backoff timing assertions.** Tests measure call counts, not
+  wall-clock spacing — pinning timing in CI would be flaky and the
+  backoff is not observably user-facing.
+- **Context cancellation mid-retry.** The retry helper honors
+  `ctx.Done()` between attempts (`callback.go:231-235`), but
+  reproducing a cancellation between two specific attempts from the
+  integration boundary requires a pre-orchestrated race; the helper's
+  behavior is asserted by unit tests instead.
+- **Non-retryable 4xx and malformed 200 responses.** PR B
+  (`callback_token_exchange_failure_test.go`).
+
+## Components
+
+| Lever                                                       | What it controls |
+| ----------------------------------------------------------- | ---------------- |
+| `provider.Script(clientKey, EndpointToken, ScriptAction{Status, Body, FailCount})` | Enqueue the next N token-endpoint responses. `FailCount` decouples "scripted response count" from "retry budget" — a script of 2 paired with budget 3 lands on default success on the final attempt. |
+| `provider.Requests(EndpointToken, ClientID)`                | Count actual `/token` calls observed by the provider — the load-bearing assertion that proves the retry loop ran. |
+| `logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)` | Surface the structured failure event so the test can assert presence (exhaustion) or absence (successful retry). |
+
+## Sequence (exhausted retry)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant PUB as Public service
+    participant DB as Postgres
+    participant R as Redis
+    participant P as OAuth provider<br/>(docker, scripted 503 × 10)
+
+    T->>P: POST /test/scripts (clientKey, EndpointToken, {Status: 503, FailCount: 10})
+
+    T->>PUB: GET /oauth2/callback?state=…&code=…
+    PUB->>R: GET state envelope, validate
+    PUB->>P: POST /token (attempt 1)
+    P-->>PUB: 503
+    PUB->>PUB: log "transient failure; retrying" (attempt=1)
+    Note over PUB: sleep 200ms
+    PUB->>P: POST /token (attempt 2)
+    P-->>PUB: 503
+    PUB->>PUB: log "transient failure; retrying" (attempt=2)
+    Note over PUB: sleep 400ms
+    PUB->>P: POST /token (attempt 3)
+    P-->>PUB: 503
+    PUB->>PUB: classifyTokenEndpointStatus → provider_5xx
+    PUB->>PUB: emitTokenExchangeFailure (one event, attempts=3)
+    PUB->>DB: HandleAuthFailed → setup_step=auth_failed,<br/>setup_error="received status code 503: …"
+    PUB-->>T: 302 → return_to_url?setup=pending&connection_id=…
+```

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.md
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.md
@@ -152,16 +152,13 @@ sequenceDiagram
     PUB->>R: GET state envelope, validate
     PUB->>P: POST /token (attempt 1)
     P-->>PUB: 503
-    PUB->>PUB: log "transient failure; retrying" (attempt=1)
-    Note over PUB: sleep 200ms
+    Note over PUB: log transient failure, retry (attempt=1)<br/>sleep 200ms
     PUB->>P: POST /token (attempt 2)
     P-->>PUB: 503
-    PUB->>PUB: log "transient failure; retrying" (attempt=2)
-    Note over PUB: sleep 400ms
+    Note over PUB: log transient failure, retry (attempt=2)<br/>sleep 400ms
     PUB->>P: POST /token (attempt 3)
     P-->>PUB: 503
-    PUB->>PUB: classifyTokenEndpointStatus → provider_5xx
-    PUB->>PUB: emitTokenExchangeFailure (one event, attempts=3)
-    PUB->>DB: HandleAuthFailed → setup_step=auth_failed,<br/>setup_error="received status code 503: …"
+    Note over PUB: classifyTokenEndpointStatus → provider_5xx<br/>emitTokenExchangeFailure (one event, attempts=3)
+    PUB->>DB: HandleAuthFailed → setup_step=auth_failed,<br/>setup_error="received status code 503"
     PUB-->>T: 302 → return_to_url?setup=pending&connection_id=…
 ```

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -4,10 +4,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"time"
 
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	gentleman "gopkg.in/h2non/gentleman.v2"
+)
+
+// Token-exchange retry policy. The token endpoint must be reachable for
+// the OAuth flow to complete; rather than fail the whole flow on a
+// momentary upstream blip, we make a small bounded number of attempts
+// before giving up. Permanent failures (4xx) are not retried — retrying
+// would re-submit the same authorization code, which a sane provider
+// rejects as invalid_grant on the second try.
+//
+// The policy is intentionally hardcoded. If different connectors need
+// different budgets, this becomes a connector-level config knob — but
+// only when there's evidence that they do.
+const (
+	// tokenExchangeMaxAttempts is the total number of token-endpoint POST
+	// attempts (including the first). 3 = 1 try + 2 retries — enough to
+	// ride through a single bad pod or a quick rolling restart, not so
+	// many that a hard outage stretches the user's wait beyond a couple
+	// of seconds.
+	tokenExchangeMaxAttempts = 3
+	// tokenExchangeBackoffStep is the linear backoff between attempts:
+	// 200ms before retry 1, 400ms before retry 2. Short enough that a
+	// user staring at the marketplace post-consent does not notice;
+	// long enough that a node-local failover has time to settle.
+	tokenExchangeBackoffStep = 200 * time.Millisecond
 )
 
 func (o *oAuth2Connection) getPublicCallbackUrl() (string, error) {
@@ -121,16 +148,6 @@ func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url
 		return "", err
 	}
 
-	req := c.Request().
-		Method("POST").
-		URL(tokenEndpoint).
-		Type("application/x-www-form-urlencoded").
-		AddHeader("accept", "application/json")
-
-	for k, v := range o.auth.Token.QueryOverrides {
-		req = req.SetQuery(k, v)
-	}
-
 	values := url.Values{
 		"client_id":     {clientId},
 		"client_secret": {clientSecret},
@@ -143,13 +160,12 @@ func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url
 		values.Set(k, v)
 	}
 
-	resp, err := req.
-		BodyString(values.Encode()).
-		Send()
-
+	resp, attempts, err := o.postTokenExchangeWithRetry(ctx, c, tokenEndpoint, values)
 	if err != nil {
 		err = fmt.Errorf("failed to post to exchange authorization code for access token: %w", err)
-		emitTokenExchangeFailure(ctx, o.logger, tokenExchangeNetworkError, o.tokenExchangeAttrsFromConn(err))
+		attrs := o.tokenExchangeAttrsFromConn(err)
+		attrs.Attempts = attempts
+		emitTokenExchangeFailure(ctx, o.logger, tokenExchangeNetworkError, attrs)
 		return "", err
 	}
 
@@ -159,6 +175,7 @@ func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url
 		attrs := o.tokenExchangeAttrsFromConn(err)
 		attrs.ProviderStatusCode = resp.StatusCode
 		attrs.ProviderError = providerErr
+		attrs.Attempts = attempts
 		emitTokenExchangeFailure(ctx, o.logger, category, attrs)
 		return "", err
 	}
@@ -181,6 +198,76 @@ func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url
 		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
 	}
 	return o.state.ReturnToUrl, nil
+}
+
+// postTokenExchangeWithRetry POSTs the token-exchange form to the provider's
+// token endpoint, retrying transient failures (transport errors and 5xx
+// responses) up to tokenExchangeMaxAttempts times. Returns the final
+// response (or last network error), along with the number of attempts
+// actually made — callers attach that to the failure event so the
+// "exhausted" case is observably distinct from a single non-retryable
+// 4xx.
+//
+// Permanent failures (4xx) are returned immediately without retry; the
+// provider has classified the request as malformed or unauthorized,
+// and resubmitting the same authorization code would only burn the
+// code and produce an `invalid_grant` on the second call.
+//
+// Each retry rebuilds the gentleman.Request from scratch — gentleman
+// requests are single-use (they panic with "Request was already
+// dispatched" on a second Send).
+func (o *oAuth2Connection) postTokenExchangeWithRetry(
+	ctx context.Context,
+	client *gentleman.Client,
+	tokenEndpoint string,
+	values url.Values,
+) (*gentleman.Response, int, error) {
+	var lastResp *gentleman.Response
+	var lastErr error
+
+	for attempt := 1; attempt <= tokenExchangeMaxAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := tokenExchangeBackoffStep * time.Duration(attempt-1)
+			select {
+			case <-ctx.Done():
+				return nil, attempt - 1, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req := client.Request().
+			Method("POST").
+			URL(tokenEndpoint).
+			Type("application/x-www-form-urlencoded").
+			AddHeader("accept", "application/json")
+
+		for k, v := range o.auth.Token.QueryOverrides {
+			req = req.SetQuery(k, v)
+		}
+
+		resp, err := req.BodyString(values.Encode()).Send()
+
+		if err == nil && resp.StatusCode < 500 {
+			return resp, attempt, nil
+		}
+
+		lastResp, lastErr = resp, err
+
+		if attempt < tokenExchangeMaxAttempts {
+			args := []any{
+				slog.Int("attempt", attempt),
+				slog.Int("max_attempts", tokenExchangeMaxAttempts),
+			}
+			if err != nil {
+				args = append(args, slog.String("error", err.Error()))
+			} else {
+				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
+			}
+			o.logger.WarnContext(ctx, "oauth token exchange transient failure; retrying", args...)
+		}
+	}
+
+	return lastResp, tokenExchangeMaxAttempts, lastErr
 }
 
 // appendSetupPendingToReturnUrl augments the return URL with query params that signal the UI

--- a/internal/auth_methods/oauth2/callback_test.go
+++ b/internal/auth_methods/oauth2/callback_test.go
@@ -1,0 +1,358 @@
+package oauth2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/config"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gentleman "gopkg.in/h2non/gentleman.v2"
+)
+
+// configWithPublicBaseUrl returns a config whose Public.GetBaseUrl()
+// resolves to the given domain (no port). Used by getPublicCallbackUrl
+// tests so the assertion can pin the rendered URL exactly without
+// pulling in TLS / port plumbing.
+func configWithPublicBaseUrl(t *testing.T, domain string) config.C {
+	t.Helper()
+	return config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				DomainVal: domain,
+				PortVal:   common.NewIntegerValueDirect(80),
+			},
+		},
+	})
+}
+
+func TestGetPublicCallbackUrl_NilConfig(t *testing.T) {
+	o := &oAuth2Connection{cfg: nil}
+	got, err := o.getPublicCallbackUrl()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config is nil")
+	assert.Empty(t, got)
+}
+
+func TestGetPublicCallbackUrl_NilRoot(t *testing.T) {
+	o := &oAuth2Connection{cfg: config.FromRoot(nil)}
+	got, err := o.getPublicCallbackUrl()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config root is nil")
+	assert.Empty(t, got)
+}
+
+func TestGetPublicCallbackUrl_AppendsCallbackPath(t *testing.T) {
+	o := &oAuth2Connection{cfg: configWithPublicBaseUrl(t, "proxy.example.com")}
+	got, err := o.getPublicCallbackUrl()
+	require.NoError(t, err)
+	assert.Equal(t, "http://proxy.example.com/oauth2/callback", got)
+}
+
+// TestAppendSetupPendingToReturnUrl_AddsExpectedQueryParams pins the
+// shape the marketplace UI keys off when re-rendering an auth_failed
+// connection. If these param names ever change, every UI consumer
+// breaks; the test exists to make that explicit.
+func TestAppendSetupPendingToReturnUrl_AddsExpectedQueryParams(t *testing.T) {
+	connID := apid.New(apid.PrefixConnection)
+	o := &oAuth2Connection{connection: &mockCore.Connection{Id: connID}}
+
+	got := o.appendSetupPendingToReturnUrl("https://app.example.com/return")
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", parsed.Query().Get("setup"))
+	assert.Equal(t, connID.String(), parsed.Query().Get("connection_id"))
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "app.example.com", parsed.Host)
+	assert.Equal(t, "/return", parsed.Path)
+}
+
+// TestAppendSetupPendingToReturnUrl_PreservesExistingQuery — the
+// marketplace passes its own state (e.g. tab selection) on the return
+// URL; we must not clobber it when adding our setup-pending markers.
+func TestAppendSetupPendingToReturnUrl_PreservesExistingQuery(t *testing.T) {
+	connID := apid.New(apid.PrefixConnection)
+	o := &oAuth2Connection{connection: &mockCore.Connection{Id: connID}}
+
+	got := o.appendSetupPendingToReturnUrl("https://app.example.com/return?tab=integrations&utm=email")
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	q := parsed.Query()
+	assert.Equal(t, "integrations", q.Get("tab"))
+	assert.Equal(t, "email", q.Get("utm"))
+	assert.Equal(t, "pending", q.Get("setup"))
+	assert.Equal(t, connID.String(), q.Get("connection_id"))
+}
+
+// TestAppendSetupPendingToReturnUrl_ParseFailureFallback covers the
+// defensive `if err != nil { return raw }` branch. url.Parse rejects
+// strings containing control characters, so we use one to exercise
+// the fallback without needing a stub URL parser.
+func TestAppendSetupPendingToReturnUrl_ParseFailureFallback(t *testing.T) {
+	o := &oAuth2Connection{connection: &mockCore.Connection{Id: apid.New(apid.PrefixConnection)}}
+
+	raw := "https://app.example.com/\x7f"
+	got := o.appendSetupPendingToReturnUrl(raw)
+	assert.Equal(t, raw, got, "unparseable URL must be returned untouched so the redirect surface is at least defined")
+}
+
+// scriptedTokenServer returns an httptest.Server that serves the
+// supplied response sequence one entry per request, then keeps
+// returning the final entry. Lets retry tests assert on attempt
+// counts deterministically without orchestrating a real provider.
+type scriptedResponse struct {
+	status int
+	body   string
+}
+
+func scriptedTokenServer(t *testing.T, responses []scriptedResponse) (*httptest.Server, *int32, *[]url.Values) {
+	t.Helper()
+	var calls int32
+	var bodies []url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(atomic.AddInt32(&calls, 1)) - 1
+		body, _ := url.ParseQuery(readBody(t, r))
+		bodies = append(bodies, body)
+		resp := responses[len(responses)-1]
+		if idx < len(responses) {
+			resp = responses[idx]
+		}
+		w.WriteHeader(resp.status)
+		_, _ = w.Write([]byte(resp.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls, &bodies
+}
+
+func readBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	defer r.Body.Close()
+	buf := make([]byte, 4096)
+	n, _ := r.Body.Read(buf)
+	return string(buf[:n])
+}
+
+func newRetryTestConn(t *testing.T) *oAuth2Connection {
+	t.Helper()
+	logger, _ := bufLogger(t)
+	return &oAuth2Connection{
+		auth:   &sconfig.AuthOAuth2{Token: cschema.AuthOauth2Token{}},
+		logger: logger,
+	}
+}
+
+func TestPostTokenExchangeWithRetry_SuccessFirstAttempt(t *testing.T) {
+	srv, calls, bodies := scriptedTokenServer(t, []scriptedResponse{
+		{status: 200, body: `{"access_token":"a"}`},
+	})
+	o := newRetryTestConn(t)
+
+	resp, attempts, err := o.postTokenExchangeWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{"grant_type": {"authorization_code"}, "code": {"abc"}},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 1, attempts, "200 must not retry")
+	assert.Equal(t, int32(1), atomic.LoadInt32(calls))
+	require.Len(t, *bodies, 1)
+	assert.Equal(t, "abc", (*bodies)[0].Get("code"),
+		"posted body must include the form values verbatim")
+}
+
+// TestPostTokenExchangeWithRetry_4xxNotRetried is the load-bearing
+// invariant of the policy: 4xx responses are non-retryable because
+// resubmitting the same authorization code would burn it. A
+// regression here (e.g. retrying on 400) would silently break every
+// 4xx integration test by changing the observed call count.
+func TestPostTokenExchangeWithRetry_4xxNotRetried(t *testing.T) {
+	for _, status := range []int{400, 401, 403, 404, 422, 429} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv, calls, _ := scriptedTokenServer(t, []scriptedResponse{
+				{status: status, body: `{"error":"invalid_grant"}`},
+			})
+			o := newRetryTestConn(t)
+
+			resp, attempts, err := o.postTokenExchangeWithRetry(
+				context.Background(),
+				gentleman.New(),
+				srv.URL,
+				url.Values{"grant_type": {"authorization_code"}},
+			)
+
+			require.NoError(t, err, "transport-layer call succeeded — 4xx is not a transport error")
+			require.NotNil(t, resp)
+			assert.Equal(t, status, resp.StatusCode)
+			assert.Equal(t, 1, attempts)
+			assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+				"4xx must terminate the loop on the first attempt")
+		})
+	}
+}
+
+func TestPostTokenExchangeWithRetry_5xxThenSuccess(t *testing.T) {
+	srv, calls, _ := scriptedTokenServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+		{status: 200, body: `{"access_token":"a"}`},
+	})
+	o := newRetryTestConn(t)
+
+	start := time.Now()
+	resp, attempts, err := o.postTokenExchangeWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, int32(2), atomic.LoadInt32(calls))
+	assert.GreaterOrEqual(t, elapsed, tokenExchangeBackoffStep,
+		"second attempt must wait at least one backoff step")
+}
+
+// TestPostTokenExchangeWithRetry_5xxExhausted asserts the exhaustion
+// shape contracted with the failure event path: after the budget is
+// burned, the helper returns the *last* response so the caller can
+// classify on its status code, plus an attempts count equal to
+// tokenExchangeMaxAttempts so the failure event can record budget
+// exhaustion.
+func TestPostTokenExchangeWithRetry_5xxExhausted(t *testing.T) {
+	srv, calls, _ := scriptedTokenServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+	})
+	o := newRetryTestConn(t)
+
+	resp, attempts, err := o.postTokenExchangeWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+
+	require.NoError(t, err, "5xx is an HTTP-level failure, not a transport error")
+	require.NotNil(t, resp, "exhausted retry must return the last response so the caller can classify")
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, tokenExchangeMaxAttempts, attempts)
+	assert.Equal(t, int32(tokenExchangeMaxAttempts), atomic.LoadInt32(calls),
+		"helper must make exactly tokenExchangeMaxAttempts calls and stop")
+}
+
+// TestPostTokenExchangeWithRetry_TransportErrorRetried — when the
+// dial fails (server closed, DNS fails, etc.) the helper has no
+// response to inspect, so it falls into the same retry branch as a
+// 5xx. We close the test server before calling so every attempt hits
+// "connection refused".
+func TestPostTokenExchangeWithRetry_TransportErrorRetried(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close() // ensure dials fail with "connection refused"
+	o := newRetryTestConn(t)
+
+	resp, attempts, err := o.postTokenExchangeWithRetry(
+		context.Background(),
+		gentleman.New(),
+		closedURL,
+		url.Values{},
+	)
+
+	require.Error(t, err, "transport failure must surface as an error")
+	if resp != nil {
+		assert.Equal(t, 0, resp.StatusCode,
+			"transport-error response carries no status code; downstream classifier keys on err, not resp")
+	}
+	assert.Equal(t, tokenExchangeMaxAttempts, attempts,
+		"transport errors are retried like 5xx — full budget should be consumed")
+}
+
+// TestPostTokenExchangeWithRetry_ContextCancelledBeforeRetry — the
+// caller's context is honored *between* attempts. Cancelling after
+// the first 5xx must short-circuit the loop with ctx.Err and an
+// attempt count reflecting only the calls actually completed.
+func TestPostTokenExchangeWithRetry_ContextCancelledBeforeRetry(t *testing.T) {
+	srv, calls, _ := scriptedTokenServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+	})
+	o := newRetryTestConn(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately after the first response would arrive; the
+	// helper checks ctx.Done() inside the backoff select.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	resp, attempts, err := o.postTokenExchangeWithRetry(
+		ctx,
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, resp, "cancellation in the backoff window returns nil response")
+	assert.Equal(t, 1, attempts,
+		"attempts records only completed calls — the in-flight cancellation was during backoff")
+	assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+		"server should have observed exactly one call before cancellation")
+}
+
+// TestPostTokenExchangeWithRetry_QueryOverridesAppliedEachAttempt —
+// the retry loop rebuilds the gentleman.Request each iteration
+// (single-use API). This test pins the contract that connector-level
+// QueryOverrides are reapplied on every retry, not silently dropped
+// after the first attempt.
+func TestPostTokenExchangeWithRetry_QueryOverridesAppliedEachAttempt(t *testing.T) {
+	var queries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		w.WriteHeader(503)
+		_, _ = w.Write([]byte(`{"error":"temporarily_unavailable"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger, _ := bufLogger(t)
+	o := &oAuth2Connection{
+		auth: &sconfig.AuthOAuth2{Token: cschema.AuthOauth2Token{
+			QueryOverrides: map[string]string{"audience": "api.example.com"},
+		}},
+		logger: logger,
+	}
+
+	_, attempts, err := o.postTokenExchangeWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, tokenExchangeMaxAttempts, attempts)
+
+	require.Len(t, queries, tokenExchangeMaxAttempts)
+	for i, q := range queries {
+		assert.Truef(t, strings.Contains(q, "audience=api.example.com"),
+			"attempt %d should carry connector QueryOverrides; got raw query %q", i+1, q)
+	}
+}

--- a/internal/auth_methods/oauth2/token_exchange_failure.go
+++ b/internal/auth_methods/oauth2/token_exchange_failure.go
@@ -79,7 +79,12 @@ type tokenExchangeAttrs struct {
 	Namespace          string
 	ProviderStatusCode int
 	ProviderError      string
-	Err                error
+	// Attempts is how many token-endpoint POSTs were made before the
+	// failure was surfaced (1 means the first attempt failed and was
+	// not retried). Emitted when > 0 so 5xx exhaustion is visibly
+	// distinct from a single non-retryable failure.
+	Attempts int
+	Err      error
 }
 
 // tokenExchangeFailureMessage is the single message string for every
@@ -115,6 +120,9 @@ func emitTokenExchangeFailure(ctx context.Context, logger *slog.Logger, category
 	}
 	if attrs.ProviderError != "" {
 		args = append(args, slog.String("provider_error", attrs.ProviderError))
+	}
+	if attrs.Attempts > 0 {
+		args = append(args, slog.Int("attempts", attrs.Attempts))
 	}
 	if attrs.Err != nil {
 		args = append(args, slog.String("error", attrs.Err.Error()))


### PR DESCRIPTION
## Summary

- Adds a small bounded retry policy to the OAuth2 token-exchange leg: 3 attempts (1 try + 2 retries), linear backoff (200ms, 400ms), retry on 5xx and transport errors only — 4xx is non-retryable because resubmitting the same authorization code would just burn it.
- Adds an \`attempts\` field to the structured \`oauth token exchange failed\` event so dashboards can distinguish budget exhaustion from a single non-retryable failure.
- Adds 3 integration tests covering transient outage that resolves within budget, sustained 5xx outage exceeding budget, and 504 specifically (sanity check that the policy is keyed on the 5xx range, not a specific status code). Companion \`.md\` doc explains the policy rationale.

This is the third and final PR for issue #168 (after #228 and #245).

## Test plan

- [x] \`go test -tags integration -run 'TestTokenExchange_TransientRetrySucceeds|TestTokenExchange_TransientRetryExhausted|TestTokenExchange_5xxVariants_AllRetried' ./oauth2/\` passes
- [x] PR B rejection tests still pass — 4xx contract preserved (no retry, exactly one /token call)
- [x] \`go test ./internal/auth_methods/oauth2/...\` passes (Attempts field added to attrs)
- [x] \`./scripts/preflight.sh\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)