### PR TITLE
Implement /_proxy_raw streaming endpoint (#330)

### DIFF
--- a/internal/core/connection_proxy.go
+++ b/internal/core/connection_proxy.go
@@ -68,7 +68,7 @@ func (c *connection) ProxyRequest(
 func (c *connection) ProxyRequestRaw(
 	ctx context.Context,
 	reqType httpf.RequestType,
-	req *iface.ProxyRequest,
+	req *iface.RawProxyRequest,
 	w http.ResponseWriter,
 ) error {
 	p, err := c.getProxyImpl()

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -64,7 +64,7 @@ type Connection interface {
 	ProxyRequestRaw(
 		ctx context.Context,
 		reqType httpf.RequestType,
-		req *ProxyRequest,
+		req *RawProxyRequest,
 		w http.ResponseWriter,
 	) error
 	SubmitForm(ctx context.Context, req SubmitConnectionRequest) (ConnectionSetupResponse, error)

--- a/internal/core/iface/proxy.go
+++ b/internal/core/iface/proxy.go
@@ -120,7 +120,26 @@ func ProxyResponseFromGentlemen(resp *gentleman.Response) (*ProxyResponse, error
 	return proxyResp, nil
 }
 
+// RawProxyRequest carries the inputs to the streaming raw-proxy path.
+// Separate from ProxyRequest because raw bodies are streamed (io.Reader on
+// the outbound request) rather than buffered into BodyRaw/BodyJson, and
+// the inbound URL + headers come pre-shaped by the route handler.
+type RawProxyRequest struct {
+	// Outbound is the request the orchestrator will send to the upstream.
+	// The route handler is responsible for resolving the URL (from
+	// X-AuthProxy-Upstream-URL), filtering hop-by-hop headers, and
+	// attaching the inbound body as outbound.Body. The orchestrator
+	// applies the connector's credentials via the Authenticator and
+	// sends it through httpf's *http.Client (rate-limit + OTel still
+	// apply, but gentleman's body buffering does not).
+	Outbound *http.Request
+	// Labels are forwarded to httpf's ForLabels chain (rate-limit,
+	// request log, OTel) — same shape as ProxyRequest.Labels for the
+	// wrapped path.
+	Labels map[string]string
+}
+
 type Proxy interface {
 	ProxyRequest(ctx context.Context, reqType httpf.RequestType, req *ProxyRequest) (*ProxyResponse, error)
-	ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *ProxyRequest, w http.ResponseWriter) error
+	ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *RawProxyRequest, w http.ResponseWriter) error
 }

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -111,7 +111,7 @@ func (m *Connection) ProxyRequest(
 func (m *Connection) ProxyRequestRaw(
 	ctx context.Context,
 	reqType httpf.RequestType,
-	req *iface.ProxyRequest,
+	req *iface.RawProxyRequest,
 	w http.ResponseWriter,
 ) error {
 	return nil

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -27,6 +27,9 @@ type clientFactory struct {
 
 	factoryParent     *gentleman.Client
 	factoryParentOnce sync.Once
+
+	wrappedTransport     http.RoundTripper
+	wrappedTransportOnce sync.Once
 }
 
 func CreateFactory(
@@ -206,7 +209,24 @@ func (f *clientFactory) New() *gentleman.Client {
 	// and we can cache with middlewares applied.
 	f.factoryParentOnce.Do(func() {
 		f.factoryParent = gentleman.New()
+		f.factoryParent.Use(transport.Set(f.buildWrappedTransport()))
+	})
 
+	return gentleman.New().UseParent(f.factoryParent)
+}
+
+// NewHTTPClient returns a stock *http.Client whose Transport is the same
+// wrapped RoundTripper used by New(). For the streaming raw-proxy path,
+// where we need direct net/http semantics (no gentleman body buffering).
+func (f *clientFactory) NewHTTPClient() *http.Client {
+	return &http.Client{Transport: f.buildWrappedTransport()}
+}
+
+// buildWrappedTransport applies the registered middlewares around the
+// default transport. Cached per factory instance so the wrap (which can
+// allocate per-request-info state inside the middleware) happens once.
+func (f *clientFactory) buildWrappedTransport() http.RoundTripper {
+	f.wrappedTransportOnce.Do(func() {
 		parent := http.DefaultTransport
 		for _, m := range f.middlewares {
 			result := m.NewRoundTripper(f.requestInfo, parent)
@@ -214,11 +234,7 @@ func (f *clientFactory) New() *gentleman.Client {
 				parent = result
 			}
 		}
-
-		f.factoryParent.Use(
-			transport.Set(parent),
-		)
+		f.wrappedTransport = parent
 	})
-
-	return gentleman.New().UseParent(f.factoryParent)
+	return f.wrappedTransport
 }

--- a/internal/httpf/interface.go
+++ b/internal/httpf/interface.go
@@ -1,6 +1,8 @@
 package httpf
 
 import (
+	"net/http"
+
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/connectors"
 	"gopkg.in/h2non/gentleman.v2"
@@ -52,6 +54,12 @@ type Actor interface {
 //go:generate mockgen -source=./interface.go -destination=./mock/httpf.go -package=mock
 type F interface {
 	New() *gentleman.Client
+	// NewHTTPClient returns a stock *http.Client whose Transport is the
+	// same wrapped RoundTripper chain (request-log, rate-limit enforcer,
+	// OTel, …) used by New(). Use this for the streaming raw-proxy path
+	// — gentleman's Send() buffers the response body, which defeats SSE
+	// and other long-lived streams.
+	NewHTTPClient() *http.Client
 	ForRequestInfo(ri RequestInfo) F
 	ForRequestType(rt RequestType) F
 	ForConnectorVersion(cv ConnectorVersion) F

--- a/internal/httpf/mock/httpf.go
+++ b/internal/httpf/mock/httpf.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -151,6 +152,43 @@ func (m *MockRateLimitConfigProvider) GetRateLimitConfig() *connectors.RateLimit
 func (mr *MockRateLimitConfigProviderMockRecorder) GetRateLimitConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRateLimitConfig", reflect.TypeOf((*MockRateLimitConfigProvider)(nil).GetRateLimitConfig))
+}
+
+// MockTracePropagationProvider is a mock of TracePropagationProvider interface.
+type MockTracePropagationProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockTracePropagationProviderMockRecorder
+}
+
+// MockTracePropagationProviderMockRecorder is the mock recorder for MockTracePropagationProvider.
+type MockTracePropagationProviderMockRecorder struct {
+	mock *MockTracePropagationProvider
+}
+
+// NewMockTracePropagationProvider creates a new mock instance.
+func NewMockTracePropagationProvider(ctrl *gomock.Controller) *MockTracePropagationProvider {
+	mock := &MockTracePropagationProvider{ctrl: ctrl}
+	mock.recorder = &MockTracePropagationProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTracePropagationProvider) EXPECT() *MockTracePropagationProviderMockRecorder {
+	return m.recorder
+}
+
+// PropagateTraceContext mocks base method.
+func (m *MockTracePropagationProvider) PropagateTraceContext() *bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropagateTraceContext")
+	ret0, _ := ret[0].(*bool)
+	return ret0
+}
+
+// PropagateTraceContext indicates an expected call of PropagateTraceContext.
+func (mr *MockTracePropagationProviderMockRecorder) PropagateTraceContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropagateTraceContext", reflect.TypeOf((*MockTracePropagationProvider)(nil).PropagateTraceContext))
 }
 
 // MockConnection is a mock of Connection interface.
@@ -430,4 +468,18 @@ func (m *MockF) New() *gentleman.Client {
 func (mr *MockFMockRecorder) New() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockF)(nil).New))
+}
+
+// NewHTTPClient mocks base method.
+func (m *MockF) NewHTTPClient() *http.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewHTTPClient")
+	ret0, _ := ret[0].(*http.Client)
+	return ret0
+}
+
+// NewHTTPClient indicates an expected call of NewHTTPClient.
+func (mr *MockFMockRecorder) NewHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewHTTPClient", reflect.TypeOf((*MockF)(nil).NewHTTPClient))
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2,15 +2,16 @@
 // resolve credentials via the auth method's Authenticator, send the request
 // through the httpf client (which carries rate-limit / telemetry /
 // request-log middleware), and on a 401 from the upstream attempt the
