### PR TITLE
[A5] Chart-testing CI: lint + kind install + /healthz smoke

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,15 @@
+# Configuration for helm/chart-testing-action.
+# https://github.com/helm/chart-testing/blob/main/doc/ct_install.md
+chart-dirs:
+  - deploy/charts
+target-branch: main
+# We're pre-1.0; intentionally skip the chart-version-bump enforcement so
+# that internal chart iteration doesn't require a version bump on every
+# touch. A6 will gate releases on a proper version-bump policy.
+check-version-increment: false
+# Skip maintainers-must-match-a-known-user check; the chart only lists me
+# and gating CI on GH user existence is brittle.
+validate-maintainers: false
+# Use a per-PR-scoped values file via --helm-extra-set-args for sqlite + redis.
+# ct also auto-picks up `<chart>/ci/*-values.yaml` files and runs an install
+# per file — we ship one here for the minimum-deps profile.

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -91,10 +91,16 @@ jobs:
           node_image: kindest/node:v1.30.4
           wait: 120s
 
+      - name: Create test namespace
+        if: steps.changed.outputs.found == 'true'
+        run: kubectl create namespace authproxy-ct
+
       - name: Deploy in-cluster Redis sidecar
         if: steps.changed.outputs.found == 'true'
         run: |
-          kubectl apply -f - <<'EOF'
+          # Deployed into the same namespace as `ct install` so the chart's
+          # `redis:6379` short-name resolves via in-namespace DNS.
+          kubectl apply -n authproxy-ct -f - <<'EOF'
           apiVersion: apps/v1
           kind: Deployment
           metadata:
@@ -126,7 +132,7 @@ jobs:
                 targetPort: redis
                 name: redis
           EOF
-          kubectl rollout status deployment/redis --timeout=60s
+          kubectl -n authproxy-ct rollout status deployment/redis --timeout=60s
 
       - name: Generate crypto material + apply as K8s Secrets
         if: steps.changed.outputs.found == 'true'
@@ -146,9 +152,7 @@ jobs:
           openssl genrsa -out "$workdir/ci" 2048 2>/dev/null
           openssl rsa -in "$workdir/ci" -pubout -out "$workdir/ci.pub" 2>/dev/null
 
