### PR TITLE
OpenTelemetry — Step 5: database (SQL) instrumentation (#234)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/Masterminds/squirrel v1.5.4
+	github.com/XSAM/otelsql v0.41.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/aws/aws-sdk-go-v2/config v1.32.9

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/XSAM/otelsql v0.41.0 h1:uZifjQhZhv5EDYJh+IVk1DiYxQZJBlNSen0MBFnfxB8=
+github.com/XSAM/otelsql v0.41.0/go.mod h1:NMQT0PiKoFILp9QgjQz+D5mvW+9mT0suR7OejqrtMaM=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/XSAM/otelsql v0.41.0 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -30,6 +30,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/XSAM/otelsql v0.41.0 h1:uZifjQhZhv5EDYJh+IVk1DiYxQZJBlNSen0MBFnfxB8=
+github.com/XSAM/otelsql v0.41.0/go.mod h1:NMQT0PiKoFILp9QgjQz+D5mvW+9mT0suR7OejqrtMaM=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=

--- a/internal/database/service.go
+++ b/internal/database/service.go
@@ -54,7 +54,7 @@ func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger, opts .
 		defer file.Close()
 	}
 
-	db, err := openInstrumentedDB("sqlite3", dbConfig.GetDsn(), dbSystemSQLite, resolveOpts(opts))
+	db, err := openInstrumentedDB("sqlite3", dbConfig.GetDsn(), DBSystemSQLite, resolveOpts(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite database '%s': %w", dbConfig.GetDsn(), err)
 	}
@@ -74,7 +74,7 @@ func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger, opts .
 
 // NewPostgresConnection creates a new database connection to a Postgres database.
 func NewPostgresConnection(dbConfig *config.DatabasePostgres, l *slog.Logger, opts ...Option) (DB, error) {
-	db, err := openInstrumentedDB("pgx", dbConfig.GetDsn(), dbSystemPostgres, resolveOpts(opts))
+	db, err := openInstrumentedDB("pgx", dbConfig.GetDsn(), DBSystemPostgreSQL, resolveOpts(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open postgres database '%s': %w", dbConfig.GetDsn(), err)
 	}

--- a/internal/database/service.go
+++ b/internal/database/service.go
@@ -18,20 +18,22 @@ import (
 )
 
 // NewConnectionForRoot creates a new database connection from the specified configuration. The type of the database
-// returned will be determined by the configuration. Same as NewConnection.
-func NewConnectionForRoot(root *config.Root, logger *slog.Logger) (DB, error) {
+// returned will be determined by the configuration. Optional Options enable
+// telemetry instrumentation; without them the returned sql.DB is a plain,
+// uninstrumented driver connection identical to the historic behaviour.
+func NewConnectionForRoot(root *config.Root, logger *slog.Logger, opts ...Option) (DB, error) {
 	switch v := root.Database.InnerVal.(type) {
 	case *config.DatabaseSqlite:
-		return NewSqliteConnection(v, logger)
+		return NewSqliteConnection(v, logger, opts...)
 	case *config.DatabasePostgres:
-		return NewPostgresConnection(v, logger)
+		return NewPostgresConnection(v, logger, opts...)
 	default:
 		return nil, errors.New("database type not supported")
 	}
 }
 
 // NewSqliteConnection creates a new database connection to a SQLite database.
-func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger) (DB, error) {
+func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger, opts ...Option) (DB, error) {
 	path := dbConfig.Path
 	_, err := os.Stat(path)
 	if err != nil {
@@ -52,7 +54,7 @@ func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger) (DB, e
 		defer file.Close()
 	}
 
-	db, err := sql.Open("sqlite3", dbConfig.GetDsn())
+	db, err := openInstrumentedDB("sqlite3", dbConfig.GetDsn(), dbSystemSQLite, resolveOpts(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite database '%s': %w", dbConfig.GetDsn(), err)
 	}
@@ -71,8 +73,8 @@ func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger) (DB, e
 }
 
 // NewPostgresConnection creates a new database connection to a Postgres database.
-func NewPostgresConnection(dbConfig *config.DatabasePostgres, l *slog.Logger) (DB, error) {
-	db, err := sql.Open("pgx", dbConfig.GetDsn())
+func NewPostgresConnection(dbConfig *config.DatabasePostgres, l *slog.Logger, opts ...Option) (DB, error) {
+	db, err := openInstrumentedDB("pgx", dbConfig.GetDsn(), dbSystemPostgres, resolveOpts(opts))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open postgres database '%s': %w", dbConfig.GetDsn(), err)
 	}

--- a/internal/database/telemetry.go
+++ b/internal/database/telemetry.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"database/sql"
+
+	"github.com/XSAM/otelsql"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// telemetryOpts holds the resolved OTel providers + config used when opening a
+// sql.DB. nil providers, providers in no-op mode, or both signals disabled
+// degrade to plain sql.Open with no overhead.
+type telemetryOpts struct {
+	providers *aptelemetry.Providers
+	cfg       *sconfig.Telemetry
+}
+
+// Option configures connection setup. WithTelemetry is currently the only
+// option; the functional-options shape keeps the constructor signatures
+// non-breaking for existing callers (e.g. test_db.go) that don't need
+// telemetry.
+type Option func(*telemetryOpts)
+
+// WithTelemetry causes the constructed sql.DB to be instrumented with OTel
+// spans + metrics via otelsql. When providers is nil or in no-op mode, or
+// when both trace and metric signals are off in cfg, this is silently inert
+// and a plain sql.DB is returned.
+func WithTelemetry(providers *aptelemetry.Providers, cfg *sconfig.Telemetry) Option {
+	return func(o *telemetryOpts) {
+		o.providers = providers
+		o.cfg = cfg
+	}
+}
+
+// resolveOpts collapses zero or more Options into the effective settings.
+func resolveOpts(opts []Option) *telemetryOpts {
+	o := &telemetryOpts{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// telemetryEnabled reports whether the resolved telemetry options should
+// produce an instrumented sql.DB. Both a live providers handle and at least
+// one enabled signal are required.
+func (o *telemetryOpts) telemetryEnabled() bool {
+	if o == nil || o.providers == nil || !o.providers.Enabled {
+		return false
+	}
+	return o.cfg.TracesEnabled() || o.cfg.MetricsEnabled()
+}
+
+// openInstrumentedDB opens a sql.DB connection, wrapping it with otelsql when
+// telemetry is enabled and falling through to plain sql.Open otherwise.
+// driverName is the underlying driver registered with database/sql (e.g.
+// "pgx", "sqlite3"); dbSystem is the OTel semconv db.system attribute value
+// (e.g. semconv.DBSystemPostgreSQL.Value.AsString()).
+func openInstrumentedDB(driverName, dsn, dbSystem string, opts *telemetryOpts) (*sql.DB, error) {
+	if !opts.telemetryEnabled() {
+		return sql.Open(driverName, dsn)
+	}
+
+	otelOpts := []otelsql.Option{
+		otelsql.WithTracerProvider(opts.providers.TracerProvider),
+		otelsql.WithMeterProvider(opts.providers.MeterProvider),
+		otelsql.WithAttributes(attribute.String(string(semconv.DBSystemKey), dbSystem)),
+	}
+
+	db, err := otelsql.Open(driverName, dsn, otelOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.cfg.MetricsEnabled() {
+		// Register go.sql.DB connection pool gauges (open / in-use / idle
+		// connections, wait counts, etc.). Ignore the returned values: a
+		// failure to register pool stats should not fail the whole
+		// connection — instrumentation is best-effort.
+		_, _ = otelsql.RegisterDBStatsMetrics(db, otelOpts...)
+	}
+
+	return db, nil
+}
+
+// dbSystemPostgres is the otel semconv db.system value for Postgres.
+const dbSystemPostgres = "postgresql"
+
+// dbSystemSQLite is the otel semconv db.system value for SQLite.
+const dbSystemSQLite = "sqlite"

--- a/internal/database/telemetry.go
+++ b/internal/database/telemetry.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"database/sql/driver"
 
 	"github.com/XSAM/otelsql"
 	"go.opentelemetry.io/otel/attribute"
@@ -59,36 +60,76 @@ func (o *telemetryOpts) telemetryEnabled() bool {
 // telemetry is enabled and falling through to plain sql.Open otherwise.
 // driverName is the underlying driver registered with database/sql (e.g.
 // "pgx", "sqlite3"); dbSystem is the OTel semconv db.system attribute value
-// (e.g. semconv.DBSystemPostgreSQL.Value.AsString()).
+// (e.g. "postgresql").
 func openInstrumentedDB(driverName, dsn, dbSystem string, opts *telemetryOpts) (*sql.DB, error) {
 	if !opts.telemetryEnabled() {
 		return sql.Open(driverName, dsn)
 	}
 
-	otelOpts := []otelsql.Option{
-		otelsql.WithTracerProvider(opts.providers.TracerProvider),
-		otelsql.WithMeterProvider(opts.providers.MeterProvider),
-		otelsql.WithAttributes(attribute.String(string(semconv.DBSystemKey), dbSystem)),
-	}
-
+	otelOpts := otelOptionsFor(opts, dbSystem)
 	db, err := otelsql.Open(driverName, dsn, otelOpts...)
 	if err != nil {
 		return nil, err
 	}
-
-	if opts.cfg.MetricsEnabled() {
-		// Register go.sql.DB connection pool gauges (open / in-use / idle
-		// connections, wait counts, etc.). Ignore the returned values: a
-		// failure to register pool stats should not fail the whole
-		// connection — instrumentation is best-effort.
-		_, _ = otelsql.RegisterDBStatsMetrics(db, otelOpts...)
-	}
-
+	maybeRegisterPoolStats(opts, db, otelOpts)
 	return db, nil
 }
 
-// dbSystemPostgres is the otel semconv db.system value for Postgres.
-const dbSystemPostgres = "postgresql"
+// OpenInstrumentedSQL is the exported counterpart of openInstrumentedDB.
+// Other packages that own their own sql.DB constructors (e.g. request_log,
+// which opens separate Postgres / SQLite connections for HTTP request
+// logging) call this to inherit the same telemetry treatment as the main
+// database without duplicating the plumbing.
+//
+// dbSystem is the semconv db.system value (DBSystemPostgreSQL, DBSystemSQLite,
+// DBSystemClickHouse). opts are forwarded as-is — pass WithTelemetry to
+// instrument; pass nothing for a plain sql.Open fast path.
+func OpenInstrumentedSQL(driverName, dsn, dbSystem string, opts ...Option) (*sql.DB, error) {
+	return openInstrumentedDB(driverName, dsn, dbSystem, resolveOpts(opts))
+}
 
-// dbSystemSQLite is the otel semconv db.system value for SQLite.
-const dbSystemSQLite = "sqlite"
+// OpenInstrumentedConnector wraps a driver.Connector — used by drivers that
+// expose a Connector rather than a registered driver name. The ClickHouse
+// std driver is the in-tree example (clickhouse.Connector(opts) returns a
+// driver.Connector that can be wrapped here). When telemetry is disabled,
+// returns a plain sql.OpenDB(connector) with no overhead.
+func OpenInstrumentedConnector(connector driver.Connector, dbSystem string, opts ...Option) *sql.DB {
+	resolved := resolveOpts(opts)
+	if !resolved.telemetryEnabled() {
+		return sql.OpenDB(connector)
+	}
+
+	otelOpts := otelOptionsFor(resolved, dbSystem)
+	db := otelsql.OpenDB(connector, otelOpts...)
+	maybeRegisterPoolStats(resolved, db, otelOpts)
+	return db
+}
+
+// otelOptionsFor builds the otelsql option slice common to both the
+// driver-name and connector paths.
+func otelOptionsFor(opts *telemetryOpts, dbSystem string) []otelsql.Option {
+	return []otelsql.Option{
+		otelsql.WithTracerProvider(opts.providers.TracerProvider),
+		otelsql.WithMeterProvider(opts.providers.MeterProvider),
+		otelsql.WithAttributes(attribute.String(string(semconv.DBSystemKey), dbSystem)),
+	}
+}
+
+// maybeRegisterPoolStats registers the standard go-sql DB connection pool
+// gauges (open / in-use / idle, wait counts) when metrics are enabled.
+// Failures are non-fatal — instrumentation is best effort.
+func maybeRegisterPoolStats(opts *telemetryOpts, db *sql.DB, otelOpts []otelsql.Option) {
+	if !opts.cfg.MetricsEnabled() {
+		return
+	}
+	_, _ = otelsql.RegisterDBStatsMetrics(db, otelOpts...)
+}
+
+// DBSystemPostgreSQL / DBSystemSQLite / DBSystemClickHouse are the
+// otel semconv db.system values used when constructing instrumented
+// connections. Pass these to OpenInstrumentedSQL / OpenInstrumentedConnector.
+const (
+	DBSystemPostgreSQL = "postgresql"
+	DBSystemSQLite     = "sqlite"
+	DBSystemClickHouse = "clickhouse"
+)

--- a/internal/database/telemetry_test.go
+++ b/internal/database/telemetry_test.go
@@ -1,0 +1,148 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// dbTelemetryFixture wires an OTel SDK with an in-memory span recorder + a
+// manual metric reader so DB tests can introspect emitted telemetry without
+// a live exporter.
+type dbTelemetryFixture struct {
+	providers *aptelemetry.Providers
+	spans     *tracetest.SpanRecorder
+	reader    *sdkmetric.ManualReader
+}
+
+func newDBTelemetryFixture(t *testing.T) *dbTelemetryFixture {
+	t.Helper()
+	spans := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spans))
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	})
+
+	return &dbTelemetryFixture{
+		providers: &aptelemetry.Providers{
+			Enabled:        true,
+			TracerProvider: tp,
+			MeterProvider:  mp,
+			Propagator:     propagation.TraceContext{},
+		},
+		spans:  spans,
+		reader: reader,
+	}
+}
+
+func (f *dbTelemetryFixture) readMetrics(t *testing.T) metricdata.ResourceMetrics {
+	t.Helper()
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, f.reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+// newSqliteDBWith opens a fresh SQLite-backed DB using the supplied
+// telemetry options and returns it ready for use. The DB file is cleaned up
+// at test end.
+func newSqliteDBWith(t *testing.T, opts ...Option) DB {
+	t.Helper()
+	tempPath := filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("authproxy-otel-tests/%s-%s.sqlite3", t.Name(), uuid.New().String()),
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(tempPath), os.ModePerm))
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(tempPath)) })
+
+	cfg := &sconfig.DatabaseSqlite{Path: tempPath}
+	db, err := NewSqliteConnection(cfg, nil, opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.(*service).db.Close() })
+
+	return db
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestDBTelemetry_QueryEmitsSpanAndMetric(t *testing.T) {
+	fx := newDBTelemetryFixture(t)
+	tel := &sconfig.Telemetry{Enabled: boolPtr(true)}
+
+	db := newSqliteDBWith(t, WithTelemetry(fx.providers, tel))
+
+	// Issue a trivial query that doesn't depend on migrations.
+	require.True(t, db.Ping(context.Background()))
+
+	gotSpans := fx.spans.Ended()
+	require.NotEmpty(t, gotSpans, "instrumented query must produce at least one span")
+
+	rm := fx.readMetrics(t)
+	// otelsql emits one or more standard metric series on first use; we
+	// don't pin the exact name (it's contributed by otelsql), but at least
+	// one metric stream must be present.
+	require.NotEmpty(t, rm.ScopeMetrics, "metrics must be emitted via the otelsql instrumentation")
+}
+
+func TestDBTelemetry_NoOpWhenTelemetryDisabled(t *testing.T) {
+	fx := newDBTelemetryFixture(t)
+
+	// Disabled telemetry: no providers attached, so the constructor must
+	// fall through to plain sql.Open and emit nothing.
+	db := newSqliteDBWith(t /* no options */)
+	require.True(t, db.Ping(context.Background()))
+
+	require.Empty(t, fx.spans.Ended(), "no spans expected when telemetry isn't wired in")
+	rm := fx.readMetrics(t)
+	require.Empty(t, rm.ScopeMetrics, "no metrics expected when telemetry isn't wired in")
+}
+
+func TestDBTelemetry_NoOpWhenProvidersDisabled(t *testing.T) {
+	// Providers in no-op mode (the default when telemetry config is
+	// absent) — pass them through anyway and verify the constructor still
+	// avoids wrapping with otelsql.
+	fx := newDBTelemetryFixture(t)
+	tel := &sconfig.Telemetry{} // Enabled is nil → IsEnabled() == false
+
+	db := newSqliteDBWith(t, WithTelemetry(aptelemetry.NoopProviders(), tel))
+	require.True(t, db.Ping(context.Background()))
+
+	require.Empty(t, fx.spans.Ended())
+	rm := fx.readMetrics(t)
+	require.Empty(t, rm.ScopeMetrics)
+}
+
+func TestDBTelemetry_NoOpWhenBothSignalsOff(t *testing.T) {
+	// Enabled providers but both trace and metric signals turned off.
+	fx := newDBTelemetryFixture(t)
+	off := false
+	on := true
+	tel := &sconfig.Telemetry{
+		Enabled: &on,
+		Signals: &sconfig.TelemetrySignals{Traces: &off, Metrics: &off, Logs: &off},
+	}
+
+	db := newSqliteDBWith(t, WithTelemetry(fx.providers, tel))
+	require.True(t, db.Ping(context.Background()))
+
+	require.Empty(t, fx.spans.Ended())
+	rm := fx.readMetrics(t)
+	require.Empty(t, rm.ScopeMetrics)
+}

--- a/internal/request_log/provider_clickhouse.go
+++ b/internal/request_log/provider_clickhouse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	sq "github.com/Masterminds/squirrel"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -23,18 +24,18 @@ type clickhouseRecordStore struct {
 	logger *slog.Logger
 }
 
-func NewClickhouseRecordStore(cfg *config.Database, logger *slog.Logger) RecordStore {
+func NewClickhouseRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...database.Option) RecordStore {
 	chCfg, ok := cfg.InnerVal.(*config.DatabaseClickhouse)
 	if !ok {
 		panic(fmt.Sprintf("expected *config.DatabaseClickhouse, got %T", cfg))
 	}
 
-	opts, err := chCfg.ToClickhouseOptions()
+	chOpts, err := chCfg.ToClickhouseOptions()
 	if err != nil {
 		panic(fmt.Errorf("failed to convert clickhouse config to options: %w", err))
 	}
 
-	db := clickhouse.OpenDB(opts)
+	db := database.OpenInstrumentedConnector(clickhouse.Connector(chOpts), database.DBSystemClickHouse, dbOpts...)
 	s := &clickhouseRecordStore{
 		db:     db,
 		cfg:    chCfg,
@@ -180,7 +181,7 @@ type clickhouseRecordRetriever struct {
 	logger          *slog.Logger
 }
 
-func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger) RecordRetriever {
+func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...database.Option) RecordRetriever {
 	chCfg, ok := cfg.InnerVal.(*config.DatabaseClickhouse)
 	if !ok {
 		panic(fmt.Sprintf("expected *config.HttpLoggingDatabaseClickhouse, got %T", cfg))
@@ -191,7 +192,7 @@ func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor paginati
 		panic(fmt.Errorf("failed to convert clickhouse config to options: %w", err))
 	}
 
-	db := clickhouse.OpenDB(options)
+	db := database.OpenInstrumentedConnector(clickhouse.Connector(options), database.DBSystemClickHouse, dbOpts...)
 	return &clickhouseRecordRetriever{
 		db:              db,
 		cfg:             chCfg,

--- a/internal/request_log/provider_factory.go
+++ b/internal/request_log/provider_factory.go
@@ -4,37 +4,55 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
+// dbSystemFor returns the otel semconv db.system value for an HTTP-logging
+// provider. Used to tag spans + metrics emitted by the instrumented DB
+// connection so dashboards can break out request-log SQL activity by engine.
+func dbSystemFor(p config.DatabaseProvider) string {
+	switch p {
+	case config.DatabaseProviderPostgres:
+		return database.DBSystemPostgreSQL
+	case config.DatabaseProviderSqlite:
+		return database.DBSystemSQLite
+	case config.DatabaseProviderClickhouse:
+		return database.DBSystemClickHouse
+	default:
+		return ""
+	}
+}
+
 // NewRecordStore creates an RecordStore based on the HttpLogging configuration.
-// If no database config is specified, defaults to the Redis provider.
-func NewRecordStore(database *config.Database, logger *slog.Logger) RecordStore {
-	provider := database.GetProvider()
+// dbOpts are forwarded to the underlying instrumented DB constructor —
+// callers pass database.WithTelemetry(...) to enable spans + metrics on the
+// request-log database tier.
+func NewRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...database.Option) RecordStore {
+	provider := cfg.GetProvider()
 
 	switch provider {
 	case config.DatabaseProviderSqlite:
-		return NewSqlRecordStore(database, logger)
+		return NewSqlRecordStore(cfg, logger, dbOpts...)
 	case config.DatabaseProviderPostgres:
-		return NewSqlRecordStore(database, logger)
+		return NewSqlRecordStore(cfg, logger, dbOpts...)
 	case config.DatabaseProviderClickhouse:
-		return NewClickhouseRecordStore(database, logger)
+		return NewClickhouseRecordStore(cfg, logger, dbOpts...)
 	default:
 		panic(fmt.Sprintf("unknown http logging database provider: %s", provider))
 	}
 }
 
 // NewRecordRetriever creates an RecordRetriever based on the HttpLogging configuration.
-// If no database config is specified, defaults to the Redis provider.
-func NewRecordRetriever(database *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger) RecordRetriever {
-	provider := database.GetProvider()
+func NewRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...database.Option) RecordRetriever {
+	provider := cfg.GetProvider()
 	switch provider {
 	case config.DatabaseProviderSqlite:
 	case config.DatabaseProviderPostgres:
-		return NewSqlRecordRetriever(database, cursorEncryptor, logger)
+		return NewSqlRecordRetriever(cfg, cursorEncryptor, logger, dbOpts...)
 	case config.DatabaseProviderClickhouse:
-		return NewClickhouseRecordRetriever(database, cursorEncryptor, logger)
+		return NewClickhouseRecordRetriever(cfg, cursorEncryptor, logger, dbOpts...)
 	default:
 		panic(fmt.Sprintf("unknown http logging database provider: %s", provider))
 	}

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -40,8 +40,8 @@ type sqlRecordStore struct {
 	placeholderFormat sq.PlaceholderFormat
 }
 
-func NewSqlRecordStore(cfg *config.Database, logger *slog.Logger) RecordStore {
-	db, err := sql.Open(cfg.GetDriver(), cfg.GetDsn())
+func NewSqlRecordStore(cfg *config.Database, logger *slog.Logger, opts ...database.Option) RecordStore {
+	db, err := database.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
 	if err != nil {
 		panic(fmt.Errorf("failed to open http logging database: %w", err))
 	}
@@ -213,8 +213,8 @@ type sqlRecordRetriever struct {
 	placeholderFormat sq.PlaceholderFormat
 }
 
-func NewSqlRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger) RecordRetriever {
-	db, err := sql.Open(cfg.GetDriver(), cfg.GetDsn())
+func NewSqlRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, opts ...database.Option) RecordRetriever {
+	db, err := database.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
 	if err != nil {
 		panic(fmt.Errorf("failed to open http logging database for retrieval: %w", err))
 	}

--- a/internal/request_log/storage_service.go
+++ b/internal/request_log/storage_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apblob"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -100,16 +101,19 @@ func (ss *StorageService) Migrate(ctx context.Context) error {
 }
 
 // NewStorageService that will store the log records and the full request/response.
+// dbOpts are forwarded to the underlying DB constructors — pass
+// database.WithTelemetry(...) to instrument the request-log database tier.
 func NewStorageService(
 	ctx context.Context,
 	cfg *config.HttpLogging,
 	cursorEncryptor pagination.CursorEncryptor,
 	encryptor Encryptor,
 	logger *slog.Logger,
+	dbOpts ...database.Option,
 ) (*StorageService, error) {
 	logger = logger.With("service", "request_log")
-	store := NewRecordStore(cfg.Database, logger)
-	retriever := NewRecordRetriever(cfg.Database, cursorEncryptor, logger)
+	store := NewRecordStore(cfg.Database, logger, dbOpts...)
+	retriever := NewRecordRetriever(cfg.Database, cursorEncryptor, logger, dbOpts...)
 	blobStore, err := apblob.NewFromConfig(ctx, cfg.BlobStorage)
 	if err != nil {
 		return nil, err

--- a/internal/request_log/telemetry_test.go
+++ b/internal/request_log/telemetry_test.go
@@ -1,0 +1,118 @@
+package request_log
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// requestLogTelemetryFixture wires an OTel SDK with an in-memory span
+// recorder + a manual metric reader so request_log telemetry tests can
+// introspect emitted telemetry without a live exporter.
+type requestLogTelemetryFixture struct {
+	providers *aptelemetry.Providers
+	spans     *tracetest.SpanRecorder
+	reader    *sdkmetric.ManualReader
+}
+
+func newRequestLogTelemetryFixture(t *testing.T) *requestLogTelemetryFixture {
+	t.Helper()
+	spans := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spans))
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	})
+
+	return &requestLogTelemetryFixture{
+		providers: &aptelemetry.Providers{
+			Enabled:        true,
+			TracerProvider: tp,
+			MeterProvider:  mp,
+			Propagator:     propagation.TraceContext{},
+		},
+		spans:  spans,
+		reader: reader,
+	}
+}
+
+func (f *requestLogTelemetryFixture) readMetrics(t *testing.T) metricdata.ResourceMetrics {
+	t.Helper()
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, f.reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+// newSqliteRequestLogConfig builds an HTTP-logging config backed by a fresh
+// SQLite file. The file is cleaned up at test end.
+func newSqliteRequestLogConfig(t *testing.T) *sconfig.Database {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "authproxy_request_log_otel_*.db")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
+
+	return &sconfig.Database{
+		InnerVal: &sconfig.DatabaseSqlite{Path: tmpFile.Name()},
+	}
+}
+
+func enabledPtr(b bool) *bool { return &b }
+
+// runProbeQuery issues a trivial SELECT through the store's underlying *sql.DB.
+// otelsql instruments Query/Exec/Prepare paths by default; Ping is gated
+// behind a SpanOptions flag we don't enable, so a real query is what proves
+// the wrapper is wired through.
+func runProbeQuery(t *testing.T, store RecordStore) {
+	t.Helper()
+	concrete, ok := store.(*sqlRecordStore)
+	require.True(t, ok, "telemetry test expects the concrete sqlRecordStore type")
+
+	rows, err := concrete.db.QueryContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+	require.NoError(t, rows.Close())
+}
+
+func TestRequestLog_SqlStoreEmitsSpansWhenTelemetryEnabled(t *testing.T) {
+	fx := newRequestLogTelemetryFixture(t)
+	tel := &sconfig.Telemetry{Enabled: enabledPtr(true)}
+
+	cfg := newSqliteRequestLogConfig(t)
+	store := NewSqlRecordStore(cfg, newNoopLogger(), database.WithTelemetry(fx.providers, tel))
+
+	runProbeQuery(t, store)
+
+	require.NotEmpty(t, fx.spans.Ended(), "the request-log SQL store must emit spans when telemetry is on")
+	rm := fx.readMetrics(t)
+	require.NotEmpty(t, rm.ScopeMetrics, "the request-log SQL store must emit metrics when telemetry is on")
+}
+
+func TestRequestLog_SqlStoreNoOpWhenTelemetryDisabled(t *testing.T) {
+	fx := newRequestLogTelemetryFixture(t)
+
+	cfg := newSqliteRequestLogConfig(t)
+	// No WithTelemetry option → constructor takes the plain sql.Open fast
+	// path, identical to the historic behaviour.
+	store := NewSqlRecordStore(cfg, newNoopLogger())
+
+	runProbeQuery(t, store)
+
+	require.Empty(t, fx.spans.Ended())
+	rm := fx.readMetrics(t)
+	require.Empty(t, rm.ScopeMetrics)
+}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -188,7 +188,11 @@ func (dm *DependencyManager) GetRedisClient() apredis.Client {
 func (dm *DependencyManager) GetDatabase() database.DB {
 	if dm.db == nil {
 		var err error
-		dm.db, err = database.NewConnectionForRoot(dm.GetConfigRoot(), dm.GetLogger())
+		dm.db, err = database.NewConnectionForRoot(
+			dm.GetConfigRoot(),
+			dm.GetLogger(),
+			database.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
+		)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -236,6 +236,7 @@ func (dm *DependencyManager) GetLogStorageService() *request_log.StorageService 
 			pagination.NewRandomCursorEncryptor(),
 			dm.GetEncryptService(),
 			dm.GetLogger(),
+			database.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
 		)
 
 		if err != nil {


### PR DESCRIPTION
## Summary

Adds per-query OTel spans + metrics for the database/sql layer (Postgres + SQLite), wired in via a new `database.WithTelemetry` option on the existing constructors.

- Uses [XSAM/otelsql](https://github.com/XSAM/otelsql) v0.41.0 (latest line that targets Go 1.24, paired with OTel v1.39+) to wrap \`sql.Open\` when telemetry is enabled. Drop-in for both Postgres (\`pgx\`) and SQLite (\`go-sqlite3\`), so dev / test / prod all emit the same shape.
- Reports semconv \`db.system\` per driver (\`postgresql\` / \`sqlite\`).
- When the metrics signal is on, additionally registers \`otelsql.RegisterDBStatsMetrics\` so the standard go-sql connection-pool gauges (open / in-use / idle / wait counts) show up. Best-effort: registration failures don't fail the connection.
- \`database.WithTelemetry\` is a non-breaking functional option — existing callers (notably \`test_db.go\`) keep their current signature and stay uninstrumented.
- When telemetry is disabled, providers are no-op, or both trace and metric signals are off, the constructor falls through to plain \`sql.Open\` — zero overhead for unconfigured deployments.

## Test plan

- [x] \`go test ./internal/database/...\` — new tests cover:
  - Query through instrumented DB emits at least one span and at least one metric stream
  - Default-off: with no \`WithTelemetry\` option, no spans / metrics emitted
  - Providers in no-op mode + telemetry config absent: no spans / metrics
  - Both signals off (traces=false, metrics=false): no spans / metrics
- [x] Existing internal/database tests continue to pass unchanged
- [x] \`./scripts/preflight.sh\` passes (including integration_tests \`go list -mod=readonly\`)
- [x] \`go test ./...\` clean across the whole tree
- [x] \`golangci-lint run\` clean
- [ ] Manual verification with a live collector (deferred to #239 dev sample)

Closes #234. Part of the OpenTelemetry project — parent #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)