### PR TITLE
[A4] Flesh out customer chart values surface with typed sections

### DIFF
--- a/deploy/charts/authproxy/templates/NOTES.txt
+++ b/deploy/charts/authproxy/templates/NOTES.txt
@@ -1,11 +1,14 @@
 {{ include "authproxy.fullname" . }} has been installed.
 
-Image:        {{ include "authproxy.image" . }}
-Replicas:     {{ .Values.replicaCount }}
+Image:       {{ include "authproxy.image" . }}
+Replicas:    {{ .Values.replicaCount }}
+Services:    {{ include "authproxy.enabledServices" . }}
+
+{{- $ports := (include "authproxy.enabledPorts" . | fromYaml).ports }}
 
 Service ports (ClusterIP {{ include "authproxy.fullname" . }}):
-{{- range $name, $port := .Values.service.ports }}
-  {{ $name | kebabcase | printf "%-14s" }} {{ $port }}
+{{- range $ports }}
+  {{ .name | printf "%-14s" }} {{ .port }}
 {{- end }}
 
 {{- if .Values.ingress.enabled }}
@@ -22,21 +25,20 @@ Ingress is enabled. Reachable hosts:
 Ingress is disabled. To reach the service from outside the cluster,
 either enable `ingress.enabled` in your values or port-forward, e.g.:
 
-  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "authproxy.fullname" . }} 8080:{{ .Values.service.ports.public }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "authproxy.fullname" . }} {{ .Values.ports.public }}:{{ .Values.ports.public }}
 {{- end }}
 
 {{- $missing := list }}
-{{- if not .Values.secrets.database.existingSecret }}{{- $missing = append $missing "secrets.database.existingSecret" }}{{- end }}
-{{- if not .Values.secrets.redis.existingSecret }}{{- $missing = append $missing "secrets.redis.existingSecret" }}{{- end }}
-{{- if not .Values.secrets.jwt.existingSecret }}{{- $missing = append $missing "secrets.jwt.existingSecret" }}{{- end }}
-{{- if not .Values.secrets.encryption.existingSecret }}{{- $missing = append $missing "secrets.encryption.existingSecret" }}{{- end }}
+{{- if not .Values.database.existingSecret }}{{- $missing = append $missing "database.existingSecret" }}{{- end }}
+{{- if not .Values.redis.existingSecret }}{{- $missing = append $missing "redis.existingSecret" }}{{- end }}
+{{- if not .Values.jwt.existingSecret }}{{- $missing = append $missing "jwt.existingSecret" }}{{- end }}
+{{- if not .Values.encryptionKeys.existingSecret }}{{- $missing = append $missing "encryptionKeys.existingSecret" }}{{- end }}
+{{- if and .Values.s3.enabled (not .Values.s3.existingSecret) (not .Values.serviceAccount.annotations) }}{{- $missing = append $missing "s3.existingSecret (or serviceAccount.annotations for IRSA)" }}{{- end }}
 {{- if $missing }}
 
 NOTE: the following secret references are unset and the pod will fail to
-start until you provide them (chart deliberately never creates Secrets):
+start until you provide them (the chart deliberately never creates Secrets):
 {{- range $missing }}
   - {{ . }}
 {{- end }}
 {{- end }}
-
-For chart options, run `helm show values authproxy/{{ .Chart.Name }}`.