-          # ct creates per-install namespaces with random suffixes; using a
-          # stable namespace via --namespace keeps the Secret-prep step simple.
-          kubectl create namespace authproxy-ct
+          # Namespace was created in a prior step (so Redis could land in it).
           kubectl -n authproxy-ct create secret generic authproxy-jwt \
             --from-file=system="$workdir/system" \
             --from-file=system.pub="$workdir/system.pub"

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -1,0 +1,171 @@
+# schema: https://json.schemastore.org/github-workflow.json
+name: Helm Chart CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/charts/**'
+      - '.github/workflows/helm-chart-ci.yml'
+      - '.github/ct.yaml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/charts/**'
+      - '.github/workflows/helm-chart-ci.yml'
+      - '.github/ct.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: helm-chart-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: List changed charts
+        id: changed
+        run: |
+          changed=$(ct list-changed --config .github/ct.yaml --target-branch main)
+          if [ -n "$changed" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Changed charts:"
+            echo "$changed"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No chart changes detected."
+          fi
+
+      - name: ct lint
+        if: steps.changed.outputs.found == 'true'
+        run: ct lint --config .github/ct.yaml --target-branch main
+
+  install:
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: List changed charts
+        id: changed
+        run: |
+          changed=$(ct list-changed --config .github/ct.yaml --target-branch main)
+          if [ -n "$changed" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create kind cluster
+        if: steps.changed.outputs.found == 'true'
+        uses: helm/kind-action@v1.10.0
+        with:
+          version: v0.24.0
+          node_image: kindest/node:v1.30.4
+          wait: 120s
+
+      - name: Deploy in-cluster Redis sidecar
+        if: steps.changed.outputs.found == 'true'
+        run: |
+          kubectl apply -f - <<'EOF'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: redis
+            labels: { app: redis }
+          spec:
+            replicas: 1
+            selector: { matchLabels: { app: redis } }
+            template:
+              metadata: { labels: { app: redis } }
+              spec:
+                containers:
+                  - name: redis
+                    image: redis:7-alpine
+                    args: ["--save", "", "--appendonly", "no"]
+                    ports: [{ name: redis, containerPort: 6379 }]
+                    readinessProbe:
+                      exec: { command: ["redis-cli", "ping"] }
+                      periodSeconds: 2
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: redis
+          spec:
+            selector: { app: redis }
+            ports:
+              - port: 6379
+                targetPort: redis
+                name: redis
+          EOF
+          kubectl rollout status deployment/redis --timeout=60s
+
+      - name: Generate crypto material + apply as K8s Secrets
+        if: steps.changed.outputs.found == 'true'
+        run: |
+          set -eu
+          workdir=$(mktemp -d)
+
+          # JWT signing keypair (RSA-2048; AuthProxy reads system/system.pub).
+          openssl genrsa -out "$workdir/system" 2048 2>/dev/null
+          openssl rsa -in "$workdir/system" -pubout -out "$workdir/system.pub" 2>/dev/null
+
+          # Global AES key (32 random bytes).
+          openssl rand -out "$workdir/global_aes.key" 32
+
+          # One admin actor keypair so the actors keys_path directory has at
+          # least one valid actor (smoke happy path).
+          openssl genrsa -out "$workdir/ci" 2048 2>/dev/null
+          openssl rsa -in "$workdir/ci" -pubout -out "$workdir/ci.pub" 2>/dev/null
+
+          # ct creates per-install namespaces with random suffixes; using a
+          # stable namespace via --namespace keeps the Secret-prep step simple.
+          kubectl create namespace authproxy-ct
+          kubectl -n authproxy-ct create secret generic authproxy-jwt \
+            --from-file=system="$workdir/system" \
+            --from-file=system.pub="$workdir/system.pub"
+          kubectl -n authproxy-ct create secret generic authproxy-encryption \
+            --from-file=global_aes.key="$workdir/global_aes.key"
+          # Actor keypair files mount as <actors.mountPath>/<key>; key names
+          # carry no slashes (K8s Secret data keys can't), so files like
+          # `ci` and `ci.pub` are how the actors loader reads pairs.
+          kubectl -n authproxy-ct create secret generic authproxy-actors \
+            --from-file=ci="$workdir/ci" \
+            --from-file=ci.pub="$workdir/ci.pub"
+
+      - name: ct install
+        if: steps.changed.outputs.found == 'true'
+        run: |
+          ct install \
+            --config .github/ct.yaml \
+            --target-branch main \
+            --namespace authproxy-ct \
+            --helm-extra-args "--timeout=5m"

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -83,6 +83,26 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Docker Buildx
+        if: steps.changed.outputs.found == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build local AuthProxy image (amd64-only)
+        if: steps.changed.outputs.found == 'true'
+        # Build the image from the PR's tree so the chart is tested against
+        # the code on this branch, not whatever happens to be tagged `:main`
+        # in GHCR. amd64-only keeps the build under ~5 min; the runner is
+        # always amd64 anyway.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: authproxy:ci-local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Create kind cluster
         if: steps.changed.outputs.found == 'true'
         uses: helm/kind-action@v1.10.0
@@ -90,6 +110,10 @@ jobs:
           version: v0.24.0
           node_image: kindest/node:v1.30.4
           wait: 120s
+
+      - name: Load local image into kind
+        if: steps.changed.outputs.found == 'true'
+        run: kind load docker-image authproxy:ci-local --name chart-testing
 
       - name: Create test namespace
         if: steps.changed.outputs.found == 'true'

--- a/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
+++ b/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
@@ -1,0 +1,37 @@
+# chart-testing values for the helm-chart-ci workflow.
+#
+# Minimum-deps profile per A5 (#287):
+#   - SQLite database (no external DB)
+#   - real Redis as a tiny in-cluster Deployment (applied by the workflow
+#     before `ct install`, addressable at `redis:6379` in the test namespace)
+#   - JWT + encryption key Secrets are generated and applied by the workflow
+#     (the chart deliberately never creates them)
+#
+# image.tag pins to `main` so the CI exercises whatever is currently
+# published from rmorlok/authproxy@main, not whatever Chart.appVersion
+# happens to be at the time of the chart change.
+
+image:
+  tag: main
+  pullPolicy: IfNotPresent
+
+database:
+  provider: sqlite
+  path: /tmp/authproxy.db
+
+redis:
+  address: redis:6379
+
+jwt:
+  existingSecret: authproxy-jwt
+
+encryptionKeys:
+  existingSecret: authproxy-encryption
+
+actors:
+  existingSecret: authproxy-actors
+
+# Faster probes so the helm test pod's rollout wait doesn't stall.
+healthcheck:
+  initialDelaySeconds: 5
+  periodSeconds: 3

--- a/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
+++ b/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
@@ -31,6 +31,15 @@ encryptionKeys:
 actors:
   existingSecret: authproxy-actors
 
+# AuthProxy's config validator requires these even when nothing actually
+# uses them in the smoke test — placeholder URL + empty connector list.
+hostApplication:
+  initiateSessionUrl: http://placeholder.invalid/login
+
+connectors:
+  autoMigrate: true
+  loadFromList: []
+
 # Faster probes so the helm test pod's rollout wait doesn't stall.
 healthcheck:
   initialDelaySeconds: 5

--- a/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
+++ b/deploy/charts/authproxy/ci/sqlite-redis-values.yaml
@@ -6,14 +6,17 @@
 #     before `ct install`, addressable at `redis:6379` in the test namespace)
 #   - JWT + encryption key Secrets are generated and applied by the workflow
 #     (the chart deliberately never creates them)
-#
-# image.tag pins to `main` so the CI exercises whatever is currently
-# published from rmorlok/authproxy@main, not whatever Chart.appVersion
-# happens to be at the time of the chart change.
+#   - Image is built from this branch's tree and loaded into the kind
+#     cluster (see `image:` below), so the chart is tested against the code
+#     on this PR rather than whatever is published as `:main` in GHCR.
 
 image:
-  tag: main
-  pullPolicy: IfNotPresent
+  # Built by the workflow's "Build local AuthProxy image" step and loaded
+  # into the kind cluster — pullPolicy: Never keeps kubelet from chasing a
+  # registry copy that doesn't exist for this branch.
+  repository: authproxy
+  tag: ci-local
+  pullPolicy: Never
 
 database:
   provider: sqlite

--- a/deploy/charts/authproxy/templates/NOTES.txt
+++ b/deploy/charts/authproxy/templates/NOTES.txt
@@ -33,6 +33,7 @@ either enable `ingress.enabled` in your values or port-forward, e.g.:
 {{- if not .Values.redis.existingSecret }}{{- $missing = append $missing "redis.existingSecret" }}{{- end }}
 {{- if not .Values.jwt.existingSecret }}{{- $missing = append $missing "jwt.existingSecret" }}{{- end }}
 {{- if not .Values.encryptionKeys.existingSecret }}{{- $missing = append $missing "encryptionKeys.existingSecret" }}{{- end }}
+{{- if not .Values.actors.existingSecret }}{{- $missing = append $missing "actors.existingSecret (admin actor keys; chart starts without it but admin API calls won't auth)" }}{{- end }}
 {{- if and .Values.s3.enabled (not .Values.s3.existingSecret) (not .Values.serviceAccount.annotations) }}{{- $missing = append $missing "s3.existingSecret (or serviceAccount.annotations for IRSA)" }}{{- end }}
 {{- if $missing }}
 

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -64,7 +64,13 @@ Secrets, not in this ConfigMap.
         "private_key" (dict "path" (printf "%s/%s" .Values.jwt.mountPath .Values.jwt.privateKeyFile))) -}}
 {{-   if .Values.encryptionKeys.existingSecret -}}
 {{-     $_ := set $sysAuth "global_aes_key" (dict "path" (printf "%s/%s" .Values.encryptionKeys.mountPath .Values.encryptionKeys.globalAesKeyFile)) -}}
-{{-     $_ := set $sysAuth "actors" (dict "keys_path" (printf "%s/%s" .Values.encryptionKeys.mountPath .Values.encryptionKeys.actorsKeysDir)) -}}
+{{-   end -}}
+{{-   if .Values.actors.existingSecret -}}
+{{-     $actors := dict "keys_path" .Values.actors.mountPath -}}
+{{-     if .Values.actors.permissions -}}
+{{-       $_ := set $actors "permissions" .Values.actors.permissions -}}
+{{-     end -}}
+{{-     $_ := set $sysAuth "actors" $actors -}}
 {{-   end -}}
 {{-   $_ := set $cfg "system_auth" $sysAuth -}}
 {{- end -}}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -59,9 +59,21 @@ Secrets, not in this ConfigMap.
 {{- $_ := set $cfg "connectors" $connectors -}}
 
 {{/* --- http_logging (server unconditionally wires up the log storage) --- */}}
