### PR TITLE
Rate limits — Step 6: 429 attribution in the request log

### DIFF
--- a/internal/ratelimit/roundtripper.go
+++ b/internal/ratelimit/roundtripper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/request_log"
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
@@ -80,6 +81,14 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			slog.String("connection_id", rt.connectionId.String()),
 			slog.Duration("retry_after", remaining),
 		)
+		// Stamp the request log so this synthetic 429 is distinguishable
+		// from a real upstream 429 — closing the gap noted on #222. The
+		// proxy bootstrap installs an Attribution on every proxy request;
+		// when it isn't there (e.g. tests that don't wire attribution),
+		// this is a no-op.
+		if attr := request_log.AttributionFromContext(ctx); attr != nil {
+			attr.Source = request_log.ResponseSourceConnectorRateLimiter
+		}
 		return rt.syntheticTooManyRequests(remaining), nil
 	}
 

--- a/internal/ratelimit/roundtripper_test.go
+++ b/internal/ratelimit/roundtripper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/request_log"
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -192,6 +193,70 @@ func TestRoundTripper_BlocksSubsequentRequests(t *testing.T) {
 
 	body, _ := io.ReadAll(resp.Body)
 	assert.Contains(t, string(body), "rate limited")
+}
+
+// Synthetic 429 short-circuit must stamp the request_log.Attribution so
+// downstream observers can tell apart a real upstream 429 and our
+// connector-level cool-down. This was the gap closed by #222.
+func TestRoundTripper_ShortCircuitStampsAttribution(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	require.NoError(t, store.SetRateLimited(ctx, connID, 30*time.Second))
+
+	attr := &request_log.Attribution{}
+	ctx = request_log.ContextWithAttribution(ctx, attr)
+
+	transport := &mockTransport{resp: &http.Response{StatusCode: 200}}
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	require.Equal(t, 429, resp.StatusCode)
+	require.False(t, transport.called)
+	require.Equal(t, request_log.ResponseSourceConnectorRateLimiter, attr.Source,
+		"synthetic 429 must mark the attribution so the request log can distinguish it from upstream")
+}
+
+// Real upstream 429s must NOT stamp the connector-rate-limiter source.
+// They should fall through to the default ResponseSourceUpstream when
+// the request log eventually populates the LogRecord.
+func TestRoundTripper_UpstreamPassThroughLeavesAttributionDefault(t *testing.T) {
+	store, _ := newTestStore(t)
+	connID := testConnectionID()
+	ctx := testCtx()
+
+	attr := &request_log.Attribution{}
+	ctx = request_log.ContextWithAttribution(ctx, attr)
+
+	transport := &mockTransport{
+		resp: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{"Retry-After": {"30"}},
+		},
+	}
+	rt := &RoundTripper{
+		connectionId: connID,
+		store:        store,
+		transport:    transport,
+		logger:       testLogger(),
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 429, resp.StatusCode)
+	require.True(t, transport.called)
+	require.Equal(t, request_log.ResponseSource(""), attr.Source,
+		"a real upstream 429 must not stamp connector_rate_limiter; the default upstream value is applied later")
 }
 
 func TestRoundTripper_ClearsCounterOnSuccess(t *testing.T) {

--- a/internal/request_log/attribution.go
+++ b/internal/request_log/attribution.go
@@ -1,0 +1,101 @@
+package request_log
+
+import (
+	"context"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+)
+
+// ResponseSource identifies *who* produced the response that a LogRecord
+// captures. Until this PR every 429 in the log looked the same — a 3rd
+// party rate-limiting us was indistinguishable from the connector-level
+// reactive backoff returning a synthetic 429. Stamping this field at the
+// point of synthesis closes that gap and reserves a value for the
+// upcoming proxy-side rate-limit resource enforcement (#223).
+type ResponseSource string
+
+const (
+	// ResponseSourceUpstream means the response (including any 429) came
+	// from the 3rd-party service — the default and historically the only
+	// possibility.
+	ResponseSourceUpstream ResponseSource = "upstream"
+
+	// ResponseSourceConnectorRateLimiter means the connector-level reactive
+	// limiter short-circuited the request because the connection is in
+	// cool-down from a prior real upstream 429. No upstream call was made
+	// for this attempt.
+	ResponseSourceConnectorRateLimiter ResponseSource = "connector_rate_limiter"
+
+	// ResponseSourceRateLimit is reserved for the proxy-side rate-limit
+	// resource enforcement (#223). Defining it here keeps the schema
+	// stable across the two PRs; population happens in #223.
+	ResponseSourceRateLimit ResponseSource = "rate_limit"
+)
+
+// IsValidResponseSource reports whether s is a recognised ResponseSource.
+// Unknown values returned from old DB rows or from forward-compatible
+// readers are not coerced — callers can choose to treat them as upstream
+// or to log a warning.
+func IsValidResponseSource(s ResponseSource) bool {
+	switch s {
+	case ResponseSourceUpstream,
+		ResponseSourceConnectorRateLimiter,
+		ResponseSourceRateLimit:
+		return true
+	}
+	return false
+}
+
+// RateLimitMatch describes a single rate-limit rule that matched the
+// request. The full set of matches is captured in
+// LogRecord.RateLimitMatched so observers can see every rule that fired
+// (in either enforce or observe mode), not just the most-restrictive one
+// that ultimately decided the request's fate.
+type RateLimitMatch struct {
+	Id     apid.ID           `json:"id"`
+	Mode   string            `json:"mode"`
+	Bucket map[string]string `json:"bucket,omitempty"`
+}
+
+// Attribution carries per-request log attribution that the proxy stack
+// populates as the request flows through it. The rate-limit
+// round-tripper writes Source when it short-circuits with a synthetic
+// 429; the (future) rate-limit resource enforcement writes the
+// RateLimit* fields when a rule fires. The request-log round-tripper
+// reads the value on its way back to populate LogRecord.
+//
+// Use a pointer in the context so middlewares writing to the same
+// Attribution see each other's edits — the pointer doesn't change, the
+// struct fields do.
+type Attribution struct {
+	Source           ResponseSource
+	RateLimitId      apid.ID
+	RateLimitMode    string
+	RateLimitBucket  map[string]string
+	RateLimitMatched []RateLimitMatch
+}
+
+type attributionKey struct{}
+
+// ContextWithAttribution returns a context that carries attr. The proxy
+// bootstrap installs an empty Attribution on the request context before
+// the round-tripper chain runs; middlewares mutate the struct in place.
+func ContextWithAttribution(ctx context.Context, attr *Attribution) context.Context {
+	if attr == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, attributionKey{}, attr)
+}
+
+// AttributionFromContext returns the Attribution carried by ctx, or nil
+// when no proxy middleware has installed one. Returning nil rather than
+// a zero-value struct lets callers distinguish "nothing was stamped" from
+// "stamped but blank" — the LogRecord-population path treats nil as
+// ResponseSourceUpstream.
+func AttributionFromContext(ctx context.Context) *Attribution {
+	if ctx == nil {
+		return nil
+	}
+	a, _ := ctx.Value(attributionKey{}).(*Attribution)
+	return a
+}