-// retry-once-after-recover dance. Owns ProxyRequest and (in #330)
-// ProxyRequestRaw so the per-auth-method packages only have to describe
-// "how to apply this credential to a request" — not how to drive a proxy
-// call.
+// retry-once-after-recover dance. Owns both the wrapped (structured)
+// ProxyRequest and the streaming ProxyRequestRaw paths so the
+// per-auth-method packages only have to describe "how to apply this
+// credential to a request" — not how to drive a proxy call.
 package proxy
 
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
@@ -66,11 +67,248 @@ func (p *proxy) ProxyRequest(ctx context.Context, reqType httpf.RequestType, req
 	return iface.ProxyResponseFromGentlemen(resp)
 }
 
-// ProxyRequestRaw is the streaming proxy path. Implemented in #330; for
-// now this preserves the prior stub behavior so callers that touch the
-// path during the refactor see no change.
-func (p *proxy) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.ProxyRequest, w http.ResponseWriter) error {
+// ProxyRequestRaw is the streaming raw-proxy path: the caller's inbound
+// HTTP body flows directly into the outbound request, the upstream
+// response streams back into w with flushing after each successful read,
+// and trailers are passed through.
+//
+// On a 401 we may attempt a single retry, but only if the inbound body
+// has not yet been consumed (Resolve succeeded but the body reader is
+// still at position zero). For streaming inbound bodies — the common
+// case here — once any bytes have been sent the 401 is surfaced to the
+// caller. Real SSE / LLM / S3 callers typically send POST bodies from
+// buffered or seekable sources, so a more sophisticated rewind path can
+// be added later if the streaming-body 401-retry case actually bites.
+func (p *proxy) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, req *iface.RawProxyRequest, w http.ResponseWriter) error {
+	if req == nil || req.Outbound == nil {
+		return errors.New("raw proxy request requires an outbound *http.Request")
+	}
+
+	client := p.httpf.
+		ForRequestType(reqType).
+		ForConnection(p.conn).
+		ForActor(apauthcore.ActorFromContext(ctx)).
+		ForLabels(req.Labels).
+		NewHTTPClient()
+
+	// Snapshot of the inbound body so we can issue a single retry if the
+	// upstream rejects with 401 *before* any inbound bytes were forwarded.
+	// Once forwarding starts the body's read position is unrecoverable;
+	// see the function comment for the rationale.
+	outbound := req.Outbound.WithContext(ctx)
+	originalBody := outbound.Body
+
+	resp, err := p.sendRaw(ctx, client, outbound)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized && canRetryRawAfter401(originalBody) {
+		recoverErr := p.auth.RecoverFrom401(ctx)
+		if recoverErr == nil {
+			drainAndClose(resp.Body)
+			retried, retryErr := p.sendRaw(ctx, client, req.Outbound.WithContext(ctx))
+			if retryErr == nil {
+				resp = retried
+			}
+		} else if !errors.Is(recoverErr, auth_methods.ErrCannotRecover) {
+			_ = recoverErr
+		}
+	}
+
+	return streamResponse(w, resp)
+}
+
+// canRetryRawAfter401 reports whether the inbound body is in a state
+// where a retry could replay it. With no body (GET/HEAD/DELETE) retry is
+// safe. With a body that's already been consumed we cannot rewind, so we
+// surface the 401. http.NoBody is the sentinel net/http uses for the
+// "no body" case after the request is built; nil also occurs in
+// constructed requests.
+func canRetryRawAfter401(body io.ReadCloser) bool {
+	if body == nil {
+		return true
+	}
+	if body == http.NoBody {
+		return true
+	}
+	// Conservative default: assume the body has been (or is being)
+	// consumed and the retry would not see the same bytes. Real callers
+	// that need streaming-body 401-retry will need a rewindable body
+	// abstraction — a future PR.
+	return false
+}
+
+// sendRaw applies the credentials to the outbound request and sends it
+// via the supplied client. Split out so the retry-after-401 path can
+// build a new request with a fresh body and reuse the same client.
+func (p *proxy) sendRaw(ctx context.Context, client *http.Client, outbound *http.Request) (*http.Response, error) {
+	app, err := p.auth.Resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Caller-supplied headers are already on outbound. Credential headers
+	// take precedence (Set, not Add) — same order/precedence as the
+	// wrapped path.
+	for h, v := range app.Headers {
+		outbound.Header.Set(h, v)
+	}
+	if len(app.QueryParams) > 0 {
+		q := outbound.URL.Query()
+		for k, v := range app.QueryParams {
+			q.Set(k, v)
+		}
+		outbound.URL.RawQuery = q.Encode()
+	}
+
+	return client.Do(outbound)
+}
+
+// streamResponse copies the upstream response back to the caller with
+// flushing after each read so SSE / chunked-transfer streams reach the
+// client incrementally instead of being buffered into a single
+// response-completion write. Trailers (declared via the Trailer header
+// per RFC 7230 §4.4) are forwarded after the body completes.
+func streamResponse(w http.ResponseWriter, resp *http.Response) error {
+	defer drainAndClose(resp.Body)
+
+	copyHeaderExceptHopByHop(w.Header(), resp.Header)
+	// Announce trailers up front so http.ResponseWriter accepts them
+	// after the body is written.
+	if len(resp.Trailer) > 0 {
+		trailerNames := make([]string, 0, len(resp.Trailer))
+		for k := range resp.Trailer {
+			trailerNames = append(trailerNames, k)
+		}
+		w.Header()["Trailer"] = trailerNames
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, _ := w.(http.Flusher)
+	if _, err := flushingCopy(w, resp.Body, flusher); err != nil {
+		return err
+	}
+
+	if len(resp.Trailer) > 0 {
+		for k, vv := range resp.Trailer {
+			for _, v := range vv {
+				w.Header().Add(http.TrailerPrefix+k, v)
+			}
+		}
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
 	return nil
+}
+
+// flushingCopy is io.Copy with a Flush call after each non-empty read.
+// Defaults to a 32KiB buffer (same as io.copyBuffer) — the chunk size
+// is the SSE event size or the upstream's preferred TCP write size, not
+// our concern; we just push whatever lands on the upstream socket
+// downstream without waiting for EOF.
+func flushingCopy(dst io.Writer, src io.Reader, flusher http.Flusher) (int64, error) {
+	buf := make([]byte, 32*1024)
+	var written int64
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[:nr])
+			if nw > 0 {
+				written += int64(nw)
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if ew != nil {
+				return written, ew
+			}
+			if nr != nw {
+				return written, io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return written, nil
+			}
+			return written, er
+		}
+	}
+}
+
+// copyHeaderExceptHopByHop copies upstream response headers onto the
+// downstream ResponseWriter, omitting hop-by-hop headers per RFC 7230
+// §6.1. Hop-by-hop headers (and anything listed in the Connection
+// header) are scoped to a single connection and must not be forwarded.
+func copyHeaderExceptHopByHop(dst, src http.Header) {
+	// Headers listed in the Connection header are also hop-by-hop for
+	// this hop only.
+	hopByConnection := map[string]struct{}{}
+	for _, v := range src.Values("Connection") {
+		for _, name := range splitCommaTrim(v) {
+			hopByConnection[http.CanonicalHeaderKey(name)] = struct{}{}
+		}
+	}
+	for k, vv := range src {
+		if isHopByHopHeader(k) {
+			continue
+		}
+		if _, ok := hopByConnection[http.CanonicalHeaderKey(k)]; ok {
+			continue
+		}
+		dst[k] = append([]string(nil), vv...)
+	}
+}
+
+// hopByHopHeaders enumerated in RFC 7230 §6.1.
+var hopByHopHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"Te":                  {},
+	"Trailers":            {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+}
+
+func isHopByHopHeader(name string) bool {
+	_, ok := hopByHopHeaders[http.CanonicalHeaderKey(name)]
+	return ok
+}
+
+func splitCommaTrim(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			seg := s[start:i]
+			// Trim ASCII spaces and tabs.
+			for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
+				seg = seg[1:]
+			}
+			for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
+				seg = seg[:len(seg)-1]
+			}
+			if seg != "" {
+				out = append(out, seg)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}
+
+func drainAndClose(rc io.ReadCloser) {
+	if rc == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, rc)
+	_ = rc.Close()
 }
 
 // send builds a fresh gentleman request with the resolved credential

