### PR TITLE
Add OAuth2 concurrent refresh safety integration test (#171 PR B)

### DIFF
--- a/integration_tests/oauth2/proxy_refresh_concurrent_test.go
+++ b/integration_tests/oauth2/proxy_refresh_concurrent_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+// Scenario 10 from issue #171: concurrent refresh safety. When N proxy
+// requests detect an expired access token at the same time, the redis
+// mutex in refreshAccessTokenInner must serialize them so:
+//
+//   - exactly one refresh POST reaches the provider — losers acquire the
+//     mutex after the winner persists the new token and find via
+//     re-read that the access token is no longer expired, so they return
+//     without re-POSTing;
+//   - every concurrent proxy request observes the *final* valid access
+//     token (all N return 200);
+//   - exactly one new oauth2_tokens row is persisted (the winner's);
+//   - the rotated refresh_token from the winner is not corrupted by a
+//     concurrent stale-write — a TOCTOU bug here would replay the old RT
+//     against the provider and 400.
+//
+// Under the test provider's default rotation policy, the old refresh_token
+// is revoked on rotation. If the mutex regressed and a loser POSTed
+// /token with the pre-refresh RT after the winner had already rotated it,
+// the provider would return 400 invalid_grant and the proxy would emit a
+// refresh-failed event. So "exactly one refresh POST + no failure event"
+// is the load-bearing signal for both the serialization property and the
+// rotation-doesn't-corrupt-credentials property.
+//
+// Why a delay-only script action
+//
+// The fixture relies on `ScriptAction{DelayMs: …}` (Status=0, Body=""):
+// the script middleware sleeps the configured duration and then falls
+// through to the *real* refresh handler. This keeps the response a real
+// provider-issued grant (valid bearer credential at /echo) while making
+// the winner's refresh slow enough that all concurrent callers reach
+// the mutex before the winner releases it. A scripted-body action
+// would mint a fake access_token that /echo would 401, triggering the
+// proxy's retry-once-after-refresh path and double-counting refreshes
+// (the same trap PR A documented for the rotation tests).
+//
+// The script action is consumed only by the *first* request that reaches
+// the script middleware. So if the proxy mutex regressed and N goroutines
+// all POSTed concurrently, the first would be delayed, the rest would
+// pass through without delay — the second-to-Nth would then try to
+// refresh with an RT the provider had already rotated, returning 400.
+// That is the exact regression signal: failure events appear, not just
+// extra successes.
+
+const concurrentRefreshConcurrency = 8
+
+// TestProxyRefresh_ConcurrentRequestsRefreshExactlyOnce — N proxy
+// requests are launched simultaneously against a connection whose
+// access_token has been forge-expired. The mutex around
+// refreshAccessTokenInner must serialize them so exactly one refresh
+// POST hits the provider; the rest read back the freshly-persisted
+// token and skip the POST.
+func TestProxyRefresh_ConcurrentRequestsRefreshExactlyOnce(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-concurrent")
+	connID := rig.completeAuthFlow(t)
+
+	preToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, preToken)
+	preTokenID := preToken.Id
+	preRefreshPlaintext := rig.env.DecryptOAuth2RefreshToken(t, preToken)
+
+	rig.forceTokenExpired(t, connID, false)
+
+	// Delay-only action: the winner's refresh POST is slept this long
+	// inside the script middleware before falling through to the real
+	// handler. Long enough that all N goroutines reach the mutex while
+	// the winner still holds it; short enough that the whole test wraps
+	// up in well under the 30s default refresh timeout.
+	const refreshDelayMs = 500
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{DelayMs: refreshDelayMs})
+
+	// Launch N concurrent proxy requests. A start barrier (close of a
+	// channel) is used instead of WaitGroup.Wait-then-go so all
+	// goroutines release ~simultaneously rather than in start-order.
+	results := make([]int, concurrentRefreshConcurrency)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(concurrentRefreshConcurrency)
+	for i := 0; i < concurrentRefreshConcurrency; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+			results[i] = w.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// Every concurrent proxy request must observe the final valid access
+	// token — the winner's refresh propagated to all losers via the
+	// mutex-protected DB re-read.
+	for i, code := range results {
+		assert.Equalf(t, http.StatusOK, code,
+			"concurrent proxy request %d must succeed; got %d", i, code)
+	}
+
+	// Exactly one refresh-token grant on the wire. This is the central
+	// assertion: serialization means losers re-read the (now fresh)
+	// token after acquiring the lock and skip the POST entirely.
+	grants := refreshGrantRequests(rig)
+	assert.Lenf(t, grants, 1,
+		"expected exactly 1 refresh-token grant under concurrent refresh; got %d "+
+			"(>1 means the mutex did not serialize concurrent refreshes)", len(grants))
+
+	// Exactly one refresh-succeeded event, no failure events. A failure
+	// event here would mean a loser POSTed the rotated-away RT and
+	// got 400 invalid_grant — i.e., the rotation-doesn't-corrupt-
+	// credentials property is broken.
+	succeeded := rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage)
+	assert.Lenf(t, succeeded, 1,
+		"expected exactly 1 refresh-succeeded event; got %d (>1 means multiple refreshes occurred)", len(succeeded))
+	failed := rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)
+	assert.Emptyf(t, failed,
+		"concurrent refresh must not emit any refresh-failed events; got %d", len(failed))
+
+	// Exactly one new oauth2_tokens row written: the active token id has
+	// rotated forward from preToken.Id, and the plaintext refresh_token
+	// has rotated (test provider defaults to rotation on). The retry-
+	// once-after-refresh path in ProxyRequest would, if it fired, insert
+	// a second token row — but the proactive expiry check forecloses
+	// that path here because the refresh succeeds and yields a fresh
+	// access_token that /echo accepts.
+	postToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, postToken)
+	assert.NotEqualf(t, preTokenID, postToken.Id,
+		"concurrent refresh must persist a new token row; pre id=%s post id=%s",
+		preTokenID, postToken.Id)
+	postRefreshPlaintext := rig.env.DecryptOAuth2RefreshToken(t, postToken)
+	assert.NotEqualf(t, preRefreshPlaintext, postRefreshPlaintext,
+		"concurrent refresh must rotate the refresh_token plaintext (provider default policy)")
+
+	// Connection stays healthy. Any permanent failure in a loser-
+	// goroutine would have flipped it unhealthy and emitted a
+	// connection-health-state-changed event.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"concurrent refresh must leave the connection healthy")
+	assert.Emptyf(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"concurrent refresh must not emit a health-state-changed event")
+}