--- a/deploy/charts/authproxy/templates/_helpers.tpl
+++ b/deploy/charts/authproxy/templates/_helpers.tpl
@@ -67,3 +67,49 @@ Container image reference. Falls back to Chart.appVersion when tag is unset.
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end -}}
+
+{{/*
+Comma-separated list of enabled services in the order accepted by
+`cmd/server serve` (admin-api,api,public,worker). Used for the container
+args. Returns empty string when nothing is enabled (chart validation
+prevents an install in that state).
+
+Output is a single string, no newline.
+*/}}
+{{- define "authproxy.enabledServices" -}}
+{{- $svc := .Values.services -}}
+{{- $list := list -}}
+{{- if $svc.adminApi.enabled }}{{- $list = append $list "admin-api" }}{{- end }}
+{{- if $svc.api.enabled }}{{- $list = append $list "api" }}{{- end }}
+{{- if $svc.public.enabled }}{{- $list = append $list "public" }}{{- end }}
+{{- if $svc.worker.enabled }}{{- $list = append $list "worker" }}{{- end }}
+{{- join "," $list -}}
+{{- end -}}
+
+{{/*
+Build a list of {name, port} tuples for the enabled services that have a
+listening port (i.e. all of public/api/admin-api and worker's health
+endpoint). Used by the Service and Deployment templates so we don't
+expose ports for disabled services.
+
+Returns YAML — call with `| fromYaml | .ports`.
+*/}}
+{{- define "authproxy.enabledPorts" -}}
+ports:
+{{- if .Values.services.public.enabled }}
+  - name: public
+    port: {{ .Values.ports.public }}
+{{- end }}
+{{- if .Values.services.api.enabled }}
+  - name: api
+    port: {{ .Values.ports.api }}
+{{- end }}
+{{- if .Values.services.adminApi.enabled }}
+  - name: admin-api
+    port: {{ .Values.ports.adminApi }}
+{{- end }}
+{{- if .Values.services.worker.enabled }}
+  - name: worker-health
+    port: {{ .Values.ports.workerHealth }}
+{{- end }}
+{{- end -}}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -1,3 +1,76 @@
+{{/*
+Render the AuthProxy config YAML from typed values, layered with the free-
+form `config` overlay. Sensitive fields reference env vars via the
+AuthProxy StringValue { env_var: NAME } pattern so passwords stay in
+Secrets, not in this ConfigMap.
+*/}}
+{{- $cfg := dict -}}
+
+{{/* --- service ports --- */}}
+{{- if .Values.services.public.enabled -}}
+{{- $_ := set $cfg "public" (dict "port" .Values.ports.public) -}}
+{{- end -}}
+{{- if .Values.services.api.enabled -}}
+{{- $_ := set $cfg "api" (dict "port" .Values.ports.api) -}}
+{{- end -}}
+{{- if .Values.services.adminApi.enabled -}}
+{{- $_ := set $cfg "admin_api" (dict "port" .Values.ports.adminApi) -}}
+{{- end -}}
+{{- if .Values.services.worker.enabled -}}
+{{- $_ := set $cfg "worker" (dict "health_check_port" .Values.ports.workerHealth) -}}
+{{- end -}}
+
+{{/* --- database --- */}}
+{{- $db := dict "provider" .Values.database.provider "auto_migrate" .Values.database.autoMigrate -}}
+{{- if eq .Values.database.provider "postgres" -}}
+{{-   $_ := set $db "host" .Values.database.host -}}
+{{-   $_ := set $db "port" .Values.database.port -}}
+{{-   $_ := set $db "user" .Values.database.user -}}
+{{-   $_ := set $db "database" .Values.database.database -}}
+{{-   $_ := set $db "sslmode" .Values.database.sslmode -}}
+{{-   if .Values.database.existingSecret -}}
+{{-     $_ := set $db "password" (dict "env_var" "AUTHPROXY_DB_PASSWORD") -}}
+{{-   end -}}
+{{- else if eq .Values.database.provider "sqlite" -}}
+{{-   $_ := set $db "path" .Values.database.path -}}
+{{- end -}}
+{{- $_ := set $cfg "database" $db -}}
+
+{{/* --- redis --- */}}
+{{- $redis := dict "provider" "redis" "address" .Values.redis.address "db" .Values.redis.db -}}
+{{- if .Values.redis.username -}}
+{{-   $_ := set $redis "username" .Values.redis.username -}}
+{{- end -}}
+{{- if .Values.redis.existingSecret -}}
+{{-   $_ := set $redis "password" (dict "env_var" "AUTHPROXY_REDIS_PASSWORD") -}}
+{{- end -}}
+{{- $_ := set $cfg "redis" $redis -}}
+
+{{/* --- s3 (request-log blob storage) --- */}}
+{{- if .Values.s3.enabled -}}
+{{-   $s3 := dict "provider" "s3" "bucket" .Values.s3.bucket "force_path_style" .Values.s3.forcePathStyle -}}
+{{-   if .Values.s3.region -}}{{- $_ := set $s3 "region" .Values.s3.region -}}{{- end -}}
+{{-   if .Values.s3.endpoint -}}{{- $_ := set $s3 "endpoint" .Values.s3.endpoint -}}{{- end -}}
+{{-   if .Values.s3.prefix -}}{{- $_ := set $s3 "prefix" .Values.s3.prefix -}}{{- end -}}
+{{-   $creds := dict "type" "implicit" -}}
+{{-   $_ := set $s3 "credentials" $creds -}}
+{{-   $_ := set $cfg "blob_storage" $s3 -}}
+{{- end -}}
+
+{{/* --- crypto material file paths --- */}}
+{{- if .Values.jwt.existingSecret -}}
+{{-   $sysAuth := dict "jwt_signing_key" (dict
+        "public_key" (dict "path" (printf "%s/%s" .Values.jwt.mountPath .Values.jwt.publicKeyFile))
+        "private_key" (dict "path" (printf "%s/%s" .Values.jwt.mountPath .Values.jwt.privateKeyFile))) -}}
+{{-   if .Values.encryptionKeys.existingSecret -}}
+{{-     $_ := set $sysAuth "global_aes_key" (dict "path" (printf "%s/%s" .Values.encryptionKeys.mountPath .Values.encryptionKeys.globalAesKeyFile)) -}}
+{{-     $_ := set $sysAuth "actors" (dict "keys_path" (printf "%s/%s" .Values.encryptionKeys.mountPath .Values.encryptionKeys.actorsKeysDir)) -}}
+{{-   end -}}
+{{-   $_ := set $cfg "system_auth" $sysAuth -}}
+{{- end -}}
+
+{{/* --- overlay: merge user-provided `config` over the rendered defaults --- */}}
+{{- $cfg = mergeOverwrite $cfg .Values.config -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,4 +79,4 @@ metadata:
     {{- include "authproxy.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml $cfg | nindent 4 }}

--- a/deploy/charts/authproxy/templates/deployment.yaml
+++ b/deploy/charts/authproxy/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- $services := include "authproxy.enabledServices" . -}}
+{{- if not $services -}}
+{{- fail "At least one service must be enabled. Set services.<id>.enabled=true for one of: api, adminApi, public, worker." -}}
+{{- end -}}
+{{- $ports := (include "authproxy.enabledPorts" . | fromYaml).ports -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,28 +48,31 @@ spec:
           args:
             - serve
             - --config=/etc/authproxy/config.yaml
-            - all
+            - {{ $services | quote }}
+          {{- if $ports }}
           ports:
-            {{- range $name, $port := .Values.service.ports }}
-            - name: {{ $name | kebabcase }}
-              containerPort: {{ $port }}
+            {{- range $ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
               protocol: TCP
             {{- end }}
-          {{- if or .Values.secrets.database.existingSecret .Values.secrets.redis.existingSecret .Values.secrets.s3.existingSecret }}
+          {{- end }}
+          {{- if or .Values.database.existingSecret .Values.redis.existingSecret .Values.s3.existingSecret }}
           envFrom:
-            {{- with .Values.secrets.database.existingSecret }}
+            {{- with .Values.database.existingSecret }}
             - secretRef:
                 name: {{ . }}
             {{- end }}
-            {{- with .Values.secrets.redis.existingSecret }}
+            {{- with .Values.redis.existingSecret }}
             - secretRef:
                 name: {{ . }}
             {{- end }}
-            {{- with .Values.secrets.s3.existingSecret }}
+            {{- with .Values.s3.existingSecret }}
             - secretRef:
                 name: {{ . }}
             {{- end }}
           {{- end }}
+          {{- if .Values.services.public.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.healthcheck.path }}
@@ -77,6 +85,7 @@ spec:
               port: public
             initialDelaySeconds: {{ .Values.healthcheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthcheck.periodSeconds }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -86,26 +95,26 @@ spec:
               mountPath: /etc/authproxy/config.yaml
               subPath: config.yaml
               readOnly: true
-            {{- with .Values.secrets.jwt.existingSecret }}
+            {{- with .Values.jwt.existingSecret }}
             - name: jwt-keys
-              mountPath: {{ $.Values.secrets.jwt.mountPath }}
+              mountPath: {{ $.Values.jwt.mountPath }}
               readOnly: true
             {{- end }}
-            {{- with .Values.secrets.encryption.existingSecret }}
+            {{- with .Values.encryptionKeys.existingSecret }}
             - name: encryption-keys
-              mountPath: {{ $.Values.secrets.encryption.mountPath }}
+              mountPath: {{ $.Values.encryptionKeys.mountPath }}
               readOnly: true
             {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "authproxy.fullname" . }}-config
-        {{- with .Values.secrets.jwt.existingSecret }}
+        {{- with .Values.jwt.existingSecret }}
         - name: jwt-keys
           secret:
             secretName: {{ . }}
         {{- end }}
-        {{- with .Values.secrets.encryption.existingSecret }}
+        {{- with .Values.encryptionKeys.existingSecret }}
         - name: encryption-keys
           secret:
             secretName: {{ . }}

--- a/deploy/charts/authproxy/templates/service.yaml
+++ b/deploy/charts/authproxy/templates/service.yaml
@@ -1,3 +1,5 @@
+{{- $ports := (include "authproxy.enabledPorts" . | fromYaml).ports -}}
+{{- if $ports -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,9 +11,10 @@ spec:
   selector:
     {{- include "authproxy.selectorLabels" . | nindent 4 }}
   ports:
-    {{- range $name, $port := .Values.service.ports }}
-    - name: {{ $name | kebabcase }}
-      port: {{ $port }}
-      targetPort: {{ $name | kebabcase }}
+    {{- range $ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
       protocol: TCP
     {{- end }}
+{{- end }}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "AuthProxy Helm chart values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag":        { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "required": ["repository"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      }
+    },
+    "nameOverride":     { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create":      { "type": "boolean" },
+        "name":        { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+
+    "replicaCount":     { "type": "integer", "minimum": 1 },
+    "podAnnotations":   { "type": "object", "additionalProperties": { "type": "string" } },
+    "podLabels":        { "type": "object", "additionalProperties": { "type": "string" } },
+    "podSecurityContext": { "type": "object" },
+    "securityContext":  { "type": "object" },
+    "resources":        { "type": "object" },
+    "nodeSelector":     { "type": "object", "additionalProperties": { "type": "string" } },
+    "tolerations":      { "type": "array" },
+    "affinity":         { "type": "object" },
+
+    "services": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "api":      { "$ref": "#/definitions/serviceToggle" },
+        "adminApi": { "$ref": "#/definitions/serviceToggle" },
+        "public":   { "$ref": "#/definitions/serviceToggle" },
+        "worker":   { "$ref": "#/definitions/serviceToggle" }
+      }
+    },
+
+    "ports": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "public":       { "$ref": "#/definitions/portNumber" },
+        "api":          { "$ref": "#/definitions/portNumber" },
+        "adminApi":     { "$ref": "#/definitions/portNumber" },
+        "workerHealth": { "$ref": "#/definitions/portNumber" }
+      }
+    },
+
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] }
+      }
+    },
+
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":     { "type": "boolean" },
+        "className":   { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": { "type": "string", "minLength": 1 },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path":     { "type": "string", "minLength": 1 },
+                    "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] },
+                    "service":  { "type": "string", "enum": ["public", "api", "adminApi", "workerHealth"] }
+                  },
+                  "required": ["path", "service"]
+                }
+              }
+            },
+            "required": ["host", "paths"]
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hosts":      { "type": "array", "items": { "type": "string" } },
+              "secretName": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider":       { "type": "string", "enum": ["postgres", "sqlite"] },
+        "host":           { "type": "string" },
+        "port":           { "$ref": "#/definitions/portNumber" },
+        "database":       { "type": "string" },
+        "user":           { "type": "string" },
+        "sslmode":        { "type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] },
+        "autoMigrate":    { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "path":           { "type": "string" }
+      },
+      "required": ["provider"]
+    },
+
+    "redis": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "address":        { "type": "string" },
+        "username":       { "type": "string" },
+        "db":             { "type": "integer", "minimum": 0 },
+        "existingSecret": { "type": "string" }
+      }
+    },
+
+    "s3": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":        { "type": "boolean" },
+        "bucket":         { "type": "string" },
+        "region":         { "type": "string" },
+        "endpoint":       { "type": "string" },
+        "prefix":         { "type": "string" },
+        "forcePathStyle": { "type": "boolean" },
+        "existingSecret": { "type": "string" }
+      }
+    },
+
+    "jwt": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "mountPath":      { "type": "string" },
+        "publicKeyFile":  { "type": "string" },
+        "privateKeyFile": { "type": "string" }
+      }
+    },
+
+    "encryptionKeys": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret":   { "type": "string" },
+        "mountPath":        { "type": "string" },
+        "globalAesKeyFile": { "type": "string" },
+        "actorsKeysDir":    { "type": "string" }
+      }
+    },
+
+    "config": { "type": "object" },
+
+    "healthcheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path":                { "type": "string", "pattern": "^/" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds":       { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "definitions": {
+    "serviceToggle": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "portNumber": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    }
+  }
+}

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -1,8 +1,14 @@
 # Default values for the authproxy chart.
 #
