### PR TITLE
[api-key] Integration test harness + cross-cutting probe tests (#258)

### DIFF
--- a/integration_tests/api_key/auto_reauth_test.go
+++ b/integration_tests/api_key/auto_reauth_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package api_key
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiKeyAutoReauth walks the full unhealthy-to-healthy recovery path
+// driven by probe-driven health:
+//
+//  1. Drive the connection to Ready with key=v1.
+//  2. Stub upstream rotates its accepted secret to v2 — v1 now 401s.
+//  3. A periodic probe fails — connection's health_state flips to unhealthy
+//     (failure_threshold=1 for test determinism).
+//  4. User submits the new key via the reauth flow.
+//  5. A subsequent periodic probe succeeds — health_state flips back to
+//     healthy (recovery_threshold=1).
+//
+// This is a single end-to-end pass that exercises both the failure and
+// recovery sides of the probe-driven health logic against an api-key
+// connection.
+func TestApiKeyAutoReauth(t *testing.T) {
+	const keyV1 = "auto-reauth-key-v1"
+	const keyV2 = "auto-reauth-key-v2"
+
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: keyV1,
+	})
+
+	one := 1
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	conn := helpers.NewApiKeyConnector(connectorID, "api-key-auto-reauth", helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+		ProbeURL:  stub.BaseURL + "/probe",
+		// Tighten the thresholds so a single failure flips unhealthy and a
+		// single success flips back. Without this, the default
+		// failure_threshold (3) would require three failed probe runs to
+		// observe the transition.
+		ProbeFailureThreshold:  &one,
+		ProbeRecoveryThreshold: &one,
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:    helpers.ServiceTypeAPI,
+		Connectors: []sconfig.Connector{conn},
+	})
+	defer env.Cleanup()
+
+	// Drive to Ready with the v1 key.
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": keyV1})
+	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	cReady := env.GetConnection(t, connectionID)
+	require.Equal(t, database.ConnectionStateReady, cReady.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, cReady.HealthState,
+		"connection should be healthy after a successful verify")
+
+	// Simulate provider-side rotation. The stored credential (v1) is now
+	// invalid against the upstream — the next probe will 401.
+	stub.RotateAcceptedKey(keyV2)
+
+	// One failed probe must flip health to unhealthy (failure_threshold=1).
+	require.Error(t, env.RunProbe(t, connectionID, "verify-credential"),
+		"probe should fail after upstream rotation invalidated the stored key")
+
+	cUnhealthy := env.GetConnection(t, connectionID)
+	assert.Equal(t, database.ConnectionStateReady, cUnhealthy.State,
+		"state should still be Ready — only health_state flips")
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, cUnhealthy.HealthState,
+		"connection should be unhealthy after one failed probe (threshold=1)")
+
+	// User submits the new key via reauth — same UI flow as TestApiKey-
+	// ManualRotation, just driven against an unhealthy connection.
+	w = env.ReauthConnection(t, connectionID)
+	require.Equalf(t, http.StatusOK, w.Code, "reauth failed: %s", w.Body.String())
+
+	w = env.SubmitApiKeyCredentials(t, connectionID, helpers.ApiKeySubmitFormStepId(), map[string]any{
+		"api_key": keyV2,
+	})
+	require.Equalf(t, http.StatusOK, w.Code, "rotation submit failed: %s", w.Body.String())
+
+	// Verify the new credential — onVerifyPassed marks healthy too, but
+	// the issue specifically calls out the probe-driven recovery path.
+	// To exercise it cleanly, advance through verify first (sets healthy
+	// once) and then assert a follow-up periodic probe is also recorded
+	// as a successful outcome.
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	cRecovered := env.GetConnection(t, connectionID)
+	require.Equal(t, database.ConnectionStateReady, cRecovered.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, cRecovered.HealthState,
+		"connection should be healthy again after submitting the new key")
+
+	// A periodic probe with the rotated credential should still succeed —
+	// closing the loop on recovery (recovery_threshold=1).
+	require.NoError(t, env.RunProbe(t, connectionID, "verify-credential"),
+		"probe should now succeed against the rotated upstream with the new key")
+
+	cFinal := env.GetConnection(t, connectionID)
+	assert.Equal(t, database.ConnectionHealthStateHealthy, cFinal.HealthState,
+		"connection should remain healthy after a successful periodic probe")
+
+	// Active credential is the new one.
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	cred, err := env.Db.GetActiveApiKeyCredential(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, keyV2, env.DecryptApiKeyCredential(t, connectionID).ApiKey)
+}

--- a/integration_tests/api_key/harness_smoke_test.go
+++ b/integration_tests/api_key/harness_smoke_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+// Package api_key holds integration tests for api-key-authenticated connectors.
+// Mirrors the structure of integration_tests/oauth2 — the tests drive a stub
+// upstream that validates an incoming credential per placement (bearer,
+// header, query, basic) and assert on the connection lifecycle the proxy
+// produces against it.
+package api_key
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHarness_StubUpstreamBearer verifies the api-key stub upstream's bearer
+// placement: requests with the configured key return 200, anything else
+// returns 401. Sanity check the helper itself before the lifecycle tests
+// depend on it.
+func TestHarness_StubUpstreamBearer(t *testing.T) {
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: "smoke-key",
+	})
+
+	// Match
+	req, err := http.NewRequest(http.MethodGet, stub.BaseURL+"/anything", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer smoke-key")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Wrong key
+	req, _ = http.NewRequest(http.MethodGet, stub.BaseURL+"/anything", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// No header
+	resp, err = http.DefaultClient.Get(stub.BaseURL + "/anything")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Rotation
+	stub.RotateAcceptedKey("new-key")
+	req, _ = http.NewRequest(http.MethodGet, stub.BaseURL+"/anything", nil)
+	req.Header.Set("Authorization", "Bearer smoke-key") // old key now rejected
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	req, _ = http.NewRequest(http.MethodGet, stub.BaseURL+"/anything", nil)
+	req.Header.Set("Authorization", "Bearer new-key")
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/integration_tests/api_key/initiate_flow_test.go
+++ b/integration_tests/api_key/initiate_flow_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package api_key
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiKeyConnection_BearerPlacement drives the full connection lifecycle
+// for a bearer-placement connector — initiate → form → submit credentials →
+// verify (via inline RunVerifyConnection) → ready — and confirms the stub
+// upstream actually received a bearer header carrying the submitted key.
+func TestApiKeyConnection_BearerPlacement(t *testing.T) {
+	runPerPlacementLifecycle(t, "bearer", helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: "secret-bearer-key",
+	}, helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+	}, map[string]any{
+		"api_key": "secret-bearer-key",
+	}, func(t *testing.T, reqs []helpers.ApiKeyStubRequest) {
+		require.NotEmpty(t, reqs, "stub should have observed at least one probe request")
+		latest := reqs[len(reqs)-1]
+		assert.Equal(t, "Bearer secret-bearer-key", latest.Headers.Get("Authorization"),
+			"probe must hit upstream with Bearer scheme carrying the submitted key")
+	})
+}
+
+// TestApiKeyConnection_HeaderPlacement covers the header placement with a
+// custom name + prefix.
+func TestApiKeyConnection_HeaderPlacement(t *testing.T) {
+	runPerPlacementLifecycle(t, "header", helpers.ApiKeyStubOptions{
+		Placement:    connectors.ApiKeyPlacementHeader,
+		HeaderName:   "X-Api-Key",
+		HeaderPrefix: "Token ",
+		AcceptedKey:  "secret-header-key",
+	}, helpers.ApiKeyConnectorOptions{
+		Placement:    connectors.ApiKeyPlacementHeader,
+		HeaderName:   "X-Api-Key",
+		HeaderPrefix: "Token ",
+	}, map[string]any{
+		"api_key": "secret-header-key",
+	}, func(t *testing.T, reqs []helpers.ApiKeyStubRequest) {
+		require.NotEmpty(t, reqs)
+		latest := reqs[len(reqs)-1]
+		assert.Equal(t, "Token secret-header-key", latest.Headers.Get("X-Api-Key"),
+			"probe must hit upstream with the configured header carrying prefix+key")
+	})
+}
+
+// TestApiKeyConnection_QueryPlacement covers query-string placement.
+func TestApiKeyConnection_QueryPlacement(t *testing.T) {
+	runPerPlacementLifecycle(t, "query", helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementQuery,
+		ParamName:   "apiKey",
+		AcceptedKey: "secret-query-key",
+	}, helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementQuery,
+		ParamName: "apiKey",
+	}, map[string]any{
+		"api_key": "secret-query-key",
+	}, func(t *testing.T, reqs []helpers.ApiKeyStubRequest) {
+		require.NotEmpty(t, reqs)
+		latest := reqs[len(reqs)-1]
+		assert.Contains(t, latest.RawQuery, "apiKey=secret-query-key",
+			"probe must hit upstream with the key in the configured query parameter")
+	})
+}
+
+// TestApiKeyConnection_BasicPlacement covers basic-auth placement (username
+// + password=key). The submit payload carries both fields; the stub upstream
+// validates the decoded "<user>:<key>" pair.
+func TestApiKeyConnection_BasicPlacement(t *testing.T) {
+	runPerPlacementLifecycle(t, "basic", helpers.ApiKeyStubOptions{
+		Placement:        connectors.ApiKeyPlacementBasic,
+		AcceptedKey:      "secret-basic-key",
+		AcceptedUsername: "alice@example.com",
+	}, helpers.ApiKeyConnectorOptions{
+		Placement:     connectors.ApiKeyPlacementBasic,
+		UsernameField: "account_email",
+	}, map[string]any{
+		"api_key":       "secret-basic-key",
+		"account_email": "alice@example.com",
+	}, func(t *testing.T, reqs []helpers.ApiKeyStubRequest) {
+		require.NotEmpty(t, reqs)
+		latest := reqs[len(reqs)-1]
+		got := latest.Headers.Get("Authorization")
+		require.Truef(t, strings.HasPrefix(got, "Basic "),
+			"probe must use Basic scheme; got %q", got)
+	})
+}
+
+// runPerPlacementLifecycle wraps the placement-dispatched setup so each
+// per-placement test only declares its inputs and the placement-specific
+// upstream assertion. Lifecycle steps that don't vary by placement
+// (initiate, submit, verify, ready, health=healthy, no-replay sanity)
+// happen here.
+func runPerPlacementLifecycle(
+	t *testing.T,
+	label string,
+	stubOpts helpers.ApiKeyStubOptions,
+	connectorOpts helpers.ApiKeyConnectorOptions,
+	credentialPayload map[string]any,
+	assertProbeRequest func(t *testing.T, reqs []helpers.ApiKeyStubRequest),
+) {
+	t.Helper()
+
+	stub := helpers.NewApiKeyStubUpstream(t, stubOpts)
+
+	// Connector definitions need a connector id; suffix with the placement
+	// label so parallel runs of this helper don't collide on the id namespace.
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorOpts.ProbeURL = stub.BaseURL + "/probe-" + label
+	conn := helpers.NewApiKeyConnector(connectorID, fmt.Sprintf("api-key-%s", label), connectorOpts)
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:    helpers.ServiceTypeAPI,
+		Connectors: []sconfig.Connector{conn},
+	})
+	defer env.Cleanup()
+
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	require.Equalf(t, helpers.ApiKeySubmitFormStepId(), form.StepId,
+		"initiate should return the synthesized credentials step id; got %q", form.StepId)
+
+	// No prior credential bytes should ever appear in a form payload —
+	// even on first initiate the synthesized JSON schema is built from the
+	// connector definition only. Catching it here too costs nothing and
+	// guards against accidental regressions where the schema gains a
+	// pre-filled default field that leaks state.
+	rawSchema := string(form.JsonSchema)
+	for _, v := range credentialPayload {
+		if vs, ok := v.(string); ok {
+			assert.NotContainsf(t, rawSchema, vs,
+				"credential bytes %q must not appear in initial form schema", vs)
+		}
+	}
+
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, credentialPayload)
+	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
+
+	// Submit transitions the connection into the verify phase (probes
+	// pending). Run verify inline — production has the asynq worker drain
+	// it; tests don't run a worker, so we drive the same code path
+	// synchronously.
+	require.NoError(t, env.RunVerifyConnection(t, connectionID), "verify should succeed against stub upstream")
+
+	conn2 := env.GetConnection(t, connectionID)
+	require.Equalf(t, database.ConnectionStateReady, conn2.State,
+		"connection should be Ready after submit + verify; got %s (setup_step=%v, setup_error=%v)",
+		conn2.State, conn2.SetupStep, conn2.SetupError)
+	assert.Equal(t, database.ConnectionHealthStateHealthy, conn2.HealthState,
+		"connection should be healthy after a successful verify")
+
+	// The probe must have actually hit the stub upstream with the submitted
+	// credential — placement-specific assertion below.
+	reqs := stub.Requests()
+	require.NotEmpty(t, reqs, "stub upstream should have received the probe request")
+	require.Greater(t, stub.SuccessCount(), int64(0), "probe should have succeeded at the stub")
+	require.Zerof(t, stub.UnauthorizedCount(),
+		"stub should not have rejected any requests during a clean lifecycle; got %d", stub.UnauthorizedCount())
+	assertProbeRequest(t, reqs)
+
+	// Active credential row should exist after submit (and only one — no
+	// rotation has happened yet on this connection).
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	cred, err := env.Db.GetActiveApiKeyCredential(t.Context(), id)
+	require.NoError(t, err)
+	assert.Equal(t, id, cred.ConnectionId, "active credential should be for this connection")
+	require.NotNilf(t, cred.PlacementSnapshot, "credential row should snapshot the placement at submit time")
+	assert.Equalf(t, connectorOpts.Placement, cred.PlacementSnapshot.Type,
+		"placement snapshot should mirror the connector's placement type")
+}

