### PR TITLE
Add OAuth2 PKCE validation integration tests (#174 scenario 14)

### DIFF
--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -81,6 +82,10 @@ type OAuth2ConnectorOptions struct {
 	// RevocationEndpoint overrides provider.RevocationEndpoint() (only used
 	// when IncludeRevocation is true).
 	RevocationEndpoint string
+	// PKCE, when non-nil, enables RFC 7636 PKCE on the authorize/token-exchange
+	// pair for this connector. Mirror the production schema block — nil means
+	// PKCE is disabled (the default, current behavior).
+	PKCE *connectors.AuthOauth2PKCE
 }
 
 // NewOAuth2Connector builds an authproxy connector wired to the given
@@ -112,6 +117,7 @@ func NewOAuth2Connector(connectorID apid.ID, displayName string, provider *OAuth
 		Scopes:       scopes,
 		Authorization: connectors.AuthOauth2Authorization{
 			Endpoint: authEndpoint,
+			PKCE:     opts.PKCE,
 		},
 		Token: connectors.AuthOauth2Token{
 			Endpoint: tokenEndpoint,
@@ -306,15 +312,17 @@ func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL s
 // JSON tags must stay in sync with the production struct; if they drift,
 // the production decode will fail with errStateTampered.
 type OAuth2StateForTest struct {
-	Id                     apid.ID   `json:"id"`
-	Namespace              string    `json:"namespace"`
-	ActorId                apid.ID   `json:"actor_id"`
-	ConnectorId            apid.ID   `json:"connector_id"`
-	ConnectorVersion       uint64    `json:"connector_version"`
-	ConnectionId           apid.ID   `json:"connection_id"`
-	ReturnToUrl            string    `json:"return_to"`
-	CancelSessionAfterAuth bool      `json:"cancel_session_after_auth"`
-	ExpiresAt              time.Time `json:"expires_at"`
+	Id                     apid.ID               `json:"id"`
+	Namespace              string                `json:"namespace"`
+	ActorId                apid.ID               `json:"actor_id"`
+	ConnectorId            apid.ID               `json:"connector_id"`
+	ConnectorVersion       uint64                `json:"connector_version"`
+	ConnectionId           apid.ID               `json:"connection_id"`
+	ReturnToUrl            string                `json:"return_to"`
+	CancelSessionAfterAuth bool                  `json:"cancel_session_after_auth"`
+	ExpiresAt              time.Time             `json:"expires_at"`
+	PKCECodeVerifier       string                `json:"pkce_code_verifier,omitempty"`
+	PKCEMethod             connectors.PKCEMethod `json:"pkce_method,omitempty"`
 }
 
 // WriteOAuth2StateForTest encrypts and stores a synthetic OAuth2 state
@@ -335,6 +343,28 @@ func (env *IntegrationTestEnv) WriteOAuth2StateForTest(t *testing.T, s OAuth2Sta
 	require.NoError(t, err)
 	key := fmt.Sprintf("oauth2:state:%s", s.Id.String())
 	require.NoError(t, env.DM.GetRedisClient().Set(ctx, key, ef.ToInlineString(), ttl).Err())
+}
+
+// ReadOAuth2StateForTest decrypts and decodes the OAuth2 state record at
+// `oauth2:state:<stateId>` so tests can read fields like PKCECodeVerifier
+// that the natural _initiate flow populates. Used by the PKCE tests to
+// snapshot the persisted verifier before mutating it.
+//
+// The JSON tags on OAuth2StateForTest must stay in sync with the production
+// struct (`internal/auth_methods/oauth2/state.go`) so the decode round-trips.
+func (env *IntegrationTestEnv) ReadOAuth2StateForTest(t *testing.T, stateId apid.ID) OAuth2StateForTest {
+	t.Helper()
+	ctx := context.Background()
+	key := fmt.Sprintf("oauth2:state:%s", stateId.String())
+	raw, err := env.DM.GetRedisClient().Get(ctx, key).Result()
+	require.NoErrorf(t, err, "state %s should exist in redis", stateId)
+	ef, err := encfield.ParseInlineString(raw)
+	require.NoError(t, err)
+	plaintext, err := env.DM.GetEncryptService().Decrypt(ctx, ef)
+	require.NoError(t, err)
+	var s OAuth2StateForTest
+	require.NoError(t, json.Unmarshal(plaintext, &s))
+	return s
 }
 
 // GetOAuth2Token reads the most recent OAuth2 token row stored for the

--- a/integration_tests/oauth2/pkce_test.go
+++ b/integration_tests/oauth2/pkce_test.go
@@ -1,0 +1,478 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pkceVerifierAlphabet mirrors RFC 7636 §4.1 — the production generator is
+// internal to the oauth2 package, so the integration tests pin the alphabet
+// here to assert the verifier the proxy persists is well-formed without
+// reaching into unexported helpers.
+const pkceVerifierAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+// minVerifierLen is RFC 7636 §4.1's floor; the production generator emits
+// exactly 43 chars but the spec allows 43-128, so the assertion accepts the
+// full range — the test cares that the verifier is conforming, not that
+// it's exactly the length the current generator picked.
+const (
+	minVerifierLen = 43
+	maxVerifierLen = 128
+)
+
+// pkceS256Challenge computes base64url(sha256(verifier)) with no padding —
+// the RFC 7636 §4.2 S256 transformation. Duplicated here (rather than
+// imported from internal/auth_methods/oauth2) because integration tests
+// should not depend on package-internal helpers; matching values prove the
+// two implementations agree on the contract.
+func pkceS256Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// freshVerifier mints a 43-char verifier from the RFC 7636 unreserved
+// alphabet for the MismatchedVerifier subtest. Distinct from the production
+// generator so test failures don't shadow real bugs.
+func freshVerifier(t *testing.T) string {
+	t.Helper()
+	const n = 43
+	buf := make([]byte, n)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+	out := make([]byte, n)
+	for i, b := range buf {
+		out[i] = pkceVerifierAlphabet[int(b)%len(pkceVerifierAlphabet)]
+	}
+	return string(out)
+}
+
+// requireVerifierShape pins the RFC 7636 §4.1 invariants on a verifier read
+// from Redis (the encrypted state record stores the plaintext verifier;
+// only the provider's request recorder redacts it on the wire). Length
+// within [43,128] and every byte from the unreserved alphabet. A verifier
+// outside these bounds would be rejected by spec-conformant providers.
+func requireVerifierShape(t *testing.T, verifier string) {
+	t.Helper()
+	require.GreaterOrEqualf(t, len(verifier), minVerifierLen,
+		"persisted verifier shorter than RFC 7636 §4.1 minimum: %q", verifier)
+	require.LessOrEqualf(t, len(verifier), maxVerifierLen,
+		"persisted verifier longer than RFC 7636 §4.1 maximum: %q", verifier)
+	for i := 0; i < len(verifier); i++ {
+		require.True(t, strings.IndexByte(pkceVerifierAlphabet, verifier[i]) >= 0,
+			"persisted verifier contains illegal byte %q at idx %d (%q)", verifier[i], i, verifier)
+	}
+}
+
+// hasCodeVerifierForm reports whether the recorded /token form carried a
+// non-empty `code_verifier`. The test provider redacts the verifier value
+// to "<redacted>" in its recorder (per its sensitive-field policy), so
+// integration tests check presence-vs-absence, not the literal value. The
+// literal-value contract is proved via the pre-callback Redis state read
+// + S256 hash equality against the authorize URL's challenge.
+func hasCodeVerifierForm(form map[string][]string) bool {
+	v, ok := form["code_verifier"]
+	if !ok {
+		return false
+	}
+	for _, x := range v {
+		if x != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPKCE_HappyPath_S256 drives the full PKCE-enabled authorization-code
+// flow through the marketplace UI against a provider client registered with
+// RequirePKCE: true. A green flow proves the proxy emits the challenge on
+// authorize and the matching verifier on token exchange — the provider
+// would reject both halves otherwise.
+//
+// See pkce_test.md for the scenario specification.
+func TestPKCE_HappyPath_S256(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := "pkce-happy-client-" + suffix
+	clientSecret := "pkce-happy-secret-" + suffix
+	userPassword := "p4ssw0rd-" + suffix
+	userEmail := "alice-pkce-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "pkce-happy-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+		PKCE:         &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:            helpers.ServiceTypeAPI,
+		StartHTTPServer:    true,
+		IncludePublic:      true,
+		ServeMarketplaceUI: true,
+		Connectors:         []sconfig.Connector{connector},
+	})
+	defer env.Cleanup()
+
+	// RequirePKCE: true makes the test provider refuse authorize without
+	// code_challenge — a missing challenge would 4xx at /web/authorize, the
+	// chromedp wait would time out, and the test would fail before any of
+	// the substantive PKCE assertions run.
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+		RequirePKCE:             true,
+	})
+	require.Equal(t, clientKey, registered.Key)
+	require.True(t, registered.RequirePKCE, "provider should echo back RequirePKCE=true on the registered client")
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: userPassword,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	authToken, err := env.PublicAuthUtil.GenerateBearerToken(
+		context.Background(),
+		"test-actor",
+		sconfig.RootNamespace,
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	browserCtx, _ := helpers.NewBrowser(t)
+
+	connectorsURL := env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(authToken)
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Navigate(connectorsURL),
+		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
+	))
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Click(`//button[normalize-space()='Connect']`, chromedp.BySearch),
+		chromedp.WaitVisible(`input[name="email"]`, chromedp.ByQuery),
+	))
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.SendKeys(`input[name="email"]`, userEmail, chromedp.ByQuery),
+		chromedp.SendKeys(`input[name="password"]`, userPassword, chromedp.ByQuery),
+		chromedp.Submit(`input[name="email"]`, chromedp.ByQuery),
+		chromedp.WaitVisible(`input[name="allow"]`, chromedp.ByQuery),
+	))
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Click(`input[name="allow"]`, chromedp.ByQuery),
+		chromedp.WaitVisible(`//h1[normalize-space()='Your Connections']`, chromedp.BySearch),
+	))
+
+	// Locate the new connection. We don't read state from Redis here — the
+	// callback handler deletes it after consuming the code, so any read
+	// after WaitVisible above would race the cleanup. Instead we assert on
+	// what the provider saw (challenge on authorize, verifier on token).
+	page := env.Db.ListConnectionsBuilder().
+		ForNamespaceMatcher(sconfig.RootNamespace).
+		Limit(10).
+		FetchPage(context.Background())
+	require.NoError(t, page.Error)
+	require.Lenf(t, page.Results, 1, "expected exactly one connection after PKCE flow; got %d", len(page.Results))
+	connectionID := page.Results[0].Id.String()
+
+	// Token persisted and not expired — the proxy must have parsed a
+	// success response from the provider, which only returns 200 when
+	// PKCE verifies.
+	token := env.GetOAuth2Token(t, connectionID)
+	require.NotNil(t, token, "PKCE success path must persist an OAuth2 token row")
+	assert.False(t, token.EncryptedAccessToken.IsZero(), "access token must be stored encrypted")
+	require.NotNil(t, token.AccessTokenExpiresAt)
+	assert.True(t, token.AccessTokenExpiresAt.After(time.Now()),
+		"PKCE success path token should not be pre-expired (expires_at=%s)", token.AccessTokenExpiresAt)
+
+	conn := env.GetConnection(t, connectionID)
+	assert.Equal(t, database.ConnectionStateReady, conn.State,
+		"PKCE success path should land the connection in ready")
+
+	// Provider must have observed a /token POST carrying code_verifier.
+	// The recorder redacts the literal value (see hasCodeVerifierForm
+	// docstring), so the strongest contract we can prove here is
+	// "present and non-empty" — but a missing or stripped verifier
+	// would fail the provider's PKCE check, and that failure would
+	// already have surfaced as a 4xx blocking the chromedp wait above.
+	// The combination of "field present in form" + "flow completed
+	// successfully" + "client was registered with RequirePKCE: true"
+	// is the literal-value contract one step removed.
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientKey,
+	})
+	require.Lenf(t, tokenReqs, 1, "expected exactly one /token POST; got %d", len(tokenReqs))
+	tokenForm := tokenReqs[0].Form
+	assert.Truef(t, hasCodeVerifierForm(tokenForm),
+		"PKCE-enabled token exchange must include code_verifier; form keys=%v",
+		formKeys(tokenForm))
+	assert.Equal(t, "authorization_code", lastForm(tokenForm, "grant_type"))
+}
+
+// formKeys returns the sorted set of keys present in a recorded form, for
+// error messages that need to convey "what fields were sent" without
+// leaking redacted bodies.
+func formKeys(form map[string][]string) []string {
+	keys := make([]string, 0, len(form))
+	for k := range form {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// TestPKCE_TokenExchangeRejected covers issue #174's "missing" and
+// "invalid" code_verifier cases by mutating the persisted state record
+// between authorize and callback. Both subtests share the rig and differ
+// only in how they mutate the verifier — empty for missing, fresh for
+// mismatched.
+//
+// The state-mutation approach is necessary because a correctly wired
+// proxy will never emit a missing or mismatched verifier on its own —
+// both come from forging the state.
+func TestPKCE_TokenExchangeRejected(t *testing.T) {
+	subtests := []struct {
+		name string
+		// mutate returns the verifier that should end up in state. Empty
+		// string means "clear the verifier" (the MissingVerifier case);
+		// any other value means "replace it" (MismatchedVerifier).
+		mutate func(t *testing.T, original string) string
+		// expectVerifierSent is what the test asserts the proxy POSTed to
+		// /token. For MissingVerifier the form key is absent; for
+		// MismatchedVerifier the form key matches the mutated value.
+		expectVerifierAbsent bool
+	}{
+		{
+			name: "MissingVerifier",
+			mutate: func(t *testing.T, _ string) string {
+				return ""
+			},
+			expectVerifierAbsent: true,
+		},
+		{
+			name: "MismatchedVerifier",
+			mutate: func(t *testing.T, original string) string {
+				v := freshVerifier(t)
+				require.NotEqualf(t, original, v,
+					"mutated verifier must differ from the original; both were %q", v)
+				return v
+			},
+			expectVerifierAbsent: false,
+		},
+	}
+
+	for _, sub := range subtests {
+		t.Run(sub.name, func(t *testing.T) {
+			provider := helpers.NewOAuth2TestProvider(t)
+
+			suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+			clientKey := "pkce-rej-" + strings.ToLower(sub.name) + "-" + suffix
+			clientSecret := "pkce-rej-secret-" + suffix
+			userEmail := "alice-pkce-rej-" + suffix + "@example.com"
+			returnToURL := "https://example.com/return"
+
+			connectorID := apid.New(apid.PrefixConnectorVersion)
+			connector := helpers.NewOAuth2Connector(connectorID, "pkce-rejected", provider, helpers.OAuth2ConnectorOptions{
+				ClientID:     clientKey,
+				ClientSecret: clientSecret,
+				Scopes:       []string{"read"},
+				PKCE:         &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+			})
+
+			logCapture := helpers.NewLogCapture()
+			env := helpers.Setup(t, helpers.SetupOptions{
+				Service:       helpers.ServiceTypeAPI,
+				IncludePublic: true,
+				Connectors:    []sconfig.Connector{connector},
+				LogCapture:    logCapture,
+			})
+			defer env.Cleanup()
+
+			provider.CreateClient(helpers.CreateClientRequest{
+				Key:                     clientKey,
+				Secret:                  clientSecret,
+				RedirectURI:             env.PublicOAuthCallbackURL(),
+				TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+				Scope:                   "read",
+				RequirePKCE:             true,
+			})
+			user := provider.CreateUser(helpers.CreateUserRequest{
+				Username: userEmail,
+				Password: "irrelevant-test-password",
+				Email:    userEmail,
+			})
+
+			// Step 1: initiate. The state record is written to Redis with a
+			// freshly generated verifier (because the connector has a PKCE
+			// block); the redirect URL points at /oauth2/redirect with the
+			// new state_id.
+			connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnToURL)
+
+			redirectParsed, err := url.Parse(redirectURL)
+			require.NoError(t, err)
+			stateIDStr := redirectParsed.Query().Get("state_id")
+			require.NotEmpty(t, stateIDStr, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+			stateID, err := apid.Parse(stateIDStr)
+			require.NoError(t, err)
+
+			// Step 2: follow the proxy's redirect to build the upstream
+			// authorize URL. The proxy emits code_challenge into this URL
+			// when the connector has a PKCE block — exercising the
+			// authorize-side leg.
+			upstreamAuthorizeURL := env.FollowOAuth2Redirect(t, redirectURL)
+			upstreamParsed, err := url.Parse(upstreamAuthorizeURL)
+			require.NoError(t, err)
+			challenge := upstreamParsed.Query().Get("code_challenge")
+			require.NotEmptyf(t, challenge,
+				"PKCE-enabled connector must emit code_challenge in the upstream authorize URL; got %s", upstreamAuthorizeURL)
+			require.Equal(t, "S256", upstreamParsed.Query().Get("code_challenge_method"),
+				"connector configured with method=S256 must emit code_challenge_method=S256")
+
+			// Snapshot the original verifier so MismatchedVerifier can assert
+			// "the mutated value, not the original, was POSTed" — proving the
+			// proxy reads verifier from state fresh on each call rather than
+			// caching it from authorize.
+			originalState := env.ReadOAuth2StateForTest(t, stateID)
+			require.NotEmpty(t, originalState.PKCECodeVerifier,
+				"natural _initiate with PKCE block must persist a non-empty verifier")
+			require.Equal(t, cschema.PKCEMethodS256, originalState.PKCEMethod)
+			require.Equal(t, challenge, pkceS256Challenge(originalState.PKCECodeVerifier),
+				"persisted verifier must hash to the challenge emitted on authorize")
+
+			// Step 3: mint a real code via /test/authorize, passing the
+			// challenge so the provider binds the code to the original
+			// challenge. After this step, the provider's PKCE check will
+			// compare anything the proxy sends at /token against `challenge`.
+			authResp := provider.Authorize(helpers.AuthorizeRequest{
+				ClientID:            clientKey,
+				UserID:              user.ID,
+				RedirectURI:         env.PublicOAuthCallbackURL(),
+				Scope:               "read",
+				State:               stateIDStr,
+				Decision:            helpers.AuthorizeApprove,
+				CodeChallenge:       challenge,
+				CodeChallengeMethod: "S256",
+			})
+			require.NotEmpty(t, authResp.RedirectURL)
+			authResultParsed, err := url.Parse(authResp.RedirectURL)
+			require.NoError(t, err)
+			code := authResultParsed.Query().Get("code")
+			require.NotEmpty(t, code, "provider should issue a code on approve")
+
+			// Step 4: forge the verifier mutation. The state record persists
+			// in Redis at oauth2:state:<stateID>; replacing the verifier
+			// before callback forces the proxy to send the mutated value (or
+			// nothing, in the MissingVerifier case) on /token.
+			mutated := sub.mutate(t, originalState.PKCECodeVerifier)
+			forged := originalState
+			forged.PKCECodeVerifier = mutated
+			env.WriteOAuth2StateForTest(t, forged, 5*time.Minute)
+
+			// Step 5: deliver the callback. The proxy reads the (mutated)
+			// state, posts /token, and the provider rejects PKCE. The
+			// failure path here mirrors any other token-exchange failure
+			// during setup: redirect to return_to_url with setup=pending so
+			// the marketplace UI re-renders the connection in its
+			// auth_failed state (same shape scenario 7 pins for plain
+			// invalid_grant cases).
+			loc := env.DeliverOAuth2Callback(t, env.ForgeOAuth2CallbackURL(stateIDStr, code))
+			require.Truef(t, strings.HasPrefix(loc, returnToURL),
+				"PKCE rejection should redirect to return_to_url with setup=pending; got %q", loc)
+			parsed, err := url.Parse(loc)
+			require.NoError(t, err)
+			assert.Equal(t, "pending", parsed.Query().Get("setup"),
+				"PKCE rejection redirect should carry setup=pending")
+			assert.Equal(t, connID, parsed.Query().Get("connection_id"),
+				"PKCE rejection redirect should carry the connection_id")
+
+			// Exactly one structured token-exchange failure event. The
+			// category depends on whether the provider's error body
+			// included `error=invalid_grant`. go-oauth2-server returns a
+			// 4xx for PKCE failures but without a §5.2 `error` field, so
+			// the proxy classifies the response as `provider_4xx_other`.
+			// We accept either to stay robust against the provider
+			// tightening its error body in a future version.
+			events := logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)
+			require.Lenf(t, events, 1, "expected exactly one token-exchange failure event; got %d (%v)", len(events), events)
+			category, _ := events[0]["category"].(string)
+			assert.Containsf(t, []string{"invalid_grant", "provider_4xx_other"}, category,
+				"PKCE rejection at /token must classify as invalid_grant or provider_4xx_other; got %q", category)
+			if status, ok := events[0]["provider_status_code"].(float64); ok {
+				assert.GreaterOrEqualf(t, int(status), 400,
+					"provider_status_code should be a 4xx; got %v", status)
+				assert.Lessf(t, int(status), 500,
+					"provider_status_code should be a 4xx; got %v", status)
+			}
+
+			// No token row created — failed PKCE must not create a connection.
+			assert.Nil(t, env.GetOAuth2Token(t, connID),
+				"failed PKCE must not persist an OAuth2 token row")
+
+			// Connection lands in the auth_failed terminal step. The state
+			// stays `created` because the connection never reached the
+			// credentials-established transition.
+			connAfter := env.GetConnection(t, connID)
+			assert.Equal(t, database.ConnectionStateCreated, connAfter.State,
+				"connection state should remain `created` on PKCE rejection")
+			require.NotNilf(t, connAfter.SetupStep,
+				"PKCE-rejected connection should have a setup_step recorded")
+			assert.Truef(t, connAfter.SetupStep.Equals(cschema.SetupStepAuthFailed),
+				"connection should land in auth_failed; got %q", connAfter.SetupStep.String())
+			require.NotNilf(t, connAfter.SetupError,
+				"PKCE-rejected connection should have setup_error populated")
+
+			// Exactly one /token call observed at the provider, with the
+			// expected verifier presence/absence. The recorder redacts the
+			// verifier value (see hasCodeVerifierForm docstring) — the
+			// MismatchedVerifier subtest cannot pin the literal value on
+			// the wire. The behavioral contract that the proxy did send
+			// the mutated value (and not the original) is proved by the
+			// provider's PKCE rejection itself: if the proxy had sent the
+			// original verifier, the provider would have accepted it and
+			// returned a valid token, and the rest of the assertions
+			// above would have failed differently.
+			tokenReqs := provider.Requests(helpers.RequestsFilter{
+				Endpoint: helpers.EndpointToken,
+				ClientID: clientKey,
+			})
+			require.Lenf(t, tokenReqs, 1, "expected exactly one /token POST; got %d", len(tokenReqs))
+			form := tokenReqs[0].Form
+			hasVerifier := hasCodeVerifierForm(form)
+			if sub.expectVerifierAbsent {
+				assert.Falsef(t, hasVerifier,
+					"MissingVerifier subtest: proxy must not send code_verifier when state has none; form keys=%v",
+					formKeys(form))
+			} else {
+				assert.Truef(t, hasVerifier,
+					"MismatchedVerifier subtest: proxy must send (some) code_verifier from state; form keys=%v",
+					formKeys(form))
+			}
+		})
+	}
+}

--- a/integration_tests/oauth2/pkce_test.md
+++ b/integration_tests/oauth2/pkce_test.md
@@ -1,0 +1,182 @@
+# PKCE validation (issue #174, scenario 14)
+
+## What this verifies
+
+The OAuth2 PKCE machinery added in #335 wires three pieces together:
+
+1. The authorize URL builder (`internal/auth_methods/oauth2/auth_url.go:96-113`)
+   emits `code_challenge` and `code_challenge_method` when the connector
+   declares a PKCE block.
+2. The state record (`internal/auth_methods/oauth2/state.go:34-46`) persists
+   the per-flow `PKCECodeVerifier` and `PKCEMethod` alongside the encrypted
+   state envelope in Redis.
+3. The callback handler (`internal/auth_methods/oauth2/callback.go:178-183`)
+   forwards `code_verifier` from state on the token-exchange POST — but only
+   on the initial code-for-token exchange, never on refresh (RFC 7636 §6).
+
+These tests prove the three pieces are wired correctly end-to-end against
+a real upstream provider that enforces PKCE (`RequirePKCE: true` on the
+client). They sit on top of the unit tests in
+`internal/auth_methods/oauth2/pkce_test.go`, which already cover the
+generator, the S256/plain transformation, and the connector schema
+validator. The integration tests catch what unit tests cannot: that the
+challenge the provider receives at authorize is the one the verifier the
+proxy persists hashes to, that the persisted verifier actually rides on
+the token exchange POST, and that the proxy fails the connection cleanly
+when the provider rejects PKCE.
+
+## Issue spec mapping
+
+Issue #174 lists four cases and three verifies. The mapping to this file's
+tests:
+
+| #174 case                          | Covered by                                              |
+|------------------------------------|---------------------------------------------------------|
+| Valid `code_verifier`              | `TestPKCE_HappyPath_S256`                               |
+| Missing `code_verifier`            | `TestPKCE_TokenExchangeRejected/MissingVerifier`        |
+| Invalid `code_verifier`            | `TestPKCE_TokenExchangeRejected/MismatchedVerifier`     |
+| Unsupported `code_challenge_method` | Unit tests in `internal/auth_methods/oauth2/pkce_test.go` (`TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod`) — schema validator rejects at config load, so the bad value never reaches an integration test. Calling it out here so the audit trail is complete. |
+
+| #174 verify                          | Covered by                                              |
+|--------------------------------------|---------------------------------------------------------|
+| Valid PKCE succeeds                  | `TestPKCE_HappyPath_S256`                               |
+| Invalid PKCE fails token exchange    | Both `TestPKCE_TokenExchangeRejected` subtests          |
+| Failed PKCE does not create a connection | Both `TestPKCE_TokenExchangeRejected` subtests       |
+
+## Test 1: `TestPKCE_HappyPath_S256`
+
+**Goal:** prove the full PKCE roundtrip works against a provider that
+enforces PKCE, driven through the marketplace UI exactly as a real user
+would experience it.
+
+**Setup:**
+- Test provider client registered with `RequirePKCE: true`. The provider
+  refuses any authorize that arrives without `code_challenge`, so a green
+  flow is a positive signal that the proxy is emitting the challenge.
+- Connector with `pkce: {method: S256}`.
+- chromedp + marketplace + provider UI (per the issue's "test approach"
+  comment and the `feedback_oauth_flow_tests_use_real_ui` memory).
+
+**Assertions:**
+1. Connection landed in `ready`. Token row persisted with non-empty
+   encrypted material and a future expiry. With `RequirePKCE: true` on
+   the provider client, a `ready` state is a positive signal: the
+   provider verified `base64url(sha256(verifier)) == challenge` on its
+   side, so if anything had gone wrong on the proxy side (missing
+   challenge on authorize, missing/stale verifier on token exchange) the
+   flow would have failed before this point.
+2. The provider observed exactly one `/token` POST with grant_type
+   `authorization_code` and the `code_verifier` form field present
+   (non-empty). The test cannot pin the literal verifier value here
+   because the provider's request recorder redacts `code_verifier` to
+   `<redacted>` per its sensitive-field policy. The literal-value
+   contract — that the verifier the proxy persisted in state is the one
+   that arrives at the provider, and that it hashes to the challenge —
+   is pinned end to end in Test 2 (see "Pre-callback PKCE assertion"
+   below).
+
+**Why chromedp over the in-process driver:** the issue explicitly calls
+for it, and #174's #scenario-comment notes that the `/test/authorize`
+shortcut would skip the user-driven leg under test. The happy-path
+verification depends on the same code that runs in production redirect
+chains, not a hand-rolled callback delivery.
+
+## Test 2: `TestPKCE_TokenExchangeRejected`
+
+**Goal:** prove the proxy fails closed when the provider rejects PKCE at
+token exchange. Driven via the in-process callback delivery so the test
+can mutate the state record between authorize and callback — the only
+way to deterministically produce a mismatched or missing verifier (a
+correctly wired proxy will never emit one on its own).
+
+**Setup (shared):**
+- Test provider client with `RequirePKCE: true`.
+- Connector with `pkce: {method: S256}`.
+- `InitiateOAuth2Connection` mints the state and connection.
+- `FollowOAuth2Redirect` returns the upstream authorize URL with the
+  challenge embedded — proves the proxy emitted PKCE on the redirect.
+- `provider.Authorize(decision=approve)` mints a real authorization
+  code bound to the original `code_challenge`.
+- Before delivering the callback, the test reads the state from Redis,
+  mutates the verifier, and writes it back at the same key with the
+  same TTL.
+- `DeliverOAuth2Callback` runs through the production handler. The
+  proxy posts to `/oauth/token` with the mutated verifier; the
+  provider compares against the stored challenge and rejects.
+
+**Two subtests:**
+
+- `MissingVerifier` — verifier mutated to empty string. The proxy's
+  callback skips the `code_verifier` form field (the production check is
+  `if o.state.PKCECodeVerifier != ""`), so the provider sees a
+  PKCE-bound code with no verifier presented. Mirrors the "what if the
+  proxy lost the verifier" failure mode.
+- `MismatchedVerifier` — verifier swapped for a freshly generated
+  43-char value. The proxy posts a valid verifier shape, but the hash
+  doesn't match the stored challenge. Mirrors the "verifier intercepted
+  and replaced by an attacker" failure mode (and any honest proxy bug
+  that produces a stale verifier).
+
+**Pre-callback PKCE assertion (both subtests):** before mutating state
+the test reads the state record from Redis (plaintext after decrypt) and
+asserts `base64url(sha256(state.PKCECodeVerifier)) == challenge` from the
+upstream authorize URL. This is the literal-value contract the happy
+path can't pin (because the request recorder redacts `code_verifier` on
+the wire): the verifier the proxy persists is the one whose hash showed
+up at authorize. Any drift between authorize-side challenge derivation
+and state persistence would surface here.
+
+**Per-subtest assertions:**
+1. Callback redirects to `return_to_url?connection_id=<id>&setup=pending`.
+   This matches the scenario 7 (`callback_token_exchange_failure_test.go`)
+   shape: a token-exchange failure during setup is a setup failure, and
+   the marketplace UI's reconnect prompt fires on the `setup=pending`
+   annotation. It does *not* redirect to `error_pages.internal_error`
+   because the connection is recoverable — the user can retry.
+2. Exactly one structured `oauth token exchange failed` log event with
+   `category` of either `invalid_grant` or `provider_4xx_other`. The
+   choice depends on whether the upstream 4xx body included an
+   `error=invalid_grant` field. The reference test provider
+   (`go-oauth2-server`) returns a 4xx for PKCE failures without a §5.2
+   `error` field, so the proxy classifies as `provider_4xx_other`; the
+   assertion accepts either to stay robust against the provider
+   tightening its error body in a future version. The
+   `provider_status_code` field is asserted to be in the 4xx range.
+3. Token row was *not* created (`env.GetOAuth2Token` returns nil).
+4. Connection's `state` stays `created` and `setup_step` is
+   `auth_failed` with a non-empty `setup_error` — same terminal state
+   any other token-exchange failure lands in, so the marketplace UI's
+   reconnect prompt fires.
+5. The provider observed exactly one `/token` POST. For
+   `MissingVerifier` the form has no `code_verifier` key; for
+   `MismatchedVerifier` the form has `code_verifier` present (redacted
+   to `<redacted>` on the wire). The literal "the mutated value, not the
+   original, was sent" contract is proved by the provider's PKCE
+   rejection itself — if the proxy had sent the original verifier, the
+   provider would have accepted it, and all the failure-path
+   assertions above would have failed differently.
+
+**Why not just script `invalid_grant`:** scenario 7
+(`callback_token_exchange_failure_test.go`) already covers "provider
+returns invalid_grant → connection lands in auth_failed". Pointing the
+PKCE test at a scripted response would duplicate that coverage without
+exercising any PKCE-specific code. The state-mutation approach forces
+the provider's real PKCE validator to fire, so the test fails if the
+provider's PKCE enforcement is ever silently weakened or the proxy
+stops persisting/sending the verifier.
+
+## Out of scope
+
+- **PKCE on refresh.** RFC 7636 §6 forbids it, and the production code
+  (`task_refresh_oauth_token.go`) has no verifier branch to test against
+  — the same code path that runs in non-PKCE refresh runs in PKCE
+  refresh. The `proxy_refresh_test.go` suite already pins the no-
+  verifier shape of refresh POSTs.
+- **PKCE with `plain` method.** Unit tested in
+  `TestPKCEChallengeFor_Plain` and
+  `TestAuthOAuth2_Validate_AcceptsPlain`. `S256` is the recommended
+  method and what production connectors use; an integration test for
+  `plain` would only exercise the same wiring this file already covers,
+  with a weaker transformation.
+- **Per-connector enablement migration.** Tracked separately — this
+  file proves the mechanism, not which connectors opt in.


