### PR TITLE
Add Limiter.Peek() — read-only counter inspection

### DIFF
--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -51,6 +51,13 @@ type Limiter interface {
 	// (Allowed=false, RetryAfter set). See Decision for the failure-mode
 	// contract.
 	Decide(ctx context.Context, bucketKey BucketKey) (Decision, error)
+
+	// Peek returns what Decide would return given the current counter
+	// state, without writing. Used by the dry-run admin endpoint so
+	// operators can validate "would this request be limited?" without
+	// polluting the runtime counters. Same fail-open semantics as Decide:
+	// on Redis error returns Allowed=true / FailedOpen=true.
+	Peek(ctx context.Context, bucketKey BucketKey) (Decision, error)
 }
 
 // NewLimiter builds a Limiter for a RateLimit row. The algorithm variant

--- a/internal/ratelimit/limiter_fixed_window.go
+++ b/internal/ratelimit/limiter_fixed_window.go
@@ -47,6 +47,33 @@ end
 return {1, limit - count}
 `)
 
+// fixedWindowPeekScript mirrors fixedWindowScript but writes nothing.
+// Reports what Decide would return for the current window state.
+//
+// Returns the same {allowed, value} shape as Decide.
+var fixedWindowPeekScript = redis.NewScript(`
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+
+local count = tonumber(redis.call('GET', key) or '0')
+
+-- Decide does INCR-then-compare; we project that by checking whether
+-- the hypothetical incremented count would exceed the limit.
+if count + 1 > limit then
+    local pttl = redis.call('PTTL', key)
+    if pttl < 0 then
+        -- Either no key (-2) or no TTL (-1). Decide would establish a
+        -- new TTL via PEXPIRE; report the full window so callers don't
+        -- see a negative number.
+        pttl = window_ms
+    end
+    return {0, pttl}
+end
+
+return {1, limit - count - 1}
+`)
+
 type fixedWindowLimiter struct {
 	ruleID   apid.ID
 	limit    int
@@ -90,6 +117,32 @@ func (l *fixedWindowLimiter) Decide(ctx context.Context, bucketKey BucketKey) (D
 	return Decision{
 		Allowed:    false,
 		RetryAfter: time.Duration(retryOrRemainingMs) * time.Millisecond,
+	}, nil
+}
+
+func (l *fixedWindowLimiter) Peek(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+	windowMs := l.window.Milliseconds()
+
+	windowID := now.UnixMilli() / windowMs
+	key := fmt.Sprintf("%s:fw:%d", limiterKeyPrefix(l.ruleID, bucketKey), windowID)
+
+	res, err := fixedWindowPeekScript.Run(ctx, l.redis, []string{key}, l.limit, windowMs).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	if allowed {
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
 	}, nil
 }
 

--- a/internal/ratelimit/limiter_peek_test.go
+++ b/internal/ratelimit/limiter_peek_test.go
@@ -1,0 +1,302 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+// The Peek tests share three invariants:
+//
+//  1. On a fresh state, Peek reports Allowed=true with the same Remaining
+//     a real Decide call would have set.
+//  2. When the bucket is saturated, Peek reports Allowed=false and a
+//     plausible RetryAfter — same shape as Decide on a saturated bucket.
+//  3. Calling Peek does not mutate Redis: a subsequent Decide sees the
+//     bucket as if the Peek had not happened. This is the load-bearing
+//     property that lets the dry-run admin endpoint hit a real
+//     production-shaped counter store without polluting it.
+
+// peekDoesNotMutate snapshots the Decide() result on a fresh state, then
+// reinitialises and asserts that {Peek, Peek, Peek} followed by Decide
+// returns the same Decision. Any state mutation in Peek would cause
+// drift between the two Decides.
+func peekDoesNotMutate(t *testing.T, env *limiterEnv, def rlschema.RateLimit) {
+	t.Helper()
+
+	baseline := mustNewLimiter(t, env, def)
+	want, err := baseline.Decide(env.ctx(), mkBucket())
+	require.NoError(t, err)
+
+	// Fresh env so the second Limiter starts from a clean Redis.
+	env2 := newLimiterEnv(t)
+	probe := mustNewLimiter(t, env2, def)
+	for i := 0; i < 3; i++ {
+		_, err := probe.Peek(env2.ctx(), mkBucket())
+		require.NoError(t, err)
+	}
+	got, err := probe.Decide(env2.ctx(), mkBucket())
+	require.NoError(t, err)
+
+	require.Equal(t, want.Allowed, got.Allowed, "Peek must not change a subsequent Decide outcome")
+	require.Equal(t, want.Remaining, got.Remaining, "Peek must not consume capacity")
+}
+
+// --- Fixed window ---
+
+func TestPeek_FixedWindow_FreshState(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 5},
+	}})
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Equal(t, 4, d.Remaining, "Peek reports what Decide would set: limit - 1")
+}
+
+func TestPeek_FixedWindow_Saturated(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 2},
+	}})
+
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+	require.LessOrEqual(t, d.RetryAfter, time.Minute)
+}
+
+func TestPeek_FixedWindow_DoesNotMutate(t *testing.T) {
+	peekDoesNotMutate(t, newLimiterEnv(t), rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 5},
+	}})
+}
+
+func TestPeek_FixedWindow_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			FixedWindow: &rlschema.FixedWindow{Window: common.HumanDuration{Duration: time.Minute}, Limit: 1},
+		}},
+	}
+	l, err := NewLimiter(rl, r, aplog.NewNoopLogger())
+	require.NoError(t, err)
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+// --- Sliding window: log mode ---
+
+func TestPeek_SlidingWindowLog_FreshState(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 4, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Equal(t, 3, d.Remaining)
+}
+
+func TestPeek_SlidingWindowLog_Saturated(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 2, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+
+	_, _ = l.Decide(env.ctx(), mkBucket())
+	_, _ = l.Decide(env.ctx(), mkBucket())
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+}
+
+func TestPeek_SlidingWindowLog_DoesNotMutate(t *testing.T) {
+	peekDoesNotMutate(t, newLimiterEnv(t), rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 5, Mode: rlschema.SlidingWindowModeLog,
+		},
+	}})
+}
+
+func TestPeek_SlidingWindowLog_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{
+				Window: common.HumanDuration{Duration: time.Minute}, Limit: 1, Mode: rlschema.SlidingWindowModeLog,
+			},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+// --- Sliding window: counter mode ---
+
+func TestPeek_SlidingWindowCounter_FreshState(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 5, Mode: rlschema.SlidingWindowModeCounter,
+		},
+	}})
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Equal(t, 4, d.Remaining)
+}
+
+func TestPeek_SlidingWindowCounter_Saturated(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 2, Mode: rlschema.SlidingWindowModeCounter,
+		},
+	}})
+
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+}
+
+func TestPeek_SlidingWindowCounter_DoesNotMutate(t *testing.T) {
+	peekDoesNotMutate(t, newLimiterEnv(t), rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		SlidingWindow: &rlschema.SlidingWindow{
+			Window: common.HumanDuration{Duration: time.Minute}, Limit: 5, Mode: rlschema.SlidingWindowModeCounter,
+		},
+	}})
+}
+
+func TestPeek_SlidingWindowCounter_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			SlidingWindow: &rlschema.SlidingWindow{
+				Window: common.HumanDuration{Duration: time.Minute}, Limit: 1, Mode: rlschema.SlidingWindowModeCounter,
+			},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}
+
+// --- Token bucket ---
+
+func TestPeek_TokenBucket_FreshState(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 5, RefillRate: 1.0},
+	}})
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Equal(t, 4, d.Remaining, "fresh full bucket, hypothetical consume → capacity-1")
+}
+
+func TestPeek_TokenBucket_Saturated(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 2, RefillRate: 1.0},
+	}})
+
+	// Drain.
+	for i := 0; i < 2; i++ {
+		_, _ = l.Decide(env.ctx(), mkBucket())
+	}
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Greater(t, d.RetryAfter, time.Duration(0))
+	require.LessOrEqual(t, d.RetryAfter, 2*time.Second, "1 tok/s → wait ~1s for 1 full token")
+}
+
+func TestPeek_TokenBucket_AccountsForRefill(t *testing.T) {
+	env := newLimiterEnv(t)
+	l := mustNewLimiter(t, env, rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 1, RefillRate: 1.0},
+	}})
+
+	// Empty the bucket via Decide.
+	d, _ := l.Decide(env.ctx(), mkBucket())
+	require.True(t, d.Allowed)
+	d, _ = l.Decide(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// Peek immediately — still empty.
+	d, _ = l.Peek(env.ctx(), mkBucket())
+	require.False(t, d.Allowed)
+
+	// Advance enough time for a token to refill; Peek should now allow.
+	env.step(1100 * time.Millisecond)
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.NoError(t, err)
+	require.True(t, d.Allowed, "after one refill interval, Peek should report Allowed without consuming")
+}
+
+func TestPeek_TokenBucket_DoesNotMutate(t *testing.T) {
+	peekDoesNotMutate(t, newLimiterEnv(t), rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+		TokenBucket: &rlschema.TokenBucket{Capacity: 5, RefillRate: 1.0},
+	}})
+}
+
+func TestPeek_TokenBucket_FailOpenOnRedisDown(t *testing.T) {
+	env := newLimiterEnv(t)
+	r := newFailedRedis(t)
+	rl := &database.RateLimit{
+		Id: apid.New(apid.PrefixRateLimit),
+		Definition: rlschema.RateLimit{Algorithm: rlschema.Algorithm{
+			TokenBucket: &rlschema.TokenBucket{Capacity: 1, RefillRate: 1.0},
+		}},
+	}
+	l, _ := NewLimiter(rl, r, aplog.NewNoopLogger())
+
+	d, err := l.Peek(env.ctx(), mkBucket())
+	require.Error(t, err)
+	require.True(t, d.Allowed)
+	require.True(t, d.FailedOpen)
+}

--- a/internal/ratelimit/limiter_sliding_window.go
+++ b/internal/ratelimit/limiter_sliding_window.go
@@ -96,6 +96,61 @@ if remaining < 0 then remaining = 0 end
 return {1, remaining}
 `)
 