--- a/integration_tests/api_key/rotation_test.go
+++ b/integration_tests/api_key/rotation_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package api_key
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiKeyManualRotation drives the user-initiated rotation path: a Ready
+// connection invokes POST /_reauth, submits a new credential, and the prior
+// row is soft-deleted in the same transaction (verified via the database
+// state). The no-replay invariant is asserted at every observable surface —
+// the reauth form payload, the credential schema, and the post-rotation
+// upstream request stream all must omit the prior key bytes.
+func TestApiKeyManualRotation(t *testing.T) {
+	const oldKey = "manual-rotation-old-key"
+	const newKey = "manual-rotation-new-key"
+
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: oldKey,
+	})
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	conn := helpers.NewApiKeyConnector(connectorID, "api-key-rotation", helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+		ProbeURL:  stub.BaseURL + "/probe",
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:    helpers.ServiceTypeAPI,
+		Connectors: []sconfig.Connector{conn},
+	})
+	defer env.Cleanup()
+
+	// 1. Drive to Ready with the old key.
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{
+		"api_key": oldKey,
+	})
+	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	cReady := env.GetConnection(t, connectionID)
+	require.Equal(t, database.ConnectionStateReady, cReady.State)
+
+	// Snapshot the active credential row before rotation so we can confirm
+	// the row id changes (i.e. a new row was inserted, not the old one
+	// updated in place).
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	credBefore, err := env.Db.GetActiveApiKeyCredential(context.Background(), id)
+	require.NoError(t, err)
+	require.Equal(t, oldKey, env.DecryptApiKeyCredential(t, connectionID).ApiKey,
+		"sanity: pre-rotation active credential should match what we submitted")
+
+	// Rotate the upstream's accepted key so the OLD credential would now
+	// fail a probe — this is what would also drive auto-reauth in real
+	// usage. We don't run a probe here yet; that's the auto_reauth test.
+	stub.RotateAcceptedKey(newKey)
+
+	// Count upstream requests before reauth so we can scan only the
+	// requests that arrive *after* rotation begins for the no-replay
+	// assertion (pre-rotation requests obviously contain the old key —
+	// that's the whole point of them being authenticated).
+	requestsBeforeReauth := len(stub.Requests())
+
+	// 2. POST /_reauth — the response must be a form (credentials step)
+	//    and must NOT contain the prior key bytes.
+	w = env.ReauthConnection(t, connectionID)
+	require.Equalf(t, http.StatusOK, w.Code, "reauth failed: %s", w.Body.String())
+
+	rawBody := w.Body.String()
+	assert.NotContainsf(t, rawBody, oldKey,
+		"reauth form payload must not echo back the prior key bytes")
+
+	// 3. Submit the new credential. The submit handler runs InsertApiKey-
+	//    Credential, which soft-deletes the prior row in the same tx —
+	//    so the active row id changes and the prior row's deleted_at is
+	//    populated.
+	w = env.SubmitApiKeyCredentials(t, connectionID, helpers.ApiKeySubmitFormStepId(), map[string]any{
+		"api_key": newKey,
+	})
+	require.Equalf(t, http.StatusOK, w.Code, "rotation submit failed: %s", w.Body.String())
+
+	// 4. Verify against the rotated upstream succeeds with the new key
+	//    and the connection lands in Ready / healthy.
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	cAfter := env.GetConnection(t, connectionID)
+	require.Equal(t, database.ConnectionStateReady, cAfter.State)
+	assert.Equal(t, database.ConnectionHealthStateHealthy, cAfter.HealthState)
+
+	// 5. Active credential row was replaced — different id, different
+	//    plaintext.
+	credAfter, err := env.Db.GetActiveApiKeyCredential(context.Background(), id)
+	require.NoError(t, err)
+	assert.NotEqualf(t, credBefore.Id, credAfter.Id,
+		"rotation must produce a new credential row (got same id)")
+	assert.Equal(t, newKey, env.DecryptApiKeyCredential(t, connectionID).ApiKey,
+		"post-rotation active credential should be the new key")
+
+	// 6. No-replay invariant: no request that arrived after the reauth
+	//    began (i.e. after the upstream-side rotation) should carry the
+	//    old key in any header or query parameter. The pre-rotation
+	//    requests carry the old key by design — we exclude them by
+	//    slicing.
+	postRequests := stub.Requests()[requestsBeforeReauth:]
+	found, offending := helpers.ContainsBytes(postRequests, oldKey)
+	assert.Falsef(t, found,
+		"old key %q must not appear in any upstream request after rotation; offending request=%+v",
+		oldKey, offending)
+}

