### PR TITLE
[A3] Scaffold customer-facing authproxy Helm chart

### DIFF
--- a/deploy/charts/authproxy/.helmignore
+++ b/deploy/charts/authproxy/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when packaging the chart.
+# Mirrors the default `helm create` ignore list.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/authproxy/Chart.yaml
+++ b/deploy/charts/authproxy/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: authproxy
+description: Embeddable integration platform-as-a-service. Manages the connection lifecycle to third-party systems and proxies authenticated requests.
+type: application
+
+# Chart version follows its own semver, independent of the application image
+# version below. Bumped on every chart change.
+version: 0.1.0
+
+# Application version this chart was last validated against. Pinned to a
+# specific image tag here; downstream values can override `image.tag`.
+appVersion: "main"
+
+home: https://github.com/rmorlok/authproxy
+sources:
+  - https://github.com/rmorlok/authproxy
+maintainers:
+  - name: Ryan Morlok
+    url: https://github.com/rmorlok
+
+keywords:
+  - authproxy
+  - oauth
+  - oauth2
+  - ipaas
+  - integration
+  - proxy
+
+annotations:
+  # category hint surfaced by some chart UIs (Artifact Hub, Rancher, etc.)
+  category: Integration

--- a/deploy/charts/authproxy/templates/NOTES.txt
+++ b/deploy/charts/authproxy/templates/NOTES.txt
@@ -1,0 +1,42 @@
+{{ include "authproxy.fullname" . }} has been installed.
+
+Image:        {{ include "authproxy.image" . }}
+Replicas:     {{ .Values.replicaCount }}
+
+Service ports (ClusterIP {{ include "authproxy.fullname" . }}):
+{{- range $name, $port := .Values.service.ports }}
+  {{ $name | kebabcase | printf "%-14s" }} {{ $port }}
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress is enabled. Reachable hosts:
+{{- range .Values.ingress.hosts }}
+  - {{ .host }}
+{{- range .paths }}
+      {{ .path }} → {{ .service | kebabcase }}
+{{- end }}
+{{- end }}
+{{- else }}
+
+Ingress is disabled. To reach the service from outside the cluster,
+either enable `ingress.enabled` in your values or port-forward, e.g.:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "authproxy.fullname" . }} 8080:{{ .Values.service.ports.public }}
+{{- end }}
+
+{{- $missing := list }}
+{{- if not .Values.secrets.database.existingSecret }}{{- $missing = append $missing "secrets.database.existingSecret" }}{{- end }}
+{{- if not .Values.secrets.redis.existingSecret }}{{- $missing = append $missing "secrets.redis.existingSecret" }}{{- end }}
+{{- if not .Values.secrets.jwt.existingSecret }}{{- $missing = append $missing "secrets.jwt.existingSecret" }}{{- end }}
+{{- if not .Values.secrets.encryption.existingSecret }}{{- $missing = append $missing "secrets.encryption.existingSecret" }}{{- end }}
+{{- if $missing }}
+
+NOTE: the following secret references are unset and the pod will fail to
+start until you provide them (chart deliberately never creates Secrets):
+{{- range $missing }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+
+For chart options, run `helm show values authproxy/{{ .Chart.Name }}`.

--- a/deploy/charts/authproxy/templates/_helpers.tpl
+++ b/deploy/charts/authproxy/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "authproxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Honors fullnameOverride, else combines release
+name with chart name unless the release name already contains the chart name.
+*/}}
+{{- define "authproxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart version label, sanitized for label values.
+*/}}
+{{- define "authproxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels emitted on every resource.
+*/}}
+{{- define "authproxy.labels" -}}
+helm.sh/chart: {{ include "authproxy.chart" . }}
+{{ include "authproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels — stable across upgrades, used by Service + Deployment.
+*/}}
+{{- define "authproxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "authproxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "authproxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "authproxy.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Container image reference. Falls back to Chart.appVersion when tag is unset.
+*/}}
+{{- define "authproxy.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "authproxy.fullname" . }}-config
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deploy/charts/authproxy/templates/deployment.yaml
+++ b/deploy/charts/authproxy/templates/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "authproxy.fullname" . }}
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "authproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "authproxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll pods when the rendered config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "authproxy.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: authproxy
+          image: {{ include "authproxy.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - serve
+            - --config=/etc/authproxy/config.yaml
+            - all
+          ports:
+            {{- range $name, $port := .Values.service.ports }}
+            - name: {{ $name | kebabcase }}
+              containerPort: {{ $port }}
+              protocol: TCP
+            {{- end }}
+          {{- if or .Values.secrets.database.existingSecret .Values.secrets.redis.existingSecret .Values.secrets.s3.existingSecret }}
+          envFrom:
+            {{- with .Values.secrets.database.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- with .Values.secrets.redis.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- with .Values.secrets.s3.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.healthcheck.path }}
+              port: public
+            initialDelaySeconds: {{ .Values.healthcheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthcheck.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.healthcheck.path }}
+              port: public
+            initialDelaySeconds: {{ .Values.healthcheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthcheck.periodSeconds }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/authproxy/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- with .Values.secrets.jwt.existingSecret }}
+            - name: jwt-keys
+              mountPath: {{ $.Values.secrets.jwt.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.secrets.encryption.existingSecret }}
+            - name: encryption-keys
+              mountPath: {{ $.Values.secrets.encryption.mountPath }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "authproxy.fullname" . }}-config
+        {{- with .Values.secrets.jwt.existingSecret }}
+        - name: jwt-keys
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- with .Values.secrets.encryption.existingSecret }}
+        - name: encryption-keys
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/authproxy/templates/ingress.yaml
+++ b/deploy/charts/authproxy/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "authproxy.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: {{ .service | kebabcase }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/authproxy/templates/service.yaml
+++ b/deploy/charts/authproxy/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "authproxy.fullname" . }}
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "authproxy.selectorLabels" . | nindent 4 }}
+  ports:
+    {{- range $name, $port := .Values.service.ports }}
+    - name: {{ $name | kebabcase }}
+      port: {{ $port }}
+      targetPort: {{ $name | kebabcase }}
+      protocol: TCP
+    {{- end }}

