### PR TITLE
Add OAuth2 malformed callback integration tests (#175 scenarios 15, 16)

### DIFF
--- a/integration_tests/oauth2/callback_malformed_test.go
+++ b/integration_tests/oauth2/callback_malformed_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+)
+
+// Scenarios 15 and 16 from issue #175: the callback handler must reject
+// callback URLs whose query-param shape violates RFC 6749 §4.1.2 (the
+// `code` xor `error` contract). Both shapes share the same observable
+// rejection signature — auth_failed connection, single failure log
+// event, no token persisted, redirect to return_to_url — but pin
+// different category strings and exercise different branches of
+// callback.go:117-134.
+//
+// The two cases:
+//
+//   - **Scenario 15: code + error.** Per RFC 6749 §4.1.2.1 a denial
+//     redirect carries `error=...` *instead of* `code=...`. The
+//     authorization server SHOULD NOT include both. If the proxy
+//     receives both, the safe interpretation is to treat the response
+//     as a failure and refuse to exchange the code — exchanging a code
+//     attached to a denial signal would burn the code against the
+//     provider for an authorization the server already said it would
+//     not honour. The proxy's current implementation
+//     (`callback.go:117-127`) reads `error` first and returns before
+//     looking at `code`, so the code is structurally unreachable in
+//     this shape. Tests pin **zero** /token calls to lock this in.
+//
+//   - **Scenario 16: missing code, no error.** A callback with valid
+//     state but neither `code` nor `error` is malformed — there is no
+//     credential to exchange and no rejection signal to surface. The
+//     proxy emits `missing_code` (`callback.go:129-134`) and never
+//     reaches the token endpoint.
+//
+// Both cases reuse `tokenExchangeFailureRig` because the post-failure
+// observables (auth_failed setup step, failure log, return_to_url
+// redirect) are identical to the rest of the token-exchange rejection
+// suite — only the trigger differs. See
+// `callback_token_exchange_failure_test.go` for the canonical example.
+
+// forgeCallbackURLWithErrorAndCode builds `/oauth2/callback?...` with
+// `state`, `code`, and `error` query params. `env.ForgeOAuth2CallbackURL`
+// can only emit state and code; this helper covers the code-plus-error
+// shape that lives only in this test file.
+func forgeCallbackURLWithErrorAndCode(env *helpers.IntegrationTestEnv, state, code, errCode, errDescription string) string {
+	q := url.Values{}
+	if state != "" {
+		q.Set("state", state)
+	}
+	if code != "" {
+		q.Set("code", code)
+	}
+	if errCode != "" {
+		q.Set("error", errCode)
+	}
+	if errDescription != "" {
+		q.Set("error_description", errDescription)
+	}
+	base := env.PublicOAuthCallbackURL()
+	if encoded := q.Encode(); encoded != "" {
+		return base + "?" + encoded
+	}
+	return base
+}
+
+// TestMalformedCallback_CodeAndErrorRejectedNoExchange — provider
+// redirects with both `code=...&error=access_denied&...`. The proxy
+// must treat this as a denial-shaped failure and refuse to POST the
+// code to the token endpoint.
+//
+// The choice of `error=access_denied` mirrors the most plausible
+// real-world source of this shape: a provider that always echoes the
+// originally-issued code into the redirect, even when the user
+// declines on the consent screen. The exact `error` value doesn't
+// change the categorization — any non-empty `error` produces
+// `provider_denied`.
+func TestMalformedCallback_CodeAndErrorRejectedNoExchange(t *testing.T) {
+	rig := newTokenExchangeFailureRig(t, "mc-code-and-error")
+	connID, stateID, code := rig.initiateAndMintCode(t)
+	require.NotEmpty(t, code, "fixture sanity: provider must mint a code so we can prove it isn't exchanged")
+
+	callbackURL := forgeCallbackURLWithErrorAndCode(rig.env, stateID, code, "access_denied", "user denied")
+	loc := rig.env.DeliverOAuth2Callback(t, callbackURL)
+	rig.requireRedirectToReturnURL(t, connID, loc)
+
+	event := rig.requireOneFailureEvent(t, "provider_denied")
+	assert.Equal(t, stateID, event["state_id"], "failure event should carry the state_id for correlation")
+	assert.Equal(t, "access_denied", event["provider_error"],
+		"failure event should record the provider's error code verbatim")
+	_, hasStatus := event["provider_status_code"]
+	assert.Falsef(t, hasStatus,
+		"provider_status_code must be absent: the proxy never POSTed to /token, there is no HTTP status to record (got %v)",
+		event["provider_status_code"])
+
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID),
+		"no token row should be persisted when the callback carries an error signal")
+	rig.requireAuthFailedConnection(t, connID, "access_denied")
+
+	// The load-bearing assertion: the proxy MUST NOT POST the code to
+	// the token endpoint when the callback also carries an error. This
+	// is what makes the "code is not exchanged" property in issue #175
+	// observable — a single /token call here would mean the proxy
+	// missed the error signal and burned the code against the provider.
+	tokenReqs := rig.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: rig.clientKey,
+	})
+	assert.Lenf(t, tokenReqs, 0,
+		"proxy must not POST to /token when callback carries an error signal; got %d call(s)", len(tokenReqs))
+}
+
+// TestMalformedCallback_MissingCodeNoError — callback URL carries a
+// valid state but has neither `code` nor `error`. The proxy classifies
+// this as `missing_code` (callback.go:129-134) and rejects the flow
+// without contacting the token endpoint.
+//
+// We still drive the provider's authorize step via
+// `initiateAndMintCode` so the rig's fixture work (state row written
+// to Redis, connection row created in `created` state) matches every
+// other failure test in the suite. The minted code is discarded — the
+// purpose of this test is the *absence* of a code in the callback URL.
+func TestMalformedCallback_MissingCodeNoError(t *testing.T) {
+	rig := newTokenExchangeFailureRig(t, "mc-missing-code")
+	connID, stateID, _ := rig.initiateAndMintCode(t)
+
+	// ForgeOAuth2CallbackURL with code="" produces `?state=<id>` — no
+	// code, no error. Exactly the malformed shape scenario 16 names.
+	callbackURL := rig.env.ForgeOAuth2CallbackURL(stateID, "")
+	loc := rig.env.DeliverOAuth2Callback(t, callbackURL)
+	rig.requireRedirectToReturnURL(t, connID, loc)
+
+	event := rig.requireOneFailureEvent(t, "missing_code")
+	assert.Equal(t, stateID, event["state_id"])
+	_, hasStatus := event["provider_status_code"]
+	assert.Falsef(t, hasStatus,
+		"provider_status_code must be absent: there is no token-endpoint POST in this code path (got %v)",
+		event["provider_status_code"])
+	_, hasProviderError := event["provider_error"]
+	assert.Falsef(t, hasProviderError,
+		"provider_error must be absent: no `error` query param was supplied (got %v)",
+		event["provider_error"])
+
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID),
+		"no token row should be persisted when the callback is missing code")
+	rig.requireAuthFailedConnection(t, connID, "no code in query")
+
+	// Same load-bearing property as the code+error case: missing-code
+	// must not produce a token-endpoint POST. The proxy's only
+	// material for the POST is the code, and there is none.
+	tokenReqs := rig.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: rig.clientKey,
+	})
+	assert.Lenf(t, tokenReqs, 0,
+		"proxy must not POST to /token when callback is missing code; got %d call(s)", len(tokenReqs))
+}

