### PR TITLE
Add probe failure_threshold + recovery_threshold (#254)

### DIFF
--- a/internal/schema/connectors/probe.go
+++ b/internal/schema/connectors/probe.go
@@ -6,6 +6,23 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
+// Default thresholds for the probe-driven health-check signal. Probes that
+// omit FailureThreshold / RecoveryThreshold inherit these. Exported so the
+// runtime (which actually counts probe outcomes and flips connection health)
+// can read the same constants the YAML layer documents.
+const (
+	// DefaultProbeFailureThreshold is the number of consecutive probe failures
+	// required to flip a connection's health_state to unhealthy when the probe
+	// definition omits its own failure_threshold.
+	DefaultProbeFailureThreshold = 3
+
+	// DefaultProbeRecoveryThreshold is the number of consecutive probe successes
+	// required to flip a connection's health_state back to healthy after a
+	// previous failure threshold-cross, when the probe definition omits its own
+	// recovery_threshold.
+	DefaultProbeRecoveryThreshold = 1
+)
+
 // Probe is a mechanism for a connection to validate the state of the world. It can be used to establish if
 // a connection still has valid credentials or if the 3rd party system has certain capabilities.
 type Probe struct {
@@ -24,6 +41,35 @@ type Probe struct {
 
 	// Http defines the probe as using a raw HTTP request as the probe.
 	Http *ProbeHttp `json:"http,omitempty" yaml:"http,omitempty"`
+
+	// FailureThreshold is the number of consecutive failures that must occur
+	// before the connection's health_state flips to unhealthy. Defaults to
+	// DefaultProbeFailureThreshold when omitted. Must be ≥ 1 when set.
+	FailureThreshold *int `json:"failure_threshold,omitempty" yaml:"failure_threshold,omitempty"`
+
+	// RecoveryThreshold is the number of consecutive successes that must occur,
+	// while the connection is unhealthy, before health_state flips back to
+	// healthy. Defaults to DefaultProbeRecoveryThreshold when omitted. Must be
+	// ≥ 1 when set.
+	RecoveryThreshold *int `json:"recovery_threshold,omitempty" yaml:"recovery_threshold,omitempty"`
+}
+
+// EffectiveFailureThreshold returns the configured failure threshold, falling
+// back to DefaultProbeFailureThreshold when the field is unset.
+func (p *Probe) EffectiveFailureThreshold() int {
+	if p == nil || p.FailureThreshold == nil {
+		return DefaultProbeFailureThreshold
+	}
+	return *p.FailureThreshold
+}
+
+// EffectiveRecoveryThreshold returns the configured recovery threshold, falling
+// back to DefaultProbeRecoveryThreshold when the field is unset.
+func (p *Probe) EffectiveRecoveryThreshold() int {
+	if p == nil || p.RecoveryThreshold == nil {
+		return DefaultProbeRecoveryThreshold
+	}
+	return *p.RecoveryThreshold
 }
 
 func (p *Probe) Validate(vc *common.ValidationContext) error {
@@ -50,6 +96,14 @@ func (p *Probe) Validate(vc *common.ValidationContext) error {
 		if err != nil {
 			result = multierror.Append(result, vc.PushField("cron").NewErrorf("cron expression is invalid: %v", err))
 		}
+	}
+
+	if p.FailureThreshold != nil && *p.FailureThreshold < 1 {
+		result = multierror.Append(result, vc.PushField("failure_threshold").NewErrorf("must be at least 1, got %d", *p.FailureThreshold))
+	}
+
+	if p.RecoveryThreshold != nil && *p.RecoveryThreshold < 1 {
+		result = multierror.Append(result, vc.PushField("recovery_threshold").NewErrorf("must be at least 1, got %d", *p.RecoveryThreshold))
 	}
 
 	return result.ErrorOrNil()

--- a/internal/schema/connectors/probe_test.go
+++ b/internal/schema/connectors/probe_test.go
@@ -1,0 +1,152 @@
+package connectors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProbe_EffectiveThresholds_DefaultsWhenUnset(t *testing.T) {
+	p := &Probe{Id: "ping"}
+	require.Equal(t, DefaultProbeFailureThreshold, p.EffectiveFailureThreshold())
+	require.Equal(t, DefaultProbeRecoveryThreshold, p.EffectiveRecoveryThreshold())
+}
+
+func TestProbe_EffectiveThresholds_UseExplicitValuesWhenSet(t *testing.T) {
+	p := &Probe{
+		Id:                "ping",
+		FailureThreshold:  util.ToPtr(5),
+		RecoveryThreshold: util.ToPtr(2),
+	}
+	require.Equal(t, 5, p.EffectiveFailureThreshold())
+	require.Equal(t, 2, p.EffectiveRecoveryThreshold())
+}
+
+func TestProbe_EffectiveThresholds_NilReceiverReturnsDefaults(t *testing.T) {
+	// Defensive: callers iterating Probes that find a nil entry shouldn't
+	// crash. The methods short-circuit to defaults.
+	var p *Probe
+	require.Equal(t, DefaultProbeFailureThreshold, p.EffectiveFailureThreshold())
+	require.Equal(t, DefaultProbeRecoveryThreshold, p.EffectiveRecoveryThreshold())
+}
+
+func TestProbe_Validate_AcceptsValidThresholds(t *testing.T) {
+	cases := []struct {
+		name string
+		f, r *int
+	}{
+		{"both unset", nil, nil},
+		{"failure set", util.ToPtr(3), nil},
+		{"recovery set", nil, util.ToPtr(1)},
+		{"both set, both 1", util.ToPtr(1), util.ToPtr(1)},
+		{"both set, large", util.ToPtr(100), util.ToPtr(50)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Probe{
+				Id:                "ping",
+				FailureThreshold:  tc.f,
+				RecoveryThreshold: tc.r,
+				Http:              &ProbeHttp{Method: "GET", URL: "https://example.com"},
+			}
+			require.NoError(t, p.Validate(&common.ValidationContext{}))
+		})
+	}
+}
+
+func TestProbe_Validate_RejectsZero(t *testing.T) {
+	t.Run("failure_threshold = 0", func(t *testing.T) {
+		p := &Probe{
+			Id:               "ping",
+			FailureThreshold: util.ToPtr(0),
+			Http:             &ProbeHttp{Method: "GET", URL: "https://example.com"},
+		}
+		err := p.Validate(&common.ValidationContext{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failure_threshold")
+	})
+
+	t.Run("recovery_threshold = 0", func(t *testing.T) {
+		p := &Probe{
+			Id:                "ping",
+			RecoveryThreshold: util.ToPtr(0),
+			Http:              &ProbeHttp{Method: "GET", URL: "https://example.com"},
+		}
+		err := p.Validate(&common.ValidationContext{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "recovery_threshold")
+	})
+}
+
+func TestProbe_Validate_RejectsNegative(t *testing.T) {
+	p := &Probe{
+		Id:                "ping",
+		FailureThreshold:  util.ToPtr(-1),
+		RecoveryThreshold: util.ToPtr(-5),
+		Http:              &ProbeHttp{Method: "GET", URL: "https://example.com"},
+	}
+	err := p.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	// Both errors should surface.
+	require.Contains(t, err.Error(), "failure_threshold")
+	require.Contains(t, err.Error(), "recovery_threshold")
+}
+
+func TestProbe_YAMLRoundTrip_WithThresholds(t *testing.T) {
+	original := &Probe{
+		Id:                "ping",
+		Cron:              util.ToPtr("*/5 * * * *"),
+		FailureThreshold:  util.ToPtr(5),
+		RecoveryThreshold: util.ToPtr(2),
+		Http:              &ProbeHttp{Method: "GET", URL: "https://example.com/ping"},
+	}
+
+	t.Run("yaml", func(t *testing.T) {
+		data, err := yaml.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "failure_threshold: 5")
+		assert.Contains(t, string(data), "recovery_threshold: 2")
+
+		var back Probe
+		require.NoError(t, yaml.Unmarshal(data, &back))
+		require.Equal(t, original, &back)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"failure_threshold":5`)
+		assert.Contains(t, string(data), `"recovery_threshold":2`)
+
+		var back Probe
+		require.NoError(t, json.Unmarshal(data, &back))
+		require.Equal(t, original, &back)
+	})
+}
+
+func TestProbe_YAMLRoundTrip_OmitsUnsetThresholds(t *testing.T) {
+	// omitempty: unset thresholds shouldn't appear in serialized output,
+	// so YAML written by AuthProxy doesn't accidentally pin the system
+	// default as an explicit value (which would survive a default change).
+	p := &Probe{
+		Id:   "ping",
+		Cron: util.ToPtr("*/5 * * * *"),
+		Http: &ProbeHttp{Method: "GET", URL: "https://example.com/ping"},
+	}
+
+	yamlData, err := yaml.Marshal(p)
+	require.NoError(t, err)
+	assert.NotContains(t, string(yamlData), "failure_threshold")
+	assert.NotContains(t, string(yamlData), "recovery_threshold")
+
+	jsonData, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.NotContains(t, string(jsonData), "failure_threshold")
+	assert.NotContains(t, string(jsonData), "recovery_threshold")
+}

--- a/internal/schema/connectors/schema.json
+++ b/internal/schema/connectors/schema.json
@@ -93,6 +93,14 @@
         },
         "http": {
           "$ref": "#/$defs/ProbeHttp"
+        },
+        "failure_threshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "recovery_threshold": {
+          "type": "integer",
+          "minimum": 1
         }
       },
       "dependencies": {

--- a/internal/schema/connectors/test_data/invalid-probe-threshold-zero.yaml
+++ b/internal/schema/connectors/test_data/invalid-probe-threshold-zero.yaml
@@ -1,0 +1,20 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana
+logo:
+  public_url: https://example.com/logo.png
+description: |
+  failure_threshold of 0 must be rejected — thresholds count consecutive events
+  and a zero would mean "flip immediately on first event", which is the same as
+  having no threshold at all and isn't a meaningful configuration.
+probes:
+  - id: ping
+    cron: "*/5 * * * *"
+    failure_threshold: 0
+    http:
+      method: GET
+      url: https://example.com/ping
+auth:
+  type: no-auth

--- a/internal/schema/connectors/test_data/valid-probe-thresholds.yaml
+++ b/internal/schema/connectors/test_data/valid-probe-thresholds.yaml
@@ -1,0 +1,36 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  Allow our agent organize your work
+probes:
+  - id: strict-ping
+    cron: "*/5 * * * *"
+    failure_threshold: 5
+    recovery_threshold: 2
+    http:
+      method: GET
+      url: https://example.com/ping
+  - id: defaults-applied
+    period: 1h
+    proxy_http:
+      method: GET
+      url: https://example.com/test
+auth:
+  type: OAuth2
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  client_secret:
+    env_var: ASANA_CLIENT_SECRET
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects


### PR DESCRIPTION
Closes #254. Part of #243.

## Summary
Schema-only extension to \`Probe\` in prep for the probe-driven health-check runtime in #255. Two new optional fields:

| Field | Default | Validation |
|---|---|---|
| \`failure_threshold\` | 3 | integer, ≥ 1 when set |
| \`recovery_threshold\` | 1 | integer, ≥ 1 when set |

Pointer-typed (\`*int\`) so \"unset, use default\" is distinguishable from \"explicitly set to N\". Effective accessors return the default when unset:

\`\`\`go
Probe.EffectiveFailureThreshold()  // default 3, or explicit value
Probe.EffectiveRecoveryThreshold() // default 1, or explicit value
\`\`\`

Defaults exported as \`DefaultProbeFailureThreshold\` / \`DefaultProbeRecoveryThreshold\` so #255's runtime reads the same constants the YAML layer documents.

Zero is rejected — a threshold of zero collapses to \"no threshold at all\" and isn't a meaningful configuration. JSON Schema mirrors with \`minimum: 1\`.

## Test plan
- [x] Effective accessors return defaults when unset (nil receiver too — defensive).
- [x] Effective accessors return explicit values when set.
- [x] Validate accepts all-unset, individual-set, both-set, both-set-to-1, both-set-large.
- [x] Validate rejects \`failure_threshold: 0\` and \`recovery_threshold: 0\` (separate test cases — error message names the field).
- [x] Validate rejects negative values (both fields reported in one error).
- [x] YAML and JSON round-trip with thresholds set, asserting the canonical wire form.
- [x] \`omitempty\`: unset thresholds don't appear in serialized output — keeps AuthProxy-emitted YAML from accidentally pinning the system default as an explicit value that survives a default change.
- [x] \`Test_SchemaAgainstRealData\` picks up \`valid-probe-thresholds.yaml\` (one probe with explicit values, one relying on defaults) and \`invalid-probe-threshold-zero.yaml\`.
- [x] Full module + preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)