--- a/deploy/charts/authproxy/templates/serviceaccount.yaml
+++ b/deploy/charts/authproxy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "authproxy.serviceAccountName" . }}
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -1,0 +1,126 @@
+# Default values for the authproxy chart.
+#
+# A3 scope: a minimal but valid surface that lets the chart render valid
+# Kubernetes manifests. A4 (#292) expands this with typed fields for
+# database, redis, s3, jwt, encryption keys, services-on/off, etc.
+
+# -- Container image to deploy.
+image:
+  repository: ghcr.io/rmorlok/authproxy
+  # -- Image tag. Empty string falls back to Chart.appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+
+# -- Override chart name in resource names.
+nameOverride: ""
+# -- Override the fully qualified release name in resource names.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount for the pods.
+  create: true
+  # -- Annotations to apply to the ServiceAccount. Set
+  # `eks.amazonaws.com/role-arn` here to wire IRSA for S3 + other AWS APIs.
+  annotations: {}
+  # -- ServiceAccount name. Generated from the release name if empty.
+  name: ""
+
+# -- Replica count for the AuthProxy pod. The chart deploys all four
+# services (api, admin-api, public, worker) as a single Deployment running
+# `serve all`; for independent scaling per service, run the chart multiple
+# times with different `runServices` (A4) or wait for the per-service mode.
+replicaCount: 1
+
+# -- Annotations applied to each pod.
+podAnnotations: {}
+# -- Extra labels applied to each pod.
+podLabels: {}
+
+# -- Security context applied at the pod level.
+podSecurityContext: {}
+# -- Security context applied at the container level.
+securityContext: {}
+
+# -- Pod resource requests and limits.
+resources: {}
+# -- Node selector.
+nodeSelector: {}
+# -- Tolerations.
+tolerations: []
+# -- Affinity rules.
+affinity: {}
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Per-service container port mapping. Names match the AuthProxy service
+  # IDs; ingress.hosts[].paths[].service references them by key.
+  ports:
+    public: 8080
+    api: 8081
+    adminApi: 8082
+    workerHealth: 8083
+
+ingress:
+  # -- Enable an Ingress resource.
+  enabled: false
+  # -- IngressClass name (e.g. `nginx`).
+  className: ""
+  # -- Annotations applied to the Ingress.
+  annotations: {}
+  # -- Host + path rules. Each path references a `service` key from
+  # `service.ports` above.
+  hosts:
+    - host: authproxy.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: public
+  # -- TLS configuration entries.
+  tls: []
+
+# -- Inline AuthProxy YAML config. Rendered into a ConfigMap and mounted at
+# /etc/authproxy/config.yaml in the container. A4 (#292) ships typed
+# top-level keys (`database`, `redis`, `s3`, etc.) that compose into this
+# map; for now the chart only ships the minimum config needed to render.
+config:
+  public:
+    port: 8080
+  api:
+    port: 8081
+  admin_api:
+    port: 8082
+  worker:
+    health_check_port: 8083
+
+# -- References to externally managed Secrets. The chart wires `envFrom`
+# entries so the container picks up credentials at startup; the chart never
+# creates the Secrets themselves. A4 will rename these to typed sections
+# (`database.existingSecret`, `redis.existingSecret`, etc.).
+secrets:
+  # -- Database connection credentials (POSTGRES_* env vars expected).
+  database:
+    existingSecret: ""
+  # -- Redis connection credentials.
+  redis:
+    existingSecret: ""
+  # -- S3 credentials (only needed when not using IRSA).
+  s3:
+    existingSecret: ""
+  # -- JWT signing key pair and admin actor keys (mounted as files).
+  jwt:
+    existingSecret: ""
+    mountPath: /etc/authproxy/keys/jwt
+  # -- Encryption keys (mounted as files).
+  encryption:
+    existingSecret: ""
+    mountPath: /etc/authproxy/keys/encryption
+
+# -- HTTP path on the public service used for liveness / readiness probes.
+healthcheck:
+  path: /healthz
+  initialDelaySeconds: 10
+  periodSeconds: 10