--- a/integration_tests/oauth2/proxy_refresh_concurrent_test.md
+++ b/integration_tests/oauth2/proxy_refresh_concurrent_test.md
@@ -1,0 +1,182 @@
+# OAuth2 Concurrent Refresh Safety (scenario 10)
+
+Companion specification for `proxy_refresh_concurrent_test.go`. Covers
+issue #171 scenario 10 — the serialization property that protects the
+refresh path when N proxy requests detect an expired access token at
+the same time.
+
+Scenario 9 (rotation) is PR A and lives in `proxy_refresh_rotation_test.go`
+/ `proxy_refresh_rotation_test.md`. The two scenarios are paired in
+issue #171 because rotation correctness is the property the
+concurrency test exercises end-to-end: the test provider's default
+revocation-on-rotation behavior turns "loser POSTed a stale RT" into
+an observable 400 invalid_grant failure event.
+
+## What is asserted
+
+For the single test in this file:
+
+- **All N proxy requests return 200.** Every concurrent caller observes
+  the *final* valid access token. A loser that escaped the mutex
+  would either 401 at `/echo` (stale access token) or fail its own
+  refresh against a rotated-away RT.
+- **Exactly one `grant_type=refresh_token` POST on the wire.** Counted
+  with `refreshGrantRequests(rig)` (filters by endpoint + client). This
+  is the central serialization signal: losers re-read the persisted
+  token after acquiring the mutex, see the access token is no longer
+  expired, and return without POSTing.
+- **Exactly one `oauth token refresh succeeded` event.** A second
+  success event would mean a loser also refreshed; combined with the
+  POST count, this pins the property at both the wire layer and the
+  observability layer.
+- **No `oauth token refresh failed` event.** If a loser POSTed the
+  rotated-away refresh_token after the winner had already rotated it,
+  the provider would 400 invalid_grant and the proxy would emit a
+  failure event. The absence of any failure event is the
+  rotation-doesn't-corrupt-credentials signal.
+- **Exactly one new `oauth2_tokens` row.** The active token id has
+  advanced past `preToken.Id`, and the decrypted refresh_token plaintext
+  differs from the pre-refresh value (test provider's default rotation
+  policy is on).
+- **Health stays healthy and no transition event is emitted.** A
+  permanent refresh failure in a loser goroutine would flip the
+  connection unhealthy.
+
+## Concurrency strategy
+
+```
+                 ┌─ goroutine 1 ─┐
+                 │  goroutine 2  │
+   <-start ──────┤      …        ├── DoProxyRequest(connID, /echo)
+                 │  goroutine N  │
+                 └───────────────┘
+```
+
+`close(start)` releases all N goroutines simultaneously so they hit the
+expired-token check inside `getValidToken` in a single tight window.
+`WaitGroup.Add(N)` + `Wait()` collects results.
+
+`N = 8` is enough to make the race visible against a regressed mutex
+without bloating the wall-clock; the test runs in under 8s end-to-end
+(dominated by the scripted refresh delay).
+
+## Why a delay-only script action
+
+A `ScriptAction{DelayMs: 500}` (Status=0, Body="") makes the test
+provider's script middleware sleep 500ms and then fall through to
+the *real* refresh handler. This gives us two properties at once:
+
+- The winner's refresh is slow enough that all N goroutines reach the
+  mutex while the winner still holds it — without that delay, the
+  refresh would finish so fast the losers would never observe the
+  expired token.
+- The response is a real provider-issued grant, so the new
+  access_token is a valid bearer credential at `/echo`. A scripted
+  body would mint a synthetic access_token that `/echo` would 401,
+  triggering the proxy's `retry-once-after-refresh` path in
+  `ProxyRequest` and double-counting refresh POSTs. PR A documented
+  that trap for the rotation tests; the same reasoning applies here.
+
+The script action is consumed only by the *first* request that reaches
+the script middleware (the queue is FIFO and `Pop` is mutex-protected).
+So under a regressed proxy mutex where N goroutines all POSTed
+concurrently, the first would be delayed and the rest would pass
+through without delay — the second-to-Nth would then try to refresh
+with the pre-rotation RT, and (because the test provider's default
+rotation policy revokes the old RT) the provider would return 400
+invalid_grant. That manifests as failure events, not just extra
+success events, which is exactly the regression signal we want.
+
+## Why `t.Cleanup` doesn't need to restore rotation policy
+
+Unlike the no-rotation test in
+`proxy_refresh_rotation_test.go`, this test does not call
+`SetRefreshRotation` — it relies on the test provider's default
+(rotation on). No cleanup is needed.
+
+## What is *not* covered here
+
+- **Cross-process / multi-API-pod concurrency.** The redis mutex is
+  the same lock both in-process goroutines and across-pod refreshers
+  would contend on. Integration tests run against a single API
+  process, so the cross-process case is covered structurally (same
+  redis key, same Lua acquire script) rather than by simulating two
+  pods.
+- **Mutex acquisition failure.** A redis outage during mutex acquire
+  would surface as `tokenRefreshInternalError`. Reproducing this from
+  the integration boundary requires injecting a redis fault; the unit
+  tests in `internal/auth_methods/oauth2/proxy_test.go` cover the
+  internal-error classification.
+- **No-rotation concurrency.** When the provider doesn't rotate, the
+  serialization property still holds (one POST, one persisted row),
+  but the "rotation doesn't corrupt credentials" failure mode
+  collapses to "the same RT was POSTed N times harmlessly". Under
+  rotation-on the test signal is strictly stronger (a regression
+  produces failure events), so we only run the test under default
+  rotation policy.
+- **Re-entrant refresh from the 401 retry path.** If the upstream
+  resource server 401's after a successful refresh, `ProxyRequest`
+  forces a second `refreshAccessToken` call. That path is covered by
+  `proxy_refresh_test.go`; here the proactive expiry check returns a
+  freshly-rotated token that `/echo` accepts, so the 401 retry path
+  never fires.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Test
+    participant G1 as Goroutine 1 (winner)
+    participant GN as Goroutines 2..N (losers)
+    participant API as API service
+    participant R as Redis (token mutex)
+    participant DB as Postgres
+    participant P as OAuth provider<br/>(docker, scripted delay)
+
+    note over T: completeAuthFlow + forceTokenExpired (omitted)
+    T->>P: POST /test/scripts (refresh, {DelayMs:500})
+    T->>G1: close(start)
+    T->>GN: close(start)
+
+    par winner path
+        G1->>API: POST /api/v1/connections/<id>/_proxy
+        API->>DB: GetOAuth2Token → expired
+        API->>R: Lock(oauth2-token-<id>) → acquired
+        API->>DB: GetOAuth2Token (re-read) → still expired
+        API->>P: POST /token (grant_type=refresh_token)
+        note over P: script middleware sleeps 500ms,<br/>then real handler rotates RT
+        P-->>API: 200 + new access_token + new refresh_token
+        API->>DB: InsertOAuth2Token (rotated RT)
+        API->>API: emit "oauth token refresh succeeded"
+        API->>R: Unlock
+        API->>P: GET /echo with new access_token
+        P-->>API: 200
+        API-->>G1: 200
+    and loser paths
+        GN->>API: POST /api/v1/connections/<id>/_proxy
+        API->>DB: GetOAuth2Token → expired (snapshot)
+        API->>R: Lock(oauth2-token-<id>) [blocks ~500ms]
+        R-->>API: acquired (after winner unlocks)
+        API->>DB: GetOAuth2Token (re-read) → fresh, not expired
+        API-->>API: return cached token (no POST)
+        API->>R: Unlock
+        API->>P: GET /echo with new access_token
+        P-->>API: 200
+        API-->>GN: 200
+    end
+
+    T->>T: assert<br/>1 refresh-token POST<br/>1 success event<br/>0 failure events<br/>1 new token row<br/>healthy connection
+```
+
+## Components
+
+| Lever                                                              | What it controls |
+| ------------------------------------------------------------------ | ---------------- |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired`       | Same fixture used by scenarios 6, 7, 8, 9, 13. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge. |
+| `provider.Script(clientKey, EndpointRefresh, ScriptAction{DelayMs: 500})` | Delay-only action. The script middleware sleeps the configured duration and then falls through to the real refresh handler, preserving real-grant semantics (so the new access_token is a valid bearer at `/echo`). |
+| `close(start)` barrier + `sync.WaitGroup`                          | Releases all N goroutines simultaneously so they hit the expired-token check inside `getValidToken` in a single tight window. |
+| `env.DoProxyRequest(...)` × N                                      | Concurrent proxy calls that all observe the same expired token and contend for the same redis mutex. |
+| `refreshGrantRequests(rig)`                                        | Counts `grant_type=refresh_token` POSTs against the provider's recorder — the central serialization signal. |
+| `env.DecryptOAuth2RefreshToken(t, token)`                          | Plaintext refresh_token for the pre/post rotation check (AES-GCM nonces make byte-equality on the encrypted column meaningless). |
+| `logCapture.RecordsWithMessage(t, …)`                              | Pins exactly one success event, zero failure events, and no health-state-changed transition. |


