### PR TITLE
OpenTelemetry — Step 4: outbound trace context propagation, opt-in (#233)

### DIFF
--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -184,6 +184,18 @@ func (c *connection) GetRateLimitConfig() *connectors.RateLimiting {
 	return def.RateLimiting
 }
 
+// PropagateTraceContext returns the per-connector override for outbound W3C
+// trace context injection. nil means "use the global default" from the
+// telemetry config block.
+func (c *connection) PropagateTraceContext() *bool {
+	def := c.cv.GetDefinition()
+	if def == nil || def.Telemetry == nil {
+		return nil
+	}
+	return def.Telemetry.PropagateTraceContext
+}
+
 var _ iface.Connection = (*connection)(nil)
 var _ aplog.HasLogger = (*connection)(nil)
 var _ httpf.RateLimitConfigProvider = (*connection)(nil)
+var _ httpf.TracePropagationProvider = (*connection)(nil)

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -108,6 +108,10 @@ func (f *clientFactory) ForConnection(c Connection) F {
 		ri.RateLimiting = rlp.GetRateLimitConfig()
 	}
 
+	if tpp, ok := c.(TracePropagationProvider); ok {
+		ri.PropagateTraceContext = tpp.PropagateTraceContext()
+	}
+
 	return fp.ForRequestInfo(ri)
 }
 

--- a/internal/httpf/factory_propagation_test.go
+++ b/internal/httpf/factory_propagation_test.go
@@ -1,0 +1,72 @@
+package httpf
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+// connectionWithPropagation is a stubConnection that also implements
+// httpf.TracePropagationProvider — modelling a core.connection whose
+// connector definition specifies telemetry.propagate_trace_context.
+type connectionWithPropagation struct {
+	stubConnection
+	propagate *bool
+}
+
+func (c *connectionWithPropagation) PropagateTraceContext() *bool { return c.propagate }
+
+func TestForConnectionPlumbsPropagationOverride(t *testing.T) {
+	// When the Connection implements TracePropagationProvider, ForConnection
+	// must copy the returned pointer into RequestInfo so downstream
+	// middlewares (telemetryRoundTripper) can resolve the decision against
+	// the global default.
+	yes := true
+	conn := &connectionWithPropagation{
+		stubConnection: stubConnection{
+			id:        apid.MustParse("cxn_test1234567890ab"),
+			namespace: "root.foo",
+			cvID:      apid.MustParse("cxr_test1234567890ab"),
+			cvVersion: 1,
+		},
+		propagate: &yes,
+	}
+
+	f := newTestFactory().ForConnection(conn).(*clientFactory)
+	require.NotNil(t, f.requestInfo.PropagateTraceContext)
+	require.True(t, *f.requestInfo.PropagateTraceContext)
+}
+
+func TestForConnectionLeavesPropagationNilWhenNotProvided(t *testing.T) {
+	// Connections that don't implement TracePropagationProvider, or that
+	// return nil, must produce a nil RequestInfo.PropagateTraceContext —
+	// i.e. "use the global default".
+	conn := &stubConnection{
+		id:        apid.MustParse("cxn_test1234567890ab"),
+		namespace: "root.foo",
+		cvID:      apid.MustParse("cxr_test1234567890ab"),
+		cvVersion: 1,
+	}
+
+	f := newTestFactory().ForConnection(conn).(*clientFactory)
+	require.Nil(t, f.requestInfo.PropagateTraceContext)
+}
+
+func TestForConnectionPropagationOverrideRespectsExplicitFalse(t *testing.T) {
+	// Connections opting OUT (explicit false) must be preserved through to
+	// RequestInfo so the roundtripper can distinguish "use global default"
+	// (nil) from "explicit opt out" (false).
+	no := false
+	conn := &connectionWithPropagation{
+		stubConnection: stubConnection{
+			id:        apid.MustParse("cxn_test1234567890ab"),
+			namespace: "root.foo",
+		},
+		propagate: &no,
+	}
+
+	f := newTestFactory().ForConnection(conn).(*clientFactory)
+	require.NotNil(t, f.requestInfo.PropagateTraceContext)
+	require.False(t, *f.requestInfo.PropagateTraceContext)
+}

--- a/internal/httpf/interface.go
+++ b/internal/httpf/interface.go
@@ -22,6 +22,13 @@ type RateLimitConfigProvider interface {
 	GetRateLimitConfig() *connectors.RateLimiting
 }
 
