### PR TITLE
Streaming integration tests: MinIO + SSE (#333)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -165,11 +165,16 @@ jobs:
           sleep 1
         done
 
-    - name: Create MinIO bucket
+    - name: Create MinIO buckets
       run: |
         docker run --rm --network host \
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
-          minio/mc mb --ignore-existing minio/authproxy-request-logs
+          --entrypoint /bin/sh \
+          minio/mc -c "
+            mc mb --ignore-existing minio/authproxy-request-logs &&
+            mc mb --ignore-existing minio/authproxy-streaming-test &&
+            mc anonymous set public minio/authproxy-streaming-test
+          "
 
     - name: Start OAuth2 test provider
       working-directory: integration_tests

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -74,7 +74,9 @@ services:
     entrypoint: >
       /bin/sh -c "
       mc alias set minio http://minio:9000 minioadmin minioadmin &&
-      mc mb --ignore-existing minio/authproxy-request-logs
+      mc mb --ignore-existing minio/authproxy-request-logs &&
+      mc mb --ignore-existing minio/authproxy-streaming-test &&
+      mc anonymous set public minio/authproxy-streaming-test
       "
 
   vault:

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -553,6 +553,77 @@ func (env *IntegrationTestEnv) DoProxyRawRequest(
 	return w
 }
 
+// DoProxyRawStreamingRequest is the streaming counterpart to
+// DoProxyRawRequest. The request body is an io.Reader (so large
+// uploads don't have to be materialised as a []byte) and the
+// response is returned as a live *http.Response so callers can read
+// it incrementally rather than buffering it whole.
+//
+// contentLength controls the inbound framing: pass -1 for chunked
+// transfer-encoding (Content-Length omitted), or the exact byte
+// count for a known-length PUT. Some upstreams (notably S3 /
+// MinIO's raw API) reject chunked uploads and require a
+// Content-Length header — pass the known size in that case.
+//
+// Requires StartHTTPServer=true: the in-process gin path uses
+// httptest.ResponseRecorder which can't be observed mid-stream.
+// Caller is responsible for closing the returned response body.
+func (env *IntegrationTestEnv) DoProxyRawStreamingRequest(
+	t *testing.T,
+	connectionID, targetURL, method string,
+	body io.Reader,
+	contentLength int64,
+	extraHeaders http.Header,
+) *http.Response {
+	t.Helper()
+	require.NotEmptyf(t, env.ServerURL, "DoProxyRawStreamingRequest requires StartHTTPServer=true")
+
+	path := "/api/v1/connections/" + connectionID + "/_proxy_raw"
+	abs, err := url.Parse(env.ServerURL + path)
+	require.NoError(t, err)
+
+	// Wrap the body in struct{io.Reader} so http.NewRequest can't
+	// infer ContentLength from a recognised concrete type
+	// (bytes.Reader, strings.Reader, etc.). We then set
+	// ContentLength explicitly below to whatever framing the caller
+	// asked for.
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = struct{ io.Reader }{body}
+	}
+
+	req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+		method,
+		path,
+		bodyReader,
+		sconfig.RootNamespace,
+		"test-actor",
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+	req.URL = abs
+	req.Host = abs.Host
+	req.RequestURI = ""
+	if body != nil {
+		if contentLength < 0 {
+			req.ContentLength = -1
+			req.TransferEncoding = []string{"chunked"}
+		} else {
+			req.ContentLength = contentLength
+		}
+	}
+	req.Header.Set("X-AuthProxy-Upstream-URL", targetURL)
+	for k, vv := range extraHeaders {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
 // CreateConnection creates a connection directly in the database.
 func (env *IntegrationTestEnv) CreateConnection(t *testing.T, connectorID apid.ID, connectorVersion uint64) string {
 	t.Helper()

--- a/integration_tests/proxy/minio_large_upload_test.go
+++ b/integration_tests/proxy/minio_large_upload_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package proxy
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/request_log"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minioBaseURL is the host-facing URL for the integration-tests MinIO
+// container. Mapped to 9003 in integration_tests/docker-compose.yml.
+const minioBaseURL = "http://127.0.0.1:9003"
+
+// minioStreamingBucket is the anonymous-policy bucket created by the
+// minio-init container. Public PUT/GET — no AWS Sig v4 required, which
+// keeps the test focused on streaming behaviour rather than signing
+// machinery.
+const minioStreamingBucket = "authproxy-streaming-test"
+
+// uploadSize is large enough that any full-body buffer in the proxy
+// path would show up clearly in the runtime.MemStats delta below.
+const uploadSize = 50 << 20 // 50 MiB
+
+// TestProxyRaw_MinIOLargeUpload proves /_proxy_raw streams a large
+// upload end-to-end without buffering: the bytes that hit MinIO are
+// byte-identical (SHA-256 match) to what the client sent, the
+// request log marks the body as too-large-skipped (so no tee
+// happened), and the process's heap delta during the upload is
+// bounded well below the upload size.
+//
+// Uses a known Content-Length rather than chunked transfer-encoding
+// because the S3 API (MinIO included) rejects raw chunked PUTs with
+// 411 MissingContentLength — the chunked-skip path is already
+// covered by TestProxyRawBodyCapture_TeeDecision against an
+// httptest.Server. The realistic scenario for AuthProxy users is a
+// signed S3 PUT with known length; the property we're asserting
+// (no full-body buffer in the proxy) holds for both skip reasons.
+//
+// The body is a lazy io.LimitReader over crypto/rand teed into a
+// sha256.Hash, so neither the client nor the test ever materialises
+// the 50 MiB as a contiguous []byte — any large delta in MemStats is
+// attributable to AuthProxy itself.
+func TestProxyRaw_MinIOLargeUpload(t *testing.T) {
+	connectorID := apid.MustParse("cxr_test0000000000330")
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Connectors: []sconfig.Connector{
+			helpers.NewNoAuthConnector(connectorID, "minio-stream", nil),
+		},
+		StartHTTPServer: true,
+	})
+	defer env.Cleanup()
+	conn := env.CreateConnection(t, connectorID, 1)
+
+	objectName := fmt.Sprintf("upload-%d.bin", time.Now().UnixNano())
+	upstream := fmt.Sprintf("%s/%s/%s", minioBaseURL, minioStreamingBucket, objectName)
+	t.Cleanup(func() { deleteMinIOObject(t, upstream) })
+
+	// Tee the lazy random stream into the hasher so we know what we
+	// sent without ever holding the bytes ourselves.
+	hasher := sha256.New()
+	body := io.TeeReader(io.LimitReader(rand.Reader, uploadSize), hasher)
+
+	// Sample HeapAlloc *after* a GC so the baseline isn't inflated by
+	// outstanding garbage. Skip the post-GC on the way out so we don't
+	// blow away allocations the proxy might still be holding — if the
+	// proxy buffered the body, we want to see it.
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	resp := env.DoProxyRawStreamingRequest(t, conn, upstream, http.MethodPut, body, uploadSize, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "minio response: %s", string(respBody))
+
+	runtime.ReadMemStats(&after)
+
+	expectedHash := hasher.Sum(nil)
+
+	// Re-download from MinIO directly (bypassing AuthProxy) and hash
+	// what came out.
+	gotHash := hashMinIOObject(t, upstream)
+	assert.Equal(t, fmt.Sprintf("%x", expectedHash), fmt.Sprintf("%x", gotHash),
+		"MinIO object must be byte-identical to what was uploaded")
+
+	// Too-large skip on the request side — proves the roundtripper
+	// declined to tee, which is the no-buffer guarantee we care
+	// about. 50 MiB ≫ the default max_request_size of 250 KiB.
+	record := waitForLog(t, env, conn, 5*time.Second)
+	assert.Equal(t, request_log.BodySkippedTooLarge, record.RequestBodySkipped,
+		"50 MiB upload must record too_large skip reason")
+
+	// Coarse memory check. A 50 MiB full-body buffer in the proxy
+	// path would push HeapAlloc up by at least 50 MiB; we allow
+	// generous headroom for GC noise, instrumentation maps, and the
+	// in-process AuthProxy server itself.
+	delta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	assert.Lessf(t, delta, int64(25<<20),
+		"heap grew by %d bytes during a %d-byte upload — looks like the body was buffered",
+		delta, uploadSize)
+}
+
+// deleteMinIOObject removes the uploaded object so the bucket doesn't
+// accumulate state across runs. Best-effort: failures are logged but
+// don't fail the test.
+func deleteMinIOObject(t *testing.T, url string) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+	if err != nil {
+		t.Logf("delete %s: build request: %v", url, err)
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Logf("delete %s: %v", url, err)
+		return
+	}
+	resp.Body.Close()
+}
+
+// hashMinIOObject GETs the object directly from MinIO and returns the
+// SHA-256 of its bytes — streamed, so the test never materialises the
+// downloaded body either.
+func hashMinIOObject(t *testing.T, url string) []byte {
+	t.Helper()
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s", url)
+	h := sha256.New()
+	_, err = io.Copy(h, resp.Body)
+	require.NoError(t, err)
+	return h.Sum(nil)
+}

