### PR TITLE
Consolidate OAuth retry loops into internal/util/retry (#357)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2
 	github.com/bsm/redislock v0.9.4
 	github.com/cbroglie/mustache v1.4.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
@@ -49,6 +50,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
+	go.opentelemetry.io/contrib/bridges/otelslog v0.16.0
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
@@ -104,7 +106,6 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
@@ -179,7 +180,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/bridges/otelslog v0.16.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/retry"
 	gentleman "gopkg.in/h2non/gentleman.v2"
 )
 
@@ -249,19 +250,25 @@ func (o *oAuth2Connection) postTokenExchangeWithRetry(
 	values url.Values,
 	authHeader string,
 ) (*gentleman.Response, int, error) {
-	var lastResp *gentleman.Response
-	var lastErr error
-
-	for attempt := 1; attempt <= tokenExchangeMaxAttempts; attempt++ {
-		if attempt > 1 {
-			backoff := tokenExchangeBackoffStep * time.Duration(attempt-1)
-			select {
-			case <-ctx.Done():
-				return nil, attempt - 1, ctx.Err()
-			case <-time.After(backoff):
+	res, err := retry.Do(ctx, retry.Options[*gentleman.Response]{
+		MaxAttempts: tokenExchangeMaxAttempts,
+		Backoff:     &retry.LinearBackOff{Step: tokenExchangeBackoffStep},
+		Classify: func(resp *gentleman.Response, err error) bool {
+			return err != nil || (resp != nil && resp.StatusCode >= 500)
+		},
+		OnRetry: func(attempt int, resp *gentleman.Response, err error) {
+			args := []any{
+				slog.Int("attempt", attempt),
+				slog.Int("max_attempts", tokenExchangeMaxAttempts),
 			}
-		}
-
+			if err != nil {
+				args = append(args, slog.String("error", err.Error()))
+			} else {
+				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
+			}
+			o.logger.WarnContext(ctx, "oauth token exchange transient failure; retrying", args...)
+		},
+	}, func(ctx context.Context) (*gentleman.Response, error) {
 		req := client.Request().
 			Method("POST").
 			URL(tokenEndpoint).
@@ -276,29 +283,16 @@ func (o *oAuth2Connection) postTokenExchangeWithRetry(
 			req = req.SetQuery(k, v)
 		}
 
-		resp, err := req.BodyString(values.Encode()).Send()
+		return req.BodyString(values.Encode()).Send()
+	})
 
-		if err == nil && resp.StatusCode < 500 {
-			return resp, attempt, nil
-		}
-
-		lastResp, lastErr = resp, err
-
-		if attempt < tokenExchangeMaxAttempts {
-			args := []any{
-				slog.Int("attempt", attempt),
-				slog.Int("max_attempts", tokenExchangeMaxAttempts),
-			}
-			if err != nil {
-				args = append(args, slog.String("error", err.Error()))
-			} else {
-				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
-			}
-			o.logger.WarnContext(ctx, "oauth token exchange transient failure; retrying", args...)
-		}
+	// See postRefreshWithRetry for the rationale on dropping the response
+	// when err is non-nil — callers and tests treat any error as "no
+	// response to inspect".
+	if err != nil {
+		return nil, res.Attempts, err
 	}
-
-	return lastResp, tokenExchangeMaxAttempts, lastErr
+	return res.Value, res.Attempts, nil
 }
 
 // appendSetupPendingToReturnUrl augments the return URL with query params that signal the UI

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/util/retry"
 	gentleman "gopkg.in/h2non/gentleman.v2"
 )
 
@@ -259,19 +260,25 @@ func (o *oAuth2Connection) postRefreshWithRetry(
 	values url.Values,
 	authHeader string,
 ) (*gentleman.Response, int, error) {
-	var lastResp *gentleman.Response
-	var lastErr error
-
-	for attempt := 1; attempt <= tokenRefreshMaxAttempts; attempt++ {
-		if attempt > 1 {
-			backoff := tokenRefreshBackoffStep * time.Duration(attempt-1)
-			select {
-			case <-ctx.Done():
-				return nil, attempt - 1, ctx.Err()
-			case <-time.After(backoff):
+	res, err := retry.Do(ctx, retry.Options[*gentleman.Response]{
+		MaxAttempts: tokenRefreshMaxAttempts,
+		Backoff:     &retry.LinearBackOff{Step: tokenRefreshBackoffStep},
+		Classify: func(resp *gentleman.Response, err error) bool {
+			return err != nil || (resp != nil && resp.StatusCode >= 500)
+		},
+		OnRetry: func(attempt int, resp *gentleman.Response, err error) {
+			args := []any{
+				slog.Int("attempt", attempt),
+				slog.Int("max_attempts", tokenRefreshMaxAttempts),
 			}
-		}
-
+			if err != nil {
+				args = append(args, slog.String("error", err.Error()))
+			} else {
+				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
+			}
+			o.logger.WarnContext(ctx, "oauth token refresh transient failure; retrying", args...)
+		},
+	}, func(ctx context.Context) (*gentleman.Response, error) {
 		req := client.
 			UseContext(ctx).
 			Request().
@@ -285,27 +292,14 @@ func (o *oAuth2Connection) postRefreshWithRetry(
 			req = req.AddHeader("Authorization", authHeader)
 		}
 
-		resp, err := req.Send()
+		return req.Send()
+	})
 
-		if err == nil && resp.StatusCode < 500 {
-			return resp, attempt, nil
-		}
-
-		lastResp, lastErr = resp, err
-
-		if attempt < tokenRefreshMaxAttempts {
-			args := []any{
-				slog.Int("attempt", attempt),
-				slog.Int("max_attempts", tokenRefreshMaxAttempts),
-			}
-			if err != nil {
-				args = append(args, slog.String("error", err.Error()))
-			} else {
-				args = append(args, slog.Int("provider_status_code", resp.StatusCode))
-			}
-			o.logger.WarnContext(ctx, "oauth token refresh transient failure; retrying", args...)
-		}
+	// Mirror the original contract: a returned error always implies a nil
+	// response. Callers (and the unit tests) key on err first; a 5xx
+	// response left dangling on a ctx-cancelled return is just noise.
+	if err != nil {
+		return nil, res.Attempts, err
 	}
-
-	return lastResp, tokenRefreshMaxAttempts, lastErr
+	return res.Value, res.Attempts, nil
 }

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -1,0 +1,152 @@
+// Package retry provides a small generic helper for retrying operations
+// with a caller-supplied backoff strategy and retry classifier.
+//
+// The package wraps a backoff strategy from cenkalti/backoff/v5 with three
+// things the bare library does not give us:
+//
+//   - Per-callsite retry classification keyed on the operation's *value*
+//     (not just its error), so an OAuth callsite can retry "5xx or err"
+//     while a 429-aware callsite can retry only "status == 429".
+//   - A returned attempt count so failure events can distinguish
+//     "exhausted budget" from "single non-retryable failure" — load-bearing
+//     for the structured failure events emitted across the codebase.
+//   - Sleeps routed through apctx.GetClock(ctx) so tests using a fake clock
+//     don't have to wait on wall-clock time.
+package retry
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/rmorlok/authproxy/internal/apctx"
+)
+
+// Result is what a successful or exhausted retry returns. Attempts is the
+// number of operation invocations actually made: 1 on first-try success,
+// MaxAttempts on exhaustion, and the count of completed calls on ctx
+// cancellation during backoff.
+type Result[T any] struct {
+	Value    T
+	Attempts int
+}
+
+// Classifier decides whether a given (value, err) outcome should be retried.
+// Return true to retry, false to terminate the loop and return the outcome
+// to the caller. The classifier is called after every operation invocation,
+// including the last one in the budget — implementations should not assume
+// they are only called when retries remain.
+type Classifier[T any] func(value T, err error) bool
+
+// Options configures a single Do call.
+type Options[T any] struct {
+	// MaxAttempts is the total number of operation invocations allowed,
+	// including the first. Must be >= 1.
+	MaxAttempts int
+
+	// Backoff is the strategy used to compute the wait between attempts.
+	// NextBackOff is called once per gap, so for MaxAttempts=N it is
+	// called at most N-1 times. If nil, ConstantBackOff(0) is used.
+	Backoff backoff.BackOff
+
+	// Classify decides retryability per attempt. If nil, retries on any
+	// non-nil error (the most common case).
+	Classify Classifier[T]
+
+	// OnRetry, if non-nil, fires after each *retryable* failure that is
+	// not the last attempt in the budget — i.e. exactly when a retry is
+	// about to be scheduled. Use it to emit per-attempt structured logs
+	// without coupling those log strings into this package.
+	OnRetry func(attempt int, value T, err error)
+}
+
+// Do runs op until it produces a non-retryable outcome, the attempt budget
+// is exhausted, or ctx is cancelled. The Classifier decides retryability;
+// the Backoff controls inter-attempt waits.
+//
+// Returned err is:
+//   - nil on success.
+//   - ctx.Err() if ctx is cancelled before or during a backoff sleep.
+//   - The last op error otherwise (including when the last attempt
+//     returned a retryable outcome and the budget is gone).
+//
+// Result.Value carries the last op return value regardless of err, so
+// callers can inspect e.g. a final 5xx response on exhaustion.
+func Do[T any](
+	ctx context.Context,
+	opts Options[T],
+	op func(ctx context.Context) (T, error),
+) (Result[T], error) {
+	if opts.MaxAttempts < 1 {
+		opts.MaxAttempts = 1
+	}
+	if opts.Backoff == nil {
+		opts.Backoff = &backoff.ConstantBackOff{Interval: 0}
+	}
+	classify := opts.Classify
+	if classify == nil {
+		classify = func(_ T, err error) bool { return err != nil }
+	}
+
+	opts.Backoff.Reset()
+	clk := apctx.GetClock(ctx)
+
+	var (
+		lastVal T
+		lastErr error
+		attempt int
+	)
+
+	for attempt = 1; attempt <= opts.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return Result[T]{Value: lastVal, Attempts: attempt - 1}, err
+		}
+
+		val, err := op(ctx)
+		lastVal, lastErr = val, err
+
+		if !classify(val, err) {
+			return Result[T]{Value: val, Attempts: attempt}, err
+		}
+
+		if attempt == opts.MaxAttempts {
+			break
+		}
+
+		if opts.OnRetry != nil {
+			opts.OnRetry(attempt, val, err)
+		}
+
+		wait := opts.Backoff.NextBackOff()
+		if wait == backoff.Stop {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return Result[T]{Value: val, Attempts: attempt}, ctx.Err()
+		case <-clk.After(wait):
+		}
+	}
+
+	return Result[T]{Value: lastVal, Attempts: attempt}, lastErr
+}
+
+// LinearBackOff returns Step, 2*Step, 3*Step, … from successive
+// NextBackOff() calls. cenkalti/backoff/v5 only ships Constant and
+// Exponential strategies, so we define our own — the OAuth callsites and
+// the disconnect revoke loop all use linear backoff in production.
+type LinearBackOff struct {
+	Step time.Duration
+
+	n int
+}
+
+func (b *LinearBackOff) NextBackOff() time.Duration {
+	b.n++
+	return b.Step * time.Duration(b.n)
+}
+
+func (b *LinearBackOff) Reset() {
+	b.n = 0
+}