+// TracePropagationProvider is an optional interface implemented by connections
+// whose connector definition specifies a per-connector override for outbound
+// W3C trace context injection. Return nil to inherit the global default.
+type TracePropagationProvider interface {
+	PropagateTraceContext() *bool
+}
+
 type Connection interface {
 	GetId() apid.ID
 	GetNamespace() string

--- a/internal/httpf/request_info.go
+++ b/internal/httpf/request_info.go
@@ -31,4 +31,11 @@ type RequestInfo struct {
 	// RateLimiting is the rate limiting configuration for the connector, if available.
 	// Nil means use default behavior (enabled with standard Retry-After parsing).
 	RateLimiting *connectors.RateLimiting
+
+	// PropagateTraceContext is the per-connection / per-connector override
+	// for W3C trace context injection on outbound calls. nil means "use the
+	// global default from telemetry.propagation.inject_outbound_default".
+	// Populated by ForConnection from a connection whose connector defines
+	// telemetry.propagate_trace_context.
+	PropagateTraceContext *bool
 }

--- a/internal/httpf/telemetry.go
+++ b/internal/httpf/telemetry.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -49,9 +50,11 @@ func NewTelemetryFactory(providers *aptelemetry.Providers, cfg *sconfig.Telemetr
 	}
 
 	f := &telemetryFactory{
-		tracesEnabled:  tracesEnabled,
-		metricsEnabled: metricsEnabled,
-		projector:      newLabelProjector(cfg.GetProxy()),
+		tracesEnabled:         tracesEnabled,
+		metricsEnabled:        metricsEnabled,
+		projector:             newLabelProjector(cfg.GetProxy()),
+		propagator:            providers.Propagator,
+		injectOutboundDefault: cfg.InjectOutboundDefault(),
 	}
 
 	if tracesEnabled {
@@ -99,6 +102,26 @@ type telemetryFactory struct {
 	requestBodySize  metric.Int64Histogram
 	responseBodySize metric.Int64Histogram
 	projector        *labelProjector
+
+	// propagator is the W3C TraceContext + Baggage composite from the
+	// providers. Always present (even with no-op providers) but only used
+	// when the resolved propagation decision is true.
+	propagator propagation.TextMapPropagator
+	// injectOutboundDefault is the global default for outbound W3C trace
+	// context injection. Per-connection / per-connector overrides on
+	// RequestInfo.PropagateTraceContext take precedence over this default.
+	injectOutboundDefault bool
+}
+
+// shouldPropagate resolves the outbound-injection decision for a given
+// RequestInfo. The per-request override (sourced from the connector's
+// telemetry.propagate_trace_context) wins when present; otherwise the global
+// telemetry.propagation.inject_outbound_default applies.
+func (f *telemetryFactory) shouldPropagate(ri RequestInfo) bool {
+	if ri.PropagateTraceContext != nil {
+		return *ri.PropagateTraceContext
+	}
+	return f.injectOutboundDefault
 }
 
 // NewRoundTripper wraps transport in a roundtripper that emits a span and
@@ -134,6 +157,15 @@ func (rt *telemetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 			trace.WithAttributes(spanAttrs...),
 		)
 		req = req.WithContext(ctx)
+	}
+
+	// Inject W3C trace context onto outbound headers when the resolved
+	// decision is true. Decision priority: per-request override > global
+	// default. Injection is unconditionally a no-op when the active span is
+	// invalid (no provider, sampling drop, etc.), so this is safe to call
+	// even with no-op providers.
+	if rt.factory.propagator != nil && rt.factory.shouldPropagate(rt.requestInfo) {
+		rt.factory.propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
 	}
 
 	start := time.Now()

--- a/internal/httpf/telemetry_propagation_test.go
+++ b/internal/httpf/telemetry_propagation_test.go
@@ -1,0 +1,134 @@
+package httpf
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// TestPropagationDecisionMatrix pins the full {global default, per-connector
+// override} matrix from the spec in #233. Outbound W3C trace context
+// injection is opt-in: it must NOT happen by default, must inject when the
+// global default is true, and the per-connector override always wins.
+func TestPropagationDecisionMatrix(t *testing.T) {
+	cases := []struct {
+		name              string
+		globalDefault     bool
+		perConnector      *bool
+		expectInjected    bool
+	}{
+		{
+			name:           "global default false, no override → no injection (default opt-in case)",
+			globalDefault:  false,
+			perConnector:   nil,
+			expectInjected: false,
+		},
+		{
+			name:           "global default true, no override → injected",
+			globalDefault:  true,
+			perConnector:   nil,
+			expectInjected: true,
+		},
+		{
+			name:           "global default false, per-connector true → injected (opt-in this connector)",
+			globalDefault:  false,
+			perConnector:   ptrBool(true),
+			expectInjected: true,
+		},
+		{
+			name:           "global default true, per-connector false → no injection (opt-out this connector)",
+			globalDefault:  true,
+			perConnector:   ptrBool(false),
+			expectInjected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newTelemetryFixture(t)
+			on := true
+			cfg := &sconfig.Telemetry{
+				Enabled: &on,
+				Propagation: &sconfig.TelemetryPropagation{
+					InjectOutboundDefault: &tc.globalDefault,
+				},
+			}
+
+			factory, err := NewTelemetryFactory(fx.providers, cfg)
+			require.NoError(t, err)
+			require.NotNil(t, factory)
+
+			ri := RequestInfo{
+				Type:                  RequestTypeProxy,
+				PropagateTraceContext: tc.perConnector,
+			}
+			upstream := &stubTransport{status: http.StatusOK, body: "ok"}
+			rt := factory.NewRoundTripper(ri, upstream)
+
+			req := newRequest(t, http.MethodGet, "https://api.example.com/v1/things", "")
+			_, err = rt.RoundTrip(req)
+			require.NoError(t, err)
+
+			tp := upstream.last.Header.Get("traceparent")
+			if tc.expectInjected {
+				require.NotEmpty(t, tp, "traceparent must be injected when the resolved decision is true")
+			} else {
+				require.Empty(t, tp, "traceparent must NOT be injected when the resolved decision is false")
+			}
+		})
+	}
+}
+
+// TestPropagationInheritsIncomingParent verifies the inbound side: when a
+// request arrives at AuthProxy with a traceparent already present in the
+// context (extracted by Gin middleware), the outbound span emitted by the
+// httpf telemetry roundtripper participates in that trace regardless of the
+// outbound injection setting. This pins the spec line:
+//
+//	"Inbound services accept incoming W3C headers via parent-based sampler
+//	regardless of the outbound setting."
+func TestPropagationInheritsIncomingParent(t *testing.T) {
+	fx := newTelemetryFixture(t)
+	on := true
+	off := false
+	// Outbound injection OFF — we should still inherit the inbound parent.
+	cfg := &sconfig.Telemetry{
+		Enabled:     &on,
+		Propagation: &sconfig.TelemetryPropagation{InjectOutboundDefault: &off},
+	}
+
+	factory, err := NewTelemetryFactory(fx.providers, cfg)
+	require.NoError(t, err)
+
+	// Simulate an inbound traceparent arriving on the request and being
+	// extracted into the context — the same shape ginhttp / our gin
+	// middleware would produce.
+	inbound := http.Header{}
+	inbound.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+	parentCtx := propagation.TraceContext{}.Extract(req(t).Context(), propagation.HeaderCarrier(inbound))
+
+	rt := factory.NewRoundTripper(RequestInfo{Type: RequestTypeProxy}, &stubTransport{status: http.StatusOK, body: "ok"})
+	r := newRequest(t, http.MethodGet, "https://api.example.com/v1/things", "")
+	r = r.WithContext(parentCtx)
+	_, err = rt.RoundTrip(r)
+	require.NoError(t, err)
+
+	got := fx.spans.Ended()
+	require.Len(t, got, 1)
+	// The outbound span's trace id must match the inbound traceparent's
+	// trace id, proving the parent was honoured.
+	require.Equal(t, "0af7651916cd43dd8448eb211c80319c", got[0].SpanContext().TraceID().String())
+}
+
+func req(t *testing.T) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, "https://example/", nil)
+	require.NoError(t, err)
+	return r
+}
+
+func ptrBool(b bool) *bool { return &b }