--- a/integration_tests/proxy/sse_stream_test.go
+++ b/integration_tests/proxy/sse_stream_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sseTokenCount and sseTokenGap define the upstream's emit cadence.
+// The maxArrival assertion below is slack enough to absorb scheduler
+// jitter and the proxy hop, but tight enough that buffering the whole
+// stream would clearly fail it (full buffering would land all tokens
+// at the same time, ~sseTokenCount*sseTokenGap later).
+const (
+	sseTokenCount   = 20
+	sseTokenGap     = 50 * time.Millisecond
+	sseMaxArrival   = 150 * time.Millisecond
+	sseTotalTimeout = 5 * time.Second
+)
+
+// sseUpstream is an httptest.Server that emits sseTokenCount SSE
+// tokens with sseTokenGap between them, recording each token's emit
+// time so the test can correlate against client arrival times.
+type sseUpstream struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	emitAt []time.Time
+}
+
+func newSSEUpstream(t *testing.T) *sseUpstream {
+	t.Helper()
+	u := &sseUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		fl, ok := w.(http.Flusher)
+		require.Truef(t, ok, "httptest.Server ResponseWriter must implement http.Flusher")
+		fl.Flush()
+		for i := 0; i < sseTokenCount; i++ {
+			if i > 0 {
+				time.Sleep(sseTokenGap)
+			}
+			u.mu.Lock()
+			u.emitAt = append(u.emitAt, time.Now())
+			u.mu.Unlock()
+			fmt.Fprintf(w, "data: token-%d\n\n", i)
+			fl.Flush()
+		}
+	}))
+	t.Cleanup(u.server.Close)
+	return u
+}
+
+func (u *sseUpstream) emitSnapshot() []time.Time {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]time.Time(nil), u.emitAt...)
+}
+
+// TestProxyRaw_SSEStreamingResponse proves the response side of
+// /_proxy_raw streams an SSE-shaped response in real time rather
+// than buffering the whole thing: each token must arrive at the
+// client within sseMaxArrival of the upstream emitting it, and the
+// proxied response must carry through the Content-Type:
+// text/event-stream header so EventSource clients recognise the
+// stream.
+//
+// Without the response-side streaming-skip (Content-Length<0 →
+// no tee in the request_log roundtripper) and the flush-after-write
+// wrapper inside the raw-proxy orchestrator, the test would fail
+// either because all tokens arrive bunched at the end or because
+// the response timing exceeds the per-token slack.
+func TestProxyRaw_SSEStreamingResponse(t *testing.T) {
+	connectorID := apid.MustParse("cxr_test0000000000331")
+
+	upstream := newSSEUpstream(t)
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Connectors: []sconfig.Connector{
+			helpers.NewNoAuthConnector(connectorID, "sse-stream", nil),
+		},
+		StartHTTPServer: true,
+	})
+	defer env.Cleanup()
+	conn := env.CreateConnection(t, connectorID, 1)
+
+	resp := env.DoProxyRawStreamingRequest(t, conn, upstream.server.URL+"/stream", http.MethodGet, nil, 0, nil)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"),
+		"SSE Content-Type must survive the proxy hop")
+
+	// Read each event ("data: token-N\n\n" = two lines) and timestamp
+	// arrival. Compare against the upstream's recorded emit time.
+	reader := bufio.NewReader(resp.Body)
+	arrivals := make([]time.Time, 0, sseTokenCount)
+	overallDeadline := time.Now().Add(sseTotalTimeout)
+
+	for i := 0; i < sseTokenCount; i++ {
+		line, err := readLineWithDeadline(reader, time.Until(overallDeadline))
+		require.NoErrorf(t, err, "token %d data line", i)
+		arrivals = append(arrivals, time.Now())
+		assert.Truef(t, strings.HasPrefix(line, "data: token-"), "token %d: got %q", i, line)
+		// Consume the trailing blank line.
+		_, err = readLineWithDeadline(reader, time.Until(overallDeadline))
+		require.NoErrorf(t, err, "token %d blank line", i)
+	}
+
+	emits := upstream.emitSnapshot()
+	require.Lenf(t, emits, sseTokenCount, "upstream must have emitted %d tokens by now", sseTokenCount)
+
+	for i := 0; i < sseTokenCount; i++ {
+		gap := arrivals[i].Sub(emits[i])
+		assert.GreaterOrEqualf(t, gap, time.Duration(0), "token %d arrived before upstream emitted it (clock skew?)", i)
+		assert.LessOrEqualf(t, gap, sseMaxArrival,
+			"token %d arrived %s after upstream emit (max %s) — proxy is buffering",
+			i, gap, sseMaxArrival)
+	}
+}
+
+// readLineWithDeadline reads up to '\n' from r, returning an error
+// if the read takes longer than budget. We can't set a Read deadline
+// on an http.Response body directly, so the goroutine + select is
+// the workable approximation.
+func readLineWithDeadline(r *bufio.Reader, budget time.Duration) (string, error) {
+	if budget <= 0 {
+		return "", fmt.Errorf("deadline already passed")
+	}
+	type result struct {
+		line string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		l, err := r.ReadString('\n')
+		done <- result{strings.TrimRight(l, "\n"), err}
+	}()
+	select {
+	case res := <-done:
+		return res.line, res.err
+	case <-time.After(budget):
+		return "", fmt.Errorf("read timeout after %s", budget)
+	}
+}


