### PR TITLE
Docs: rate limits + labels guides, docs/ index, main README TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,47 @@ Embeddable connector marketplace UI:
 Pre-built admin UI for managing connectors and connections:
 ![admin-ui.jpg](docs/images/admin-walkthrough.gif)
 
+## Table of contents
+
+- [Key Concepts](#key-concepts)
+  - [Authenticating Proxy](#authenticating-proxy)
+  - [Connectors and Connections](#connectors-and-connections)
+  - [Connector Versioning](#connector-versioning)
+  - [Namespaces and Access Control](#namespaces-and-access-control)
+  - [JWT Authentication and Scoped Tokens](#jwt-authentication-and-scoped-tokens)
+  - [Dev Env Authentication](#dev-env-authentication)
+  - [Application-Level Encryption](#application-level-encryption)
+  - [Embeddable Marketplace](#embeddable-marketplace)
+  - [Request Logging and Auditability](#request-logging-and-auditability)
+  - [Labels and Annotations](#labels-and-annotations)
+  - [Rate Limits](#rate-limits)
+- [Architecture](#architecture)
+- [Running Locally](#running-locally)
+  - [Quick Start with Docker Compose](#quick-start-with-docker-compose)
+  - [Manual Setup](#manual-setup)
+  - [TLS Certificates](#tls-certificates)
+  - [Testing](#testing)
+  - [Pre-push Preflight](#pre-push-preflight)
+- [UI](#ui)
+  - [Marketplace UI](#marketplace-ui)
+  - [Admin UI](#admin-ui)
+- [Client Config](#client-config)
+- [Related Projects](#related-projects)
+- [License](#license)
+- [Documentation](#documentation)
+
+## Feature documentation
+
+In-depth guides live under [`docs/`](docs/README.md):
+
+- [Rate limits](docs/rate-limits.md) — defining rate-limit resources, the connector-level reactive 429 handler, and the request-log attribution fields.
+- [Labels and annotations](docs/labels.md) — the label system, system labels under `apxy/`, carry-forward through namespaces and connectors, label selectors.
+- [Background tasks](docs/background_tasks.md) — running the worker, monitoring queues.
+- [Blob storage](docs/blob_storage.md) — viewing data stored in MinIO / S3.
+- [Redis insight](docs/redis_insight.md) — viewing data stored in Redis.
+
+See the [docs index](docs/README.md) for the full list.
+
 ## Key Concepts
 
 ### Authenticating Proxy
@@ -214,6 +255,17 @@ Use cases include:
 - **Workflow tracking**: Mark connections with pipeline or workflow identifiers
 
 Labels support Kubernetes-style selector syntax for querying, making it easy to find resources matching complex criteria.
+
+See [docs/labels.md](docs/labels.md) for the full reference — system labels under `apxy/`, carry-forward semantics through the namespace → connector → connection hierarchy, the per-request label snapshot, and selector syntax.
+
+### Rate Limits
+
+Two complementary rate-limiting systems are built in:
+
+1. **Connector-level reactive 429 handling.** When a 3rd party returns 429, AuthProxy parses the `Retry-After` header (or applies exponential backoff) and short-circuits subsequent requests on that connection until the cool-down expires. Built into every connector; configurable via the connector definition.
+2. **Rate-limit resources.** Declarative, namespace-scoped rules you define via API or Terraform. They run **before** the upstream call and enforce caps you configure — for example, "no more than 60 writes per minute per actor against Salesforce." Supports fixed-window / sliding-window / token-bucket algorithms, label-selector and path-based matching, per-actor / per-team / per-label bucketing, and `enforce` vs. `observe` mode for safe rollout.
+
+Both can fire on the same request and both stamp the request log so you can tell them apart. See [docs/rate-limits.md](docs/rate-limits.md) for the full reference.
 
 ## Architecture
 
@@ -502,8 +554,16 @@ See [RELATED.md](RELATED.md) for a list of related products in the API integrati
 
 AuthProxy is open source. See [LICENSE](LICENSE) for details.
 
-## Additional Documentation
+## Documentation
 
-* [Managing background tasks](docs/background_tasks.md)
-* [Viewing data stored in Blob Storage such as request logs](docs/blob_storage.md)
-* [Viewing data stored in Redis](docs/redis_insight.md)
+The full set of long-form guides lives under [`docs/`](docs/README.md):
+
+| Topic | Doc |
+|---|---|
+| Define rate-limit resources, connector reactive 429 handling, log attribution | [docs/rate-limits.md](docs/rate-limits.md) |
+| Label system, system labels, carry-forward, selectors | [docs/labels.md](docs/labels.md) |
+| Managing background tasks | [docs/background_tasks.md](docs/background_tasks.md) |
+| Viewing data stored in Blob Storage (request logs, etc.) | [docs/blob_storage.md](docs/blob_storage.md) |
+| Viewing data stored in Redis | [docs/redis_insight.md](docs/redis_insight.md) |
+| Terraform provider — resource reference | [terraform/provider/docs/resources/](terraform/provider/docs/resources/) |
+| Terraform provider — runnable examples | [terraform/provider/examples/resources/](terraform/provider/examples/resources/) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# AuthProxy Documentation
+
+This directory holds long-form documentation that supplements the [main repo README](../README.md). The main README has the conceptual overview and getting-started material; the pages here go deep on specific features and operational topics.
+
+## Feature guides
+
+- **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
+- **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
+
+## Operational guides
+
+- **[Background tasks](background_tasks.md)** — running the worker, monitoring queues with Asynqmon.
+- **[Blob storage](blob_storage.md)** — viewing data stored in MinIO / S3 (full request bodies, etc.).
+- **[Redis insight](redis_insight.md)** — viewing data stored in Redis (rate-limit counters, session state, etc.).
+
+## Reference
+
+- **[OAuth test provider gaps](oauth_test_provider_gaps.md)** — limitations of the in-repo OAuth test provider that the integration tests run against.
+
+## Architecture diagrams
+
+- **[OAuth connection flow](oauth_flow.mmd)** — Mermaid diagram of the OAuth2 authorization-code lifecycle.
+- **[Marketplace portal session flow](marketplace_portal.mmd)** — Mermaid diagram of the embeddable marketplace's session handshake.
+
+## Where else docs live
+
+- **[Main README](../README.md)** — overview, core concepts, running locally, testing, UI, CLI.
+- **[RELATED.md](../RELATED.md)** — related products in the API integration space.
+- **[Terraform provider docs](../terraform/provider/docs/resources/)** — generated reference for each `authproxy_*` Terraform resource.
+- **[Terraform examples](../terraform/provider/examples/resources/)** — runnable HCL examples per resource.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -58,7 +58,6 @@ Every namespace-scoped resource carries `labels` and `annotations` columns:
 | `connection` | Inherits labels from its connector version, plus the namespace. |
 | `encryption_key` | Inherits from its namespace. |
 | `rate_limit` | Inherits from its namespace. See [Rate limits](rate-limits.md). |
-| `oauth2_token` | Inherits from its connection. |
 | `request_log` entry | The frozen label snapshot of the request that produced it. |
 
 Request log entries store the per-request label snapshot (the values that were active when the request ran), not a live reference — so a label change on the connection does not retroactively change old log entries.
@@ -100,7 +99,6 @@ The `<rt>` token comes from the resource's apid prefix (strip the trailing `_`):
 | Connector version | `cxr` |
 | Encryption key | `ek` |
 | Rate limit | `rl` |
-| OAuth2 token | `tok` |
 
 For example, a connection with id `cxn_abc123` in namespace `root.acme` always carries:
 
@@ -125,7 +123,6 @@ namespace
    ├── encryption_key                   (labels carry forward through "ns/")
    ├── connector (version)              (labels carry forward through "cxr/")
    │      └── connection                (labels carry forward through "cxn/")
-   │             └── oauth2_token       (labels carry forward through "tok/")
    ├── rate_limit                       (labels carry forward through "ns/")
    └── (child namespace)                (labels carry forward through "ns/")
 ```
@@ -160,14 +157,18 @@ apxy/cxn/-/ns:          root.acme        # implicit identifier
 
 ### Propagation on parent change
 
-Carry-forward is **materialised on create**. If the parent's labels change later, the values on existing children are stale until the propagation job runs.
+Carry-forward is **materialised on create** — and **eventually consistent** afterwards. If the parent's labels change later, the values on existing children are stale until the propagation job catches up; depending on fleet size, fan-out depth, and how rate-limited the reconciler is, that delay can be anywhere from a few seconds to several hours.
 
 There are two propagation paths:
 
-1. **Targeted refresh.** Admin API mutators (e.g., updating a namespace's labels) enqueue a background task that re-derives every descendant's `apxy/` mirror — running each row's update in its own short transaction so concurrent reads aren't blocked.
-2. **Daily consistency checker.** A scheduled job walks every resource type, compares the on-disk labels to what the carry-forward rule would compute, and corrects any drift. Belt-and-braces for the targeted refresh.
+1. **Targeted refresh.** Admin API mutators (e.g., updating a namespace's labels) enqueue a background task that re-derives every descendant's `apxy/` mirror — running each row's update in its own short transaction so concurrent reads aren't blocked. Typical latency: seconds to a few minutes, longer for deep fan-outs.
+2. **Daily consistency checker.** A scheduled job walks every resource type, compares the on-disk labels to what the carry-forward rule would compute, and corrects any drift. Belt-and-braces for the targeted refresh; the worst-case bound is "next daily run plus the time the walk itself takes" — minutes to hours.
 
-Operational implication: a label change on a deep namespace can fan out to many descendants. The propagation job batches updates and runs out of band; do not rely on a label change being visible to in-flight proxy requests within the next few seconds.
+**Operational implications:**
+
+- Treat carry-forward labels as eventually-consistent reads. Application logic that needs to observe a fresh parent-label change should not rely on a child's mirrored `apxy/<parent>/...` having caught up yet.
+- A label change on a deep namespace can fan out to many descendants. The propagation job batches updates and runs out of band; do not rely on a label change being visible to in-flight proxy requests within the next few seconds.
+- Per-request label snapshots on **new** requests after the update reflect the parent change as soon as each individual descendant row is rewritten — so propagation progresses visibly through the fleet rather than landing atomically.
 
 ## Per-request label snapshot
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,234 @@
+# Labels and Annotations
+
+AuthProxy attaches Kubernetes-style **labels** (key=value metadata) and **annotations** (free-form key=value pairs) to every long-lived resource. Labels are the lightweight integration surface between AuthProxy and your host application: tag a connection with your tenant id, search for it later by selector, and have the same tag appear automatically on every request log entry that connection produces.
+
+This page is the reference for the label system — what labels exist, how they propagate, and how to query them.
+
+## Table of contents
+
+- [Quick start](#quick-start)
+- [Where labels and annotations live](#where-labels-and-annotations-live)
+- [Label vs. annotation](#label-vs-annotation)
+- [System labels — the `apxy/` namespace](#system-labels--the-apxy-namespace)
+- [Carry-forward — how labels flow through the hierarchy](#carry-forward--how-labels-flow-through-the-hierarchy)
+- [Per-request label snapshot](#per-request-label-snapshot)
+- [Label selectors](#label-selectors)
+- [API surface](#api-surface)
+- [Implementation notes](#implementation-notes)
+
+## Quick start
+
+Tag a connection with your tenant id and environment:
+
+```http
+PATCH /api/v1/connections/cxn_abc123
+Content-Type: application/json
+
+{
+  "labels": {
+    "app.example.com/tenant-id": "tenant-42",
+    "app.example.com/env": "production"
+  }
+}
+```
+
+List all connections in production for that tenant:
+
+```http
+GET /api/v1/connections?label_selector=app.example.com/tenant-id=tenant-42,app.example.com/env=production
+```
+
+Find every request log entry produced by that tenant:
+
+```http
+GET /api/v1/request-log?label_selector=app.example.com/tenant-id=tenant-42
+```
+
+You did not have to write a separate "AuthProxy connection id → my tenant id" mapping table. The label travelled with the connection onto every request log entry automatically (see [Carry-forward](#carry-forward--how-labels-flow-through-the-hierarchy)).
+
+## Where labels and annotations live
+
+Every namespace-scoped resource carries `labels` and `annotations` columns:
+
+| Resource | Notes |
+|---|---|
+| `namespace` | Top of the hierarchy. Its labels carry forward to every resource defined in it. |
+| `actor` | Users / service accounts. Labels carry forward to requests an actor initiates. |
+| `connector` (versioned) | Each version is a separate resource with its own labels. |
+| `connection` | Inherits labels from its connector version, plus the namespace. |
+| `encryption_key` | Inherits from its namespace. |
+| `rate_limit` | Inherits from its namespace. See [Rate limits](rate-limits.md). |
+| `oauth2_token` | Inherits from its connection. |
+| `request_log` entry | The frozen label snapshot of the request that produced it. |
+
+Request log entries store the per-request label snapshot (the values that were active when the request ran), not a live reference — so a label change on the connection does not retroactively change old log entries.
+
+## Label vs. annotation
+
+Both are `map[string]string`. The differences are operational:
+
+| | Labels | Annotations |
+|---|---|---|
+| Purpose | Identification, selection | Arbitrary metadata, descriptions |
+| Selectable? | Yes — label selectors filter list queries | No |
+| Key format | DNS-subdomain prefix + name (max 253 + 63 chars) | Same prefix rules but values are unrestricted |
+| Value format | Up to 63 chars, alphanumeric + `-_.` | Anything — up to a 256 KB total cap per resource |
+| Carry forward? | Yes (see below) | No |
+
+Use labels for things you'll search by. Use annotations for things you want to attach but never filter on (long descriptions, ticket links, ownership emails, etc.).
+
+## System labels — the `apxy/` namespace
+
+The `apxy/` prefix is reserved. User-written labels under that prefix are rejected at validation; in exchange, AuthProxy auto-populates a small set of system labels on every resource so consumers can locate, join, and filter by structural identity.
+
+### Identifier labels
+
+Every resource gets two implicit labels stamped on create / update:
+
+| Label key | Value |
+|---|---|
+| `apxy/<rt>/-/id` | This resource's id |
+| `apxy/<rt>/-/ns` | This resource's namespace path |
+
+The `<rt>` token comes from the resource's apid prefix (strip the trailing `_`):
+
+| Resource | `<rt>` |
+|---|---|
+| Namespace | `ns` |
+| Actor | `act` |
+| Connection | `cxn` |
+| Connector version | `cxr` |
+| Encryption key | `ek` |
+| Rate limit | `rl` |
+| OAuth2 token | `tok` |
+
+For example, a connection with id `cxn_abc123` in namespace `root.acme` always carries:
+
+```
+apxy/cxn/-/id: cxn_abc123
+apxy/cxn/-/ns: root.acme
+```
+
+These are useful for **selecting the resource by its own id** (e.g., from a per-request snapshot when you don't have the connection id directly to hand) and for joining audit data across resources.
+
+### Carry-forward labels
+
+When a parent resource's labels appear on a child, they are **re-keyed** under the parent's resource-type token so they don't collide with the child's own keys. This is the central abstraction of label propagation; see the next section.
+
+## Carry-forward — how labels flow through the hierarchy
+
+The hierarchy looks like this:
+
+```
+namespace
+   ├── actor                            (labels carry forward through "act/")
+   ├── encryption_key                   (labels carry forward through "ns/")
+   ├── connector (version)              (labels carry forward through "cxr/")
+   │      └── connection                (labels carry forward through "cxn/")
+   │             └── oauth2_token       (labels carry forward through "tok/")
+   ├── rate_limit                       (labels carry forward through "ns/")
+   └── (child namespace)                (labels carry forward through "ns/")
+```
+
+### The rule
+
+When a child resource is created, every parent's user labels are copied onto the child, **re-keyed** under `apxy/<parent_rt>/<original_key>`:
+
+- Parent namespace `root.acme` has label `team=alpha`
+- Connection created in `root.acme` gets a materialised label `apxy/ns/team=alpha`
+- A request through that connection gets the same `apxy/ns/team=alpha` recorded in its log entry
+
+Anything already on the parent under `apxy/...` is **forwarded as-is** (no double-prefixing). So if `root.acme` itself inherited `apxy/ns/team=alpha` from `root` (which had `team=alpha`), the connection still ends up with `apxy/ns/team=alpha` — not `apxy/ns/apxy/ns/team`.
+
+### Worked example
+
+```
+root                    labels: { env: prod }
+  └─ root.acme          labels: { team: alpha }
+        └─ connection   labels: { app.example.com/cohort: beta }
+```
+
+The connection's full label set after creation:
+
+```
+app.example.com/cohort: beta             # user-set
+apxy/ns/team:           alpha            # carried from parent namespace
+apxy/ns/env:            prod             # carried from root (transitively)
+apxy/cxn/-/id:          cxn_…            # implicit identifier
+apxy/cxn/-/ns:          root.acme        # implicit identifier
+```
+
+### Propagation on parent change
+
+Carry-forward is **materialised on create**. If the parent's labels change later, the values on existing children are stale until the propagation job runs.
+
+There are two propagation paths:
+
+1. **Targeted refresh.** Admin API mutators (e.g., updating a namespace's labels) enqueue a background task that re-derives every descendant's `apxy/` mirror — running each row's update in its own short transaction so concurrent reads aren't blocked.
+2. **Daily consistency checker.** A scheduled job walks every resource type, compares the on-disk labels to what the carry-forward rule would compute, and corrects any drift. Belt-and-braces for the targeted refresh.
+
+Operational implication: a label change on a deep namespace can fan out to many descendants. The propagation job batches updates and runs out of band; do not rely on a label change being visible to in-flight proxy requests within the next few seconds.
+
+## Per-request label snapshot
+
+When an application sends a request through the proxy, AuthProxy assembles a **label snapshot** for that request. This is what gets recorded on the request log entry and what label selectors evaluate against (e.g., the `label_selector` clause on a [rate limit](rate-limits.md)).
+
+The snapshot is the union of:
+
+1. **The connection's labels** (which already include namespace + connector carry-forward — see above).
+2. **The actor's contribution**, if the request was initiated by an authenticated actor. The actor's user labels are re-keyed under `apxy/act/<key>`, plus the actor's own identifier labels (`apxy/act/-/id`, `apxy/act/-/ns`). Other `apxy/*` entries on the actor (e.g. its own namespace's `apxy/ns/*`) are **not** forwarded — those describe the actor's home context, not the request's.
+3. **Per-request labels** supplied by the caller in the `labels` field of a proxy request. These are user labels only; `apxy/`-prefixed keys are rejected so callers can't impersonate system labels.
+
+The composed snapshot is then stamped onto the request log entry's `labels` field, frozen at that point in time.
+
+## Label selectors
+
+Anywhere the API takes a `label_selector` query parameter, the syntax is Kubernetes-style:
+
+| Form | Matches |
+|---|---|
+| `key=value`, `key==value` | key present and equal to value |
+| `key!=value` | key absent **or** present with a different value |
+| `key` | key present (any value) |
+| `!key` | key absent |
+
+Combine with commas — clauses are ANDed:
+
+```
+app.example.com/tenant-id=tenant-42,app.example.com/env=production,!debug
+```
+
+Selectors can target system labels too:
+
+```
+# Every connection in any descendant of root.acme:
+apxy/ns/-/id=root.acme
+
+# Every request log entry from connections of type "salesforce":
+apxy/cxr/type=salesforce
+```
+
+## API surface
+
+Every resource that supports labels exposes the same four sub-resource endpoints, layered on top of the resource's CRUD URLs. Substitute the resource's URL segment (e.g., `connections`, `rate-limits`, `encryption-keys`):
+
+| Method + Path | Behaviour |
+|---|---|
+| `GET /api/v1/<resource>/:id/labels` | Read all labels |
+| `GET /api/v1/<resource>/:id/labels/:label` | Read one label by key |
+| `PUT /api/v1/<resource>/:id/labels/:label` | Set / update one label |
+| `DELETE /api/v1/<resource>/:id/labels/:label` | Remove one label |
+
+Annotations have the same shape under `/annotations`.
+
+The resource-level `PATCH` endpoint additionally supports replacing the entire user-label set in one shot via a top-level `labels` field. `PUT`s on the sub-resource path use merge semantics; `PATCH` on the parent with `labels` populated is a full replace.
+
+System (`apxy/`) labels survive a full replace — only user labels are replaced.
+
+## Implementation notes
+
+- **Validation.** Labels are validated on every write: keys follow `[<prefix>/]<name>` where the prefix is a DNS subdomain (max 253 chars) and the name is 1–63 chars from `[a-zA-Z0-9_.-]`, with values up to 63 chars. The `apxy/` prefix is reserved on user input.
+- **Storage.** Labels are stored as a JSON column (`jsonb` on Postgres, `text` on SQLite, `String` on Clickhouse for the request log). Label selectors compile to provider-specific JSON predicates.
+- **Annotations** share the same encoding but cap at 256 KB total per resource; values are not further validated.
+- **Propagation transactions.** Each carry-forward update runs in its own short transaction so long-fan-out updates do not hold long-running locks. The daily consistency checker uses a rate-limited enumerator to bound resource use even on large fleets.
+- **What's not carried forward.** Annotations don't propagate. Per-request labels don't end up on the connection. Once a request log entry is written, its label snapshot is frozen — future label changes on the connection don't backfill old log entries.

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -1,0 +1,471 @@
+# Rate Limits
+
+AuthProxy has two complementary rate-limiting systems:
+
+1. **Connector-level reactive rate limiting** — built into every connector. When a 3rd party returns 429, AuthProxy parses the `Retry-After` header and blocks subsequent requests on that connection until the wait expires. This protects you from hammering the upstream after it has already told you to slow down.
+2. **Rate limit resources** — declarative, namespace-scoped rules you define via API or Terraform. They run **before** the upstream call and reject requests that would breach a quota you have configured (e.g., "no more than 60 writes per minute per actor against Salesforce").
+
+Both can fire on the same request and both stamp the request log so you can tell them apart. This page covers each in detail.
+
+## Table of contents
+
+- [Customer guide](#customer-guide)
+  - [When to use which system](#when-to-use-which-system)
+  - [Defining a rate limit](#defining-a-rate-limit)
+    - [Via the API](#via-the-api)
+    - [Via Terraform](#via-terraform)
+  - [Selectors — picking which requests get limited](#selectors--picking-which-requests-get-limited)
+  - [Buckets — projecting requests into independent counters](#buckets--projecting-requests-into-independent-counters)
+  - [Algorithms](#algorithms)
+  - [`enforce` vs. `observe` mode](#enforce-vs-observe-mode)
+  - [What the caller sees on rejection](#what-the-caller-sees-on-rejection)
+  - [Multiple matching rules](#multiple-matching-rules)
+  - [Namespace inheritance and permissions](#namespace-inheritance-and-permissions)
+  - [Connector-level reactive 429 handling](#connector-level-reactive-429-handling)
+  - [Request log attribution](#request-log-attribution)
+- [Implementation reference](#implementation-reference)
+  - [Architecture](#architecture)
+  - [Bucket key resolution](#bucket-key-resolution)
+  - [Algorithm internals](#algorithm-internals)
+  - [Fail-open semantics](#fail-open-semantics)
+  - [Coexistence with the reactive limiter](#coexistence-with-the-reactive-limiter)
+  - [Performance characteristics](#performance-characteristics)
+  - [Known limitations](#known-limitations)
+
+---
+
+# Customer guide
+
+## When to use which system
+
+| Need | Use |
+|---|---|
+| Stop hammering a 3rd party that just returned 429. | The reactive limiter — built in, no configuration required for the common case. |
+| Tune what counts as a "retryable" 429 and how aggressively to back off. | Configure `rate_limiting` on the connector definition. |
+| Cap your own usage to stay below a known 3rd-party quota. | Define a rate-limit resource with `enforce` mode. |
+| Cap per-actor / per-team / per-cohort usage so noisy neighbours don't drain a shared quota. | Define a rate-limit resource with bucket dimensions. |
+| Roll out a new limit safely — see how many requests it *would have* rejected before turning it on. | Define a rate-limit resource with `observe` mode. |
+| Both — back off when upstream says 429 **and** never exceed our own configured cap. | Use both. They coexist; both can fire on the same request. |
+
+The rest of this page is mostly about the second system (rate-limit resources). The [connector-level reactive limiter](#connector-level-reactive-429-handling) gets its own section near the end.
+
+## Defining a rate limit
+
+A rate-limit resource lives in a namespace. It applies to proxy / probe traffic against connections in that namespace and any descendant namespace.
+
+### Via the API
+
+```http
+POST /api/v1/rate-limits
+Content-Type: application/json
+Authorization: Bearer <admin token>
+
+{
+  "namespace": "root.acme",
+  "labels": { "team": "acme" },
+  "annotations": { "owner": "platform@example.com" },
+  "definition": {
+    "mode": "enforce",
+    "selector": {
+      "label_selector": "apxy/cxr/type=salesforce",
+      "methods": ["POST", "PATCH", "PUT"],
+      "path_match": {
+        "kind": "prefix",
+        "value": "/services/data/"
+      }
+    },
+    "bucket": {
+      "dimensions": ["actor", "labels/team"]
+    },
+    "algorithm": {
+      "token_bucket": { "capacity": 60, "refill_rate": 1.0 }
+    }
+  }
+}
+```
+
+The response carries the server-assigned id (e.g., `rl_AbcXyz…`), the materialised label set (including the implicit `apxy/rl/-/id` / `apxy/rl/-/ns` and any carried-forward namespace labels — see [Labels](labels.md)), and timestamps.
+
+Update with `PATCH /api/v1/rate-limits/{id}` (the request body can carry any of `definition`, `labels`, `annotations`; omit fields you don't want to change). Delete with `DELETE /api/v1/rate-limits/{id}`. List with `GET /api/v1/rate-limits` (supports `namespace`, `label_selector`, and pagination cursor params).
+
+Labels and annotations also have sub-resource endpoints — see [Labels — API surface](labels.md#api-surface).
+
+### Via Terraform
+
+The `authproxy_rate_limit` resource exposes every field as typed HCL — no `jsonencode` blobs:
+
+```hcl
+resource "authproxy_rate_limit" "salesforce_writes" {
+  namespace = authproxy_namespace.acme.path
+  mode      = "enforce"
+
+  labels = {
+    team = "acme"
+  }
+  annotations = {
+    owner = "platform@example.com"
+  }
+
+  selector {
+    label_selector = "apxy/cxr/type=salesforce"
+    methods        = ["POST", "PATCH", "PUT"]
+    path_match {
+      kind  = "prefix"
+      value = "/services/data/"
+    }
+  }
+
+  bucket {
+    dimensions = ["actor", "labels/team"]
+  }
+
+  algorithm {
+    token_bucket {
+      capacity    = 60
+      refill_rate = 1.0
+    }
+  }
+}
+```
+
+Plan-time validation catches "exactly one of `fixed_window` / `sliding_window` / `token_bucket`" before `terraform apply`. The `namespace` is `ForceNew` — changing it replaces the resource. See [`authproxy_rate_limit` reference](../terraform/provider/docs/resources/authproxy_rate_limit.md) for the full attribute reference, and [`examples/`](../terraform/provider/examples/resources/authproxy_rate_limit/) for three end-to-end examples (token bucket, observe-mode rollout, sliding-window counter).
+
+## Selectors — picking which requests get limited
+
+The `selector` block decides which requests the rule applies to. All clauses are ANDed:
+
+| Clause | What it matches | Default if omitted |
+|---|---|---|
+| `label_selector` | Per-request label snapshot via [K8s-style selector syntax](labels.md#label-selectors). | Match any. |
+| `methods` | HTTP verb (exact, upper-case). | Match any. |
+| `path_match` | Final upstream URL path (after connector templating / rewriting). Three flavours: `prefix`, `glob` (`*` doesn't cross `/`), `regex`. | Match any. |
+| `request_types` | What kind of traffic — `proxy`, `probe`, `oauth2_token_exchange`, etc. | `[proxy, probe]`. |
+
+### Examples
+
+**By actor and tenant**, via the per-request label snapshot:
+```json
+"selector": {
+  "label_selector": "apxy/act/-/id=act_AbcXyz,app.example.com/tenant-id=tenant-42"
+}
+```
+
+**By connector type** — pin the rule to all Salesforce connections in the namespace:
+```json
+"selector": {
+  "label_selector": "apxy/cxr/type=salesforce"
+}
+```
+
+(`apxy/cxr/type` is carried forward from the connector version's user labels into each connection it's used by — see [Labels — Carry-forward](labels.md#carry-forward--how-labels-flow-through-the-hierarchy).)
+
+**By path** — limit only writes against the Salesforce REST API:
+```json
+"selector": {
+  "methods": ["POST", "PATCH", "PUT"],
+  "path_match": { "kind": "prefix", "value": "/services/data/" }
+}
+```
+
+**By specific operation** — regex when prefix / glob aren't precise enough:
+```json
+"selector": {
+  "path_match": {
+    "kind": "regex",
+    "value": "^/v1/users/[0-9]+/permissions$"
+  }
+}
+```
+
+### Request types
+
+Most rules govern user-driven `proxy` traffic and connector-defined `probe` traffic — that's the default. **OAuth2 token exchange / refresh / revocation are *not* governed by default** because rate-limiting your own auth flows is usually a self-inflicted outage. If you do need to throttle those (e.g., a 3rd party that throttles refresh aggressively), opt in explicitly:
+
+```json
+"selector": { "request_types": ["oauth2_refresh"] }
+```
+
+An explicit empty `request_types: []` is rejected at validation — omit the field to use the default.
+
+## Buckets — projecting requests into independent counters
+
+A bucket projects matched requests into separate counters so a limit can be "per actor" or "per team" or "per actor + team" rather than one global counter for the rule.
+
+```json
+"bucket": {
+  "dimensions": ["actor", "labels/team"]
+}
+```
+
+Each unique combination of values is its own counter. So `{actor=act_a, team=acme}` and `{actor=act_b, team=acme}` are two counters; both `act_a` calls to two different teams are also two counters.
+
+| Reserved dimension | Resolves to |
+|---|---|
+| `actor` | The initiating actor's id (`apxy/act/-/id`). Empty for system / unauthenticated traffic. |
+| `connection` | The connection's id. |
+| `connector` | The connector's id. |
+| `connector_version` | The numeric connector version. |
+| `namespace` | The namespace path. |
+| `method` | The HTTP verb. |
+| `labels/<key>` | A per-request label value. Missing = empty string. |
+
+An **empty `dimensions` list** is a single global counter for the rule — useful for whole-namespace or whole-system caps.
+
+A missing-but-referenced dimension resolves to `""`. So a rule that buckets by `actor` and gets unauthenticated traffic puts all of that traffic in the `actor=""` bucket — distinct from any populated actor.
+
+## Algorithms
+
+Pick exactly one algorithm. Each makes a different tradeoff between accuracy, memory, and burst tolerance.
+
+### `fixed_window`
+
+A counter that resets at boundaries derived from `floor(now / window)`.
+
+```json
+{ "fixed_window": { "window": "1m", "limit": 100 } }
+```
+
+Simple and cheap. Susceptible to **boundary bursts** — a client can fire `limit` calls in the last 100 ms of one window and another `limit` in the first 100 ms of the next, getting `2 × limit` in a 200 ms interval.
+
+### `sliding_window` — `log` mode
+
+A precise sliding window. Stores a timestamped log of recent allowed requests and removes entries older than `window` on each evaluation.
+
+```json
+{ "sliding_window": { "window": "1m", "limit": 100, "mode": "log" } }
+```
+
+Exactly `limit` requests permitted in any rolling `window` interval. Most accurate; most memory (a sorted set per bucket).
+
+### `sliding_window` — `counter` mode
+
+An approximation using two adjacent fixed-window counters, weighted by how far into the current window we are. Cheaper than `log` mode; accurate to a small constant factor.
+
+```json
+{ "sliding_window": { "window": "1m", "limit": 100, "mode": "counter" } }
+```
+
+Use when you need sliding-window semantics without the per-request memory cost.
+
+### `token_bucket`
+
+A bucket of tokens refilled at a constant rate. Each request consumes one token; if the bucket is empty, the request is rejected.
+
+```json
+{ "token_bucket": { "capacity": 60, "refill_rate": 1.0 } }
+```
+
+`capacity` is the burst — the max tokens the bucket can hold. `refill_rate` is tokens per second (may be fractional, e.g. `0.5` = one new token every two seconds). New buckets start full so first-time callers get the configured burst capacity rather than instantly hitting an empty pool.
+
+## `enforce` vs. `observe` mode
+
+| Mode | Behaviour |
+|---|---|
+| `enforce` (default) | When the rule rejects, return a 429 to the caller. |
+| `observe` | When the rule rejects, **pass the request through to upstream anyway** but record the would-have-rejected event on the request log. |
+
+`observe` is the safe-rollout switch. Deploy a new rule in `observe`, watch the request log for a few days, confirm the match volume / bucket distribution look sensible, then flip to `enforce`.
+
+Observe-mode rules **still increment counters** so when you flip to `enforce` the buckets are already warmed up — you don't see an instant spike of rejections from cold buckets.
+
+## What the caller sees on rejection
+
+When an `enforce`-mode rule rejects a proxy request, AuthProxy returns:
+
+| Header / field | Value |
+|---|---|
+| HTTP status | `429 Too Many Requests` |
+| `Retry-After` header | Seconds until the next request from this bucket would be permitted (window remainder for window algorithms; time-to-next-token for token bucket). |
+| `X-Authproxy-Ratelimited` header | `true` — distinguishes any AuthProxy synthetic 429 from a real upstream 429. |
+| `X-Authproxy-Ratelimit` header | The firing rule's id (e.g., `rl_AbcXyz…`). |
+| Body | JSON: `{ "error": "rate limited", "rate_limit_id": "<id>", "retry_after_seconds": <n> }` |
+
+Your application should treat 429 as a transient error and back off according to `Retry-After`. The `X-Authproxy-Ratelimit` header lets you correlate a 429 with the specific rule for support / debugging.
+
+The connector-level reactive limiter ([below](#connector-level-reactive-429-handling)) also produces a 429 with `X-Authproxy-Ratelimited: true` but **no** `X-Authproxy-Ratelimit` header (it has no rule id). Use the request log's `response_source` field (`upstream` / `connector_rate_limiter` / `rate_limit`) to disambiguate after the fact.
+
+## Multiple matching rules
+
+A request can match several rules at once — e.g., one rule at the root namespace, one at the child, and one targeting a specific label. AuthProxy evaluates **all matching rules** for every request and:
+
+- **Most-restrictive wins.** If more than one `enforce`-mode rule rejects, the one with the longest `Retry-After` is the one whose id ends up in `X-Authproxy-Ratelimit` and in the response body. The caller sees a single 429 with the most pessimistic wait.
+- **Observe rules never reject** but still evaluate (and increment their counters). Their decisions are recorded in the request log so you can see what would have happened.
+- **The full match set lives on the log entry.** Every rule that matched — firing, observe, or didn't-reject — is recorded under `rate_limit_matched` on the request log entry. See [Request log attribution](#request-log-attribution).
+
+Composition is "all apply" — there is no priority field, no specificity scoring, no first-match-wins. Layer org-wide caps at the root namespace with per-team caps at child namespaces and they stack cleanly.
+
+## Namespace inheritance and permissions
+
+A rate limit defined in namespace `N` applies to requests against connections in `N` **and any descendant namespace**. Define a rule at `root` to cover the whole system; define it at `root.team-acme` to scope it to that team's traffic.
+
+The implicit `apxy/rl/-/ns` label records the rule's home namespace, and the rule's user labels are inherited from that namespace via [carry-forward](labels.md#carry-forward--how-labels-flow-through-the-hierarchy).
+
+Permission to create / read / update / delete a rate limit follows the standard AuthProxy permission model — a token can manage rate limits in any namespace in which it has `rate_limits` access.
+
+## Connector-level reactive 429 handling
+
+The reactive limiter is built into every connector. When a 3rd party returns 429, AuthProxy parses the response, blocks the connection for the suggested wait, and short-circuits subsequent requests on that connection with its own 429 until the cool-down expires. This prevents you from hammering an API that has already told you to slow down.
+
+Configuration lives on the connector definition under `rate_limiting`. Every field has a sensible default — you only need to set the ones you want to override.
+
+```yaml
+# In a connector definition YAML
+rate_limiting:
+  disabled: false                       # Set true to pass 429s through unchanged
+  retry_after_headers: ["Retry-After"]  # Headers to check, in priority order
+  max_retry_after: 15m                  # Cap on any wait
+  default_retry_after: 60s              # Fallback when no parseable header found
+  exponential_backoff:                  # Used on consecutive 429s without a header
+    initial_interval: 1s
+    multiplier: 2.0
+    max_interval: 5m
+    jitter_fraction: 0.1
+```
+
+| Field | Default | What it does |
+|---|---|---|
+| `disabled` | `false` | When `true`, 429s pass through to the caller unchanged; no cool-down is recorded. |
+| `retry_after_headers` | `["Retry-After"]` | Headers to inspect, in order. First parseable value wins. Supports integer seconds, RFC 7231 HTTP-date, and ISO 8601 timestamps. |
+| `max_retry_after` | `15m` | Hard cap on any cool-down — protects against unreasonably long retry-after values from misbehaving upstreams. |
+| `default_retry_after` | `60s` | Used when a 429 has no parseable header and exponential backoff is not configured. |
+| `exponential_backoff.initial_interval` | `1s` | First-429 backoff. |
+| `exponential_backoff.multiplier` | `2.0` | Applied per consecutive 429. |
+| `exponential_backoff.max_interval` | `5m` | Cap on the per-step backoff. |
+| `exponential_backoff.jitter_fraction` | `0.1` | Each computed backoff is uniformly sampled in `[(1−j)·t, (1+j)·t]`. Prevents thundering-herd retries. |
+
+When the reactive limiter short-circuits a request, the synthetic 429 carries `X-Authproxy-Ratelimited: true` and shows up in the request log with `response_source: connector_rate_limiter`. No `X-Authproxy-Ratelimit` header (there's no rule id — this is opportunistic, not a configured rule).
+
+## Request log attribution
+
+Every 429 — real upstream, connector-level reactive, or rate-limit resource — is recorded on the request log with a `response_source` field so you can tell them apart:
+
+| `response_source` | Means |
+|---|---|
+| `upstream` (default) | The response (incl. any 429) came from the 3rd party. |
+| `connector_rate_limiter` | The connector-level reactive limiter short-circuited the request because the connection was in cool-down. No upstream call was made. |
+| `rate_limit` | A rate-limit resource rejected the request before any upstream call. |
+
+When a rate-limit resource is involved (firing or in observe-mode), the request log entry also carries:
+
+| Field | When populated | Notes |
+|---|---|---|
+| `rate_limit_id` | Any time a rate-limit rule matched (incl. observe-only). | The most-restrictive firing rule, or the first observe match if none fired. |
+| `rate_limit_mode` | Same. | `enforce` or `observe`. |
+| `rate_limit_bucket` | Same. | The resolved dimension → value map for the matched rule. |
+| `rate_limit_matched` | Same. | Full list of every rule that matched: `[{id, mode, bucket}, …]` — observe rules included. |
+
+The list endpoint accepts `response_source` and `rate_limit_id` filters so you can scope a request-log search to "every request rejected by `rl_AbcXyz`" or "every 429 that came from upstream".
+
+```http
+GET /api/v1/request-log?response_source=rate_limit&rate_limit_id=rl_AbcXyz
+```
+
+The admin UI surfaces `response_source` as a column (chip-rendered with a colour for synthetic-429 sources) and `rate_limit_id` as a hidden-by-default column with a link to the rate-limit detail page.
+
+---
+
+# Implementation reference
+
+The rest of this document covers internals — useful if you're operating or debugging an AuthProxy deployment, or if you're reading the request-log fields and want to know exactly what they mean.
+
+## Architecture
+
+The proxy-side rate-limit feature is composed of four moving parts:
+
+```
+            ┌────────────────────────────────────────────┐
+            │   admin API: CRUD rate_limit resources     │
+            └───────────────┬────────────────────────────┘
+                            │
+                            ▼
+            ┌────────────────────────────────────────────┐
+            │   Postgres: rate_limits table              │
+            └───────────────┬────────────────────────────┘
+                            │ refreshed every 5 min
+                            ▼
+            ┌────────────────────────────────────────────┐
+            │   In-memory rule cache (per proxy process) │◀─────┐
+            └───────────────┬────────────────────────────┘       │
+                            │                                     │
+                            ▼                                     │
+   [proxy request] ──▶  Match(rule, request) ──▶ Limiter.Decide(ctx, bucket_key)
+                            │                          │
+                            │                          ▼
+                            │              ┌─────────────────────┐
+                            │              │  Redis: counters    │
+                            │              └─────────────────────┘
+                            │
+                            ▼
+                  synth 429   /   pass through
+                  +  stamp request_log.Attribution
+```
+
+- **Rule cache** — every proxy process holds an in-memory snapshot of all rate-limit rules. A background goroutine refreshes from the database every 5 minutes (configurable, minimum 5 s). On Postgres failure the cache keeps its last-known-good snapshot.
+- **Matcher** — pure function `Match(rule, request) → (matched, bucket_key)`. Evaluates the rule's selector clauses against the request's type / method / upstream URL / label snapshot.
+- **Limiter** — per-algorithm Redis-backed counter. Each `Decide(ctx, bucket_key)` call runs a single Lua script so check-and-increment is atomic across processes.
+- **Enforcer round-tripper** — runs in the HTTP client chain. Iterates the cache, calls `Match` then `Decide` on every match, picks the most-restrictive enforce rejection (or passes through), and stamps the request log Attribution either way.
+
+The middleware chain on every proxied request is:
+
+```
+client → request log → telemetry → enforcer → connector reactive 429 → upstream
+```
+
+Request log is outermost so every request — including ones synth-rejected by either rate limiter — gets logged. Telemetry wraps both rate limiters so the client span covers any rate-limit waits. The enforcer runs before the reactive 429 limiter so a proxy-side rule rejection short-circuits cool-down checks. A real upstream 429 flows back through all of them.
+
+## Bucket key resolution
+
+The `BucketKey` for a matched request is the tuple of `(name, value)` pairs corresponding to the rule's `dimensions`, in the same order. Its canonical string form is used as the Redis sub-key:
+
+```
+actor=act_AbcXyz|labels/team=alpha
+```
+
+Pipe `|` separates components; `=` separates name from value. Both — plus `%` — are percent-encoded in values to keep the form unambiguous. An empty dimensions list yields the global key `*`. A missing-but-referenced dimension renders as the empty string (`actor=|labels/team=alpha`) — a distinct counter from any populated value.
+
+## Algorithm internals
+
+All three algorithms run their check-and-increment in a single Redis Lua script keyed on `ratelimit:rule:<rule_id>:<bucket_key>:<algo>:…`. Lua execution is atomic per shard, so even with thousands of concurrent goroutines hitting the same bucket the count is consistent.
+
+| Algorithm | State per bucket | Atomic operation |
+|---|---|---|
+| `fixed_window` | One `INCR` counter at `…:fw:<window_id>` with TTL = window. Old windows self-expire. | `INCR` + `PEXPIRE`; reject if `> limit`, retry-after = `PTTL`. |
+| `sliding_window` log | One ZSET at `…:swl` with `score=now_ms`, `member=<random tag>`. | `ZREMRANGEBYSCORE` (evict old) → `ZCARD` → reject + read oldest score for retry-after, or `ZADD` to admit. |
+| `sliding_window` counter | Two `INCR` counters at `…:swc:<window_id>` and `:<window_id-1>` (current + previous). | Weighted average: `curr + floor(prev × (window − elapsed_in_curr) / window)`. |
+| `token_bucket` | Hash at `…:tb` with `tokens`, `last_refill_ms`. New buckets start full. | Refill = `elapsed_s × rate`, cap at `capacity`; reject if `< 1` token, retry-after = `ceil((1 − tokens) / rate × 1000) ms`. |
+
+Refill rates may be fractional (e.g. `0.5`) — the Lua arithmetic is float.
+
+## Fail-open semantics
+
+Every Redis call inside a `Limiter.Decide` is wrapped: on any error, the limiter returns `{Allowed: true, FailedOpen: true}` and logs a structured warning. Rate limits are guardrails, not security boundaries — a Redis blip should not produce a customer-visible outage.
+
+Operationally:
+
+- A persistent Redis outage means rate limits are effectively disabled while the outage lasts.
+- The `FailedOpen` flag on the decision lets the enforcer surface this to operators via the structured log. Wire a metric on these events; sustained values indicate Redis health, not "you're under-utilising your limits".
+- The matcher itself never fails open — it's a pure function, no I/O. Bad rule data (e.g., uncompilable regex that somehow escaped schema validation) is logged and the rule is skipped for that request.
+
+## Coexistence with the reactive limiter
+
+Both systems can fire on the same request. The order is determined by the middleware chain ([above](#architecture)):
+
+1. **Enforcer first.** If a proxy-side rule rejects, you get a 429 with `response_source: rate_limit` — the request never reaches the reactive limiter.
+2. **Reactive limiter second.** If the enforcer passed through but the connection is in cool-down from a prior real upstream 429, you get a 429 with `response_source: connector_rate_limiter`.
+3. **Upstream third.** If both passed through, the upstream call happens. A real upstream 429 returns with `response_source: upstream` and the reactive limiter records the cool-down for next time.
+
+This ordering means proxy-side rule rejections "win" over connector cool-down rejections. From an attribution standpoint that's the right call — operators configured the rule intentionally, while cool-down is opportunistic.
+
+## Performance characteristics
+
+- **Cache reads** are O(1) lock-free (atomic snapshot pointer).
+- **Match evaluation** is linear in the number of cached rules per request. For most deployments this is in the tens to low hundreds; tests pin the matcher to microsecond-scale per call.
+- **Redis round-trips** are one Lua script invocation per matched rule. With a typical rule count and a sane bucket distribution, 1–3 round trips per proxied request.
+- **No connection draining at refresh time.** The cache refresh swaps an atomic snapshot pointer; in-flight `Match` calls keep their old snapshot.
+
+## Known limitations
+
+- **Cross-process invalidation on admin-API writes is not yet wired.** When an admin creates or updates a rule, each proxy process picks it up on its next 5-minute cache refresh. For most rollouts this is fine — you typically deploy a rule, then wait a refresh interval before relying on it. If you need faster propagation, reduce the interval (down to the 5 s minimum) or restart proxy processes after a write.
+- **Counter sharding is per Redis instance.** AuthProxy assumes a single logical Redis. Sharding across Redis clusters is not yet supported.
+- **Bucket dimensions reference only request-time data.** They cannot reference data only available after the upstream call (e.g., response size, response status). That model would require a "post-call" evaluation pass which is not part of this design.
+- **Observe-mode rules count toward Redis storage.** Even though they don't reject, they increment counters — by design, so flipping to enforce doesn't reset buckets. Be aware that observe rules consume the same Redis memory as enforce rules.

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -9,7 +9,7 @@ Both can fire on the same request and both stamp the request log so you can tell
 
 ## Table of contents
 
-- [Customer guide](#customer-guide)
+- [User guide](#user-guide)
   - [When to use which system](#when-to-use-which-system)
   - [Defining a rate limit](#defining-a-rate-limit)
     - [Via the API](#via-the-api)
@@ -34,7 +34,7 @@ Both can fire on the same request and both stamp the request log so you can tell
 
 ---
 
-# Customer guide
+# User guide
 
 ## When to use which system
 
@@ -92,7 +92,7 @@ Labels and annotations also have sub-resource endpoints — see [Labels — API 
 
 ### Via Terraform
 
-The `authproxy_rate_limit` resource exposes every field as typed HCL — no `jsonencode` blobs:
+The `authproxy_rate_limit` resource exposes every field as typed HCL:
 
 ```hcl
 resource "authproxy_rate_limit" "salesforce_writes" {


### PR DESCRIPTION
## Summary

Now that the eight #3 PRs are merged and rate-limit support is live end-to-end, this adds customer-facing documentation.

## What's in

**\`docs/rate-limits.md\` (~360 lines)**
Opens with a customer guide:
- When to use the connector-level reactive 429 handler vs. proxy-side rate-limit resources.
- Defining a rate limit via API and via Terraform (with side-by-side examples).
- Selectors — label selector, methods, path match (prefix / glob / regex), request types (default \`[proxy, probe]\` + opt-in for OAuth2 sub-types).
- Buckets — reserved dimensions (\`actor\`, \`connection\`, \`connector\`, etc.) and \`labels/<key>\` references.
- Algorithms — fixed_window, sliding_window (log + counter), token_bucket, with the relevant tradeoffs.
- \`enforce\` vs. \`observe\` mode, including why observe still increments counters.
- What the caller sees on rejection — 429, \`Retry-After\`, \`X-Authproxy-Ratelimited\`, \`X-Authproxy-Ratelimit\`, body shape.
- Multi-rule "all apply, most-restrictive wins" semantics.
- Namespace inheritance and permissions.
- Connector-level reactive 429 handling — full options table including the \`exponential_backoff\` sub-options.
- Request log attribution — \`response_source\` enum, \`rate_limit_id\`/\`mode\`/\`bucket\`/\`matched\` fields, list-endpoint filters.

Continues with an implementation reference for operators:
- Architecture diagram (cache → matcher → limiter → Redis).
- Middleware chain order (request log → telemetry → enforcer → reactive 429 → upstream).
- Bucket key canonical serialization rules.
- Per-algorithm internals (Lua scripts, state shape, retry-after computation).
- Fail-open semantics on Redis outage.
- Coexistence with the reactive limiter (which fires first, what wins on attribution).
- Performance characteristics.
- Known limitations (cross-process invalidation on admin writes deferred, etc.).

**\`docs/labels.md\` (~190 lines)**
Companion page covering the label system end to end:
- Where labels live across resource types.
- Label vs. annotation tradeoffs.
- The \`apxy/\` system label namespace — identifier labels (\`apxy/<rt>/-/id\`, \`apxy/<rt>/-/ns\`) and the resource-type token table.
- Carry-forward through the hierarchy with a worked three-level example showing exactly what ends up on a connection.
- Propagation on parent change (targeted refresh + daily reconciler).
- The per-request label snapshot — what's in it and how the actor contribution gets re-keyed.
- Label selector syntax with examples for both user and system labels.
- The four-endpoint label/annotation API surface every resource exposes.

**\`docs/README.md\`**
Index for the \`docs/\` directory grouped into feature guides, operational guides, reference, and architecture diagrams. Renders on GitHub as the directory landing page.

**\`README.md\` updates**
- Adds a top-level Table of Contents linking to existing sections via anchors.
- Adds a "Feature documentation" section near the top with links to the new docs.
- Adds a "Rate Limits" sub-section under Key Concepts that introduces the feature and points at \`docs/rate-limits.md\`.
- Expands the existing "Labels and Annotations" section with a pointer to \`docs/labels.md\`.
- Reorganises the bottom "Additional Documentation" section into a full "Documentation" table linking feature guides + operational guides + Terraform provider docs / examples.

## Notes for the reviewer

- The two long docs are **opinionated**: customer concerns first, internals near the end so an integrator can stop reading at the point that's relevant to them.
- Every API path, header name, default value, and field name was verified against the code on \`main\` (e.g., \`X-Authproxy-Ratelimited\` / \`X-Authproxy-Ratelimit\`, the \`rate_limit_matched\` field shape, the connector-level \`exponential_backoff\` defaults).
- Cross-links between \`labels.md\` and \`rate-limits.md\` use relative paths so they work both on GitHub and locally.
- I left the existing \`docs/index.md\` alone — it looked like it serves a different purpose (the GitHub Pages landing rather than the docs directory's GitHub-rendered README).

## Test plan

- [x] \`./scripts/preflight.sh\` — clean (docs-only change but worth confirming nothing slipped)
- [x] Spot-checked every relative link target — all files / sections exist.
- [x] Main README TOC anchors verified against actual heading text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)