### PR TITLE
OAuth2 refresh failure-mode integration tests (#170 PR B)

### DIFF
--- a/integration_tests/oauth2/proxy_refresh_failure_test.go
+++ b/integration_tests/oauth2/proxy_refresh_failure_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 7 from issue #170: deterministic refresh failures. The proxy
+// detects an expired access token, POSTs a refresh-token grant to the
+// provider, and the provider returns a permanent failure (a 4xx with one
+// of the RFC 6749 §5.2 error codes, a 4xx with no recognized code, a
+// malformed 200 body, or a 200 with no access_token). Every case must:
+//
+//   - emit exactly one structured "oauth token refresh failed" event with
+//     the right `category` (the dashboards key off this string), with the
+//     `provider_status_code` and `provider_error` fields populated when
+//     applicable;
+//   - flip the connection's `health_state` to `unhealthy` and emit a
+//     single `connection health state changed` event with `reason` of
+//     `refresh_<category>` (so the dashboards correlate the two);
+//   - NOT corrupt the persisted token row — a malformed refresh response
+//     must not overwrite the existing refresh_token with garbage;
+//   - cause the original proxy request to fail (no valid access token →
+//     no proxy);
+//   - hit the refresh endpoint exactly once. None of the scenario 7 cases
+//     are retryable, so the retry loop must short-circuit on the first
+//     4xx / unparseable-200 / no-access-token response.
+//
+// The 5xx / transient cases (scenario 8) are PR C and live in
+// proxy_refresh_retry_test.go.
+
+// refreshFailureCase describes one scripted refresh-endpoint response and
+// the observable shape the proxy must produce. The fixture differs only
+// in the scripted action and the expected category/status; every other
+// lever (connector, auth flow, expiry forge, proxy call) is identical.
+type refreshFailureCase struct {
+	name                string
+	scriptAction        helpers.ScriptAction
+	expectedCategory    string
+	expectedStatusCode  int    // 0 = assert field omitted on the event
+	expectedProviderErr string // "" = assert field omitted on the event
+}
+
+// scenario 7 cases, mapped one-to-one onto the categories enumerated in
+// `internal/auth_methods/oauth2/token_refresh_failure.go`. The mapping is
+// load-bearing for dashboards — changing any of these category strings
+// is a public observability break.
+var refreshFailureCases = []refreshFailureCase{
+	{
+		name:                "InvalidGrant",
+		scriptAction:        helpers.ScriptAction{Status: 400, Body: `{"error":"invalid_grant"}`},
+		expectedCategory:    "invalid_grant",
+		expectedStatusCode:  400,
+		expectedProviderErr: "invalid_grant",
+	},
+	{
+		// Per RFC 6749 §5.2 a 401 with WWW-Authenticate is the canonical
+		// invalid_client shape; the proxy classifies on the body, so the
+		// header is irrelevant to this test.
+		name:                "InvalidClient",
+		scriptAction:        helpers.ScriptAction{Status: 401, Body: `{"error":"invalid_client"}`},
+		expectedCategory:    "invalid_client",
+		expectedStatusCode:  401,
+		expectedProviderErr: "invalid_client",
+	},
+	{
+		// Non-spec 4xx — typical of a WAF / rate-limiter page sitting in
+		// front of the provider's token endpoint. provider_error is
+		// omitted because there is nothing safe to log.
+		name: "Provider4xxOther",
+		scriptAction: helpers.ScriptAction{
+			Status:  403,
+			Headers: map[string]string{"Content-Type": "text/html"},
+			Body:    "<html><body>Forbidden by WAF</body></html>",
+		},
+		expectedCategory:   "provider_4xx_other",
+		expectedStatusCode: 403,
+	},
+	{
+		// 200 with an unparseable body — distinct from any 4xx. The
+		// request "succeeded" at the HTTP layer but the proxy could not
+		// extract an access_token, so the refresh is observably broken
+		// without being attributable to a known §5.2 cause.
+		name:               "MalformedResponse",
+		scriptAction:       helpers.ScriptAction{Status: 200, BodyTemplate: helpers.BodyMalformedJSON},
+		expectedCategory:   "malformed_response",
+		expectedStatusCode: 200,
+	},
+	{
+		// 200 with a well-formed JSON envelope that omits `access_token`.
+		// `createDbTokenFromResponse` rejects this as a malformed
+		// response — the proxy has no useful credential to persist. Same
+		// observable category as the unparseable-body case (issue #189
+		// folds into this case).
+		name:               "NoAccessTokenInResponse",
+		scriptAction:       helpers.ScriptAction{Status: 200, Body: `{"token_type":"Bearer","expires_in":3600}`},
+		expectedCategory:   "malformed_response",
+		expectedStatusCode: 200,
+	},
+}
+
+// TestProxyRefreshFailure_Scenarios drives every scripted refresh-endpoint
+// failure through the same fixture and asserts the full observable shape:
+// health flip, structured events, token-row preservation, no excess
+// refresh calls.
+//
+// Each subtest stands up its own rig because the test provider's request
+// log + script queues are per-fixture, and because cross-subtest leakage
+// of LogCapture records would make the "exactly one failure event"
+// assertion meaningless. Subtest startup is dominated by container reuse,
+// so the cost is negligible compared to the clarity benefit.
+func TestProxyRefreshFailure_Scenarios(t *testing.T) {
+	for _, tc := range refreshFailureCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The test provider lowercases registered client keys, so the
+			// rig name is normalized; the subtest name stays CamelCase for
+			// readability in test output.
+			rig := newProxyRefreshRig(t, fmt.Sprintf("refresh-fail-%s", strings.ToLower(tc.name)))
+			connID := rig.completeAuthFlow(t)
+
+			rig.forceTokenExpired(t, connID, false)
+
+			// Snapshot the token row AFTER force-expire (forceTokenExpired
+			// itself inserts a new replacement row), so the
+			// "no corrupt token state" assertion compares against the row
+			// that exists when the refresh POST is about to fire. A
+			// permanent refresh failure must leave this exact row in place.
+			preFailureToken := rig.env.GetOAuth2Token(t, connID)
+			require.NotNil(t, preFailureToken, "forge-expire must leave a token row")
+			preFailureTokenID := preFailureToken.Id
+			preFailureEncryptedRefresh := preFailureToken.EncryptedRefreshToken
+
+			rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, tc.scriptAction)
+
+			w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+			require.NotEqualf(t, 200, w.Code,
+				"proxy must fail when refresh fails permanently; got 200 body=%s", w.Body.String())
+
+			// Health flipped unhealthy — the load-bearing signal that drives
+			// the marketplace reconnect prompt.
+			conn := rig.env.GetConnection(t, connID)
+			assert.Equal(t, database.ConnectionHealthStateUnhealthy, conn.HealthState,
+				"permanent refresh failure must flip the connection unhealthy")
+
+			// Exactly one refresh-failed event with the expected category
+			// and status/error fields. No retries on permanent failures, so
+			// the attempts field would be 1 if emitted — proxy.go omits it
+			// when attempts == 1 only via the >0 gate, so we don't pin its
+			// presence here; the retry tests cover attempts emission.
+			failed := rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)
+			require.Lenf(t, failed, 1, "expected exactly one refresh-failed event; got %d (%v)", len(failed), failed)
+			event := failed[0]
+			assert.Equal(t, tc.expectedCategory, event["category"], "failure category mismatch")
+			assert.Equal(t, connID, event["connection_id"])
+			if tc.expectedStatusCode != 0 {
+				assert.Equal(t, float64(tc.expectedStatusCode), event["provider_status_code"],
+					"provider_status_code mismatch for %s", tc.name)
+			}
+			if tc.expectedProviderErr != "" {
+				assert.Equal(t, tc.expectedProviderErr, event["provider_error"],
+					"provider_error mismatch for %s", tc.name)
+			} else {
+				_, hasProviderError := event["provider_error"]
+				assert.Falsef(t, hasProviderError,
+					"provider_error should be omitted when no recognized §5.2 code; got %v", event["provider_error"])
+			}
+
+			// Health-state-changed transition event with reason
+			// `refresh_<category>` — this is the field dashboards join
+			// against the refresh-failed event on.
+			transitions := rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage)
+			require.Lenf(t, transitions, 1, "expected exactly one health-state-changed event; got %d", len(transitions))
+			assert.Equal(t, "healthy", transitions[0]["previous_health_state"])
+			assert.Equal(t, "unhealthy", transitions[0]["health_state"])
+			assert.Equal(t, "refresh_"+tc.expectedCategory, transitions[0]["reason"],
+				"transition reason must encode the refresh category for dashboard correlation")
+
+			// No refresh-succeeded event — even one would corrupt the
+			// success/failure dashboards.
+			assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage),
+				"failed refresh must not emit a refresh-succeeded event")
+
+			// Token state preservation. A malformed refresh response must
+			// NOT overwrite the persisted refresh_token with garbage — the
+			// existing row remains as forge-expired left it (same id, same
+			// encrypted refresh_token bytes). If the proxy ever started
+			// persisting partial refresh responses, the next refresh
+			// attempt would be running with corrupted state.
+			postFailureToken := rig.env.GetOAuth2Token(t, connID)
+			require.NotNil(t, postFailureToken, "permanent refresh failure must not delete the token row")
+			assert.Equalf(t, preFailureTokenID, postFailureToken.Id,
+				"permanent refresh failure must not insert a replacement token row; new id=%s old id=%s",
+				postFailureToken.Id, preFailureTokenID)
+			assert.Equalf(t, preFailureEncryptedRefresh, postFailureToken.EncryptedRefreshToken,
+				"permanent refresh failure must not mutate the stored refresh_token")
+
+			// Exactly one POST to the refresh endpoint — none of the
+			// scenario 7 cases are retryable, so the retry loop short-
+			// circuits on the first response. completeAuthFlow uses
+			// grant_type=authorization_code at the token endpoint, never
+			// the refresh endpoint, so any EndpointRefresh request here
+			// can only have been driven by the expired-token flow under
+			// test.
+			refreshCalls := 0
+			for _, req := range rig.provider.Requests(helpers.RequestsFilter{
+				Endpoint: helpers.EndpointRefresh,
+				ClientID: rig.clientKey,
+			}) {
+				if lastForm(req.Form, "grant_type") == "refresh_token" {
+					refreshCalls++
+				}
+			}
+			assert.Equalf(t, 1, refreshCalls,
+				"expected exactly one refresh-token POST; got %d (permanent failures must not retry)",
+				refreshCalls)
+		})
+	}
+}