--- a/integration_tests/helpers/api_key_upstream.go
+++ b/integration_tests/helpers/api_key_upstream.go
@@ -1,0 +1,236 @@
+package helpers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/require"
+)
+
+// ApiKeyStubUpstream is an in-process HTTP server that validates an incoming
+// API-key credential per the configured placement (bearer / header / query /
+// basic) and returns 200 on match, 401 otherwise. The accepted credential can
+// be rotated at runtime to simulate provider-side key rotation.
+//
+// Recorded request bodies and headers are kept verbatim so tests can assert
+// that the prior credential bytes never appear after a rotation (the
+// no-replay invariant).
+type ApiKeyStubUpstream struct {
+	server  *http.Server
+	BaseURL string
+
+	placement    connectors.ApiKeyPlacementType
+	headerName   string // when placement == "header"
+	headerPrefix string
+	paramName    string // when placement == "query"
+
+	mu              sync.RWMutex
+	acceptedKey     string
+	acceptedUser    string // basic placement only
+	requests        []ApiKeyStubRequest
+	requestCount    atomic.Int64
+	successCount    atomic.Int64
+	unauthorizedCount atomic.Int64
+}
+
+// ApiKeyStubRequest captures one inbound request to the stub upstream for
+// later inspection. Headers and the raw query are recorded so tests can prove
+// that a particular byte string never traversed the upstream after a rotation.
+type ApiKeyStubRequest struct {
+	Method     string
+	Path       string
+	RawQuery   string
+	Headers    http.Header
+	Status     int
+}
+
+// ApiKeyStubOptions configures NewApiKeyStubUpstream.
+type ApiKeyStubOptions struct {
+	// Placement selects which credential placement the upstream expects.
+	Placement connectors.ApiKeyPlacementType
+
+	// HeaderName is required when Placement == "header".
+	HeaderName string
+
+	// HeaderPrefix is an optional literal prepended to the key value when
+	// Placement == "header" (e.g. "Token "). Matches the connector's
+	// placement.prefix.
+	HeaderPrefix string
+
+	// ParamName is required when Placement == "query".
+	ParamName string
+
+	// AcceptedKey is the credential the upstream initially accepts. Can be
+	// rotated at runtime via RotateAcceptedKey / RotateAcceptedBasic.
+	AcceptedKey string
+
+	// AcceptedUsername is only used for basic placement.
+	AcceptedUsername string
+}
+
+// NewApiKeyStubUpstream starts a stub upstream on a random localhost port.
+// The server is automatically shut down at the end of the test.
+func NewApiKeyStubUpstream(t *testing.T, opts ApiKeyStubOptions) *ApiKeyStubUpstream {
+	t.Helper()
+
+	require.NotEmptyf(t, string(opts.Placement), "Placement is required")
+	require.NotEmptyf(t, opts.AcceptedKey, "AcceptedKey is required")
+	switch opts.Placement {
+	case connectors.ApiKeyPlacementHeader:
+		require.NotEmptyf(t, opts.HeaderName, "HeaderName is required for header placement")
+	case connectors.ApiKeyPlacementQuery:
+		require.NotEmptyf(t, opts.ParamName, "ParamName is required for query placement")
+	case connectors.ApiKeyPlacementBasic:
+		require.NotEmptyf(t, opts.AcceptedUsername, "AcceptedUsername is required for basic placement")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	s := &ApiKeyStubUpstream{
+		BaseURL:      fmt.Sprintf("http://127.0.0.1:%d", port),
+		placement:    opts.Placement,
+		headerName:   opts.HeaderName,
+		headerPrefix: opts.HeaderPrefix,
+		paramName:    opts.ParamName,
+		acceptedKey:  opts.AcceptedKey,
+		acceptedUser: opts.AcceptedUsername,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handle)
+	s.server = &http.Server{Handler: mux}
+
+	go func() {
+		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			// Server stopped — nothing to report from the goroutine.
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = s.server.Close()
+	})
+
+	return s
+}
+
+// RotateAcceptedKey replaces the credential the stub upstream accepts. Used
+// to simulate provider-side rotation: pre-rotation calls with the old key
+// will now 401, while post-rotation calls with the new key will 200.
+func (s *ApiKeyStubUpstream) RotateAcceptedKey(newKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acceptedKey = newKey
+}
+
+// RotateAcceptedBasic rotates both the username and key for a basic-auth
+// stub upstream — usually only the key rotates in practice, but this lets
+// tests force both to change.
+func (s *ApiKeyStubUpstream) RotateAcceptedBasic(newUsername, newKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acceptedUser = newUsername
+	s.acceptedKey = newKey
+}
+
+// RequestCount returns the total number of requests that reached the stub.
+func (s *ApiKeyStubUpstream) RequestCount() int64 {
+	return s.requestCount.Load()
+}
+
+// SuccessCount returns the number of requests that returned 200.
+func (s *ApiKeyStubUpstream) SuccessCount() int64 {
+	return s.successCount.Load()
+}
+
+// UnauthorizedCount returns the number of requests that returned 401.
+func (s *ApiKeyStubUpstream) UnauthorizedCount() int64 {
+	return s.unauthorizedCount.Load()
+}
+
+// Requests returns a snapshot of every request recorded by the stub.
+func (s *ApiKeyStubUpstream) Requests() []ApiKeyStubRequest {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ApiKeyStubRequest, len(s.requests))
+	copy(out, s.requests)
+	return out
+}
+
+func (s *ApiKeyStubUpstream) handle(w http.ResponseWriter, r *http.Request) {
+	s.requestCount.Add(1)
+
+	status := http.StatusOK
+	if !s.credentialMatches(r) {
+		status = http.StatusUnauthorized
+	}
+
+	// Capture the request before responding so a panic in response writing
+	// doesn't lose the observation.
+	hdr := make(http.Header, len(r.Header))
+	for k, vs := range r.Header {
+		hdr[k] = append(hdr[k], vs...)
+	}
+	s.mu.Lock()
+	s.requests = append(s.requests, ApiKeyStubRequest{
+		Method:   r.Method,
+		Path:     r.URL.Path,
+		RawQuery: r.URL.RawQuery,
+		Headers:  hdr,
+		Status:   status,
+	})
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if status == http.StatusOK {
+		s.successCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "path": r.URL.Path})
+	} else {
+		s.unauthorizedCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "unauthorized"})
+	}
+}
+
+func (s *ApiKeyStubUpstream) credentialMatches(r *http.Request) bool {
+	s.mu.RLock()
+	expectedKey := s.acceptedKey
+	expectedUser := s.acceptedUser
+	s.mu.RUnlock()
+
+	switch s.placement {
+	case connectors.ApiKeyPlacementBearer:
+		got := r.Header.Get("Authorization")
+		return got == "Bearer "+expectedKey
+	case connectors.ApiKeyPlacementHeader:
+		got := r.Header.Get(s.headerName)
+		return got == s.headerPrefix+expectedKey
+	case connectors.ApiKeyPlacementQuery:
+		got := r.URL.Query().Get(s.paramName)
+		return got == expectedKey
+	case connectors.ApiKeyPlacementBasic:
+		got := r.Header.Get("Authorization")
+		if !strings.HasPrefix(got, "Basic ") {
+			return false
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+		if err != nil {
+			return false
+		}
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			return false
+		}
+		return parts[0] == expectedUser && parts[1] == expectedKey
+	}
+	return false
+}