--- a/internal/schema/connectors/connector.go
+++ b/internal/schema/connectors/connector.go
@@ -80,6 +80,10 @@ type Connector struct {
 
 	// Labels are the labels for the connector.
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	// Telemetry carries per-connector overrides for OpenTelemetry behaviour
+	// on outbound calls routed through this connector. See ConnectorTelemetry.
+	Telemetry *ConnectorTelemetry `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 }
 
 func (c *Connector) Clone() *Connector {
@@ -107,6 +111,8 @@ func (c *Connector) Clone() *Connector {
 			clone.Labels[k] = v
 		}
 	}
+
+	clone.Telemetry = c.Telemetry.Clone()
 
 	return &clone
 }

--- a/internal/schema/connectors/schema.json
+++ b/internal/schema/connectors/schema.json
@@ -15,6 +15,15 @@
         }
       }
     },
+    "ConnectorTelemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "propagate_trace_context": {
+          "type": "boolean"
+        }
+      }
+    },
     "ApiKeyPlacement": {
       "type": "object",
       "additionalProperties": false,
@@ -265,6 +274,9 @@
     },
     "setup_flow": {
       "$ref": "#/$defs/SetupFlow"
+    },
+    "telemetry": {
+      "$ref": "#/$defs/ConnectorTelemetry"
     }
   },
   "required": ["labels", "display_name", "logo", "auth"],

--- a/internal/schema/connectors/telemetry.go
+++ b/internal/schema/connectors/telemetry.go
@@ -1,0 +1,32 @@
+package connectors
+
+// ConnectorTelemetry carries per-connector overrides for the OpenTelemetry
+// behaviour applied to outbound calls routed through this connector. The
+// global defaults for these knobs live in the top-level telemetry: config
+// block; values here override the global default for this connector only.
+type ConnectorTelemetry struct {
+	// PropagateTraceContext, when non-nil, sets the per-connector decision
+	// for W3C traceparent / tracestate injection on outbound proxy requests.
+	// Use this to opt a single connector in (true) or out (false) of the
+	// global telemetry.propagation.inject_outbound_default. Leave nil to
+	// inherit the global default.
+	//
+	// Reason this is opt-in by default: third-party services may reject
+	// unknown headers, log them in ways that surface internal trace IDs, or
+	// use them in unexpected ways. Only enable when the destination is
+	// known to handle W3C trace context gracefully.
+	PropagateTraceContext *bool `json:"propagate_trace_context,omitempty" yaml:"propagate_trace_context,omitempty"`
+}
+
+// Clone returns a deep copy. Safe to call on nil.
+func (ct *ConnectorTelemetry) Clone() *ConnectorTelemetry {
+	if ct == nil {
+		return nil
+	}
+	clone := *ct
+	if ct.PropagateTraceContext != nil {
+		v := *ct.PropagateTraceContext
+		clone.PropagateTraceContext = &v
+	}
+	return &clone
+}


### PR DESCRIPTION
## Summary

- W3C \`traceparent\` / \`tracestate\` injection on outbound proxy requests is **opt-in**. Default behaviour: no injection.
- Global default: \`telemetry.propagation.inject_outbound_default\` (default \`false\`), from #230's config block.
- Per-connector override: new \`telemetry.propagate_trace_context\` field on the connector definition (in \`internal/schema/connectors\`). Always takes precedence over the global default. \`true\` opts a connector in, \`false\` opts it out, unset inherits the global default.
- Plumbed through a new optional \`httpf.TracePropagationProvider\` interface. \`core.connection\` implements it by reading from its connector's definition; \`httpf.F.ForConnection\` copies the resolved value onto a new \`RequestInfo.PropagateTraceContext\` field. The telemetry roundtripper from #232 consults the W3C propagator (already on \`aptelemetry.Providers\`) at \`RoundTrip\` time and injects only when the resolved decision is \`true\`.
- Inbound propagation unchanged: services continue to accept incoming W3C headers via the parent-based sampler wired in #230 regardless of the outbound setting.

## Test plan

- [x] \`go test ./internal/httpf/...\` — new tests cover:
  - Full **2×2 outbound decision matrix**: {global false, no override} → no inject; {global true, no override} → inject; {global false, per-connector true} → inject; {global true, per-connector false} → no inject
  - **Inbound parent honoured**: even with outbound injection OFF, an inbound \`traceparent\` flows into the outbound client span's trace ID
  - \`ForConnection\` plumbing: connection implementing \`TracePropagationProvider\` populates \`RequestInfo.PropagateTraceContext\`; non-implementer leaves it nil ("use global default"); explicit \`false\` is preserved through (distinct from nil)
- [x] \`./scripts/preflight.sh\` passes
- [x] \`go test ./...\` clean across the whole tree
- [x] \`golangci-lint run\` clean
- [x] Connector \`schema.json\` updated with the new \`ConnectorTelemetry\` definition + connector property
- [ ] Manual verification with a live collector and a real upstream (deferred to #239 dev sample)

Closes #233. Part of the OpenTelemetry project — parent #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)