### PR TITLE
OpenTelemetry — Step 2: HTTP server instrumentation for Gin (#231)

### DIFF
--- a/internal/apgin/gin.go
+++ b/internal/apgin/gin.go
@@ -14,12 +14,37 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
+// ServiceOption configures a Gin engine produced by ForService. Pass options
+// constructed via WithTelemetry, etc.
+type ServiceOption func(*serviceOptions)
+
+type serviceOptions struct {
+	telemetry        *aptelemetry.Providers
+	telemetryConfig  *config.Telemetry
+	telemetryService string
+}
+
+// WithTelemetry registers HTTP server instrumentation on the engine using the
+// supplied OTel providers and telemetry config. When the providers are nil or
+// in no-op mode (telemetry disabled), the option is inert and the engine
+// remains identical to one built without it. The serviceID is reported as an
+// attribute on every span and metric point.
+func WithTelemetry(providers *aptelemetry.Providers, cfg *config.Telemetry, serviceID string) ServiceOption {
+	return func(o *serviceOptions) {
+		o.telemetry = providers
+		o.telemetryConfig = cfg
+		o.telemetryService = serviceID
+	}
+}
+
 // ForService creates a Gin engine configured for a production service with
-// debug mode, logging, recovery, and error logging middleware.
-func ForService(service config.Service, logger *slog.Logger, debugMode bool) *gin.Engine {
+// debug mode, logging, recovery, and error logging middleware. Pass
+// WithTelemetry to add OTel instrumentation (server spans + HTTP metrics).
+func ForService(service config.Service, logger *slog.Logger, debugMode bool, opts ...ServiceOption) *gin.Engine {
 	logFormatter := func(param gin.LogFormatterParams) string {
 		var statusColor, methodColor, resetColor string
 		if param.IsOutputColor() {
@@ -43,7 +68,48 @@ func ForService(service config.Service, logger *slog.Logger, debugMode bool) *gi
 	}
 
 	engine := gin.New()
-	engine.Use(DebugModeMiddleware(debugMode), gin.LoggerWithFormatter(logFormatter), gin.Recovery(), ErrorLoggingMiddleware(logger))
+
+	// Build the middleware chain. Telemetry middleware (when enabled) goes
+	// outermost so the server span wraps logging, recovery, and handlers —
+	// and so panics are observable as exception events on the span before
+	// gin.Recovery converts them into 500 responses.
+	chain := []gin.HandlerFunc{}
+
+	o := serviceOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	telemetryEnabled := false
+	if mw, err := newTelemetryMiddleware(o.telemetryService, o.telemetry, o.telemetryConfig); err != nil {
+		// Construction errors at startup are programmer errors (bad meter
+		// names, etc.) — log loudly so they surface immediately rather than
+		// silently dropping instrumentation.
+		if logger != nil {
+			logger.Error("apgin: failed to construct telemetry middleware", "error", err)
+		} else {
+			log.Printf("apgin: failed to construct telemetry middleware: %v", err)
+		}
+	} else if mw != nil {
+		chain = append(chain, mw)
+		telemetryEnabled = true
+	}
+
+	// When telemetry is active, swap gin.Recovery() for one that records the
+	// panic as an exception event on the active span before writing 500.
+	// Same response behaviour either way.
+	recovery := gin.Recovery()
+	if telemetryEnabled {
+		recovery = telemetryRecovery()
+	}
+
+	chain = append(chain,
+		DebugModeMiddleware(debugMode),
+		gin.LoggerWithFormatter(logFormatter),
+		recovery,
+		ErrorLoggingMiddleware(logger),
+	)
+
+	engine.Use(chain...)
 
 	return engine
 }

--- a/internal/apgin/telemetry.go
+++ b/internal/apgin/telemetry.go
@@ -1,0 +1,331 @@
+package apgin
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// telemetryInstrumentationName is the instrumentation scope reported on the
+// emitted spans and metrics. Useful for filtering by source in dashboards.
+const telemetryInstrumentationName = "github.com/rmorlok/authproxy/internal/apgin"
+
+// telemetryMiddleware emits a server span per inbound request plus the
+// standard semconv HTTP server metrics (duration histogram + active requests
+// up-down counter). Errored 5xx responses are recorded on the span along with
+// httperr metadata; panics are recorded as exception events before being
+// re-raised for downstream Recovery middleware to handle.
+//
+// When telemetry is disabled (no providers, providers in no-op mode, or both
+// trace and metric signals turned off), telemetryMiddleware returns a nil
+// gin.HandlerFunc so the caller can skip registration entirely — keeping the
+// hot path zero-cost for unconfigured deployments.
+type telemetryMiddleware struct {
+	tracer         trace.Tracer
+	meter          metric.Meter
+	duration       metric.Float64Histogram
+	activeRequests metric.Int64UpDownCounter
+	excluded       map[string]struct{}
+	tracesEnabled  bool
+	metricsEnabled bool
+	serviceID      string
+}
+
+// newTelemetryMiddleware constructs a request-handling middleware from the
+// supplied providers and config. When the providers are nil/disabled or both
+// the trace and metric signals are off, it returns nil so the caller can skip
+// registration.
+func newTelemetryMiddleware(
+	serviceID string,
+	providers *aptelemetry.Providers,
+	cfg *sconfig.Telemetry,
+) (gin.HandlerFunc, error) {
+	if providers == nil || !providers.Enabled {
+		return nil, nil
+	}
+
+	tracesEnabled := cfg.TracesEnabled()
+	metricsEnabled := cfg.MetricsEnabled()
+	if !tracesEnabled && !metricsEnabled {
+		return nil, nil
+	}
+
+	mw := &telemetryMiddleware{
+		serviceID:      serviceID,
+		tracesEnabled:  tracesEnabled,
+		metricsEnabled: metricsEnabled,
+		excluded:       buildExcludedSet(cfg.GetHTTPExcludedPaths()),
+	}
+
+	if tracesEnabled {
+		mw.tracer = providers.TracerProvider.Tracer(telemetryInstrumentationName)
+	}
+
+	if metricsEnabled {
+		mw.meter = providers.MeterProvider.Meter(telemetryInstrumentationName)
+
+		var err error
+		mw.duration, err = mw.meter.Float64Histogram(
+			"http.server.request.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Duration of HTTP server requests."),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("apgin: create duration histogram: %w", err)
+		}
+
+		mw.activeRequests, err = mw.meter.Int64UpDownCounter(
+			"http.server.active_requests",
+			metric.WithUnit("{request}"),
+			metric.WithDescription("Number of active HTTP server requests."),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("apgin: create active_requests counter: %w", err)
+		}
+	}
+
+	return mw.handle, nil
+}
+
+func buildExcludedSet(paths []string) map[string]struct{} {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+// isExcluded reports whether the request path is on the exclusion list.
+// Matches on the raw URL path (not the route template) so health checks pinned
+// at a specific URL are filtered before route matching has a chance to run.
+func (m *telemetryMiddleware) isExcluded(path string) bool {
+	if len(m.excluded) == 0 {
+		return false
+	}
+	_, ok := m.excluded[path]
+	return ok
+}
+
+// handle is the per-request middleware function. It opens a server span
+// (when traces are enabled), increments the active-requests gauge, defers
+// status / error recording and metric emission, and re-raises any panic so
+// the existing Recovery middleware can render a 500.
+func (m *telemetryMiddleware) handle(c *gin.Context) {
+	if m.isExcluded(c.Request.URL.Path) {
+		c.Next()
+		return
+	}
+
+	req := c.Request
+	startAttrs := startAttributes(c, m.serviceID)
+
+	ctx := req.Context()
+	var span trace.Span
+	if m.tracesEnabled {
+		ctx, span = m.tracer.Start(
+			ctx,
+			"HTTP "+req.Method,
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(startAttrs...),
+		)
+		c.Request = req.WithContext(ctx)
+	}
+
+	if m.metricsEnabled {
+		m.activeRequests.Add(ctx, 1, metric.WithAttributes(activeRequestAttrs(c, m.serviceID)...))
+		defer m.activeRequests.Add(ctx, -1, metric.WithAttributes(activeRequestAttrs(c, m.serviceID)...))
+	}
+
+	start := time.Now()
+
+	// Span finalisation runs after the handler chain returns. Panics are
+	// captured by telemetryRecovery (registered later in the middleware
+	// chain) — by the time finalise runs, the recovery middleware has
+	// already attached the exception event to the active span and set the
+	// response status to 500.
+	defer m.finalise(c, span, start)
+
+	c.Next()
+}
+
+// finalise records the response status, errors, and metric observations
+// after the handler chain has run. Safe to call when traces or metrics are
+// disabled.
+func (m *telemetryMiddleware) finalise(c *gin.Context, span trace.Span, start time.Time) {
+	status := c.Writer.Status()
+	route := routeName(c)
+
+	if span != nil {
+		span.SetAttributes(finishAttributes(status, route)...)
+		recordSpanErrors(span, c, status)
+		span.End()
+	}
+
+	if m.metricsEnabled {
+		m.duration.Record(
+			c.Request.Context(),
+			time.Since(start).Seconds(),
+			metric.WithAttributes(metricAttributes(c, route, status, m.serviceID)...),
+		)
+	}
+}
+
+// telemetryRecovery replaces gin.Recovery() in the middleware chain when
+// telemetry is enabled. It records the panic as an exception event on the
+// active span (started by telemetryMiddleware further out in the chain) and
+// writes a 500 response — same response behaviour as gin.Recovery().
+func telemetryRecovery() gin.HandlerFunc {
+	return gin.CustomRecoveryWithWriter(gin.DefaultErrorWriter, func(c *gin.Context, rec any) {
+		span := trace.SpanFromContext(c.Request.Context())
+		if span.IsRecording() {
+			span.RecordError(panicError(rec), trace.WithStackTrace(true))
+			span.SetStatus(codes.Error, "panic recovered")
+		}
+		c.AbortWithStatus(http.StatusInternalServerError)
+	})
+}
+
+func panicError(rec any) error {
+	if err, ok := rec.(error); ok {
+		return err
+	}
+	return fmt.Errorf("panic: %v", rec)
+}
+
+// startAttributes returns the attribute set known at request start.
+func startAttributes(c *gin.Context, serviceID string) []attribute.KeyValue {
+	req := c.Request
+	attrs := []attribute.KeyValue{
+		semconv.HTTPRequestMethodKey.String(req.Method),
+		semconv.URLPath(req.URL.Path),
+		semconv.URLScheme(schemeFor(req.TLS != nil)),
+	}
+	if proto := req.Proto; proto != "" {
+		attrs = append(attrs, attribute.String("network.protocol.version", proto))
+	}
+	if host := req.Host; host != "" {
+		attrs = append(attrs, semconv.ServerAddress(host))
+	}
+	if ua := req.UserAgent(); ua != "" {
+		attrs = append(attrs, semconv.UserAgentOriginal(ua))
+	}
+	if ip := c.ClientIP(); ip != "" {
+		attrs = append(attrs, semconv.ClientAddress(ip))
+	}
+	if serviceID != "" {
+		attrs = append(attrs, attribute.String("authproxy.service", serviceID))
+	}
+	return attrs
+}
+
+// activeRequestAttrs are a smaller set used for the active-requests counter:
+// keeping cardinality low avoids exploding the gauge by URL path.
+func activeRequestAttrs(c *gin.Context, serviceID string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.HTTPRequestMethodKey.String(c.Request.Method),
+	}
+	if serviceID != "" {
+		attrs = append(attrs, attribute.String("authproxy.service", serviceID))
+	}
+	return attrs
+}
+
+// finishAttributes returns the attribute set known once the handler has
+// returned: the matched route template (if any) and the response status.
+func finishAttributes(status int, route string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.HTTPResponseStatusCode(status),
+	}
+	if route != "" {
+		attrs = append(attrs, semconv.HTTPRoute(route))
+	}
+	return attrs
+}
+
+// metricAttributes for the duration histogram. Limited to bounded-cardinality
+// labels (method, route template, status code, service) to avoid metric
+// explosion by URL path.
+func metricAttributes(c *gin.Context, route string, status int, serviceID string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.HTTPRequestMethodKey.String(c.Request.Method),
+		semconv.HTTPResponseStatusCode(status),
+	}
+	if route != "" {
+		attrs = append(attrs, semconv.HTTPRoute(route))
+	}
+	if serviceID != "" {
+		attrs = append(attrs, attribute.String("authproxy.service", serviceID))
+	}
+	return attrs
+}
+
+// routeName resolves the matched route template for the request. Falls back
+// to the URL path when no route matched (e.g., 404s) so the span still has a
+// useful identifier.
+func routeName(c *gin.Context) string {
+	if fp := c.FullPath(); fp != "" {
+		return fp
+	}
+	return c.Request.URL.Path
+}
+
+func schemeFor(tls bool) string {
+	if tls {
+		return "https"
+	}
+	return "http"
+}
+
+// recordSpanErrors marks the span errored on 5xx and attaches httperr
+// metadata where available. 4xx client errors leave the span status Unset
+// per OpenTelemetry HTTP semantic conventions: client mistakes are not
+// "the server malfunctioned" and should not show up as service errors.
+func recordSpanErrors(span trace.Span, c *gin.Context, status int) {
+	if status < 500 {
+		return
+	}
+
+	span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
+
+	for _, ginErr := range c.Errors {
+		err := ginErr.Err
+		if err == nil {
+			continue
+		}
+
+		var httpErr *httperr.Error
+		if errors.As(err, &httpErr) {
+			attrs := []attribute.KeyValue{
+				attribute.Int("authproxy.httperr.status", httpErr.Status),
+			}
+			if msg := httpErr.ResponseMsgOrDefault(); msg != "" {
+				attrs = append(attrs, attribute.String("authproxy.httperr.response_msg", msg))
+			}
+			span.SetAttributes(attrs...)
+			if httpErr.InternalErr != nil {
+				span.RecordError(httpErr.InternalErr)
+			} else {
+				span.RecordError(httpErr)
+			}
+			continue
+		}
+
+		span.RecordError(err)
+	}
+}
+

