### PR TITLE
Auto-retry flakey integration tests via gotestsum (#350)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -195,6 +195,9 @@ jobs:
         docker logs integration_tests-oauth-server-1 2>&1 | tail -50
         exit 1
 
+    - name: Install gotestsum
+      run: go install gotest.tools/gotestsum@latest
+
     - name: Integration Tests
       working-directory: integration_tests
       env:
@@ -206,4 +209,17 @@ jobs:
         POSTGRES_TEST_DATABASE: authproxy_integration
         POSTGRES_TEST_OPTIONS: sslmode=disable
         TF_ACC: "1"
-      run: go test -tags integration -v -timeout 10m ./...
+      # Auto-retry failing tests up to twice (3 attempts total). The
+      # chromedp browser tests in integration_tests/oauth2 are known
+      # transient-flakey (websocket attach timeouts under CI load);
+      # rerunning per-test on failure is cheaper than a forced manual
+      # rerun of the whole 7-minute job. If more than 10 distinct
+      # tests fail the first pass, skip retry — something is broken
+      # at scale, not flakey. See issue #350.
+      run: |
+        gotestsum \
+          --format=testname \
+          --rerun-fails=2 \
+          --rerun-fails-max-failures=10 \
+          --packages=./... \
+          -- -tags integration -timeout 10m


### PR DESCRIPTION
Closes #350.

The integration-test job picks up the chromedp browser tests in `integration_tests/oauth2/`, which occasionally fail with `"websocket url timeout reached"` — Chrome can't always attach its DevTools websocket under CI load (observed on PRs #339, #347, #349). The tests themselves are correct; the failure is transient.

Rather than touch each test, swap the test invocation to [`gotestsum`](https://github.com/gotestyourself/gotestsum) with `--rerun-fails=2`: each failing test gets up to 2 reruns individually (3 attempts total). The job exits non-zero only if a test fails every attempt — genuinely-broken tests still fail loudly while one-off websocket flakes stop wasting reviewer time on manual reruns.

Bounded by `--rerun-fails-max-failures=10`: if more than 10 distinct tests fail the first pass, skip retry. Something is broken at scale, not flakey.

## What's NOT changing

- No source-code changes to any test file.
- `test (sqlite)` / `test (postgres)` jobs keep using bare `go test` — unit tests aren't flakey.
- `.github/workflows/{aws,gcp,vault}-integration.yml` — separate workflows, not flakey today.
- No JUnit XML, no quarantine list. Per the agreed scope.

## Output format

`--format=testname` prints one line per test (`PASS pkg.TestName`, `FAIL pkg.TestName`, `RERUN`). gotestsum always re-prints the **full** output of failed tests in a `FAILED` summary section at the end of the run, regardless of format — so debugging a test that fails all 3 attempts won't require a rerun.

## Test plan

- [x] Local smoke test: `gotestsum --format=testname --rerun-fails=2 --packages=./proxy -- -tags integration -timeout 5m -run TestProxyRaw_SSEStreamingResponse` runs and exits 0.
- [ ] CI integration-test job goes green on the first try (the gotestsum installer step is the new variable).
- [ ] (Eventual) When a chromedp flake actually happens, the RERUN line is visible in the logs and the job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)