### PR TITLE
Add OAuth2 sensitive-value redaction integration tests (#173 spec 12)

### DIFF
--- a/integration_tests/oauth2/redaction_test.go
+++ b/integration_tests/oauth2/redaction_test.go
@@ -1,0 +1,265 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+)
+
+// Scenario 12 from issue #173: logs, errors, and metrics emitted by any
+// OAuth flow must not contain access tokens, refresh tokens, authorization
+// codes, client secrets, PKCE code verifiers, or raw provider credentials.
+// Logs may include connection_id, tenant id, provider id, correlation id,
+// error category, retry count, and scope-mismatch metadata.
+//
+// The proxy redacts at the wire layer (request_log) and at the structured
+// log layer (each oauth2 log call lists explicit slog attributes — no
+// %+v dumps of token responses). This file drives a representative subset
+// of flows and asserts the redaction holds end-to-end.
+//
+// Approach
+//
+// The OAuth flow's secrets are *known to the test* — the client secret is
+// configured locally, the authorization code comes back from
+// provider.Authorize, and the access/refresh tokens are decrypted from the
+// persisted DB row. After the flow, we serialize every captured log record
+// back to JSON and check that none of those exact strings appear in the
+// serialized text. This catches both attribute leaks (a slog.String key
+// whose value contains the secret) and message-string leaks (an error
+// message that includes the raw provider response).
+//
+// What this *doesn't* cover
+//
+//   - PKCE code verifiers: the proxy does not implement PKCE in the
+//     codebase yet (issue #174 / scenario 14 is P1). When PKCE lands, this
+//     test should add a code_verifier secret to the per-flow checks.
+//   - Gin's HTTP access log line. Gin writes those directly to stdout,
+//     not through the configured slog handler, so the LogCapture does
+//     not see them. The access log only contains method + path + status +
+//     latency — none of the listed sensitive values would appear there
+//     either, but if the proxy ever changes to emit access logs through
+//     slog, this test will start checking them automatically.
+//   - The structured request_log (full HTTP transcripts persisted to
+//     ClickHouse). request_log applies its own redaction layer; that's
+//     tested in `internal/request_log`. The integration-test harness
+//     doesn't wire request_log up by default, so this test cannot
+//     exercise it from the boundary.
+//
+// PKCE code verifiers, raw provider credentials beyond client_secret, and
+// any future secret types should be added to `flowSecrets` as the proxy
+// gains the relevant features. Adding a new secret type without adding it
+// here is the silent-leak failure mode this test is designed to catch.
+
+// flowSecrets are the per-flow values whose plaintext must never appear in
+// any captured log record. Each field is the raw value, not a substring —
+// short or empty values are skipped because they'd false-positive against
+// unrelated record content (e.g., a 4-char client_id colliding with a
+// numeric attribute value).
+type flowSecrets struct {
+	ClientSecret      string
+	AuthorizationCode string
+	AccessTokenValue  string
+	RefreshTokenValue string
+	UserPassword      string
+}
+
+// assertNoSecretsInLogs serializes every captured record to JSON and
+// asserts none of the supplied secrets appear as a substring. Values
+// shorter than minSecretLen (or empty) are skipped — a 3-character
+// client_id can easily collide with unrelated field content.
+func assertNoSecretsInLogs(t *testing.T, capture *helpers.LogCapture, secrets flowSecrets) {
+	t.Helper()
+
+	const minSecretLen = 8
+
+	records := capture.Records(t)
+	require.NotEmptyf(t, records, "log capture has no records — fixture sanity check failed")
+
+	// Re-serialize each record to JSON; we want a uniform haystack
+	// regardless of slog attribute shape (string, int, nested map).
+	joined := serializeRecords(t, records)
+
+	check := func(label, value string) {
+		t.Helper()
+		if value == "" || len(value) < minSecretLen {
+			return
+		}
+		assert.NotContainsf(t, joined, value,
+			"%s plaintext must not appear in any captured log record (value=%q)", label, value)
+	}
+
+	check("client_secret", secrets.ClientSecret)
+	check("authorization_code", secrets.AuthorizationCode)
+	check("access_token", secrets.AccessTokenValue)
+	check("refresh_token", secrets.RefreshTokenValue)
+	check("user_password", secrets.UserPassword)
+}
+
+// serializeRecords concatenates the JSON form of every captured record.
+// Re-encoding (rather than reusing the raw buffer) normalizes formatting
+// and guarantees we scan the exact key/value text the slog handler would
+// have written.
+func serializeRecords(t *testing.T, records []map[string]any) string {
+	t.Helper()
+	var b strings.Builder
+	enc := json.NewEncoder(&b)
+	for _, r := range records {
+		require.NoError(t, enc.Encode(r), "re-encode captured log record")
+	}
+	return b.String()
+}
+
+// assertConnectionIDPresent is a positive control: if logs from the OAuth
+// flow are NOT being captured at all, the negative assertions in
+// assertNoSecretsInLogs trivially pass. Pin a known-allowed value
+// (connection_id) so the test fails loudly when the capture path
+// regresses.
+func assertConnectionIDPresent(t *testing.T, capture *helpers.LogCapture, connectionID string) {
+	t.Helper()
+	require.NotEmpty(t, connectionID, "positive control: connection_id is empty — test bug")
+	joined := serializeRecords(t, capture.Records(t))
+	require.Containsf(t, joined, connectionID,
+		"positive control: connection_id %q should appear in some captured record — log capture may be misconfigured", connectionID)
+}
+
+// TestRedaction_HappyPathFlowLeaksNoSecrets — drive a complete authorization-
+// code flow + one proxied API call. The resulting log stream covers
+// initiate, callback (token exchange), and proxy request handling. None
+// of the per-flow secrets must appear in any captured record.
+func TestRedaction_HappyPathFlowLeaksNoSecrets(t *testing.T) {
+	rig := newProxyRefreshRig(t, "redaction-happy")
+	secrets := flowSecrets{}
+
+	// completeAuthFlow uses the test provider's /test/authorize shortcut
+	// (matches the rest of the refresh suite). We reproduce its work
+	// inline here so we can capture the authorization code as it crosses
+	// from the provider to the proxy — that exact code value is the
+	// secret we need to assert never appears in logs.
+	connID, redirectURL := rig.env.InitiateOAuth2Connection(t, rig.connectorID, rig.returnToURL)
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID)
+
+	authResp := rig.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    rig.clientKey,
+		UserID:      rig.userID,
+		RedirectURI: rig.env.PublicOAuthCallbackURL(),
+		Scope:       strings.Join(rig.scopes, " "),
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	pc, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	secrets.AuthorizationCode = pc.Query().Get("code")
+	require.NotEmpty(t, secrets.AuthorizationCode, "fixture sanity: provider must mint a code")
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, secrets.AuthorizationCode))
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"auth flow must land on return_to_url; got %q", loc)
+
+	// One proxied API call so proxy-path logs are exercised too.
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code, "proxied request must succeed; got %d body=%s", w.Code, w.Body.String())
+
+	// After persistence, decrypt the access + refresh tokens. Both are
+	// raw provider-issued strings — if any code path logs them in
+	// plaintext (e.g. by dumping the token response), the substring
+	// check below will catch it.
+	token := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, token, "happy-path flow must persist a token row")
+	secrets.AccessTokenValue = rig.env.DecryptOAuth2AccessToken(t, token)
+	secrets.RefreshTokenValue = rig.env.DecryptOAuth2RefreshToken(t, token)
+
+	// The client_secret is what the rig configures the connector with
+	// — pinned to the rig's deterministic suffix so it's a known
+	// substring to search for.
+	secrets.ClientSecret = extractClientSecret(t, rig.clientKey)
+
+	assertConnectionIDPresent(t, rig.logCapture, connID)
+	assertNoSecretsInLogs(t, rig.logCapture, secrets)
+}
+
+// TestRedaction_TokenExchangeFailureLeaksNoSecrets — failure paths
+// historically leak more than success paths: error messages tend to
+// include the original request body and the provider response body, both
+// of which carry secrets. Drive an `invalid_grant` token-exchange failure
+// and assert nothing slipped through.
+func TestRedaction_TokenExchangeFailureLeaksNoSecrets(t *testing.T) {
+	rig := newTokenExchangeFailureRig(t, "redaction-token-exchange-fail")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+	rig.scriptTokenEndpoint(helpers.ScriptAction{Status: 400, Body: rfc6749Error("invalid_grant")})
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, code))
+	rig.requireRedirectToReturnURL(t, connID, loc)
+	// Sanity: the failure event was emitted so we know logs from the
+	// failure path are in the capture.
+	rig.requireOneFailureEvent(t, "invalid_grant")
+
+	secrets := flowSecrets{
+		ClientSecret:      extractClientSecret(t, rig.clientKey),
+		AuthorizationCode: code,
+	}
+
+	assertConnectionIDPresent(t, rig.logCapture, connID)
+	assertNoSecretsInLogs(t, rig.logCapture, secrets)
+}
+
+// TestRedaction_RefreshFailureLeaksNoSecrets — drive an invalid_grant
+// refresh failure and assert no secrets leak. The refresh failure path
+// in `token_refresh_failure.go` includes a `provider_error` attribute
+// with the provider's error string; we pin that it stays a bounded RFC
+// 6749 code, not a dump of the response body that includes the access /
+// refresh token.
+func TestRedaction_RefreshFailureLeaksNoSecrets(t *testing.T) {
+	rig := newProxyRefreshRig(t, "redaction-refresh-fail")
+	connID := rig.completeAuthFlow(t)
+
+	token := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, token)
+	accessPlaintext := rig.env.DecryptOAuth2AccessToken(t, token)
+	refreshPlaintext := rig.env.DecryptOAuth2RefreshToken(t, token)
+
+	rig.forceTokenExpired(t, connID, false)
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		Status: 400,
+		Body:   rfc6749Error("invalid_grant"),
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.NotEqualf(t, 200, w.Code, "proxy must NOT return 200 when refresh fails with invalid_grant; got 200 body=%s", w.Body.String())
+	// Sanity: failure event present in the capture.
+	require.NotEmpty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"refresh-failed event must be emitted on invalid_grant")
+
+	secrets := flowSecrets{
+		ClientSecret:      extractClientSecret(t, rig.clientKey),
+		AccessTokenValue:  accessPlaintext,
+		RefreshTokenValue: refreshPlaintext,
+	}
+
+	assertConnectionIDPresent(t, rig.logCapture, connID)
+	assertNoSecretsInLogs(t, rig.logCapture, secrets)
+}
+
+// extractClientSecret recovers the client_secret value the rig configured
+// the connector with. The rigs use the deterministic suffix pattern
+// `<name>-secret-<unix-nano>`, parallel to `<name>-client-<unix-nano>`,
+// so we derive the secret from the known clientKey.
+func extractClientSecret(t *testing.T, clientKey string) string {
+	t.Helper()
+	idx := strings.Index(clientKey, "-client-")
+	require.Greaterf(t, idx, 0, "expected clientKey shaped <name>-client-<suffix>; got %q", clientKey)
+	name := clientKey[:idx]
+	suffix := clientKey[idx+len("-client-"):]
+	require.NotEmpty(t, suffix, "clientKey missing suffix: %q", clientKey)
+	return name + "-secret-" + suffix
+}