--- a/internal/util/retry/retry_test.go
+++ b/internal/util/retry/retry_test.go
@@ -1,0 +1,304 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tclock "k8s.io/utils/clock/testing"
+)
+
+func TestDo_SuccessFirstTry(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 0},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", res.Value)
+	assert.Equal(t, 1, res.Attempts)
+	assert.Equal(t, 1, calls)
+}
+
+func TestDo_RetriesUntilSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	res, err := Do(ctx, Options[int]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+	}, func(ctx context.Context) (int, error) {
+		calls++
+		if calls < 3 {
+			return 0, errors.New("transient")
+		}
+		return 42, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, res.Value)
+	assert.Equal(t, 3, res.Attempts)
+}
+
+func TestDo_ExhaustsBudgetReturnsLastError(t *testing.T) {
+	ctx := context.Background()
+
+	wantErr := errors.New("always fails")
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "last", wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, "last", res.Value, "Result.Value carries last attempt's value on exhaustion")
+	assert.Equal(t, 3, res.Attempts)
+	assert.Equal(t, 3, calls)
+}
+
+func TestDo_ClassifierFalseStopsImmediately(t *testing.T) {
+	ctx := context.Background()
+
+	wantErr := errors.New("permanent")
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 5,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+		Classify: func(_ string, err error) bool {
+			return false
+		},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "v", wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls, "non-retryable error must not be retried")
+	assert.Equal(t, 1, res.Attempts)
+}
+
+func TestDo_ClassifierInspectsValue(t *testing.T) {
+	// Mimics the OAuth callsites: retry on err OR resp.StatusCode >= 500.
+	ctx := context.Background()
+
+	type fakeResp struct{ status int }
+
+	calls := 0
+	res, err := Do(ctx, Options[*fakeResp]{
+		MaxAttempts: 4,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+		Classify: func(v *fakeResp, err error) bool {
+			return err != nil || (v != nil && v.status >= 500)
+		},
+	}, func(ctx context.Context) (*fakeResp, error) {
+		calls++
+		if calls < 3 {
+			return &fakeResp{status: 503}, nil
+		}
+		return &fakeResp{status: 200}, nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Value)
+	assert.Equal(t, 200, res.Value.status)
+	assert.Equal(t, 3, res.Attempts)
+}
+
+func TestDo_OnRetryCalledOnceLessThanAttemptsOnExhaustion(t *testing.T) {
+	ctx := context.Background()
+
+	var hookCalls int32
+	_, _ = Do(ctx, Options[string]{
+		MaxAttempts: 4,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+		OnRetry: func(attempt int, _ string, err error) {
+			atomic.AddInt32(&hookCalls, 1)
+		},
+	}, func(ctx context.Context) (string, error) {
+		return "", errors.New("transient")
+	})
+
+	assert.Equal(t, int32(3), atomic.LoadInt32(&hookCalls),
+		"OnRetry fires before each retry — MaxAttempts-1 times on exhaustion")
+}
+
+func TestDo_OnRetryReceivesAttemptNumber(t *testing.T) {
+	ctx := context.Background()
+
+	var seen []int
+	_, _ = Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+		OnRetry: func(attempt int, _ string, _ error) {
+			seen = append(seen, attempt)
+		},
+	}, func(ctx context.Context) (string, error) {
+		return "", errors.New("transient")
+	})
+
+	assert.Equal(t, []int{1, 2}, seen, "OnRetry receives the attempt number that just failed")
+}
+
+func TestDo_CtxCancelBeforeFirstCallReturnsCtxErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 0},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "", nil
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, calls)
+	assert.Equal(t, 0, res.Attempts)
+}
+
+func TestDo_CtxCancelDuringBackoffReturnsCtxErrWithCompletedAttempts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 5,
+		Backoff:     &backoff.ConstantBackOff{Interval: 50 * time.Millisecond},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		if calls == 2 {
+			go cancel()
+		}
+		return "v", errors.New("transient")
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 2, calls, "ctx cancel during the 2nd backoff should abort before the 3rd call")
+	assert.Equal(t, 2, res.Attempts, "Attempts reflects completed op invocations only")
+}
+
+func TestDo_UsesInjectedClock(t *testing.T) {
+	// Verifies the helper sleeps through apctx.GetClock(ctx) rather than
+	// time.After directly — this is the testability hook that lets
+	// downstream sites (notably the disconnect revoke loop) drop in.
+	fakeClk := tclock.NewFakeClock(time.Now())
+	ctx := apctx.WithClock(context.Background(), fakeClk)
+
+	const backoff_ = 10 * time.Second // huge — would hang on a real clock
+	calls := make(chan int, 5)
+
+	done := make(chan struct {
+		res Result[string]
+		err error
+	}, 1)
+	go func() {
+		res, err := Do(ctx, Options[string]{
+			MaxAttempts: 3,
+			Backoff:     &backoff.ConstantBackOff{Interval: backoff_},
+		}, func(ctx context.Context) (string, error) {
+			calls <- 1
+			return "", errors.New("transient")
+		})
+		done <- struct {
+			res Result[string]
+			err error
+		}{res, err}
+	}()
+
+	// First call.
+	<-calls
+	// Helper is now waiting on clk.After(backoff_).
+	require.Eventually(t, fakeClk.HasWaiters, time.Second, time.Millisecond)
+	fakeClk.Step(backoff_)
+
+	// Second call.
+	<-calls
+	require.Eventually(t, fakeClk.HasWaiters, time.Second, time.Millisecond)
+	fakeClk.Step(backoff_)
+
+	// Third (final) call.
+	<-calls
+
+	r := <-done
+	require.Error(t, r.err)
+	assert.Equal(t, 3, r.res.Attempts)
+}
+
+func TestDo_BackoffStopTerminates(t *testing.T) {
+	// If the backoff strategy returns Stop, the loop ends with the last
+	// error — even if the budget isn't exhausted.
+	ctx := context.Background()
+
+	wantErr := errors.New("transient")
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 10,
+		Backoff:     &backoff.StopBackOff{},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "", wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls, "Stop from backoff terminates after the failing attempt")
+	assert.Equal(t, 1, res.Attempts, "Attempts reflects completed op invocations, not the unused budget")
+}
+
+func TestDo_DefaultClassifierRetriesOnError(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	_, err := Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "", errors.New("nope")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestDo_MaxAttemptsBelowOneCoercedToOne(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	res, err := Do(ctx, Options[string]{
+		MaxAttempts: 0,
+		Backoff:     &backoff.ConstantBackOff{Interval: 0},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 1, res.Attempts)
+}
+
+func TestLinearBackOff(t *testing.T) {
+	b := &LinearBackOff{Step: 100 * time.Millisecond}
+
+	assert.Equal(t, 100*time.Millisecond, b.NextBackOff())
+	assert.Equal(t, 200*time.Millisecond, b.NextBackOff())
+	assert.Equal(t, 300*time.Millisecond, b.NextBackOff())
+
+	b.Reset()
+	assert.Equal(t, 100*time.Millisecond, b.NextBackOff(), "Reset restarts the sequence")
+}


### PR DESCRIPTION
Closes #357. Phase 1 of #277.

## Summary
- New `internal/util/retry` package — generic `Do[T]` over a `cenkalti/backoff/v5` strategy, with a value-keyed `Classifier`, `OnRetry` hook, and `Attempts` returned to the caller.
- Adds `LinearBackOff` since `backoff/v5` ships only `Constant`/`Exponential` and every callsite under migration uses linear backoff.
- Sleeps go through `apctx.GetClock(ctx)` so callers (notably the disconnect revoke loop in Phase 3) retain their injected-clock testability.
- Migrates `postRefreshWithRetry` (`internal/auth_methods/oauth2/proxy.go`) and `postTokenExchangeWithRetry` (`internal/auth_methods/oauth2/callback.go`) onto the helper. The existing structured-log lines (`oauth token refresh transient failure; retrying` / `oauth token exchange transient failure; retrying`) are preserved via `OnRetry`, with the same field shape.
- Promotes `cenkalti/backoff/v5` from indirect to direct in `go.mod`.

Phases 2 (vault retry transport, #358) and 3 (disconnect revoke loop, #359) follow in their own PRs.

## Why a wrapper, not raw `backoff.Retry`
`backoff.Retry` doesn't return an attempt count and uses a `PermanentError` pattern for non-retryability — both are awkward for callsites that need to inspect a value (e.g. retry on `resp.StatusCode >= 500`) and emit `attempts` on the failure event. The wrapper is ~50 lines and reuses the backoff math.

## Test plan
- [x] `go test ./internal/util/retry/...` — 14 cases, 96.8% coverage. Covers max-attempts, classifier, OnRetry call count, `Result.Attempts` on success/exhaustion/cancel, ctx cancel during backoff, injected-clock contract.
- [x] `go test ./internal/auth_methods/oauth2/...` — all existing token-exchange and refresh retry unit tests pass unchanged.
- [x] `go test -tags=integration ./integration_tests/oauth2/...` — `TestTokenExchange_*` and `TestProxyRefresh_*` pass; `events[].attempts` contract intact.
- [x] `./scripts/preflight.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)