### PR DESCRIPTION
Closes #333. Closes #319.

Two end-to-end integration tests that prove `/_proxy_raw` actually streams.

## MinIO large upload — `TestProxyRaw_MinIOLargeUpload`

PUTs a 50 MiB body to a public-anonymous MinIO bucket through `/_proxy_raw`, then re-downloads the object and asserts byte-identity by SHA-256.

- Body is a lazy `io.LimitReader` over `crypto/rand` teed into a `sha256.Hash` — neither the test nor the client ever materialises the 50 MiB as a `[]byte`, so any large delta in `runtime.MemStats.HeapAlloc` is attributable to AuthProxy itself.
- Assertion: `HeapAlloc` delta < 25 MiB during the upload (50 MiB body — a full-body buffer would clearly fail it).
- Assertion: request log records `BodySkippedTooLarge`, proving the roundtripper declined to tee.

Uses known `Content-Length` rather than chunked transfer-encoding because the S3 API rejects raw `Transfer-Encoding: chunked` PUTs with 411 `MissingContentLength`. The chunked-skip path is already covered by `TestProxyRawBodyCapture_TeeDecision` against an httptest.Server; the streaming property (no full-body buffer) holds for both skip reasons.

## SSE streaming response — `TestProxyRaw_SSEStreamingResponse`

