### PR TITLE
Add OAuth2 refresh-token rotation integration tests (#171 PR A)

### DIFF
--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -350,3 +350,19 @@ func (env *IntegrationTestEnv) GetOAuth2Token(t *testing.T, connectionID string)
 	require.NoError(t, err)
 	return tok
 }
+
+// DecryptOAuth2RefreshToken decrypts the persisted refresh_token for the
+// connection's current token row and returns the plaintext. Tests that need
+// to assert on the *value* of the refresh token (e.g. rotation tests) must
+// decrypt because EncryptedField bytes change on every encryption (AES-GCM
+// uses a fresh nonce), so equality of encrypted bytes is not a reliable
+// signal that the plaintext changed.
+func (env *IntegrationTestEnv) DecryptOAuth2RefreshToken(t *testing.T, tok *database.OAuth2Token) string {
+	t.Helper()
+	require.NotNil(t, tok, "DecryptOAuth2RefreshToken: token must not be nil")
+	require.False(t, tok.EncryptedRefreshToken.IsZero(),
+		"DecryptOAuth2RefreshToken: token has no encrypted refresh_token")
+	plaintext, err := env.DM.GetEncryptService().DecryptString(context.Background(), tok.EncryptedRefreshToken)
+	require.NoError(t, err, "decrypt refresh_token")
+	return plaintext
+}