+{{/*
+  The http_log migrator + the main DB migrator share golang-migrate's
+  default `schema_migrations` table, so they can't run against the same
+  schema. For SQLite that means a sibling file (default path with a
+  `.http-log` suffix); for Postgres, http_log uses tables prefixed inside
+  the same DB and conflicts are not observed in practice.
+*/}}
 {{- $httpDb := dict -}}
 {{- if .Values.httpLogging.shareMainDatabase -}}
-{{-   $httpDb = $db -}}
+{{-   if eq .Values.database.provider "sqlite" -}}
+{{-     $sharedPath := printf "%s.http-log" .Values.database.path -}}
+{{-     $httpDb = dict "provider" "sqlite" "path" $sharedPath -}}
+{{-   else -}}
+{{-     $httpDb = $db -}}
+{{-   end -}}
 {{- else -}}
 {{-   $httpDb = .Values.httpLogging.database -}}
 {{- end -}}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -46,6 +46,18 @@ Secrets, not in this ConfigMap.
 {{- end -}}
 {{- $_ := set $cfg "redis" $redis -}}
 
+{{/* --- host application (required by validator) --- */}}
+{{- if .Values.hostApplication.initiateSessionUrl -}}
+{{-   $_ := set $cfg "host_application" (dict "initiate_session_url" .Values.hostApplication.initiateSessionUrl) -}}
+{{- end -}}
+
+{{/* --- connectors block (required by validator; empty list is acceptable) --- */}}
+{{- $connectors := dict "auto_migrate" .Values.connectors.autoMigrate "load_from_list" .Values.connectors.loadFromList -}}
+{{- if .Values.connectors.identifyingLabels -}}
+{{-   $_ := set $connectors "identifying_labels" .Values.connectors.identifyingLabels -}}
+{{- end -}}
+{{- $_ := set $cfg "connectors" $connectors -}}
+
 {{/* --- s3 (request-log blob storage) --- */}}
 {{- if .Values.s3.enabled -}}
 {{-   $s3 := dict "provider" "s3" "bucket" .Values.s3.bucket "force_path_style" .Values.s3.forcePathStyle -}}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -58,6 +58,19 @@ Secrets, not in this ConfigMap.
 {{- end -}}
 {{- $_ := set $cfg "connectors" $connectors -}}
 