--- a/integration_tests/helpers/setup_api_key.go
+++ b/integration_tests/helpers/setup_api_key.go
@@ -1,0 +1,280 @@
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/require"
+)
+
+// ApiKeyConnectorOptions configures NewApiKeyConnector.
+type ApiKeyConnectorOptions struct {
+	// Placement selects how the api key is sent on outbound requests. One of
+	// connectors.ApiKeyPlacementBearer/Header/Query/Basic.
+	Placement connectors.ApiKeyPlacementType
+
+	// HeaderName is required for header placement.
+	HeaderName string
+	// HeaderPrefix is the optional literal prepended to the key value for
+	// header placement.
+	HeaderPrefix string
+	// ParamName is required for query placement.
+	ParamName string
+	// UsernameField is required for basic placement.
+	UsernameField string
+
+	// ProbeURL is the URL the connector's verify-time probe hits. Typically
+	// the stub upstream's BaseURL plus a path. If empty, no probe is added —
+	// the connection skips verify and lands ready immediately after submit.
+	ProbeURL string
+	// ProbeFailureThreshold overrides the probe's failure threshold. When
+	// zero, the connector default applies (DefaultProbeFailureThreshold).
+	// Tests that drive probe-driven health typically set this to 1 so a
+	// single failed probe flips health_state.
+	ProbeFailureThreshold *int
+	// ProbeRecoveryThreshold overrides the probe's recovery threshold. When
+	// zero, DefaultProbeRecoveryThreshold (1) applies.
+	ProbeRecoveryThreshold *int
+}
+
+// NewApiKeyConnector builds an authproxy connector with the given api-key
+// placement and optionally a single proxy_http probe pointing at probeURL.
+// The probe path exercises the same authentication logic the real proxy
+// uses, so verifying the probe passes is equivalent to verifying the
+// credential was placed correctly on outbound requests.
+func NewApiKeyConnector(connectorID apid.ID, displayName string, opts ApiKeyConnectorOptions) sconfig.Connector {
+	placement := &connectors.ApiKeyPlacement{Type: opts.Placement}
+	switch opts.Placement {
+	case connectors.ApiKeyPlacementHeader:
+		placement.HeaderName = opts.HeaderName
+		placement.Prefix = opts.HeaderPrefix
+	case connectors.ApiKeyPlacementQuery:
+		placement.ParamName = opts.ParamName
+	case connectors.ApiKeyPlacementBasic:
+		placement.UsernameField = opts.UsernameField
+	}
+
+	c := sconfig.Connector{
+		Id:          connectorID,
+		Version:     1,
+		Labels:      map[string]string{"type": displayName},
+		DisplayName: displayName,
+		Auth: &connectors.Auth{
+			InnerVal: &connectors.AuthApiKey{
+				Type:      connectors.AuthTypeAPIKey,
+				Placement: placement,
+			},
+		},
+	}
+
+	if opts.ProbeURL != "" {
+		probe := connectors.Probe{
+			Id: "verify-credential",
+			ProxyHttp: &connectors.ProbeHttp{
+				Method: "GET",
+				URL:    opts.ProbeURL,
+			},
+			FailureThreshold:  opts.ProbeFailureThreshold,
+			RecoveryThreshold: opts.ProbeRecoveryThreshold,
+		}
+		c.Probes = []connectors.Probe{probe}
+	}
+
+	// Normalize synthesizes the credentials setup-flow step on top of the
+	// AuthApiKey placement so the connector definition is "ready to use" before
+	// migration sees it. The migration path also normalizes via Validate, but
+	// we call it here too so callers (and tests that inspect the returned
+	// definition) see the same shape that lands in the database.
+	c.Normalize()
+
+	return c
+}
+
+// InitiateApiKeyConnection POSTs to /api/v1/connections/_initiate for an api-key
+// connector. Unlike the OAuth2 path, the response is a form (the credentials
+// step), not a redirect. Returns the new connection id and the form payload.
+// Signed by default as actor "test-actor" in the root namespace; pass
+// WithActor(...) to mirror a specific tenant.
+func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorID apid.ID, opts ...OAuth2Option) (connectionID string, form *coreIface.ConnectionSetupForm) {
+	t.Helper()
+	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
+		"InitiateApiKeyConnection requires either in-process gin or a running HTTP server")
+
+	cfg := env.resolveOAuth2Options(opts)
+
+	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
+		ConnectorId:   connectorID,
+		IntoNamespace: cfg.actorNamespace,
+	})
+	require.NoError(t, err)
+
+	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/_initiate", body, cfg)
+	require.Equalf(t, http.StatusOK, w.Code, "initiate failed: %s", w.Body.String())
+
+	var generic struct {
+		Type string `json:"type"`
+		Id   string `json:"id"`
+	}
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &generic))
+	require.Equal(t, string(coreIface.ConnectionSetupResponseTypeForm), generic.Type,
+		"expected api-key connector to return form response (got %s): %s", generic.Type, w.Body.String())
+
+	var resp coreIface.ConnectionSetupForm
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &resp))
+	return resp.Id.String(), &resp
+}
+
+// SubmitApiKeyCredentials POSTs to /api/v1/connections/{id}/_submit with the
+// supplied step id and field data. Returns the response body so callers can
+// inspect what shape came back (form / verifying / complete).
+func (env *IntegrationTestEnv) SubmitApiKeyCredentials(t *testing.T, connectionID, stepID string, data map[string]any, opts ...OAuth2Option) *httptest.ResponseRecorder {
+	t.Helper()
+	cfg := env.resolveOAuth2Options(opts)
+
+	rawData, err := json.Marshal(data)
+	require.NoError(t, err)
+	body, err := jsonMarshal(coreIface.SubmitConnectionRequest{
+		StepId: stepID,
+		Data:   rawData,
+	})
+	require.NoError(t, err)
+
+	return env.doSignedRequest(t, http.MethodPost,
+		"/api/v1/connections/"+connectionID+"/_submit", body, cfg)
+}
+
+// ReauthConnection POSTs to /api/v1/connections/{id}/_reauth and returns the
+// raw response. For api-key connectors the response is a form (credentials
+// step) the user fills in to rotate the key.
+func (env *IntegrationTestEnv) ReauthConnection(t *testing.T, connectionID string, opts ...OAuth2Option) *httptest.ResponseRecorder {
+	t.Helper()
+	cfg := env.resolveOAuth2Options(opts)
+
+	// Body is optional for api-key; sending an empty struct exercises the
+	// JSON unmarshal path on the route.
+	body, err := jsonMarshal(struct{}{})
+	require.NoError(t, err)
+
+	return env.doSignedRequest(t, http.MethodPost,
+		"/api/v1/connections/"+connectionID+"/_reauth", body, cfg)
+}
+
+// RunProbe synchronously invokes the named probe against the connection and
+// records the outcome against health-state counters. Wraps the public iface
+// method so tests don't need a background worker to exercise the
+// probe-driven health path.
+func (env *IntegrationTestEnv) RunProbe(t *testing.T, connectionID, probeID string) error {
+	t.Helper()
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	return env.Core.RunProbe(context.Background(), id, probeID)
+}
+
+// RunVerifyConnection synchronously runs the verify-phase probes for the
+// connection. Used to advance a connection through the verify step without
+// running a background worker. No-ops cleanly if the connection isn't in
+// verify phase (matches the task handler's stale-task guard).
+func (env *IntegrationTestEnv) RunVerifyConnection(t *testing.T, connectionID string) error {
+	t.Helper()
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	return env.Core.RunVerifyConnection(context.Background(), id)
+}
+
+// DecryptApiKeyCredential returns the plaintext api-key (and username, when
+// basic) currently active on the connection. Used by tests to confirm
+// rotation actually replaced the stored secret.
+func (env *IntegrationTestEnv) DecryptApiKeyCredential(t *testing.T, connectionID string) database.ApiKeyCredentialPlaintext {
+	t.Helper()
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	cred, err := env.Db.GetActiveApiKeyCredential(context.Background(), id)
+	require.NoError(t, err)
+	plaintext, err := env.DM.GetEncryptService().DecryptString(context.Background(), cred.EncryptedCredentials)
+	require.NoError(t, err)
+	var out database.ApiKeyCredentialPlaintext
+	require.NoError(t, json.Unmarshal([]byte(plaintext), &out))
+	return out
+}
+
+// doSignedRequest signs an admin-namespace request as the configured actor
+// and dispatches it through either the in-process gin engine or the real
+// HTTP server, returning a recorder uniformly.
+func (env *IntegrationTestEnv) doSignedRequest(t *testing.T, method, path string, body io.Reader, cfg oauth2Options) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+		method,
+		path,
+		body,
+		cfg.actorNamespace,
+		cfg.actorExternalID,
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	if env.ApiGin != nil {
+		env.ApiGin.ServeHTTP(w, req)
+		return w
+	}
+
+	abs, err := url.Parse(env.ServerURL + path)
+	require.NoError(t, err)
+	req.URL = abs
+	req.Host = abs.Host
+	req.RequestURI = ""
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	w.Code = resp.StatusCode
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	if _, err := w.Body.ReadFrom(resp.Body); err != nil {
+		require.NoError(t, err)
+	}
+	return w
+}
+
+// ApiKeySubmitFormStepId returns the step id used by api-key connectors that
+// don't declare their own credentials step. The runtime synthesizes a step
+// with this id; tests must echo it back on submit. Exported to keep tests
+// from hardcoding the magic string.
+func ApiKeySubmitFormStepId() string {
+	return connectors.SynthesizedApiKeyCredentialsStepId
+}
+
+// ContainsBytes is a small helper for the no-replay assertion — checks
+// whether the supplied raw bytes appear in any header value of any
+// recorded stub-upstream request. Returns the first offending request
+// for use in failure messages.
+func ContainsBytes(reqs []ApiKeyStubRequest, needle string) (bool, ApiKeyStubRequest) {
+	for _, r := range reqs {
+		if strings.Contains(r.RawQuery, needle) {
+			return true, r
+		}
+		for _, vs := range r.Headers {
+			for _, v := range vs {
+				if strings.Contains(v, needle) {
+					return true, r
+				}
+			}
+		}
+	}
+	return false, ApiKeyStubRequest{}
+}

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -81,6 +81,11 @@ type OAuth2ConnectorOptions struct {
 	// RevocationEndpoint overrides provider.RevocationEndpoint() (only used
 	// when IncludeRevocation is true).
 	RevocationEndpoint string
+
+	// Probes are appended to the connector definition verbatim. Tests that
+	// exercise probe-driven health configure these (e.g. a proxy_http probe
+	// pointing at provider.ResourceURL("/echo")).
+	Probes []connectors.Probe
 }
 
 // NewOAuth2Connector builds an authproxy connector wired to the given
@@ -136,6 +141,7 @@ func NewOAuth2Connector(connectorID apid.ID, displayName string, provider *OAuth
 		Auth: &connectors.Auth{
 			InnerVal: auth,
 		},
+		Probes: opts.Probes,
 	}
 }
 

