### PR TITLE
[A6] Publish authproxy chart as OCI artifact to GHCR on tag

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,128 @@
+# schema: https://json.schemastore.org/github-workflow.json
+name: Release Chart
+
+# Tag-driven: pushing a `chart-vX.Y.Z` tag publishes the chart at that
+# version to oci://ghcr.io/<owner>/charts/authproxy. Chart versioning is
+# intentionally decoupled from the app's `vX.Y.Z` image tags so chart
+# fixes can ship without rebuilding the server.
+on:
+  push:
+    tags: ['chart-v*.*.*']
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: 'Chart version (without leading v). Required for manual dispatch.'
+        required: true
+        type: string
+      app_version:
+        description: 'App version to pin (without leading v). Defaults to latest vX.Y.Z tag, or Chart.yaml appVersion if no tags exist.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # The OCI namespace for charts. The chart name (`authproxy`) is appended
+  # by `helm push`, so consumers pull from oci://ghcr.io/<owner>/charts/authproxy.
+  CHART_REPO: ghcr.io/${{ github.repository_owner }}/charts
+  CHART_DIR: deploy/charts/authproxy
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so we can resolve the latest vX.Y.Z app tag.
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Derive chart + app versions
+        id: vers
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            chart_version="${{ inputs.chart_version }}"
+            app_version_input="${{ inputs.app_version }}"
+          else
+            # Strip the `chart-v` prefix from the tag ref (refs/tags/chart-vX.Y.Z → X.Y.Z).
+            chart_version="${GITHUB_REF_NAME#chart-v}"
+            app_version_input=""
+          fi
+
+          # Validate chart_version is plain semver (no leading v, no suffix).
+          if ! [[ "$chart_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::chart_version must be X.Y.Z (got '$chart_version')"
+            exit 1
+          fi
+
+          # Resolve app version. Precedence:
+          #   1. workflow_dispatch input (without leading v)
+          #   2. latest vX.Y.Z tag from git
+          #   3. Chart.yaml's existing appVersion (the no-tags-yet fallback)
+          if [ -n "$app_version_input" ]; then
+            app_version="$app_version_input"
+          else
+            latest_tag=$(git tag -l 'v*.*.*' --sort=-v:refname | head -n1 || true)
+            if [ -n "$latest_tag" ]; then
+              app_version="${latest_tag#v}"
+            else
+              app_version=$(grep '^appVersion:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}' | tr -d '"')
+              echo "::notice::No vX.Y.Z app tags found; falling back to Chart.yaml appVersion='${app_version}'"
+            fi
+          fi
+
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "app_version=${app_version}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: ${chart_version}"
+          echo "App version:   ${app_version}"
+
+      - name: Lint chart
+        run: helm lint "${CHART_DIR}"
+
+      - name: Package chart
+        id: pkg
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package "${CHART_DIR}" \
+            --version "${{ steps.vers.outputs.chart_version }}" \
+            --app-version "${{ steps.vers.outputs.app_version }}" \
+            --destination dist
+          # Capture the produced .tgz so the next step doesn't have to guess.
+          echo "tgz=$(ls dist/authproxy-*.tgz | head -n1)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR (helm)
+        run: |
+          # helm registry login reads from stdin so the token never lands in
+          # the process arg list.
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login "${REGISTRY}" \
+                --username "${{ github.actor }}" \
+                --password-stdin
+
+      - name: Push chart to OCI registry
+        run: |
+          helm push "${{ steps.pkg.outputs.tgz }}" "oci://${CHART_REPO}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Chart published"
+            echo ""
+            echo "- Chart version: \`${{ steps.vers.outputs.chart_version }}\`"
+            echo "- App version:   \`${{ steps.vers.outputs.app_version }}\`"
+            echo "- Pull command:"
+            echo ""
+            echo "  \`\`\`"
+            echo "  helm pull oci://${CHART_REPO}/authproxy --version ${{ steps.vers.outputs.chart_version }}"
+            echo "  \`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/charts/authproxy/README.md
+++ b/deploy/charts/authproxy/README.md
@@ -1,0 +1,103 @@
+# AuthProxy Helm Chart
+
+[AuthProxy](https://github.com/rmorlok/authproxy) is an open-source, embeddable
+integration platform-as-a-service. It manages the connection lifecycle to
+third-party systems and proxies authenticated requests for an embedding host
+application.
+
+This chart deploys the AuthProxy server (`api`, `admin-api`, `public`, and
+`worker` services) as a single Deployment with a configurable subset of
+services enabled.
+
+## TL;DR
+
+```bash
+# 1. Create the Secrets the chart references (it deliberately never generates them).
+kubectl create secret generic authproxy-jwt \
+  --from-file=system=/path/to/jwt-private \
+  --from-file=system.pub=/path/to/jwt-public
+
+kubectl create secret generic authproxy-encryption \
+  --from-file=global_aes.key=/path/to/global_aes.key
+
+# 2. Install from the GHCR OCI registry.
+helm install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
+  --version <chart-version> \
+  --set database.provider=postgres \
+  --set database.host=postgres.example.com \
+  --set database.existingSecret=authproxy-db \
+  --set redis.address=redis.example.com:6379 \
+  --set jwt.existingSecret=authproxy-jwt \
+  --set encryptionKeys.existingSecret=authproxy-encryption \
+  --set hostApplication.initiateSessionUrl=https://app.example.com/login
+```
+
+## Installing from the OCI registry
+
+Charts are published to `oci://ghcr.io/rmorlok/charts/authproxy` on each
+`chart-vX.Y.Z` tag. The chart version is independent of the AuthProxy
+application version (`image.tag`).
+
+```bash
+# Inspect available versions:
+helm show chart oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.0
+
+# Pull a tarball locally:
+helm pull oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.0
+
+# Install:
+helm install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
+  --version 0.1.0 \
+  -f my-values.yaml
+```
+
+## Values reference
+
+The chart exposes typed values for the common connectivity blocks. See
+[`values.yaml`](values.yaml) for the full surface; the section headings:
+
+| Section          | Purpose                                                              |
+|------------------|----------------------------------------------------------------------|
+| `image`          | Container image repository, tag, pull policy                         |
+| `services.*`     | Per-service enable toggles (`api`, `adminApi`, `public`, `worker`)   |
+| `ports`          | Container port assignments                                            |
+| `ingress`        | Single Ingress with path → port-name routing                          |
+| `database`       | Postgres or SQLite connectivity (+ `existingSecret` for credentials)  |
+| `redis`          | Redis connectivity (+ optional `existingSecret`)                      |
+| `s3`             | Optional S3-compatible blob storage for request-log payloads          |
+| `jwt`            | Secret mount + key paths for JWT signing material                     |
+| `encryptionKeys` | Secret mount + path for the global AES key                            |
+| `actors`         | Secret mount + ACL permissions for admin actor keypairs               |
+| `hostApplication`| URL the marketplace UI redirects to for login                         |
+| `connectors`     | Inline connector definitions + identifying labels                     |
+| `httpLogging`    | HTTP request/response log storage (defaults to shared main DB)        |
+| `config`         | Free-form overlay merged into the rendered AuthProxy YAML             |
+
+### Secrets the chart expects you to create
+
+The chart **never generates** sensitive material — instead, it references
+Secrets by name. You provision them once and pass the names via `existingSecret`:
+
+| Values key                          | Secret keys expected                                  |
+|-------------------------------------|-------------------------------------------------------|
+| `jwt.existingSecret`                | `system` (private), `system.pub` (public)             |
+| `encryptionKeys.existingSecret`     | `global_aes.key` (32 raw bytes)                       |
+| `actors.existingSecret`             | `<name>` + `<name>.pub` pairs for each admin actor    |
+| `database.existingSecret` *(optional)* | `AUTHPROXY_DB_PASSWORD`                            |
+| `redis.existingSecret` *(optional)* | `AUTHPROXY_REDIS_PASSWORD`                            |
+| `s3.existingSecret` *(optional)*    | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`          |
+
+## Compatibility
+
+| Chart version | App version (`appVersion`) |
+|---------------|----------------------------|
+| 0.1.x         | `main`                     |
+
+The chart's `appVersion` is automatically pinned to the latest `vX.Y.Z` app tag
+at chart-release time. Override per-deploy with `--set image.tag=<tag>`.
+
+## Development
+
+For chart-on-source-tree work (running CI locally, iterating on templates),
+see [`AGENTS.md`](../../AGENTS.md) at the repo root and the chart-testing
+CI workflow under `.github/workflows/helm-chart-ci.yml`.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release-chart.yml`: tag-driven workflow (`chart-vX.Y.Z` or `workflow_dispatch`) that lints, packages, and pushes the chart to `oci://ghcr.io/<owner>/charts/authproxy`.
- Resolve `appVersion` from the latest `vX.Y.Z` app tag at release time (falls back to `Chart.yaml`'s `appVersion` when no app tags exist yet), so chart releases automatically pin to the most recent server release.
- Add chart README documenting the OCI install path, the typed values surface, and which Secrets customers must provision themselves.

Closes #286.

## How it works
- Trigger: `git tag chart-v1.2.3 && git push --tags` → workflow runs.
- Manual: `workflow_dispatch` with `chart_version` (required) and `app_version` (optional override) inputs.
- Auth: uses `GITHUB_TOKEN` via `helm registry login --password-stdin`; permissions scoped to `contents: read, packages: write`.

After a release, customers run:

```bash
helm install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
  --version <chart-version> \
  -f my-values.yaml
```

## Test plan
- [x] `helm package` runs cleanly on the chart with the new README in-tree.
- [x] YAML schema validates (workflow file).
- [ ] Push a `chart-v0.1.0` tag after merge → observe a published OCI artifact and verify `helm pull oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.0` from outside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)