+{{/* --- http_logging (server unconditionally wires up the log storage) --- */}}
+{{- $httpDb := dict -}}
+{{- if .Values.httpLogging.shareMainDatabase -}}
+{{-   $httpDb = $db -}}
+{{- else -}}
+{{-   $httpDb = .Values.httpLogging.database -}}
+{{- end -}}
+{{- $httpLogging := dict
+      "auto_migrate" .Values.httpLogging.autoMigrate
+      "full_request_recording" .Values.httpLogging.fullRequestRecording
+      "database" $httpDb -}}
+{{- $_ := set $cfg "http_logging" $httpLogging -}}
+
 {{/* --- s3 (request-log blob storage) --- */}}
 {{- if .Values.s3.enabled -}}
 {{-   $s3 := dict "provider" "s3" "bucket" .Values.s3.bucket "force_path_style" .Values.s3.forcePathStyle -}}

--- a/deploy/charts/authproxy/templates/deployment.yaml
+++ b/deploy/charts/authproxy/templates/deployment.yaml
@@ -105,6 +105,11 @@ spec:
               mountPath: {{ $.Values.encryptionKeys.mountPath }}
               readOnly: true
             {{- end }}
+            {{- with .Values.actors.existingSecret }}
+            - name: actors-keys
+              mountPath: {{ $.Values.actors.mountPath }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: config
           configMap:
@@ -116,6 +121,11 @@ spec:
         {{- end }}
         {{- with .Values.encryptionKeys.existingSecret }}
         - name: encryption-keys
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- with .Values.actors.existingSecret }}
+        - name: actors-keys
           secret:
             secretName: {{ . }}
         {{- end }}