--- a/integration_tests/probes/oauth2_probe_health_test.go
+++ b/integration_tests/probes/oauth2_probe_health_test.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+// Package probes holds cross-cutting integration tests that exercise the
+// probe-driven health logic across auth methods. The probe-runtime is
+// auth-agnostic — failure/recovery thresholds and the connection's
+// health_state should behave identically regardless of whether credentials
+// were established via OAuth2 or api-key. The api-key half lives in
+// integration_tests/api_key/auto_reauth_test.go; this file proves the same
+// invariants hold against an OAuth2 connection.
+package probes
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOAuth2ProbeHealth_FailureAndRecovery verifies that the probe-driven
+// health-state transitions behave identically for OAuth2 connections:
+// forced probe failures flip the connection to unhealthy, and subsequent
+// successes flip it back to healthy. Uses the test provider's resource
+// endpoint as the probe target and scripts it to return 401 to force the
+// failure window.
+func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := "probe-health-client-" + suffix
+	clientSecret := "probe-health-secret-" + suffix
+	userEmail := "probe-health-" + suffix + "@example.com"
+	userPassword := "p4ssw0rd-" + suffix
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+
+	one := 1
+	probeURL := provider.ResourceURL("/probe-" + suffix)
+	connector := helpers.NewOAuth2Connector(connectorID, "probe-health-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+		Probes: []connectors.Probe{{
+			Id: "probe-health",
+			ProxyHttp: &connectors.ProbeHttp{
+				Method: "GET",
+				URL:    probeURL,
+			},
+			// Tight thresholds so a single probe outcome flips the
+			// connection on each transition — the alternative is many
+			// outcome cycles to cross the default thresholds.
+			FailureThreshold:  &one,
+			RecoveryThreshold: &one,
+		}},
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+	})
+	defer env.Cleanup()
+
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: userPassword,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	// Drive the OAuth2 flow to Ready. Same shortcut path the
+	// proxyRefreshRig uses — /test/authorize for the consent step
+	// (#169) — since we're testing health transitions, not the user-
+	// facing consent leg.
+	returnToURL := "https://example.com/return"
+	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnToURL)
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID)
+
+	authResp := provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    clientKey,
+		UserID:      user.ID,
+		RedirectURI: env.PublicOAuthCallbackURL(),
+		Scope:       "read",
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	pc, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code := pc.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	loc := env.DeliverOAuth2Callback(t, env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Truef(t, strings.HasPrefix(loc, returnToURL),
+		"auth flow should land on return_to_url; got %q", loc)
+
+	// After auth callback the connection is in verify phase (we added a
+	// probe). Drive verify synchronously — production has the asynq
+	// worker drain it; tests don't run a worker.
+	require.NoError(t, env.RunVerifyConnection(t, connID))
+
+	conn := env.GetConnection(t, connID)
+	require.Equal(t, database.ConnectionStateReady, conn.State,
+		"connection should land Ready after a successful verify")
+	require.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"healthy is the baseline after a successful initial verify")
+
+	// 1. Force probe failure: script the resource endpoint to return 401
+	//    for the next several calls. FailCount > 1 because OAuth2's
+	//    RecoverFrom401 path attempts a token refresh on a 401 and then
+	//    replays the resource request — the script needs to cover both
+	//    the original call and the retry so the probe sees 401 each time.
+	//    Clearing the script after the probe stops further interference.
+	provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status:    401,
+		Body:      `{"error":"invalid_token"}`,
+		FailCount: 10,
+	})
+
+	probeErr := env.RunProbe(t, connID, "probe-health")
+	provider.ClearScripts("", helpers.EndpointResource)
+	require.Error(t, probeErr, "probe must surface upstream 401 as a failure outcome")
+
+	conn = env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateReady, conn.State,
+		"state should still be Ready — only health_state flips on probe failures")
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, conn.HealthState,
+		"failure_threshold=1: a single failed probe must flip health to unhealthy")
+
+	// 2. Clear the failure window. Subsequent probes hit the un-scripted
+	//    resource endpoint and 200.
+	provider.ClearScripts("", helpers.EndpointResource)
+
+	require.NoError(t, env.RunProbe(t, connID, "probe-health"),
+		"probe should succeed once the upstream stops 401ing")
+
+	conn = env.GetConnection(t, connID)
+	require.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"recovery_threshold=1: a single successful probe must flip health back to healthy")
+
+	// The most recent recorded probe outcome should reflect the success.
+	id, err := apid.Parse(connID)
+	require.NoError(t, err)
+	outcomes, err := env.Db.GetRecentProbeOutcomes(context.Background(), id, "probe-health", 1)
+	require.NoError(t, err)
+	require.Lenf(t, outcomes, 1, "expected exactly one recent outcome row; got %d", len(outcomes))
+	assert.Equalf(t, database.ProbeOutcomeStatusSuccess, outcomes[0].Outcome,
+		"most recent outcome should be success after recovery; got %q", outcomes[0].Outcome)
+}

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -106,6 +106,20 @@ type C interface {
 	// the verify step of the setup flow. The task advances the connection's setup step based on the outcome.
 	EnqueueVerifyConnection(ctx context.Context, id apid.ID) error
 
+	// RunProbe synchronously invokes a single probe against a connection and records the outcome
+	// against the connection's health-state counters — the same code path the periodic asynq probe
+	// task takes, just inline. Returns the probe's invocation error (or nil on success). Used by
+	// integration tests that need deterministic probe execution and by future callers that want to
+	// nudge a probe sooner than its next scheduled tick.
+	RunProbe(ctx context.Context, connectionId apid.ID, probeId string) error
+
+	// RunVerifyConnection synchronously runs every probe declared on the connection's connector
+	// and advances setup_step based on the outcome — the same code path the asynq verify task
+	// takes, just inline. Used by integration tests that drive the setup lifecycle without a
+	// background worker. Returns asynq.SkipRetry for non-recoverable shapes (connection not found,
+	// no longer in verify phase); other errors propagate unwrapped.
+	RunVerifyConnection(ctx context.Context, connectionId apid.ID) error
+
 	// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the user
 	// can try setup again — either restarting preconnect forms, or re-initiating OAuth if the connector
 	// has no preconnect steps. Returns the initial setup step response for the retry.

--- a/internal/core/probe_http.go
+++ b/internal/core/probe_http.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httpf"
@@ -12,6 +13,12 @@ type probeHttp struct {
 	probeBase
 }
 
+// Invoke runs the probe and reports either success or error. Both branches
+// (proxy and raw) treat any non-2xx upstream response as a probe failure —
+// without this, an upstream that 401s the proxied request would silently be
+// considered a success and the probe-driven health signal would never flip
+// to unhealthy. The recorded error carries the status code so operators can
+// see what the upstream actually returned.
 func (p *probeHttp) Invoke(ctx context.Context) (string, error) {
 	return p.recordInvokeOutcome(ctx, func(ctx context.Context) (string, error) {
 		if p.cfg.ProxyHttp != nil {
@@ -30,13 +37,17 @@ func (p *probeHttp) Invoke(ctx context.Context) (string, error) {
 				BodyJson: h.BodyJson,
 			}
 
-			// TODO: translate result
-			_, err = proxy.ProxyRequest(ctx, httpf.RequestTypeProbe, &req)
+			resp, err := proxy.ProxyRequest(ctx, httpf.RequestTypeProbe, &req)
 			if err != nil {
 				return ProbeOutcomeError, err
-			} else {
-				return ProbeOutcomeSuccess, nil
 			}
+			if resp == nil {
+				return ProbeOutcomeError, fmt.Errorf("probe upstream returned no response")
+			}
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return ProbeOutcomeError, fmt.Errorf("probe upstream returned status %d", resp.StatusCode)
+			}
+			return ProbeOutcomeSuccess, nil
 		} else {
 			req := p.s.httpf.
 				ForConnection(p.c).
@@ -62,12 +73,17 @@ func (p *probeHttp) Invoke(ctx context.Context) (string, error) {
 				req.BodyString(h.Body)
 			}
 
-			_, err := req.Do()
+			resp, err := req.Do()
 			if err != nil {
 				return ProbeOutcomeError, err
-			} else {
-				return ProbeOutcomeSuccess, nil
 			}
+			if resp == nil {
+				return ProbeOutcomeError, fmt.Errorf("probe upstream returned no response")
+			}
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return ProbeOutcomeError, fmt.Errorf("probe upstream returned status %d", resp.StatusCode)
+			}
+			return ProbeOutcomeSuccess, nil
 		}
 	})
 }