-# A3 scope: a minimal but valid surface that lets the chart render valid
-# Kubernetes manifests. A4 (#292) expands this with typed fields for
-# database, redis, s3, jwt, encryption keys, services-on/off, etc.
+# Section guide:
+#   image / serviceAccount / replicaCount / resources / ...  — standard pod knobs
+#   services.<id>.enabled                                     — toggle individual services
+#   ports                                                     — container port assignments
+#   ingress                                                   — single Ingress, port-name backends
+#   database / redis / s3                                     — typed connectivity blocks
+#   jwt / encryptionKeys                                      — Secret volumes for crypto material
+#   config                                                    — escape hatch merged into the rendered AuthProxy YAML
+#   healthcheck                                               — liveness / readiness shared knobs
 
 # -- Container image to deploy.
 image:
@@ -23,15 +29,16 @@ serviceAccount:
   # -- Create a ServiceAccount for the pods.
   create: true
   # -- Annotations to apply to the ServiceAccount. Set
-  # `eks.amazonaws.com/role-arn` here to wire IRSA for S3 + other AWS APIs.
+  # `eks.amazonaws.com/role-arn` here to wire IRSA for S3 (and skip
+  # `s3.existingSecret`).
   annotations: {}
   # -- ServiceAccount name. Generated from the release name if empty.
   name: ""
 
