### PR TITLE
Implement PKCE (RFC 7636) for OAuth2 authorization-code flow

### DIFF
--- a/internal/auth_methods/oauth2/auth_url.go
+++ b/internal/auth_methods/oauth2/auth_url.go
@@ -102,6 +102,16 @@ func (o *oAuth2Connection) GenerateAuthUrl(ctx context.Context, actor IActorData
 	query.Set("scope", strings.Join(scopes, " "))
 	query.Set("state", o.state.Id.String())
 
+	if o.auth.Authorization.PKCE != nil {
+		method := o.auth.Authorization.PKCE.GetMethodOrDefault()
+		challenge, err := pkceChallengeFor(method, o.state.PKCECodeVerifier)
+		if err != nil {
+			return "", fmt.Errorf("failed to compute pkce challenge for connector %s: %w", cv.GetId(), err)
+		}
+		query.Set("code_challenge", challenge)
+		query.Set("code_challenge_method", string(method))
+	}
+
 	for k, v := range o.auth.Authorization.QueryOverrides {
 		rendered, err := o.renderMustache(ctx, v)
 		if err != nil {

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -175,6 +175,13 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 		"redirect_uri":  {callbackUrl},
 	}
 
+	// RFC 7636 §4.5 — the verifier is only sent on the initial code-for-token
+	// exchange. Refresh-token grants must not carry it (§6), which is why
+	// task_refresh_oauth_token.go does not have a mirror of this block.
+	if o.state.PKCECodeVerifier != "" {
+		values.Set("code_verifier", o.state.PKCECodeVerifier)
+	}
+
 	for k, v := range o.auth.Token.FormOverrides {
 		values.Set(k, v)
 	}

--- a/internal/auth_methods/oauth2/pkce.go
+++ b/internal/auth_methods/oauth2/pkce.go
@@ -1,0 +1,81 @@
+package oauth2
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// pkceVerifierAlphabet is the RFC 7636 §4.1 unreserved character set:
+//
+//	A-Z / a-z / 0-9 / "-" / "." / "_" / "~"
+//
+// 66 characters total. Picking from it uniformly yields ~6.04 bits per
+// char; a 43-char verifier therefore carries ~256 bits of entropy, well
+// past the 128-bit floor RFC 7636 sets.
+const pkceVerifierAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+// pkceVerifierLength is the length we generate. 43 is also the minimum
+// length permitted by RFC 7636 §4.1, so any conforming verifier we emit is
+// at least as long as anything the spec allows.
+const pkceVerifierLength = 43
+
+// generatePKCEVerifier returns a fresh RFC 7636 §4.1 code_verifier — a
+// crypto/rand-sourced string of pkceVerifierLength characters drawn from
+// the unreserved alphabet.
+//
+// The implementation rejects bytes that fall in the rolled-over tail of
+// 256 % 66 so the distribution is exactly uniform. The loop's expected
+// iteration count is well under 2× the output length even in the worst
+// case.
+func generatePKCEVerifier() (string, error) {
+	const alpha = pkceVerifierAlphabet
+	out := make([]byte, 0, pkceVerifierLength)
+	// Pull bytes in small batches to amortize the rand.Read call without
+	// over-reading when most bytes are usable.
+	buf := make([]byte, pkceVerifierLength)
+	// Largest multiple of len(alpha) that fits in a byte; bytes >= cutoff are discarded
+	// to keep the modulo distribution uniform.
+	cutoff := byte(256 - (256 % len(alpha)))
+	for len(out) < pkceVerifierLength {
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("failed to read random bytes for pkce verifier: %w", err)
+		}
+		for _, b := range buf {
+			if b >= cutoff {
+				continue
+			}
+			out = append(out, alpha[int(b)%len(alpha)])
+			if len(out) == pkceVerifierLength {
+				break
+			}
+		}
+	}
+	return string(out), nil
+}
+
+// pkceChallengeFor produces the code_challenge value that pairs with the
+// given verifier under the named method.
+//
+//   - S256: base64url(sha256(verifier)) without padding (RFC 7636 §4.2).
+//   - plain: the verifier verbatim — included for connectors that cannot
+//     validate S256. Plain offers no defense against an attacker who can
+//     read the authorize redirect, which is the threat PKCE exists to
+//     mitigate; prefer S256 unless a provider forces our hand.
+//
+// Returns an error for an unknown method so a future enum extension can't
+// silently fall through and emit no challenge at all.
+func pkceChallengeFor(method sconfig.PKCEMethod, verifier string) (string, error) {
+	switch method {
+	case sconfig.PKCEMethodS256:
+		sum := sha256.Sum256([]byte(verifier))
+		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	case sconfig.PKCEMethodPlain:
+		return verifier, nil
+	default:
+		return "", fmt.Errorf("unsupported pkce method %q", method)
+	}
+}

--- a/internal/auth_methods/oauth2/pkce_test.go
+++ b/internal/auth_methods/oauth2/pkce_test.go
@@ -1,0 +1,404 @@
+package oauth2
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	mockRedis "github.com/rmorlok/authproxy/internal/apredis/mock"
+	"github.com/rmorlok/authproxy/internal/config"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+func TestGeneratePKCEVerifier_LengthAndAlphabet(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		v, err := generatePKCEVerifier()
+		require.NoError(t, err)
+		require.Len(t, v, pkceVerifierLength, "verifier must be %d chars", pkceVerifierLength)
+		for j := 0; j < len(v); j++ {
+			require.True(t, strings.IndexByte(pkceVerifierAlphabet, v[j]) >= 0,
+				"verifier contains illegal char %q at idx %d (full: %q)", v[j], j, v)
+		}
+	}
+}
+
+func TestGeneratePKCEVerifier_UniquePerCall(t *testing.T) {
+	// Birthday-paradox sanity check; 256 bits of entropy means collisions
+	// across 64 draws are statistically impossible — a duplicate here would
+	// flag a bug in the generator, not bad luck.
+	seen := make(map[string]struct{}, 64)
+	for i := 0; i < 64; i++ {
+		v, err := generatePKCEVerifier()
+		require.NoError(t, err)
+		_, dup := seen[v]
+		require.False(t, dup, "duplicate verifier generated")
+		seen[v] = struct{}{}
+	}
+}
+
+func TestPKCEChallengeFor_S256(t *testing.T) {
+	// RFC 7636 Appendix B test vector.
+	const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	got, err := pkceChallengeFor(sconfig.PKCEMethodS256, verifier)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+
+	// Independent confirmation of the encoding choice (no padding, URL-safe).
+	sum := sha256.Sum256([]byte(verifier))
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(sum[:]), got)
+}
+
+func TestPKCEChallengeFor_Plain(t *testing.T) {
+	const verifier = "the-verifier"
+	got, err := pkceChallengeFor(sconfig.PKCEMethodPlain, verifier)
+	require.NoError(t, err)
+	assert.Equal(t, verifier, got)
+}
+
+func TestPKCEChallengeFor_UnknownMethodErrors(t *testing.T) {
+	_, err := pkceChallengeFor(sconfig.PKCEMethod("bogus"), "x")
+	require.Error(t, err)
+}
+
+func TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type: cschema.AuthTypeOAuth2,
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{Method: "bogus"},
+		},
+	}
+	vc := &common.ValidationContext{}
+	err := a.Validate(vc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pkce")
+	assert.Contains(t, err.Error(), "method")
+}
+
+func TestAuthOAuth2_Validate_AcceptsS256(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type: cschema.AuthTypeOAuth2,
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+		},
+	}
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+}
+
+func TestAuthOAuth2_Validate_AcceptsPlain(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type: cschema.AuthTypeOAuth2,
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodPlain},
+		},
+	}
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+}
+
+func TestAuthOAuth2_Validate_DefaultsMethodWhenBlockPresent(t *testing.T) {
+	// Block present but method omitted: schema-level validation must accept;
+	// runtime defaults to S256 via GetMethodOrDefault.
+	a := &cschema.AuthOAuth2{
+		Type: cschema.AuthTypeOAuth2,
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{},
+		},
+	}
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+	assert.Equal(t, cschema.PKCEMethodS256, a.Authorization.PKCE.GetMethodOrDefault())
+}
+
+func TestAuthOauth2PKCE_GetMethodOrDefault_NilReturnsS256(t *testing.T) {
+	var p *cschema.AuthOauth2PKCE
+	assert.Equal(t, cschema.PKCEMethodS256, p.GetMethodOrDefault())
+}
+
+// TestGenerateAuthUrl_PKCEEmitsChallenge verifies the authorize URL carries
+// code_challenge / code_challenge_method when PKCE is enabled and that the
+// challenge matches the verifier persisted in state under S256.
+func TestGenerateAuthUrl_PKCEEmitsChallenge(t *testing.T) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	const verifier = "test-verifier-with-enough-entropy-1234567890"
+	sum := sha256.Sum256([]byte(verifier))
+	wantChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	o := &oAuth2Connection{
+		cfg: cfg,
+		connection: &configuredConnection{
+			Connection: &mockCore.Connection{
+				Id: apid.New(apid.PrefixConnection),
+			},
+			connectorVersion: &mockCore.ConnectorVersion{
+				Id: apid.New(apid.PrefixConnectorVersion),
+			},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:     cschema.AuthTypeOAuth2,
+			ClientId: common.NewStringValueDirect("client-id"),
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: "https://example.com/oauth/authorize",
+				PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+			},
+		},
+		state: &state{
+			Id:               apid.New(apid.PrefixOauth2State),
+			PKCECodeVerifier: verifier,
+			PKCEMethod:       cschema.PKCEMethodS256,
+		},
+	}
+
+	authUrl, err := o.GenerateAuthUrl(context.Background(), &mockActorData{id: apid.New(apid.PrefixActor)})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authUrl)
+	require.NoError(t, err)
+	q := parsed.Query()
+	assert.Equal(t, wantChallenge, q.Get("code_challenge"))
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+}
+
+// TestGenerateAuthUrl_PKCEOmittedWhenDisabled verifies the authorize URL stays
+// unchanged when no PKCE block is configured — backwards-compatible behavior.
+func TestGenerateAuthUrl_PKCEOmittedWhenDisabled(t *testing.T) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	o := &oAuth2Connection{
+		cfg: cfg,
+		connection: &configuredConnection{
+			Connection: &mockCore.Connection{
+				Id: apid.New(apid.PrefixConnection),
+			},
+			connectorVersion: &mockCore.ConnectorVersion{
+				Id: apid.New(apid.PrefixConnectorVersion),
+			},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:     cschema.AuthTypeOAuth2,
+			ClientId: common.NewStringValueDirect("client-id"),
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: "https://example.com/oauth/authorize",
+			},
+		},
+		state: &state{
+			Id: apid.New(apid.PrefixOauth2State),
+		},
+	}
+
+	authUrl, err := o.GenerateAuthUrl(context.Background(), &mockActorData{id: apid.New(apid.PrefixActor)})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authUrl)
+	require.NoError(t, err)
+	q := parsed.Query()
+	assert.Empty(t, q.Get("code_challenge"))
+	assert.Empty(t, q.Get("code_challenge_method"))
+}
+
+// captureBody is a gock matcher that records the raw request body so the
+// test can assert on the form fields the proxy actually sent. The matcher
+// always returns true — it inspects, it does not gate.
+func captureBody(dst *string) func(*http.Request, *gock.Request) (bool, error) {
+	return func(req *http.Request, _ *gock.Request) (bool, error) {
+		if req.Body == nil {
+			return true, nil
+		}
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return false, err
+		}
+		*dst = string(b)
+		req.Body = io.NopCloser(strings.NewReader(*dst))
+		return true, nil
+	}
+}
+
+// TestCallbackFrom3rdParty_PKCESendsVerifier asserts that when state carries
+// a verifier, the token-exchange POST body includes code_verifier with the
+// matching value.
+func TestCallbackFrom3rdParty_PKCESendsVerifier(t *testing.T) {
+	const verifier = "callback-verifier-1234567890abcdef-fixedlen"
+
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	r := mockRedis.NewMockClient(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	r.EXPECT().Del(gomock.Any(), gomock.Any()).Return(redis.NewIntCmd(context.Background())).AnyTimes()
+
+	connectionId := apid.New(apid.PrefixConnection)
+	tokenId := apid.New(apid.PrefixOAuth2Token)
+
+	o := &oAuth2Connection{
+		cfg:     cfg,
+		db:      db,
+		httpf:   h,
+		r:       r,
+		encrypt: encrypt,
+		logger:  logger,
+		connection: &mockCore.Connection{
+			Id: connectionId,
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			ClientId:     common.NewStringValueDirect("client-id"),
+			ClientSecret: common.NewStringValueDirect("client-secret"),
+			Token: cschema.AuthOauth2Token{
+				Endpoint: "https://example.com/oauth/token",
+			},
+		},
+		state: &state{
+			Id:               apid.New(apid.PrefixOauth2State),
+			ReturnToUrl:      "https://app.example.com/callback",
+			PKCECodeVerifier: verifier,
+			PKCEMethod:       cschema.PKCEMethodS256,
+		},
+	}
+
+	var capturedBody string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"a","expires_in":3600}`)
+
+	encrypt.EXPECT().EncryptStringForEntity(gomock.Any(), gomock.Any(), "a").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "enc-a"}, nil)
+	db.EXPECT().InsertOAuth2Token(gomock.Any(), connectionId, nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.OAuth2Token{Id: tokenId}, nil)
+
+	_, err := o.CallbackFrom3rdParty(context.Background(), url.Values{"code": {"auth-code"}})
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, verifier, form.Get("code_verifier"))
+	assert.Equal(t, "auth-code", form.Get("code"))
+	assert.Equal(t, "authorization_code", form.Get("grant_type"))
+}
+
+// TestCallbackFrom3rdParty_PKCEOmittedWhenStateHasNoVerifier asserts that a
+// connection set up without PKCE does not send code_verifier — backwards
+// compat with existing connectors.
+func TestCallbackFrom3rdParty_PKCEOmittedWhenStateHasNoVerifier(t *testing.T) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	r := mockRedis.NewMockClient(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	r.EXPECT().Del(gomock.Any(), gomock.Any()).Return(redis.NewIntCmd(context.Background())).AnyTimes()
+
+	connectionId := apid.New(apid.PrefixConnection)
+	tokenId := apid.New(apid.PrefixOAuth2Token)
+
+	o := &oAuth2Connection{
+		cfg:     cfg,
+		db:      db,
+		httpf:   h,
+		r:       r,
+		encrypt: encrypt,
+		logger:  logger,
+		connection: &mockCore.Connection{
+			Id: connectionId,
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			ClientId:     common.NewStringValueDirect("client-id"),
+			ClientSecret: common.NewStringValueDirect("client-secret"),
+			Token: cschema.AuthOauth2Token{
+				Endpoint: "https://example.com/oauth/token",
+			},
+		},
+		state: &state{
+			Id:          apid.New(apid.PrefixOauth2State),
+			ReturnToUrl: "https://app.example.com/callback",
+		},
+	}
+
+	var capturedBody string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"a","expires_in":3600}`)
+
+	encrypt.EXPECT().EncryptStringForEntity(gomock.Any(), gomock.Any(), "a").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "enc-a"}, nil)
+	db.EXPECT().InsertOAuth2Token(gomock.Any(), connectionId, nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.OAuth2Token{Id: tokenId}, nil)
+
+	_, err := o.CallbackFrom3rdParty(context.Background(), url.Values{"code": {"auth-code"}})
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Empty(t, form.Get("code_verifier"))
+}

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -31,6 +31,18 @@ type state struct {
 	ReturnToUrl            string    `json:"return_to"`
 	CancelSessionAfterAuth bool      `json:"cancel_session_after_auth"`
 	ExpiresAt              time.Time `json:"expires_at"`
+
+	// PKCECodeVerifier is the RFC 7636 §4.1 high-entropy per-flow secret.
+	// Empty when PKCE is not enabled for this connector. Stored alongside
+	// the rest of the state record (same TTL, same AES-GCM envelope) — the
+	// verifier never leaves the proxy except as the matching value sent to
+	// the token endpoint during the code exchange.
+	PKCECodeVerifier string `json:"pkce_code_verifier,omitempty"`
+	// PKCEMethod records which challenge transformation was used when the
+	// authorize URL was emitted. Persisting it (rather than re-reading the
+	// connector at callback time) means a connector reconfig mid-flow
+	// can't silently break the exchange.
+	PKCEMethod sconfig.PKCEMethod `json:"pkce_method,omitempty"`
 }
 
 func (s *state) IsValid() bool {
@@ -113,6 +125,16 @@ func (o *oAuth2Connection) saveStateToRedis(ctx context.Context, actor IActorDat
 		ExpiresAt:        time.Now().Add(ttl),
 		ReturnToUrl:      returnToUrl,
 	}
+
+	if o.auth != nil && o.auth.Authorization.PKCE != nil {
+		verifier, err := generatePKCEVerifier()
+		if err != nil {
+			return fmt.Errorf("failed to generate pkce verifier for connection %s: %w", o.connection.GetId(), err)
+		}
+		s.PKCECodeVerifier = verifier
+		s.PKCEMethod = o.auth.Authorization.PKCE.GetMethodOrDefault()
+	}
+
 	if err := writeStateToRedis(ctx, o.r, o.encrypt, s, ttl); err != nil {
 		return fmt.Errorf("failed to set state in redis for connection %s: %w", o.connection.GetId(), err)
 	}

--- a/internal/schema/config/reexport.go
+++ b/internal/schema/config/reexport.go
@@ -50,9 +50,11 @@ type (
 	AuthOAuth2              = connectors.AuthOAuth2
 	AuthNoAuth              = connectors.AuthNoAuth
 	AuthOauth2Authorization = connectors.AuthOauth2Authorization
+	AuthOauth2PKCE          = connectors.AuthOauth2PKCE
 	AuthOauth2Token         = connectors.AuthOauth2Token
 	Connector               = connectors.Connector
 	Connectors              = connectors.Connectors
+	PKCEMethod              = connectors.PKCEMethod
 	Scope                   = connectors.Scope
 )
 
@@ -65,4 +67,7 @@ const (
 	ApiKeyPlacementHeader = connectors.ApiKeyPlacementHeader
 	ApiKeyPlacementQuery  = connectors.ApiKeyPlacementQuery
 	ApiKeyPlacementBasic  = connectors.ApiKeyPlacementBasic
+
+	PKCEMethodS256  = connectors.PKCEMethodS256
+	PKCEMethodPlain = connectors.PKCEMethodPlain
 )

--- a/internal/schema/connectors/auth_oauth2.go
+++ b/internal/schema/connectors/auth_oauth2.go
@@ -81,7 +81,36 @@ func (a *AuthOAuth2) Clone() AuthImpl {
 	}
 	clone.Scopes = scopes
 
+	clone.Authorization.PKCE = a.Authorization.PKCE.Clone()
+
 	return &clone
 }
 