### PR DESCRIPTION
## Summary

Closes the scenario 10 half of issue #171 (PR A — rotation, scenario 9 — landed in #312). Pins the serialization property of the redis mutex around `refreshAccessTokenInner`: when N proxy requests detect an expired access token at the same time, exactly one refresh-token POST reaches the provider; losers re-read the freshly persisted token and skip the POST.

- New integration test: `TestProxyRefresh_ConcurrentRequestsRefreshExactlyOnce` — 8 concurrent `DoProxyRequest` goroutines launched via a `close(start)` barrier against a forge-expired token. Asserts all return 200, exactly one `grant_type=refresh_token` on the wire, exactly one `oauth token refresh succeeded` event, zero failure events, one rotated token row, healthy connection.
- The fixture uses a delay-only `ScriptAction{DelayMs: 500}` so the test provider's script middleware sleeps the winner's POST and then falls through to the real refresh handler. This keeps the response a real provider-issued grant (valid bearer at `/echo`) while making the race observable. A scripted body would mint a synthetic access_token that `/echo` would 401, triggering the `retry-once-after-refresh` path and double-counting refreshes — the same trap PR A documented for the rotation tests.
- Under the test provider's default rotation policy, the old RT is revoked on rotation. So if the mutex regressed and a loser POSTed the pre-rotation RT after the winner rotated it, the provider would 400 invalid_grant and the proxy would emit a refresh-failed event. "Exactly one POST + no failure event" is the load-bearing signal for both the serialization property and the rotation-doesn't-corrupt-credentials property listed in scenario 10.

Companion spec: `proxy_refresh_concurrent_test.md` covers what's asserted, the concurrency strategy, why a delay-only script action, and what's intentionally out of scope (cross-process concurrency, mutex acquisition failure, no-rotation concurrency, re-entrant refresh via 401 retry).

## Test plan
- [x] `go test -tags=integration -run TestProxyRefresh_ConcurrentRequestsRefreshExactlyOnce -count=1 ./oauth2/` — passes (7.5s)
- [x] `go test -tags=integration -race -run TestProxyRefresh_ConcurrentRequestsRefreshExactlyOnce -count=3 ./oauth2/` — 3 iterations under race detector, all pass (17.6s)
- [x] `go test -tags=integration -run 'TestProxyRefresh' -count=1 ./oauth2/` — full proxy-refresh suite still passes (12s)
- [x] `./scripts/preflight.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)