--- a/internal/proxy/proxy_raw_test.go
+++ b/internal/proxy/proxy_raw_test.go
@@ -1,0 +1,308 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/auth_methods"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gentleman "gopkg.in/h2non/gentleman.v2"
+)
+
+// fakeAuth is a hand-written Authenticator that records call sequencing
+// without pulling in mockgen for this single fixture. RecoverFrom401 is
+// allowed exactly maxRecover times before returning ErrCannotRecover.
+type fakeAuth struct {
+	headers     map[string]string
+	maxRecover  int
+	resolveN    int32
+	recoverN    int32
+	failResolve error
+}
+
+func (a *fakeAuth) Resolve(ctx context.Context) (auth_methods.AuthApplication, error) {
+	atomic.AddInt32(&a.resolveN, 1)
+	if a.failResolve != nil {
+		return auth_methods.AuthApplication{}, a.failResolve
+	}
+	hs := make(map[string]string, len(a.headers))
+	for k, v := range a.headers {
+		hs[k] = v
+	}
+	return auth_methods.AuthApplication{Headers: hs}, nil
+}
+
+func (a *fakeAuth) RecoverFrom401(ctx context.Context) error {
+	if atomic.LoadInt32(&a.recoverN) >= int32(a.maxRecover) {
+		return auth_methods.ErrCannotRecover
+	}
+	atomic.AddInt32(&a.recoverN, 1)
+	return nil
+}
+
+// stubHttpf returns a single supplied http.Client through NewHTTPClient,
+// ignoring all chain methods. Sufficient for testing the orchestrator —
+// the real chain semantics are covered by httpf's own tests.
+type stubHttpf struct {
+	client *http.Client
+}
+
+func (s *stubHttpf) New() *gentleman.Client { return gentleman.New() }
+func (s *stubHttpf) NewHTTPClient() *http.Client {
+	return s.client
+}
+func (s *stubHttpf) ForRequestInfo(httpf.RequestInfo) httpf.F      { return s }
+func (s *stubHttpf) ForRequestType(httpf.RequestType) httpf.F      { return s }
+func (s *stubHttpf) ForConnectorVersion(httpf.ConnectorVersion) httpf.F {
+	return s
+}
+func (s *stubHttpf) ForConnection(httpf.Connection) httpf.F        { return s }
+func (s *stubHttpf) ForActor(httpf.Actor) httpf.F                  { return s }
+func (s *stubHttpf) ForLabels(map[string]string) httpf.F           { return s }
+
+func newRawTestProxy(t *testing.T, h http.Handler, auth *fakeAuth) (iface.Proxy, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	conn := &mockCore.Connection{
+		Id:        apid.New(apid.PrefixConnection),
+		Namespace: "root/",
+	}
+	p := New(&stubHttpf{client: srv.Client()}, conn, auth)
+	return p, srv
+}
+
+// TestProxyRequestRaw_StreamsChunkedBytes — the critical streaming
+// invariant: an upstream that writes a chunk, flushes, pauses, writes
+// another chunk, must surface as two separately-observable arrivals on
+// the downstream writer. A regression where the orchestrator buffered
+// the whole body before flushing would break SSE consumers, LLM token
+// streaming, and large S3 downloads.
+func TestProxyRequestRaw_StreamsChunkedBytes(t *testing.T) {
+	const chunkA = "event: alpha\ndata: 1\n\n"
+	const chunkB = "event: beta\ndata: 2\n\n"
+
+	releaseB := make(chan struct{})
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(chunkA))
+		w.(http.Flusher).Flush()
+		<-releaseB
+		_, _ = w.Write([]byte(chunkB))
+		w.(http.Flusher).Flush()
+	})
+	auth := &fakeAuth{headers: map[string]string{"Authorization": "Bearer test"}}
+	p, srv := newRawTestProxy(t, upstream, auth)
+
+	outbound, err := http.NewRequest(http.MethodGet, srv.URL+"/stream", nil)
+	require.NoError(t, err)
+
+	rec := newRecordingResponseWriter()
+	done := make(chan error, 1)
+	go func() {
+		done <- p.ProxyRequestRaw(context.Background(), httpf.RequestTypeProxy, &iface.RawProxyRequest{Outbound: outbound}, rec)
+	}()
+
+	// First chunk must arrive before we release the second — proves no
+	// end-of-response buffering.
+	require.Eventually(t, func() bool {
+		return rec.containsString(chunkA)
+	}, 2*time.Second, 10*time.Millisecond, "first chunk did not arrive before second was released")
+	assert.NotContains(t, rec.snapshot(), chunkB, "second chunk arrived before being released — server-side serialization broken")
+
+	close(releaseB)
+	require.NoError(t, <-done)
+	assert.Equal(t, chunkA+chunkB, rec.snapshot())
+	assert.GreaterOrEqual(t, rec.flushCount(), 2, "must flush at least once per chunk")
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+}
+
+// TestProxyRequestRaw_AttachesCredentialHeader — auth.Resolve's headers
+// must end up on the outbound request before it hits the upstream, and
+// they must overwrite any caller-supplied value (credential always wins).
+func TestProxyRequestRaw_AttachesCredentialHeader(t *testing.T) {
+	var receivedAuth string
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	auth := &fakeAuth{headers: map[string]string{"Authorization": "Bearer correct"}}
+	p, srv := newRawTestProxy(t, upstream, auth)
+
+	outbound, err := http.NewRequest(http.MethodGet, srv.URL+"/x", nil)
+	require.NoError(t, err)
+	outbound.Header.Set("Authorization", "Bearer should-be-overwritten")
+
+	rec := newRecordingResponseWriter()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), httpf.RequestTypeProxy, &iface.RawProxyRequest{Outbound: outbound}, rec))
+	assert.Equal(t, "Bearer correct", receivedAuth)
+}
+
+// TestProxyRequestRaw_401TriggersRecoverAndRetry — for bodyless
+// requests (the case where retry is safe) a 401 must call
+// RecoverFrom401, re-Resolve, and replay the request. A regression here
+// would mean expired-token retries stop working on the streaming path.
+func TestProxyRequestRaw_401TriggersRecoverAndRetry(t *testing.T) {
+	var calls int32
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	auth := &fakeAuth{
+		headers:    map[string]string{"Authorization": "Bearer t"},
+		maxRecover: 1,
+	}
+	p, srv := newRawTestProxy(t, upstream, auth)
+
+	outbound, err := http.NewRequest(http.MethodGet, srv.URL+"/y", nil)
+	require.NoError(t, err)
+
+	rec := newRecordingResponseWriter()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), httpf.RequestTypeProxy, &iface.RawProxyRequest{Outbound: outbound}, rec))
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "expected exactly one retry after 401")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&auth.recoverN), "RecoverFrom401 must be called exactly once")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&auth.resolveN), "Resolve must be called once per attempt")
+	assert.Equal(t, http.StatusOK, rec.status())
+	assert.Equal(t, "ok", rec.snapshot())
+}
+
+// TestProxyRequestRaw_401SurfacedWhenInboundBodyWasConsumed — when the
+// inbound body is non-empty and not rewindable, the orchestrator must
+// NOT retry. Retrying with an exhausted reader would send an empty
+// body and look success-y to the upstream, masking the real 401 from
+// the caller's perspective.
+func TestProxyRequestRaw_401SurfacedWhenInboundBodyWasConsumed(t *testing.T) {
+	var calls int32
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		// Drain to simulate the body being consumed.
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	auth := &fakeAuth{headers: map[string]string{"Authorization": "Bearer t"}, maxRecover: 1}
+	p, srv := newRawTestProxy(t, upstream, auth)
+
+	body := io.NopCloser(strings.NewReader("payload"))
+	outbound, err := http.NewRequest(http.MethodPost, srv.URL+"/z", body)
+	require.NoError(t, err)
+
+	rec := newRecordingResponseWriter()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), httpf.RequestTypeProxy, &iface.RawProxyRequest{Outbound: outbound}, rec))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "no retry when inbound body was already consumed")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&auth.recoverN), "RecoverFrom401 must not be called when retry is unsafe")
+	assert.Equal(t, http.StatusUnauthorized, rec.status())
+}
+
+// TestProxyRequestRaw_HopByHopResponseHeadersStripped — the orchestrator
+// is the trust boundary for what the upstream is allowed to send back
+// to the caller's TCP connection. Hop-by-hop headers must be dropped
+// per RFC 7230 §6.1; otherwise an upstream Transfer-Encoding announcement
+// would conflict with the downstream's actual framing.
+func TestProxyRequestRaw_HopByHopResponseHeadersStripped(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "X-Hop-Custom")
+		w.Header().Set("X-Hop-Custom", "leak")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Allowed", "passes-through")
+		w.WriteHeader(http.StatusOK)
+	})
+	auth := &fakeAuth{headers: map[string]string{"Authorization": "Bearer t"}}
+	p, srv := newRawTestProxy(t, upstream, auth)
+
+	outbound, err := http.NewRequest(http.MethodGet, srv.URL+"/h", nil)
+	require.NoError(t, err)
+
+	rec := newRecordingResponseWriter()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), httpf.RequestTypeProxy, &iface.RawProxyRequest{Outbound: outbound}, rec))
+
+	assert.Empty(t, rec.Header().Get("Connection"), "hop-by-hop must not be forwarded")
+	assert.Empty(t, rec.Header().Get("X-Hop-Custom"), "header named by Connection: must not be forwarded")
+	assert.Empty(t, rec.Header().Get("Transfer-Encoding"), "hop-by-hop must not be forwarded")
+	assert.Empty(t, rec.Header().Get("Keep-Alive"), "hop-by-hop must not be forwarded")
+	assert.Equal(t, "passes-through", rec.Header().Get("X-Allowed"))
+}
+
+// recordingResponseWriter captures everything sent to the writer so the
+// tests can assert on body bytes, flush counts, status, and headers
+// without spinning up a second httptest.Server.
+type recordingResponseWriter struct {
+	mu      sync.Mutex
+	hdr     http.Header
+	buf     strings.Builder
+	flushes int
+	st      int
+}
+
+func newRecordingResponseWriter() *recordingResponseWriter {
+	return &recordingResponseWriter{hdr: http.Header{}, st: 200}
+}
+
+func (r *recordingResponseWriter) Header() http.Header { return r.hdr }
+
+func (r *recordingResponseWriter) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.Write(p)
+}
+
+func (r *recordingResponseWriter) WriteHeader(s int) {
+	r.mu.Lock()
+	r.st = s
+	r.mu.Unlock()
+}
+
+func (r *recordingResponseWriter) Flush() {
+	r.mu.Lock()
+	r.flushes++
+	r.mu.Unlock()
+}
+
+func (r *recordingResponseWriter) status() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.st
+}
+
+func (r *recordingResponseWriter) snapshot() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.String()
+}
+
+func (r *recordingResponseWriter) containsString(s string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return strings.Contains(r.buf.String(), s)
+}
+
+func (r *recordingResponseWriter) flushCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flushes
+}
+
+// silence unused import lint if bufio gets dropped during edits
+var _ = bufio.NewReader