+// Validate enforces OAuth2-specific schema invariants. Today this just
+// checks the optional PKCE block — the rest of the type's fields are
+// validated structurally elsewhere.
+func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
+	if a == nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+
+	if a.Authorization.PKCE != nil {
+		pkceVC := vc.PushField("authorization").PushField("pkce")
+		switch a.Authorization.PKCE.Method {
+		case "", PKCEMethodS256, PKCEMethodPlain:
+			// "" defaults to S256 at runtime — accept here.
+		default:
+			result = multierror.Append(result, pkceVC.NewErrorfForField("method",
+				"%q is not a valid PKCE method; must be %q or %q",
+				a.Authorization.PKCE.Method, PKCEMethodS256, PKCEMethodPlain,
+			))
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
 var _ AuthImpl = (*AuthOAuth2)(nil)
+var _ AuthValidator = (*AuthOAuth2)(nil)

--- a/internal/schema/connectors/auth_oauth2_authorization.go
+++ b/internal/schema/connectors/auth_oauth2_authorization.go
@@ -1,6 +1,48 @@
 package connectors
 
+// PKCEMethod selects the code-challenge transformation used by the
+// connector's authorize/token-exchange pair. Values follow RFC 7636 §4.2.
+type PKCEMethod string
+
+const (
+	// PKCEMethodS256 is the recommended challenge method:
+	// challenge = base64url(sha256(verifier)). Always use this unless the
+	// 3rd-party explicitly rejects it.
+	PKCEMethodS256 = PKCEMethod("S256")
+	// PKCEMethodPlain is the fallback method: challenge = verifier. RFC 7636
+	// §4.2 marks plain as discouraged — it removes the cryptographic
+	// hop that protects the verifier on a leaky TLS terminator. Configure
+	// only when a provider cannot validate S256.
+	PKCEMethodPlain = PKCEMethod("plain")
+)
+
+// AuthOauth2PKCE turns on RFC 7636 Proof Key for Code Exchange for a
+// connector's authorization-code flow. nil disables PKCE (current default
+// behavior); a non-nil block enables it with the chosen method.
+type AuthOauth2PKCE struct {
+	// Method is the challenge transformation. Defaults to S256 when unset.
+	Method PKCEMethod `json:"method,omitempty" yaml:"method,omitempty"`
+}
+
+// GetMethodOrDefault returns the configured method, defaulting to S256 if
+// the block is present but the method was omitted.
+func (p *AuthOauth2PKCE) GetMethodOrDefault() PKCEMethod {
+	if p == nil || p.Method == "" {
+		return PKCEMethodS256
+	}
+	return p.Method
+}
+
+func (p *AuthOauth2PKCE) Clone() *AuthOauth2PKCE {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return &clone
+}
+
 type AuthOauth2Authorization struct {
 	Endpoint       string            `json:"endpoint" yaml:"endpoint"`
 	QueryOverrides map[string]string `json:"query_overrides,omitempty" yaml:"query_overrides,omitempty"`
+	PKCE           *AuthOauth2PKCE   `json:"pkce,omitempty" yaml:"pkce,omitempty"`
 }

--- a/internal/schema/connectors/schema-oauth.json
+++ b/internal/schema/connectors/schema-oauth.json
@@ -27,9 +27,21 @@
         },
         "template": {
           "type": "string"
+        },
+        "pkce": {
+          "$ref": "#/$defs/PKCE"
         }
       },
       "required": ["endpoint"],
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PKCE": {
+      "properties": {
+        "method": {
+          "enum": ["S256", "plain"]
+        }
+      },
       "additionalProperties": false,
       "type": "object"
     },