### PR DESCRIPTION
## Summary

First commit of `deploy/charts/authproxy/` — the chart customers will install on their own Kubernetes clusters. Bring-your-own deps: the chart **references** but never **creates** Postgres / Redis / S3 / JWT / encryption-key Secrets, matching the scope agreed in #284.

## What's in the scaffold

```
deploy/charts/authproxy/
├── Chart.yaml         chart metadata; appVersion pinned to "main" for now
├── values.yaml        minimum surface for valid manifests (A4 expands)
├── .helmignore
└── templates/
    ├── _helpers.tpl       fullname / labels / selector / SA / image helpers
    ├── serviceaccount.yaml  IRSA-ready via serviceAccount.annotations
    ├── configmap.yaml     renders values.config into /etc/authproxy/config.yaml
    ├── deployment.yaml    single pod, `serve all`, 4 named ports
    ├── service.yaml       multi-port ClusterIP (public, api, admin-api, worker-health)
    ├── ingress.yaml       disabled by default; subpath rules → port name
    └── NOTES.txt          post-install summary + warns about unset secret refs
```

## Design choices

- **Single Deployment running `serve all`** (matches #290 acceptance: "all four services on the single binary"). Per-service mode and independent scaling are deferred — they need either multiple chart installs or a `runServices` knob, which #292 (A4) will decide.
- **Multi-port Service** with named ports (`public`, `api`, `admin-api`, `worker-health`). Ingress paths reference these by name, so umbrella charts can route subpaths to specific services without ports leaking into ingress.
- **Secrets are referenced, never created.** Each block (`secrets.database`, `secrets.redis`, `secrets.s3`, `secrets.jwt`, `secrets.encryption`) has an `existingSecret` field. The Deployment only emits envFrom/volume blocks when the corresponding name is set, so default render doesn't produce invalid empty `envFrom:` lists.
- **`checksum/config` annotation** rolls pods on config change — standard chart hygiene.
- **`/healthz` on the public port** drives both liveness and readiness, since all four services run in one pod and only the public service exposes a usable HTTP probe target.
- **IRSA wiring** via `serviceAccount.annotations` (set `eks.amazonaws.com/role-arn` for S3 etc).

## Verified locally

```
$ helm lint deploy/charts/authproxy
==> Linting deploy/charts/authproxy
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

- `helm template test deploy/charts/authproxy` — renders cleanly with defaults
- `helm template test deploy/charts/authproxy -f overrides.yaml` — wires ingress, all five Secrets, IRSA annotation correctly with the override values I tested
- `helm install --dry-run=client` passes; NOTES emits the "secret X is unset" reminder list
- `./scripts/preflight.sh` clean

## Acceptance (per #290)

- [x] `helm lint deploy/charts/authproxy` clean
- [x] `helm template` produces valid manifests with default values
- [x] `helm install --dry-run` passes

## What's next

- **#292 (A4)**: rename the `secrets` block to typed sections, add typed \`database\`/\`redis\`/\`s3\` fields, ship a \`values.schema.json\` schema validator, add per-service enable flags
- **#287 (A5)**: kind-based CI for the chart (real install + HTTP smoke against \`/healthz\`)
- **#286 (A6)**: OCI publish of the chart to \`oci://ghcr.io/rmorlok/charts/authproxy\` on tag

Closes #290. Part of #284.