--- a/internal/routes/connections_proxy.go
+++ b/internal/routes/connections_proxy.go
@@ -102,15 +102,14 @@ func (r *ConnectionsProxyRoutes) proxy(gctx *gin.Context) {
 }
 
 func (r *ConnectionsProxyRoutes) Register(g gin.IRouter) {
-	g.POST(
-		"/connections/:id/_proxy",
-		r.auth.NewRequiredBuilder().
-			ForResource("connections").
-			ForVerb("proxy").
-			ForIdField("id").
-			Build(),
-		r.proxy,
-	)
+	proxyAuth := r.auth.NewRequiredBuilder().
+		ForResource("connections").
+		ForVerb("proxy").
+		ForIdField("id").
+		Build()
+
+	g.POST("/connections/:id/_proxy", proxyAuth, r.proxy)
+	g.Any("/connections/:id/_proxy_raw", proxyAuth, r.proxyRaw)
 }
 
 func NewConnectionsProxyRoutes(

--- a/internal/routes/connections_proxy_raw.go
+++ b/internal/routes/connections_proxy_raw.go
@@ -1,0 +1,235 @@
+package routes
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/httpf"
+)
+
+const (
+	// HeaderUpstreamURL identifies the upstream URL to forward to.
+	// Required on every /_proxy_raw request. Spelled with the API's
+	// public capitalization (X-AuthProxy-…); Go's http.Header
+	// canonicalizes on lookup so the comparison still hits.
+	HeaderUpstreamURL = "X-AuthProxy-Upstream-URL"
+	// HeaderLabel carries a single key=value label, repeated once per
+	// label. Repeated rather than a single comma-joined header so label
+	// keys may contain `/` and other characters not safe inside an HTTP
+	// header value alongside comma delimiters.
+	HeaderLabel = "X-AuthProxy-Label"
+)
+
+// Canonical-form variants used for switch comparisons after we've already
+// run http.CanonicalHeaderKey on the inbound header name. Go canonicalizes
+// "X-AuthProxy-Upstream-URL" to "X-Authproxy-Upstream-Url" (only the first
+// rune of each dash-segment is upper-cased), so the public constants above
+// don't compare equal to a canonical-form name. Defining these privately
+// keeps the public API spelling intact.
+var (
+	headerUpstreamURLCanonical = http.CanonicalHeaderKey(HeaderUpstreamURL)
+	headerLabelCanonical       = http.CanonicalHeaderKey(HeaderLabel)
+)
+
+// proxyRaw is the streaming raw-proxy handler. Parses the inbound
+// envelope (X-AuthProxy-Upstream-URL, repeated X-AuthProxy-Label, plus
+// the request body), builds an outbound *http.Request, and delegates to
+// Connection.ProxyRequestRaw which applies the connection's credentials
+// and streams the upstream response back to the caller.
+//
+// Bound on the same `connections:proxy` verb as the wrapped /_proxy
+// route — both are "make a proxied call as this connection".
+//
+//	ANY /connections/{id}/_proxy_raw
+func (r *ConnectionsProxyRoutes) proxyRaw(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	connectionUuid, err := apid.Parse(gctx.Param("id"))
+	if err != nil || connectionUuid == apid.Nil {
+		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid connection id", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	conn, err := r.core.GetConnection(ctx, connectionUuid)
+	if err != nil {
+		if errors.Is(err, iface.ErrConnectionNotFound) {
+			apgin.WriteError(gctx, r.logger, httperr.NotFound("connection not found"))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(conn); httpErr != nil {
+		apgin.WriteError(gctx, r.logger, httpErr)
+		return
+	}
+
+	parsed, perr := parseRawProxyEnvelope(gctx.Request)
+	if perr != nil {
+		apgin.WriteError(gctx, r.logger, perr)
+		return
+	}
+
+	outbound, oerr := http.NewRequestWithContext(ctx, gctx.Request.Method, parsed.upstreamURL.String(), gctx.Request.Body)
+	if oerr != nil {
+		apgin.WriteError(gctx, r.logger, httperr.BadRequest("could not build outbound request", httperr.WithInternalErr(oerr)))
+		return
+	}
+	// Forward the inbound Content-Length so chunked-vs-known framing
+	// survives the hop. Go's http.NewRequest only sets this for known
+	// body types; for our io.ReadCloser it stays unset.
+	outbound.ContentLength = gctx.Request.ContentLength
+	if hl := gctx.Request.Header.Get("Content-Length"); hl != "" {
+		outbound.Header.Set("Content-Length", hl)
+	}
+	copyInboundHeadersForRawProxy(outbound.Header, gctx.Request.Header)
+
+	rawReq := &iface.RawProxyRequest{
+		Outbound: outbound,
+		Labels:   parsed.labels,
+	}
+
+	if err := conn.ProxyRequestRaw(ctx, httpf.RequestTypeProxy, rawReq, gctx.Writer); err != nil {
+		// If headers haven't been flushed yet we can still surface a
+		// JSON error; once they are on the wire we can only log.
+		if !gctx.Writer.Written() {
+			apgin.WriteErr(gctx, r.logger, err)
+			return
+		}
+		r.logger.WarnContext(ctx, "raw proxy stream aborted after headers were sent", "error", err)
+		_ = gctx.Error(err)
+	}
+}
+
+// rawProxyEnvelope is the parsed result of pulling AuthProxy envelope
+// headers off the inbound request.
+type rawProxyEnvelope struct {
+	upstreamURL *url.URL
+	labels      map[string]string
+}
+
+func parseRawProxyEnvelope(req *http.Request) (*rawProxyEnvelope, *httperr.Error) {
+	rawURL := req.Header.Get(HeaderUpstreamURL)
+	if rawURL == "" {
+		return nil, httperr.BadRequest("missing required header " + HeaderUpstreamURL)
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, httperr.BadRequest("invalid "+HeaderUpstreamURL+": "+err.Error(), httperr.WithInternalErr(err))
+	}
+	if !u.IsAbs() || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, httperr.BadRequest(HeaderUpstreamURL + " must be an absolute http(s) URL")
+	}
+	if u.Host == "" {
+		return nil, httperr.BadRequest(HeaderUpstreamURL + " must include a host")
+	}
+
+	labels, lerr := parseLabelHeaders(req.Header.Values(HeaderLabel))
+	if lerr != nil {
+		return nil, lerr
+	}
+
+	return &rawProxyEnvelope{upstreamURL: u, labels: labels}, nil
+}
+
+// parseLabelHeaders splits each X-AuthProxy-Label value at the first
+// `=`. Keys are validated downstream by the rate-limit / request-log
+// label pipeline (same path the wrapped ProxyRequest takes), so this
+// layer only enforces structural validity — key non-empty, separator
+// present, value may be empty.
+func parseLabelHeaders(values []string) (map[string]string, *httperr.Error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	labels := make(map[string]string, len(values))
+	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		idx := strings.IndexByte(raw, '=')
+		if idx <= 0 {
+			return nil, httperr.BadRequest("invalid " + HeaderLabel + ": expected <key>=<value>")
+		}
+		labels[raw[:idx]] = raw[idx+1:]
+	}
+	return labels, nil
+}
+
+// copyInboundHeadersForRawProxy copies the caller's headers onto the
+// outbound request, stripping headers that don't make sense on the new
+// hop: authentication (the connector's auth replaces it), our envelope
+// headers, and RFC 7230 §6.1 hop-by-hop headers. Host is set
+// automatically by http.NewRequest from the outbound URL.
+func copyInboundHeadersForRawProxy(dst, src http.Header) {
+	hopByConnection := map[string]struct{}{}
+	for _, v := range src.Values("Connection") {
+		for _, name := range splitCommaTrim(v) {
+			hopByConnection[http.CanonicalHeaderKey(name)] = struct{}{}
+		}
+	}
+	for k, vv := range src {
+		canon := http.CanonicalHeaderKey(k)
+		switch canon {
+		case "Authorization":
+			continue
+		case headerUpstreamURLCanonical, headerLabelCanonical:
+			continue
+		case "Host", "Content-Length":
+			continue
+		}
+		if isHopByHopHeader(canon) {
+			continue
+		}
+		if _, ok := hopByConnection[canon]; ok {
+			continue
+		}
+		dst[canon] = append([]string(nil), vv...)
+	}
+}
+
+// isHopByHopHeader mirrors the same list used inside internal/proxy for
+// the response direction. Duplicated rather than imported to keep
+// internal/proxy a clean leaf package.
+func isHopByHopHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
+		"Te", "Trailers", "Transfer-Encoding", "Upgrade":
+		return true
+	}
+	return false
+}
+
+func splitCommaTrim(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, seg := range strings.Split(s, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
+
+// Compile-time check that gin.ResponseWriter satisfies what the proxy
+// orchestrator needs (Header + WriteHeader + Write + Flush) — caught at
+// build time rather than at the first request.
+var _ http.ResponseWriter = gin.ResponseWriter(nil)
+var _ io.Writer = gin.ResponseWriter(nil)

--- a/internal/routes/connections_proxy_raw_test.go
+++ b/internal/routes/connections_proxy_raw_test.go
@@ -1,0 +1,154 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeReq builds a synthetic *http.Request carrying the supplied
+// envelope headers. The body is left empty — these tests only exercise
+// header parsing.
+func makeReq(t *testing.T, headers map[string][]string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "https://api.local/connections/cxn_1/_proxy_raw", strings.NewReader(""))
+	for k, vv := range headers {
+		for _, v := range vv {
+			r.Header.Add(k, v)
+		}
+	}
+	return r
+}
+
+func TestParseRawProxyEnvelope_RequiresUpstreamURL(t *testing.T) {
+	_, err := parseRawProxyEnvelope(makeReq(t, nil))
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+	assert.Contains(t, err.ResponseMsg, HeaderUpstreamURL)
+}
+
+func TestParseRawProxyEnvelope_RejectsRelativeURL(t *testing.T) {
+	_, err := parseRawProxyEnvelope(makeReq(t, map[string][]string{
+		HeaderUpstreamURL: {"/just/a/path"},
+	}))
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+}
+
+func TestParseRawProxyEnvelope_RejectsNonHTTPScheme(t *testing.T) {
+	for _, u := range []string{"ftp://example.com/x", "ws://example.com/x", "file:///etc/passwd"} {
+		t.Run(u, func(t *testing.T) {
+			_, err := parseRawProxyEnvelope(makeReq(t, map[string][]string{
+				HeaderUpstreamURL: {u},
+			}))
+			require.NotNil(t, err)
+			assert.Equal(t, http.StatusBadRequest, err.Status)
+		})
+	}
+}
+
+func TestParseRawProxyEnvelope_AcceptsHTTPAndHTTPS(t *testing.T) {
+	for _, u := range []string{"http://api.example.com/v1/x", "https://api.example.com/v1/x?q=1"} {
+		t.Run(u, func(t *testing.T) {
+			parsed, err := parseRawProxyEnvelope(makeReq(t, map[string][]string{
+				HeaderUpstreamURL: {u},
+			}))
+			require.Nil(t, err)
+			assert.Equal(t, u, parsed.upstreamURL.String())
+		})
+	}
+}
+
+// TestParseLabelHeaders_RoundTripsKeysContainingSlash is load-bearing:
+// the whole reason we use a repeated header rather than a single
+// comma-joined value is so label keys can contain `/` and other
+// characters that aren't safe inside a comma-delimited list. If this
+// regresses, namespace-scoped labels (org/key) silently lose their
+// separator.
+func TestParseLabelHeaders_RoundTripsKeysContainingSlash(t *testing.T) {
+	labels, err := parseLabelHeaders([]string{
+		"customer=acme",
+		"team/region=us-east",
+		"org/project/env=prod",
+	})
+	require.Nil(t, err)
+	assert.Equal(t, map[string]string{
+		"customer":        "acme",
+		"team/region":     "us-east",
+		"org/project/env": "prod",
+	}, labels)
+}
+
+func TestParseLabelHeaders_SplitsOnFirstEquals(t *testing.T) {
+	labels, err := parseLabelHeaders([]string{"key=a=b=c"})
+	require.Nil(t, err)
+	assert.Equal(t, "a=b=c", labels["key"])
+}
+
+func TestParseLabelHeaders_EmptyValueAllowed(t *testing.T) {
+	labels, err := parseLabelHeaders([]string{"k="})
+	require.Nil(t, err)
+	assert.Equal(t, "", labels["k"])
+}
+
+func TestParseLabelHeaders_RejectsMissingSeparator(t *testing.T) {
+	_, err := parseLabelHeaders([]string{"keyonly"})
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+}
+
+func TestParseLabelHeaders_RejectsLeadingEquals(t *testing.T) {
+	_, err := parseLabelHeaders([]string{"=v"})
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.Status)
+}
+
+func TestParseLabelHeaders_SkipsEmptyEntries(t *testing.T) {
+	labels, err := parseLabelHeaders([]string{"", "  ", "k=v"})
+	require.Nil(t, err)
+	assert.Equal(t, map[string]string{"k": "v"}, labels)
+}
+
+func TestParseLabelHeaders_Nil(t *testing.T) {
+	labels, err := parseLabelHeaders(nil)
+	require.Nil(t, err)
+	assert.Nil(t, labels)
+}
+
+// TestCopyInboundHeadersForRawProxy ensures Authorization, the envelope
+// headers, and the RFC 7230 hop-by-hop set are stripped while a generic
+// caller header (Content-Type, Accept) passes through.
+func TestCopyInboundHeadersForRawProxy(t *testing.T) {
+	src := http.Header{}
+	src.Set("Authorization", "Bearer secret")
+	src.Set(HeaderUpstreamURL, "https://api.example.com/x")
+	src.Add(HeaderLabel, "k=v")
+	src.Set("Content-Type", "application/json")
+	src.Set("Accept", "text/event-stream")
+	src.Set("Connection", "X-Custom-Hop")
+	src.Set("X-Custom-Hop", "should-be-stripped")
+	src.Set("Transfer-Encoding", "chunked")
+	src.Set("Host", "api.local")
+	src.Set("Content-Length", "42")
+	src.Set("X-Customer-Trace", "trace-1")
+
+	dst := http.Header{}
+	copyInboundHeadersForRawProxy(dst, src)
+
+	assert.Equal(t, "application/json", dst.Get("Content-Type"), "passthrough header preserved")
+	assert.Equal(t, "text/event-stream", dst.Get("Accept"), "passthrough header preserved")
+	assert.Equal(t, "trace-1", dst.Get("X-Customer-Trace"), "arbitrary caller header preserved")
+
+	assert.Empty(t, dst.Get("Authorization"), "Authorization must be stripped — connector replaces it")
+	assert.Empty(t, dst.Get(HeaderUpstreamURL), "envelope header must not leak to upstream")
+	assert.Empty(t, dst.Get(HeaderLabel), "envelope header must not leak to upstream")
+	assert.Empty(t, dst.Get("Connection"), "hop-by-hop stripped")
+	assert.Empty(t, dst.Get("X-Custom-Hop"), "header named by Connection: ... stripped")
+	assert.Empty(t, dst.Get("Transfer-Encoding"), "hop-by-hop stripped")
+	assert.Empty(t, dst.Get("Host"), "Host set by http.NewRequest from outbound URL")
+	assert.Empty(t, dst.Get("Content-Length"), "Content-Length set separately from inbound ContentLength")
+}