--- a/integration_tests/oauth2/proxy_refresh_rotation_test.go
+++ b/integration_tests/oauth2/proxy_refresh_rotation_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 9 from issue #171: refresh-token rotation. RFC 6749 §6 allows
+// (but does not require) the provider to issue a new `refresh_token` on
+// every refresh response. Providers that enforce rotation invalidate the
+// previous refresh_token once a new one is issued — re-using the old one
+// returns `invalid_grant`. The proxy must:
+//
+//   - persist any new `refresh_token` from a refresh response (replacing
+//     the previous value in the stored token row);
+//   - carry the prior `refresh_token` plaintext forward when the provider
+//     reuses it across refreshes (RFC 6749 §6 leaves rotation as the
+//     provider's choice);
+//   - send the *current* `refresh_token` on subsequent refresh POSTs —
+//     never an old one. After a rotation, the old refresh_token is dead
+//     to the provider and resubmitting it would 400 the next refresh.
+//
+// We exercise the real go-oauth2-server rotation path rather than scripting
+// synthetic tokens because:
+//
+//   - the test provider redacts `refresh_token` form values in its request
+//     recorder, so pinning wire-level RT bytes is impossible — we read the
+//     persisted token row and decrypt instead;
+//   - scripted access tokens are not valid bearer credentials at the
+//     resource server, so the proxied /echo would 401 and trigger the
+//     proxy's retry-once-after-refresh path, double-counting refresh POSTs
+//     and emitting a refresh-failed event for the second attempt;
+//   - the real provider revokes the old refresh_token on rotation (CAS:
+//     `WHERE id = ? AND revoked_at IS NULL`) and responds 400 invalid_grant
+//     when an old RT is replayed — exactly the signal we want for the
+//     forward-chain test, but only available against a real rotation
+//     implementation.
+//
+// The "old refresh token is not restored by stale writes" property
+// listed in scenario 9 is a concurrency property — the redis mutex
+// around refreshAccessToken prevents a slow concurrent refresh from
+// writing back a stale value after a faster one has rotated. That is
+// exercised in scenario 10 (PR B for #171).
+//
+// Because AES-GCM uses a fresh nonce on every encryption, the encrypted
+// bytes of the refresh_token column change on every write even when the
+// underlying plaintext is identical. Rotation tests therefore decrypt the
+// persisted refresh_token and compare *plaintext* values.
+
+// TestProxyRefresh_RotationPersistsNewToken — provider rotates the
+// refresh_token (test mode default). The proxy must persist the new
+// value into the token row, replacing the existing one. We pin the
+// post-refresh decrypted refresh_token against the pre-refresh decrypted
+// value — a rotation must produce a *different* plaintext. This is the
+// minimal end-to-end correctness check on the rotation path.
+func TestProxyRefresh_RotationPersistsNewToken(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-rotation-persist")
+	connID := rig.completeAuthFlow(t)
+	rig.forceTokenExpired(t, connID, false)
+
+	preRotation := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, preRotation)
+	preRotationRefresh := rig.env.DecryptOAuth2RefreshToken(t, preRotation)
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code, "proxy must succeed on rotated-token response; got %d body=%s", w.Code, w.Body.String())
+
+	postRotation := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, postRotation, "rotation must leave a token row")
+	assert.NotEqualf(t, preRotation.Id, postRotation.Id,
+		"rotation must insert a new token row (id should change); got same id %s", postRotation.Id)
+	postRotationRefresh := rig.env.DecryptOAuth2RefreshToken(t, postRotation)
+	assert.NotEqualf(t, preRotationRefresh, postRotationRefresh,
+		"rotation must replace refresh_token plaintext; got identical value (suggests old RT was carried forward)")
+
+	// One success event, no failure event. Rotation must not be alertable.
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
+		"rotation must emit exactly one refresh-succeeded event")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"rotation must not emit a refresh-failed event")
+}
+
+// TestProxyRefresh_RotationNextRefreshUsesRotatedToken — the forward-
+// chain assertion. After the provider rotates the refresh_token on
+// refresh #1, the proxy must send the *rotated* value on refresh #2,
+// never the original. This is the assertion that catches a regression
+// where the proxy persists the new RT but reads the old one back on
+// the next refresh (e.g., cached in memory, or a transaction-isolation
+// bug in the token-row lookup).
+//
+// We rely on the test provider's revocation-on-rotation behaviour:
+// replaying a rotated-away refresh_token returns 400 invalid_grant
+// (`Refresh token revoked` per `/test/refresh-tokens/rotate-policy`
+// docs). So if the proxy regressed and sent the original RT on refresh
+// #2, the provider would 400, the proxy would emit a refresh-failed
+// event, and the connection would flip unhealthy. The chain succeeding
+// twice with the persisted refresh_token plaintext changing each
+// time is therefore proof-by-survival that the proxy is reading and
+// sending the current RT.
+func TestProxyRefresh_RotationNextRefreshUsesRotatedToken(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-rotation-forward-chain")
+	connID := rig.completeAuthFlow(t)
+
+	originalRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+
+	rig.forceTokenExpired(t, connID, false)
+	w1 := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w1.Code, "first refresh must succeed; got %d body=%s", w1.Code, w1.Body.String())
+
+	afterFirstRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+	require.NotEqualf(t, originalRefresh, afterFirstRefresh,
+		"refresh #1 must rotate the refresh_token plaintext (fixture sanity)")
+
+	// Refresh #2: if the proxy regressed and replayed the original RT
+	// here, the provider would 400 invalid_grant and this proxy call
+	// would fail. The chain succeeding is the load-bearing assertion.
+	rig.forceTokenExpired(t, connID, false)
+	w2 := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w2.Code,
+		"second refresh must succeed using the rotated refresh_token; got %d body=%s — "+
+			"a 4xx here means the proxy replayed the rotated-away RT", w2.Code, w2.Body.String())
+
+	afterSecondRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+	assert.NotEqualf(t, afterFirstRefresh, afterSecondRefresh,
+		"refresh #2 must rotate the refresh_token plaintext again")
+	assert.NotEqualf(t, originalRefresh, afterSecondRefresh,
+		"rotation chain must never resurrect the original refresh_token")
+
+	// Exactly two refresh-token grants observed on the wire — one per
+	// proxy call. A 401-then-refresh retry firing here would inflate this
+	// count; the proactive expiry check forecloses that path.
+	grants := refreshGrantRequests(rig)
+	assert.Lenf(t, grants, 2, "expected exactly 2 refresh-token grants; got %d", len(grants))
+
+	// Two success events, no failure events — proves both refreshes were
+	// accepted by the provider.
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 2,
+		"rotation chain must emit exactly two refresh-succeeded events")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"rotation chain must not emit any refresh-failed events")
+}
+
+// TestProxyRefresh_NoRotationRetainsRefreshToken — provider has rotation
+// disabled. Every refresh response reuses the existing refresh_token, so
+// the persisted plaintext must remain the same across the chain. The
+// proxy still re-encrypts to a fresh nonce on every write (AES-GCM), so
+// the encrypted column bytes change — but the underlying plaintext must
+// not.
+//
+// This pins two related guarantees from RFC 6749 §6 and the proxy's
+// internal `createDbTokenFromResponse` logic:
+//
+//   - when the provider does NOT rotate, the proxy must not synthesize a
+//     new refresh_token from nowhere (the next refresh would fail);
+//   - the proxy must continue to send a working refresh_token on the
+//     next refresh — i.e. the chain survives indefinitely under the
+//     provider's no-rotation policy.
+func TestProxyRefresh_NoRotationRetainsRefreshToken(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-no-rotation")
+	connID := rig.completeAuthFlow(t)
+
+	// Disable rotation on the provider. Test-mode default is on, so
+	// restore it on cleanup to avoid leaking state between tests.
+	rig.provider.SetRefreshRotation(false)
+	t.Cleanup(func() { rig.provider.SetRefreshRotation(true) })
+
+	originalRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+
+	rig.forceTokenExpired(t, connID, false)
+	w1 := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w1.Code, "first refresh must succeed; got %d body=%s", w1.Code, w1.Body.String())
+
+	afterFirstRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+	assert.Equalf(t, originalRefresh, afterFirstRefresh,
+		"no-rotation refresh must preserve refresh_token plaintext across the chain")
+
+	rig.forceTokenExpired(t, connID, false)
+	w2 := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w2.Code, "second refresh must succeed; got %d body=%s", w2.Code, w2.Body.String())
+
+	afterSecondRefresh := rig.env.DecryptOAuth2RefreshToken(t, rig.env.GetOAuth2Token(t, connID))
+	assert.Equalf(t, originalRefresh, afterSecondRefresh,
+		"no-rotation chain must leave refresh_token plaintext unchanged across all refreshes")
+
+	grants := refreshGrantRequests(rig)
+	assert.Lenf(t, grants, 2, "expected exactly 2 refresh-token grants; got %d", len(grants))
+
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 2,
+		"no-rotation chain must emit exactly two refresh-succeeded events")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"no-rotation chain must not emit any refresh-failed events")
+}
+
+// refreshGrantRequests returns just the `grant_type=refresh_token` POSTs
+// observed by the test provider for this rig's client, in the order
+// they arrived.
+func refreshGrantRequests(r *proxyRefreshRig) []helpers.RecordedRequest {
+	out := []helpers.RecordedRequest{}
+	for _, req := range r.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointRefresh,
+		ClientID: r.clientKey,
+	}) {
+		if lastForm(req.Form, "grant_type") == "refresh_token" {
+			out = append(out, req)
+		}
+	}
+	return out
+}