--- a/internal/core/probe_http_test.go
+++ b/internal/core/probe_http_test.go
@@ -1,0 +1,279 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+)
+
+// stubProxy is a fake iface.Proxy used by probe_http tests. It records the
+// last ProxyRequest call and returns a programmable response/error pair.
+type stubProxy struct {
+	resp  *iface.ProxyResponse
+	err   error
+	calls []*iface.ProxyRequest
+}
+
+func (s *stubProxy) ProxyRequest(ctx context.Context, _ httpf.RequestType, req *iface.ProxyRequest) (*iface.ProxyResponse, error) {
+	s.calls = append(s.calls, req)
+	return s.resp, s.err
+}
+
+func (s *stubProxy) ProxyRequestRaw(ctx context.Context, _ httpf.RequestType, _ *iface.RawProxyRequest, _ http.ResponseWriter) error {
+	panic("ProxyRequestRaw should not be invoked by probe_http")
+}
+
+// newProbeTestConnection builds a connection wired to a stubProxy so the
+// probe code under test exercises the real iface.Proxy contract without
+// going through resolveAuthenticator (which would require a fully wired
+// auth-method factory).
+func newProbeTestConnection(t *testing.T, ctrl *gomock.Controller, def cschema.Connector) (*connection, *stubProxy) {
+	t.Helper()
+	s, _, _, _, _, _ := FullMockService(t, ctrl)
+	cv := NewTestConnectorVersion(def)
+
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	conn := &connection{
+		Connection: database.Connection{
+			Id:               apid.New(apid.PrefixConnection),
+			Namespace:        "root",
+			State:            database.ConnectionStateReady,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      cv.GetId(),
+			ConnectorVersion: cv.GetVersion(),
+		},
+		s:      s,
+		cv:     cv,
+		logger: logger,
+	}
+
+	proxy := &stubProxy{}
+	// Consume the sync.Once so getProxyImpl returns the stub on the first
+	// call rather than running the real auth-resolution path.
+	conn.proxyImpl = proxy
+	conn.proxyImplOnce.Do(func() {})
+
+	return conn, proxy
+}
+
+// testWriter routes log lines into t.Log so they appear with the failing
+// test rather than on stderr. The Write signature satisfies io.Writer.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+func TestProbeHttp_ProxyHttp_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	probeCfg := &cschema.Probe{
+		Id: "ping",
+		ProxyHttp: &cschema.ProbeHttp{
+			Method: "GET",
+			URL:    "https://example.com/health",
+		},
+	}
+	conn, proxy := newProbeTestConnection(t, ctrl, cschema.Connector{Probes: []cschema.Probe{*probeCfg}})
+	proxy.resp = &iface.ProxyResponse{StatusCode: 200}
+
+	probe := NewProbe(probeCfg, conn.s, conn.cv, conn)
+	outcome, err := probe.Invoke(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProbeOutcomeSuccess, outcome)
+	require.Len(t, proxy.calls, 1, "exactly one proxied probe request")
+	assert.Equal(t, "GET", proxy.calls[0].Method)
+	assert.Equal(t, "https://example.com/health", proxy.calls[0].URL)
+}
+
+// TestProbeHttp_ProxyHttp_Non2xxIsFailure covers the regression this PR
+// fixed: an upstream 401 or 500 must register as a probe failure, not a
+// silent success — without that, the probe-driven health signal would
+// never flip a connection unhealthy on a credential rejection.
+func TestProbeHttp_ProxyHttp_Non2xxIsFailure(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"401 unauthorized", http.StatusUnauthorized},
+		{"403 forbidden", http.StatusForbidden},
+		{"404 not found", http.StatusNotFound},
+		{"500 internal server error", http.StatusInternalServerError},
+		{"503 service unavailable", http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			probeCfg := &cschema.Probe{
+				Id: "ping",
+				ProxyHttp: &cschema.ProbeHttp{
+					Method: "GET",
+					URL:    "https://example.com/health",
+				},
+			}
+			conn, proxy := newProbeTestConnection(t, ctrl, cschema.Connector{Probes: []cschema.Probe{*probeCfg}})
+			proxy.resp = &iface.ProxyResponse{StatusCode: tc.status}
+
+			probe := NewProbe(probeCfg, conn.s, conn.cv, conn)
+			outcome, err := probe.Invoke(context.Background())
+
+			require.Errorf(t, err, "status %d must surface as a probe error", tc.status)
+			assert.Equal(t, ProbeOutcomeError, outcome)
+			// The status code should be embedded in the error so operators
+			// can read it from the recorded outcome row without digging
+			// into upstream logs.
+			assert.Contains(t, err.Error(), "status",
+				"recorded probe error should mention status; got %q", err.Error())
+		})
+	}
+}
+
+func TestProbeHttp_ProxyHttp_2xxRangeIsSuccess(t *testing.T) {
+	cases := []int{200, 201, 204, 299}
+	for _, status := range cases {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			probeCfg := &cschema.Probe{
+				Id: "ping",
+				ProxyHttp: &cschema.ProbeHttp{
+					Method: "GET",
+					URL:    "https://example.com/health",
+				},
+			}
+			conn, proxy := newProbeTestConnection(t, ctrl, cschema.Connector{Probes: []cschema.Probe{*probeCfg}})
+			proxy.resp = &iface.ProxyResponse{StatusCode: status}
+
+			probe := NewProbe(probeCfg, conn.s, conn.cv, conn)
+			outcome, err := probe.Invoke(context.Background())
+
+			require.NoErrorf(t, err, "status %d must be treated as success", status)
+			assert.Equal(t, ProbeOutcomeSuccess, outcome)
+		})
+	}
+}
+
+func TestProbeHttp_ProxyHttp_TransportErrorIsFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	probeCfg := &cschema.Probe{
+		Id: "ping",
+		ProxyHttp: &cschema.ProbeHttp{
+			Method: "GET",
+			URL:    "https://example.com/health",
+		},
+	}
+	conn, proxy := newProbeTestConnection(t, ctrl, cschema.Connector{Probes: []cschema.Probe{*probeCfg}})
+	proxy.err = errors.New("dial tcp: connection refused")
+
+	probe := NewProbe(probeCfg, conn.s, conn.cv, conn)
+	outcome, err := probe.Invoke(context.Background())
+
+	require.Error(t, err)
+	assert.Equal(t, ProbeOutcomeError, outcome)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+// TestProbeHttp_RawHttp_Success covers the non-proxied branch — the probe
+// hits the upstream directly via httpf without going through the proxy
+// orchestrator. gentleman-mock intercepts the request and replies 200.
+func TestProbeHttp_RawHttp_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	s, _, _, _, _, _ := FullMockService(t, ctrl)
+	s.httpf = h
+	cv := NewTestConnectorVersion(cschema.Connector{})
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	conn := &connection{
+		Connection: database.Connection{
+			Id:               apid.New(apid.PrefixConnection),
+			Namespace:        "root",
+			State:            database.ConnectionStateReady,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      cv.GetId(),
+			ConnectorVersion: cv.GetVersion(),
+		},
+		s:      s,
+		cv:     cv,
+		logger: logger,
+	}
+
+	genmock.New("https://raw.example.com").Get("/health").Reply(200)
+
+	probeCfg := &cschema.Probe{
+		Id: "ping-raw",
+		Http: &cschema.ProbeHttp{
+			Method: "GET",
+			URL:    "https://raw.example.com/health",
+		},
+	}
+
+	probe := NewProbe(probeCfg, s, cv, conn)
+	outcome, err := probe.Invoke(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProbeOutcomeSuccess, outcome)
+}
+
+func TestProbeHttp_RawHttp_Non2xxIsFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	s, _, _, _, _, _ := FullMockService(t, ctrl)
+	s.httpf = h
+	cv := NewTestConnectorVersion(cschema.Connector{})
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	conn := &connection{
+		Connection: database.Connection{
+			Id:               apid.New(apid.PrefixConnection),
+			Namespace:        "root",
+			State:            database.ConnectionStateReady,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      cv.GetId(),
+			ConnectorVersion: cv.GetVersion(),
+		},
+		s:      s,
+		cv:     cv,
+		logger: logger,
+	}
+
+	genmock.New("https://raw.example.com").Get("/health").Reply(500)
+
+	probeCfg := &cschema.Probe{
+		Id: "ping-raw",
+		Http: &cschema.ProbeHttp{
+			Method: "GET",
+			URL:    "https://raw.example.com/health",
+		},
+	}
+
+	probe := NewProbe(probeCfg, s, cv, conn)
+	outcome, err := probe.Invoke(context.Background())
+
+	require.Error(t, err, "raw HTTP probe must treat 500 as failure")
+	assert.Equal(t, ProbeOutcomeError, outcome)
+	assert.Contains(t, err.Error(), "status")
+}

--- a/internal/core/probe_no_op_test.go
+++ b/internal/core/probe_no_op_test.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProbeNoOp_Invoke covers the no-op probe variant: NewProbe falls back
+// to probeNoOp when the connector declares neither http nor proxy_http.
+// Every invocation should be reported as success with no error so the
+// connector's health signal stays healthy by default when no real probe is
+// configured.
+func TestProbeNoOp_Invoke(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s, _, _, _, _, _ := FullMockService(t, ctrl)
+	cv := NewTestConnectorVersion(cschema.Connector{})
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	conn := &connection{
+		Connection: database.Connection{
+			Id:               apid.New(apid.PrefixConnection),
+			Namespace:        "root",
+			State:            database.ConnectionStateReady,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      cv.GetId(),
+			ConnectorVersion: cv.GetVersion(),
+		},
+		s:      s,
+		cv:     cv,
+		logger: logger,
+	}
+
+	// No Http or ProxyHttp on the probe definition → NewProbe returns the
+	// no-op probe variant.
+	probeCfg := &cschema.Probe{Id: "noop"}
+	probe := NewProbe(probeCfg, s, cv, conn)
+
+	outcome, err := probe.Invoke(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, ProbeOutcomeSuccess, outcome)
+
+	// Invariant should hold across repeated invocations — the no-op probe
+	// has no state that could drift.
+	for i := 0; i < 3; i++ {
+		outcome, err := probe.Invoke(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, ProbeOutcomeSuccess, outcome)
+	}
+}

--- a/internal/core/task_probe.go
+++ b/internal/core/task_probe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -62,25 +63,39 @@ func (s *service) runProbeForConnection(ctx context.Context, t *asynq.Task) erro
 		With("probe_id", p.ProbeId).
 		Build()
 
