### PR TITLE
OAuth2 refresh transient-retry integration tests (#170 PR C)

### DIFF
--- a/integration_tests/oauth2/proxy_refresh_retry_test.go
+++ b/integration_tests/oauth2/proxy_refresh_retry_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 8 from issue #170: transient retry behavior. When the
+// provider's refresh endpoint returns a 5xx response, the proxy must:
+//
+//   - retry up to `tokenRefreshMaxAttempts` (=3) times with linear
+//     backoff before giving up;
+//   - on success-after-retry, persist the new token row and emit a
+//     refresh-succeeded event (no failure event — transient blips are
+//     not alertable);
+//   - on retry-budget exhaustion, emit exactly one refresh-failed event
+//     with `category=provider_5xx` and `attempts=tokenRefreshMaxAttempts`
+//     so dashboards can split exhausted-budget from single non-retryable
+//     failures;
+//   - on every retried attempt, emit a per-attempt
+//     `oauth token refresh transient failure; retrying` warn log line
+//     so operators can correlate the latency hit with the retry.
+//
+// Connection health behavior is the asymmetry with scenario 7: a 5xx
+// exhaustion is *transient* (the next proxy call gets another chance),
+// so it must NOT flip the connection unhealthy. Only the permanent
+// categories (invalid_grant, invalid_client, provider_4xx_other,
+// malformed_response, no_refresh_token) flip health — see PR B.
+
+// tokenRefreshRetryMessage mirrors the warn-level per-attempt log line
+// emitted by `postRefreshWithRetry`. Operators may key dashboards off
+// the attempt count, so the message string is part of the public
+// observability contract.
+const tokenRefreshRetryMessage = "oauth token refresh transient failure; retrying"
+
+// tokenRefreshMaxAttempts mirrors the production constant in
+// `internal/auth_methods/oauth2/proxy.go`. Redeclared here so the test
+// fails fast if the production value drifts (the retry-attempt-budget
+// assertions would otherwise silently weaken).
+const tokenRefreshMaxAttempts = 3
+
+// refreshCallCount returns the number of `grant_type=refresh_token`
+// POSTs the test provider has observed for this rig's client.
+// `completeAuthFlow` only hits EndpointToken (authorization_code grant),
+// not EndpointRefresh — so refresh counts are clean to compare without
+// taking a baseline.
+func (r *proxyRefreshRig) refreshCallCount() int {
+	n := 0
+	for _, req := range r.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointRefresh,
+		ClientID: r.clientKey,
+	}) {
+		if lastForm(req.Form, "grant_type") == "refresh_token" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestProxyRefresh_TransientRetrySucceeds — provider returns 503 on the
+// first two refresh calls, succeeds on the third (FailCount=2 consumes
+// two scripted 503s, then the queue falls through to the provider's
+// default refresh-token behavior). The proxy's max-attempts budget
+// (=tokenRefreshMaxAttempts=3) is exactly enough to ride through the
+// transient outage and end up with a fresh access token.
+//
+// This is the happy-path retry case: the proxy hides the 5xxs from the
+// customer's app entirely. Asserts the proxy request succeeds, the new
+// token is persisted, health stays healthy, no failure event fires, and
+// exactly two retry warn logs are emitted (one per retried attempt).
+func TestProxyRefresh_TransientRetrySucceeds(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-retry-success")
+	connID := rig.completeAuthFlow(t)
+	rig.forceTokenExpired(t, connID, false)
+
+	preFailureToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, preFailureToken)
+	preFailureTokenID := preFailureToken.Id
+
+	// FailCount=2 makes the next two refresh calls return this scripted
+	// 503; the third call falls through to a real refresh-token grant.
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		Status:    503,
+		Body:      `{"error":"temporarily_unavailable"}`,
+		FailCount: 2,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code,
+		"proxy must succeed after retried-then-successful refresh; got %d body=%s", w.Code, w.Body.String())
+
+	// New token row persisted with a future expiry — the retried success
+	// is observably indistinguishable from a first-try success.
+	refreshed := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, refreshed)
+	assert.NotEqualf(t, preFailureTokenID, refreshed.Id,
+		"retried success must persist a new token row (id should change)")
+	require.NotNil(t, refreshed.AccessTokenExpiresAt)
+
+	// Exactly tokenRefreshMaxAttempts refresh calls observed: 2 retried
+	// 503s + 1 success. If the proxy gave up early this would be < 3;
+	// if it kept retrying past the budget on success, > 3.
+	assert.Equalf(t, tokenRefreshMaxAttempts, rig.refreshCallCount(),
+		"expected exactly %d refresh-token POSTs (2 retried 503s + 1 success)", tokenRefreshMaxAttempts)
+
+	// One success event, no failure event. The retry-warn lines are
+	// fine; the structured failure event is the alertable channel and
+	// must stay clean on eventual success.
+	succeeded := rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage)
+	require.Lenf(t, succeeded, 1, "retried success must emit exactly one refresh-succeeded event; got %d", len(succeeded))
+	assert.Equal(t, connID, succeeded[0]["connection_id"])
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"retried success must not emit a refresh-failed event")
+
+	// Two retry-warn logs: one before attempt 2, one before attempt 3.
+	// The last attempt never emits a retry log because its outcome is
+	// terminal (success here, exhaustion in the test below).
+	retryWarns := rig.logCapture.RecordsWithMessage(t, tokenRefreshRetryMessage)
+	assert.Lenf(t, retryWarns, 2, "expected 2 retry-warn logs (one per retried attempt); got %d", len(retryWarns))
+
+	// Connection stayed healthy through the transient blips. The success
+	// path's MarkHealthState(healthy) is idempotent, so a healthy→healthy
+	// transition should not have emitted a "connection health state
+	// changed" record either.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"healthy→healthy transitions must not emit a state-change event")
+}
+
+// TestProxyRefresh_TransientRetryExhausted — provider returns 503 on
+// every refresh call (FailCount=10 is well past the retry budget). The
+// proxy retries until tokenRefreshMaxAttempts is exhausted, then
+// surfaces the failure.
+//
+// Distinct shape from scenario 7's permanent failures: the
+// provider_5xx category is *transient*, so retry exhaustion must NOT
+// flip the connection unhealthy. The next proxy call gets another
+// chance. The single failure event records attempts=3 so the alert
+// can distinguish exhaustion from a one-shot non-retryable failure.
+func TestProxyRefresh_TransientRetryExhausted(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-retry-exhausted")
+	connID := rig.completeAuthFlow(t)
+	rig.forceTokenExpired(t, connID, false)
+
+	preFailureToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, preFailureToken)
+	preFailureTokenID := preFailureToken.Id
+	preFailureEncryptedRefresh := preFailureToken.EncryptedRefreshToken
+
+	// FailCount=10 outlasts the retry budget — the proxy gives up after
+	// tokenRefreshMaxAttempts calls and the remaining scripted 503s sit
+	// unconsumed.
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		Status:    503,
+		Body:      `{"error":"temporarily_unavailable"}`,
+		FailCount: 10,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.NotEqualf(t, 200, w.Code,
+		"proxy must fail when refresh exhausts retry budget; got 200 body=%s", w.Body.String())
+
+	// Exactly one failure event with category=provider_5xx and
+	// attempts=tokenRefreshMaxAttempts. The attempts field is the
+	// dashboard signal that lets exhausted-budget alerts be tuned
+	// differently from single-failure alerts.
+	failed := rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)
+	require.Lenf(t, failed, 1, "exhausted retry must emit exactly one refresh-failed event; got %d (%v)", len(failed), failed)
+	event := failed[0]
+	assert.Equal(t, "provider_5xx", event["category"])
+	assert.Equal(t, connID, event["connection_id"])
+	assert.Equal(t, float64(503), event["provider_status_code"])
+	assert.Equalf(t, float64(tokenRefreshMaxAttempts), event["attempts"],
+		"failure event should record attempts=tokenRefreshMaxAttempts on exhaustion")
+
+	// 5xx is transient — health must NOT flip unhealthy. This is the
+	// asymmetry with scenario 7 (which always flips on the first failure
+	// for permanent categories). Without this assertion, a regression
+	// that reclassified 5xx as permanent would silently pessimize the
+	// reconnect UX.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equalf(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"transient 5xx exhaustion must not flip the connection unhealthy; got %q", conn.HealthState)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"transient 5xx exhaustion must not emit a health-state-changed event")
+
+	// Exactly tokenRefreshMaxAttempts retry warn lines preceded the
+	// final failure. The last attempt never logs a retry-warn because
+	// there is no further attempt to schedule — so retry-warns count is
+	// tokenRefreshMaxAttempts - 1.
+	retryWarns := rig.logCapture.RecordsWithMessage(t, tokenRefreshRetryMessage)
+	assert.Lenf(t, retryWarns, tokenRefreshMaxAttempts-1,
+		"expected %d retry-warn logs (one before each retried attempt); got %d",
+		tokenRefreshMaxAttempts-1, len(retryWarns))
+
+	// Token row preservation. A retry exhaustion must not overwrite the
+	// stored refresh_token (no partial responses ever land in the DB on
+	// 5xx — the response body is unparsed). The pre-failure row remains
+	// as forceTokenExpired left it.
+	postFailureToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, postFailureToken, "retry exhaustion must not delete the token row")
+	assert.Equalf(t, preFailureTokenID, postFailureToken.Id,
+		"retry exhaustion must not insert a replacement token row")
+	assert.Equalf(t, preFailureEncryptedRefresh, postFailureToken.EncryptedRefreshToken,
+		"retry exhaustion must not mutate the stored refresh_token")
+
+	// Exactly tokenRefreshMaxAttempts refresh POSTs. If the proxy gave
+	// up early this is < 3; if it ignored the budget, > 3.
+	assert.Equalf(t, tokenRefreshMaxAttempts, rig.refreshCallCount(),
+		"proxy must make exactly tokenRefreshMaxAttempts refresh POSTs before giving up; got %d",
+		rig.refreshCallCount())
+
+	// No success event. If a success event fires alongside the failure,
+	// the dashboards double-count or worse claim recovery that didn't
+	// happen.
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage),
+		"failed refresh must not emit a refresh-succeeded event")
+}
+
+// TestProxyRefresh_5xxVariants_AllRetried — sanity check that retry
+// triggers on the 5xx range, not on a specific status code. Issue #170
+// mentions "temporarily_unavailable" via 503 as the canonical example,
+// but real providers return 500/502/504 for the same class of issue.
+// We exercise 502 to pin a less obvious 5xx — gateway-bad-upstream — as
+// retry-eligible, with a single retry that then succeeds.
+func TestProxyRefresh_5xxVariants_AllRetried(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-retry-502")
+	connID := rig.completeAuthFlow(t)
+	rig.forceTokenExpired(t, connID, false)
+
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		Status:    502,
+		Body:      `{"error":"bad_gateway"}`,
+		FailCount: 1,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code, "single-retry 502 should succeed on the next attempt; got %d", w.Code)
+
+	// 2 refresh calls observed: the 502 + the recovery success. Anything
+	// less means the proxy didn't retry; anything more means the budget
+	// was over-spent on a single recoverable blip.
+	assert.Equalf(t, 2, rig.refreshCallCount(),
+		"expected 2 refresh POSTs (1 retried 502 + 1 success); got %d", rig.refreshCallCount())
+
+	// One retry-warn (between the 502 and the recovery), one success
+	// event, no failure event.
+	retryWarns := rig.logCapture.RecordsWithMessage(t, tokenRefreshRetryMessage)
+	assert.Lenf(t, retryWarns, 1, "expected 1 retry-warn between 502 and success; got %d", len(retryWarns))
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
+		"502→success must emit one refresh-succeeded event")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"502→success must not emit a refresh-failed event")
+}