### PR DESCRIPTION
## Summary

Closes #330. Adds the header-driven streaming raw-proxy path so SSE / LLM token streams / large S3 uploads can flow through AuthProxy without being buffered into a single response.

### New route

`ANY /api/v1/connections/{id}/_proxy_raw`

Reuses the existing `connections:proxy` verb so existing API keys / roles work without policy changes.

### Envelope

- `X-AuthProxy-Upstream-URL` (required) — absolute http(s) URL to forward to.
- `X-AuthProxy-Label` (optional, repeated) — one `<key>=<value>` per header. Repeated rather than comma-joined because label keys may contain `/`.
- `Authorization` is stripped from the inbound request; the connector's `Authenticator` supplies its own.
- Hop-by-hop headers (RFC 7230 §6.1) and headers named by `Connection: ...` are stripped on both directions.

### Streaming path

- Inbound `gctx.Request.Body` is handed directly to the outbound `http.Request.Body`.
- Outbound call goes through `httpf.F.NewHTTPClient()` (new) — the same wrapped RoundTripper chain as the wrapped path (request-log, rate-limit enforcer, OTel), but no gentleman buffering.
- Response copy uses a 32 KiB buffer with `http.Flusher.Flush()` after every successful read, so each upstream chunk reaches the caller as it lands. Trailers pass through via `http.TrailerPrefix`.