-# -- Replica count for the AuthProxy pod. The chart deploys all four
-# services (api, admin-api, public, worker) as a single Deployment running
-# `serve all`; for independent scaling per service, run the chart multiple
-# times with different `runServices` (A4) or wait for the per-service mode.
+# -- Replica count for the AuthProxy pod. The chart deploys a single
+# Deployment running the union of enabled services in one process; for
+# independent scaling per service, install the chart multiple times with
+# different `services` blocks (see chart README for examples).
 replicaCount: 1
 
 # -- Annotations applied to each pod.
@@ -53,16 +60,29 @@ tolerations: []
 # -- Affinity rules.
 affinity: {}
 
+# -- Toggle individual services. Disabled services are dropped from the
+# `serve` argument list and from the Service's port list. Disabling
+# `public` also disables the liveness/readiness probe (no HTTP listener).
+services:
+  api:
+    enabled: true
+  adminApi:
+    enabled: true
+  public:
+    enabled: true
+  worker:
+    enabled: true
+
+# -- Container port assignments. Match the AuthProxy config port fields.
+ports:
+  public: 8080
+  api: 8081
+  adminApi: 8082
+  workerHealth: 8083
+
 service:
   # -- Service type.
   type: ClusterIP
-  # -- Per-service container port mapping. Names match the AuthProxy service
-  # IDs; ingress.hosts[].paths[].service references them by key.
-  ports:
-    public: 8080
-    api: 8081
-    adminApi: 8082
-    workerHealth: 8083
 
 ingress:
   # -- Enable an Ingress resource.