+	probe, invokeErr := s.runProbeInternal(ctx, logger, p.ConnectionId, p.ProbeId)
+	if probe != nil && invokeErr != nil {
+		return skipTaskErrorIfProbeIsPeriodic(probe, invokeErr)
+	}
+	return invokeErr
+}
+
+// runProbeInternal is the shared body executed by both the periodic asynq task
+// handler and the inline RunProbe entry point. It loads the connection, looks
+// up the probe by id, invokes it, and records the outcome against the
+// connection's health-state counters. Returns the probe (when found) and any
+// error from looking it up or invoking it; health-recording errors are logged
+// but not returned because they don't invalidate the probe outcome itself.
+func (s *service) runProbeInternal(ctx context.Context, logger *slog.Logger, connectionId apid.ID, probeId string) (iface.Probe, error) {
 	logger.Debug("getting connection")
-	conn, err := s.getConnection(ctx, p.ConnectionId)
+	conn, err := s.getConnection(ctx, connectionId)
 	if err != nil {
 		if errors.Is(database.ErrNotFound, err) {
 			logger.Error("connection not found", "error", err)
-			return asynq.SkipRetry
+			return nil, asynq.SkipRetry
 		}
 
-		return err
+		return nil, err
 	}
 
-	probe, err := conn.GetProbe(p.ProbeId)
+	probe, err := conn.GetProbe(probeId)
 	if err != nil {
 		if errors.Is(ErrProbeNotFound, err) {
 			logger.Error("probe not found", "error", err)
-			return fmt.Errorf("%s probe not found: %w", taskTypeProbe, asynq.SkipRetry)
+			return nil, fmt.Errorf("%s probe not found: %w", taskTypeProbe, asynq.SkipRetry)
 		}
 
-		return skipTaskErrorIfProbeIsPeriodic(probe, err)
+		return probe, err
 	}
 
 	_, invokeErr := probe.Invoke(ctx)
@@ -93,9 +108,19 @@ func (s *service) runProbeForConnection(ctx context.Context, t *asynq.Task) erro
 		logger.Error("failed to record probe outcome for health state", "error", healthErr)
 	}
 
-	if invokeErr != nil {
-		return skipTaskErrorIfProbeIsPeriodic(probe, invokeErr)
-	}
+	return probe, invokeErr
+}
 
-	return nil
+// RunProbe invokes a single probe synchronously and records the outcome
+// against health-state counters — see iface.C.RunProbe for the public
+// contract. The task handler shares the same underlying logic.
+func (s *service) RunProbe(ctx context.Context, connectionId apid.ID, probeId string) error {
+	logger := aplog.NewBuilder(s.logger).
+		WithCtx(ctx).
+		WithConnectionId(connectionId).
+		With("probe_id", probeId).
+		Build()
+
+	_, invokeErr := s.runProbeInternal(ctx, logger, connectionId, probeId)
+	return invokeErr
 }

--- a/internal/core/task_probe.go
+++ b/internal/core/task_probe.go
@@ -80,7 +80,11 @@ func (s *service) runProbeInternal(ctx context.Context, logger *slog.Logger, con
 	logger.Debug("getting connection")
 	conn, err := s.getConnection(ctx, connectionId)
 	if err != nil {
-		if errors.Is(database.ErrNotFound, err) {
+		// Arg order matters: errors.Is(err, target). s.getConnection
+		// wraps database.ErrNotFound inside iface.ErrConnectionNotFound,
+		// so the unwrap-aware order is required to detect the
+		// not-found case.
+		if errors.Is(err, database.ErrNotFound) {
 			logger.Error("connection not found", "error", err)
 			return nil, asynq.SkipRetry
 		}
@@ -90,7 +94,7 @@ func (s *service) runProbeInternal(ctx context.Context, logger *slog.Logger, con
 
 	probe, err := conn.GetProbe(probeId)
 	if err != nil {
-		if errors.Is(ErrProbeNotFound, err) {
+		if errors.Is(err, ErrProbeNotFound) {
 			logger.Error("probe not found", "error", err)
 			return nil, fmt.Errorf("%s probe not found: %w", taskTypeProbe, asynq.SkipRetry)
 		}

--- a/internal/core/task_probe_test.go
+++ b/internal/core/task_probe_test.go
@@ -1,0 +1,225 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+)
+
+// TestRunProbe_Success exercises the periodic-probe path inline: probe.Invoke
+// returns ok, recordPeriodicProbeOutcome appends a success row, and (since
+// the connection is already healthy) no health-state transition fires.
+func TestRunProbe_Success(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connectorId := apid.New(apid.PrefixConnectorVersion)
+	connector := &cschema.Connector{
+		Id:          connectorId,
+		Version:     1,
+		DisplayName: "probe-success-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "ping",
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/health",
+			},
+		}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	svc.httpf = mockH.NewFactoryWithMockingClient(ctrl)
+	genmock.New("https://upstream.example.invalid").Get("/health").Reply(200)
+
+	// Periodic probe path: success → append outcome row. Connection
+	// already healthy → no transition → no SetConnectionHealthState call.
+	db.EXPECT().
+		InsertProbeOutcome(gomock.Any(), connectionId, "ping", database.ProbeOutcomeStatusSuccess, "").
+		Return(&database.ConnectionProbeOutcome{}, nil)
+	// maybeUpdateApiKeyLastValidated on success against an api-key
+	// connection: look up the active credential, stamp last_validated_at.
+	// No active credential in this test setup; GetActiveApiKeyCredential
+	// returns ErrNotFound and the call is a no-op.
+	db.EXPECT().
+		GetActiveApiKeyCredential(gomock.Any(), connectionId).
+		Return(nil, database.ErrNotFound)
+
+	require.NoError(t, svc.RunProbe(context.Background(), connectionId, "ping"))
+}
+
+// TestRunProbe_FailureBelowThreshold: a single failure when the probe's
+// failure threshold is 3 records the outcome but does NOT flip health.
+// The runtime returns the probe's invoke error so callers can log it.
+func TestRunProbe_FailureBelowThreshold(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	threshold := 3
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-failure-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "ping",
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/health",
+			},
+			FailureThreshold: &threshold,
+		}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	svc.httpf = mockH.NewFactoryWithMockingClient(ctrl)
+	genmock.New("https://upstream.example.invalid").Get("/health").Reply(401)
+
+	db.EXPECT().
+		InsertProbeOutcome(gomock.Any(), connectionId, "ping", database.ProbeOutcomeStatusFailure, gomock.Any()).
+		Return(&database.ConnectionProbeOutcome{}, nil)
+	// Streak lookup returns one failure (just-inserted), threshold is 3
+	// — sub-threshold, no transition.
+	db.EXPECT().
+		GetRecentProbeOutcomes(gomock.Any(), connectionId, "ping", threshold).
+		Return([]*database.ConnectionProbeOutcome{
+			{Outcome: database.ProbeOutcomeStatusFailure},
+		}, nil)
+	// NO SetConnectionHealthState call — streak below threshold.
+
+	err := svc.RunProbe(context.Background(), connectionId, "ping")
+	require.Error(t, err, "RunProbe must surface the probe's invoke error")
+	assert.Contains(t, err.Error(), "status",
+		"recorded error should mention the upstream status code")
+}
+
+// TestRunProbe_FailureCrossesThreshold: with threshold=1 and one failure,
+// the runtime flips the connection to unhealthy via MarkHealthState (which
+// calls SetConnectionHealthState).
+func TestRunProbe_FailureCrossesThreshold(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	threshold := 1
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-threshold-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "ping",
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/health",
+			},
+			FailureThreshold: &threshold,
+		}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	svc.httpf = mockH.NewFactoryWithMockingClient(ctrl)
+	genmock.New("https://upstream.example.invalid").Get("/health").Reply(401)
+
+	db.EXPECT().
+		InsertProbeOutcome(gomock.Any(), connectionId, "ping", database.ProbeOutcomeStatusFailure, gomock.Any()).
+		Return(&database.ConnectionProbeOutcome{}, nil)
+	db.EXPECT().
+		GetRecentProbeOutcomes(gomock.Any(), connectionId, "ping", threshold).
+		Return([]*database.ConnectionProbeOutcome{
+			{Outcome: database.ProbeOutcomeStatusFailure},
+		}, nil)
+	db.EXPECT().
+		SetConnectionHealthState(gomock.Any(), connectionId, database.ConnectionHealthStateUnhealthy).
+		Return(nil)
+
+	err := svc.RunProbe(context.Background(), connectionId, "ping")
+	require.Error(t, err)
+}
+
+// TestRunProbe_ProbeNotFound covers the lookup-failure branch — probe id
+// missing from the connector definition is treated as a non-retryable
+// condition (the probe will never appear on retry).
+func TestRunProbe_ProbeNotFound(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "missing-probe-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		// No probes — the lookup for "ping" must fail.
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	err := svc.RunProbe(context.Background(), connectionId, "ping")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry,
+		"missing probe id should be SkipRetry — retrying won't bring it back")
+}
+
+// TestRunProbe_ConnectionNotFound returns SkipRetry so the asynq retry loop
+// doesn't pile up against a non-existent row.
+func TestRunProbe_ConnectionNotFound(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	svc := &service{db: db, encrypt: encrypt, logger: logger}
+
+	db.EXPECT().
+		GetConnection(gomock.Any(), connectionId).
+		Return(nil, database.ErrNotFound)
+
+	err := svc.RunProbe(context.Background(), connectionId, "ping")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -48,11 +48,36 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 		return fmt.Errorf("%s connection id not specified: %w", taskTypeVerifyConnection, asynq.SkipRetry)
 	}
 