--- a/internal/request_log/attribution_codec.go
+++ b/internal/request_log/attribution_codec.go
@@ -1,0 +1,64 @@
+package request_log
+
+import "encoding/json"
+
+// marshalRateLimitBucket renders the bucket map to a stable JSON form
+// suitable for storage. An empty / nil map serializes to "{}" so the DB
+// column always holds valid JSON (matches the migration default).
+func marshalRateLimitBucket(b map[string]string) (string, error) {
+	if len(b) == 0 {
+		return "{}", nil
+	}
+	out, err := json.Marshal(b)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// unmarshalRateLimitBucket parses a bucket JSON blob from the DB. nil /
+// empty / "{}" all yield a nil map so callers don't need to special-case
+// "missing" vs "explicitly empty" — semantically the same for log
+// readers.
+func unmarshalRateLimitBucket(data []byte) (map[string]string, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// marshalRateLimitMatched renders the matched list to JSON. Empty / nil
+// → "[]" so the DB column always holds valid JSON.
+func marshalRateLimitMatched(m []RateLimitMatch) (string, error) {
+	if len(m) == 0 {
+		return "[]", nil
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// unmarshalRateLimitMatched parses a matched-list JSON blob. nil / empty
+// / "[]" yield a nil slice.
+func unmarshalRateLimitMatched(data []byte) ([]RateLimitMatch, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var out []RateLimitMatch
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}

--- a/internal/request_log/attribution_codec_test.go
+++ b/internal/request_log/attribution_codec_test.go
@@ -1,0 +1,126 @@
+package request_log
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+// --- bucket ---
+
+func TestMarshalRateLimitBucket_NilProducesEmptyObject(t *testing.T) {
+	out, err := marshalRateLimitBucket(nil)
+	require.NoError(t, err)
+	require.Equal(t, "{}", out, "nil bucket must serialize to valid JSON so the DB column NOT-NULL invariant holds")
+}
+
+func TestMarshalRateLimitBucket_EmptyProducesEmptyObject(t *testing.T) {
+	out, err := marshalRateLimitBucket(map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, "{}", out)
+}
+
+func TestMarshalRateLimitBucket_PopulatedRoundTrips(t *testing.T) {
+	in := map[string]string{"actor": "act_x", "labels/team": "alpha"}
+	encoded, err := marshalRateLimitBucket(in)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	decoded, err := unmarshalRateLimitBucket([]byte(encoded))
+	require.NoError(t, err)
+	require.Equal(t, in, decoded)
+}
+
+func TestUnmarshalRateLimitBucket_NilOrEmptyYieldsNil(t *testing.T) {
+	// nil/empty/{} all collapse to a nil map. Distinguishing "missing" from
+	// "explicitly empty" is not useful for log readers — both render as no
+	// bucket dimensions in the UI / API response.
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"nil", nil},
+		{"empty bytes", []byte("")},
+		{"empty object", []byte("{}")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := unmarshalRateLimitBucket(tc.in)
+			require.NoError(t, err)
+			require.Nil(t, out)
+		})
+	}
+}
+
+func TestUnmarshalRateLimitBucket_BadJSONReturnsError(t *testing.T) {
+	_, err := unmarshalRateLimitBucket([]byte("{not json"))
+	require.Error(t, err)
+}
+
+// --- matched ---
+
+func TestMarshalRateLimitMatched_NilProducesEmptyArray(t *testing.T) {
+	out, err := marshalRateLimitMatched(nil)
+	require.NoError(t, err)
+	require.Equal(t, "[]", out)
+}
+
+func TestMarshalRateLimitMatched_EmptyProducesEmptyArray(t *testing.T) {
+	out, err := marshalRateLimitMatched([]RateLimitMatch{})
+	require.NoError(t, err)
+	require.Equal(t, "[]", out)
+}
+
+func TestMarshalRateLimitMatched_PopulatedRoundTrips(t *testing.T) {
+	in := []RateLimitMatch{
+		{Id: apid.ID("rl_a"), Mode: "enforce", Bucket: map[string]string{"actor": "act_x"}},
+		{Id: apid.ID("rl_b"), Mode: "observe", Bucket: map[string]string{"team": "alpha"}},
+	}
+
+	encoded, err := marshalRateLimitMatched(in)
+	require.NoError(t, err)
+
+	decoded, err := unmarshalRateLimitMatched([]byte(encoded))
+	require.NoError(t, err)
+	require.Equal(t, in, decoded)
+}
+
+func TestUnmarshalRateLimitMatched_NilOrEmptyYieldsNil(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"nil", nil},
+		{"empty bytes", []byte("")},
+		{"empty array", []byte("[]")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := unmarshalRateLimitMatched(tc.in)
+			require.NoError(t, err)
+			require.Nil(t, out)
+		})
+	}
+}
+
+func TestUnmarshalRateLimitMatched_BadJSONReturnsError(t *testing.T) {
+	_, err := unmarshalRateLimitMatched([]byte("[not json"))
+	require.Error(t, err)
+}
+
+// TestRateLimitMatchedJSON_PreservesOrder pins the property the firing-rule
+// reporting depends on: when there are multiple matches, the order in the
+// returned slice equals the order in which they were stored. Storing as a
+// JSON array preserves order across encode/decode; this test is the
+// regression guard.
+func TestRateLimitMatchedJSON_PreservesOrder(t *testing.T) {
+	in := []RateLimitMatch{
+		{Id: apid.ID("rl_z"), Mode: "enforce"},
+		{Id: apid.ID("rl_a"), Mode: "observe"},
+		{Id: apid.ID("rl_m"), Mode: "observe"},
+	}
+	encoded, err := marshalRateLimitMatched(in)
+	require.NoError(t, err)
+	decoded, err := unmarshalRateLimitMatched([]byte(encoded))
+	require.NoError(t, err)
+	require.Equal(t, in, decoded)
+}