--- a/integration_tests/oauth2/redaction_test.md
+++ b/integration_tests/oauth2/redaction_test.md
@@ -1,0 +1,130 @@
+# OAuth2 Sensitive-Value Redaction (scenario 12)
+
+Companion specification for `redaction_test.go`. Covers issue #173
+scenario 12 — logs, errors, and metrics emitted by any OAuth flow must
+not contain access tokens, refresh tokens, authorization codes, client
+secrets, PKCE code verifiers, or raw provider credentials.
+
+Logs *may* include connection_id, tenant id, provider id, correlation
+id, error category, retry count, and scope-mismatch metadata — those
+are the operator-visible identifiers operators correlate alerts
+against.
+
+## What is asserted
+
+Three tests, each driving a different code path so the redaction
+property is exercised on:
+
+1. **`TestRedaction_HappyPathFlowLeaksNoSecrets`** — full
+   authorization-code flow (initiate → provider authorize → callback →
+   token exchange → persist) plus one proxied API call. Covers the
+   token-response logging path (success leg of
+   `callback.go` / `proxy.go`), the persistence path, and the
+   proxy-request path. The decrypted access_token and refresh_token
+   from the persisted row, plus the client_secret and authorization
+   code, are checked against every captured record.
+2. **`TestRedaction_TokenExchangeFailureLeaksNoSecrets`** — scripted
+   `invalid_grant` on `/token` during callback. Covers
+   `token_exchange_failure.go`'s classify/log path. The client_secret
+   and authorization code are checked. No tokens are persisted (failed
+   exchange), so access/refresh aren't part of the check.
+3. **`TestRedaction_RefreshFailureLeaksNoSecrets`** — scripted
+   `invalid_grant` on `/token` during refresh. Covers
+   `token_refresh_failure.go`'s classify/log path, which is the most
+   likely leak vector because error messages historically tend to
+   include the failing request's form values and the provider response
+   body. The persisted access_token + refresh_token plaintexts and the
+   client_secret are checked.
+
+Each test ends with two assertions:
+
+- **`assertConnectionIDPresent`** — positive control. The flow's
+  connection_id must appear in *some* captured record, proving the
+  capture is wired up. Without this, "no secret found" trivially
+  passes when nothing is captured at all.
+- **`assertNoSecretsInLogs`** — for each secret in `flowSecrets`, the
+  serialized record stream is searched for the literal plaintext.
+  Values under 8 characters are skipped (anti-false-positive).
+
+## How the secrets are recovered
+
+| Secret | Source |
+| --- | --- |
+| `ClientSecret` | Derived from `rig.clientKey` via `extractClientSecret`. Both rigs use the deterministic shape `<name>-client-<unix-nano>` / `<name>-secret-<unix-nano>`. |
+| `AuthorizationCode` | Returned by `provider.Authorize(...).RedirectURL`'s `?code=` query param — the exact bytes the provider would have sent in the callback. |
+| `AccessTokenValue` | `env.DecryptOAuth2AccessToken(t, token)` — decrypts the persisted `oauth2_tokens.encrypted_access_token` column. |
+| `RefreshTokenValue` | `env.DecryptOAuth2RefreshToken(t, token)` — same, for the refresh column. |
+| `UserPassword` | Currently always empty (the rigs don't surface it past `CreateUser`). Slot retained so future tests that do drive a password grant can include it without changing the helper. |
+
+Each secret is a substring search, not a structural one — both
+attribute leaks (a `slog.String("token", t.AccessToken)`) and
+message-string leaks (an error that formats `%v` over the response
+body) are caught. The substring scan compares against re-encoded JSON
+of every record, so it sees keys, values, and any nested map content
+slog emitted.
+
+## What is *not* covered here
+
+- **PKCE code verifiers.** The proxy does not implement PKCE
+  (`internal/auth_methods/oauth2` has no `code_verifier` reference; issue
+  #174 / scenario 14 is P1). When PKCE lands, the test should add a
+  `CodeVerifier` field to `flowSecrets` and a per-flow capture point.
+  Adding PKCE without adding it to this test is the silent-leak
+  failure mode this scenario exists to catch.
+- **Gin HTTP access log.** Gin writes its `[api] ... | 200 | ... |
+  POST /...` line directly to stdout, not through the configured slog
+  handler, so `LogCapture` does not see it. The access log already
+  only contains method/path/status/latency — none of the secret
+  values would appear there even if it were captured. If the proxy
+  ever moves access logging onto slog, this test starts checking it
+  automatically.
+- **Structured request_log (full HTTP transcripts → ClickHouse).**
+  `internal/request_log` applies its own redaction layer (see
+  `attribution_codec.go`). The integration-test harness does not wire
+  request_log up by default, so this boundary test cannot exercise
+  it. Unit tests in `internal/request_log` cover that layer.
+- **OpenTelemetry metric attributes.** `telemetry.go` only uses
+  bounded enum labels (`result`, `reason`, `revocation_kind`) plus
+  the projected connection-label allowlist; no token values can
+  reach metric dimensions structurally. The unit tests in
+  `telemetry_test.go` pin this.
+- **OpenTelemetry span attributes.** Spans currently set
+  `authproxy.connector_id` and `authproxy.oauth2.operation`, both
+  bounded. No secret values are added on span attributes.
+- **API response bodies returned to the calling client.** If the
+  proxy ever embeds a provider error body into the response it
+  returns to the customer's app, that's a leak vector this test does
+  not check — it scans *logs*, not response payloads. The proxy's
+  error redaction at the response boundary is tested separately in
+  `internal/auth_methods/oauth2/token_refresh_failure_test.go` /
+  `token_exchange_failure_test.go`.
+
+## Why substring scan against decrypted plaintext
+
+The wire-format redaction tests in `request_log` are about checking
+specific known keys (`Authorization`, `client_secret`, etc.).
+Scenario 12 is about catching *any* leak path, including ones that
+emit the value under an unexpected key. The strongest test against
+that class of bug is: the bytes that the provider actually emitted
+must not appear anywhere in the captured log stream. Decrypting the
+persisted row gives us the exact plaintext the proxy held in memory
+and is the only source for the post-rotation refresh_token value.
+
+A weaker version of this test would scan for keys like `access_token`
+or `refresh_token` in record maps. That misses leaks via different
+keys (`token`, `auth`, `body`, `response`) or via message-string
+interpolation. The byte-level substring scan catches all of them.
+
+## Components
+
+| Lever | What it controls |
+| --- | --- |
+| `proxyRefreshRig` + `completeAuthFlow` | Standard auth-flow fixture; reused for the happy-path and refresh-failure tests. |
+| `tokenExchangeFailureRig` | Token-exchange failure fixture (lets us script a 400 invalid_grant on /token mid-callback). |
+| `provider.Authorize(...).RedirectURL` | Source of the exact authorization code the provider would have issued. |
+| `env.DecryptOAuth2AccessToken(t, token)` / `env.DecryptOAuth2RefreshToken(t, token)` | Plaintext recovery for the encrypted DB columns — the only way to obtain the post-rotation values for the refresh-failure case. |
+| `extractClientSecret(t, clientKey)` | Derives the configured client_secret from the deterministic rig naming convention. |
+| `LogCapture.Records(t)` | Returns every captured slog record as a parsed map. We re-encode each one to JSON and concatenate into a single haystack to scan. |
+| `flowSecrets` | Per-flow bundle of plaintexts the substring scan must not find. Adding a new secret type (e.g. `CodeVerifier` when PKCE lands) extends the check. |
+| `assertConnectionIDPresent` | Positive control that the capture path is live. Without this, the negative-check tests pass trivially when no records are captured. |
+| `assertNoSecretsInLogs` | The redaction check itself. Skips values shorter than 8 chars to avoid false positives on short attributes. |


### PR DESCRIPTION
## Summary

Closes #173 — scenario 12 from #159 (sensitive-value redaction).

Three tests drive a representative subset of OAuth flows and assert that no plaintext secret appears anywhere in the captured slog stream:

- **`TestRedaction_HappyPathFlowLeaksNoSecrets`** — full authorization-code flow + one proxied API call. Covers initiate, callback / token exchange, persistence, and proxy-request log paths. Checks client_secret, authorization code, decrypted access_token, decrypted refresh_token.
- **`TestRedaction_TokenExchangeFailureLeaksNoSecrets`** — scripted `invalid_grant` on `/token` during callback. Covers `token_exchange_failure.go`'s classify/log path. Checks client_secret and authorization code (no token persisted on failed exchange).
- **`TestRedaction_RefreshFailureLeaksNoSecrets`** — scripted `invalid_grant` on `/token` during refresh. Covers `token_refresh_failure.go` — the most likely leak vector because error messages historically tend to include request form values and the provider response body. Checks client_secret, decrypted access_token, decrypted refresh_token.

Each test ends with two assertions:

- **Positive control** — the connection_id must appear in *some* captured record. Without this, the negative checks pass trivially when the capture path is misconfigured. Confirmed: a representative flow produces ~22 records with the connection_id present.
- **Negative check** — re-encode every captured record to JSON, concatenate, and assert each known plaintext secret never appears as a substring. Catches both attribute leaks (`slog.String("token", t.AccessToken)`) and message-string leaks (errors that interpolate the response body). Values under 8 chars are skipped to avoid false positives.

## Out of scope (documented in `redaction_test.md`)

- **PKCE `code_verifier`.** The proxy does not implement PKCE yet (P1 #174). Adding a new secret type without adding it to `flowSecrets` here is the silent-leak failure mode this test is designed to catch — the file flags this explicitly.
- **Gin HTTP access log.** Writes straight to stdout, not through the slog handler the LogCapture is wired into. Access lines only contain method + path + status + latency anyway.
- **Structured `request_log` (full HTTP transcripts → ClickHouse).** Has its own redaction layer covered by `internal/request_log` unit tests; not wired up in the integration harness.
- **OpenTelemetry metric / span attributes.** Bounded enum labels + projected allowlist; no token values can reach metric dimensions structurally. Covered by `telemetry_test.go`.

## Test plan

- [x] `go test -tags=integration -run TestRedaction ./oauth2/` passes (3/3 tests, ~2.4s)
- [x] Sanity check: temporary test that feeds connection_id as a "secret" finds it in the captured stream — proves the substring scan has teeth.
- [x] `./scripts/preflight.sh` passes
- [x] Companion `redaction_test.md` covers what's asserted, how secrets are recovered, why a substring scan (not a key-scan), and what's not covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)