--- a/integration_tests/oauth2/proxy_refresh_retry_test.md
+++ b/integration_tests/oauth2/proxy_refresh_retry_test.md
@@ -1,0 +1,183 @@
+# OAuth2 Refresh Transient Retry (scenario 8)
+
+Companion specification for `proxy_refresh_retry_test.go`. Covers
+issue #170 scenario 8 — the *transient* refresh failure cases that
+exercise the bounded retry policy in `postRefreshWithRetry` (#276).
+
+The permanent failure cases (scenario 7) are PR B and live in
+`proxy_refresh_failure_test.go`. The retry policy itself (constants and
+loop shape) lives in `internal/auth_methods/oauth2/proxy.go` and is
+unit-tested in `proxy_test.go`; this file pins the end-to-end observable
+shape via real provider scripts.
+
+## Retry policy under test
+
+Mirrors the token-exchange retry policy in PR A (#276):
+
+| Setting                       | Value (production)                |
+| ----------------------------- | --------------------------------- |
+| Max attempts                  | `tokenRefreshMaxAttempts = 3`     |
+| Backoff between attempts      | linear: 200ms, 400ms (`tokenRefreshBackoffStep × (attempt-1)`) |
+| Retryable categories          | provider 5xx, transport errors    |
+| Non-retryable                 | every 4xx and every 2xx outcome   |
+
+4xx is never retried because resubmitting the same refresh token cannot
+change the provider's verdict, and with rotation policies, retries can
+make things observably worse. 2xx is never retried because there is no
+remaining transient signal to wait out.
+
+## Cases covered
+
+| Test                                            | Scripted refresh response                | Expected outcome                                                                                                                                        |
+| ----------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TestProxyRefresh_TransientRetrySucceeds`       | 503 ×2, then default refresh-token grant | Proxy returns 200; new token persisted; one success event; no failure event; 2 retry-warn logs.                                                          |
+| `TestProxyRefresh_TransientRetryExhausted`      | 503 ×10 (well past budget)               | Proxy returns non-200; one failure event with `category=provider_5xx`, `provider_status_code=503`, `attempts=3`; health stays **healthy** (5xx is transient); token row unchanged. |
+| `TestProxyRefresh_5xxVariants_AllRetried`       | 502 ×1, then default                     | Proxy returns 200 after one retry; pins that retry triggers on the 5xx *range*, not on 503 specifically.                                                |
+
+## What is asserted
+
+For every case:
+
+- **Proxy outcome.** Success-after-retry → 200; exhausted → non-200.
+- **Refresh-endpoint call count.** Exactly `tokenRefreshMaxAttempts`
+  (=3) on exhaustion; `failures + 1` on success-after-retry. Counted
+  with the `grant_type=refresh_token` filter to exclude the
+  authorization-code POST that `completeAuthFlow` already made against
+  the token endpoint.
+- **Retry-warn logs.** Exactly one
+  `oauth token refresh transient failure; retrying` line *between*
+  each consecutive pair of attempts — i.e. `tokenRefreshMaxAttempts - 1`
+  on exhaustion, `n-1` on success after `n` total attempts. The final
+  attempt never logs a retry-warn because there is no further attempt
+  to schedule.
+- **Structured success/failure events.** Eventual success → one
+  `oauth token refresh succeeded` event, no failure event. Exhaustion →
+  one `oauth token refresh failed` event with
+  `category=provider_5xx`, `connection_id`, `provider_status_code`, and
+  `attempts=tokenRefreshMaxAttempts`. The `attempts` field is the
+  dashboard signal that distinguishes exhausted-budget failures from
+  single non-retryable failures and is the central reason this file
+  exists.
+
+### Health-flip asymmetry with scenario 7
+
+`provider_5xx` is *transient* — `IsPermanent()` returns false for it —
+so retry-budget exhaustion must NOT flip the connection unhealthy. The
+next proxy call gets another chance.
+
+This is the load-bearing asymmetry with scenario 7, where every
+permanent category (`invalid_grant`, `invalid_client`,
+`provider_4xx_other`, `malformed_response`, `no_refresh_token`) flips
+health on the first failure. A regression that reclassified 5xx as
+permanent would silently pessimize the reconnect UX: every transient
+provider blip would flip the marketplace into a reconnect prompt,
+training users to ignore those prompts. The exhausted-retry test asserts
+both `health_state` and the absence of a `connection health state
+changed` event so the regression would be caught both at the field level
+and at the event level.
+
+### Token row preservation
+
+The exhausted-retry test snapshots `token.Id` and
+`token.EncryptedRefreshToken` after `forceTokenExpired`, then asserts
+both are unchanged after the exhausted-retry proxy call. The proxy must
+not write a partial response on 5xx (the response body is unparsed in
+that path), and must not mutate the existing row on any failed refresh.
+A regression that started persisting partial responses would corrupt
+the next refresh attempt's input state — this catches it.
+
+## Why direct DB forge + scripts, not real TTLs
+
+Same reasoning as scenario 7 (`proxy_refresh_failure_test.md`): the
+failure point under test is purely at the refresh endpoint. The
+go-oauth2-server test provider's `/test/scripts` queue mints arbitrary
+refresh-endpoint responses without booting a browser, and
+`forceTokenExpired` advances `access_token_expires_at` into the past
+directly in the DB so the proxy's proactive expiry check fires
+immediately. Driving this through chromedp would add 30+ seconds per
+case for zero observable signal.
+
+## Why `FailCount` on `ScriptAction`
+
+`FailCount=2` consumes two scripted responses then falls through to the
+provider's default refresh-token behavior. This is exactly the
+"transient blip then recovery" shape needed for the
+success-after-retry test, without having to enqueue a second scripted
+action with a real refresh-token grant body (which would duplicate the
+provider's own logic). For the exhausted-retry test, `FailCount=10`
+outlasts the proxy's budget so the test does not have to count
+scripted actions to know the queue will not drain.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant API as API service
+    participant DB as Postgres
+    participant P as OAuth provider<br/>(docker, scripted)
+
+    note over T: rig.completeAuthFlow drives the<br/>standard auth flow to Ready (omitted)
+
+    T->>DB: forceTokenExpired (access_token_expires_at in past)
+    T->>P: POST /test/scripts (clientKey, EndpointRefresh, {Status:503, FailCount:N})
+
+    T->>API: POST /api/v1/connections/<id>/_proxy
+    API->>DB: GetOAuth2Token → access_token expired
+
+    loop attempt 1 → tokenRefreshMaxAttempts
+        API->>P: POST /token (grant_type=refresh_token)
+        alt scripted 503 (queue not drained)
+            P-->>API: 503 temporarily_unavailable
+            API->>API: log "oauth token refresh transient failure; retrying"
+            API->>API: sleep tokenRefreshBackoffStep × (attempt-1)
+        else queue drained, default behavior
+            P-->>API: 200 + access_token (real grant)
+        end
+    end
+
+    alt eventual success
+        API->>DB: insert new oauth2_tokens row
+        API->>API: emit "oauth token refresh succeeded"
+        API->>P: proxy the original request with the new access token
+        API-->>T: 200
+    else retry budget exhausted
+        API->>API: emit "oauth token refresh failed" (category=provider_5xx, attempts=N)
+        note over API: health stays healthy — 5xx is transient
+        API-->>T: non-200 (no valid token = no proxy)
+    end
+```
+
+## What is *not* covered here
+
+- **Permanent failure categories** (`invalid_grant`, `invalid_client`,
+  `provider_4xx_other`, `malformed_response`, `no_refresh_token`).
+  Scenario 7 — see `proxy_refresh_failure_test.md`.
+- **Per-attempt log line schema.** The retry-warn line carries
+  `attempt`, `max_attempts`, and `provider_status_code` / `error` fields;
+  the field-level shape is pinned by the unit tests in
+  `internal/auth_methods/oauth2/proxy_test.go`. These integration tests
+  only assert the message count, which is the public observability
+  contract.
+- **Backoff timing.** Linear-backoff schedule is constants in
+  `proxy.go`; the unit tests around `postRefreshWithRetry` pin the
+  schedule. Asserting wall-clock timing from an integration test would
+  be flaky.
+- **Transport-error retries.** `network_error` is retried the same way
+  as `provider_5xx` but reproducing a transport error against the test
+  provider requires `DropConnection` or in-process fault injection. The
+  unit tests in `proxy_test.go` cover the transport-error branch
+  (`TestPostRefreshWithRetry_TransportErrorRetried`).
+
+## Components
+
+| Lever                                                       | What it controls |
+| ----------------------------------------------------------- | ---------------- |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Same fixture used by scenarios 6, 7, and 13. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge so the proxy's expiry check fires immediately. |
+| `provider.Script(clientKey, EndpointRefresh, ScriptAction{Status:5xx, FailCount:N})` | Enqueue N scripted 5xx responses; subsequent calls fall through to the provider's default refresh-token grant. `FailCount=10` outlasts the retry budget for the exhaustion case. |
+| `env.DoProxyRequest(...)`                                   | Triggers the expired-token → refresh path in-process. The retry loop is driven entirely server-side; the test never has to wait for real TTLs. |
+| `rig.refreshCallCount()`                                    | Counts `grant_type=refresh_token` POSTs the provider has observed for this client. Filtered to exclude the authorization-code POSTs from the auth-flow leg. |
+| `logCapture.RecordsWithMessage(t, tokenRefreshRetryMessage)` | Surface every per-attempt retry-warn log so the test can assert the expected count. |
+| `logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)` | Surface the structured failure event for `attempts` / `category` / `provider_status_code` assertions. |
+| `logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage)` | Pin the *absence* of a health transition on transient exhaustion. |

--- a/integration_tests/oauth2/proxy_refresh_retry_test.md
+++ b/integration_tests/oauth2/proxy_refresh_retry_test.md
@@ -124,14 +124,14 @@ sequenceDiagram
     T->>P: POST /test/scripts (clientKey, EndpointRefresh, {Status:503, FailCount:N})
 
     T->>API: POST /api/v1/connections/<id>/_proxy
-    API->>DB: GetOAuth2Token → access_token expired
+    API->>DB: GetOAuth2Token, access_token expired
 
-    loop attempt 1 → tokenRefreshMaxAttempts
+    loop attempt 1 to tokenRefreshMaxAttempts
         API->>P: POST /token (grant_type=refresh_token)
         alt scripted 503 (queue not drained)
             P-->>API: 503 temporarily_unavailable
-            API->>API: log "oauth token refresh transient failure; retrying"
-            API->>API: sleep tokenRefreshBackoffStep × (attempt-1)
+            API->>API: log oauth token refresh transient failure, retrying
+            API->>API: sleep tokenRefreshBackoffStep * (attempt-1)
         else queue drained, default behavior
             P-->>API: 200 + access_token (real grant)
         end


### PR DESCRIPTION
## Summary

PR C for #170 — scenario 8: transient-retry integration tests for the bounded retry policy on the refresh path (landed in PR A, #276). PR B (#279) covered scenario 7 (deterministic / permanent failures).

Three end-to-end cases driven through the test provider's `/test/scripts` queue:

- **`TestProxyRefresh_TransientRetrySucceeds`** — `503 ×2 → default refresh-token grant`. Proxy hides the 503s; new token persisted; one success event; no failure event; two retry-warn logs (between each consecutive pair of attempts).
- **`TestProxyRefresh_TransientRetryExhausted`** — `503 ×10` (well past budget). One failure event with `category=provider_5xx`, `provider_status_code=503`, `attempts=tokenRefreshMaxAttempts`; **health stays healthy** (5xx is transient — the load-bearing asymmetry with scenario 7); token row unchanged; exactly `tokenRefreshMaxAttempts` refresh POSTs.
- **`TestProxyRefresh_5xxVariants_AllRetried`** — `502 ×1 → success`. Pins that retry triggers on the 5xx range, not on 503 specifically.

The exhausted-retry test is the centerpiece: it pins both the `attempts` field on the failure event (so exhausted-budget alerts can be tuned separately from one-shot non-retryable failures) and the *absence* of a health flip + state-change event (so a regression that reclassified 5xx as permanent would be caught at both the field level and the event level).

Includes a companion `proxy_refresh_retry_test.md` documenting the retry policy under test, the cases, the health-flip asymmetry with scenario 7, and what is and is not covered.

## Test plan

- [x] `go test -tags=integration -run '^TestProxyRefresh_(TransientRetrySucceeds|TransientRetryExhausted|5xxVariants_AllRetried)$' ./oauth2/...` — all 3 tests pass.
- [x] `go test -tags=integration -run '^TestProxyRefresh' ./oauth2/...` — all refresh tests (scenarios 6, 7, 8, 13) pass together.
- [x] `./scripts/preflight.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)