--- a/internal/apgin/telemetry_test.go
+++ b/internal/apgin/telemetry_test.go
@@ -1,0 +1,298 @@
+package apgin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// telemetryFixture wires up an OTel SDK with a span recorder + manual metric
+// reader and returns the providers + accessors so tests can introspect
+// emissions without needing a live exporter.
+type telemetryFixture struct {
+	providers *aptelemetry.Providers
+	spans     *tracetest.SpanRecorder
+	reader    *sdkmetric.ManualReader
+}
+
+func newTelemetryFixture(t *testing.T) *telemetryFixture {
+	t.Helper()
+	spans := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spans))
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	})
+
+	return &telemetryFixture{
+		providers: &aptelemetry.Providers{
+			Enabled:        true,
+			TracerProvider: tp,
+			MeterProvider:  mp,
+			Propagator:     propagation.TraceContext{},
+		},
+		spans:  spans,
+		reader: reader,
+	}
+}
+
+// readMetrics collects everything currently observed by the manual reader.
+func (f *telemetryFixture) readMetrics(t *testing.T) metricdata.ResourceMetrics {
+	t.Helper()
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, f.reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+func enabled(b bool) *bool { return &b }
+
+func TestTelemetryMiddleware_EmitsSpanAndMetrics(t *testing.T) {
+	f := newTelemetryFixture(t)
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)}
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/api/v1/things/:id", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"id": c.Param("id")})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/things/abc", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	gotSpans := f.spans.Ended()
+	require.Len(t, gotSpans, 1)
+	span := gotSpans[0]
+
+	require.Equal(t, "HTTP GET", span.Name())
+
+	attrs := attrMap(span.Attributes())
+	require.Equal(t, "/api/v1/things/:id", attrs["http.route"], "route template (not raw path) should be the http.route attribute")
+	require.EqualValues(t, http.StatusOK, attrs["http.response.status_code"])
+	require.Equal(t, http.MethodGet, attrs["http.request.method"])
+	require.Equal(t, "/api/v1/things/abc", attrs["url.path"])
+	require.Equal(t, "api", attrs["authproxy.service"])
+
+	rm := f.readMetrics(t)
+	requireMetric(t, rm, "http.server.request.duration")
+	requireMetric(t, rm, "http.server.active_requests")
+}
+
+func TestTelemetryMiddleware_ExcludesConfiguredPaths(t *testing.T) {
+	f := newTelemetryFixture(t)
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)} // default exclusions: /ping, /healthz
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+	engine.GET("/healthz", func(c *gin.Context) { c.Status(http.StatusOK) })
+	engine.GET("/observed", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for _, p := range []string{"/ping", "/healthz"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		engine.ServeHTTP(rec, req)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/observed", nil)
+	engine.ServeHTTP(rec, req)
+
+	got := f.spans.Ended()
+	require.Len(t, got, 1, "only the non-excluded path should produce a span")
+	require.Equal(t, "/observed", attrMap(got[0].Attributes())["url.path"])
+}
+
+func TestTelemetryMiddleware_ExclusionsConfigurable(t *testing.T) {
+	f := newTelemetryFixture(t)
+
+	// Override: exclude /livez instead of the default /ping + /healthz.
+	cfg := &sconfig.Telemetry{
+		Enabled: enabled(true),
+		HTTP:    &sconfig.TelemetryHTTP{ExcludedPaths: []string{"/livez"}},
+	}
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/livez", func(c *gin.Context) { c.Status(http.StatusOK) })
+	engine.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for _, p := range []string{"/livez", "/ping"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		engine.ServeHTTP(rec, req)
+	}
+
+	got := f.spans.Ended()
+	require.Len(t, got, 1, "only /ping should be observed when /livez is the override")
+	require.Equal(t, "/ping", attrMap(got[0].Attributes())["url.path"])
+}
+
+func TestTelemetryMiddleware_5xxMarksSpanErroredWithHttperrMetadata(t *testing.T) {
+	f := newTelemetryFixture(t)
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)}
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/boom", func(c *gin.Context) {
+		// Mirror the WriteError pattern: attach an httperr to gin's error
+		// stack and write the response. The middleware should pick the
+		// httperr up from c.Errors and project its metadata onto the span.
+		err := httperr.InternalServerError(httperr.WithInternalErr(errors.New("downstream failure")))
+		_ = c.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.ResponseMsgOrDefault()})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	got := f.spans.Ended()
+	require.Len(t, got, 1)
+	span := got[0]
+
+	require.Equal(t, codes.Error, span.Status().Code, "5xx must mark the span errored")
+
+	attrs := attrMap(span.Attributes())
+	require.EqualValues(t, http.StatusInternalServerError, attrs["authproxy.httperr.status"])
+
+	require.NotEmpty(t, span.Events(), "RecordError should emit an exception event")
+}
+
+func TestTelemetryMiddleware_4xxLeavesSpanStatusUnset(t *testing.T) {
+	f := newTelemetryFixture(t)
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)}
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/forbidden", func(c *gin.Context) {
+		c.JSON(http.StatusForbidden, gin.H{})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/forbidden", nil)
+	engine.ServeHTTP(rec, req)
+
+	got := f.spans.Ended()
+	require.Len(t, got, 1)
+	require.Equal(t, codes.Unset, got[0].Status().Code,
+		"4xx client errors must not be reported as service errors")
+}
+
+func TestTelemetryMiddleware_PanicEmitsExceptionEvent(t *testing.T) {
+	f := newTelemetryFixture(t)
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)}
+
+	engine := ForService(stubService{}, nil, false, WithTelemetry(f.providers, cfg, "api"))
+	engine.GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code, "gin.Recovery should still convert panics to 500")
+
+	got := f.spans.Ended()
+	require.Len(t, got, 1)
+	span := got[0]
+
+	require.Equal(t, codes.Error, span.Status().Code, "panic must mark the span errored")
+
+	events := span.Events()
+	require.NotEmpty(t, events, "panic must produce an exception event")
+}
+
+func TestTelemetryMiddleware_NoOpWhenProvidersDisabled(t *testing.T) {
+	disabled := aptelemetry.NoopProviders()
+	cfg := &sconfig.Telemetry{Enabled: enabled(true)} // even though config says enabled, providers report disabled
+
+	mw, err := newTelemetryMiddleware("api", disabled, cfg)
+	require.NoError(t, err)
+	require.Nil(t, mw, "no-op providers must skip middleware registration entirely")
+}
+
+func TestTelemetryMiddleware_NoOpWhenSignalsAllOff(t *testing.T) {
+	f := newTelemetryFixture(t)
+	off := false
+	on := true
+	cfg := &sconfig.Telemetry{
+		Enabled: &on,
+		Signals: &sconfig.TelemetrySignals{Traces: &off, Metrics: &off, Logs: &off},
+	}
+
+	mw, err := newTelemetryMiddleware("api", f.providers, cfg)
+	require.NoError(t, err)
+	require.Nil(t, mw, "with both traces and metrics off there is no work for the middleware")
+}
+
+func TestForService_NoTelemetry_NoOpFastPath(t *testing.T) {
+	// Without WithTelemetry, the engine is identical to the historic build:
+	// no extra middleware and no panic from a nil providers pointer.
+	engine := ForService(stubService{}, nil, false)
+	require.NotNil(t, engine)
+
+	engine.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- helpers -----------------------------------------------------------------
+
+// stubService satisfies config.Service for ForService's signature without
+// pulling in real config. The middleware doesn't read fields from it.
+type stubService struct{}
+
+func (stubService) GetId() sconfig.ServiceId { return sconfig.ServiceIdApi }
+func (stubService) HealthCheckPort() uint64  { return 0 }
+
+// attrMap flattens an attribute slice into a map keyed by string. Convenient
+// for require.Equal assertions on individual attributes.
+func attrMap(kvs []attribute.KeyValue) map[string]any {
+	out := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		out[string(kv.Key)] = kv.Value.AsInterface()
+	}
+	return out
+}
+
+// requireMetric asserts that a metric with the given name was emitted.
+func requireMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return
+			}
+		}
+	}
+	names := []string{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names = append(names, m.Name)
+		}
+	}
+	t.Fatalf("metric %q not emitted; got: %v", name, names)
+}

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -56,7 +56,8 @@ func GetGinServer(
 		logger,
 	)
 