--- a/internal/request_log/attribution_test.go
+++ b/internal/request_log/attribution_test.go
@@ -1,0 +1,121 @@
+package request_log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidResponseSource(t *testing.T) {
+	require.True(t, IsValidResponseSource(ResponseSourceUpstream))
+	require.True(t, IsValidResponseSource(ResponseSourceConnectorRateLimiter))
+	require.True(t, IsValidResponseSource(ResponseSourceRateLimit))
+	require.False(t, IsValidResponseSource(""))
+	require.False(t, IsValidResponseSource("bogus"))
+}
+
+func TestAttributionContext_Roundtrip(t *testing.T) {
+	ctx := context.Background()
+	require.Nil(t, AttributionFromContext(ctx))
+
+	attr := &Attribution{Source: ResponseSourceConnectorRateLimiter}
+	ctx2 := ContextWithAttribution(ctx, attr)
+	got := AttributionFromContext(ctx2)
+	require.NotNil(t, got)
+	require.Equal(t, ResponseSourceConnectorRateLimiter, got.Source)
+}
+
+func TestAttributionContext_NilAttrIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	ctx2 := ContextWithAttribution(ctx, nil)
+	require.Equal(t, ctx, ctx2)
+	require.Nil(t, AttributionFromContext(ctx2))
+}
+
+func TestAttributionContext_PointerSharedAcrossLayers(t *testing.T) {
+	// The attribution pointer is the only thing in the context — middlewares
+	// mutate the struct it points to, and observers higher in the stack see
+	// the change. This is the property the round-tripper chain relies on.
+	attr := &Attribution{}
+	ctx := ContextWithAttribution(context.Background(), attr)
+
+	// Inner middleware writes…
+	if a := AttributionFromContext(ctx); a != nil {
+		a.Source = ResponseSourceRateLimit
+		a.RateLimitId = apid.ID("rl_42")
+	}
+
+	// Outer middleware reads.
+	got := AttributionFromContext(ctx)
+	require.Equal(t, ResponseSourceRateLimit, got.Source)
+	require.Equal(t, apid.ID("rl_42"), got.RateLimitId)
+
+	// And the pointer the caller passed in is the same struct.
+	require.Same(t, attr, got)
+}
+
+func TestApplyAttributionToLogRecord_NilContextDefaultsUpstream(t *testing.T) {
+	er := &LogRecord{}
+	ApplyAttributionToLogRecord(er, nil)
+	require.Equal(t, ResponseSourceUpstream, er.ResponseSource)
+}
+
+func TestApplyAttributionToLogRecord_NoAttributionInContext(t *testing.T) {
+	er := &LogRecord{}
+	ApplyAttributionToLogRecord(er, context.Background())
+	require.Equal(t, ResponseSourceUpstream, er.ResponseSource)
+}
+
+func TestApplyAttributionToLogRecord_StampsAllFields(t *testing.T) {
+	er := &LogRecord{}
+	attr := &Attribution{
+		Source:          ResponseSourceRateLimit,
+		RateLimitId:     apid.ID("rl_a"),
+		RateLimitMode:   "enforce",
+		RateLimitBucket: map[string]string{"actor": "act_x"},
+		RateLimitMatched: []RateLimitMatch{
+			{Id: apid.ID("rl_a"), Mode: "enforce", Bucket: map[string]string{"actor": "act_x"}},
+		},
+	}
+	ctx := ContextWithAttribution(context.Background(), attr)
+
+	ApplyAttributionToLogRecord(er, ctx)
+
+	require.Equal(t, ResponseSourceRateLimit, er.ResponseSource)
+	require.Equal(t, apid.ID("rl_a"), er.RateLimitId)
+	require.Equal(t, "enforce", er.RateLimitMode)
+	require.Equal(t, map[string]string{"actor": "act_x"}, er.RateLimitBucket)
+	require.Len(t, er.RateLimitMatched, 1)
+}
+
+func TestApplyAttributionToLogRecord_KeepsExistingValuesWhenAttrIsBlank(t *testing.T) {
+	// If a future code path pre-stamps the LogRecord then asks to layer
+	// attribution on top, an empty attribution shouldn't clobber what's
+	// already there (only non-zero fields overwrite).
+	er := &LogRecord{
+		ResponseSource: ResponseSourceConnectorRateLimiter,
+		RateLimitId:    apid.ID("rl_existing"),
+	}
+	ctx := ContextWithAttribution(context.Background(), &Attribution{})
+	ApplyAttributionToLogRecord(er, ctx)
+
+	require.Equal(t, ResponseSourceConnectorRateLimiter, er.ResponseSource)
+	require.Equal(t, apid.ID("rl_existing"), er.RateLimitId)
+}
+
+func TestRateLimitMatchJSON_RoundTrip(t *testing.T) {
+	// The codec is exercised end-to-end in DB tests; this just pins the
+	// public JSON shape used in API responses.
+	m := []RateLimitMatch{{
+		Id:     apid.ID("rl_alpha"),
+		Mode:   "observe",
+		Bucket: map[string]string{"team": "alpha"},
+	}}
+	encoded, err := marshalRateLimitMatched(m)
+	require.NoError(t, err)
+	decoded, err := unmarshalRateLimitMatched([]byte(encoded))
+	require.NoError(t, err)
+	require.Equal(t, m, decoded)
+}

--- a/internal/request_log/list.go
+++ b/internal/request_log/list.go
@@ -81,6 +81,8 @@ type ListRequestBuilder interface {
 	WithTimestampRange(start, end time.Time) ListRequestBuilder
 	WithParsedTimestampRange(r string) (ListRequestBuilder, error)
 	WithLabelSelector(selector string) (ListRequestBuilder, error)
+	WithResponseSource(s ResponseSource) ListRequestBuilder
+	WithRateLimitId(id apid.ID) ListRequestBuilder
 }
 
 // ListFilters holds the filter, pagination, and ordering data for list requests.