--- a/deploy/charts/authproxy/templates/tests/test-healthz.yaml
+++ b/deploy/charts/authproxy/templates/tests/test-healthz.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.services.public.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "authproxy.fullname" . }}-test-healthz
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+  annotations:
+    # Run when `helm test` is invoked; remove on success so the pod doesn't
+    # pile up in the namespace across reruns.
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -eu
+          url="http://{{ include "authproxy.fullname" . }}:{{ .Values.ports.public }}{{ .Values.healthcheck.path }}"
+          echo "curling $url"
+          # Retry for up to ~60s while the pod becomes ready and migrations run.
+          curl --silent --show-error --fail \
+            --retry 20 --retry-delay 3 --retry-connrefused --max-time 5 \
+            "$url"
+{{- end }}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -179,8 +179,27 @@
       "properties": {
         "existingSecret":   { "type": "string" },
         "mountPath":        { "type": "string" },
-        "globalAesKeyFile": { "type": "string" },
-        "actorsKeysDir":    { "type": "string" }
+        "globalAesKeyFile": { "type": "string" }
+      }
+    },
+
+    "actors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "mountPath":      { "type": "string" },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "namespace": { "type": "string" },
+              "resources": { "type": "array", "items": { "type": "string" } },
+              "verbs":     { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
       }
     },
 

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -203,6 +203,24 @@
       }
     },
 
+    "hostApplication": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "initiateSessionUrl": { "type": "string" }
+      }
+    },
+
+    "connectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "autoMigrate":       { "type": "boolean" },
+        "loadFromList":      { "type": "array" },
+        "identifyingLabels": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
     "config": { "type": "object" },
 
     "healthcheck": {

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -221,6 +221,17 @@
       }
     },
 