### 401 retry

- For requests with no inbound body (nil / `http.NoBody`) the orchestrator runs the same single-attempt retry as the wrapped path: `RecoverFrom401` → re-`Resolve` → replay once.
- For requests where the inbound body has been (or is being) consumed the 401 is surfaced unchanged. A rewindable-body abstraction can be added if this becomes a real problem.

### Notes on the touched interface

`iface.Proxy.ProxyRequestRaw` (and `iface.Connection.ProxyRequestRaw`) now take `*iface.RawProxyRequest` (outbound `*http.Request` + labels) instead of `*ProxyRequest` — the wrapped struct's `BodyRaw []byte` / `BodyJson interface{}` don't fit a streaming body. The only existing impls are this package and `core/mock`, both updated.

## Test plan

- [x] `go test ./...` — all green, including:
  - `internal/proxy.TestProxyRequestRaw_StreamsChunkedBytes` proves bytes arrive before EOF (per-chunk flush)
  - `TestProxyRequestRaw_AttachesCredentialHeader` proves the credential overwrites any caller-supplied `Authorization`
  - `TestProxyRequestRaw_401TriggersRecoverAndRetry` for the bodyless retry path
  - `TestProxyRequestRaw_401SurfacedWhenInboundBodyWasConsumed` for the no-rewind case
  - `TestProxyRequestRaw_HopByHopResponseHeadersStripped`
  - `internal/routes` parse tests cover URL/label header round-trip including keys with `/`, and that the inbound-header sanitizer strips Authorization + envelope + hop-by-hop
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)