### PR TITLE
Add OAuth2 provider timeout integration tests (#177 scenario 18)

### DIFF
--- a/integration_tests/oauth2/provider_timeouts_test.go
+++ b/integration_tests/oauth2/provider_timeouts_test.go
@@ -1,0 +1,264 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+)
+
+// Scenario 18 from issue #177: the proxy's HTTP client has no configured
+// timeout (httpf.factory uses http.DefaultTransport as-is). The closest
+// observable failure mode is a connection that terminates mid-flight —
+// from the proxy's perspective a server-side timeout, a forced TCP reset,
+// and a process crash all surface identically as a transport error on the
+// pending POST/GET. The test provider's ScriptAction{DropConnection:true}
+// reproduces this by hijacking the response writer and closing the
+// underlying connection.
+//
+// The proxy classifies any transport-layer failure on the token-exchange
+// or refresh leg as `network_error` (transient). The token endpoint and
+// refresh endpoint both retry transport errors through their shared
+// retry helpers (`postTokenExchangeWithRetry`, `postRefreshWithRetry`)
+// up to {tokenExchange,tokenRefresh}MaxAttempts. The upstream-API leg
+// (`ProxyRequest` → `sendProxyRequest`) does NOT retry on transport
+// errors — the 401-retry-after-refresh path is the only retry on the
+// proxy leg and it keys on the HTTP status, which doesn't exist when
+// the connection dies.
+//
+// What is NOT covered here (documented in provider_timeouts_test.md):
+//
+//   - **Authorize endpoint timeouts.** The proxy never POSTs to the
+//     authorize endpoint — the browser hits it directly. A timeout
+//     there manifests as a UI failure, not a proxy failure.
+//   - **Revocation endpoint timeouts.** Revocation runs in the
+//     background via the disconnect_connection Asynq task. Coverage
+//     for the disconnect path lives with the P2 disconnect tests
+//     (#181); folding it in here would require standing up a worker
+//     in the integration env.
+
+// TestTokenExchangeTimeout_RetriesAndExhausts — provider drops the
+// connection on every /token POST. The proxy must retry the full budget
+// (tokenExchangeMaxAttempts = 3), emit exactly one failure event with
+// category=network_error and attempts=3, and land in the auth_failed
+// terminal state with no token persisted.
+//
+// FailCount=10 outlasts the retry budget; the proxy gives up after 3
+// attempts and the remaining scripted drops sit unconsumed.
+func TestTokenExchangeTimeout_RetriesAndExhausts(t *testing.T) {
+	rig := newTokenExchangeRetryRig(t, "te-timeout-exhausted")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+
+	rig.provider.Script(rig.clientKey, helpers.EndpointToken, helpers.ScriptAction{
+		DropConnection: true,
+		FailCount:      10,
+	})
+
+	loc := rig.env.DeliverOAuth2Callback(t, rig.env.ForgeOAuth2CallbackURL(stateID, code))
+
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"timeout exhaustion should still 302 to return_to_url with setup=pending; got %q", loc)
+	parsed, err := url.Parse(loc)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", parsed.Query().Get("setup"))
+	assert.Equal(t, connID, parsed.Query().Get("connection_id"))
+
+	// Exactly one failure event with category=network_error and
+	// attempts=tokenExchangeMaxAttempts. provider_status_code is
+	// absent because no response was ever received — the failure is
+	// at the transport layer before any HTTP status exists.
+	events := rig.logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)
+	require.Lenf(t, events, 1, "exhausted timeout should emit exactly one failure event; got %d (%v)", len(events), events)
+	assert.Equal(t, "network_error", events[0]["category"])
+	assert.Equal(t, stateID, events[0]["state_id"])
+	assert.Equal(t, float64(3), events[0]["attempts"],
+		"failure event should record attempts=tokenExchangeMaxAttempts on exhaustion")
+	_, hasStatus := events[0]["provider_status_code"]
+	assert.Falsef(t, hasStatus,
+		"provider_status_code must be absent on a pure transport failure; got %v", events[0]["provider_status_code"])
+
+	// No token row persisted — the exchange never produced a response
+	// to parse.
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID))
+
+	// Connection in auth_failed terminal state.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateCreated, conn.State)
+	require.NotNil(t, conn.SetupStep)
+	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
+		"exhausted timeout should land in auth_failed; got %q", conn.SetupStep.String())
+	require.NotNil(t, conn.SetupError)
+
+	// Exactly tokenExchangeMaxAttempts POSTs to /token. If the proxy
+	// gave up early this is < 3; if it ignored the budget, > 3. The
+	// recorder counts requests that completed enough of the HTTP
+	// preamble for the server to dispatch them — DropConnection runs
+	// inside the script middleware after dispatch, so each dropped
+	// attempt still increments the recorder.
+	assert.Equal(t, 3, rig.tokenCallCount(),
+		"proxy should make exactly tokenExchangeMaxAttempts POSTs before giving up")
+}
+
+// TestTokenRefreshTimeout_RetriesAndExhausts — provider drops the
+// connection on every refresh-token POST. The proxy must retry the
+// full budget, emit one failure event with category=network_error and
+// attempts=tokenRefreshMaxAttempts, return non-200 to the caller, and
+// — critically — keep the connection healthy because network_error is
+// classified transient. The persisted refresh-token row must not be
+// mutated.
+func TestTokenRefreshTimeout_RetriesAndExhausts(t *testing.T) {
+	rig := newProxyRefreshRig(t, "refresh-timeout-exhausted")
+	connID := rig.completeAuthFlow(t)
+	rig.forceTokenExpired(t, connID, false)
+
+	// Snapshot the row that exists when the refresh POST is about to
+	// fire. A transport failure must leave this exact row in place —
+	// no partial response can corrupt the encrypted refresh_token.
+	preFailureToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, preFailureToken, "forge-expire must leave a token row")
+	preFailureTokenID := preFailureToken.Id
+	preFailureEncryptedRefresh := preFailureToken.EncryptedRefreshToken
+
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		DropConnection: true,
+		FailCount:      10,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.NotEqualf(t, 200, w.Code,
+		"proxy must fail when refresh exhausts retry budget on transport errors; got 200 body=%s", w.Body.String())
+
+	// Exactly one failure event with category=network_error and
+	// attempts=tokenRefreshMaxAttempts. provider_status_code is
+	// omitted (no response was ever received).
+	failed := rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)
+	require.Lenf(t, failed, 1, "exhausted refresh timeout must emit exactly one refresh-failed event; got %d (%v)", len(failed), failed)
+	event := failed[0]
+	assert.Equal(t, "network_error", event["category"])
+	assert.Equal(t, connID, event["connection_id"])
+	assert.Equalf(t, float64(tokenRefreshMaxAttempts), event["attempts"],
+		"failure event should record attempts=tokenRefreshMaxAttempts on exhaustion")
+	_, hasStatus := event["provider_status_code"]
+	assert.Falsef(t, hasStatus,
+		"provider_status_code must be absent on a pure transport failure; got %v", event["provider_status_code"])
+
+	// network_error is transient — must NOT flip the connection
+	// unhealthy. This is the load-bearing distinction from the
+	// permanent categories: the next proxy call gets another chance,
+	// so dashboards shouldn't paint the connection as broken on a
+	// transient blip.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equalf(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"transient transport failure must not flip the connection unhealthy; got %q", conn.HealthState)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"transient transport failure must not emit a health-state-changed event")
+
+	// Exactly tokenRefreshMaxAttempts - 1 retry-warn lines preceded
+	// the final failure (the terminal attempt does not schedule a
+	// further retry).
+	retryWarns := rig.logCapture.RecordsWithMessage(t, tokenRefreshRetryMessage)
+	assert.Lenf(t, retryWarns, tokenRefreshMaxAttempts-1,
+		"expected %d retry-warn logs (one before each retried attempt); got %d",
+		tokenRefreshMaxAttempts-1, len(retryWarns))
+
+	// Token row preservation: a transport failure cannot land partial
+	// bytes in the DB because the response body is never parsed. The
+	// pre-failure row must remain byte-identical.
+	postFailureToken := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, postFailureToken, "transport-error exhaustion must not delete the token row")
+	assert.Equalf(t, preFailureTokenID, postFailureToken.Id,
+		"transport-error exhaustion must not insert a replacement token row")
+	assert.Equalf(t, preFailureEncryptedRefresh, postFailureToken.EncryptedRefreshToken,
+		"transport-error exhaustion must not mutate the stored refresh_token")
+
+	// Exactly tokenRefreshMaxAttempts refresh POSTs observed.
+	assert.Equalf(t, tokenRefreshMaxAttempts, rig.refreshCallCount(),
+		"proxy must make exactly tokenRefreshMaxAttempts refresh POSTs before giving up; got %d",
+		rig.refreshCallCount())
+
+	// No success event.
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage),
+		"failed refresh must not emit a refresh-succeeded event")
+}
+
+// TestUpstreamApiTimeout_SurfacedToCaller — provider drops the
+// connection on the proxied resource call. The proxy's resource leg
+// has no retry budget (only the 401-after-refresh path retries, and
+// that keys on HTTP status which is absent here). The transport error
+// must propagate as a non-200 to the caller, must not trigger a
+// refresh attempt, and must leave both the connection state and its
+// health unchanged.
+func TestUpstreamApiTimeout_SurfacedToCaller(t *testing.T) {
+	rig := newProxyRefreshRig(t, "upstream-timeout")
+	connID := rig.completeAuthFlow(t)
+
+	// Token from completeAuthFlow is still valid, so the proxy will
+	// not attempt a proactive refresh. Any refresh attempt observed
+	// after this point would indicate the transport error was
+	// misclassified as a 401.
+	//
+	// EndpointResource requests carry a Bearer access token, not a
+	// client_id form field or Basic auth, so extractClientID on the
+	// test provider returns "" for them. Script on the wildcard
+	// (empty clientID) queue so the action actually matches the
+	// inbound request.
+	//
+	// The recorder is process-global on the docker test provider, so
+	// other tests in the package have already accumulated /test/resource
+	// records. Snapshot `since` before firing the proxy request so the
+	// "exactly one upstream call" assertion only counts the calls this
+	// test produced. completeAuthFlow does not call /test/resource, so
+	// `since` only needs to exclude prior tests, not earlier steps in
+	// this one.
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		DropConnection: true,
+		FailCount:      10,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.NotEqualf(t, 200, w.Code,
+		"upstream transport failure must surface as non-200 to the caller; got 200 body=%s", w.Body.String())
+
+	// Exactly one resource GET observed since the snapshot. The
+	// proxy leg does not retry on transport errors —
+	// sendProxyRequest returns the error directly and ProxyRequest
+	// propagates it without consulting the 401-retry path.
+	resourceReqs := rig.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointResource,
+		Since:    since,
+	})
+	assert.Lenf(t, resourceReqs, 1,
+		"proxy must make exactly one upstream call on transport failure (no retry); got %d", len(resourceReqs))
+
+	// No refresh attempted: the transport error must not be confused
+	// with a 401. A non-zero refresh count here would mean the proxy
+	// reacted to an error that looked like an auth failure when it
+	// was actually a connectivity failure.
+	assert.Equalf(t, 0, rig.refreshCallCount(),
+		"upstream transport failure must not trigger a refresh; got %d refresh POSTs", rig.refreshCallCount())
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"upstream transport failure must not emit a refresh-failed event")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage),
+		"upstream transport failure must not emit a refresh-succeeded event")
+
+	// Connection and health untouched. An upstream connectivity blip
+	// is not a credential problem; flipping unhealthy here would
+	// paint a working connection broken.
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateReady, conn.State,
+		"upstream transport failure must not change the connection state")
+	assert.Equalf(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"upstream transport failure must not flip the connection unhealthy; got %q", conn.HealthState)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"upstream transport failure must not emit a health-state-changed event")
+}

