### PR TITLE
Add AuthApiKey placement schema with validation (#250)

### DIFF
--- a/internal/schema/connectors/auth_api_key.go
+++ b/internal/schema/connectors/auth_api_key.go
@@ -1,7 +1,57 @@
 package connectors
 
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// ApiKeyPlacementType identifies how a connector's API key (and optional username for
+// basic auth) is applied to outbound proxied requests.
+type ApiKeyPlacementType string
+
+const (
+	ApiKeyPlacementBearer = ApiKeyPlacementType("bearer")
+	ApiKeyPlacementHeader = ApiKeyPlacementType("header")
+	ApiKeyPlacementQuery  = ApiKeyPlacementType("query")
+	ApiKeyPlacementBasic  = ApiKeyPlacementType("basic")
+)
+
+// ApiKeyPlacement declares how the API key is sent on outbound requests. Exactly one
+// placement variant must be configured; the runtime injects credentials accordingly.
+type ApiKeyPlacement struct {
+	// Type selects the placement variant. Required.
+	Type ApiKeyPlacementType `json:"type" yaml:"type"`
+
+	// HeaderName is the HTTP header to set when Type == header. Required for header.
+	HeaderName string `json:"header_name,omitempty" yaml:"header_name,omitempty"`
+
+	// Prefix is an optional literal prepended to the key value when Type == header.
+	// e.g. "Token " produces a header value of "Token <key>".
+	Prefix string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+
+	// ParamName is the URL query parameter name when Type == query. Required for query.
+	ParamName string `json:"param_name,omitempty" yaml:"param_name,omitempty"`
+
+	// UsernameField is the name of the user-supplied form field that holds the username
+	// (or account-id-like value) paired with the api key when Type == basic. Required
+	// for basic. The proxy base64-encodes "<username>:<key>" for the Authorization
+	// header; the user is never asked for the encoded form directly.
+	UsernameField string `json:"username_field,omitempty" yaml:"username_field,omitempty"`
+}
+
+func (p *ApiKeyPlacement) Clone() *ApiKeyPlacement {
+	if p == nil {
+		return nil
+	}
+
+	clone := *p
+	return &clone
+}
+
+// AuthApiKey describes an API-key-authenticated connector.
 type AuthApiKey struct {
-	Type AuthType `json:"type" yaml:"type"`
+	Type      AuthType         `json:"type" yaml:"type"`
+	Placement *ApiKeyPlacement `json:"placement" yaml:"placement"`
 }
 
 func (a *AuthApiKey) GetType() AuthType {
@@ -14,7 +64,113 @@ func (a *AuthApiKey) Clone() AuthImpl {
 	}
 
 	clone := *a
+	clone.Placement = a.Placement.Clone()
 	return &clone
 }
 
+// Validate enforces the api-key schema invariants:
+//   - placement is required;
+//   - placement.type is one of bearer / header / query / basic;
+//   - placement-type-specific required fields are present and well-formed;
+//   - fields that don't apply to the chosen placement type are rejected (catches typos).
+func (a *AuthApiKey) Validate(vc *common.ValidationContext) error {
+	if a == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+
+	if a.Placement == nil {
+		result = multierror.Append(result, vc.NewErrorfForField("placement", "is required"))
+		return result.ErrorOrNil()
+	}
+
+	pvc := vc.PushField("placement")
+
+	switch a.Placement.Type {
+	case ApiKeyPlacementBearer:
+		// no further fields required
+	case ApiKeyPlacementHeader:
+		if a.Placement.HeaderName == "" {
+			result = multierror.Append(result, pvc.NewErrorfForField("header_name", "is required when placement.type is %q", ApiKeyPlacementHeader))
+		} else if !isValidHttpHeaderFieldName(a.Placement.HeaderName) {
+			result = multierror.Append(result, pvc.NewErrorfForField("header_name", "%q is not a valid HTTP header name", a.Placement.HeaderName))
+		}
+	case ApiKeyPlacementQuery:
+		if a.Placement.ParamName == "" {
+			result = multierror.Append(result, pvc.NewErrorfForField("param_name", "is required when placement.type is %q", ApiKeyPlacementQuery))
+		} else if !isValidUrlQueryParamName(a.Placement.ParamName) {
+			result = multierror.Append(result, pvc.NewErrorfForField("param_name", "%q is not a valid URL query parameter name", a.Placement.ParamName))
+		}
+	case ApiKeyPlacementBasic:
+		if a.Placement.UsernameField == "" {
+			result = multierror.Append(result, pvc.NewErrorfForField("username_field", "is required when placement.type is %q", ApiKeyPlacementBasic))
+		}
+	case "":
+		result = multierror.Append(result, pvc.NewErrorfForField("type", "is required"))
+	default:
+		result = multierror.Append(result, pvc.NewErrorfForField("type",
+			"%q is not a valid api-key placement type; must be one of %q, %q, %q, %q",
+			a.Placement.Type,
+			ApiKeyPlacementBearer, ApiKeyPlacementHeader, ApiKeyPlacementQuery, ApiKeyPlacementBasic,
+		))
+	}
+
+	if a.Placement.Type != ApiKeyPlacementHeader {
+		if a.Placement.HeaderName != "" {
+			result = multierror.Append(result, pvc.NewErrorfForField("header_name", "is only valid when placement.type is %q", ApiKeyPlacementHeader))
+		}
+		if a.Placement.Prefix != "" {
+			result = multierror.Append(result, pvc.NewErrorfForField("prefix", "is only valid when placement.type is %q", ApiKeyPlacementHeader))
+		}
+	}
+	if a.Placement.Type != ApiKeyPlacementQuery && a.Placement.ParamName != "" {
+		result = multierror.Append(result, pvc.NewErrorfForField("param_name", "is only valid when placement.type is %q", ApiKeyPlacementQuery))
+	}
+	if a.Placement.Type != ApiKeyPlacementBasic && a.Placement.UsernameField != "" {
+		result = multierror.Append(result, pvc.NewErrorfForField("username_field", "is only valid when placement.type is %q", ApiKeyPlacementBasic))
+	}
+
+	return result.ErrorOrNil()
+}
+
 var _ AuthImpl = (*AuthApiKey)(nil)
+var _ AuthValidator = (*AuthApiKey)(nil)
+
+// isValidHttpHeaderFieldName reports whether s is a valid HTTP field-name per RFC 7230,
+// which restricts names to a token: 1*tchar.
+func isValidHttpHeaderFieldName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isTchar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidUrlQueryParamName uses the same RFC 7230 token rule as headers — conservative
+// but covers all common API conventions (alphanumeric plus a small set of symbols) and
+// guarantees the value can be emitted into a URL query without escaping.
+func isValidUrlQueryParamName(s string) bool {
+	return isValidHttpHeaderFieldName(s)
+}
+
+// isTchar reports whether c is an RFC 7230 tchar.
+func isTchar(c byte) bool {
+	switch {
+	case c >= '0' && c <= '9':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return false
+}

--- a/internal/schema/connectors/auth_api_key_test.go
+++ b/internal/schema/connectors/auth_api_key_test.go
@@ -1,0 +1,371 @@
+package connectors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAuthApiKey_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *AuthApiKey
+		yaml string
+	}{
+		{
+			name: "bearer",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type: ApiKeyPlacementBearer,
+				},
+			},
+			yaml: `
+				type: api-key
+				placement:
+					type: bearer
+`,
+		},
+		{
+			name: "header with prefix",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "Authorization",
+					Prefix:     "Token ",
+				},
+			},
+			yaml: `
+				type: api-key
+				placement:
+					type: header
+					header_name: Authorization
+					prefix: 'Token '
+`,
+		},
+		{
+			name: "header without prefix",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "X-API-Key",
+				},
+			},
+			yaml: `
+				type: api-key
+				placement:
+					type: header
+					header_name: X-API-Key
+`,
+		},
+		{
+			name: "query",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:      ApiKeyPlacementQuery,
+					ParamName: "appid",
+				},
+			},
+			yaml: `
+				type: api-key
+				placement:
+					type: query
+					param_name: appid
+`,
+		},
+		{
+			name: "basic",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:          ApiKeyPlacementBasic,
+					UsernameField: "account_id",
+				},
+			},
+			yaml: `
+				type: api-key
+				placement:
+					type: basic
+					username_field: account_id
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("yaml", func(t *testing.T) {
+				wrapper := &Auth{InnerVal: tt.auth}
+				data, err := yaml.Marshal(wrapper)
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					util.TabsToSpaces(util.Deindent(tt.yaml), 4),
+					util.TabsToSpaces(util.Deindent(string(data)), 4),
+				)
+				back := &Auth{}
+				require.NoError(t, yaml.Unmarshal(data, back))
+				require.Equal(t, tt.auth, back.Inner())
+			})
+			t.Run("json", func(t *testing.T) {
+				wrapper := &Auth{InnerVal: tt.auth}
+				data, err := json.Marshal(wrapper)
+				require.NoError(t, err)
+				back := &Auth{}
+				require.NoError(t, json.Unmarshal(data, back))
+				require.Equal(t, tt.auth, back.Inner())
+			})
+		})
+	}
+}
+
+func TestAuthApiKey_Clone(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var a *AuthApiKey
+		require.Nil(t, a.Clone())
+	})
+
+	t.Run("deep copy of placement", func(t *testing.T) {
+		orig := &AuthApiKey{
+			Type: AuthTypeAPIKey,
+			Placement: &ApiKeyPlacement{
+				Type:       ApiKeyPlacementHeader,
+				HeaderName: "X-API-Key",
+				Prefix:     "Token ",
+			},
+		}
+
+		clone := orig.Clone().(*AuthApiKey)
+		require.Equal(t, orig, clone)
+		require.NotSame(t, orig.Placement, clone.Placement)
+
+		clone.Placement.HeaderName = "X-Other"
+		require.Equal(t, "X-API-Key", orig.Placement.HeaderName)
+	})
+
+	t.Run("nil placement", func(t *testing.T) {
+		orig := &AuthApiKey{Type: AuthTypeAPIKey}
+		clone := orig.Clone().(*AuthApiKey)
+		require.Equal(t, orig, clone)
+		require.Nil(t, clone.Placement)
+	})
+}
+
+func TestAuthApiKey_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		auth        *AuthApiKey
+		wantErrSubs []string
+	}{
+		{
+			name: "nil receiver",
+			auth: nil,
+		},
+		{
+			name: "valid bearer",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{Type: ApiKeyPlacementBearer},
+			},
+		},
+		{
+			name: "valid header",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "X-API-Key",
+				},
+			},
+		},
+		{
+			name: "valid header with prefix",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "Authorization",
+					Prefix:     "Token ",
+				},
+			},
+		},
+		{
+			name: "valid query",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:      ApiKeyPlacementQuery,
+					ParamName: "api_key",
+				},
+			},
+		},
+		{
+			name: "valid basic",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:          ApiKeyPlacementBasic,
+					UsernameField: "account_id",
+				},
+			},
+		},
+		{
+			name: "missing placement",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+			},
+			wantErrSubs: []string{"placement", "is required"},
+		},
+		{
+			name: "missing placement type",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{},
+			},
+			wantErrSubs: []string{"placement.type", "is required"},
+		},
+		{
+			name: "unknown placement type",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{Type: ApiKeyPlacementType("aws-sigv4")},
+			},
+			wantErrSubs: []string{"placement.type", "aws-sigv4", "is not a valid api-key placement type"},
+		},
+		{
+			name: "header missing header_name",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{Type: ApiKeyPlacementHeader},
+			},
+			wantErrSubs: []string{"placement.header_name", "is required"},
+		},
+		{
+			name: "header with invalid header_name (space)",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "X API Key",
+				},
+			},
+			wantErrSubs: []string{"placement.header_name", "is not a valid HTTP header name"},
+		},
+		{
+			name: "header with invalid header_name (newline)",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "X-API\nKey",
+				},
+			},
+			wantErrSubs: []string{"placement.header_name", "is not a valid HTTP header name"},
+		},
+		{
+			name: "query missing param_name",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{Type: ApiKeyPlacementQuery},
+			},
+			wantErrSubs: []string{"placement.param_name", "is required"},
+		},
+		{
+			name: "query with invalid param_name (space)",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:      ApiKeyPlacementQuery,
+					ParamName: "api key",
+				},
+			},
+			wantErrSubs: []string{"placement.param_name", "is not a valid URL query parameter name"},
+		},
+		{
+			name: "basic missing username_field",
+			auth: &AuthApiKey{
+				Type:      AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{Type: ApiKeyPlacementBasic},
+			},
+			wantErrSubs: []string{"placement.username_field", "is required"},
+		},
+		{
+			name: "bearer with stray header_name",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementBearer,
+					HeaderName: "X-API-Key",
+				},
+			},
+			wantErrSubs: []string{"placement.header_name", "is only valid when placement.type is \"header\""},
+		},
+		{
+			name: "bearer with stray prefix",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:   ApiKeyPlacementBearer,
+					Prefix: "Token ",
+				},
+			},
+			wantErrSubs: []string{"placement.prefix", "is only valid when placement.type is \"header\""},
+		},
+		{
+			name: "header with stray param_name",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:       ApiKeyPlacementHeader,
+					HeaderName: "X-API-Key",
+					ParamName:  "api_key",
+				},
+			},
+			wantErrSubs: []string{"placement.param_name", "is only valid when placement.type is \"query\""},
+		},
+		{
+			name: "query with stray username_field",
+			auth: &AuthApiKey{
+				Type: AuthTypeAPIKey,
+				Placement: &ApiKeyPlacement{
+					Type:          ApiKeyPlacementQuery,
+					ParamName:     "api_key",
+					UsernameField: "account_id",
+				},
+			},
+			wantErrSubs: []string{"placement.username_field", "is only valid when placement.type is \"basic\""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.auth.Validate(&common.ValidationContext{})
+			if len(tt.wantErrSubs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			msg := err.Error()
+			for _, sub := range tt.wantErrSubs {
+				assert.Contains(t, msg, sub)
+			}
+		})
+	}
+}
+
+func TestAuthApiKey_ValidatorInterface(t *testing.T) {
+	// Compile-time check kept here as a runtime smoke too.
+	var _ AuthValidator = (*AuthApiKey)(nil)
+	a := &AuthApiKey{
+		Type:      AuthTypeAPIKey,
+		Placement: &ApiKeyPlacement{Type: ApiKeyPlacementBearer},
+	}
+	require.NoError(t, AuthValidator(a).Validate(&common.ValidationContext{}))
+}

--- a/internal/schema/connectors/auth_validator.go
+++ b/internal/schema/connectors/auth_validator.go
@@ -1,0 +1,10 @@
+package connectors
+
+import "github.com/rmorlok/authproxy/internal/schema/common"
+
+// AuthValidator is implemented by Auth concrete types that have schema invariants
+// to enforce. Connector.Validate type-asserts on this interface so an auth type
+// without invariants (e.g. NoAuth) doesn't need to declare an empty Validate.
+type AuthValidator interface {
+	Validate(vc *common.ValidationContext) error
+}

--- a/internal/schema/connectors/schema.json
+++ b/internal/schema/connectors/schema.json
@@ -3,13 +3,53 @@
   "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/connectors/schema.json",
   "$defs": {
     "AuthApiKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
       "properties": {
         "type": {
           "const": "api-key"
+        },
+        "placement": {
+          "$ref": "#/$defs/ApiKeyPlacement"
+        }
+      }
+    },
+    "ApiKeyPlacement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "enum": ["bearer", "header", "query", "basic"]
+        },
+        "header_name": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "param_name": {
+          "type": "string"
+        },
+        "username_field": {
+          "type": "string"
         }
       },
-      "additionalProperties": false,
-      "type": "object"
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "header" } } },
+          "then": { "required": ["header_name"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "query" } } },
+          "then": { "required": ["param_name"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "basic" } } },
+          "then": { "required": ["username_field"] }
+        }
+      ]
     },
     "AuthNoAuth": {
       "properties": {

--- a/internal/schema/connectors/test_data/invalid-api-key-header-no-name.yaml
+++ b/internal/schema/connectors/test_data/invalid-api-key-header-no-name.yaml
@@ -1,0 +1,13 @@
+# $schema: ./schema.json
+
+labels:
+  type: invalid-header-no-name
+display_name: Invalid (header placement missing header_name)
+logo:
+  public_url: https://example.com/x.png
+description: |
+  header placement requires header_name; this file omits it.
+auth:
+  type: api-key
+  placement:
+    type: header

--- a/internal/schema/connectors/test_data/valid-api-key-basic.yaml
+++ b/internal/schema/connectors/test_data/valid-api-key-basic.yaml
@@ -1,0 +1,14 @@
+# $schema: ./schema.json
+
+labels:
+  type: legacy-basic
+display_name: Legacy Basic Auth Service
+logo:
+  public_url: https://example.com/legacy.png
+description: |
+  Service that authenticates via HTTP Basic Auth using an account id and an API key.
+auth:
+  type: api-key
+  placement:
+    type: basic
+    username_field: account_id

--- a/internal/schema/connectors/test_data/valid-api-key-bearer.yaml
+++ b/internal/schema/connectors/test_data/valid-api-key-bearer.yaml
@@ -1,0 +1,13 @@
+# $schema: ./schema.json
+
+labels:
+  type: sendgrid
+display_name: SendGrid
+logo:
+  public_url: https://example.com/sendgrid.png
+description: |
+  Send transactional email through SendGrid.
+auth:
+  type: api-key
+  placement:
+    type: bearer

--- a/internal/schema/connectors/test_data/valid-api-key-header.yaml
+++ b/internal/schema/connectors/test_data/valid-api-key-header.yaml
@@ -1,0 +1,15 @@
+# $schema: ./schema.json
+
+labels:
+  type: openweathermap
+display_name: OpenWeatherMap
+logo:
+  public_url: https://example.com/owm.png
+description: |
+  Weather data via OpenWeatherMap.
+auth:
+  type: api-key
+  placement:
+    type: header
+    header_name: X-API-Key
+    prefix: ""

--- a/internal/schema/connectors/test_data/valid-api-key-query.yaml
+++ b/internal/schema/connectors/test_data/valid-api-key-query.yaml
@@ -1,0 +1,14 @@
+# $schema: ./schema.json
+
+labels:
+  type: openweathermap-query
+display_name: OpenWeatherMap (query key)
+logo:
+  public_url: https://example.com/owm.png
+description: |
+  Weather data with the API key passed as a query parameter.
+auth:
+  type: api-key
+  placement:
+    type: query
+    param_name: appid


### PR DESCRIPTION
Closes #250. Part of #243.

## Summary
- Extends `AuthApiKey` with a `Placement` variant (`bearer`, `header`, `query`, `basic`) plus per-placement fields (`header_name`+`prefix`, `param_name`, `username_field`).
- Adds `AuthApiKey.Validate` enforcing required fields per placement, RFC 7230 token grammar for header/query names, and rejection of stray fields that don't match the chosen placement (catches typos like setting `header_name` under a `bearer` placement).
- Introduces an `AuthValidator` interface so a future `Connector.Validate` wire-up can dispatch by type assertion without forcing `AuthOAuth2`/`AuthNoAuth` to declare empty `Validate` methods.
- Updates `schema.json` with the placement object and per-type required-field rules. `placement` itself is **not** marked required at the JSON-schema layer in this PR — the existing `dev_config/default.yaml` greenhouse stub uses `auth.type: api-key` with no placement, and greenhouse cleanup is owned by #252. Go-level validation enforces presence; #252 will tighten the JSON schema as part of that cleanup.

## What's intentionally NOT in this PR
- `Connector.Validate` does not yet call `AuthValidator.Validate` — wiring it now would break startup validation of the existing greenhouse stub. Both the wire-up and the stub fix belong to #252 (initiate-flow PR).
- Auto-form generation, credential storage, proxy injection — separate sub-issues per #243.

## Test plan
- [x] `go test ./internal/schema/connectors/...` — new `auth_api_key_test.go` covers YAML+JSON round-trip for every placement, `Clone` deep-copy, and validation for every required/forbidden field scenario.
- [x] `Test_SchemaAgainstRealData` picks up four new `valid-api-key-*.yaml` fixtures (one per placement) plus an `invalid-api-key-header-no-name.yaml` fixture exercising the per-type required-field rule.
- [x] `go test ./...` (full module) green.
- [x] `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)