@@ -72,7 +92,7 @@ ingress:
   # -- Annotations applied to the Ingress.
   annotations: {}
   # -- Host + path rules. Each path references a `service` key from
-  # `service.ports` above.
+  # `ports` above (in camelCase).
   hosts:
     - host: authproxy.local
       paths:
@@ -82,44 +102,83 @@ ingress:
   # -- TLS configuration entries.
   tls: []
 
-# -- Inline AuthProxy YAML config. Rendered into a ConfigMap and mounted at
-# /etc/authproxy/config.yaml in the container. A4 (#292) ships typed
-# top-level keys (`database`, `redis`, `s3`, etc.) that compose into this
-# map; for now the chart only ships the minimum config needed to render.
-config:
-  public:
-    port: 8080
-  api:
-    port: 8081
-  admin_api:
-    port: 8082
-  worker:
-    health_check_port: 8083
+# -- Database connectivity. AuthProxy supports postgres + sqlite; postgres
+# is the production-typical choice and is the default here.
+database:
+  # -- Provider: `postgres` or `sqlite`.
+  provider: postgres
+  # -- Postgres host (required for postgres provider).
+  host: ""
+  # -- Postgres port.
+  port: 5432
+  # -- Database name.
+  database: authproxy
+  # -- Postgres user.
+  user: authproxy
+  # -- Postgres SSL mode (`disable`, `require`, `verify-ca`, `verify-full`).
+  sslmode: require
+  # -- Run schema migrations at startup.
+  autoMigrate: true
+  # -- Secret holding the database password. Must contain a key named
+  # `AUTHPROXY_DB_PASSWORD` (the env var the rendered config references).
+  # The chart wires it via `envFrom`; the password never appears in the
+  # rendered ConfigMap.
+  existingSecret: ""
+  # -- SQLite-only: filesystem path. Ignored when provider=postgres.
+  path: /var/lib/authproxy/authproxy.db
 