--- a/integration_tests/oauth2/provider_timeouts_test.go
+++ b/integration_tests/oauth2/provider_timeouts_test.go
@@ -16,14 +16,35 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
 )
 
-// Scenario 18 from issue #177: the proxy's HTTP client has no configured
-// timeout (httpf.factory uses http.DefaultTransport as-is). The closest
-// observable failure mode is a connection that terminates mid-flight —
-// from the proxy's perspective a server-side timeout, a forced TCP reset,
-// and a process crash all surface identically as a transport error on the
-// pending POST/GET. The test provider's ScriptAction{DropConnection:true}
-// reproduces this by hijacking the response writer and closing the
-// underlying connection.
+// Scenario 18 from issue #177: provider-side timeouts. The proxy has
+// no time-budgeted HTTP timeout configured — `httpf.factory` wraps
+// `http.DefaultTransport` without setting `Timeout` on the underlying
+// client, and the inbound gin server is constructed without
+// `ReadTimeout` / `WriteTimeout`, so no per-request deadline ever
+// lands on the ctx the handler runs under. Cancellation can still
+// arrive via context propagation if the *calling client* closes its
+// connection: the refresh, proxy, and revocation legs thread `ctx`
+// through `gentleman.UseContext(ctx)` so the in-flight upstream
+// request aborts in that case. The token-exchange leg
+// (`postTokenExchangeWithRetry`) does not call `UseContext` on the
+// request itself, but the retry-loop's backoff `select` does check
+// `ctx.Done()` between attempts.
+//
+// What this means for "what happens when the provider hangs":
+//   - if the calling client stays connected, there is no source of
+//     timeout — the request waits indefinitely on whichever leg is
+//     blocked;
+//   - if the calling client disconnects, refresh/proxy/revocation
+//     abort the upstream request via ctx; token exchange aborts only
+//     between attempts.
+//
+// The closest faithful reproduction of a "provider stopped responding"
+// failure that the proxy can actually observe is a connection that
+// terminates mid-flight. From the proxy's perspective a server-side
+// timeout, a TCP reset, and a process crash all surface identically
+// as a transport error on the pending POST/GET. The test provider's
+// `ScriptAction{DropConnection: true}` reproduces this by hijacking
+// the response writer and closing the underlying connection.
 //
 // The proxy classifies any transport-layer failure on the token-exchange
 // or refresh leg as `network_error` (transient). The token endpoint and