--- a/internal/schema/connectors/test_data/invalid-oauth-connector-pkce-method.yaml
+++ b/internal/schema/connectors/test_data/invalid-oauth-connector-pkce-method.yaml
@@ -1,0 +1,25 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana (bad PKCE)
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  PKCE block with an unsupported method — must be rejected by the schema.
+auth:
+  type: OAuth2
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  client_secret:
+    env_var: ASANA_CLIENT_SECRET
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+    pkce:
+      method: bogus
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects

--- a/internal/schema/connectors/test_data/valid-oauth-connector-pkce.yaml
+++ b/internal/schema/connectors/test_data/valid-oauth-connector-pkce.yaml
@@ -1,0 +1,25 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana (PKCE)
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  PKCE-enabled OAuth2 connector fixture used by the schema validator tests.
+auth:
+  type: OAuth2
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  client_secret:
+    env_var: ASANA_CLIENT_SECRET
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+    pkce:
+      method: S256
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects


### PR DESCRIPTION
## Summary
- Adds RFC 7636 PKCE support to the OAuth2 authorization-code flow, gated by a new optional `pkce` block on each connector. Connectors without the block behave exactly as before.
- Mints a 43-char crypto/rand verifier from the RFC 7636 unreserved alphabet (~256 bits of entropy, well past the 128-bit floor) and persists it alongside the rest of the OAuth state record — same TTL, same AES-GCM envelope.
- Emits `code_challenge` and `code_challenge_method` on the authorize URL, and sends `code_verifier` on the **initial** token exchange only. Refresh-token grants and revocation are untouched (RFC 7636 §6).