-# -- References to externally managed Secrets. The chart wires `envFrom`
-# entries so the container picks up credentials at startup; the chart never
-# creates the Secrets themselves. A4 will rename these to typed sections
-# (`database.existingSecret`, `redis.existingSecret`, etc.).
-secrets:
-  # -- Database connection credentials (POSTGRES_* env vars expected).
-  database:
-    existingSecret: ""
-  # -- Redis connection credentials.
-  redis:
-    existingSecret: ""
-  # -- S3 credentials (only needed when not using IRSA).
-  s3:
-    existingSecret: ""
-  # -- JWT signing key pair and admin actor keys (mounted as files).
-  jwt:
-    existingSecret: ""
-    mountPath: /etc/authproxy/keys/jwt
-  # -- Encryption keys (mounted as files).
-  encryption:
-    existingSecret: ""
-    mountPath: /etc/authproxy/keys/encryption
+# -- Redis connectivity. Required for sessions, async tasks, rate-limit
+# cache, and OAuth round-trip state.
+redis:
+  # -- host:port (required).
+  address: ""
+  # -- Optional Redis username (Redis 6 ACLs).
+  username: ""
+  # -- Logical DB index.
+  db: 0
+  # -- Secret holding the redis password. Must contain a key named
+  # `AUTHPROXY_REDIS_PASSWORD` (the env var the rendered config references).
+  existingSecret: ""
 
-# -- HTTP path on the public service used for liveness / readiness probes.
+# -- S3-compatible blob storage for request-log payloads. Disabled by
+# default; AuthProxy falls back to local/no blob storage when omitted.
+s3:
+  enabled: false
+  bucket: ""
+  region: ""
+  # -- Optional S3 endpoint (e.g. MinIO). Leave empty to use AWS defaults.
+  endpoint: ""
+  # -- Optional key prefix for stored objects.
+  prefix: ""
+  # -- Force path-style addressing (MinIO + most S3-compatible services).
+  forcePathStyle: false
+  # -- Secret holding AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars.
+  # Leave empty when using IRSA (set `serviceAccount.annotations` instead).
+  existingSecret: ""
+
+# -- JWT signing key pair, mounted into the container as files (paths are
+# substituted into the rendered config). The chart only references the
+# Secret; customers create it.
+jwt:
+  existingSecret: ""
+  mountPath: /etc/authproxy/keys/jwt
+  publicKeyFile: system.pub
+  privateKeyFile: system
+
+# -- Encryption keys (global AES key + actor signing keys), mounted as a
+# Secret volume.
+encryptionKeys:
+  existingSecret: ""
+  mountPath: /etc/authproxy/keys/encryption
+  globalAesKeyFile: global_aes.key
+  actorsKeysDir: actors
+
+# -- Free-form config overlay merged on top of the rendered AuthProxy YAML.
+# Use this for fields the chart hasn't promoted to typed values yet.
+config: {}
+
+# -- Liveness / readiness probe configuration. Targets the public service;
+# only emitted when `services.public.enabled` is true.
 healthcheck:
   path: /healthz
   initialDelaySeconds: 10