-	logger = aplog.NewBuilder(logger).
-		WithConnectionId(p.ConnectionId).
+	if err := s.runVerifyConnection(ctx, p.ConnectionId); err != nil {
+		// Failures from onVerifyFailed propagate as retryable so asynq retries
+		// the bookkeeping write; non-recoverable shapes (not-found, no-op) are
+		// returned wrapped in SkipRetry by runVerifyConnection itself.
+		return err
+	}
+	return nil
+}
+
+// RunVerifyConnection is the synchronous counterpart to the verify_connection
+// asynq task — see iface.C.RunVerifyConnection. Used by integration tests
+// that need to drive the verify phase without running a worker and by code
+// paths that prefer inline execution.
+func (s *service) RunVerifyConnection(ctx context.Context, connectionId apid.ID) error {
+	return s.runVerifyConnection(ctx, connectionId)
+}
+
+// runVerifyConnection is the shared body of the verify_connection task and
+// the inline RunVerifyConnection entry. It loads the connection, runs every
+// probe in order, and advances the setup step based on the outcome. Returns
+// asynq.SkipRetry for non-recoverable shapes (not-found, wrong phase) so the
+// task handler can return without retrying; wraps onVerifyFailed errors
+// unchanged so they remain retryable.
+func (s *service) runVerifyConnection(ctx context.Context, connectionId apid.ID) error {
+	logger := aplog.NewBuilder(s.logger).
+		WithCtx(ctx).
+		WithConnectionId(connectionId).
 		Build()
 
-	conn, err := s.getConnection(ctx, p.ConnectionId)
+	conn, err := s.getConnection(ctx, connectionId)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			logger.Error("connection not found", "error", err)
@@ -76,7 +101,6 @@ func (s *service) verifyConnection(ctx context.Context, t *asynq.Task) error {
 		}
 		logger.Error("probe failed during verify", "probe_id", probe.GetId(), "outcome", outcome, "error", invokeErr)
 		if failErr := conn.onVerifyFailed(ctx, probe.GetId(), invokeErr); failErr != nil {
-			// Return the failErr so asynq retries — probe outcome is preserved for a later attempt.
 			return fmt.Errorf("failed to record verify failure: %w", failErr)
 		}
 		return asynq.SkipRetry

--- a/internal/core/task_verify_connection_test.go
+++ b/internal/core/task_verify_connection_test.go
@@ -1,0 +1,216 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+)
+
+// setupVerifyTest wires a minimal service whose db.GetConnection returns the
+// supplied connection and whose db.GetConnectorVersion + encrypt.DecryptString
+// resolve to the supplied connector. Lets each subtest customize the
+// connection's setup_step / health_state without sharing fixture state.
+func setupVerifyTest(
+	t *testing.T,
+	connectionId apid.ID,
+	conn *database.Connection,
+	connector *cschema.Connector,
+) (*service, *mockDb.MockDB, *mockEncrypt.MockE, *gomock.Controller) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	svc := &service{
+		cfg:     nil,
+		db:      db,
+		encrypt: encrypt,
+		logger:  logger,
+	}
+
+	db.EXPECT().
+		GetConnection(gomock.Any(), connectionId).
+		Return(conn, nil).
+		AnyTimes()
+
+	encryptedDef := encfield.EncryptedField{ID: "ekv_mock", Data: "encrypted-def"}
+	db.EXPECT().
+		GetConnectorVersion(gomock.Any(), connector.Id, connector.Version).
+		Return(&database.ConnectorVersion{
+			Id:                  connector.Id,
+			Version:             connector.Version,
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                "hash",
+			EncryptedDefinition: encryptedDef,
+		}, nil).
+		AnyTimes()
+
+	connJSON, err := json.Marshal(connector)
+	require.NoError(t, err)
+	encrypt.EXPECT().
+		DecryptString(gomock.Any(), encryptedDef).
+		Return(string(connJSON), nil).
+		AnyTimes()
+
+	return svc, db, encrypt, ctrl
+}
+
+// TestRunVerifyConnection_NoProbes_AdvancesToReady covers the happy path:
+// connector with no probes → verify is a structural no-op (loop runs zero
+// times) → onVerifyPassed clears setup_step and advances state to Ready.
+func TestRunVerifyConnection_NoProbes_AdvancesToReady(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "verify-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		// No probes → runVerifyConnection's loop does nothing.
+	}
+	verifyStep := cschema.SetupStepVerify
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateCreated,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+		SetupStep:        &verifyStep,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	// onVerifyPassed: no configure step → next is zero → clear setup_step
+	// + advance to Ready.
+	db.EXPECT().
+		SetConnectionSetupStep(gomock.Any(), connectionId, (*cschema.SetupStep)(nil)).
+		Return(nil)
+	db.EXPECT().
+		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateReady).
+		Return(nil)
+
+	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
+}
+
+// TestRunVerifyConnection_StalePhase_SkipsCleanly covers the guard that
+// short-circuits the runtime when the connection has moved past the verify
+// phase (e.g. a stale asynq task fires after a manual reset). The handler
+// must return nil and must not write to the DB.
+func TestRunVerifyConnection_StalePhase_SkipsCleanly(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "stale-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+		SetupStep:        nil, // already past verify
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	// No SetConnectionSetupStep / SetConnectionState expectations — the
+	// guard returns before either is reached. gomock controller fails at
+	// Finish if either is called.
+	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
+}
+
+// TestRunVerifyConnection_ConnectionNotFound returns SkipRetry so the asynq
+// retry loop doesn't pile up against a non-existent row.
+func TestRunVerifyConnection_ConnectionNotFound(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	logger, _ := mockLog.NewTestLogger(t)
+
+	svc := &service{db: db, encrypt: encrypt, logger: logger}
+
+	db.EXPECT().
+		GetConnection(gomock.Any(), connectionId).
+		Return(nil, database.ErrNotFound)
+
+	err := svc.RunVerifyConnection(context.Background(), connectionId)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+// TestRunVerifyConnection_ProbeFailure routes through onVerifyFailed: the
+// probe returns a non-2xx → recorded failure → setup_error populated →
+// setup_step advanced to the verify_failed terminal pseudo-step → asynq
+// SkipRetry surfaces so the retry loop doesn't fight recorded state.
+func TestRunVerifyConnection_ProbeFailure(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "fail-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "always-fails",
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/health",
+			},
+		}},
+	}
+	verifyStep := cschema.SetupStepVerify
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateCreated,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+		SetupStep:        &verifyStep,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	// gentleman-mock returns 500 for any unmatched request, which is then
+	// classified by probe_http as a failure (non-2xx). Wire the httpf
+	// factory so the probe actually dispatches through gentleman + gock.
+	svc.httpf = mockH.NewFactoryWithMockingClient(ctrl)
+	genmock.New("https://upstream.example.invalid").Get("/health").Reply(500)
+
+	// onVerifyFailed → setup_error stored, setup_step=verify_failed.
+	failedStep := cschema.SetupStepVerifyFailed
+	db.EXPECT().
+		SetConnectionSetupError(gomock.Any(), connectionId, gomock.AssignableToTypeOf((*string)(nil))).
+		Return(nil)
+	db.EXPECT().
+		SetConnectionSetupStep(gomock.Any(), connectionId, &failedStep).
+		Return(nil)
+
+	err := svc.RunVerifyConnection(context.Background(), connectionId)
+	require.Error(t, err, "verify must surface an error when a probe fails")
+	assert.ErrorIs(t, err, asynq.SkipRetry,
+		"verify failure must be SkipRetry — recorded state, no point retrying")
+}


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for the api-key auth method (per-placement initiate→ready, manual rotation, auto-reauth via probe-driven health) and a cross-cutting OAuth2 probe-driven health test that proves the probe runtime generalizes across auth types.

Closes #258 — the validation pass for the #243 api-key project.

## Probe runtime fix

`internal/core/probe_http.go` silently treated non-2xx upstream responses as successful probes. Without this fix, an upstream that 401s the proxied request would never flip the connection unhealthy — which broke the probe-driven health story end-to-end. Both probe branches (proxy and raw) now treat status codes outside `[200,300)` as a failure, surfacing the status code in the recorded error.

## iface.C surface additions

Two synchronous entry points used by the integration tests, and reusable for future operational paths (e.g. #257's probe-now optimization):

- `RunProbe(ctx, connectionId, probeId)` — inline counterpart to the periodic asynq probe task. Invokes a probe and records the outcome against health-state counters.
- `RunVerifyConnection(ctx, connectionId)` — inline counterpart to the verify_connection asynq task. Runs every probe and advances `setup_step` on the outcome.

Both share the existing task-handler body via small refactors; behavior under asynq is unchanged.

## Test coverage

**``integration_tests/api_key/``**
- `harness_smoke_test.go` — `ApiKeyStubUpstream` sanity for bearer.
- `initiate_flow_test.go` — `initiate → form → submit → verify → ready` for bearer / header / query / basic, asserting on the placement-specific upstream request shape.
- `rotation_test.go` — manual rotation via `/_reauth`, active credential row id changes, **no-replay** invariant: old key bytes never appear in any upstream request that arrives after rotation begins.
- `auto_reauth_test.go` — provider-side rotation invalidates the stored key → probe fails → health flips unhealthy → user submits new key → probe succeeds → health flips back to healthy. `failure_threshold=1` and `recovery_threshold=1` for test determinism.

**``integration_tests/probes/``**
- `oauth2_probe_health_test.go` — same failure / recovery transitions against an OAuth2 connection, using the test provider's resource endpoint as the probe target and scripted 401s to force the failure window. Proves the probe-driven health logic is auth-method-agnostic.

## Test plan

- [x] `go test -tags integration ./api_key/...`
- [x] `go test -tags integration ./probes/...`
- [x] Existing OAuth2 non-chromedp tests still pass
- [x] `./scripts/preflight.sh` clean

Note: two pre-existing chromedp tests (`TestStandardAuthorizationCodeFlow`, `TestUserDenialFlow`) fail in this environment with `unknown IPAddressSpace value: Loopback` chromedp/Chrome version mismatch. Verified to fail on bare main as well — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)