## Files
- `internal/schema/connectors/auth_oauth2_authorization.go` — new `AuthOauth2PKCE` type and `PKCE` field; `PKCEMethodS256` (default) / `PKCEMethodPlain` constants.
- `internal/schema/connectors/auth_oauth2.go` — `AuthOAuth2.Validate` rejects unknown PKCE methods; `Clone` carries the block.
- `internal/schema/config/reexport.go` — re-exports the new types/constants.
- `internal/auth_methods/oauth2/pkce.go` (new) — verifier generator (uniform rejection-sampling) and `pkceChallengeFor` (S256 / plain).
- `internal/auth_methods/oauth2/state.go` — extended state struct with `PKCECodeVerifier` and `PKCEMethod`; `saveStateToRedis` mints the verifier in the same write when PKCE is configured.
- `internal/auth_methods/oauth2/auth_url.go` — emits the challenge params when PKCE is on.
- `internal/auth_methods/oauth2/callback.go` — adds `code_verifier` to the token-exchange form when state carries one.
- `internal/auth_methods/oauth2/pkce_test.go` (new) — 14 unit tests.

## Test plan
- [x] `go test ./internal/auth_methods/oauth2/... ./internal/schema/... -count=1`
- [x] `./scripts/preflight.sh`
- [x] RFC 7636 Appendix B vector — `pkceChallengeFor(S256, "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")` produces `"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"`.
- [x] Authorize URL emits `code_challenge` / `code_challenge_method=S256` when PKCE is on; omits both when off.
- [x] Token exchange sends `code_verifier` matching the persisted state; omits it when no verifier was persisted.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)