### PR TITLE
Implement OAuth2 token-endpoint client auth method support (#351)

### DIFF
--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -146,16 +146,8 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 		New().
 		UseContext(ctx)
 
-	clientId, err := o.auth.ClientId.GetValue(ctx)
+	clientId, clientSecret, err := o.resolveClientCredentials(ctx)
 	if err != nil {
-		err = fmt.Errorf("failed to get client id for connector: %w", err)
-		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
-		return "", err
-	}
-
-	clientSecret, err := o.auth.ClientSecret.GetValue(ctx)
-	if err != nil {
-		err = fmt.Errorf("failed to get client secret for connector: %w", err)
 		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
 		return "", err
 	}
@@ -168,11 +160,9 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 	}
 
 	values := url.Values{
-		"client_id":     {clientId},
-		"client_secret": {clientSecret},
-		"grant_type":    {"authorization_code"},
-		"code":          {code},
-		"redirect_uri":  {callbackUrl},
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {callbackUrl},
 	}
 
 	// RFC 7636 §4.5 — the verifier is only sent on the initial code-for-token
@@ -182,11 +172,19 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 		values.Set("code_verifier", o.state.PKCECodeVerifier)
 	}
 
+	values, authHeader, err := applyTokenEndpointClientAuth(
+		o.auth.GetTokenEndpointAuthMethodOrDefault(), clientId, clientSecret, values,
+	)
+	if err != nil {
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return "", err
+	}
+
 	for k, v := range o.auth.Token.FormOverrides {
 		values.Set(k, v)
 	}
 