--- a/integration_tests/oauth2/proxy_refresh_failure_test.md
+++ b/integration_tests/oauth2/proxy_refresh_failure_test.md
@@ -1,0 +1,148 @@
+# OAuth2 Refresh Failure Modes (scenario 7)
+
+Companion specification for `proxy_refresh_failure_test.go`. Covers
+issue #170 scenario 7 — the *deterministic* refresh failure cases that
+must flip the connection unhealthy on the first failed POST.
+
+The scenario 8 transient/retry cases (5xx-then-success, exhausted retry
+budget) are PR C and live in a separate file. The auth-flow leg uses the
+`/test/authorize` shortcut rather than chromedp because the failure
+point under test is the refresh endpoint, not the consent screen — same
+reasoning as `callback_token_exchange_failure_test.md`.
+
+## Cases covered
+
+Scenario 7 in issue #170 lists six observable failure modes for the
+refresh leg:
+
+| Case (issue #170)                        | Test                       | Scripted refresh response                              | Category            |
+| ---------------------------------------- | -------------------------- | ------------------------------------------------------ | ------------------- |
+| Refresh token expired / revoked / invalid; provider returns `invalid_grant` | `InvalidGrant`             | `400 {"error":"invalid_grant"}`                       | `invalid_grant`     |
+| Provider returns `invalid_client`         | `InvalidClient`            | `401 {"error":"invalid_client"}`                      | `invalid_client`    |
+| Non-spec 4xx (WAF / rate-limiter page)    | `Provider4xxOther`         | `403 text/html "Forbidden by WAF"`                    | `provider_4xx_other`|
+| Provider returns malformed refresh response | `MalformedResponse`        | `200` with unparseable JSON body                       | `malformed_response`|
+| Provider returns success without an access token | `NoAccessTokenInResponse`  | `200 {"token_type":"Bearer","expires_in":3600}`        | `malformed_response`|
+
+### Why `invalid_grant` collapses three issue-#170 cases
+
+RFC 6749 §5.2 deliberately folds *refresh-token expired*, *refresh-token
+revoked*, and *refresh-token invalid* into the single `error=invalid_grant`
+response code:
+
+> The provided authorization grant (e.g., authorization code, resource
+> owner credentials) or refresh token is invalid, expired, revoked, does
+> not match the redirection URI used in the authorization request, or
+> was issued to another client.
+
+The proxy classifies on `error=invalid_grant` from the body, not on which
+underlying provider-side condition produced it, so producing each
+condition against the real test provider would not strengthen the
+assertion. A single scripted case exercises the classification path.
+
+### Why `NoAccessTokenInResponse` folds into `malformed_response`
+
+A 200 with a well-formed JSON envelope that omits `access_token` is
+indistinguishable from a 200 with unparseable JSON from the proxy's
+recovery perspective — both leave it with no usable credential and no
+useful information about *why*. `createDbTokenFromResponse` rejects both
+into `tokenRefreshMalformedResponse`. Issue #189 (an endless-refresh-loop
+symptom report) folded into this case once #170's MarkHealthState wiring
+landed in PR #265.
+
+## What is asserted
+
+For every case:
+
+- **Proxy request fails.** The original `/api/v1/connections/<id>/_proxy`
+  call must not return 200 — no valid access token means no proxy.
+- **Health flips unhealthy.** `connection.health_state` reads
+  `unhealthy`. The marketplace UI keys reconnect prompts off this column.
+- **Structured refresh-failed event.** Exactly one
+  `oauth token refresh failed` record with the expected `category`,
+  `connection_id`, and (where applicable) `provider_status_code` /
+  `provider_error`. Operators alert on `category=…` rather than parsing
+  message strings — silent category renames break dashboards.
+- **Structured health-transition event.** Exactly one
+  `connection health state changed` record with
+  `previous_health_state=healthy`, `health_state=unhealthy`, and
+  `reason=refresh_<category>`. Joining this against the refresh-failed
+  event by `connection_id` is what the operational dashboards do.
+- **No success event.** Even a single
+  `oauth token refresh succeeded` event would corrupt
+  success/failure ratios.
+- **Token row preservation.** The persisted `oauth2_tokens` row must
+  still have its `id` and its `encrypted_refresh_token` bytes unchanged
+  — a malformed refresh response must not overwrite the row with
+  garbage, because the next refresh attempt would then run against
+  corrupted state.
+- **Exactly one refresh POST.** Scenario 7 cases are non-retryable, so
+  the retry loop must short-circuit on the first response. Filtered on
+  `grant_type=refresh_token` so the authorization-code POST from the
+  initial auth flow doesn't count.
+
+## What is *not* covered here
+
+- **5xx / transport-error retry behavior.** Bounded retry policy + the
+  "exhausted-budget" failure shape are scenario 8 (PR C) — see
+  `proxy_refresh_retry_test.md`.
+- **No-refresh-token short-circuit.** That case never hits the refresh
+  endpoint; it's covered by `TestProxyRefresh_NoRefreshTokenFlipsUnhealthy`
+  in `proxy_refresh_test.go`.
+- **401-then-refresh path in `ProxyRequest`.** When the local
+  expiry-clock says the access token is valid but the provider rejects
+  it with a 401, `ProxyRequest` forces a refresh and replays once. That
+  is covered separately; here the proactive expiry check runs *before*
+  any proxy POST, so the 401 retry path never fires.
+- **Internal errors** (`tokenRefreshInternalError`: decryption failures,
+  mustache render failures, credential fetch failures). Reproducing
+  these from the integration boundary requires injecting a fault into
+  proxy infrastructure; they're covered by the unit tests in
+  `internal/auth_methods/oauth2/token_refresh_failure_test.go` and
+  `proxy_test.go`.
+
+## Components
+
+| Lever                                                       | What it controls |
+| ----------------------------------------------------------- | ---------------- |
+| `helpers.SetupOptions{IncludePublic: true, LogCapture: …}`  | Bring up the API + public services in-process; capture every slog record so the test can pin the failure + health-transition events. |
+| `rig.completeAuthFlow(t)`                                   | Drives the standard authorization-code flow to a Ready connection with real provider-issued tokens persisted. Same one-shot helper as `proxy_refresh_test.go`. |
+| `rig.forceTokenExpired(t, connID, false)`                   | Overwrites the persisted token row with one whose `access_token_expires_at` is in the past, keeping the existing `encrypted_refresh_token` intact. This is the DB-level forge used everywhere in the refresh suite — it avoids waiting for real provider TTLs. |
+| `provider.Script(clientKey, EndpointRefresh, ScriptAction{…})` | Enqueue the next refresh-endpoint response. `Status + Body` covers RFC §5.2 shapes and non-spec 4xx; `BodyTemplate: BodyMalformedJSON` covers the unparseable-200 case. |
+| `env.DoProxyRequest(t, connID, …)`                          | In-process POST to `/api/v1/connections/<id>/_proxy` signed as `test-actor`. The proxy detects the expired access token, hits the refresh endpoint with the scripted response, and the test inspects the resulting observable state. |
+| `logCapture.RecordsWithMessage(t, …)`                       | Surface the structured failure / success / health-transition events for category + status + reason assertions. |
+| `provider.Requests(EndpointRefresh, …)`                     | Confirm exactly one `grant_type=refresh_token` call hit the provider's refresh endpoint — proves no retry loop fired. |
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant API as API service
+    participant DB as Postgres
+    participant P as OAuth provider<br/>(docker, scripted)
+
+    note over T: rig.completeAuthFlow drives the<br/>standard auth flow to Ready (omitted)
+
+    T->>DB: forceTokenExpired (InsertOAuth2Token<br/>with access_token_expires_at in past)
+    T->>P: POST /test/scripts (clientKey, EndpointRefresh, {Status, Body})
+
+    T->>API: POST /api/v1/connections/<id>/_proxy (signed as test-actor)
+    API->>DB: GetOAuth2Token → access_token expired
+    API->>P: POST /token (grant_type=refresh_token)
+    P-->>API: scripted failure (4xx, malformed 200, or 200 with no access_token)
+    API->>API: classifyTokenRefreshStatus → category, provider_error
+    API->>API: emitTokenRefreshFailure (one log event)
+    API->>DB: MarkHealthState(unhealthy, refresh_<category>)
+    DB-->>API: emits "connection health state changed" event
+    API-->>T: non-200 proxy response
+```
+
+## Direct HTTP, not chromedp
+
+Same reasoning as `callback_token_exchange_failure_test.md`: the user-
+flow leg is irrelevant to these cases — the failure mode is purely
+server-side at the refresh endpoint. The `/test/*` control plane on the
+go-oauth2-server test provider mints real codes/tokens without booting a
+browser, and the DB-level forge advances the access-token expiry without
+waiting for real provider TTLs.


### PR DESCRIPTION
## Summary

PR B for #170 — scenario 7: deterministic refresh-failure integration tests. PR A landed the bounded retry policy (#276); PR C will cover scenario 8 (transient retry behavior).

Five scripted refresh-endpoint cases drive through the same fixture and assert the full observable shape:

- `invalid_grant` (400) — refresh token expired/revoked/invalid; provider returns RFC 6749 §5.2 `invalid_grant`.
- `invalid_client` (401) — provider rejects client credentials.
- `provider_4xx_other` (403, HTML) — non-spec 4xx (WAF / rate-limiter page in front of provider).
- `malformed_response` (200, unparseable JSON) — provider sends 200 but the body cannot be parsed.
- `malformed_response` (200, well-formed JSON without `access_token`) — issue #189's symptom case.

For each case, the test asserts:
- proxy request fails;
- `connection.health_state` flips to `unhealthy`;
- exactly one `oauth token refresh failed` event with the right `category` (and `provider_status_code` / `provider_error` when applicable);
- exactly one `connection health state changed` event with `reason=refresh_<category>`;
- no `oauth token refresh succeeded` event;
- the persisted token row's id and `encrypted_refresh_token` bytes are unchanged (no corruption on malformed responses);
- exactly one POST to the refresh endpoint (no retries on permanent failures).

Includes a companion `proxy_refresh_failure_test.md` documenting the cases, what is and is not asserted, the components used, and a sequence diagram. Matches the convention used by the other oauth2 integration tests.

The transient 5xx-then-success and retry-budget-exhausted cases (scenario 8) will land in PR C as `proxy_refresh_retry_test.go`.

## Test plan

- [x] `go test -tags=integration -run '^TestProxyRefreshFailure_Scenarios$' ./oauth2/...` — all 5 subtests pass.
- [x] `go test -tags=integration -run '^TestProxyRefresh' ./oauth2/...` — existing refresh tests (scenarios 6 and 13) still pass after rig-sharing changes.
- [x] `./scripts/preflight.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)