### PR TITLE
Remove ProxyRequestRaw — no callers, can re-add when needed

### DIFF
--- a/internal/auth_methods/no_auth/interface.go
+++ b/internal/auth_methods/no_auth/interface.go
@@ -2,7 +2,6 @@ package no_auth
 
 import (
 	"context"
-	"net/http"
 
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httpf"
@@ -11,5 +10,4 @@ import (
 //go:generate mockgen -source=./interface.go -destination=./mock/noauth.go -package=mock
 type NoAuthConnection interface {
 	ProxyRequest(ctx context.Context, reqType httpf.RequestType, req *connIface.ProxyRequest) (*connIface.ProxyResponse, error)
-	ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *connIface.ProxyRequest, w http.ResponseWriter) error
 }

--- a/internal/auth_methods/no_auth/mock/noauth.go
+++ b/internal/auth_methods/no_auth/mock/noauth.go
@@ -6,12 +6,11 @@ package mock
 
 import (
 	context "context"
-	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	iface "github.com/rmorlok/authproxy/internal/core/iface"
-	"github.com/rmorlok/authproxy/internal/httpf"
+	httpf "github.com/rmorlok/authproxy/internal/httpf"
 )
 
 // MockNoAuthConnection is a mock of NoAuthConnection interface.
@@ -50,18 +49,4 @@ func (m *MockNoAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.R
 func (mr *MockNoAuthConnectionMockRecorder) ProxyRequest(ctx, reqType, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyRequest", reflect.TypeOf((*MockNoAuthConnection)(nil).ProxyRequest), ctx, reqType, req)
-}
-
-// ProxyRequestRaw mocks base method.
-func (m *MockNoAuthConnection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProxyRequestRaw", ctx, reqType, req, w)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProxyRequestRaw indicates an expected call of ProxyRequestRaw.
-func (mr *MockNoAuthConnectionMockRecorder) ProxyRequestRaw(ctx, reqType, req, w interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyRequestRaw", reflect.TypeOf((*MockNoAuthConnection)(nil).ProxyRequestRaw), ctx, reqType, req, w)
 }

--- a/internal/auth_methods/no_auth/proxy.go
+++ b/internal/auth_methods/no_auth/proxy.go
@@ -2,7 +2,6 @@ package no_auth
 
 import (
 	"context"
-	"net/http"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/core/iface"
@@ -27,10 +26,6 @@ func (n *noAuthConnection) ProxyRequest(ctx context.Context, reqType httpf.Reque
 	}
 
 	return iface.ProxyResponseFromGentlemen(resp)
-}
-
-func (n *noAuthConnection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
-	return nil
 }
 
 var _ iface.Proxy = (*noAuthConnection)(nil)

--- a/internal/auth_methods/oauth2/interface.go
+++ b/internal/auth_methods/oauth2/interface.go
@@ -2,7 +2,6 @@ package oauth2
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -36,7 +35,6 @@ type OAuth2Connection interface {
 	) (string, error)
 	CallbackFrom3rdParty(ctx context.Context, query url.Values) (string, error)
 	ProxyRequest(ctx context.Context, reqType httpf.RequestType, req *coreIface.ProxyRequest) (*coreIface.ProxyResponse, error)
-	ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *coreIface.ProxyRequest, w http.ResponseWriter) error
 	SupportsRevokeTokens() bool
 	RevokeTokens(ctx context.Context) error
 }

--- a/internal/auth_methods/oauth2/mock/oauth2.go
+++ b/internal/auth_methods/oauth2/mock/oauth2.go
@@ -6,7 +6,6 @@ package mock
 
 import (
 	context "context"
-	http "net/http"
 	url "net/url"
 	reflect "reflect"
 
@@ -14,7 +13,7 @@ import (
 	apid "github.com/rmorlok/authproxy/internal/apid"
 	oauth2 "github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	iface "github.com/rmorlok/authproxy/internal/core/iface"
-	"github.com/rmorlok/authproxy/internal/httpf"
+	httpf "github.com/rmorlok/authproxy/internal/httpf"
 	auth "github.com/rmorlok/authproxy/internal/schema/auth"
 )
 
@@ -243,20 +242,6 @@ func (m *MockOAuth2Connection) ProxyRequest(ctx context.Context, reqType httpf.R
 func (mr *MockOAuth2ConnectionMockRecorder) ProxyRequest(ctx, reqType, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyRequest", reflect.TypeOf((*MockOAuth2Connection)(nil).ProxyRequest), ctx, reqType, req)
-}
-
-// ProxyRequestRaw mocks base method.
-func (m *MockOAuth2Connection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProxyRequestRaw", ctx, reqType, req, w)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProxyRequestRaw indicates an expected call of ProxyRequestRaw.
-func (mr *MockOAuth2ConnectionMockRecorder) ProxyRequestRaw(ctx, reqType, req, w interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyRequestRaw", reflect.TypeOf((*MockOAuth2Connection)(nil).ProxyRequestRaw), ctx, reqType, req, w)
 }
 
 // RecordCancelSessionAfterAuth mocks base method.

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -307,10 +307,6 @@ func (o *oAuth2Connection) sendProxyRequest(
 	return r.Do()
 }
 
-func (o *oAuth2Connection) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
-	return nil
-}
-
 // postRefreshWithRetry POSTs a refresh-token grant to the provider's token
 // endpoint with a small bounded retry budget for transient failures
 // (transport errors and 5xx responses). Returns the final response (or

--- a/internal/core/connection_proxy.go
+++ b/internal/core/connection_proxy.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/rmorlok/authproxy/internal/auth_methods/no_auth"
 	"github.com/rmorlok/authproxy/internal/core/iface"
@@ -63,16 +62,3 @@ func (c *connection) ProxyRequest(
 	return p.ProxyRequest(ctx, reqType, req)
 }
 
-func (c *connection) ProxyRequestRaw(
-	ctx context.Context,
-	reqType httpf.RequestType,
-	req *iface.ProxyRequest,
-	w http.ResponseWriter,
-) error {
-	p, err := c.getProxyImpl()
-	if err != nil {
-		return err
-	}
-
-	return p.ProxyRequestRaw(ctx, reqType, req, w)
-}

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -2,7 +2,6 @@ package iface
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -61,12 +60,6 @@ type Connection interface {
 		reqType httpf.RequestType,
 		req *ProxyRequest,
 	) (*ProxyResponse, error)
-	ProxyRequestRaw(
-		ctx context.Context,
-		reqType httpf.RequestType,
-		req *ProxyRequest,
-		w http.ResponseWriter,
-	) error
 	SubmitForm(ctx context.Context, req SubmitConnectionRequest) (ConnectionSetupResponse, error)
 	GetCurrentSetupStepResponse(ctx context.Context) (ConnectionSetupResponse, error)
 	GetDataSource(ctx context.Context, sourceId string) ([]apjs.DataSourceOption, error)

--- a/internal/core/iface/proxy.go
+++ b/internal/core/iface/proxy.go
@@ -122,5 +122,4 @@ func ProxyResponseFromGentlemen(resp *gentleman.Response) (*ProxyResponse, error
 
 type Proxy interface {
 	ProxyRequest(ctx context.Context, reqType httpf.RequestType, req *ProxyRequest) (*ProxyResponse, error)
-	ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *ProxyRequest, w http.ResponseWriter) error
 }

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -106,15 +105,6 @@ func (m *Connection) ProxyRequest(
 	req *iface.ProxyRequest,
 ) (*iface.ProxyResponse, error) {
 	return nil, nil
-}
-
-func (m *Connection) ProxyRequestRaw(
-	ctx context.Context,
-	reqType httpf.RequestType,
-	req *iface.ProxyRequest,
-	w http.ResponseWriter,
-) error {
-	return nil
 }
 
 func (m *Connection) GetSetupStep() *cschema.SetupStep {


### PR DESCRIPTION
Closes #319.

## Summary

`ProxyRequestRaw` was sketched for a "direct proxy without JSON wrapping" path but never landed any production callers — both `oauth2` and `no_auth` implementations just `return nil`, and the only invocation outside the implementations themselves was a delegation shim in `connection_proxy.go`. Removing it now per the issue's "or remove" option.

If a streaming / no-wrapper variant becomes warranted later, this can be resurrected behind a real implementation.

## Touched

- `internal/core/iface/proxy.go` — removed method from `Proxy` interface.
- `internal/core/iface/connection.go` — removed method from `Connection` interface; dropped now-unused `net/http` import.
- `internal/core/connection_proxy.go` — dropped the dispatch shim.
- `internal/core/mock/connection.go` — removed the hand-written stub; dropped now-unused `net/http` import.
- `internal/auth_methods/oauth2/{interface.go,proxy.go}` — removed from interface and concrete impl.
- `internal/auth_methods/no_auth/{interface.go,proxy.go}` — same.
- `internal/auth_methods/oauth2/mock/oauth2.go`, `internal/auth_methods/no_auth/mock/noauth.go` — regenerated via `go generate`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/core/... ./internal/auth_methods/... -count=1` passes
- [x] `./scripts/preflight.sh` clean (no swagger drift)

Diff: `-77 +2` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)