-	resp, attempts, err := o.postTokenExchangeWithRetry(ctx, c, tokenEndpoint, values)
+	resp, attempts, err := o.postTokenExchangeWithRetry(ctx, c, tokenEndpoint, values, authHeader)
 	if err != nil {
 		err = fmt.Errorf("failed to post to exchange authorization code for access token: %w", err)
 		attrs := o.tokenExchangeAttrsFromConn(err)
@@ -249,6 +247,7 @@ func (o *oAuth2Connection) postTokenExchangeWithRetry(
 	client *gentleman.Client,
 	tokenEndpoint string,
 	values url.Values,
+	authHeader string,
 ) (*gentleman.Response, int, error) {
 	var lastResp *gentleman.Response
 	var lastErr error
@@ -268,6 +267,10 @@ func (o *oAuth2Connection) postTokenExchangeWithRetry(
 			URL(tokenEndpoint).
 			Type("application/x-www-form-urlencoded").
 			AddHeader("accept", "application/json")
+
+		if authHeader != "" {
+			req = req.AddHeader("Authorization", authHeader)
+		}
 
 		for k, v := range o.auth.Token.QueryOverrides {
 			req = req.SetQuery(k, v)

--- a/internal/auth_methods/oauth2/callback_test.go
+++ b/internal/auth_methods/oauth2/callback_test.go
@@ -165,6 +165,7 @@ func TestPostTokenExchangeWithRetry_SuccessFirstAttempt(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{"grant_type": {"authorization_code"}, "code": {"abc"}},
+		"",
 	)
 
 	require.NoError(t, err)
@@ -195,6 +196,7 @@ func TestPostTokenExchangeWithRetry_4xxNotRetried(t *testing.T) {
 				gentleman.New(),
 				srv.URL,
 				url.Values{"grant_type": {"authorization_code"}},
+				"",
 			)
 
 			require.NoError(t, err, "transport-layer call succeeded — 4xx is not a transport error")
@@ -220,6 +222,7 @@ func TestPostTokenExchangeWithRetry_5xxThenSuccess(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 	elapsed := time.Since(start)
 
@@ -249,6 +252,7 @@ func TestPostTokenExchangeWithRetry_5xxExhausted(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 
 	require.NoError(t, err, "5xx is an HTTP-level failure, not a transport error")
@@ -275,6 +279,7 @@ func TestPostTokenExchangeWithRetry_TransportErrorRetried(t *testing.T) {
 		gentleman.New(),
 		closedURL,
 		url.Values{},
+		"",
 	)
 
 	require.Error(t, err, "transport failure must surface as an error")
@@ -309,6 +314,7 @@ func TestPostTokenExchangeWithRetry_ContextCancelledBeforeRetry(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 
 	require.ErrorIs(t, err, context.Canceled)
@@ -346,6 +352,7 @@ func TestPostTokenExchangeWithRetry_QueryOverridesAppliedEachAttempt(t *testing.
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, tokenExchangeMaxAttempts, attempts)

--- a/internal/auth_methods/oauth2/client_auth.go
+++ b/internal/auth_methods/oauth2/client_auth.go
@@ -1,0 +1,87 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// resolveClientCredentials reads the connector's client_id and (when present)
+// client_secret. For token_endpoint_auth_method == "none" the secret is
+// optional — public clients have no secret to send — so its absence is not
+// an error.
+func (o *oAuth2Connection) resolveClientCredentials(ctx context.Context) (string, string, error) {
+	clientId, err := o.auth.ClientId.GetValue(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get client id for connector: %w", err)
+	}
+
+	if o.auth.GetTokenEndpointAuthMethodOrDefault() == sconfig.TokenEndpointAuthNone {
+		return clientId, "", nil
+	}
+
+	clientSecret, err := o.auth.ClientSecret.GetValue(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get client secret for connector: %w", err)
+	}
+	return clientId, clientSecret, nil
+}
+
+// applyTokenEndpointClientAuth attaches client credentials to the
+// token-endpoint request per the connector's configured
+// token_endpoint_auth_method (RFC 6749 §2.3.1, RFC 7591 §2).
+//
+// Returns the (possibly augmented) form values that should be sent in the
+// request body, and the value of the Authorization header to set on the
+// request (empty string when no header is required).
+//
+// Method semantics:
+//   - client_secret_post (default): client_id + client_secret go in the form
+//     body, no Authorization header.
+//   - client_secret_basic: Authorization: Basic base64(qs(id):qs(secret)) is
+//     set; neither client_id nor client_secret goes in the form body.
+//     RFC 6749 §2.3.1 forbids sending the credentials in two places.
+//   - none: client_id only in the form body, no client_secret, no header.
+//     The token endpoint relies on PKCE for proof-of-possession.
+//
+// The values map is treated as input-only and not mutated; the returned
+// url.Values is a copy with the appropriate fields set.
+func applyTokenEndpointClientAuth(
+	method sconfig.TokenEndpointAuthMethod,
+	clientId, clientSecret string,
+	values url.Values,
+) (url.Values, string, error) {
+	// Effective default — empty method behaves as client_secret_post for
+	// backwards compatibility.
+	if method == "" {
+		method = sconfig.TokenEndpointAuthClientSecretPost
+	}
+
+	out := make(url.Values, len(values)+2)
+	for k, v := range values {
+		out[k] = v
+	}
+
+	switch method {
+	case sconfig.TokenEndpointAuthClientSecretPost:
+		out.Set("client_id", clientId)
+		out.Set("client_secret", clientSecret)
+		return out, "", nil
+	case sconfig.TokenEndpointAuthClientSecretBasic:
+		// RFC 6749 §2.3.1: client_id and client_secret are
+		// application/x-www-form-urlencoded before being colon-joined and
+		// base64-encoded. The gentleman/std basic-auth helpers do not do
+		// this form-encoding step, so we build the header by hand.
+		userPass := url.QueryEscape(clientId) + ":" + url.QueryEscape(clientSecret)
+		encoded := base64.StdEncoding.EncodeToString([]byte(userPass))
+		return out, "Basic " + encoded, nil
+	case sconfig.TokenEndpointAuthNone:
+		out.Set("client_id", clientId)
+		return out, "", nil
+	default:
+		return nil, "", fmt.Errorf("unsupported token_endpoint_auth_method %q", method)
+	}
+}

--- a/internal/auth_methods/oauth2/client_auth.go
+++ b/internal/auth_methods/oauth2/client_auth.go
@@ -38,14 +38,10 @@ func (o *oAuth2Connection) resolveClientCredentials(ctx context.Context) (string
 // request body, and the value of the Authorization header to set on the
 // request (empty string when no header is required).
 //
-// Method semantics:
-//   - client_secret_post (default): client_id + client_secret go in the form
-//     body, no Authorization header.
-//   - client_secret_basic: Authorization: Basic base64(qs(id):qs(secret)) is
-//     set; neither client_id nor client_secret goes in the form body.
-//     RFC 6749 §2.3.1 forbids sending the credentials in two places.
-//   - none: client_id only in the form body, no client_secret, no header.
-//     The token endpoint relies on PKCE for proof-of-possession.
+// Callers MUST pass a resolved (non-empty) method — typically by routing
+// through AuthOAuth2.GetTokenEndpointAuthMethodOrDefault, which is the
+// single place where the nil → client_secret_post default is applied.
+// Empty-string is treated as invalid here, not silently defaulted.
 //
 // The values map is treated as input-only and not mutated; the returned
 // url.Values is a copy with the appropriate fields set.
@@ -54,12 +50,6 @@ func applyTokenEndpointClientAuth(
 	clientId, clientSecret string,
 	values url.Values,
 ) (url.Values, string, error) {
-	// Effective default — empty method behaves as client_secret_post for
-	// backwards compatibility.
-	if method == "" {
-		method = sconfig.TokenEndpointAuthClientSecretPost
-	}
-
 	out := make(url.Values, len(values)+2)
 	for k, v := range values {
 		out[k] = v
@@ -67,6 +57,10 @@ func applyTokenEndpointClientAuth(
 
 	switch method {
 	case sconfig.TokenEndpointAuthClientSecretPost:
+		// RFC 6749 §2.3.1 / RFC 7591 §2 — credentials in the form body.
+		// RFC 6749 §2.3.1 marks this NOT RECOMMENDED relative to Basic
+		// but it is widely supported and is AuthProxy's historical
+		// default, so it stays as the nil → default fallback.
 		out.Set("client_id", clientId)
 		out.Set("client_secret", clientSecret)
 		return out, "", nil
@@ -79,6 +73,10 @@ func applyTokenEndpointClientAuth(
 		encoded := base64.StdEncoding.EncodeToString([]byte(userPass))
 		return out, "Basic " + encoded, nil
 	case sconfig.TokenEndpointAuthNone:
+		// RFC 7591 §2 — public-client method. client_id identifies the
+		// client; no client_secret exists. Proof-of-possession comes from
+		// PKCE (RFC 7636), which the connector validator requires when
+		// this method is selected.
 		out.Set("client_id", clientId)
 		return out, "", nil
 	default:

--- a/internal/auth_methods/oauth2/client_auth_test.go
+++ b/internal/auth_methods/oauth2/client_auth_test.go
@@ -29,18 +29,12 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestApplyTokenEndpointClientAuth_PostDefault(t *testing.T) {
-	in := url.Values{"grant_type": {"authorization_code"}, "code": {"abc"}}
-
-	out, header, err := applyTokenEndpointClientAuth("", "client-id", "client-secret", in)
-	require.NoError(t, err)
-	assert.Empty(t, header, "post must not set Authorization header")
-	assert.Equal(t, "client-id", out.Get("client_id"))
-	assert.Equal(t, "client-secret", out.Get("client_secret"))
-	assert.Equal(t, "authorization_code", out.Get("grant_type"))
-	assert.Equal(t, "abc", out.Get("code"))
-	// Input not mutated.
-	assert.Empty(t, in.Get("client_id"))
+func TestApplyTokenEndpointClientAuth_RejectsEmptyMethod(t *testing.T) {
+	// Empty string is no longer silently defaulted — callers MUST pass a
+	// resolved method (typically via AuthOAuth2.GetTokenEndpointAuthMethodOrDefault).
+	// This guards against the helper drifting away from that contract.
+	_, _, err := applyTokenEndpointClientAuth("", "client-id", "client-secret", url.Values{})
+	require.Error(t, err)
 }
 
 func TestApplyTokenEndpointClientAuth_PostExplicit(t *testing.T) {
@@ -161,7 +155,7 @@ func callbackConnFor(t *testing.T, ctrl *gomock.Controller, method sconfig.Token
 
 	auth := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: method,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(method),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		Token: cschema.AuthOauth2Token{
 			Endpoint: "https://example.com/oauth/token",
@@ -294,7 +288,7 @@ func TestCallback_None(t *testing.T) {
 func TestAuthOAuth2_Validate_BasicRequiresClientSecret(t *testing.T) {
 	a := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: cschema.TokenEndpointAuthClientSecretBasic,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthClientSecretBasic),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
@@ -310,7 +304,7 @@ func TestAuthOAuth2_Validate_BasicRequiresClientSecret(t *testing.T) {
 func TestAuthOAuth2_Validate_NoneRejectsClientSecret(t *testing.T) {
 	a := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthNone),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		ClientSecret:            common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{
@@ -329,7 +323,7 @@ func TestAuthOAuth2_Validate_NoneRejectsClientSecret(t *testing.T) {
 func TestAuthOAuth2_Validate_NoneRequiresPKCE(t *testing.T) {
 	a := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthNone),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
@@ -345,7 +339,7 @@ func TestAuthOAuth2_Validate_NoneRequiresPKCE(t *testing.T) {
 func TestAuthOAuth2_Validate_NoneAcceptsWhenPKCESet(t *testing.T) {
 	a := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthNone),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
@@ -355,13 +349,50 @@ func TestAuthOAuth2_Validate_NoneAcceptsWhenPKCESet(t *testing.T) {
 	require.NoError(t, a.Validate(&common.ValidationContext{}))
 }
 
+// TestAuthOAuth2_Validate_RejectsExplicitEmptyTokenEndpointAuthMethod
+// asserts that explicitly setting the field to "" is rejected — the
+// nil-vs-empty distinction is load-bearing. nil means "use the default",
+// empty string means the YAML author wrote something meaningless, and the
+// validator must surface that rather than silently falling through.
+func TestAuthOAuth2_Validate_RejectsExplicitEmptyTokenEndpointAuthMethod(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(""),
+		ClientId:                common.NewStringValueDirect("client-id"),
+		ClientSecret:            common.NewStringValueDirect("client-secret"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token_endpoint_auth_method")
+	assert.Contains(t, err.Error(), "empty")
+}
+
+// TestAuthOAuth2_Validate_NilMethodAcceptedAsDefault asserts that omitting
+// the field (nil pointer) is accepted as "use the default" — preserves
+// the no-change behavior for every existing connector.
+func TestAuthOAuth2_Validate_NilMethodAcceptedAsDefault(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:         cschema.AuthTypeOAuth2,
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+	assert.Equal(t, cschema.TokenEndpointAuthClientSecretPost, a.GetTokenEndpointAuthMethodOrDefault())
+}
+
 // TestAuthOAuth2_Validate_RejectsUnknownTokenEndpointAuthMethod guards
 // the validator against typos / unsupported RFC 7591 methods (client_secret_jwt
 // etc., out of scope).
 func TestAuthOAuth2_Validate_RejectsUnknownTokenEndpointAuthMethod(t *testing.T) {
 	a := &cschema.AuthOAuth2{
 		Type:                    cschema.AuthTypeOAuth2,
-		TokenEndpointAuthMethod: cschema.TokenEndpointAuthMethod("bogus"),
+		TokenEndpointAuthMethod: cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthMethod("bogus")),
 		ClientId:                common.NewStringValueDirect("client-id"),
 		ClientSecret:            common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{

--- a/internal/auth_methods/oauth2/client_auth_test.go
+++ b/internal/auth_methods/oauth2/client_auth_test.go
@@ -1,0 +1,375 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	mockRedis "github.com/rmorlok/authproxy/internal/apredis/mock"
+	"github.com/rmorlok/authproxy/internal/config"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestApplyTokenEndpointClientAuth_PostDefault(t *testing.T) {
+	in := url.Values{"grant_type": {"authorization_code"}, "code": {"abc"}}
+
+	out, header, err := applyTokenEndpointClientAuth("", "client-id", "client-secret", in)
+	require.NoError(t, err)
+	assert.Empty(t, header, "post must not set Authorization header")
+	assert.Equal(t, "client-id", out.Get("client_id"))
+	assert.Equal(t, "client-secret", out.Get("client_secret"))
+	assert.Equal(t, "authorization_code", out.Get("grant_type"))
+	assert.Equal(t, "abc", out.Get("code"))
+	// Input not mutated.
+	assert.Empty(t, in.Get("client_id"))
+}
+
+func TestApplyTokenEndpointClientAuth_PostExplicit(t *testing.T) {
+	out, header, err := applyTokenEndpointClientAuth(
+		sconfig.TokenEndpointAuthClientSecretPost,
+		"client-id", "client-secret",
+		url.Values{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, header)
+	assert.Equal(t, "client-id", out.Get("client_id"))
+	assert.Equal(t, "client-secret", out.Get("client_secret"))
+}
+
+func TestApplyTokenEndpointClientAuth_Basic(t *testing.T) {
+	out, header, err := applyTokenEndpointClientAuth(
+		sconfig.TokenEndpointAuthClientSecretBasic,
+		"client-id", "client-secret",
+		url.Values{"grant_type": {"refresh_token"}},
+	)
+	require.NoError(t, err)
+	// RFC 6749 §2.3.1: client_id / client_secret URL-form-encoded then
+	// colon-joined then base64-encoded.
+	wantEnc := base64.StdEncoding.EncodeToString([]byte(
+		url.QueryEscape("client-id") + ":" + url.QueryEscape("client-secret"),
+	))
+	assert.Equal(t, "Basic "+wantEnc, header)
+	assert.Empty(t, out.Get("client_id"), "basic must not duplicate creds in the form body")
+	assert.Empty(t, out.Get("client_secret"))
+	assert.Equal(t, "refresh_token", out.Get("grant_type"))
+}
+
+func TestApplyTokenEndpointClientAuth_BasicEncodesSpecialChars(t *testing.T) {
+	// Per RFC 6749 §2.3.1, the credentials are application/x-www-form-urlencoded
+	// before base64. A secret containing ':' (which would otherwise corrupt the
+	// userinfo split on the server) must come through url-encoded.
+	clientId := "client id with space"
+	clientSecret := "secret:with:colons+and&amps"
+
+	_, header, err := applyTokenEndpointClientAuth(
+		sconfig.TokenEndpointAuthClientSecretBasic,
+		clientId, clientSecret,
+		url.Values{},
+	)
+	require.NoError(t, err)
+
+	require.True(t, strings.HasPrefix(header, "Basic "))
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(header, "Basic "))
+	require.NoError(t, err)
+
+	// The decoded value should be qs(clientId) + ":" + qs(clientSecret) —
+	// the colons inside the secret are escaped, so there is exactly one
+	// unescaped colon (the user:pass separator).
+	parts := strings.SplitN(string(decoded), ":", 2)
+	require.Len(t, parts, 2)
+	gotId, err := url.QueryUnescape(parts[0])
+	require.NoError(t, err)
+	gotSecret, err := url.QueryUnescape(parts[1])
+	require.NoError(t, err)
+	assert.Equal(t, clientId, gotId)
+	assert.Equal(t, clientSecret, gotSecret)
+}
+
+func TestApplyTokenEndpointClientAuth_None(t *testing.T) {
+	out, header, err := applyTokenEndpointClientAuth(
+		sconfig.TokenEndpointAuthNone,
+		"client-id", "",
+		url.Values{"grant_type": {"authorization_code"}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, header, "none must not set Authorization header")
+	assert.Equal(t, "client-id", out.Get("client_id"))
+	assert.Empty(t, out.Get("client_secret"))
+}
+
+func TestApplyTokenEndpointClientAuth_UnknownMethod(t *testing.T) {
+	_, _, err := applyTokenEndpointClientAuth(
+		sconfig.TokenEndpointAuthMethod("bogus"),
+		"client-id", "client-secret",
+		url.Values{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+}
+
+// captureHeader is a gock matcher that records the value of a specific
+// header from the incoming request. Pairs with captureBody (defined in
+// pkce_test.go) when a test needs both.
+func captureHeader(name string, dst *string) func(*http.Request, *gock.Request) (bool, error) {
+	return func(req *http.Request, _ *gock.Request) (bool, error) {
+		*dst = req.Header.Get(name)
+		return true, nil
+	}
+}
+
+// callbackConnFor builds a minimal oAuth2Connection wired against the
+// gentleman mock client. Shared by the per-method callback tests below to
+// avoid repeating 30-line fixture blocks.
+func callbackConnFor(t *testing.T, ctrl *gomock.Controller, method sconfig.TokenEndpointAuthMethod, clientSecret string) (*oAuth2Connection, apid.ID) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	r := mockRedis.NewMockClient(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	r.EXPECT().Del(gomock.Any(), gomock.Any()).Return(redis.NewIntCmd(context.Background())).AnyTimes()
+
+	connectionId := apid.New(apid.PrefixConnection)
+	tokenId := apid.New(apid.PrefixOAuth2Token)
+
+	auth := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: method,
+		ClientId:                common.NewStringValueDirect("client-id"),
+		Token: cschema.AuthOauth2Token{
+			Endpoint: "https://example.com/oauth/token",
+		},
+	}
+	if clientSecret != "" {
+		auth.ClientSecret = common.NewStringValueDirect(clientSecret)
+	}
+
+	o := &oAuth2Connection{
+		cfg:     cfg,
+		db:      db,
+		httpf:   h,
+		r:       r,
+		encrypt: encrypt,
+		logger:  logger,
+		connection: &mockCore.Connection{
+			Id: connectionId,
+		},
+		auth: auth,
+		state: &state{
+			Id:          apid.New(apid.PrefixOauth2State),
+			ReturnToUrl: "https://app.example.com/callback",
+		},
+	}
+
+	encrypt.EXPECT().EncryptStringForEntity(gomock.Any(), gomock.Any(), "a").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "enc-a"}, nil)
+	db.EXPECT().InsertOAuth2Token(gomock.Any(), connectionId, nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.OAuth2Token{Id: tokenId}, nil)
+
+	return o, connectionId
+}
+
+// TestCallback_ClientSecretPost asserts the default behaviour: client_id and
+// client_secret are sent in the form body, no Authorization header.
+func TestCallback_ClientSecretPost(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	o, _ := callbackConnFor(t, ctrl, sconfig.TokenEndpointAuthClientSecretPost, "client-secret")
+
+	var capturedBody, capturedAuth string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		AddMatcher(captureHeader("Authorization", &capturedAuth)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"a","expires_in":3600}`)
+
+	_, err := o.CallbackFrom3rdParty(context.Background(), url.Values{"code": {"auth-code"}})
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "client-id", form.Get("client_id"))
+	assert.Equal(t, "client-secret", form.Get("client_secret"))
+	assert.Empty(t, capturedAuth, "client_secret_post must not set Authorization")
+}
+
+// TestCallback_ClientSecretBasic asserts the basic-auth path: Authorization
+// header carries base64(qs(id):qs(secret)) and the form body carries
+// neither client_id nor client_secret (RFC 6749 §2.3.1 forbids
+// duplication).
+func TestCallback_ClientSecretBasic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	o, _ := callbackConnFor(t, ctrl, sconfig.TokenEndpointAuthClientSecretBasic, "client-secret")
+
+	var capturedBody, capturedAuth string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		AddMatcher(captureHeader("Authorization", &capturedAuth)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"a","expires_in":3600}`)
+
+	_, err := o.CallbackFrom3rdParty(context.Background(), url.Values{"code": {"auth-code"}})
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Empty(t, form.Get("client_id"), "basic must not duplicate creds in body")
+	assert.Empty(t, form.Get("client_secret"))
+	assert.Equal(t, "auth-code", form.Get("code"))
+	wantEnc := base64.StdEncoding.EncodeToString([]byte(
+		url.QueryEscape("client-id") + ":" + url.QueryEscape("client-secret"),
+	))
+	assert.Equal(t, "Basic "+wantEnc, capturedAuth)
+}
+
+// TestCallback_None asserts the public-client path: client_id only in the
+// form body, no client_secret, no Authorization header.
+func TestCallback_None(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	o, _ := callbackConnFor(t, ctrl, sconfig.TokenEndpointAuthNone, "")
+
+	var capturedBody, capturedAuth string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		AddMatcher(captureHeader("Authorization", &capturedAuth)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"a","expires_in":3600}`)
+
+	_, err := o.CallbackFrom3rdParty(context.Background(), url.Values{"code": {"auth-code"}})
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "client-id", form.Get("client_id"))
+	assert.Empty(t, form.Get("client_secret"), "none must not send client_secret")
+	assert.Empty(t, capturedAuth)
+}
+
+// TestAuthOAuth2_Validate_BasicRequiresClientSecret guards the validator
+// invariant that client_secret_basic must have client_secret set.
+func TestAuthOAuth2_Validate_BasicRequiresClientSecret(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.TokenEndpointAuthClientSecretBasic,
+		ClientId:                common.NewStringValueDirect("client-id"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_secret")
+}
+
+// TestAuthOAuth2_Validate_NoneRejectsClientSecret guards the invariant that
+// the none method must NOT carry a client_secret.
+func TestAuthOAuth2_Validate_NoneRejectsClientSecret(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		ClientId:                common.NewStringValueDirect("client-id"),
+		ClientSecret:            common.NewStringValueDirect("client-secret"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_secret")
+}
+
+// TestAuthOAuth2_Validate_NoneRequiresPKCE guards the invariant that the
+// none method without PKCE is rejected (public client without
+// proof-of-possession would be a security regression).
+func TestAuthOAuth2_Validate_NoneRequiresPKCE(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		ClientId:                common.NewStringValueDirect("client-id"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pkce")
+}
+
+// TestAuthOAuth2_Validate_NoneAcceptsWhenPKCESet exercises the happy path
+// for public-client validation.
+func TestAuthOAuth2_Validate_NoneAcceptsWhenPKCESet(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.TokenEndpointAuthNone,
+		ClientId:                common.NewStringValueDirect("client-id"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
+		},
+	}
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+}
+
+// TestAuthOAuth2_Validate_RejectsUnknownTokenEndpointAuthMethod guards
+// the validator against typos / unsupported RFC 7591 methods (client_secret_jwt
+// etc., out of scope).
+func TestAuthOAuth2_Validate_RejectsUnknownTokenEndpointAuthMethod(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:                    cschema.AuthTypeOAuth2,
+		TokenEndpointAuthMethod: cschema.TokenEndpointAuthMethod("bogus"),
+		ClientId:                common.NewStringValueDirect("client-id"),
+		ClientSecret:            common.NewStringValueDirect("client-secret"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token_endpoint_auth_method")
+}
+

--- a/internal/auth_methods/oauth2/pkce_test.go
+++ b/internal/auth_methods/oauth2/pkce_test.go
@@ -85,7 +85,9 @@ func TestPKCEChallengeFor_UnknownMethodErrors(t *testing.T) {
 
 func TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod(t *testing.T) {
 	a := &cschema.AuthOAuth2{
-		Type: cschema.AuthTypeOAuth2,
+		Type:         cschema.AuthTypeOAuth2,
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
 			PKCE:     &cschema.AuthOauth2PKCE{Method: "bogus"},
@@ -100,7 +102,9 @@ func TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod(t *testing.T) {
 
 func TestAuthOAuth2_Validate_AcceptsS256(t *testing.T) {
 	a := &cschema.AuthOAuth2{
-		Type: cschema.AuthTypeOAuth2,
+		Type:         cschema.AuthTypeOAuth2,
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
 			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256},
@@ -111,7 +115,9 @@ func TestAuthOAuth2_Validate_AcceptsS256(t *testing.T) {
 
 func TestAuthOAuth2_Validate_AcceptsPlain(t *testing.T) {
 	a := &cschema.AuthOAuth2{
-		Type: cschema.AuthTypeOAuth2,
+		Type:         cschema.AuthTypeOAuth2,
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
 			PKCE:     &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodPlain},
@@ -124,7 +130,9 @@ func TestAuthOAuth2_Validate_DefaultsMethodWhenBlockPresent(t *testing.T) {
 	// Block present but method omitted: schema-level validation must accept;
 	// runtime defaults to S256 via GetMethodOrDefault.
 	a := &cschema.AuthOAuth2{
-		Type: cschema.AuthTypeOAuth2,
+		Type:         cschema.AuthTypeOAuth2,
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
 		Authorization: cschema.AuthOauth2Authorization{
 			Endpoint: "https://example.com/oauth/authorize",
 			PKCE:     &cschema.AuthOauth2PKCE{},

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -104,12 +104,7 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshNoRefreshToken, 0, "", 0, errNoRefreshToken)
 	}
 
-	clientId, err := o.auth.ClientId.GetValue(ctx)
-	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
-	}
-
-	clientSecret, err := o.auth.ClientSecret.GetValue(ctx)
+	clientId, clientSecret, err := o.resolveClientCredentials(ctx)
 	if err != nil {
 		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
@@ -132,11 +127,16 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 	values := url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {refreshToken},
-		"client_id":     {clientId},
-		"client_secret": {clientSecret},
 	}
 
-	refreshResp, attempts, err := o.postRefreshWithRetry(ctx, client, tokenEndpoint, values)
+	values, authHeader, err := applyTokenEndpointClientAuth(
+		o.auth.GetTokenEndpointAuthMethodOrDefault(), clientId, clientSecret, values,
+	)
+	if err != nil {
+		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
+	}
+
+	refreshResp, attempts, err := o.postRefreshWithRetry(ctx, client, tokenEndpoint, values, authHeader)
 	if err != nil {
 		// Transport-layer failure — provider never produced a status code.
 		// Transient by classification; does not flip unhealthy.
@@ -257,6 +257,7 @@ func (o *oAuth2Connection) postRefreshWithRetry(
 	client *gentleman.Client,
 	tokenEndpoint string,
 	values url.Values,
+	authHeader string,
 ) (*gentleman.Response, int, error) {
 	var lastResp *gentleman.Response
 	var lastErr error
@@ -279,6 +280,10 @@ func (o *oAuth2Connection) postRefreshWithRetry(
 			SetHeader("Content-Type", "application/x-www-form-urlencoded").
 			AddHeader("accept", "application/json").
 			BodyString(values.Encode())
+
+		if authHeader != "" {
+			req = req.AddHeader("Authorization", authHeader)
+		}
 
 		resp, err := req.Send()
 

--- a/internal/auth_methods/oauth2/proxy_test.go
+++ b/internal/auth_methods/oauth2/proxy_test.go
@@ -288,6 +288,7 @@ func TestPostRefreshWithRetry_SuccessFirstAttempt(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"rt"}},
+		"",
 	)
 
 	require.NoError(t, err)
@@ -320,6 +321,7 @@ func TestPostRefreshWithRetry_4xxNotRetried(t *testing.T) {
 				gentleman.New(),
 				srv.URL,
 				url.Values{"grant_type": {"refresh_token"}},
+				"",
 			)
 
 			require.NoError(t, err, "transport-layer call succeeded — 4xx is not a transport error")
@@ -345,6 +347,7 @@ func TestPostRefreshWithRetry_5xxThenSuccess(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 	elapsed := time.Since(start)
 
@@ -372,6 +375,7 @@ func TestPostRefreshWithRetry_5xxExhausted(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 
 	require.NoError(t, err, "5xx is an HTTP-level failure, not a transport error")
@@ -397,6 +401,7 @@ func TestPostRefreshWithRetry_TransportErrorRetried(t *testing.T) {
 		gentleman.New(),
 		closedURL,
 		url.Values{},
+		"",
 	)
 
 	require.Error(t, err, "transport failure must surface as an error")
@@ -429,6 +434,7 @@ func TestPostRefreshWithRetry_ContextCancelledBeforeRetry(t *testing.T) {
 		gentleman.New(),
 		srv.URL,
 		url.Values{},
+		"",
 	)
 
 	require.ErrorIs(t, err, context.Canceled)

--- a/internal/schema/config/reexport.go
+++ b/internal/schema/config/reexport.go
@@ -56,6 +56,7 @@ type (
 	Connectors              = connectors.Connectors
 	PKCEMethod              = connectors.PKCEMethod
 	Scope                   = connectors.Scope
+	TokenEndpointAuthMethod = connectors.TokenEndpointAuthMethod
 )
 
 // Re-export constants from the connectors sub-package
@@ -70,4 +71,8 @@ const (
 
 	PKCEMethodS256  = connectors.PKCEMethodS256
 	PKCEMethodPlain = connectors.PKCEMethodPlain
+
+	TokenEndpointAuthClientSecretPost  = connectors.TokenEndpointAuthClientSecretPost
+	TokenEndpointAuthClientSecretBasic = connectors.TokenEndpointAuthClientSecretBasic
+	TokenEndpointAuthNone              = connectors.TokenEndpointAuthNone
 )

--- a/internal/schema/connectors/auth_oauth2.go
+++ b/internal/schema/connectors/auth_oauth2.go
@@ -5,14 +5,53 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
+// TokenEndpointAuthMethod selects how the connector authenticates itself to
+// the OAuth2 token endpoint per RFC 6749 §2.3.1 / RFC 7591 §2. Values follow
+// the RFC 7591 token_endpoint_auth_method registry.
+type TokenEndpointAuthMethod string
+
+const (
+	// TokenEndpointAuthClientSecretPost sends client_id and client_secret in
+	// the form-encoded request body. This is the current AuthProxy default
+	// for backwards compatibility — every connector authored before this
+	// option existed assumed post-body credentials.
+	TokenEndpointAuthClientSecretPost = TokenEndpointAuthMethod("client_secret_post")
+	// TokenEndpointAuthClientSecretBasic sends "client_id:client_secret"
+	// URL-form-encoded then base64-encoded in an HTTP Basic Authorization
+	// header. RFC 6749 §2.3.1 designates this as the canonical method
+	// ("The authorization server MUST support" it) and many providers
+	// (Google, Salesforce, Okta variants) reject the post-body form.
+	TokenEndpointAuthClientSecretBasic = TokenEndpointAuthMethod("client_secret_basic")
+	// TokenEndpointAuthNone marks the connector as a public client
+	// (RFC 7591 §2). The token-endpoint POST sends client_id only — no
+	// secret, no Authorization header. Public clients have no
+	// proof-of-possession from a secret, so we additionally require PKCE
+	// (RFC 7636) for the authorize/exchange to be meaningful.
+	TokenEndpointAuthNone = TokenEndpointAuthMethod("none")
+)
+
 type AuthOAuth2 struct {
-	Type          AuthType                `json:"type" yaml:"type"`
-	ClientId      *common.StringValue     `json:"client_id" yaml:"client_id"`
-	ClientSecret  *common.StringValue     `json:"client_secret" yaml:"client_secret"`
-	Scopes        []Scope                 `json:"scopes" yaml:"scopes"`
-	Authorization AuthOauth2Authorization `json:"authorization" yaml:"authorization"`
-	Token         AuthOauth2Token         `json:"token" yaml:"token"`
-	Revocation    *AuthOauth2Revocation   `json:"revocation,omitempty" yaml:"revocation,omitempty"`
+	Type AuthType `json:"type" yaml:"type"`
+	// TokenEndpointAuthMethod selects how client credentials are presented
+	// to the token endpoint. When empty, defaults to client_secret_post —
+	// matches the proxy's behavior before this field existed.
+	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
+	ClientId                *common.StringValue     `json:"client_id,omitempty" yaml:"client_id,omitempty"`
+	ClientSecret            *common.StringValue     `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	Scopes                  []Scope                 `json:"scopes" yaml:"scopes"`
+	Authorization           AuthOauth2Authorization `json:"authorization" yaml:"authorization"`
+	Token                   AuthOauth2Token         `json:"token" yaml:"token"`
+	Revocation              *AuthOauth2Revocation   `json:"revocation,omitempty" yaml:"revocation,omitempty"`
+}
+
+// GetTokenEndpointAuthMethodOrDefault returns the configured method, defaulting
+// to client_secret_post when the field was omitted. Keeps the default in one
+// place so callsites don't have to repeat the empty-string check.
+func (a *AuthOAuth2) GetTokenEndpointAuthMethodOrDefault() TokenEndpointAuthMethod {
+	if a == nil || a.TokenEndpointAuthMethod == "" {
+		return TokenEndpointAuthClientSecretPost
+	}
+	return a.TokenEndpointAuthMethod
 }
 
 func (a *AuthOAuth2) GetType() AuthType {
@@ -86,9 +125,9 @@ func (a *AuthOAuth2) Clone() AuthImpl {
 	return &clone
 }
 
-// Validate enforces OAuth2-specific schema invariants. Today this just
-// checks the optional PKCE block — the rest of the type's fields are
-// validated structurally elsewhere.
+// Validate enforces OAuth2-specific schema invariants: the optional PKCE
+// block, and the optional token_endpoint_auth_method selector and its
+// cross-field requirements on client_secret / PKCE.
 func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 	if a == nil {
 		return nil
@@ -107,6 +146,36 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 				a.Authorization.PKCE.Method, PKCEMethodS256, PKCEMethodPlain,
 			))
 		}
+	}
+
+	hasSecret := a.ClientSecret != nil && a.ClientSecret.InnerVal != nil
+	switch a.TokenEndpointAuthMethod {
+	case "", TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic:
+		if !hasSecret {
+			result = multierror.Append(result, vc.NewErrorfForField("client_secret",
+				"is required when token_endpoint_auth_method is %q",
+				a.GetTokenEndpointAuthMethodOrDefault(),
+			))
+		}
+	case TokenEndpointAuthNone:
+		if hasSecret {
+			result = multierror.Append(result, vc.NewErrorfForField("client_secret",
+				"must be omitted when token_endpoint_auth_method is %q",
+				TokenEndpointAuthNone,
+			))
+		}
+		if a.Authorization.PKCE == nil {
+			result = multierror.Append(result, vc.PushField("authorization").NewErrorfForField("pkce",
+				"is required when token_endpoint_auth_method is %q (public clients have no proof-of-possession without PKCE)",
+				TokenEndpointAuthNone,
+			))
+		}
+	default:
+		result = multierror.Append(result, vc.NewErrorfForField("token_endpoint_auth_method",
+			"%q is not a valid method; must be %q, %q, or %q",
+			a.TokenEndpointAuthMethod,
+			TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic, TokenEndpointAuthNone,
+		))
 	}
 
 	return result.ErrorOrNil()

--- a/internal/schema/connectors/auth_oauth2.go
+++ b/internal/schema/connectors/auth_oauth2.go
@@ -33,25 +33,39 @@ const (
 type AuthOAuth2 struct {
 	Type AuthType `json:"type" yaml:"type"`
 	// TokenEndpointAuthMethod selects how client credentials are presented
-	// to the token endpoint. When empty, defaults to client_secret_post —
-	// matches the proxy's behavior before this field existed.
-	TokenEndpointAuthMethod TokenEndpointAuthMethod `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
-	ClientId                *common.StringValue     `json:"client_id,omitempty" yaml:"client_id,omitempty"`
-	ClientSecret            *common.StringValue     `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
-	Scopes                  []Scope                 `json:"scopes" yaml:"scopes"`
-	Authorization           AuthOauth2Authorization `json:"authorization" yaml:"authorization"`
-	Token                   AuthOauth2Token         `json:"token" yaml:"token"`
-	Revocation              *AuthOauth2Revocation   `json:"revocation,omitempty" yaml:"revocation,omitempty"`
+	// to the token endpoint. nil signals "use the default" and resolves to
+	// client_secret_post via GetTokenEndpointAuthMethodOrDefault, matching
+	// the proxy's behavior before this field existed. An explicit
+	// empty-string value is rejected by the validator — it is not a valid
+	// method per RFC 7591 §2 and must not silently fall through to the
+	// default.
+	TokenEndpointAuthMethod *TokenEndpointAuthMethod `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
+	ClientId                *common.StringValue      `json:"client_id,omitempty" yaml:"client_id,omitempty"`
+	ClientSecret            *common.StringValue      `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	Scopes                  []Scope                  `json:"scopes" yaml:"scopes"`
+	Authorization           AuthOauth2Authorization  `json:"authorization" yaml:"authorization"`
+	Token                   AuthOauth2Token          `json:"token" yaml:"token"`
+	Revocation              *AuthOauth2Revocation    `json:"revocation,omitempty" yaml:"revocation,omitempty"`
+}
+
+// NewTokenEndpointAuthMethod returns a pointer to m. Convenience constructor
+// for callers that need to set the optional connector field — Go does not
+// allow taking the address of a typed-string constant directly.
+func NewTokenEndpointAuthMethod(m TokenEndpointAuthMethod) *TokenEndpointAuthMethod {
+	return &m
 }
 
 // GetTokenEndpointAuthMethodOrDefault returns the configured method, defaulting
-// to client_secret_post when the field was omitted. Keeps the default in one
-// place so callsites don't have to repeat the empty-string check.
+// to client_secret_post only when the field was omitted (nil). This is the
+// single place where the nil → post collapse happens; callers that already
+// invoke this method receive a resolved, non-empty value and must not apply
+// any further default. An explicitly-set empty-string value is preserved as
+// empty — it is the validator's job to reject it, not this getter's.
 func (a *AuthOAuth2) GetTokenEndpointAuthMethodOrDefault() TokenEndpointAuthMethod {
-	if a == nil || a.TokenEndpointAuthMethod == "" {
+	if a == nil || a.TokenEndpointAuthMethod == nil {
 		return TokenEndpointAuthClientSecretPost
 	}
-	return a.TokenEndpointAuthMethod
+	return *a.TokenEndpointAuthMethod
 }
 
 func (a *AuthOAuth2) GetType() AuthType {
@@ -148,13 +162,26 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 		}
 	}
 
+	// An explicit empty-string value is rejected here rather than silently
+	// resolved to the default — the YAML author wrote *something* and we
+	// owe them a clear error rather than a surprising fallback. nil
+	// (field omitted) is the only "use the default" signal.
+	if a.TokenEndpointAuthMethod != nil && *a.TokenEndpointAuthMethod == "" {
+		result = multierror.Append(result, vc.NewErrorfForField("token_endpoint_auth_method",
+			"must not be empty; omit the field to use the default (%q), or set one of %q, %q, %q",
+			TokenEndpointAuthClientSecretPost,
+			TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic, TokenEndpointAuthNone,
+		))
+		return result.ErrorOrNil()
+	}
+
 	hasSecret := a.ClientSecret != nil && a.ClientSecret.InnerVal != nil
-	switch a.TokenEndpointAuthMethod {
-	case "", TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic:
+	method := a.GetTokenEndpointAuthMethodOrDefault()
+	switch method {
+	case TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic:
 		if !hasSecret {
 			result = multierror.Append(result, vc.NewErrorfForField("client_secret",
-				"is required when token_endpoint_auth_method is %q",
-				a.GetTokenEndpointAuthMethodOrDefault(),
+				"is required when token_endpoint_auth_method is %q", method,
 			))
 		}
 	case TokenEndpointAuthNone:
@@ -173,7 +200,7 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 	default:
 		result = multierror.Append(result, vc.NewErrorfForField("token_endpoint_auth_method",
 			"%q is not a valid method; must be %q, %q, or %q",
-			a.TokenEndpointAuthMethod,
+			method,
 			TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic, TokenEndpointAuthNone,
 		))
 	}

--- a/internal/schema/connectors/schema-oauth.json
+++ b/internal/schema/connectors/schema-oauth.json
@@ -103,6 +103,9 @@
     "client_secret": {
       "$ref": "../common/schema.json#/$defs/StringValue"
     },
+    "token_endpoint_auth_method": {
+      "enum": ["client_secret_post", "client_secret_basic", "none"]
+    },
     "authorization": {
       "$ref": "#/$defs/Authorization"
     },

--- a/internal/schema/connectors/test_data/invalid-oauth-connector-auth-method.yaml
+++ b/internal/schema/connectors/test_data/invalid-oauth-connector-auth-method.yaml
@@ -1,0 +1,25 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana (bad token_endpoint_auth_method)
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  token_endpoint_auth_method with an unsupported value — must be rejected
+  by the schema.
+auth:
+  type: OAuth2
+  token_endpoint_auth_method: bogus
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  client_secret:
+    env_var: ASANA_CLIENT_SECRET
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects

--- a/internal/schema/connectors/test_data/valid-oauth-connector-basic.yaml
+++ b/internal/schema/connectors/test_data/valid-oauth-connector-basic.yaml
@@ -1,0 +1,25 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana (Basic)
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  OAuth2 connector that authenticates to the token endpoint via HTTP Basic
+  (RFC 6749 §2.3.1).
+auth:
+  type: OAuth2
+  token_endpoint_auth_method: client_secret_basic
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  client_secret:
+    env_var: ASANA_CLIENT_SECRET
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects

--- a/internal/schema/connectors/test_data/valid-oauth-connector-public.yaml
+++ b/internal/schema/connectors/test_data/valid-oauth-connector-public.yaml
@@ -1,0 +1,25 @@
+# $schema: ./schema.json
+
+labels:
+  type: asana
+display_name: Asana (Public Client)
+logo:
+  public_url: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Asana_logo.svg/2880px-Asana_logo.svg.png
+description: |
+  Public-client OAuth2 connector — no client_secret, PKCE-only proof of
+  possession (RFC 7591 §2, RFC 7636).
+auth:
+  type: OAuth2
+  token_endpoint_auth_method: none
+  client_id:
+    env_var: ASANA_CLIENT_ID
+  authorization:
+    endpoint: https://app.asana.com/-/oauth_authorize
+    pkce:
+      method: S256
+  token:
+    endpoint: https://app.asana.com/-/oauth_token
+  scopes:
+    - id: projects:read
+      reason: |
+        We need access to see the projects


### PR DESCRIPTION
## Summary

Implements #351 — adds the RFC 7591 §2 `token_endpoint_auth_method` selector to the OAuth2 connector. Three methods are supported:

- **`client_secret_post`** (default; today's behaviour): `client_id` and `client_secret` in the form body.
- **`client_secret_basic`**: `Authorization: Basic <base64(qs(id):qs(secret))>` per RFC 6749 §2.3.1, with credentials removed from the form body.
- **`none`**: public clients (RFC 7591 §2) — `client_id` only, no secret, paired with mandatory PKCE so the exchange retains proof-of-possession.

A single helper (`applyTokenEndpointClientAuth`) renders the body+header shape per method; callback (initial code exchange) and refresh both call through it, so the wire format cannot drift between the two grants.

Validator enforces:
- Unknown methods rejected.
- `client_secret` required for `post`/`basic`.
- `client_secret` forbidden + PKCE required for `none`.

Default behaviour is unchanged — every existing connector takes the `client_secret_post` branch.

Unblocks #178.

## Note on redaction

The ticket asks to verify the `Authorization: Basic` header is redacted symmetrically with the `client_secret` form field. The request-log already protects credential material **structurally**, not via a field-level allowlist:

- `LogRecord` (the searchable / indexed record) carries no headers or body — only safe metadata. This is what shows up in dashboards and search results.
- `FullLog` (the full-payload capture, optionally written to blob storage) carries the full request including all headers and body verbatim.

For `client_secret_post`, the secret lives in `FullLog.Request.Body`. For `client_secret_basic`, it lives in `FullLog.Request.Headers["Authorization"]`. Both have identical exposure (FullStore only); neither leaks via `LogRecord`. No code change required.

## Test plan

- [x] Unit tests for `applyTokenEndpointClientAuth` covering all three methods, default-when-empty, special-char encoding in basic auth, and unknown-method rejection.
- [x] Wire-format tests for the callback path with each method (gock-captured body + Authorization header).
- [x] Validator tests for each invariant: basic-needs-secret, none-rejects-secret, none-requires-PKCE, none-with-PKCE accepted, unknown-method rejected.
- [x] JSON schema fixtures: `valid-oauth-connector-basic.yaml`, `valid-oauth-connector-public.yaml` (PKCE+none), `invalid-oauth-connector-auth-method.yaml`.
- [x] Full `./scripts/preflight.sh` clean.
- [x] Full `go test ./internal/...` clean — no regressions in callback / refresh / retry suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)