### PR DESCRIPTION
## Summary

Replaces the A3 scaffold's stub `secrets.X.existingSecret` blocks with typed top-level sections that map directly to AuthProxy's config schema, plus per-service `enabled` toggles, plus `values.schema.json` so bad values fail at `helm install` rather than at pod startup.

## What the values surface looks like now

```yaml
database:                         # postgres (default) or sqlite
  provider: postgres
  host: ""
  port: 5432
  user: authproxy
  database: authproxy
  sslmode: require
  autoMigrate: true
  existingSecret: ""              # must contain AUTHPROXY_DB_PASSWORD key
  path: /var/lib/authproxy/...    # sqlite-only

redis:
  address: ""
  username: ""
  db: 0
  existingSecret: ""              # must contain AUTHPROXY_REDIS_PASSWORD key

s3:                               # request-log blob storage, disabled by default
  enabled: false
  bucket: "" / region: "" / endpoint: "" / prefix: ""
  forcePathStyle: false
  existingSecret: ""              # AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
                                  # (omit when using IRSA — set
                                  # serviceAccount.annotations instead)

jwt:                              # signing key pair (Secret volume)
  existingSecret: ""
  mountPath: /etc/authproxy/keys/jwt
  publicKeyFile: system.pub
  privateKeyFile: system

encryptionKeys:                   # global AES + actor keys (Secret volume)
  existingSecret: ""
  mountPath: /etc/authproxy/keys/encryption
  globalAesKeyFile: global_aes.key
  actorsKeysDir: actors

services:                         # per-service enable flags drive
  api:      { enabled: true }     #   - the `serve` arg list
  adminApi: { enabled: true }     #   - the Service's port list
  public:   { enabled: true }     #   - whether probes are emitted
  worker:   { enabled: true }
```

## Secret pattern

Passwords flow through env vars, not the ConfigMap:
- The chart renders `password: { env_var: AUTHPROXY_DB_PASSWORD }` in the config when `database.existingSecret` is set
- `envFrom: { secretRef: { name: <secret> } }` lands the Secret's keys as env vars
- AuthProxy's `StringValue` type reads the env var at startup

The convention: customer's Secret has keys named `AUTHPROXY_DB_PASSWORD`, `AUTHPROXY_REDIS_PASSWORD`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Tooling like External Secrets Operator handles remapping if their source secret uses different names.

## Per-service `enabled` toggles

`services.<id>.enabled` controls three things:

| Mode | `serve` arg | Ports exposed | Probes |
|---|---|---|---|
| All enabled (default) | `admin-api,api,public,worker` | all 4 | yes |
| Only api + worker     | `api,worker`                  | api, worker-health | no |
| Only public           | `public`                      | public | yes |

The Deployment renders one container running the union; `cmd/server serve` already accepts a comma-separated service list, so no app code changes are needed. Subset mode is useful for splitting roles across separate releases (e.g. worker pool sized independently from API tier).

## Schema validation

New `values.schema.json` validates the typed surface. Catches:
- bad `database.provider` → must be `postgres` or `sqlite`
- port out of range
- non-boolean `enabled`
- unknown keys under any typed block (`additionalProperties: false`)
- garbage `ingress.hosts[].paths[].service` values (must reference a defined service key)

`config:` remains a free-form escape hatch (`additionalProperties: true` at the root).

## Verified locally

- `helm lint` clean (informational `icon is recommended` only)
- `helm template` with defaults: 4 services, no envFrom (no secrets set), no password fields in rendered config
- `helm template` with full overrides: env_var references in config, envFrom + volume mounts, ingress wired correctly
- `helm template` subset (only api+worker): args = `"api,worker"`, only api + worker-health ports exposed, no probes block
- `helm install --dry-run=client` passes; NOTES emits the now-typed "secret X unset" list
- `values.schema.json` rejects bad provider / port / type with clear errors
- `./scripts/preflight.sh` clean

## Acceptance (per #292)

- [x] Every value documented in `values.yaml` with comments
- [x] All values referenced by templates (no dead keys)
- [x] Schema validation via `values.schema.json`

Closes #292. Part of #284.