-	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 
 	corsConfig := GetCorsConfig(dm.GetConfig())
 	if corsConfig != nil {
@@ -79,7 +80,8 @@ func GetGinServer(
 
 	var healthChecker *gin.Engine
 	if service.Port() != service.HealthCheckPort() {
-		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 	} else {
 		healthChecker = server
 	}

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -33,7 +33,8 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		dm.GetLogger(),
 	)
 
-	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 
 	corsConfig := root.Api.CorsVal.ToGinCorsConfig(nil)
 	if corsConfig != nil {
@@ -56,7 +57,8 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 
 	var healthChecker *gin.Engine
 	if service.Port() != service.HealthCheckPort() {
-		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 	} else {
 		healthChecker = server
 	}

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -57,11 +57,13 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		dm.GetLogger(),
 	)
 
-	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+	server := apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 
 	var healthChecker *gin.Engine
 	if service.Port() != service.HealthCheckPort() {
-		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode())
+		healthChecker = apgin.ForService(service, logger, dm.GetConfig().IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 	} else {
 		healthChecker = server
 	}

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -35,7 +35,8 @@ func Serve(cfg config.C) {
 	defer dm.ShutdownTelemetry()
 
 	workerConfig := cfg.GetRoot().Worker
-	router := apgin.ForService(&workerConfig, logger, cfg.IsDebugMode())
+	router := apgin.ForService(&workerConfig, logger, cfg.IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
 
 	router.GET("/ping", func(c *gin.Context) {
 		c.PureJSON(http.StatusOK, gin.H{


### PR DESCRIPTION
## Summary

- Adds a server span per inbound request (route template as `http.route`, semconv HTTP server attributes) plus the standard `http.server.request.duration` histogram and `http.server.active_requests` up-down counter on every AuthProxy service.
- Honors `telemetry.http.excluded_paths` from #230's config block (defaults `/ping` and `/healthz`). Excluded requests produce no span or metric observation.
- 5xx responses set span status to Error and attach `httperr` metadata (status, response message); the underlying internal error is recorded via `span.RecordError`. 4xx client errors leave the span status Unset per OTel HTTP semantic conventions.
- Panics are captured as exception events on the active span by a telemetry-aware recovery that replaces `gin.Recovery()` only when instrumentation is active. Same 500 response, just with the panic preserved on the trace.
- Wired via a non-breaking functional option `apgin.WithTelemetry(providers, cfg, serviceID)`. Engines built without the option are byte-for-byte identical to the historic middleware chain. When providers are no-op (telemetry disabled or unconfigured), middleware registration is skipped entirely — zero overhead on the hot path.

## Test plan

- [x] `go test ./internal/apgin/...` — new tests cover: span emitted with `http.route` template, default and configured exclusion lists, 5xx marks span errored + projects `httperr` metadata, 4xx leaves span Unset, panic produces an exception event + 500 response, no-op fast paths (disabled providers, signals all off, no option supplied)
- [x] `./scripts/preflight.sh` passes
- [x] `go test ./...` clean across the whole tree
- [x] `golangci-lint run` clean
- [ ] Manual verification with a live collector (deferred to #239 dev sample, where there's a Grafana stack to actually observe)

Closes #231. Part of the OpenTelemetry project — parent #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)