In-process `httptest.Server` emits 20 SSE tokens 50 ms apart with explicit `Flush` after each, recording emit timestamps. The test sends `GET /_proxy_raw` and reads tokens incrementally.

- Asserts `Content-Type: text/event-stream` survives the proxy hop.
- Per-token arrival within 150 ms of upstream emission. A buffered response would land all tokens at the end (~1 s after the first emit) and trivially fail this.

## Supporting changes

- `integration_tests/docker-compose.yml`: `minio-init` also creates `authproxy-streaming-test` with `mc anonymous set public`, so the test can PUT/GET without AWS Sig v4 plumbing.
- `helpers.DoProxyRawStreamingRequest`: streaming counterpart to `DoProxyRawRequest` — `io.Reader` body, `contentLength` parameter (-1 for chunked, otherwise known length), returns live `*http.Response` so callers can read incrementally. Requires `StartHTTPServer=true`.

## Test plan
- [x] `go test -tags integration -count=1 ./proxy/...` passes (full proxy package, all three tests)
- [x] `./scripts/preflight.sh` passes
- [x] Both new tests pass against an existing `docker compose up -d` stack
- [x] No special opt-in; gated by the `integration` build tag like other tests in the module
- [x] Cleanup: MinIO object deleted via `t.Cleanup`; `httptest.Server.Close()` registered via `t.Cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)