--- a/integration_tests/oauth2/callback_malformed_test.md
+++ b/integration_tests/oauth2/callback_malformed_test.md
@@ -1,0 +1,163 @@
+# OAuth2 Malformed Callbacks (scenarios 15, 16)
+
+Companion specification for `callback_malformed_test.go`. Covers
+issue #175 — the callback handler must reject callback URLs whose
+query-param shape violates RFC 6749 §4.1.2 (the `code` xor `error`
+contract).
+
+## Scope
+
+Two tests, one per malformed shape:
+
+1. **`TestMalformedCallback_CodeAndErrorRejectedNoExchange`** —
+   callback URL carries both `code=...` AND `error=...`. The proxy
+   must classify the failure as `provider_denied` and refuse to
+   exchange the code at the token endpoint.
+2. **`TestMalformedCallback_MissingCodeNoError`** — callback URL
+   carries valid `state` but neither `code` nor `error`. The proxy
+   must classify the failure as `missing_code` and reject the flow
+   without contacting the token endpoint.
+
+Both tests reuse `tokenExchangeFailureRig` (from
+`callback_token_exchange_failure_test.go`); the post-failure
+observable surface is identical to the rest of the token-exchange
+rejection suite.
+
+## Why one shared file
+
+The two scenarios share the *callback-shape rejection* code path —
+both fire from the early-return guards in `callback.go:117-134`,
+before any token-endpoint logic runs. Splitting them across two
+files would duplicate the rig and the "no /token call observed"
+assertion, and would obscure the shared property that the load-bearing
+guard for both is "never reach the token endpoint when the callback
+is malformed."
+
+A single companion file also makes the inverse property obvious to a
+reviewer: every other test in the directory drives the token endpoint
+via the rig; this file is the one place where the token endpoint must
+*not* be called.
+
+## What each test pins
+
+### `TestMalformedCallback_CodeAndErrorRejectedNoExchange`
+
+- Callback URL: `?state=<valid>&code=<minted>&error=access_denied&error_description=user+denied`
+- Exactly one `oauth token exchange failed` event with:
+  - `category = provider_denied`
+  - `provider_error = access_denied`
+  - `state_id` populated
+  - `provider_status_code` field **absent** — the proxy never POSTed
+    to `/token`, so there is no HTTP status to attach.
+- Connection lands in `state=created`, `setup_step=auth_failed`,
+  `setup_error` populated (contains `access_denied`).
+- No token row persisted.
+- 302 redirect to `return_to_url?setup=pending&connection_id=<id>` so
+  the marketplace UI re-renders the connection in its failed state.
+- **Zero POSTs to `/token`** — the load-bearing assertion. A single
+  call here would mean the proxy missed the `error=` signal and
+  burned the authorization code against the provider for an
+  authorization the server already said it would not honour.
+
+The code parameter is minted via `initiateAndMintCode` (the same path
+every other test in the file uses) and then attached to a malformed
+callback URL. Minting a real code rather than a synthetic string is
+deliberate: it proves the proxy refused to exchange a *valid* code
+purely because of the `error=` signal accompanying it, not because the
+code was structurally unparseable.
+
+### `TestMalformedCallback_MissingCodeNoError`
+
+- Callback URL: `?state=<valid>` (no `code`, no `error`)
+- Exactly one `oauth token exchange failed` event with:
+  - `category = missing_code`
+  - `state_id` populated
+  - `provider_status_code` **absent** — no token-endpoint POST happened.
+  - `provider_error` **absent** — no `error=` was in the callback.
+- Connection lands in `state=created`, `setup_step=auth_failed`,
+  `setup_error` populated (contains `no code in query`).
+- No token row persisted.
+- 302 redirect to `return_to_url?setup=pending&connection_id=<id>`.
+- **Zero POSTs to `/token`** — there is no material for the POST
+  (the only thing it could POST is the code, and there isn't one).
+
+`initiateAndMintCode` is still used here for fixture consistency with
+the rest of the suite — the rig wires up the state row, connection,
+and provider scripting context the same way for every test. The
+minted code is discarded; the callback URL deliberately omits it.
+
+## Why `provider_denied` for the code+error case (not a separate category)
+
+RFC 6749 §4.1.2.1 defines `error=...` as the denial-shaped redirect.
+The §4.1.2.1 spec text says the authorization server "MUST NOT" issue
+an authorization code in a denial redirect, so an `error` query
+*always* implies the code (if present) is not a usable grant — same
+operator interpretation as the no-code-just-error case. Folding both
+shapes into `provider_denied` keeps dashboards simple: one category
+for "the provider's redirect carried a denial signal." Distinguishing
+"clean denial" from "denial with stale code" would split alerting on
+a provider-side bug the operator cannot fix.
+
+If we ever want to surface the "provider sent a stale code with the
+denial" anomaly as its own signal, the right place to add it is a
+secondary attribute on the existing `provider_denied` event (e.g.,
+`code_present=true`) rather than a new category. That keeps the
+primary alerting axis stable.
+
+## Property: "code is not exchanged"
+
+Issue #175 names "Authorization code is not exchanged unless
+explicitly allowed" as a verify item. Operationally that property is
+visible as a single observable: **zero POSTs to the provider's
+`/token` endpoint** when the callback is malformed. Both tests pin
+this directly with `provider.Requests(RequestsFilter{Endpoint:
+EndpointToken, ClientID: rig.clientKey})`.
+
+The filter uses `ClientID = rig.clientKey` rather than `Since =
+time.Now()` because each rig provisions a fresh client key on the
+shared docker provider; only this rig's flow can produce a /token
+call tagged with this key. Other tests running concurrently against
+the same provider container do not appear in the filter result.
+
+## What is *not* covered here
+
+- **Token endpoint refusing the code.** If the proxy did exchange the
+  code despite the malformed callback shape, the provider would
+  likely respond `invalid_grant` (RFC 6749 §5.2). That is the
+  `TestTokenExchangeRejection_InvalidGrant` case in
+  `callback_token_exchange_failure_test.go`. This file's "zero
+  /token calls" assertion makes the inverse property — the proxy
+  must not reach that path — a separate failure mode.
+- **Replayed / cross-tenant / unknown state.** Those callback-state
+  shapes are covered by `callback_state_security_test.go`,
+  `callback_actor_mismatch_test.go`, and
+  `callback_cross_namespace_test.go`. Scenarios 15 and 16 are
+  specifically about the `code`/`error` query-param shape with an
+  otherwise-valid state row.
+- **PKCE on the callback.** PKCE isn't implemented in the proxy yet
+  (issue #174 / scenario 14). When it lands, a separate file should
+  cover missing/wrong `code_verifier` shapes.
+- **HTML / non-redirect responses from the authorize endpoint.** Not
+  reachable through the proxy — the user's browser interacts with the
+  authorize endpoint directly. A hung authorize page is also out of
+  scope (`provider_timeouts_test.md` notes the same exclusion).
+
+## Cross-references
+
+| Property | Where else covered |
+| --- | --- |
+| User denial via `error=access_denied` (callback carries error, no code) | `user_denial_test.go` — end-to-end through the browser UI. Same category (`provider_denied`), but the trigger is a real user click rather than a forged callback. |
+| Token-endpoint rejection of an exchanged code | `callback_token_exchange_failure_test.go` — covers `invalid_grant`, `invalid_client`, and the rest of RFC 6749 §5.2. Those tests exercise the path *after* the callback shape is accepted; this file exercises rejection *before* the token endpoint is reached. |
+| Malformed *response* from the token endpoint | `callback_token_exchange_malformed_test.go` (scenario 17). Distinct from this file: that one tests broken bodies in the provider's response to a successful POST. This file tests malformed callbacks *to* the proxy, before any POST happens. |
+| Callback state security (CSRF, replay, cross-tenant) | `callback_state_security_test.go` and friends. Orthogonal — those tests vary the `state` row; this file varies the `code`/`error` query params with a valid state. |
+
+## Components
+
+| Lever | What it controls |
+| --- | --- |
+| `tokenExchangeFailureRig` + `initiateAndMintCode` + `requireOneFailureEvent` + `requireAuthFailedConnection` + `requireRedirectToReturnURL` | Per-test fixture and shared assertions; reused from `callback_token_exchange_failure_test.go`. |
+| `env.ForgeOAuth2CallbackURL(state, "")` | Builds the missing-code callback URL. Existing helper; passing `code=""` already produces `?state=<id>` with no code parameter. |
+| `forgeCallbackURLWithErrorAndCode(env, state, code, errCode, errDescription)` | New helper local to this file — covers the code-plus-error shape that `ForgeOAuth2CallbackURL` can't emit. |
+| `env.DeliverOAuth2Callback(t, url)` | Drives the in-process callback delivery; reused unchanged. |
+| `provider.Requests(RequestsFilter{Endpoint: EndpointToken, ClientID: rig.clientKey})` | Counts `/token` POSTs scoped to this rig's client key. The zero-length assertion is the property `#175` is fundamentally about. |
+| `tokenExchangeProviderDenied = "provider_denied"`, `tokenExchangeMissingCode = "missing_code"` | Category strings pinned by the tests. Defined in `internal/auth_methods/oauth2/token_exchange_failure.go:22, 25`. |


### PR DESCRIPTION
## Summary
- Two integration tests covering issue #175: callback URL with both `code` and `error`, and callback URL with valid state but no `code`/`error`.
- Both pin the load-bearing property that the proxy must not POST to `/token` when the callback shape is malformed — a single call would mean the proxy burned an authorization code after the provider signalled denial, or attempted an exchange with nothing to exchange.
- Tests reuse `tokenExchangeFailureRig`; only new helper is a local URL forger for the code-plus-error shape.
- Companion `.md` spec captures scope, the zero-/token-calls property, category-choice rationale, and cross-references.

## Test plan
- [x] `go test -tags integration -run TestMalformedCallback_ -count=1 ./oauth2/...` → ok
- [x] `go test -tags integration -run 'TestTokenExchange|TestMalformedCallback' -count=1 ./oauth2/...` → ok (no regressions in the broader callback suite)
- [x] `./scripts/preflight.sh` → passed

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)