### PR DESCRIPTION
## Summary

- Closes #174. Adds three integration tests covering the PKCE cases enumerated in spec scenario 14 (#159): valid `code_verifier` (happy path, S256), missing `code_verifier`, and invalid (mismatched) `code_verifier`. Unsupported `code_challenge_method` is covered by unit tests at `internal/auth_methods/oauth2/pkce_test.go` (`TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod`) — the schema validator rejects at config load, so it never reaches an integration test; the spec doc maps the case through for the audit trail.
- Happy path is driven through the marketplace UI with chromedp per the issue's [#174 test approach comment](https://github.com/rmorlok/authproxy/issues/174#issuecomment-4361426899) — `/test/authorize` would skip the user-driven leg under test. The provider client is registered with ` + "`RequirePKCE: true`" + ` so the green flow itself is a positive PKCE signal: any missing challenge on authorize or stale verifier on token would fail the flow before the assertions run.
- The two failure subtests use the in-process callback driver because a correctly wired proxy cannot naturally produce a missing or mismatched verifier — the test reads the persisted state record from Redis (decrypting via ` + "`env.DM.GetEncryptService()`" + `), mutates ` + "`PKCECodeVerifier`" + `, and writes it back so the provider's real PKCE validator fires on the subsequent ` + "`/token`" + ` POST. Before mutating, the test asserts ` + "`base64url(sha256(persisted_verifier)) == challenge_from_authorize_URL`" + ` — this is the literal-value PKCE contract the happy path can't pin (the provider redacts ` + "`code_verifier`" + ` to ` + "`<redacted>`" + ` in its request recorder).
- Helper changes (` + "`integration_tests/helpers/setup_oauth2.go`" + `):
  - ` + "`OAuth2ConnectorOptions`" + ` gains an optional ` + "`PKCE *cschema.AuthOauth2PKCE`" + ` field.
  - ` + "`OAuth2StateForTest`" + ` gains ` + "`PKCECodeVerifier`" + ` and ` + "`PKCEMethod`" + ` fields (JSON tags match the production ` + "`state`" + ` struct so the decode round-trips).
  - New ` + "`ReadOAuth2StateForTest`" + ` decrypts and decodes the state record from Redis so tests can snapshot the persisted verifier.

## Test plan

- [x] ` + "`go test -tags integration -count=1 -run TestPKCE_ ./oauth2/...`" + ` — all three pass locally.
- [x] ` + "`go test -tags integration -count=1 -run TestCallbackRejection_Namespace ./oauth2/...`" + ` — existing ` + "`OAuth2StateForTest`" + ` callers still pass after the struct extension.
- [x] ` + "`./scripts/preflight.sh`" + ` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)