+// slidingWindowLogPeekScript mirrors slidingWindowLogScript but writes
+// nothing. ZCOUNT (read-only) counts entries inside the trailing
+// window; ZRANGEBYSCORE LIMIT 0 1 reads the oldest for retry-after.
+var slidingWindowLogPeekScript = redis.NewScript(`
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local now_ms = tonumber(ARGV[2])
+local window_ms = tonumber(ARGV[3])
+
+-- Count just the entries Decide would not evict.
+local count = redis.call('ZCOUNT', key, '(' .. tostring(now_ms - window_ms), '+inf')
+
+if count >= limit then
+    local oldest = redis.call('ZRANGEBYSCORE', key,
+        '(' .. tostring(now_ms - window_ms), '+inf',
+        'WITHSCORES', 'LIMIT', 0, 1)
+    local retry_ms = window_ms
+    if #oldest == 2 then
+        retry_ms = (tonumber(oldest[2]) + window_ms) - now_ms
+        if retry_ms < 1 then retry_ms = 1 end
+    end
+    return {0, retry_ms}
+end
+
+return {1, limit - count - 1}
+`)
+
+// slidingWindowCounterPeekScript mirrors slidingWindowCounterScript but
+// writes nothing. Same weighted-window math, no INCR.
+var slidingWindowCounterPeekScript = redis.NewScript(`
+local key_curr = KEYS[1]
+local key_prev = KEYS[2]
+local limit = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+local elapsed_ms = tonumber(ARGV[3])
+
+local prev_count = tonumber(redis.call('GET', key_prev) or '0')
+local curr_count = tonumber(redis.call('GET', key_curr) or '0')
+
+local prev_weight = (window_ms - elapsed_ms) / window_ms
+if prev_weight < 0 then prev_weight = 0 end
+
+local approx = curr_count + math.floor(prev_count * prev_weight)
+
+if approx >= limit then
+    local retry_ms = window_ms - elapsed_ms
+    if retry_ms < 1 then retry_ms = 1 end
+    return {0, retry_ms}
+end
+
+local remaining = limit - approx - 1
+if remaining < 0 then remaining = 0 end
+return {1, remaining}
+`)
+
 type slidingWindowLimiter struct {
 	ruleID  apid.ID
 	limit   int
@@ -189,6 +244,73 @@ func (l *slidingWindowLimiter) decideCounter(ctx context.Context, bucketKey Buck
 		// allows -1 for "not computable cheaply"; we do have a number
 		// here so we report it, but consumers should treat it as a
 		// rough estimate not a precise budget.
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}
+
+func (l *slidingWindowLimiter) Peek(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+
+	switch l.mode {
+	case rlschema.SlidingWindowModeLog:
+		return l.peekLog(ctx, bucketKey, now)
+	case rlschema.SlidingWindowModeCounter:
+		return l.peekCounter(ctx, bucketKey, now)
+	}
+	return failOpen(l.logger, l.ruleID, fmt.Errorf("unknown sliding window mode %q", l.mode))
+}
+
+func (l *slidingWindowLimiter) peekLog(ctx context.Context, bucketKey BucketKey, now time.Time) (Decision, error) {
+	key := fmt.Sprintf("%s:swl", limiterKeyPrefix(l.ruleID, bucketKey))
+	windowMs := l.window.Milliseconds()
+
+	res, err := slidingWindowLogPeekScript.Run(ctx, l.redis,
+		[]string{key},
+		l.limit, now.UnixMilli(), windowMs,
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+	if allowed {
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}
+
+func (l *slidingWindowLimiter) peekCounter(ctx context.Context, bucketKey BucketKey, now time.Time) (Decision, error) {
+	windowMs := l.window.Milliseconds()
+	windowID := now.UnixMilli() / windowMs
+	elapsedMs := now.UnixMilli() % windowMs
+
+	prefix := limiterKeyPrefix(l.ruleID, bucketKey)
+	keyCurr := fmt.Sprintf("%s:swc:%d", prefix, windowID)
+	keyPrev := fmt.Sprintf("%s:swc:%d", prefix, windowID-1)
+
+	res, err := slidingWindowCounterPeekScript.Run(ctx, l.redis,
+		[]string{keyCurr, keyPrev},
+		l.limit, windowMs, elapsedMs,
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+	if allowed {
 		return Decision{Allowed: true, Remaining: value}, nil
 	}
 	return Decision{

--- a/internal/ratelimit/limiter_token_bucket.go
+++ b/internal/ratelimit/limiter_token_bucket.go
@@ -70,6 +70,43 @@ redis.call('PEXPIRE', key, idle_ttl_ms)
 return {1, math.floor(tokens)}
 `)
 
+// tokenBucketPeekScript mirrors tokenBucketScript but writes nothing.
+// Reports what Decide would return for the current state.
+//
+// Returns the same {allowed, value} shape as Decide so result parsing
+// can be shared.
+var tokenBucketPeekScript = redis.NewScript(`
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_per_sec = tonumber(ARGV[2])
+local now_ms = tonumber(ARGV[3])
+
+local data = redis.call('HMGET', key, 'tokens', 'last_refill_ms')
+local tokens = tonumber(data[1])
+local last_refill_ms = tonumber(data[2])
+
+if tokens == nil or last_refill_ms == nil then
+    -- No state yet: Decide would create a full bucket and consume one
+    -- token. Remaining = capacity - 1.
+    return {1, capacity - 1}
+end
+
+local elapsed_ms = now_ms - last_refill_ms
+if elapsed_ms < 0 then elapsed_ms = 0 end
+local refill = (elapsed_ms / 1000.0) * refill_per_sec
+local projected = math.min(capacity, tokens + refill)
+
+if projected < 1 then
+    local needed = 1 - projected
+    local wait_ms = math.ceil(needed / refill_per_sec * 1000)
+    if wait_ms < 1 then wait_ms = 1 end
+    return {0, wait_ms}
+end
+
+-- Match Decide's post-consume Remaining: floor(projected - 1).
+return {1, math.floor(projected - 1)}
+`)
+
 // tokenBucketIdleTTL is how long we keep a quiescent bucket before
 // letting Redis garbage-collect it. An hour is plenty for proxy traffic
 // patterns; a longer TTL just costs Redis memory.
@@ -105,6 +142,34 @@ func (l *tokenBucketLimiter) Decide(ctx context.Context, bucketKey BucketKey) (D
 	res, err := tokenBucketScript.Run(ctx, l.redis,
 		[]string{key},
 		l.capacity, rateStr, now.UnixMilli(), tokenBucketIdleTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	allowed, value, err := parseDecisionResult(res)
+	if err != nil {
+		return failOpen(l.logger, l.ruleID, err)
+	}
+
+	if allowed {
+		return Decision{Allowed: true, Remaining: value}, nil
+	}
+	return Decision{
+		Allowed:    false,
+		RetryAfter: time.Duration(value) * time.Millisecond,
+	}, nil
+}
+
+func (l *tokenBucketLimiter) Peek(ctx context.Context, bucketKey BucketKey) (Decision, error) {
+	now := apctx.GetClock(ctx).Now()
+	key := fmt.Sprintf("%s:tb", limiterKeyPrefix(l.ruleID, bucketKey))
+
+	rateStr := strconv.FormatFloat(l.refillRate, 'g', -1, 64)
+
+	res, err := tokenBucketPeekScript.Run(ctx, l.redis,
+		[]string{key},
+		l.capacity, rateStr, now.UnixMilli(),
 	).Result()
 	if err != nil {
 		return failOpen(l.logger, l.ruleID, err)


### PR DESCRIPTION
Closes #295.

## Summary

- Adds \`Peek(ctx, bucketKey) (Decision, error)\` to the \`Limiter\` interface.
- Implements it across all three algorithms (token bucket, fixed window, sliding window — log + counter modes) via sibling Lua scripts that mirror the existing \`Decide\` math but write nothing.
- Fail-open semantics match \`Decide\`: a Redis error returns \`Allowed=true\` with \`FailedOpen=true\`.
- Unblocks #296 (the \`_dry_run\` admin-api endpoint) so the runtime counter store can be queried without polluting it.

## Test plan

- [x] \`go test ./internal/ratelimit/... -count=1\` (passes — existing + 17 new \`TestPeek_*\` cases)
- [x] \`./scripts/preflight.sh\` (clean)

Per-algorithm coverage:
- Fresh state — \`Peek\` matches what \`Decide\` would set (\`Allowed=true\`, \`Remaining=limit-1\`).
- Saturated — \`Peek\` reports \`Allowed=false\` with a positive \`RetryAfter\`.
- \`Peek\` does not mutate — a baseline single-\`Decide\` from a clean Redis equals "three \`Peek\`s, then one \`Decide\`" on a fresh Redis. Any state mutation in \`Peek\` would cause drift between the two \`Decide\`s.
- Token bucket specifically accounts for refill: \`Peek\` flips from rejected back to allowed once enough time passes without any prior \`Decide\` call.
- Redis-down fail-open per algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)