+    "httpLogging": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "shareMainDatabase":    { "type": "boolean" },
+        "autoMigrate":          { "type": "boolean" },
+        "database":             { "type": "object" },
+        "fullRequestRecording": { "type": "string", "enum": ["never", "always"] }
+      }
+    },
+
     "config": { "type": "object" },
 
     "healthcheck": {

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -165,13 +165,31 @@ jwt:
   publicKeyFile: system.pub
   privateKeyFile: system
 
-# -- Encryption keys (global AES key + actor signing keys), mounted as a
-# Secret volume.
+# -- Global encryption key, mounted as a single-file Secret volume. The
+# Secret should contain a key named `globalAesKeyFile` whose value is the
+# raw key bytes (e.g. `openssl rand 32 > global_aes.key`).
 encryptionKeys:
   existingSecret: ""
   mountPath: /etc/authproxy/keys/encryption
   globalAesKeyFile: global_aes.key
-  actorsKeysDir: actors
+
+# -- Configured admin actors, mounted as a Secret volume at `mountPath`.
+# Each actor is a pair of files in the Secret: `<name>` (private key) and
+# `<name>.pub` (public key). The AuthProxy server reads the directory at
+# startup and exposes each actor under its `<name>` external id.
+#
+# Lives in a separate Secret from `encryptionKeys.existingSecret` because
+# K8s Secret data keys can't carry nested directory structure — one Secret
+# = one mount directory.
+actors:
+  existingSecret: ""
+  mountPath: /etc/authproxy/keys/actors
+  # -- ACL permissions granted to every actor in the Secret. Mirrors
+  # AuthProxy's `system_auth.actors.permissions` block.
+  permissions:
+    - namespace: "root.**"
+      resources: ["*"]
+      verbs: ["*"]
 
 # -- Free-form config overlay merged on top of the rendered AuthProxy YAML.
 # Use this for fields the chart hasn't promoted to typed values yet.

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -200,6 +200,27 @@ actors:
 hostApplication:
   initiateSessionUrl: ""
 
+# -- HTTP request/response logging. The AuthProxy server always wires up a
+# log storage service, so the rendered config must contain an `http_logging`
+# block with a database reference. By default the chart points it at the
+# main `database` block above — fine for small deploys, override for
+# production data-warehouse setups (e.g. a separate ClickHouse).
+httpLogging:
+  # -- Reuse the main `database` block. When true, the chart copies the
+  # main database section into `http_logging.database`. Set to false to
+  # configure a dedicated `database:` block below.
+  shareMainDatabase: true
+  # -- Run http_logging schema migrations at startup. Defaults to true on
+  # the server side; surfaced here so customers can disable it when a
+  # separate process owns the http-log schema.
+  autoMigrate: true
+  # -- Dedicated database block for http_logging metadata. Only consulted
+  # when `shareMainDatabase` is false. Same field shape as the top-level
+  # `database` block (provider, host, port, etc.).
+  database: {}
+  # -- Full request/response recording mode (`never` or `always`).
+  fullRequestRecording: never
+
 # -- Connector registry. AuthProxy refuses to start without the connectors
 # block — supply at least an empty `loadFromList` even when you intend to
 # manage connectors through the admin API at runtime.

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -191,6 +191,29 @@ actors:
       resources: ["*"]
       verbs: ["*"]
 
+# -- Host application integration. AuthProxy redirects unauthenticated
+# users (e.g. anyone landing on the marketplace UI) to this URL with a
+# `return_to` query param so the host app can establish a session and
+# bounce back. Required by the AuthProxy server's config validator —
+# leave the placeholder set, but point at a real host login URL for any
+# deployment that actually fronts a UI.
+hostApplication:
+  initiateSessionUrl: ""
+
+# -- Connector registry. AuthProxy refuses to start without the connectors
+# block — supply at least an empty `loadFromList` even when you intend to
+# manage connectors through the admin API at runtime.
+connectors:
+  # -- Run connector schema migrations at startup.
+  autoMigrate: true
+  # -- Inline connector definitions loaded at boot. See the AuthProxy
+  # connector schema docs for the format. Leave empty to manage connectors
+  # exclusively through the admin API.
+  loadFromList: []
+  # -- Labels used to identify connectors across reloads (matching the
+  # AuthProxy `connectors.identifying_labels` field).
+  identifyingLabels: []
+
 # -- Free-form config overlay merged on top of the rendered AuthProxy YAML.
 # Use this for fields the chart hasn't promoted to typed values yet.
 config: {}

--- a/internal/request_log/provider_factory.go
+++ b/internal/request_log/provider_factory.go
@@ -49,6 +49,7 @@ func NewRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorE
 	provider := cfg.GetProvider()
 	switch provider {
 	case config.DatabaseProviderSqlite:
+		return NewSqlRecordRetriever(cfg, cursorEncryptor, logger, dbOpts...)
 	case config.DatabaseProviderPostgres:
 		return NewSqlRecordRetriever(cfg, cursorEncryptor, logger, dbOpts...)
 	case config.DatabaseProviderClickhouse:
@@ -56,6 +57,4 @@ func NewRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorE
 	default:
 		panic(fmt.Sprintf("unknown http logging database provider: %s", provider))
 	}
-
-	panic(fmt.Sprintf("unknown http logging database provider: %s", provider))
 }