--- a/integration_tests/oauth2/proxy_refresh_rotation_test.md
+++ b/integration_tests/oauth2/proxy_refresh_rotation_test.md
@@ -1,0 +1,166 @@
+# OAuth2 Refresh Token Rotation (scenario 9)
+
+Companion specification for `proxy_refresh_rotation_test.go`. Covers
+issue #171 scenario 9 — refresh-token rotation. RFC 6749 §6 allows but
+does not require the provider to issue a new `refresh_token` on every
+refresh response. The proxy must persist any rotated value, carry the
+prior value forward when the provider chooses not to rotate, and send
+the *current* `refresh_token` on every subsequent refresh.
+
+The "old refresh token is not restored by stale writes" property listed
+in scenario 9 is a concurrency property — the redis mutex around
+`refreshAccessToken` prevents a slow concurrent refresh from writing
+back a stale value after a faster one has rotated. That is exercised in
+scenario 10 (PR B for #171).
+
+## Cases covered
+
+| Test                                                  | Provider rotation policy | Asserted shape                                                                                                                                |
+| ----------------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TestProxyRefresh_RotationPersistsNewToken`           | on (test-mode default)   | One proxy call → one refresh POST → new token row with rotated refresh_token plaintext.                                                       |
+| `TestProxyRefresh_RotationNextRefreshUsesRotatedToken`| on (test-mode default)   | Two proxy calls → two refresh POSTs → second refresh succeeds, proving the proxy sent the rotated RT (replaying the original would 400).      |
+| `TestProxyRefresh_NoRotationRetainsRefreshToken`      | off (toggled by test)    | Two proxy calls → two refresh POSTs → refresh_token plaintext is unchanged across the chain.                                                  |
+
+## What is asserted
+
+For every case:
+
+- **Proxy outcome.** Every proxy call returns 200 — a successful refresh
+  is invisible to the customer's app modulo the fresh token.
+- **Refresh-token plaintext shape.** Read via
+  `env.DecryptOAuth2RefreshToken(t, tok)`. AES-GCM uses a fresh nonce per
+  encryption, so the column bytes change on every write even when the
+  underlying plaintext is identical. Comparing plaintext is the only
+  reliable signal of whether the proxy actually changed the
+  refresh_token.
+- **Refresh-endpoint call count.** Exactly one
+  `grant_type=refresh_token` POST per proxy call, filtered via
+  `refreshGrantRequests(rig)`. An inflated count would mean the
+  retry-once-after-refresh path fired against `/echo` — would silently
+  invalidate the rotation chain assertions and is itself a regression.
+- **Structured events.** One `oauth token refresh succeeded` event per
+  successful refresh, zero `oauth token refresh failed` events. A
+  failure event in the rotation chain test would mean refresh #2 sent
+  the rotated-away RT and the provider rejected it.
+
+### Why the forward-chain test relies on the provider's revocation behaviour
+
+When rotation is on, go-oauth2-server atomically marks the prior
+refresh_token revoked
+(`UPDATE oauth_refresh_tokens SET revoked_at = now() WHERE id = ? AND revoked_at IS NULL`),
+and `GetValidRefreshToken` returns `invalid_grant` on a revoked replay.
+So if a regression caused the proxy to keep sending the original RT
+after refresh #1, refresh #2 would 400, the proxy would emit a
+refresh-failed event, and the connection would flip unhealthy. The
+chain succeeding twice is therefore proof-by-survival that the proxy is
+reading the rotated value and sending it.
+
+## Why direct DB-level expiry forge + real rotation, not scripts
+
+Scripting refresh responses (the technique used by scenarios 7 and 8)
+fails for rotation tests because:
+
+- the test provider redacts `refresh_token` values in the recorded
+  request log (`recorder.go:redactedFormFields`), so pinning wire-level
+  RT bytes is impossible regardless of which side mints the tokens;
+- scripted access tokens are not valid bearer credentials at the
+  provider's resource server. Proxying with one to `/echo` would 401,
+  triggering the proxy's retry-once-after-refresh path, which double-
+  counts refresh POSTs *and* burns the next scripted action;
+- the revocation-on-replay signal that makes the forward-chain test
+  meaningful only exists on the real rotation implementation.
+
+The real go-oauth2-server rotation path (test-mode default on) issues a
+new access AND refresh token per refresh, atomically revokes the old
+RT, and links the new RT to the old via `parent_id`. Toggling
+`/test/refresh-tokens/rotate-policy` (via `provider.SetRefreshRotation`)
+switches between rotation and reuse without restarting the provider.
+
+`forceTokenExpired` is the same DB-level forge used everywhere in the
+refresh suite — it advances `access_token_expires_at` into the past
+without waiting for real provider TTLs.
+
+## Why decrypt, not compare encrypted bytes
+
+`createDbTokenFromResponse` re-encrypts every refresh_token written to
+the DB, even on the "no rotation" carry-forward path when it copies
+the plaintext directly from the prior row. AES-GCM is randomized — the
+nonce changes per encryption — so `EncryptedField.Data` will differ
+across writes of identical plaintext. A naive byte-equality assertion
+on the column would flake every time. Decrypt the column and compare
+plaintext.
+
+`env.DecryptOAuth2RefreshToken(t, tok)` uses the same
+`DM.GetEncryptService().DecryptString` path the proxy itself uses, so
+the test reads what the proxy reads.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant API as API service
+    participant DB as Postgres
+    participant P as OAuth provider (docker, real rotation)
+
+    note over T: rig.completeAuthFlow drives the standard auth flow to Ready (omitted)
+
+    T->>DB: forceTokenExpired (access_token_expires_at in past)
+    T->>DB: GetOAuth2Token → decrypt refresh_token (plaintext RT-A)
+
+    T->>API: POST /api/v1/connections/<id>/_proxy (1st)
+    API->>DB: GetOAuth2Token, access_token expired
+    API->>P: POST /token (grant_type=refresh_token, refresh_token=RT-A)
+    P->>P: rotate: mark RT-A revoked, mint RT-B
+    P-->>API: 200 {access_token, refresh_token=RT-B}
+    API->>DB: InsertOAuth2Token (encrypted RT-B)
+    API-->>T: 200
+
+    T->>DB: GetOAuth2Token → decrypt refresh_token (plaintext RT-B, distinct from RT-A)
+
+    T->>DB: forceTokenExpired
+    T->>API: POST /api/v1/connections/<id>/_proxy (2nd)
+    API->>P: POST /token (grant_type=refresh_token, refresh_token=RT-B)
+    P->>P: rotate: mark RT-B revoked, mint RT-C
+    P-->>API: 200 {access_token, refresh_token=RT-C}
+    API->>DB: InsertOAuth2Token (encrypted RT-C)
+    API-->>T: 200
+
+    note over T: chain survives because the proxy sent RT-B on refresh #2,<br/>not the rotated-away RT-A
+```
+
+## What is *not* covered here
+
+- **Concurrent refresh safety.** The mutex around `refreshAccessToken`
+  serializes concurrent refreshes; a slow goroutine must not write back
+  a stale RT after a faster one rotated. Scenario 10 — PR B for #171,
+  driven by a `DelayMs`-padded scripted refresh.
+- **`response omits refresh_token` carry-forward branch.** The proxy's
+  `createDbTokenFromResponse` has a branch that copies
+  `refreshFrom.EncryptedRefreshToken` byte-for-byte when the response
+  JSON omits `refresh_token`. The test provider always *includes*
+  `refresh_token` in its response (even in no-rotation mode it returns
+  the same value), so this branch is not exercisable from the
+  integration boundary against go-oauth2-server. The internal carry-
+  forward semantics are pinned by unit tests in
+  `internal/auth_methods/oauth2/token_response_test.go`. The integration
+  contract — plaintext refresh_token is preserved across the chain — is
+  pinned here regardless of which proxy branch implements it.
+- **Wire-level refresh_token value.** Redacted by the test provider's
+  request recorder; we read the persisted (decrypted) column instead.
+- **Rotation under provider 5xx / transient retry.** Covered by
+  scenario 8 (`proxy_refresh_retry_test.go`); the rotation tests assume
+  the happy path on the refresh response itself.
+
+## Components
+
+| Lever                                                       | What it controls |
+| ----------------------------------------------------------- | ---------------- |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Same fixture used by scenarios 6, 7, 8, 13. Drives the standard auth flow to Ready, then advances `access_token_expires_at` into the past via a DB-level forge so the proxy's expiry check fires immediately. |
+| `provider.SetRefreshRotation(bool)` (+ `t.Cleanup` restore)  | Toggle the provider's rotation policy at runtime. Test mode defaults to **on**; the no-rotation test disables and restores. |
+| `env.DoProxyRequest(t, connID, …)`                          | Triggers the expired-token → refresh path in-process. The retry loop is driven entirely server-side; the test never has to wait for real TTLs. |
+| `env.GetOAuth2Token(t, connID)`                             | Read the current token row out of the database. |
+| `env.DecryptOAuth2RefreshToken(t, tok)`                     | Decrypt the persisted refresh_token to plaintext. Required for any meaningful equality assertion because AES-GCM ciphertext changes per write. |
+| `refreshGrantRequests(rig)`                                 | Count `grant_type=refresh_token` POSTs the provider has observed for this client. Filtered to exclude the authorization-code POSTs from the auth-flow leg. |
+| `logCapture.RecordsWithMessage(t, …)`                       | Surface the structured success / failure events for chain-survival assertions. |


### PR DESCRIPTION
## Summary
- Cover scenario 9 from #171: provider rotates the refresh_token, proxy persists it, and the next refresh sends the rotated value (proved by chain survival against revocation-on-replay).
- Add a `NoRotation` test that pins the carry-forward plaintext when the provider toggles rotation off.
- Add `env.DecryptOAuth2RefreshToken` so rotation tests can compare plaintext — AES-GCM ciphertext bytes change on every write, so encrypted-blob equality is not a reliable signal.

Concurrent refresh safety (scenario 10) follows in PR B.

## Test plan
- [x] `go test -tags=integration -run '^TestProxyRefresh_(RotationPersistsNewToken|RotationNextRefreshUsesRotatedToken|NoRotationRetainsRefreshToken)$' -count=1 -v ./oauth2/...` — all three pass
- [x] `./scripts/preflight.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)