### PR TITLE
Size-bounded body capture for /_proxy_raw (#331)

### DIFF
--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -1,8 +1,10 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -448,6 +450,89 @@ func (env *IntegrationTestEnv) DoProxyRequest(t *testing.T, connectionID, target
 	}
 
 	// HTTP mode: rewrite the path-only URL onto env.ServerURL and send.
+	abs, err := url.Parse(env.ServerURL + path)
+	require.NoError(t, err)
+	req.URL = abs
+	req.Host = abs.Host
+	req.RequestURI = ""
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	w.Code = resp.StatusCode
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	if _, err := w.Body.ReadFrom(resp.Body); err != nil {
+		require.NoError(t, err)
+	}
+	return w
+}
+
+// DoProxyRawRequest performs a streaming /_proxy_raw request through the
+// integration test environment. The upstream URL is carried in the
+// X-AuthProxy-Upstream-URL header per the raw-proxy contract; body and
+// extraHeaders are forwarded as-is to the upstream. forceChunked, when
+// true, sends the body with Content-Length omitted so net/http negotiates
+// chunked transfer-encoding — used to exercise the streaming/skipped
+// path in the request log.
+func (env *IntegrationTestEnv) DoProxyRawRequest(
+	t *testing.T,
+	connectionID, targetURL, method string,
+	body []byte,
+	forceChunked bool,
+	extraHeaders http.Header,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	require.Truef(t, env.ApiGin != nil || env.ServerURL != "", "DoProxyRawRequest requires either in-process gin or a running HTTP server")
+
+	path := "/api/v1/connections/" + connectionID + "/_proxy_raw"
+
+	var bodyReader io.Reader
+	if body != nil {
+		if forceChunked {
+			// Wrapping bytes.NewReader in struct{ io.Reader } strips the
+			// Len() method so http.NewRequest can't infer ContentLength,
+			// forcing chunked transfer-encoding on the wire.
+			bodyReader = struct{ io.Reader }{bytes.NewReader(body)}
+		} else {
+			bodyReader = bytes.NewReader(body)
+		}
+	}
+
+	req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+		method,
+		path,
+		bodyReader,
+		sconfig.RootNamespace,
+		"test-actor",
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+	if forceChunked {
+		// net/http's server side reports ContentLength=-1 for chunked
+		// transfer-encoding. For in-process tests the request struct
+		// is shared rather than re-parsed off the wire, so set the
+		// signal explicitly — the route handler propagates it to the
+		// outbound request and the roundtripper keys its skip
+		// decision off ContentLength<0.
+		req.ContentLength = -1
+		req.TransferEncoding = []string{"chunked"}
+	}
+	req.Header.Set("X-AuthProxy-Upstream-URL", targetURL)
+	for k, vv := range extraHeaders {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	if env.ApiGin != nil {
+		env.ApiGin.ServeHTTP(w, req)
+		return w
+	}
+
 	abs, err := url.Parse(env.ServerURL + path)
 	require.NoError(t, err)
 	req.URL = abs

--- a/integration_tests/proxy/raw_body_capture_test.go
+++ b/integration_tests/proxy/raw_body_capture_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package proxy
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/request_log"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upstreamEcho captures the bytes received and the framing the client
+// used (chunked vs content-length) so the test can assert end-to-end
+// pass-through regardless of which capture path was taken.
+type upstreamEcho struct {
+	server   *httptest.Server
+	received atomic.Int64
+	last     []byte
+	mu       chan struct{}
+}
+
+func newUpstreamEcho(t *testing.T) *upstreamEcho {
+	t.Helper()
+	e := &upstreamEcho{mu: make(chan struct{}, 1)}
+	e.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		e.received.Store(int64(len(body)))
+		e.last = body
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(e.server.Close)
+	return e
+}
+
+// waitForLog polls the request log retriever for a record matching the
+// connection id, up to deadline. Necessary because the round-tripper
+// persists the log in a detached goroutine.
+func waitForLog(t *testing.T, env *helpers.IntegrationTestEnv, connectionID string, deadline time.Duration) *request_log.LogRecord {
+	t.Helper()
+	connID, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+
+	store := env.DM.GetLogStorageService()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		page := store.NewListRequestsBuilder().
+			WithConnectionId(connID).
+			Limit(5).
+			FetchPage(context.Background())
+		if page.Error == nil && len(page.Results) > 0 {
+			return page.Results[0]
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("no log record persisted for connection %s within %s", connectionID, deadline)
+	return nil
+}
+
+// TestProxyRawBodyCapture_TeeDecision is the end-to-end version of the
+// unit-test invariants in request_log/roundtripper_test.go: the raw
+// /_proxy_raw path drives the same RoundTripper, so the
+// streaming/too_large/captured choice must show up on the LogRecord
+// without any per-path special-casing.
+//
+// Per-subtest cleanup builds a fresh env so each one gets its own
+// in-process state (the request log accumulates across subtests
+// otherwise).
+func TestProxyRawBodyCapture_TeeDecision(t *testing.T) {
+	connectorID := apid.MustParse("cxr_test0000000000302")
+
+	t.Run("small known-length request: body captured", func(t *testing.T) {
+		upstream := newUpstreamEcho(t)
+		env := helpers.Setup(t, helpers.SetupOptions{
+			Connectors: []sconfig.Connector{
+				helpers.NewNoAuthConnector(connectorID, "raw-capture", nil),
+			},
+		})
+		defer env.Cleanup()
+		conn := env.CreateConnection(t, connectorID, 1)
+
+		body := []byte("hello world")
+		w := env.DoProxyRawRequest(t, conn, upstream.server.URL+"/echo", http.MethodPost, body, false, nil)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		assert.Equal(t, int64(len(body)), upstream.received.Load(), "upstream must receive the full body")
+
+		record := waitForLog(t, env, conn, 5*time.Second)
+		assert.Empty(t, record.RequestBodySkipped, "small known-length body must be captured (no skip reason)")
+	})
+
+	t.Run("oversized known-length request: skipped too_large, body still forwarded", func(t *testing.T) {
+		upstream := newUpstreamEcho(t)
+		env := helpers.Setup(t, helpers.SetupOptions{
+			Connectors: []sconfig.Connector{
+				helpers.NewNoAuthConnector(connectorID, "raw-capture", nil),
+			},
+		})
+		defer env.Cleanup()
+		conn := env.CreateConnection(t, connectorID, 1)
+
+		// Default max_request_size is 250 KiB — send 300 KiB. The
+		// load-bearing assertion is that the upstream still sees all
+		// 300 KiB even though the log skipped capture; the previous
+		// implementation truncated the *forwarded* body to the cap.
+		body := make([]byte, 300*1024)
+		_, _ = rand.Read(body)
+		w := env.DoProxyRawRequest(t, conn, upstream.server.URL+"/echo", http.MethodPost, body, false, nil)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		assert.Equal(t, int64(len(body)), upstream.received.Load(), "upstream must receive the full body, not the truncated cap")
+
+		record := waitForLog(t, env, conn, 5*time.Second)
+		assert.Equal(t, request_log.BodySkippedTooLarge, record.RequestBodySkipped,
+			"oversized body must record too_large skip reason")
+	})
+
+	t.Run("chunked request: skipped streaming, body still forwarded", func(t *testing.T) {
+		upstream := newUpstreamEcho(t)
+		env := helpers.Setup(t, helpers.SetupOptions{
+			Connectors: []sconfig.Connector{
+				helpers.NewNoAuthConnector(connectorID, "raw-capture", nil),
+			},
+		})
+		defer env.Cleanup()
+		conn := env.CreateConnection(t, connectorID, 1)
+
+		body := []byte("chunked-stream-body")
+		w := env.DoProxyRawRequest(t, conn, upstream.server.URL+"/echo", http.MethodPost, body, true, nil)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		assert.Equal(t, int64(len(body)), upstream.received.Load(), "upstream must receive the full body even when chunked")
+
+		record := waitForLog(t, env, conn, 5*time.Second)
+		assert.Equal(t, request_log.BodySkippedStreaming, record.RequestBodySkipped,
+			"chunked body must record streaming skip reason")
+	})
+}

--- a/internal/request_log/full_log.go
+++ b/internal/request_log/full_log.go
@@ -12,6 +12,24 @@ import (
 // full request. To represent the redacted version of the request, an LogRecord is used,
 // which is a subset of the EntryRequest and organized for searching.
 
+// BodySkippedReason explains why a request/response body was not captured
+// into the full log. Empty string means the body was captured (or there
+// was no body to capture).
+type BodySkippedReason string
+
+const (
+	// BodySkippedStreaming indicates the body had no advance size
+	// (Content-Length unset / chunked). The full log has no way to know
+	// how big the body will be, so capture is skipped rather than risk
+	// OOMing the proxy or growing the blob unboundedly.
+	BodySkippedStreaming BodySkippedReason = "streaming"
+	// BodySkippedTooLarge indicates Content-Length was set but exceeded
+	// the configured max_request_size / max_response_size. Capture is
+	// skipped — operators that want the body anyway can raise the cap
+	// in config.
+	BodySkippedTooLarge BodySkippedReason = "too_large"
+)
+
 type FullLogRequest struct {
 	URL           string              `json:"u"`
 	HttpVersion   string              `json:"v"`
@@ -19,6 +37,10 @@ type FullLogRequest struct {
 	Headers       map[string][]string `json:"h"`
 	ContentLength int64               `json:"cl,omitempty"`
 	Body          []byte              `json:"b,omitempty"`
+	// BodySkipped is non-empty when the body bytes were not captured —
+	// see BodySkippedReason. Mutually exclusive with Body (a captured
+	// body has BodySkipped == "").
+	BodySkipped BodySkippedReason `json:"bs,omitempty"`
 }
 
 func (e *FullLogRequest) setRecordFields(er *LogRecord) {
@@ -35,6 +57,7 @@ func (e *FullLogRequest) setRecordFields(er *LogRecord) {
 	er.Method = e.Method
 	er.RequestHttpVersion = e.HttpVersion
 	er.RequestSizeBytes = e.ContentLength
+	er.RequestBodySkipped = e.BodySkipped
 
 	if e.Headers != nil && e.Headers["Content-Type"] != nil && len(e.Headers["Content-Type"]) > 0 {
 		er.RequestMimeType = e.Headers["Content-Type"][0]
@@ -48,6 +71,9 @@ type FullLogResponse struct {
 	Body          []byte              `json:"b,omitempty"`
 	ContentLength int64               `json:"cl,omitempty"`
 	Err           string              `json:"err,omitempty"`
+	// BodySkipped is non-empty when the response body was not captured
+	// (chunked SSE, oversize). Same shape as FullLogRequest.BodySkipped.
+	BodySkipped BodySkippedReason `json:"bs,omitempty"`
 }
 
 func (e *FullLogResponse) setRecordFields(er *LogRecord) {
@@ -64,6 +90,7 @@ func (e *FullLogResponse) setRecordFields(er *LogRecord) {
 	er.ResponseSizeBytes = e.ContentLength
 	er.ResponseStatusCode = e.StatusCode
 	er.ResponseError = e.Err
+	er.ResponseBodySkipped = e.BodySkipped
 }
 
 type FullLog struct {
@@ -139,6 +166,7 @@ func NewFullLogFromRecord(er *LogRecord) *FullLog {
 		Method:        er.Method,
 		ContentLength: er.RequestSizeBytes,
 		Headers:       make(map[string][]string),
+		BodySkipped:   er.RequestBodySkipped,
 	}
 	if er.RequestMimeType != "" {
 		entry.Request.Headers["Content-Type"] = []string{er.RequestMimeType}
@@ -151,6 +179,7 @@ func NewFullLogFromRecord(er *LogRecord) *FullLog {
 		ContentLength: er.ResponseSizeBytes,
 		Err:           er.ResponseError,
 		Headers:       make(map[string][]string),
+		BodySkipped:   er.ResponseBodySkipped,
 	}
 	if er.ResponseMimeType != "" {
 		entry.Response.Headers["Content-Type"] = []string{er.ResponseMimeType}

--- a/internal/request_log/log_record.go
+++ b/internal/request_log/log_record.go
@@ -32,11 +32,18 @@ type LogRecord struct {
 	RequestHttpVersion  string              `json:"request_http_version,omitempty"`
 	RequestSizeBytes    int64               `json:"request_size_bytes,omitempty"`
 	RequestMimeType     string              `json:"request_mime_type,omitempty"`
+	// RequestBodySkipped explains why the request body was not captured
+	// into the full log (chunked / unknown size, or larger than the
+	// configured cap). Empty when captured. See BodySkippedReason.
+	RequestBodySkipped  BodySkippedReason   `json:"request_body_skipped,omitempty"`
 	ResponseStatusCode  int                 `json:"response_status_code,omitempty"`
 	ResponseError       string              `json:"response_error,omitempty"`
 	ResponseHttpVersion string              `json:"response_http_version,omitempty"`
 	ResponseSizeBytes   int64               `json:"response_size_bytes,omitempty"`
 	ResponseMimeType    string              `json:"response_mime_type,omitempty"`
+	// ResponseBodySkipped mirrors RequestBodySkipped for the response
+	// side — chunked SSE / LLM token streams are the common case.
+	ResponseBodySkipped BodySkippedReason   `json:"response_body_skipped,omitempty"`
 	InternalTimeout     bool                `json:"internal_timeout,omitempty"`
 	RequestCancelled    bool                `json:"request_cancelled,omitempty"`
 	FullRequestRecorded bool                `json:"full_request_recorded,omitempty"`

--- a/internal/request_log/migrations/postgres/000003_add_body_skipped.down.sql
+++ b/internal/request_log/migrations/postgres/000003_add_body_skipped.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE http_log_entry_records
+    DROP COLUMN request_body_skipped,
+    DROP COLUMN response_body_skipped;

--- a/internal/request_log/migrations/postgres/000003_add_body_skipped.up.sql
+++ b/internal/request_log/migrations/postgres/000003_add_body_skipped.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE http_log_entry_records
+    ADD COLUMN request_body_skipped TEXT NOT NULL DEFAULT '',
+    ADD COLUMN response_body_skipped TEXT NOT NULL DEFAULT '';

--- a/internal/request_log/migrations/sqlite/000003_add_body_skipped.down.sql
+++ b/internal/request_log/migrations/sqlite/000003_add_body_skipped.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE http_log_entry_records DROP COLUMN request_body_skipped;
+ALTER TABLE http_log_entry_records DROP COLUMN response_body_skipped;

--- a/internal/request_log/migrations/sqlite/000003_add_body_skipped.up.sql
+++ b/internal/request_log/migrations/sqlite/000003_add_body_skipped.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE http_log_entry_records
+    ADD COLUMN request_body_skipped TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE http_log_entry_records
+    ADD COLUMN response_body_skipped TEXT NOT NULL DEFAULT '';

--- a/internal/request_log/provider_clickhouse.go
+++ b/internal/request_log/provider_clickhouse.go
@@ -61,8 +61,9 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 			"response_http_version, response_size_bytes, response_mime_type, "+
 			"internal_timeout, request_cancelled, full_request_recorded, "+
 			"labels, response_source, rate_limit_id, rate_limit_mode, "+
-			"rate_limit_bucket, rate_limit_matched) "+
-			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			"rate_limit_bucket, rate_limit_matched, "+
+			"request_body_skipped, response_body_skipped) "+
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		entryRecordsTable,
 	))
 	if err != nil {
@@ -103,6 +104,7 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 			labelsVal,
 			string(source), r.RateLimitId.String(), r.RateLimitMode,
 			bucketJSON, matchedJSON,
+			string(r.RequestBodySkipped), string(r.ResponseBodySkipped),
 		)
 		if err != nil {
 			s.logger.Error("failed to insert record into clickhouse", "error", err, "entry_id", r.RequestId.String())
@@ -153,7 +155,9 @@ func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 		rate_limit_id String DEFAULT '',
 		rate_limit_mode String DEFAULT '',
 		rate_limit_bucket String DEFAULT '{}',
-		rate_limit_matched String DEFAULT '[]'
+		rate_limit_matched String DEFAULT '[]',
+		request_body_skipped String DEFAULT '',
+		response_body_skipped String DEFAULT ''
 	) ENGINE = MergeTree()
 	ORDER BY (namespace, timestamp_ms, request_id)`, entryRecordsTable)
 

--- a/internal/request_log/provider_sql.go
+++ b/internal/request_log/provider_sql.go
@@ -98,6 +98,8 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 			"rate_limit_mode",
 			"rate_limit_bucket",
 			"rate_limit_matched",
+			"request_body_skipped",
+			"response_body_skipped",
 		)
 
 	for _, record := range records {
@@ -148,6 +150,8 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 			record.RateLimitMode,
 			bucketJSON,
 			matchedJSON,
+			string(record.RequestBodySkipped),
+			string(record.ResponseBodySkipped),
 		)
 	}
 
@@ -239,6 +243,7 @@ var entryRecordColumns = []string{
 	"labels",
 	"response_source", "rate_limit_id", "rate_limit_mode",
 	"rate_limit_bucket", "rate_limit_matched",
+	"request_body_skipped", "response_body_skipped",
 }
 
 func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error) {
@@ -247,6 +252,7 @@ func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error)
 	var timestampMs, durationMs int64
 	var responseSource, rateLimitId, rateLimitMode string
 	var rateLimitBucket, rateLimitMatched []byte
+	var requestBodySkipped, responseBodySkipped string
 
 	err := row.Scan(
 		&requestId, &er.Namespace, &er.Type, &er.CorrelationId, &timestampMs,
@@ -259,10 +265,13 @@ func scanLogRecord(row interface{ Scan(dest ...any) error }) (*LogRecord, error)
 		&er.Labels,
 		&responseSource, &rateLimitId, &rateLimitMode,
 		&rateLimitBucket, &rateLimitMatched,
+		&requestBodySkipped, &responseBodySkipped,
 	)
 	if err != nil {
 		return nil, err
 	}
+	er.RequestBodySkipped = BodySkippedReason(requestBodySkipped)
+	er.ResponseBodySkipped = BodySkippedReason(responseBodySkipped)
 
 	er.RequestId = apid.ID(requestId)
 	er.ConnectionId = apid.ID(connectionId)

--- a/internal/request_log/roundtripper.go
+++ b/internal/request_log/roundtripper.go
@@ -42,6 +42,8 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	var requestBodyBuf *bytes.Buffer
 	var requestBodyTrackingReader trackingReader
 	var responseBodyTrackingReader trackingReader
+	var requestBodySkipped BodySkippedReason
+	var responseBodySkipped BodySkippedReason
 
 	// Generate a unique ID for this request
 	id := apctx.GetIdGenerator(ctx).New(apid.PrefixRequestLog)
@@ -52,23 +54,33 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if req.Body != nil {
 		if cc.recordFullRequest && cc.maxFullRequestSize > 0 {
-			// Create a buffer to store the request body
-			requestBodyBuf = &bytes.Buffer{}
-
-			// Create a TeeReader that copies to our buffer but passes through all data
-			bodyReader := io.TeeReader(
-				io.LimitReader(req.Body, int64(cc.maxFullRequestSize)),
-				requestBodyBuf,
-			)
-
-			// Split the reader so the data is read from the tee reader, but the close happens on the body
-			split := newSplitReadCloser(bodyReader, req.Body)
-
-			// Standardize the tracking of response size regardless of if we are tracking the body
-			requestBodyTrackingReader = split
-
-			// Replace the request body with our reader while preserving the original closer
-			req.Body = split
+			// Size-bounded capture: decide tee-vs-skip up front based on
+			// the advance-known Content-Length. Streaming bodies (chunked,
+			// no Content-Length) and bodies larger than the configured cap
+			// are forwarded *un-tee'd* so the upstream sees the full
+			// stream and the proxy does not accumulate an unbounded body
+			// in memory. The "skipped" reason lands on the log record so
+			// operators can see why a body wasn't captured.
+			switch {
+			case req.ContentLength < 0:
+				requestBodySkipped = BodySkippedStreaming
+				tracking := newTrackingReadCloser(req.Body)
+				requestBodyTrackingReader = tracking
+				req.Body = tracking
+			case uint64(req.ContentLength) > cc.maxFullRequestSize:
+				requestBodySkipped = BodySkippedTooLarge
+				tracking := newTrackingReadCloser(req.Body)
+				requestBodyTrackingReader = tracking
+				req.Body = tracking
+			default:
+				// ContentLength is set and within the cap. Tee straight
+				// through — no LimitReader, since we know the body fits.
+				requestBodyBuf = &bytes.Buffer{}
+				bodyReader := io.TeeReader(req.Body, requestBodyBuf)
+				split := newSplitReadCloser(bodyReader, req.Body)
+				requestBodyTrackingReader = split
+				req.Body = split
+			}
 		} else {
 			// Track the body size
 			tracking := newTrackingReadCloser(req.Body)
@@ -104,6 +116,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			Method:        req.Method,
 			Headers:       req.Header,
 			ContentLength: reqContentLength,
+			BodySkipped:   requestBodySkipped,
 		},
 		MillisecondDuration: MillisecondDuration(clock.Since(startTime)),
 	}
@@ -157,23 +170,40 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	full_log.Response.ContentLength = resp.ContentLength // This will be overwritten if we are recording the full response
 
 	if cc.recordFullRequest && cc.maxFullResponseSize > 0 && resp.Body != nil {
-		var responseBodyWriter *io.PipeWriter
+		// Same size-bounded decision as the request side, against the
+		// upstream's Content-Length and max_full_response_size. SSE /
+		// chunked streams skip the tee — the whole point of the raw
+		// path is "don't buffer the upstream response."
+		switch {
+		case resp.ContentLength < 0:
+			responseBodySkipped = BodySkippedStreaming
+			bodyReader := newTrackingReadCloser(resp.Body)
+			responseBodyTrackingReader = bodyReader
+			resp.Body = bodyReader
+		case uint64(resp.ContentLength) > cc.maxFullResponseSize:
+			responseBodySkipped = BodySkippedTooLarge
+			bodyReader := newTrackingReadCloser(resp.Body)
+			responseBodyTrackingReader = bodyReader
+			resp.Body = bodyReader
+		default:
+			var responseBodyWriter *io.PipeWriter
 
-		// Create a new reader that allows us to read the response without consuming it
-		responseBodyReader, responseBodyWriter = io.Pipe()
-		originalBody := resp.Body
+			// Create a new reader that allows us to read the response without consuming it
+			responseBodyReader, responseBodyWriter = io.Pipe()
+			originalBody := resp.Body
 
-		// Create a TeeReader to copy the response to our writer while still passing it through
-		teeReader := io.TeeReader(io.LimitReader(originalBody, int64(cc.maxFullResponseSize)), responseBodyWriter)
+			// Content-Length is known and within the cap — tee without
+			// a LimitReader so the upstream body passes through whole.
+			teeReader := io.TeeReader(originalBody, responseBodyWriter)
 
-		bodyReader := newSplitReadCloser(teeReader, originalBody, responseBodyWriter)
+			bodyReader := newSplitReadCloser(teeReader, originalBody, responseBodyWriter)
 
-		// Track the response being read for size as well
-		responseBodyTrackingReader = bodyReader
+			// Track the response being read for size as well
+			responseBodyTrackingReader = bodyReader
 
-		// Replace the response body with our tee reader
-		resp.Body = bodyReader
-
+			// Replace the response body with our tee reader
+			resp.Body = bodyReader
+		}
 	} else {
 		bodyReader := newTrackingReadCloser(resp.Body)
 
@@ -183,6 +213,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Replace the response body with our tee reader
 		resp.Body = bodyReader
 	}
+	full_log.Response.BodySkipped = responseBodySkipped
 
 	// Store the full_log in Redis asynchronously
 	go func() {

--- a/internal/request_log/roundtripper_test.go
+++ b/internal/request_log/roundtripper_test.go
@@ -164,7 +164,12 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			},
 		},
 		{
-			name:                "successful request, full logging enabled, request and response truncated",
+			// Behavior change in #331: oversized bodies are no longer
+			// truncated. The proxy forwards the full body upstream and
+			// records BodySkipped=too_large; the captured Body remains
+			// nil. Truncating would have OOM'd the proxy or corrupted
+			// the upstream body for the raw-streaming path.
+			name:                "successful request, oversized request and response skipped (too_large)",
 			recordFullRequest:   true,
 			maxFullRequestSize:  4,
 			maxFullResponseSize: 5,
@@ -208,7 +213,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 						"Some":         []string{"header"},
 					},
 					ContentLength: int64(len([]byte(`{"some": "json"}`))),
-					Body:          []byte(`{"so`),
+					BodySkipped:   BodySkippedTooLarge,
 				},
 				Response: FullLogResponse{
 					HttpVersion: "HTTP/2",
@@ -218,7 +223,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 						"Other":        []string{"header"},
 					},
 					ContentLength: int64(len([]byte(`{"other": "json"}`))),
-					Body:          []byte(`{"oth`),
+					BodySkipped:   BodySkippedTooLarge,
 				},
 			},
 		},
@@ -278,6 +283,125 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 					},
 					ContentLength: int64(len([]byte(`{"other": "json"}`))),
 					Body:          nil,
+				},
+			},
+		},
+		{
+			// Streaming-direction skip: ContentLength=-1 means chunked
+			// transfer-encoding (or otherwise unknown size). The proxy
+			// can't make a size-bounded decision, so the body is
+			// forwarded untouched and BodySkipped=streaming is stamped.
+			name:                "streaming request body, no Content-Length, skipped (streaming)",
+			recordFullRequest:   true,
+			maxFullRequestSize:  1024,
+			maxFullResponseSize: 1024,
+			request: &http.Request{
+				Method:     "POST",
+				URL:        util.Must(url.Parse("http://example.com/upload")),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Content-Type": []string{"application/octet-stream"},
+				},
+				Body:          io.NopCloser(bytes.NewBufferString(`stream-body`)),
+				ContentLength: -1,
+			},
+			response: &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Proto:      "HTTP/2",
+				ProtoMajor: 2,
+				ProtoMinor: 0,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body:          io.NopCloser(bytes.NewBufferString(`{"ok":true}`)),
+				ContentLength: int64(len(`{"ok":true}`)),
+			},
+			expectedFullLog: &FullLog{
+				Id:            apid.New(apid.PrefixRequestLog),
+				CorrelationID: "some-value",
+				Timestamp:     time.Now(),
+				Full:          true,
+				Request: FullLogRequest{
+					URL:         "http://example.com/upload",
+					HttpVersion: "HTTP/1.1",
+					Method:      "POST",
+					Headers: http.Header{
+						"Content-Type": []string{"application/octet-stream"},
+					},
+					ContentLength: int64(len("stream-body")), // inferred from bytes-read since ContentLength was -1
+					BodySkipped:   BodySkippedStreaming,
+				},
+				Response: FullLogResponse{
+					HttpVersion: "HTTP/2",
+					StatusCode:  http.StatusOK,
+					Headers: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					ContentLength: int64(len(`{"ok":true}`)),
+					Body:          []byte(`{"ok":true}`),
+				},
+			},
+		},
+		{
+			// Chunked / SSE response: ContentLength=-1. Same skip
+			// behavior on the response side as on the request side.
+			name:                "streaming response body, no Content-Length, skipped (streaming)",
+			recordFullRequest:   true,
+			maxFullRequestSize:  1024,
+			maxFullResponseSize: 1024,
+			request: &http.Request{
+				Method:     "GET",
+				URL:        util.Must(url.Parse("http://example.com/sse")),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Accept": []string{"text/event-stream"},
+				},
+				Body:          http.NoBody,
+				ContentLength: 0,
+			},
+			response: &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+				},
+				Body:          io.NopCloser(bytes.NewBufferString("event: x\ndata: 1\n\n")),
+				ContentLength: -1,
+			},
+			expectedFullLog: &FullLog{
+				Id:            apid.New(apid.PrefixRequestLog),
+				CorrelationID: "some-value",
+				Timestamp:     time.Now(),
+				Full:          true,
+				Request: FullLogRequest{
+					URL:         "http://example.com/sse",
+					HttpVersion: "HTTP/1.1",
+					Method:      "GET",
+					Headers: http.Header{
+						"Accept": []string{"text/event-stream"},
+					},
+					// ContentLength=0 with non-nil http.NoBody falls
+					// into the default tee branch; the tee captures
+					// zero bytes and the buffer round-trips as [] not
+					// nil.
+					Body: []byte{},
+				},
+				Response: FullLogResponse{
+					HttpVersion: "HTTP/1.1",
+					StatusCode:  http.StatusOK,
+					Headers: http.Header{
+						"Content-Type": []string{"text/event-stream"},
+					},
+					ContentLength: int64(len("event: x\ndata: 1\n\n")),
+					BodySkipped:   BodySkippedStreaming,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Closes #331. Makes the request_log body-capture path size-bounded so streaming raw-proxy traffic (SSE, large uploads, chunked transfers) is forwarded whole instead of being truncated or unboundedly buffered. The decision is made up front based on Content-Length:

| Inbound Content-Length | Capture path | LogRecord field |
|---|---|---|
| `< 0` (chunked / unknown) | tee skipped, body forwarded as-is | `RequestBodySkipped = "streaming"` |
| `> max_request_size`     | tee skipped, body forwarded as-is | `RequestBodySkipped = "too_large"` |
| within cap               | full tee into blob storage         | `RequestBodySkipped = ""` |

Same shape on the response side keyed off `resp.ContentLength` and `max_response_size`.

The change lives in `internal/request_log.RoundTripper` so both the wrapped `_proxy` path and the new `_proxy_raw` path benefit. The wrapped path always had Content-Length ≤ cap (its route handler JSON-decodes the body), so its behavior is unchanged.

### Behavior change worth a second look

Previously the tee wrapped `io.LimitReader(req.Body, max)`, which silently truncated the *forwarded* body to the cap. That was masked for the wrapped path (bodies are always small) but would have corrupted streaming raw uploads. The new code only attaches a tee when it knows the body fits, so it can safely drop the LimitReader. The previously-named `request_and_response_truncated` test is renamed to `..._too_large` and updated to expect the skip-record-pass-through behavior.

### Schema

New migration `000003_add_body_skipped` adds two `TEXT NOT NULL DEFAULT ''` columns (postgres + sqlite). Clickhouse DDL + INSERT mirror.

## Test plan

- [x] `go test ./...` — all green; existing `TestRoundTripper_RoundTrip` table gains two new subtests (streaming-request, streaming-response).
- [x] `go test -tags integration ./proxy` — `TestProxyRawBodyCapture_TeeDecision` covers all three subtests end-to-end:
  - small known-length body → `BodySkipped == ""`, upstream sees full bytes
  - 300 KiB body (cap is 250 KiB) → `BodySkipped == "too_large"`, upstream still sees all 300 KiB (the load-bearing regression check)
  - chunked transfer-encoding body → `BodySkipped == "streaming"`, upstream still sees full bytes
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)