### PR TITLE
Add bounded retry policy to OAuth2 refresh path (#170 PR A)

### DIFF
--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/core/iface"
@@ -13,6 +15,23 @@ import (
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	gentleman "gopkg.in/h2non/gentleman.v2"
+)
+
+// Refresh-token retry policy. Mirrors the token-exchange policy in
+// callback.go: a small bounded number of attempts with linear backoff,
+// retrying transport errors and 5xx responses only. 4xx responses
+// (invalid_grant, invalid_client, etc.) are permanent — resubmitting the
+// same refresh token won't change the provider's decision and may, with
+// some providers, count toward a per-refresh-token attempt budget.
+const (
+	// tokenRefreshMaxAttempts is the total number of refresh-endpoint POST
+	// attempts (including the first). 3 = 1 try + 2 retries.
+	tokenRefreshMaxAttempts = 3
+	// tokenRefreshBackoffStep is the linear backoff between attempts:
+	// 200ms before retry 1, 400ms before retry 2. Same shape as
+	// tokenExchangeBackoffStep — short enough not to stall a proxied
+	// request perceptibly, long enough to ride out a node-local hiccup.
+	tokenRefreshBackoffStep = 200 * time.Millisecond
 )
 
 // errNoRefreshToken is returned by refreshAccessToken when the persisted
@@ -32,14 +51,14 @@ func (o *oAuth2Connection) refreshAccessToken(ctx context.Context, token *databa
 	m := o.tokenMutex()
 	err := m.Lock(ctx)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
 	defer m.Unlock(ctx)
 
 	// Get the latest token to make sure we still need to refresh
 	token, err = o.db.GetOAuth2Token(ctx, o.connection.GetId())
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
 
 	if mode == refreshModeOnlyExpired && !token.IsAccessTokenExpired(ctx) {
@@ -50,25 +69,23 @@ func (o *oAuth2Connection) refreshAccessToken(ctx context.Context, token *databa
 		// Permanent — there is no way to obtain a new access token without
 		// user interaction. Flip the connection unhealthy so the unified
 		// reauth UX surfaces the prompt.
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshNoRefreshToken, 0, "", errNoRefreshToken)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshNoRefreshToken, 0, "", 0, errNoRefreshToken)
 	}
 
 	clientId, err := o.auth.ClientId.GetValue(ctx)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
 
 	clientSecret, err := o.auth.ClientSecret.GetValue(ctx)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
 
 	refreshToken, err := o.encrypt.DecryptString(ctx, token.EncryptedRefreshToken)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
-
-	// Prepare a refresh token request
 
 	client := o.httpf.
 		ForRequestType(httpf.RequestTypeOAuth).
@@ -76,43 +93,33 @@ func (o *oAuth2Connection) refreshAccessToken(ctx context.Context, token *databa
 		New()
 	tokenEndpoint, err := o.renderMustache(ctx, o.auth.Token.Endpoint)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "",
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0,
 			fmt.Errorf("failed to render token endpoint template: %w", err))
 	}
 
-	refreshReq := client.
-		UseContext(ctx).
-		Request().
-		Method("POST").
-		URL(tokenEndpoint).
-		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		AddHeader("accept", "application/json").
-		BodyString(
-			url.Values{
-				"grant_type":    {"refresh_token"},
-				"refresh_token": {refreshToken},
-				"client_id":     {clientId},
-				"client_secret": {clientSecret},
-			}.Encode(),
-		)
+	values := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientId},
+		"client_secret": {clientSecret},
+	}
 
-	// Submit the refresh request
-	refreshResp, err := refreshReq.Send()
+	refreshResp, attempts, err := o.postRefreshWithRetry(ctx, client, tokenEndpoint, values)
 	if err != nil {
 		// Transport-layer failure — provider never produced a status code.
 		// Transient by classification; does not flip unhealthy.
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshNetworkError, 0, "", err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshNetworkError, 0, "", attempts, err)
 	}
 
 	if refreshResp.StatusCode != 200 {
 		category, providerErr := classifyTokenRefreshStatus(refreshResp.StatusCode, refreshResp.Bytes())
 		err := fmt.Errorf("refresh token request failed with status %d", refreshResp.StatusCode)
-		return nil, o.classifyAndRecordRefreshFailure(ctx, category, refreshResp.StatusCode, providerErr, err)
+		return nil, o.classifyAndRecordRefreshFailure(ctx, category, refreshResp.StatusCode, providerErr, attempts, err)
 	}
 
 	newToken, err := o.createDbTokenFromResponse(ctx, refreshResp, token)
 	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshMalformedResponse, refreshResp.StatusCode, "",
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshMalformedResponse, refreshResp.StatusCode, "", attempts,
 			fmt.Errorf("failed to refresh token: %w", err))
 	}
 