--- a/integration_tests/oauth2/provider_timeouts_test.md
+++ b/integration_tests/oauth2/provider_timeouts_test.md
@@ -1,0 +1,160 @@
+# OAuth2 Provider Timeouts (scenario 18)
+
+Companion specification for `provider_timeouts_test.go`. Covers issue
+#177 scenario 18 — when a provider endpoint hangs (or, more broadly,
+when the connection terminates mid-flight), the proxy must classify the
+failure as a transient transport error, retry on the legs where retry
+is policy, and never silently overwrite credentials.
+
+## Scope
+
+Three tests, one per leg the proxy itself drives:
+
+1. **`TestTokenExchangeTimeout_RetriesAndExhausts`** — token endpoint
+   during the authorization-code → access-token exchange leg
+   (`callback.go` → `postTokenExchangeWithRetry`).
+2. **`TestTokenRefreshTimeout_RetriesAndExhausts`** — refresh leg
+   (`proxy.go` → `postRefreshWithRetry`).
+3. **`TestUpstreamApiTimeout_SurfacedToCaller`** — upstream API leg
+   (`proxy.go` → `sendProxyRequest`).
+
+Each test asserts (a) the proxy's response, (b) the structured log
+event(s), (c) the connection's state and health, (d) the persisted
+token row's integrity, and (e) the exact number of HTTP attempts the
+proxy made.
+
+## Why DropConnection (not a literal timeout)
+
+The proxy has **no HTTP-level timeout configured**:
+
+- `internal/httpf/factory.go` wraps `http.DefaultTransport` and never
+  sets `Timeout` on the underlying client.
+- `internal/schema/connectors/auth_oauth2_token.go`'s `RefreshTimeout`
+  (default 30s) is used only by the Redis mutex (`lock.go` →
+  `apredis.MutexOption*`), not by any HTTP client.
+
+A scripted server-side `time.Sleep` therefore has no observable effect
+on the proxy — the proxy would happily wait until the test framework
+killed it. The closest faithful reproduction of a "provider hung and
+the request died" failure is to terminate the connection mid-flight.
+`helpers.ScriptAction{DropConnection: true}` does this: the test
+provider's script middleware hijacks the `http.ResponseWriter` and
+calls `Close()` on the underlying conn, producing an `EOF` /
+`connection reset` on the proxy's pending POST or GET.
+
+From the proxy's perspective, a server-side timeout, a TCP reset, and
+a process crash are all the same failure: a transport error on the
+pending request, with no HTTP status to classify. That is the
+observable surface scenario 18 is about.
+
+If and when the proxy adds an HTTP client timeout, the same tests
+should still cover the property — the failure surfaces the same way
+(`network_error` category, no `provider_status_code`).
+
+## What each test pins
+
+### `TestTokenExchangeTimeout_RetriesAndExhausts`
+
+- 3 POSTs to `/token` (the full `tokenExchangeMaxAttempts` budget).
+  `FailCount=10` outlasts the budget; the unused drops sit in the
+  script queue.
+- Exactly one `oauth token exchange failed` event with:
+  - `category = network_error`
+  - `attempts = 3`
+  - `provider_status_code` field **absent** — there is no status code
+    to record when the connection died before a response.
+- Connection lands in `state=created`, `setup_step=auth_failed`,
+  `setup_error` populated.
+- No token row persisted.
+- 302 redirect to `return_to_url?setup=pending&connection_id=<id>` so
+  the marketplace UI re-renders the connection in its failed state.
+
+### `TestTokenRefreshTimeout_RetriesAndExhausts`
+
+- 3 POSTs to `/token` with `grant_type=refresh_token` (the full
+  `tokenRefreshMaxAttempts` budget).
+- Exactly one `oauth token refresh failed` event with
+  `category=network_error`, `attempts=3`, no `provider_status_code`.
+- 2 `oauth token refresh transient failure; retrying` warn lines (one
+  before each retried attempt — the terminal attempt does not schedule
+  a further retry).
+- **Connection health stays `healthy`** and no
+  `connection health state changed` event is emitted. This is the
+  load-bearing distinction from the permanent refresh categories
+  (`invalid_grant`, `invalid_client`, `provider_4xx_other`,
+  `malformed_response`): network errors are transient, so the next
+  proxy call gets another chance and dashboards shouldn't paint the
+  connection as broken on a blip.
+- Token row preserved byte-for-byte: same id, same
+  `EncryptedRefreshToken` as snapshotted right after
+  `forceTokenExpired`. A transport failure cannot leave partial bytes
+  in the DB because the body is never parsed — this assertion is the
+  proof.
+- Proxy API returns non-200 to the caller (500 from `apgin.WriteErr`
+  wrapping the transport error).
+- No `oauth token refresh succeeded` event.
+
+### `TestUpstreamApiTimeout_SurfacedToCaller`
+
+- Exactly **one** upstream GET to `/test/resource/echo` since a
+  snapshot timestamp captured before the proxy call. **No retry**: the
+  proxy's resource leg only retries on a 401 response (the
+  refresh-and-replay path), and a transport error has no status to
+  trigger that. `sendProxyRequest` returns the error directly and
+  `ProxyRequest` propagates it.
+- **No refresh attempted** (0 refresh POSTs). The transport error must
+  not be misclassified as a 401 — a non-zero refresh count here would
+  mean the proxy mistook a connectivity failure for an auth failure.
+- No `oauth token refresh failed` and no `oauth token refresh
+  succeeded` event.
+- Connection state stays `ready`, health stays `healthy`, no
+  `connection health state changed` event. An upstream connectivity
+  blip is not a credential problem.
+- Proxy API returns non-200 to the caller.
+
+## Cross-references
+
+| Property | Where else covered |
+| --- | --- |
+| Token-exchange retry budget on 5xx | `callback_token_exchange_retry_test.go` (PR for #168). Same retry helper as the timeout case; 5xx exhaustion and timeout exhaustion both produce `attempts=tokenExchangeMaxAttempts`. |
+| Refresh retry budget on 5xx | `proxy_refresh_retry_test.go` (PR for scenario 8). Asserts the parallel observable shape against 5xx; the 5xx test is the canonical case and this scenario is the transport-layer companion. |
+| Transport-error retry at the helper level | `internal/auth_methods/oauth2/proxy_test.go::TestPostRefreshWithRetry_TransportErrorRetried` and `internal/auth_methods/oauth2/callback_test.go::TestPostTokenExchangeWithRetry_TransportErrorRetried`. Unit-level coverage of the same retry branch this scenario drives end-to-end. |
+| Permanent vs transient health flip | `proxy_refresh_failure_test.go` (scenario 7) for the permanent categories; this file for the transient `network_error` category. |
+| Wire-format response parsing on the refresh leg | `proxy_refresh_failure_test.go::MalformedResponse` row and `callback_token_exchange_malformed_test.go` (scenario 17). |
+
+## What is *not* covered here
+
+- **Authorize endpoint timeouts.** The proxy never POSTs to the
+  authorize endpoint — the user's browser hits it directly. A hung
+  authorize page manifests as a UI failure (the user sees a spinner
+  forever, then closes the tab) and never reaches any proxy code path
+  that scenario 18 could cover. The state row would expire on TTL.
+- **Revocation endpoint timeouts.** Revocation is fired from the
+  background `disconnect_connection` Asynq task in
+  `internal/auth_methods/oauth2/revocation.go`; the integration-test
+  harness doesn't run the worker by default, so reproducing a
+  revoke-timeout end-to-end requires standing one up. The P2
+  disconnect tests (issue #181) cover the disconnect path including
+  revocation failure modes. The unit test
+  `revocation_test.go::TestRevokeRefreshToken_*` pins the per-call
+  classifier behavior.
+- **Time-budgeted HTTP-client timeouts.** The proxy doesn't have one.
+  When/if it does, the same tests cover the property — a client-side
+  timeout surfaces as the same transport error as the server dropping
+  the connection.
+- **Partial-body / mid-response drops.** `DropConnection` runs before
+  the response body is written, so the body-parser path is not
+  exercised here. A drop mid-body would surface as an `io.ErrUnexpectedEOF`
+  on the read; that is a different code path that the malformed-
+  response scenario (#176) is the natural home for if needed.
+
+## Components
+
+| Lever | What it controls |
+| --- | --- |
+| `tokenExchangeRetryRig` + `initiateAndMintCode` | Per-test fixture for the exchange-leg test. Reused from `callback_token_exchange_retry_test.go`; provides `tokenCallCount()` for the attempt-count assertion. |
+| `proxyRefreshRig` + `completeAuthFlow` + `forceTokenExpired` | Per-test fixture for the refresh and upstream tests. Reused from `proxy_refresh_test.go`; `refreshCallCount()` from `proxy_refresh_retry_test.go` counts `grant_type=refresh_token` POSTs. |
+| `helpers.ScriptAction{DropConnection: true, FailCount: 10}` | The single primitive driving every failure in this file. `FailCount` is set well past the proxy's retry budget so the test exercises the exhaustion path on the retried legs and is robust to any future retry-budget bump on the upstream leg. |
+| `helpers.RequestsFilter{Since: time.Now()}` | Snapshots a baseline timestamp before the upstream-test fires its proxy call. The test provider's recorder is process-global on the docker container — without a `since` cutoff, prior tests' `/test/resource/*` records would contaminate the "exactly one upstream call" count. The refresh and exchange tests use `ClientID` filtering for the same effect (each rig uses a unique per-test client key). |
+| `provider.Script("", EndpointResource, …)` | Scripts on the wildcard (empty `clientID`) queue. Resource requests carry only a Bearer access token (no `client_id` form field, no Basic auth), so the test provider's `extractClientID` returns `""` for them — only the wildcard queue can match. |
+| `tokenExchangeFailureMessage` / `tokenRefreshFailureMessage` / `tokenRefreshRetryMessage` / `connectionHealthStateChangedMessage` | Message strings pinned in the existing failure / retry test files. Used as `logCapture.RecordsWithMessage` haystacks. |


### PR DESCRIPTION
## Summary

End-to-end coverage for scenario 18 in #177: how the proxy behaves when a provider endpoint hangs (or, more precisely, when the connection terminates mid-flight). The proxy has no HTTP client timeout configured — `httpf.factory` wraps `http.DefaultTransport` without a `Timeout`, and `RefreshTimeout` only feeds the Redis mutex — so the faithful reproduction is `ScriptAction{DropConnection: true}` on the test provider, which hijacks the writer and closes the conn. From the proxy's perspective, a server-side timeout, a TCP reset, and a process crash are all the same transport error on the pending request.

Three tests, one per leg the proxy itself drives:

- **`TestTokenExchangeTimeout_RetriesAndExhausts`** — `/token` POST during the code-exchange leg. Asserts 3 attempts (full `tokenExchangeMaxAttempts` budget), exactly one failure event with `category=network_error` / `attempts=3` / no `provider_status_code`, no token persisted, connection lands in `auth_failed`, and a clean 302 to `return_to_url?setup=pending`.
- **`TestTokenRefreshTimeout_RetriesAndExhausts`** — refresh leg. Same 3-attempt retry shape, plus: connection health **stays healthy** (network_error is transient), 2 retry-warn lines, persisted refresh-token row is byte-preserved (load-bearing — a partial write here would corrupt every future refresh).
- **`TestUpstreamApiTimeout_SurfacedToCaller`** — upstream API leg. Exactly **one** attempt (no retry on the resource leg), no refresh attempted (transport error must not be confused with a 401 → refresh-and-replay), connection state and health unchanged.

Companion `provider_timeouts_test.md` documents the DropConnection-as-timeout rationale, the missing-timeout observation that motivates it, and explicitly out-of-scope cases:

- **Authorize endpoint** — not proxy-driven (the browser hits it), so no proxy code path exists to test.
- **Revocation endpoint** — runs in the background `disconnect_connection` Asynq task; coverage belongs to the P2 disconnect tests in #181.

Closes #177.

## Test plan

- [x] `go test -tags=integration -run 'TestTokenExchangeTimeout_RetriesAndExhausts|TestTokenRefreshTimeout_RetriesAndExhausts|TestUpstreamApiTimeout_SurfacedToCaller' ./oauth2/...` — all 3 pass
- [x] `./scripts/preflight.sh` — passes