@@ -104,6 +106,8 @@ type ListFilters struct {
 	PathRegex                *string           `json:"path_regex,omitempty"`
 	NamespaceMatchers        []string          `json:"namespace_matchers,omitempty"`
 	LabelSelector            *string           `json:"label_selector,omitempty"`
+	ResponseSource           *string           `json:"response_source,omitempty"`
+	RateLimitId              *apid.ID          `json:"rate_limit_id,omitempty"`
 	Errors                   *multierror.Error `json:"-"`
 }
 
@@ -205,4 +209,12 @@ func (l *ListFilters) SetTimestampRange(start, end time.Time) {
 
 func (l *ListFilters) SetLabelSelector(selector string) {
 	l.LabelSelector = util.ToPtr(selector)
+}
+
+func (l *ListFilters) SetResponseSource(s ResponseSource) {
+	l.ResponseSource = util.ToPtr(string(s))
+}
+
+func (l *ListFilters) SetRateLimitId(id apid.ID) {
+	l.RateLimitId = util.ToPtr(id)
 }

--- a/internal/request_log/log_record.go
+++ b/internal/request_log/log_record.go
@@ -41,6 +41,26 @@ type LogRecord struct {
 	RequestCancelled    bool                `json:"request_cancelled,omitempty"`
 	FullRequestRecorded bool                `json:"full_request_recorded,omitempty"`
 	Labels              database.Labels     `json:"labels,omitempty"`
+
+	// ResponseSource identifies who produced the response. Defaults to
+	// ResponseSourceUpstream so historical entries — and any non-429
+	// response — keep the obvious meaning. See attribution.go.
+	ResponseSource ResponseSource `json:"response_source,omitempty"`
+
+	// RateLimitId, RateLimitMode, RateLimitBucket are populated when a
+	// proxy-side RateLimit resource matched the request, regardless of
+	// whether it was the firing rule or just a logged observation. The
+	// connector-level reactive limiter does not populate these (it has
+	// no rule id).
+	RateLimitId     apid.ID           `json:"rate_limit_id,omitempty"`
+	RateLimitMode   string            `json:"rate_limit_mode,omitempty"`
+	RateLimitBucket map[string]string `json:"rate_limit_bucket,omitempty"`
+
+	// RateLimitMatched is the full set of rate-limit rules that matched
+	// this request — the firing rule plus any observe-mode matches. Lets
+	// operators see *every* rule that contributed to the decision, not
+	// just the one that ultimately rejected the request.
+	RateLimitMatched []RateLimitMatch `json:"rate_limit_matched,omitempty"`
 }
 
 func (e *LogRecord) GetId() apid.ID {

--- a/internal/request_log/migrations/postgres/000002_add_response_source_and_rate_limit.down.sql
+++ b/internal/request_log/migrations/postgres/000002_add_response_source_and_rate_limit.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_entry_records_rate_limit_id;
+DROP INDEX IF EXISTS idx_entry_records_response_source;
+
+ALTER TABLE http_log_entry_records
+    DROP COLUMN IF EXISTS rate_limit_matched,
+    DROP COLUMN IF EXISTS rate_limit_bucket,
+    DROP COLUMN IF EXISTS rate_limit_mode,
+    DROP COLUMN IF EXISTS rate_limit_id,
+    DROP COLUMN IF EXISTS response_source;

--- a/internal/request_log/migrations/postgres/000002_add_response_source_and_rate_limit.up.sql
+++ b/internal/request_log/migrations/postgres/000002_add_response_source_and_rate_limit.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE http_log_entry_records
+    ADD COLUMN response_source TEXT NOT NULL DEFAULT 'upstream',
+    ADD COLUMN rate_limit_id TEXT NOT NULL DEFAULT '',
+    ADD COLUMN rate_limit_mode TEXT NOT NULL DEFAULT '',
+    ADD COLUMN rate_limit_bucket JSONB NOT NULL DEFAULT '{}',
+    ADD COLUMN rate_limit_matched JSONB NOT NULL DEFAULT '[]';
+
+CREATE INDEX IF NOT EXISTS idx_entry_records_response_source
+    ON http_log_entry_records (response_source);
+
+CREATE INDEX IF NOT EXISTS idx_entry_records_rate_limit_id
+    ON http_log_entry_records (rate_limit_id)
+    WHERE rate_limit_id <> '';

--- a/internal/request_log/migrations/sqlite/000002_add_response_source_and_rate_limit.down.sql
+++ b/internal/request_log/migrations/sqlite/000002_add_response_source_and_rate_limit.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_entry_records_rate_limit_id;
+DROP INDEX IF EXISTS idx_entry_records_response_source;
+
+ALTER TABLE http_log_entry_records DROP COLUMN rate_limit_matched;
+ALTER TABLE http_log_entry_records DROP COLUMN rate_limit_bucket;
+ALTER TABLE http_log_entry_records DROP COLUMN rate_limit_mode;
+ALTER TABLE http_log_entry_records DROP COLUMN rate_limit_id;
+ALTER TABLE http_log_entry_records DROP COLUMN response_source;

--- a/internal/request_log/migrations/sqlite/000002_add_response_source_and_rate_limit.up.sql
+++ b/internal/request_log/migrations/sqlite/000002_add_response_source_and_rate_limit.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE http_log_entry_records ADD COLUMN response_source TEXT NOT NULL DEFAULT 'upstream';
+ALTER TABLE http_log_entry_records ADD COLUMN rate_limit_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE http_log_entry_records ADD COLUMN rate_limit_mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE http_log_entry_records ADD COLUMN rate_limit_bucket TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE http_log_entry_records ADD COLUMN rate_limit_matched TEXT NOT NULL DEFAULT '[]';
+
+CREATE INDEX IF NOT EXISTS idx_entry_records_response_source
+    ON http_log_entry_records (response_source);
+
+CREATE INDEX IF NOT EXISTS idx_entry_records_rate_limit_id
+    ON http_log_entry_records (rate_limit_id);

--- a/internal/request_log/mock/list.go
+++ b/internal/request_log/mock/list.go
@@ -34,6 +34,8 @@ type MockListRequestBuilderExecutor struct {
 	Path                     *string     `json:"path,omitempty"`
 	PathRegex                *string     `json:"path_regex,omitempty"`
 	LabelSelector            *string     `json:"label_selector,omitempty"`
+	ResponseSource           *string     `json:"response_source,omitempty"`
+	RateLimitId              *apid.ID    `json:"rate_limit_id,omitempty"`
 }
 
 func (l *MockListRequestBuilderExecutor) WithNamespaceMatcher(matcher string) request_log.ListRequestBuilder {
@@ -121,6 +123,16 @@ func (l *MockListRequestBuilderExecutor) WithParsedTimestampRange(r string) (req
 func (l *MockListRequestBuilderExecutor) WithLabelSelector(selector string) (request_log.ListRequestBuilder, error) {
 	l.LabelSelector = util.ToPtr(selector)
 	return l, nil
+}
+
+func (l *MockListRequestBuilderExecutor) WithResponseSource(s request_log.ResponseSource) request_log.ListRequestBuilder {
+	l.ResponseSource = util.ToPtr(string(s))
+	return l
+}
+
+func (l *MockListRequestBuilderExecutor) WithRateLimitId(id apid.ID) request_log.ListRequestBuilder {
+	l.RateLimitId = util.ToPtr(id)
+	return l
 }
 
 func (l *MockListRequestBuilderExecutor) Limit(limit int32) request_log.ListRequestBuilder {

--- a/internal/request_log/provider_clickhouse.go
+++ b/internal/request_log/provider_clickhouse.go
@@ -59,7 +59,9 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 			"request_http_version, request_size_bytes, request_mime_type, "+
 			"response_http_version, response_size_bytes, response_mime_type, "+
 			"internal_timeout, request_cancelled, full_request_recorded, "+
-			"labels) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			"labels, response_source, rate_limit_id, rate_limit_mode, "+
+			"rate_limit_bucket, rate_limit_matched) "+
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		entryRecordsTable,
 	))
 	if err != nil {
@@ -74,6 +76,20 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 		if labelsVal == nil {
 			labelsVal = "{}"
 		}
+		source := r.ResponseSource
+		if source == "" {
+			source = ResponseSourceUpstream
+		}
+		bucketJSON, err := marshalRateLimitBucket(r.RateLimitBucket)
+		if err != nil {
+			s.logger.Error("failed to marshal rate-limit bucket", "error", err, "entry_id", r.RequestId.String())
+			continue
+		}
+		matchedJSON, err := marshalRateLimitMatched(r.RateLimitMatched)
+		if err != nil {
+			s.logger.Error("failed to marshal rate-limit matched", "error", err, "entry_id", r.RequestId.String())
+			continue
+		}
 		_, err = stmt.ExecContext(ctx,
 			r.RequestId.String(), r.Namespace, string(r.Type), r.CorrelationId,
 			r.Timestamp.UnixMilli(), r.MillisecondDuration.Duration().Milliseconds(),
@@ -84,6 +100,8 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 			r.ResponseHttpVersion, r.ResponseSizeBytes, r.ResponseMimeType,
 			r.InternalTimeout, r.RequestCancelled, r.FullRequestRecorded,
 			labelsVal,
+			string(source), r.RateLimitId.String(), r.RateLimitMode,
+			bucketJSON, matchedJSON,
 		)
 		if err != nil {
 			s.logger.Error("failed to insert record into clickhouse", "error", err, "entry_id", r.RequestId.String())
@@ -129,7 +147,12 @@ func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 		internal_timeout Bool,
 		request_cancelled Bool,
 		full_request_recorded Bool,
-		labels String DEFAULT '{}'
+		labels String DEFAULT '{}',
+		response_source String DEFAULT 'upstream',
+		rate_limit_id String DEFAULT '',
+		rate_limit_mode String DEFAULT '',
+		rate_limit_bucket String DEFAULT '{}',
+		rate_limit_matched String DEFAULT '[]'
 	) ENGINE = MergeTree()
 	ORDER BY (namespace, timestamp_ms, request_id)`, entryRecordsTable)
 
@@ -375,6 +398,16 @@ func (l *clickhouseListRequestsBuilder) WithLabelSelector(selector string) (List
 		return nil, err
 	}
 	return l, nil
+}
+
+func (l *clickhouseListRequestsBuilder) WithResponseSource(s ResponseSource) ListRequestBuilder {
+	l.sqlListRequestsBuilder.WithResponseSource(s)
+	return l
+}
+
+func (l *clickhouseListRequestsBuilder) WithRateLimitId(id apid.ID) ListRequestBuilder {
+	l.sqlListRequestsBuilder.WithRateLimitId(id)
+	return l
 }
 
 var _ ListRequestExecutor = (*clickhouseListRequestsBuilder)(nil)

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -93,12 +93,29 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 			"request_cancelled",
 			"full_request_recorded",
 			"labels",
+			"response_source",
+			"rate_limit_id",
+			"rate_limit_mode",
+			"rate_limit_bucket",
+			"rate_limit_matched",
 		)
 
 	for _, record := range records {
 		labelsVal, _ := record.Labels.Value()
 		if labelsVal == nil {
 			labelsVal = "{}"
+		}
+		source := record.ResponseSource
+		if source == "" {
+			source = ResponseSourceUpstream
+		}
+		bucketJSON, err := marshalRateLimitBucket(record.RateLimitBucket)
+		if err != nil {
+			return fmt.Errorf("failed to marshal rate-limit bucket: %w", err)
+		}
+		matchedJSON, err := marshalRateLimitMatched(record.RateLimitMatched)
+		if err != nil {
+			return fmt.Errorf("failed to marshal rate-limit matched: %w", err)
 		}
 		builder = builder.Values(
 			record.RequestId.String(),
@@ -126,6 +143,11 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 			record.RequestCancelled,
 			record.FullRequestRecorded,
 			labelsVal,
+			string(source),
+			record.RateLimitId.String(),
+			record.RateLimitMode,
+			bucketJSON,
+			matchedJSON,
 		)
 	}
 
@@ -215,12 +237,16 @@ var entryRecordColumns = []string{
 	"response_http_version", "response_size_bytes", "response_mime_type",
 	"internal_timeout", "request_cancelled", "full_request_recorded",
 	"labels",
+	"response_source", "rate_limit_id", "rate_limit_mode",
+	"rate_limit_bucket", "rate_limit_matched",
 }
 
 func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error) {
 	er := &LogRecord{}
 	var requestId, connectionId, connectorId string
 	var timestampMs, durationMs int64
+	var responseSource, rateLimitId, rateLimitMode string
+	var rateLimitBucket, rateLimitMatched []byte
 
 	err := row.Scan(
 		&requestId, &er.Namespace, &er.Type, &er.CorrelationId, &timestampMs,
@@ -231,6 +257,8 @@ func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error)
 		&er.ResponseHttpVersion, &er.ResponseSizeBytes, &er.ResponseMimeType,
 		&er.InternalTimeout, &er.RequestCancelled, &er.FullRequestRecorded,
 		&er.Labels,
+		&responseSource, &rateLimitId, &rateLimitMode,
+		&rateLimitBucket, &rateLimitMatched,
 	)
 	if err != nil {
 		return nil, err
@@ -241,6 +269,19 @@ func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error)
 	er.ConnectorId = apid.ID(connectorId)
 	er.Timestamp = time.Unix(0, timestampMs*int64(time.Millisecond)).In(time.UTC)
 	er.MillisecondDuration = MillisecondDuration(time.Duration(durationMs) * time.Millisecond)
+
+	if responseSource == "" {
+		responseSource = string(ResponseSourceUpstream)
+	}
+	er.ResponseSource = ResponseSource(responseSource)
+	er.RateLimitId = apid.ID(rateLimitId)
+	er.RateLimitMode = rateLimitMode
+	if bucket, err := unmarshalRateLimitBucket(rateLimitBucket); err == nil {
+		er.RateLimitBucket = bucket
+	}
+	if matched, err := unmarshalRateLimitMatched(rateLimitMatched); err == nil {
+		er.RateLimitMatched = matched
+	}
 
 	return er, nil
 }
@@ -433,6 +474,16 @@ func (l *sqlListRequestsBuilder) WithLabelSelector(selector string) (ListRequest
 	return l, nil
 }
 
+func (l *sqlListRequestsBuilder) WithResponseSource(s ResponseSource) ListRequestBuilder {
+	l.ListFilters.SetResponseSource(s)
+	return l
+}
+
+func (l *sqlListRequestsBuilder) WithRateLimitId(id apid.ID) ListRequestBuilder {
+	l.ListFilters.SetRateLimitId(id)
+	return l
+}
+
 func (l *sqlListRequestsBuilder) buildQuery() sq.SelectBuilder {
 	builder := sq.Select(entryRecordColumns...).
 		From(entryRecordsTable).
@@ -516,6 +567,14 @@ func (l *sqlListRequestsBuilder) buildQuery() sq.SelectBuilder {
 		if err == nil && len(selector) > 0 {
 			builder = selector.ApplyToSqlBuilderWithProvider(builder, "labels", l.provider)
 		}
+	}
+
+	if l.ResponseSource != nil {
+		builder = builder.Where(sq.Eq{"response_source": *l.ResponseSource})
+	}
+
+	if l.RateLimitId != nil {
+		builder = builder.Where(sq.Eq{"rate_limit_id": l.RateLimitId.String()})
 	}
 
 	// Order by

--- a/internal/request_log/request_info.go
+++ b/internal/request_log/request_info.go
@@ -1,6 +1,8 @@
 package request_log
 
 import (
+	"context"
+
 	"github.com/rmorlok/authproxy/internal/httpf"
 )
 
@@ -16,4 +18,43 @@ func SetLogRecordFieldsFromRequestInfo(er *LogRecord, ri httpf.RequestInfo) {
 	er.ConnectorVersion = ri.ConnectorVersion
 	er.ConnectionId = ri.ConnectionId
 	er.Labels = ri.Labels
+}
+
+// ApplyAttributionToLogRecord stamps the LogRecord with whatever the
+// proxy stack recorded on the request context — the response source
+// plus, when a rate-limit resource matched, the rule id / mode / bucket
+// / full match set. When no attribution was installed (older code paths
+// or non-proxy traffic), defaults the source to ResponseSourceUpstream
+// so the column is always populated.
+//
+// Designed as a separate call from SetLogRecordFieldsFromRequestInfo so
+// the existing signature isn't disturbed; the request-log round-tripper
+// invokes both in sequence.
+func ApplyAttributionToLogRecord(er *LogRecord, ctx context.Context) {
+	attr := AttributionFromContext(ctx)
+	if attr == nil {
+		if er.ResponseSource == "" {
+			er.ResponseSource = ResponseSourceUpstream
+		}
+		return
+	}
+
+	if attr.Source != "" {
+		er.ResponseSource = attr.Source
+	} else if er.ResponseSource == "" {
+		er.ResponseSource = ResponseSourceUpstream
+	}
+
+	if !attr.RateLimitId.IsNil() {
+		er.RateLimitId = attr.RateLimitId
+	}
+	if attr.RateLimitMode != "" {
+		er.RateLimitMode = attr.RateLimitMode
+	}
+	if len(attr.RateLimitBucket) > 0 {
+		er.RateLimitBucket = attr.RateLimitBucket
+	}
+	if len(attr.RateLimitMatched) > 0 {
+		er.RateLimitMatched = attr.RateLimitMatched
+	}
 }

--- a/internal/request_log/roundtripper.go
+++ b/internal/request_log/roundtripper.go
@@ -25,6 +25,14 @@ type RoundTripper struct {
 // RoundTrip implements the http.RoundTripper interface
 func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
+	// Install an Attribution on the request context so inner middlewares
+	// (e.g. the connector-level reactive 429 limiter) can stamp who
+	// produced the response. We share the pointer with this round-tripper
+	// so we read the same struct on the way back out — see attribution.go.
+	if AttributionFromContext(ctx) == nil {
+		ctx = ContextWithAttribution(ctx, &Attribution{})
+		req = req.WithContext(ctx)
+	}
 	// Create a context that won't be cancelled when the request completes, for use in async
 	// goroutines that store logs after the round trip returns. This preserves context values
 	// (correlation ID, clock, etc.) but prevents "context canceled" errors.
@@ -123,6 +131,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 			record := full_log.ToRecord()
 			SetLogRecordFieldsFromRequestInfo(record, t.requestInfo)
+			ApplyAttributionToLogRecord(record, ctx)
 
 			err = t.store.StoreRecord(asyncCtx, record)
 			if err != nil {
@@ -216,6 +225,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		record := full_log.ToRecord()
 		SetLogRecordFieldsFromRequestInfo(record, t.requestInfo)
+		ApplyAttributionToLogRecord(record, ctx)
 
 		if err := t.store.StoreRecord(asyncCtx, record); err != nil {
 			t.logger.Error("error storing HTTP log record", "error", err, "entry_id", full_log.Id.String(), "correlation_id", full_log.CorrelationID)

--- a/internal/routes/request_log.go
+++ b/internal/routes/request_log.go
@@ -43,6 +43,8 @@ type ListRequestsQuery struct {
 	Path                     *string  `form:"path"`
 	PathRegex                *string  `form:"path_regex"`
 	LabelSelector            *string  `form:"label_selector"`
+	ResponseSource           *string  `form:"response_source"`
+	RateLimitId              *apid.ID `form:"rate_limit_id" swaggertype:"string"`
 }
 
 func (q *ListRequestsQuery) ApplyToBuilder(
@@ -122,6 +124,18 @@ func (q *ListRequestsQuery) ApplyToBuilder(
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if q.ResponseSource != nil {
+		src := request_log.ResponseSource(*q.ResponseSource)
+		if !request_log.IsValidResponseSource(src) {
+			return nil, httperr.BadRequestf("invalid response_source %q", *q.ResponseSource)
+		}
+		b = b.WithResponseSource(src)
+	}
+
+	if q.RateLimitId != nil {
+		b = b.WithRateLimitId(*q.RateLimitId)
 	}
 
 	return b, nil

--- a/sdks/js/src/requests.ts
+++ b/sdks/js/src/requests.ts
@@ -10,6 +10,28 @@ export enum RequestType {
     PUBLIC = 'public',
 }
 
+// Identifies who produced the response captured by a RequestEntryRecord.
+// "upstream" is the historical default and means the response (including
+// any 429) came from the 3rd-party. "connector_rate_limiter" means the
+// connector-level reactive 429 limiter short-circuited the request before
+// reaching the 3rd party. "rate_limit" means a proxy-side RateLimit
+// resource matched and rejected the request.
+export enum ResponseSource {
+    UPSTREAM = 'upstream',
+    CONNECTOR_RATE_LIMITER = 'connector_rate_limiter',
+    RATE_LIMIT = 'rate_limit',
+}
+
+// A single rate-limit rule that matched a request. The full set of
+// matches is stored on RequestEntryRecord.rate_limit_matched so observers
+// can see every rule that contributed to the decision, not just the one
+// that ultimately rejected the request.
+export interface RateLimitMatch {
+    id: string; // The ID of the rate-limit resource that matched
+    mode: string; // 'enforce' or 'observe'
+    bucket?: Record<string, string>; // Resolved bucket dimensions (dimension name → value)
+}
+
 // RequestEntryRecord is the log data recorded for every request. It does not contain header and body data,
 // which is only conditionally recorded.
 export interface RequestEntryRecord {
@@ -38,6 +60,17 @@ export interface RequestEntryRecord {
     request_cancelled?: boolean; // If the caller cancelled the request before the full body was consumed
     full_request_recorded?: boolean; // If the full request body was recorded; This means you may be able to get the full request
     labels?: Record<string, string>; // Labels associated with the request (merged from connection and per-request labels)
+
+    // Rate-limit attribution. Defaults to ResponseSource.UPSTREAM for any
+    // request that was not short-circuited by a rate limiter. The
+    // rate_limit_* fields are populated when a proxy-side RateLimit
+    // resource matched the request — they remain empty for upstream and
+    // connector_rate_limiter responses.
+    response_source?: ResponseSource;
+    rate_limit_id?: string; // ID of the RateLimit resource that fired (when response_source = rate_limit)
+    rate_limit_mode?: string; // 'enforce' or 'observe' (when response_source = rate_limit)
+    rate_limit_bucket?: Record<string, string>; // Resolved bucket dimensions for the firing rule
+    rate_limit_matched?: RateLimitMatch[]; // Full set of rate-limit rules that matched this request
 }
 
 // RequestEntry is the full data for a single request. It contains header and body data.
@@ -94,6 +127,8 @@ export interface ListRequestsParams {
     timestamp_range?: string;
     path?: string;
     path_regex?: string; // Changed to string to match Go's format
+    response_source?: ResponseSource; // Filter by who produced the response
+    rate_limit_id?: string; // Filter for entries that fired a specific RateLimit resource
 }
 
 /**

--- a/ui/admin/src/pages/Requests.tsx
+++ b/ui/admin/src/pages/Requests.tsx
@@ -57,12 +57,12 @@ export const columns: (GridColDef<RequestEntryRecord> & {hideInitial?: boolean})
         description: 'who produced the response (upstream / connector rate limiter / rate limit resource)',
         sortable: true,
         renderCell: (params) => {
-            const v = (params.value as string) || 'upstream';
-            const label = v === 'upstream' ? 'upstream'
-                : v === 'connector_rate_limiter' ? 'connector RL'
-                : v === 'rate_limit' ? 'rate limit'
+            const v = (params.value as ResponseSource) || ResponseSource.UPSTREAM;
+            const label = v === ResponseSource.UPSTREAM ? 'upstream'
+                : v === ResponseSource.CONNECTOR_RATE_LIMITER ? 'connector RL'
+                : v === ResponseSource.RATE_LIMIT ? 'rate limit'
                 : v;
-            const color = v === 'upstream' ? 'default' : 'warning';
+            const color = v === ResponseSource.UPSTREAM ? 'default' : 'warning';
             return <Chip label={label} size="small" color={color as any} variant="outlined" />;
         },
     },

--- a/ui/admin/src/pages/Requests.tsx
+++ b/ui/admin/src/pages/Requests.tsx
@@ -12,8 +12,10 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import {
     ListResponse, RequestEntryRecord,
-    RequestType, ListRequestsParams, listRequests
+    RequestType, ResponseSource, ListRequestsParams, listRequests
 } from '@authproxy/api';
+import { Link as RouterLink } from 'react-router-dom';
+import Link from '@mui/material/Link';
 import dayjs from 'dayjs';
 import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
@@ -45,6 +47,50 @@ export const columns: (GridColDef<RequestEntryRecord> & {hideInitial?: boolean})
         sortable: true,
         align: 'center',
         renderCell: (params) => (<HttpStatusChip value={params.value} />),
+    },
+    {
+        // Visible by default — tells operators at a glance whether a 429
+        // came from the 3rd party or from one of authproxy's own rate
+        // limiters.
+        field: 'response_source',
+        headerName: 'Source',
+        description: 'who produced the response (upstream / connector rate limiter / rate limit resource)',
+        sortable: true,
+        renderCell: (params) => {
+            const v = (params.value as string) || 'upstream';
+            const label = v === 'upstream' ? 'upstream'
+                : v === 'connector_rate_limiter' ? 'connector RL'
+                : v === 'rate_limit' ? 'rate limit'
+                : v;
+            const color = v === 'upstream' ? 'default' : 'warning';
+            return <Chip label={label} size="small" color={color as any} variant="outlined" />;
+        },
+    },
+    {
+        // Hidden by default — only meaningful for the small fraction of
+        // requests where a rate-limit resource fired. When present, link
+        // to the rate-limiter detail page so operators can jump straight
+        // to the rule that produced the 429.
+        field: 'rate_limit_id',
+        headerName: 'Rate Limit',
+        description: 'ID of the rate-limit resource that fired (if any)',
+        sortable: true,
+        hideInitial: true,
+        minWidth: 220,
+        renderCell: (params) => {
+            const id = params.value as string;
+            if (!id) return null;
+            return (
+                <Link
+                    component={RouterLink}
+                    to={`/rate-limits/${id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    underline="hover"
+                >
+                    {id}
+                </Link>
+            );
+        },
     },
     {
         field: 'type',


### PR DESCRIPTION
## Summary

Closes #222. Sixth of the eight sub-issues under #3. Mostly independent of the other rate-limit PRs except where it stamps fields they will populate.

Adds attribution fields to the request log so every 429 records its source — closing the existing gap where the connector-level reactive limiter's synthetic 429s were indistinguishable from real upstream ones, and reserving a value for the proxy-side rate-limit resource enforcement (#223).

## What's in

**LogRecord schema additions**
- \`ResponseSource\` enum: \`upstream\` (default) | \`connector_rate_limiter\` | \`rate_limit\`. The \`rate_limit\` value is reserved here; population happens in #223.
- \`RateLimitId\`, \`RateLimitMode\` (\`enforce\`|\`observe\`), \`RateLimitBucket\` (resolved dimension → value map), and \`RateLimitMatched\` (full match set as a list of \`{id, mode, bucket}\`). Populated by the proxy-side rate-limit enforcement (#223); the connector-level reactive limiter does not populate these (it has no rule id).

**Plumbing — context-shared Attribution pointer**
- \`internal/request_log/attribution.go\` — \`ResponseSource\` constants + \`IsValidResponseSource\`, \`RateLimitMatch\` struct, \`Attribution\` struct + context helpers. Pointer is shared across the round-tripper chain so inner middlewares mutate the same struct that the outer log-writer reads on the way back.
- request-log RoundTripper installs an empty Attribution on the request context if one isn't already present, then calls \`ApplyAttributionToLogRecord(ctx)\` after \`SetLogRecordFieldsFromRequestInfo\` so the LogRecord is populated regardless of which middleware stamped attribution.
- ratelimit RoundTripper writes \`Source=connector_rate_limiter\` on the synthetic-429 short-circuit. Real upstream 429s leave the Attribution alone — they fall through to the default \`upstream\`.

**Storage**
- Migrations \`000002\` for postgres and sqlite. New columns: \`response_source TEXT NOT NULL DEFAULT 'upstream'\`, \`rate_limit_id\` / \`rate_limit_mode\` TEXT, \`rate_limit_bucket\` / \`rate_limit_matched\` JSON. Indexes on \`response_source\` and (\`rate_limit_id\` where non-empty).
- ClickHouse \`Migrate()\` DDL extended with the same columns.
- SQL + ClickHouse insert paths and scan path round-trip the new fields. Bucket and Matched marshal via \`attribution_codec.go\` which treats nil/empty as \`{}\` / \`[]\` so the columns always hold valid JSON.

**List filters**
- \`ListFilters\` gains \`ResponseSource\` + \`RateLimitId\`; \`SetX\` setters and \`WithX\` builder methods on the public \`ListRequestBuilder\` interface.
- SQL + ClickHouse + Mock builders all forward to the SQL \`buildQuery()\` that emits \`sq.Eq\` filters.
- \`ListRequestsQuery\` in routes binds \`response_source\` and \`rate_limit_id\` form params; \`ApplyToBuilder\` validates \`response_source\` against the enum.

## Notes for the reviewer

- **Why a context-pointer instead of a header**: stamping a header on the synthetic response (e.g., extending the existing \`X-Authproxy-Ratelimited: true\`) would also work for distinguishing connector_rate_limiter from upstream, but the rate-limit resource enforcement (#223) needs to convey rich data (rule id, bucket map, full match set) that doesn't belong on the wire. A pointer in the context handles both cases uniformly.
- **Default backfill**: existing rows get \`response_source = 'upstream'\` via the \`NOT NULL DEFAULT\` migration. New writes always set it explicitly via \`ApplyAttributionToLogRecord\`, which falls back to upstream when no attribution was installed.
- **No behavioural change to non-429 responses**: a successful 200 sees \`response_source = upstream\` (the default). Existing entries keep validating.

## Test plan

- [x] \`go test ./internal/request_log/ ./internal/ratelimit/\` — 9 + 2 new sub-tests pass
- [x] \`go test ./...\` — full repo green
- [x] \`./scripts/preflight.sh\` — clean

## Out of scope (later sub-issues)

- Proxy-path enforcement (#223 — populates the \`rate_limit\` source value + the RateLimit* fields)
- Terraform \`authproxy_rate_limit\` resource (#224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)