@@ -139,16 +146,24 @@ func (o *oAuth2Connection) refreshAccessToken(ctx context.Context, token *databa
 // Centralizing the emit + mark dance here ensures every refresh failure
 // path produces the same observable shape, and that the "permanent →
 // unhealthy" mapping lives in one place.
+//
+// attempts is the number of refresh-endpoint POSTs actually made (0 for
+// failures that occur before any HTTP call — internal_error,
+// no_refresh_token). When > 0 it's emitted on the failure event so the
+// "retry exhausted" case is visibly distinct from a single non-retryable
+// failure.
 func (o *oAuth2Connection) classifyAndRecordRefreshFailure(
 	ctx context.Context,
 	category tokenRefreshCategory,
 	providerStatusCode int,
 	providerErr string,
+	attempts int,
 	err error,
 ) error {
 	attrs := o.tokenRefreshAttrsFromConn(err)
 	attrs.ProviderStatusCode = providerStatusCode
 	attrs.ProviderError = providerErr
+	attrs.Attempts = attempts
 	emitTokenRefreshFailure(ctx, o.logger, category, attrs)
 
 	if category.IsPermanent() && o.connection != nil {
@@ -257,6 +272,74 @@ func (o *oAuth2Connection) sendProxyRequest(
 
 func (o *oAuth2Connection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
 	return nil
+}
+
+// postRefreshWithRetry POSTs a refresh-token grant to the provider's token
+// endpoint with a small bounded retry budget for transient failures
+// (transport errors and 5xx responses). Returns the final response (or
+// last network error) along with the number of attempts actually made;
+// callers attach that to the failure event so "exhausted budget" is
+// visibly distinct from a single non-retryable failure.
+//
+// 4xx responses are never retried — the provider has classified the
+// refresh token itself as invalid/expired/revoked, and resubmitting it
+// will not change the outcome. With some providers (notably ones that
+// enforce refresh-token rotation), a retried 4xx counts against the
+// token's lifetime, so retrying is observably worse than not.
+//
+// gentleman requests are single-use (Send panics on the second call), so
+// each iteration rebuilds the request from scratch.
+func (o *oAuth2Connection) postRefreshWithRetry(
+	ctx context.Context,
+	client *gentleman.Client,
+	tokenEndpoint string,
+	values url.Values,
+) (*gentleman.Response, int, error) {
+	var lastResp *gentleman.Response
+	var lastErr error
+
+	for attempt := 1; attempt <= tokenRefreshMaxAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := tokenRefreshBackoffStep * time.Duration(attempt-1)
+			select {
+			case <-ctx.Done():
+				return nil, attempt - 1, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req := client.
+			UseContext(ctx).
+			Request().
+			Method("POST").
+			URL(tokenEndpoint).
+			SetHeader("Content-Type", "application/x-www-form-urlencoded").
+			AddHeader("accept", "application/json").
+			BodyString(values.Encode())
+
+		resp, err := req.Send()
+
+		if err == nil && resp.StatusCode < 500 {
+			return resp, attempt, nil
+		}
+
+		lastResp, lastErr = resp, err
+
+		if attempt < tokenRefreshMaxAttempts {
+			args := []any{
+				slog.Int("attempt", attempt),
+				slog.Int("max_attempts", tokenRefreshMaxAttempts),
+			}
+			if err != nil {
+				args = append(args, slog.String("error", err.Error()))
+			} else {
+				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
+			}
+			o.logger.WarnContext(ctx, "oauth token refresh transient failure; retrying", args...)
+		}
+	}
+
+	return lastResp, tokenRefreshMaxAttempts, lastErr
 }
 
 var _ iface.Proxy = (*oAuth2Connection)(nil)

--- a/internal/auth_methods/oauth2/proxy_test.go
+++ b/internal/auth_methods/oauth2/proxy_test.go
@@ -3,13 +3,19 @@ package oauth2
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gentleman "gopkg.in/h2non/gentleman.v2"
 )
 
 // TestClassifyAndRecordRefreshFailure_PermanentFlipsUnhealthy is the
@@ -41,6 +47,7 @@ func TestClassifyAndRecordRefreshFailure_PermanentFlipsUnhealthy(t *testing.T) {
 				cat,
 				400,
 				"invalid_grant",
+				1,
 				errors.New("status 400"),
 			)
 			require.Error(t, err, "the underlying error must be propagated")
@@ -79,6 +86,7 @@ func TestClassifyAndRecordRefreshFailure_TransientLeavesHealthAlone(t *testing.T
 				cat,
 				503,
 				"",
+				tokenRefreshMaxAttempts,
 				errors.New("status 503"),
 			)
 			require.Error(t, err)
@@ -111,6 +119,7 @@ func TestClassifyAndRecordRefreshFailure_PermanentOnAlreadyUnhealthyNoop(t *test
 		tokenRefreshInvalidGrant,
 		400,
 		"invalid_grant",
+		1,
 		errors.New("status 400"),
 	)
 	require.Error(t, err)
@@ -134,6 +143,7 @@ func TestClassifyAndRecordRefreshFailure_NilConnectionDoesNotPanic(t *testing.T)
 		tokenRefreshInternalError,
 		0,
 		"",
+		0,
 		errors.New("decrypt failed"),
 	)
 	require.Error(t, err)
@@ -159,6 +169,7 @@ func TestClassifyAndRecordRefreshFailure_ReasonStringFormat(t *testing.T) {
 		tokenRefreshInvalidGrant,
 		400,
 		"invalid_grant",
+		1,
 		errors.New("status 400"),
 	)
 
@@ -178,4 +189,252 @@ type reasonCapturingConnection struct {
 func (c *reasonCapturingConnection) MarkHealthState(ctx context.Context, state database.ConnectionHealthState, reason string) error {
 	c.lastReason = reason
 	return c.Connection.MarkHealthState(ctx, state, reason)
+}
+
+// TestClassifyAndRecordRefreshFailure_AttemptsEmittedWhenSet pins that
+// the attempts field plumbed in from postRefreshWithRetry actually lands
+// on the structured event. PR C's integration tests will assert
+// attempts=tokenRefreshMaxAttempts on the exhausted-retry path; if the
+// wiring here regressed, those assertions would silently see attempts=0
+// and pass for the wrong reason.
+func TestClassifyAndRecordRefreshFailure_AttemptsEmittedWhenSet(t *testing.T) {
+	logger, read := bufLogger(t)
+	conn := &mockCore.Connection{
+		Id:          apid.New(apid.PrefixConnection),
+		HealthState: database.ConnectionHealthStateHealthy,
+	}
+	o := &oAuth2Connection{logger: logger, connection: conn}
+
+	_ = o.classifyAndRecordRefreshFailure(
+		context.Background(),
+		tokenRefreshProvider5xx,
+		503,
+		"",
+		tokenRefreshMaxAttempts,
+		errors.New("status 503"),
+	)
+
+	records := onlyTokenRefreshFailure(read())
+	require.Len(t, records, 1)
+	assert.EqualValues(t, tokenRefreshMaxAttempts, records[0]["attempts"],
+		"attempts must round-trip through the structured event so retry exhaustion is observable")
+}
+
+// TestClassifyAndRecordRefreshFailure_AttemptsOmittedWhenZero — the
+// no-HTTP-call paths (no_refresh_token, internal_error before the POST)
+// supply attempts=0. The event must omit the field entirely rather than
+// emitting attempts=0, which would be observably confusing on dashboards
+// (looks like the helper claims it didn't try at all).
+func TestClassifyAndRecordRefreshFailure_AttemptsOmittedWhenZero(t *testing.T) {
+	logger, read := bufLogger(t)
+	conn := &mockCore.Connection{
+		Id:          apid.New(apid.PrefixConnection),
+		HealthState: database.ConnectionHealthStateHealthy,
+	}
+	o := &oAuth2Connection{logger: logger, connection: conn}
+
+	_ = o.classifyAndRecordRefreshFailure(
+		context.Background(),
+		tokenRefreshNoRefreshToken,
+		0,
+		"",
+		0,
+		errNoRefreshToken,
+	)
+
+	records := onlyTokenRefreshFailure(read())
+	require.Len(t, records, 1)
+	_, present := records[0]["attempts"]
+	assert.False(t, present, "attempts=0 must be omitted, not emitted as the literal zero value")
+}
+
+// scriptedRefreshServer is the refresh-path analog of scriptedTokenServer
+// in callback_test.go — serves the supplied responses one per request,
+// returning the final entry for further calls. Lets the retry tests pin
+// attempt counts deterministically.
+func scriptedRefreshServer(t *testing.T, responses []scriptedResponse) (*httptest.Server, *int32, *[]url.Values) {
+	t.Helper()
+	var calls int32
+	var bodies []url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(atomic.AddInt32(&calls, 1)) - 1
+		body, _ := url.ParseQuery(readBody(t, r))
+		bodies = append(bodies, body)
+		resp := responses[len(responses)-1]
+		if idx < len(responses) {
+			resp = responses[idx]
+		}
+		w.WriteHeader(resp.status)
+		_, _ = w.Write([]byte(resp.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls, &bodies
+}
+
+func newRefreshRetryTestConn(t *testing.T) *oAuth2Connection {
+	t.Helper()
+	logger, _ := bufLogger(t)
+	return &oAuth2Connection{logger: logger}
+}
+
+func TestPostRefreshWithRetry_SuccessFirstAttempt(t *testing.T) {
+	srv, calls, bodies := scriptedRefreshServer(t, []scriptedResponse{
+		{status: 200, body: `{"access_token":"a"}`},
+	})
+	o := newRefreshRetryTestConn(t)
+
+	resp, attempts, err := o.postRefreshWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"rt"}},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 1, attempts, "200 must not retry")
+	assert.Equal(t, int32(1), atomic.LoadInt32(calls))
+	require.Len(t, *bodies, 1)
+	assert.Equal(t, "rt", (*bodies)[0].Get("refresh_token"),
+		"posted body must include the refresh_token form value verbatim")
+	assert.Equal(t, "refresh_token", (*bodies)[0].Get("grant_type"))
+}
+
+// TestPostRefreshWithRetry_4xxNotRetried is the load-bearing invariant
+// of the refresh retry policy: 4xx responses are non-retryable. The
+// provider has classified the refresh token as invalid/expired/revoked
+// and resubmitting won't change that — with rotating-refresh providers
+// it can actively make things worse. A regression here would silently
+// break PR B's integration tests by inflating the observed call count.
+func TestPostRefreshWithRetry_4xxNotRetried(t *testing.T) {
+	for _, status := range []int{400, 401, 403, 404, 422, 429} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv, calls, _ := scriptedRefreshServer(t, []scriptedResponse{
+				{status: status, body: `{"error":"invalid_grant"}`},
+			})
+			o := newRefreshRetryTestConn(t)
+
+			resp, attempts, err := o.postRefreshWithRetry(
+				context.Background(),
+				gentleman.New(),
+				srv.URL,
+				url.Values{"grant_type": {"refresh_token"}},
+			)
+
+			require.NoError(t, err, "transport-layer call succeeded — 4xx is not a transport error")
+			require.NotNil(t, resp)
+			assert.Equal(t, status, resp.StatusCode)
+			assert.Equal(t, 1, attempts)
+			assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+				"4xx must terminate the loop on the first attempt")
+		})
+	}
+}
+
+func TestPostRefreshWithRetry_5xxThenSuccess(t *testing.T) {
+	srv, calls, _ := scriptedRefreshServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+		{status: 200, body: `{"access_token":"a"}`},
+	})
+	o := newRefreshRetryTestConn(t)
+
+	start := time.Now()
+	resp, attempts, err := o.postRefreshWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, int32(2), atomic.LoadInt32(calls))
+	assert.GreaterOrEqual(t, elapsed, tokenRefreshBackoffStep,
+		"second attempt must wait at least one backoff step")
+}
+
+// TestPostRefreshWithRetry_5xxExhausted pins the exhaustion shape: the
+// helper returns the last response (so the caller can classify on its
+// status code), with attempts=tokenRefreshMaxAttempts so the failure
+// event can record budget exhaustion.
+func TestPostRefreshWithRetry_5xxExhausted(t *testing.T) {
+	srv, calls, _ := scriptedRefreshServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+	})
+	o := newRefreshRetryTestConn(t)
+
+	resp, attempts, err := o.postRefreshWithRetry(
+		context.Background(),
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+
+	require.NoError(t, err, "5xx is an HTTP-level failure, not a transport error")
+	require.NotNil(t, resp, "exhausted retry must return the last response so the caller can classify")
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, tokenRefreshMaxAttempts, attempts)
+	assert.Equal(t, int32(tokenRefreshMaxAttempts), atomic.LoadInt32(calls),
+		"helper must make exactly tokenRefreshMaxAttempts calls and stop")
+}
+
+// TestPostRefreshWithRetry_TransportErrorRetried — when the dial fails
+// (server closed, DNS, etc.) the helper has no response to inspect, so
+// it falls into the same retry branch as a 5xx. Closing the test server
+// before the call ensures every attempt hits "connection refused".
+func TestPostRefreshWithRetry_TransportErrorRetried(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+	o := newRefreshRetryTestConn(t)
+
+	resp, attempts, err := o.postRefreshWithRetry(
+		context.Background(),
+		gentleman.New(),
+		closedURL,
+		url.Values{},
+	)
+
+	require.Error(t, err, "transport failure must surface as an error")
+	if resp != nil {
+		assert.Equal(t, 0, resp.StatusCode,
+			"transport-error response carries no status code; classifier keys on err, not resp")
+	}
+	assert.Equal(t, tokenRefreshMaxAttempts, attempts,
+		"transport errors are retried like 5xx — full budget should be consumed")
+}
+
+// TestPostRefreshWithRetry_ContextCancelledBeforeRetry — caller context
+// is honored between attempts. Cancellation after the first 5xx must
+// short-circuit with ctx.Err and an attempt count reflecting only the
+// calls actually completed before cancellation.
+func TestPostRefreshWithRetry_ContextCancelledBeforeRetry(t *testing.T) {
+	srv, calls, _ := scriptedRefreshServer(t, []scriptedResponse{
+		{status: 503, body: `{"error":"temporarily_unavailable"}`},
+	})
+	o := newRefreshRetryTestConn(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	resp, attempts, err := o.postRefreshWithRetry(
+		ctx,
+		gentleman.New(),
+		srv.URL,
+		url.Values{},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, resp, "cancellation in the backoff window returns nil response")
+	assert.Equal(t, 1, attempts,
+		"attempts records only completed calls — the in-flight cancellation was during backoff")
+	assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+		"server should have observed exactly one call before cancellation")
 }