### PR DESCRIPTION
## Summary

Wires `.github/workflows/helm-chart-ci.yml` so every PR touching `deploy/charts/**` actually proves the chart deploys: `helm lint` + `helm install` on a kind cluster + `helm test` hitting `/healthz` via a Helm test Pod.

## Pipeline shape

```
lint job
  ct list-changed                            (no-op on unrelated PRs)
  ct lint                                    helm lint + Chart.yaml validation

install job (depends on lint)
  helm/kind-action                            v1.30.4 kind cluster
  kubectl apply -f -                          redis:7-alpine Deployment + Service
  Generate keys + apply Secrets:
    authproxy-jwt          RSA-2048 system + system.pub
    authproxy-encryption   32-byte global_aes.key
    authproxy-actors       RSA-2048 ci + ci.pub  (one admin actor)
  ct install --namespace authproxy-ct
    -> helm install -f deploy/charts/authproxy/ci/sqlite-redis-values.yaml
    -> helm test                              runs tests/test-healthz.yaml
                                              (curlimages/curl → /healthz, retry up to ~60s)
```

CI values: `database.provider=sqlite`, `redis.address=redis:6379`, `image.tag=main`. Minimum deps — no external DB, only an ephemeral in-cluster Redis.

## Required chart change (rolled into this PR)

K8s Secret data keys can't contain `/`, so a single Secret can't carry the nested directory structure that AuthProxy's actor-key loader expects (`global_aes.key` alongside `actors/<name>.pub`). The A4 chart coupled both into `encryptionKeys.existingSecret`, which can't actually work on a real cluster.

Split into two independent typed sections:

| Block | Holds | Mounted at |
|---|---|---|
| `encryptionKeys.existingSecret` | `global_aes.key` (flat) | `encryptionKeys.mountPath` |
| `actors.existingSecret` | `<name>` + `<name>.pub` pairs (flat) | `actors.mountPath` |

`actors.permissions` mirrors AuthProxy's `system_auth.actors.permissions` so the chart user can set ACLs without dropping into the `config:` escape hatch. Schema validation + NOTES updated accordingly.

A4-era customers can keep their `global_aes.key` Secret unchanged; admin actor keypairs move to a new Secret, which they were going to maintain separately anyway (per-deployment by definition).

## Verified locally

- `helm lint` clean
- `helm template` (defaults): no `system_auth` block (no secrets set; expected)
- `helm template` (CI values): sqlite, redis at `redis:6379`, `system_auth.actors` with `keys_path: /etc/authproxy/keys/actors`, three separate volume mounts (`jwt-keys`, `encryption-keys`, `actors-keys`), three separate Secret references
- `ct lint` via the chart-testing container: success, auto-picks up `ci/sqlite-redis-values.yaml`
- `helm install --dry-run=client` with the CI values: passes; NOTES still flags `database.existingSecret` and `redis.existingSecret` as unset (accurate — both are non-applicable in this profile but the generic warning is fine)
- preflight clean

The CI workflow's `kind`-based install can only be exercised by the PR itself — that's the actual validator.

## Acceptance (per #287)

- [x] `.github/workflows/helm-chart-ci.yml` triggered on `deploy/charts/**`
- [x] Uses `helm/chart-testing-action`
- [x] Stages: lint → install on kind with a minimal-deps profile → helm test → /healthz check
- [x] Runs on every PR

CI status will turn green once this PR's own run completes; the next change to the chart (A6 publish, A9 docs, future fixes) will exercise the path again.

Closes #287. Part of #284.