### PR TITLE
OpenTelemetry — Step 9: slog → OTel logs bridge + trace correlation (#238)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/peterldowns/pgtestdb v0.1.1
 	github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1
+	github.com/redis/go-redis/extra/redisotel/v9 v9.7.3
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
@@ -166,7 +167,6 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.7.3 // indirect
-	github.com/redis/go-redis/extra/redisotel/v9 v9.7.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
@@ -179,6 +179,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/bridges/otelslog v0.16.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/bridges/otelslog v0.16.0 h1:ZtVk8SzgioZhBJmJoezi6Jl5uuXoNVLnZxcJCDTqSbM=
+go.opentelemetry.io/contrib/bridges/otelslog v0.16.0/go.mod h1:p0C45DA3hvvo+5hwDilrMIp43ddVBGmwWEHZft4pY6c=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -198,6 +198,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/bridges/otelslog v0.16.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -533,6 +533,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmB
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/bridges/otelslog v0.16.0 h1:ZtVk8SzgioZhBJmJoezi6Jl5uuXoNVLnZxcJCDTqSbM=
+go.opentelemetry.io/contrib/bridges/otelslog v0.16.0/go.mod h1:p0C45DA3hvvo+5hwDilrMIp43ddVBGmwWEHZft4pY6c=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=

--- a/internal/aplog/telemetry.go
+++ b/internal/aplog/telemetry.go
@@ -1,0 +1,147 @@
+package aplog
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// otelInstrumentationName is the instrumentation scope reported on log
+// records emitted through the OTel logs SDK bridge.
+const otelInstrumentationName = "github.com/rmorlok/authproxy/internal/aplog"
+
+// WrapWithTelemetry returns a logger derived from base whose handler:
+//
+//  1. Always injects trace_id and span_id record attributes when the
+//     logger is invoked within a context that carries a recording span.
+//     This works regardless of whether telemetry is enabled — the cost is
+//     a context lookup per Handle call; the attrs only land when a real
+//     trace is in flight.
+//
+//  2. When telemetry.signals.logs is on AND the providers are live, ALSO
+//     fans every record through go.opentelemetry.io/contrib/bridges/otelslog
+//     so logs ship via the OTLP logs pipeline alongside traces + metrics.
+//     The base handler still emits to its original sink (tint stderr, JSON,
+//     etc.) — fanning out is purely additive.
+//
+// Safe to call with any combination of nil providers / disabled signals /
+// nil base — returns base unchanged when there's nothing to add.
+//
+// The existing CorrelationId field on LogRecord (the request-log entity)
+// is unaffected; it carries through independently from trace_id, so logs
+// emitted within a traced request carry both.
+func WrapWithTelemetry(base *slog.Logger, providers *aptelemetry.Providers, cfg *sconfig.Telemetry) *slog.Logger {
+	if base == nil {
+		return base
+	}
+
+	inner := base.Handler()
+
+	// Always layer the trace-context attrs wrapper. Records emitted outside
+	// a traced context fall through unchanged; records emitted inside a
+	// recording span gain trace_id / span_id attrs.
+	wrapped := &traceContextHandler{inner: inner}
+
+	// When the OTel logs signal is on and providers are live, fan out to
+	// the contrib bridge alongside the original sink so logs ship via OTLP.
+	if providers != nil && providers.Enabled && cfg.LogsEnabled() {
+		otelHandler := otelslog.NewHandler(
+			otelInstrumentationName,
+			otelslog.WithLoggerProvider(providers.LoggerProvider),
+		)
+		return slog.New(&multiHandler{handlers: []slog.Handler{wrapped, otelHandler}})
+	}
+
+	return slog.New(wrapped)
+}
+
+// traceContextHandler injects trace_id / span_id record attributes when the
+// supplied context carries a recording span. It is intentionally a thin
+// passthrough — no attribute rewriting, no level filtering, no formatting
+// changes. Records emitted outside a traced context are forwarded to the
+// inner handler unchanged.
+type traceContextHandler struct {
+	inner slog.Handler
+}
+
+// Enabled defers to the inner handler — we never raise or lower the
+// effective level.
+func (h *traceContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle stamps trace_id / span_id on the record before delegating. The
+// span lookup uses trace.SpanContextFromContext (no SDK dependency) so the
+// handler is safe to use with no-op providers.
+func (h *traceContextHandler) Handle(ctx context.Context, record slog.Record) error {
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		record = record.Clone()
+		record.AddAttrs(
+			slog.String("trace_id", sc.TraceID().String()),
+			slog.String("span_id", sc.SpanID().String()),
+		)
+	}
+	return h.inner.Handle(ctx, record)
+}
+
+func (h *traceContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &traceContextHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *traceContextHandler) WithGroup(name string) slog.Handler {
+	return &traceContextHandler{inner: h.inner.WithGroup(name)}
+}
+
+// multiHandler fans every record / WithAttrs / WithGroup call out to every
+// configured inner handler. Errors from one handler don't short-circuit the
+// others — a transient failure on the OTLP logs path must not break stderr
+// logging, and vice versa.
+type multiHandler struct {
+	handlers []slog.Handler
+}
+
+// Enabled returns true if any inner handler considers the level enabled.
+// This avoids dropping records bound for one handler because another has
+// a higher threshold.
+func (h *multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, inner := range h.handlers {
+		if inner.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *multiHandler) Handle(ctx context.Context, record slog.Record) error {
+	var firstErr error
+	for _, inner := range h.handlers {
+		if !inner.Enabled(ctx, record.Level) {
+			continue
+		}
+		if err := inner.Handle(ctx, record.Clone()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (h *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	wrapped := make([]slog.Handler, len(h.handlers))
+	for i, inner := range h.handlers {
+		wrapped[i] = inner.WithAttrs(attrs)
+	}
+	return &multiHandler{handlers: wrapped}
+}
+
+func (h *multiHandler) WithGroup(name string) slog.Handler {
+	wrapped := make([]slog.Handler, len(h.handlers))
+	for i, inner := range h.handlers {
+		wrapped[i] = inner.WithGroup(name)
+	}
+	return &multiHandler{handlers: wrapped}
+}

--- a/internal/aplog/telemetry_test.go
+++ b/internal/aplog/telemetry_test.go
@@ -1,0 +1,282 @@
+package aplog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// inMemoryLogExporter buffers every Record passed to Export so tests can
+// introspect what reaches the OTel logs pipeline. The sdk/log package
+// doesn't ship a tracetest-style recorder for logs in v0.16, so we provide
+// our own minimal exporter here.
+type inMemoryLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func (e *inMemoryLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.records = append(e.records, records...)
+	return nil
+}
+
+func (e *inMemoryLogExporter) Shutdown(_ context.Context) error  { return nil }
+func (e *inMemoryLogExporter) ForceFlush(_ context.Context) error { return nil }
+
+func (e *inMemoryLogExporter) Records() []sdklog.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdklog.Record, len(e.records))
+	copy(out, e.records)
+	return out
+}
+
+// telemetryProviders builds enabled OTel providers with an in-memory log
+// exporter (so we can assert what flows through the bridge). Traces and
+// metrics aren't asserted in this test file; we instantiate real providers
+// so the otelslog bridge's logger lookup succeeds.
+func telemetryProviders(t *testing.T) (*aptelemetry.Providers, *inMemoryLogExporter) {
+	t.Helper()
+
+	exporter := &inMemoryLogExporter{}
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewSimpleProcessor(exporter)),
+	)
+	tp := sdktrace.NewTracerProvider()
+	mp := sdkmetric.NewMeterProvider()
+
+	t.Cleanup(func() {
+		_ = lp.Shutdown(context.Background())
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	})
+
+	return &aptelemetry.Providers{
+		Enabled:        true,
+		TracerProvider: tp,
+		MeterProvider:  mp,
+		LoggerProvider: lp,
+		Propagator:     propagation.TraceContext{},
+	}, exporter
+}
+
+func enabledPtr(b bool) *bool { return &b }
+
+// newJSONLogger wraps a buffer-backed slog.JSONHandler so tests can read
+// the formatted bytes and assert attribute presence.
+func newJSONLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})), buf
+}
+
+// parseLastRecord parses the most recent JSON object emitted to buf.
+func parseLastRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.NotEmpty(t, lines)
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[len(lines)-1]), &record))
+	return record
+}
+
+func TestWrapWithTelemetry_AddsTraceIDsWhenInTracedContext(t *testing.T) {
+	providers, _ := telemetryProviders(t)
+
+	base, buf := newJSONLogger()
+	logger := WrapWithTelemetry(base, providers, &sconfig.Telemetry{Enabled: enabledPtr(true)})
+	require.NotNil(t, logger)
+
+	// Construct a context with a recording span — the wrapper must lift
+	// trace_id + span_id onto every record emitted within it.
+	tracer := providers.TracerProvider.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "op")
+	defer span.End()
+
+	logger.InfoContext(ctx, "hello")
+
+	record := parseLastRecord(t, buf)
+	require.Equal(t, span.SpanContext().TraceID().String(), record["trace_id"])
+	require.Equal(t, span.SpanContext().SpanID().String(), record["span_id"])
+}
+
+func TestWrapWithTelemetry_NoTraceAttrsOutsideTrace(t *testing.T) {
+	providers, _ := telemetryProviders(t)
+
+	base, buf := newJSONLogger()
+	logger := WrapWithTelemetry(base, providers, &sconfig.Telemetry{Enabled: enabledPtr(true)})
+
+	logger.Info("hello") // no context, no span
+
+	record := parseLastRecord(t, buf)
+	_, hasTrace := record["trace_id"]
+	_, hasSpan := record["span_id"]
+	require.False(t, hasTrace, "trace_id must not be set when no span is in flight")
+	require.False(t, hasSpan, "span_id must not be set when no span is in flight")
+}
+
+func TestWrapWithTelemetry_LogsSignalOnFansToOTelExporter(t *testing.T) {
+	providers, exporter := telemetryProviders(t)
+
+	base, _ := newJSONLogger()
+	logger := WrapWithTelemetry(base, providers, &sconfig.Telemetry{Enabled: enabledPtr(true)})
+
+	logger.Info("hello via otel bridge")
+
+	// Force-flush by shutting the LoggerProvider — the simple processor
+	// would already have exported, but be defensive about it.
+	require.NoError(t, providers.LoggerProvider.(*sdklog.LoggerProvider).ForceFlush(context.Background()))
+
+	records := exporter.Records()
+	require.NotEmpty(t, records, "logs signal on must fan records to the OTel exporter")
+}
+
+func TestWrapWithTelemetry_LogsSignalOffSkipsOTelFanOut(t *testing.T) {
+	providers, exporter := telemetryProviders(t)
+
+	off := false
+	on := true
+	cfg := &sconfig.Telemetry{
+		Enabled: &on,
+		Signals: &sconfig.TelemetrySignals{Traces: &on, Metrics: &on, Logs: &off},
+	}
+
+	base, buf := newJSONLogger()
+	logger := WrapWithTelemetry(base, providers, cfg)
+
+	logger.Info("hello via stderr only")
+
+	require.NoError(t, providers.LoggerProvider.(*sdklog.LoggerProvider).ForceFlush(context.Background()))
+
+	// Original sink still received the record.
+	require.Contains(t, buf.String(), "hello via stderr only")
+	// OTel exporter received nothing — the logs signal is off.
+	require.Empty(t, exporter.Records(),
+		"logs signal off must NOT fan records to the OTel exporter")
+}
+
+func TestWrapWithTelemetry_NoOpProvidersStillStampsTraceAttrs(t *testing.T) {
+	// Even with no-op providers (telemetry block absent), the wrapper
+	// must still stamp trace_id / span_id when in a traced context.
+	// Operators who haven't enabled OTel still benefit from trace
+	// correlation in logs as soon as someone starts a span in their app.
+	base, buf := newJSONLogger()
+	logger := WrapWithTelemetry(base, aptelemetry.NoopProviders(), nil)
+	require.NotNil(t, logger)
+
+	// Spin a real tracer so SpanContextFromContext returns a valid id.
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "op")
+	defer span.End()
+
+	logger.InfoContext(ctx, "hello")
+
+	record := parseLastRecord(t, buf)
+	require.Equal(t, span.SpanContext().TraceID().String(), record["trace_id"])
+	require.Equal(t, span.SpanContext().SpanID().String(), record["span_id"])
+}
+
+func TestWrapWithTelemetry_NilLoggerReturnedUnchanged(t *testing.T) {
+	require.Nil(t, WrapWithTelemetry(nil, nil, nil))
+}
+
+func TestWrapWithTelemetry_PreservesWithAttrs(t *testing.T) {
+	// The wrapped logger must still honor logger.With(...) for both
+	// telemetry-on and telemetry-off configurations — losing inherited
+	// attrs would break every existing log-builder helper.
+	providers, _ := telemetryProviders(t)
+
+	base, buf := newJSONLogger()
+	wrapped := WrapWithTelemetry(base, providers, &sconfig.Telemetry{Enabled: enabledPtr(true)})
+
+	scoped := wrapped.With("service", "test", "component", "x")
+	scoped.Info("hello")
+
+	record := parseLastRecord(t, buf)
+	require.Equal(t, "test", record["service"])
+	require.Equal(t, "x", record["component"])
+}
+
+// TestWrapWithTelemetry_CorrelationIdStaysIndependent pins the spec line:
+// "The existing CorrelationId field stays independent from trace_id —
+// logs emitted within a request carry both." The trace-context wrapper
+// stamps trace_id / span_id without touching any application-supplied
+// attributes — including correlation_id added via slog.With.
+func TestWrapWithTelemetry_CorrelationIdStaysIndependent(t *testing.T) {
+	providers, _ := telemetryProviders(t)
+
+	base, buf := newJSONLogger()
+	logger := WrapWithTelemetry(base, providers, &sconfig.Telemetry{Enabled: enabledPtr(true)})
+
+	tracer := providers.TracerProvider.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "op")
+	defer span.End()
+
+	// Application attaches its correlation_id via slog.With as usual.
+	scoped := logger.With("correlation_id", "corr-12345")
+	scoped.InfoContext(ctx, "hello")
+
+	record := parseLastRecord(t, buf)
+	require.Equal(t, "corr-12345", record["correlation_id"],
+		"correlation_id must pass through untouched by the trace-context handler")
+	require.Equal(t, span.SpanContext().TraceID().String(), record["trace_id"],
+		"trace_id stamped alongside, not in place of, correlation_id")
+}
+
+func TestTraceContextHandler_DelegatesEnabled(t *testing.T) {
+	// Inner handler is the source of truth for level decisions — the
+	// wrapper must not raise or lower the effective threshold.
+	base, _ := newJSONLogger() // JSON handler defaults to LevelDebug above
+	h := &traceContextHandler{inner: base.Handler()}
+	require.True(t, h.Enabled(context.Background(), slog.LevelDebug))
+	require.True(t, h.Enabled(context.Background(), slog.LevelInfo))
+	require.True(t, h.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestMultiHandler_FanOutContinuesOnError(t *testing.T) {
+	// A failure in one branch must not short-circuit the others.
+	failing := &failingHandler{}
+	base, buf := newJSONLogger()
+
+	mh := &multiHandler{handlers: []slog.Handler{failing, base.Handler()}}
+	logger := slog.New(mh)
+	logger.Info("hello")
+
+	require.Contains(t, buf.String(), "hello",
+		"working handler must receive the record even when a sibling errors")
+}
+
+// failingHandler is a slog.Handler that always reports an error from
+// Handle. Used to verify multiHandler's fan-out is fault-tolerant.
+type failingHandler struct{}
+
+func (failingHandler) Enabled(context.Context, slog.Level) bool      { return true }
+func (failingHandler) Handle(context.Context, slog.Record) error     { return errSomething }
+func (failingHandler) WithAttrs([]slog.Attr) slog.Handler            { return failingHandler{} }
+func (failingHandler) WithGroup(string) slog.Handler                 { return failingHandler{} }
+
+var errSomething = errSentinel("intentional test failure")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
+
+// silence trace dependency in the small smoke test
+var _ trace.SpanContext = trace.SpanContext{}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -50,6 +50,9 @@ type DependencyManager struct {
 	telemetryOnce sync.Once
 	telemetryErr  error
 
+	rootLogger     *slog.Logger
+	rootLoggerOnce sync.Once
+
 	// Rate-limit cache + refresher are owned by the dependency manager so
 	// the lifecycle is tied to the proxy process. The cache is populated
 	// lazily via GetRateLimitCache(); StartRateLimitRefresher() boots the
@@ -153,14 +156,32 @@ func (dm *DependencyManager) GetServiceId() string {
 
 func (dm *DependencyManager) GetLogBuilder() aplog.Builder {
 	if dm.logBuilder == nil {
-		dm.logBuilder = aplog.NewBuilder(dm.cfg.GetRootLogger())
+		dm.logBuilder = aplog.NewBuilder(dm.GetRootLogger())
 	}
 
 	return dm.logBuilder
 }
 
+// GetRootLogger returns the application-wide root slog.Logger, wrapped with
+// the telemetry-aware handler from internal/aplog so every emitted record
+// gains trace_id / span_id when in a traced context (and is fanned to the
+// OTel logs pipeline when telemetry.signals.logs is on). Cached on first
+// call — every other DM lookup that needs a logger derives from this one,
+// so the wrap happens exactly once per process.
+//
+// Force-initialises telemetry providers before wrapping so the OTel logs
+// bridge picks up the live LoggerProvider regardless of call order in the
+// service's Serve func.
 func (dm *DependencyManager) GetRootLogger() *slog.Logger {
-	return dm.GetConfigRoot().GetRootLogger()
+	dm.rootLoggerOnce.Do(func() {
+		providers := dm.GetTelemetry()
+		dm.rootLogger = aplog.WrapWithTelemetry(
+			dm.GetConfigRoot().GetRootLogger(),
+			providers,
+			dm.GetConfigRoot().Telemetry,
+		)
+	})
+	return dm.rootLogger
 }
 
 func (dm *DependencyManager) GetLogger() *slog.Logger {


### PR DESCRIPTION
## Summary

Wires every slog record emitted by the running services through a telemetry-aware handler that does two things:

1. **Trace correlation** — stamps `trace_id` + `span_id` record attributes when the logger is invoked with a context carrying a recording span. The trace-context lookup uses `trace.SpanContextFromContext` (no SDK dependency), so the wrapper is safe to apply unconditionally. Records emitted outside a traced context pass through unchanged; records emitted with no-op providers still get trace correlation as soon as someone starts a span.

2. **OTel logs fan-out** — when `telemetry.signals.logs: true` and the providers are live, every record is additionally fanned through [`go.opentelemetry.io/contrib/bridges/otelslog`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog) so logs ship via the OTLP logs pipeline alongside traces + metrics. The base handler keeps emitting to its original sink (tint stderr, JSON, etc.) — fan-out is purely additive. When the signal is off, the bridge is not constructed and stderr / JSON output stays byte-for-byte identical to the historic behaviour.

The fan-out uses a `multiHandler` that tolerates errors on one branch (an OTLP outage must not break stderr logging, and vice versa).

`DependencyManager.GetRootLogger` now wraps once and caches; `GetLogBuilder` derives from it so every per-service logger picks up the trace-aware handler. Telemetry providers are force-initialised inside `GetRootLogger` before the wrap so the OTel bridge captures the live `LoggerProvider` regardless of call order in the Serve func.

The existing `CorrelationId` on `LogRecord` (the request-log entity) is untouched. Logs emitted within a traced request carry both `trace_id` and `correlation_id`, satisfying the "stays independent" contract from #225 / #238.

Pinned `otelslog v0.16.0` + the existing `otel/log v0.17.0` + bridge as the go-1.24-compatible line.

## Test plan

- [x] `go test ./internal/aplog/...` — new tests pin:
  - `trace_id` + `span_id` present in JSON output when emitted in a traced context
  - Neither present when emitted outside a traced context
  - `telemetry.signals.logs: true` fans records to the OTel exporter
  - `telemetry.signals.logs: false` does not fan to the OTel exporter (stderr-only path unchanged)
  - No-op providers still stamp trace attrs when a real tracer is in flight
  - `nil` base logger returned unchanged
  - `logger.With(...)` attributes survive the wrap
  - `correlation_id` passes through untouched and appears alongside `trace_id`
  - `traceContextHandler.Enabled` delegates to the inner handler
  - `multiHandler` fan-out continues on error in one branch
- [x] `./scripts/preflight.sh` passes (including integration_tests \`go list -mod=readonly\`)
- [x] `go test ./...` clean across the whole tree
- [x] `golangci-lint run` clean
- [ ] Manual verification with a live collector (deferred to #239 dev sample)

Closes #238. Part of the OpenTelemetry project — parent #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)