--- a/internal/auth_methods/oauth2/token_refresh_failure.go
+++ b/internal/auth_methods/oauth2/token_refresh_failure.go
@@ -82,7 +82,12 @@ type tokenRefreshAttrs struct {
 	Namespace          string
 	ProviderStatusCode int
 	ProviderError      string
-	Err                error
+	// Attempts is how many refresh-endpoint POSTs were made before the
+	// failure was surfaced (1 means the first attempt failed and was
+	// not retried). Emitted when > 0 so 5xx exhaustion is visibly
+	// distinct from a single non-retryable failure.
+	Attempts int
+	Err      error
 }
 
 // tokenRefreshFailureMessage / tokenRefreshSuccessMessage are the single
@@ -114,6 +119,9 @@ func emitTokenRefreshFailure(ctx context.Context, logger *slog.Logger, category 
 	}
 	if attrs.ProviderError != "" {
 		args = append(args, slog.String("provider_error", attrs.ProviderError))
+	}
+	if attrs.Attempts > 0 {
+		args = append(args, slog.Int("attempts", attrs.Attempts))
 	}
 	if attrs.Err != nil {
 		args = append(args, slog.String("error", attrs.Err.Error()))


### PR DESCRIPTION
First of three PRs for issue #170 (refresh failure modes + retry policy). Also resolves the symptom reported in #189 — the refresh path was single-shot, so a transient upstream blip surfaced as a permanent refresh failure.

## Summary
- Adds `postRefreshWithRetry` helper on `oAuth2Connection`: 3 attempts with 200ms/400ms linear backoff, retrying transport errors and 5xx responses only. 4xx is returned immediately (refresh tokens are often single-use under rotation; a retried 4xx can actively make things worse).
- Refactors `refreshAccessToken` to use the helper. Plumbs `attempts` through `classifyAndRecordRefreshFailure` and onto the structured `oauth token refresh failed` event (emitted when > 0, omitted at zero so pre-HTTP failure paths don't log a misleading literal zero).
- Unit tests in `proxy_test.go` mirror the postTokenExchangeWithRetry test set: success first attempt, 4xx-not-retried (the load-bearing invariant of the policy), 5xx-then-success, 5xx exhaustion, transport-error retry, and context cancellation during backoff. Plus two new tests pinning the `attempts` field round-trips through the emitted event.

## Followup PRs (issue #170)
- **PR B**: integration tests for scenario 7 — deterministic refresh failures (`invalid_grant`, `invalid_client`, `provider_4xx_other`, malformed 200, 200-without-access-token).
- **PR C**: integration tests for scenario 8 — retry succeeds after N transient 5xxs, exhausts after budget, attempts count on the failure event.

## Test plan
- [x] \`go test ./internal/auth_methods/oauth2/...\` passes (full package, including 11 new test cases for the retry helper + attempts plumbing)
- [x] \`./scripts/preflight.sh\` passes
- [x] Existing integration tests \`TestProxyRefresh_ExpiredAccessTokenRefreshes\` and \`TestProxyRefresh_NoRefreshTokenFlipsUnhealthy\` still pass (refresh path end-to-end with the new helper in place)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)