### PR TITLE
[api-key] Proxy-triggered probe acceleration on 401/403 (#257)

### DIFF
--- a/integration_tests/api_key/probe_acceleration_test.go
+++ b/integration_tests/api_key/probe_acceleration_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+
+package api_key
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiKeyProbeAcceleration_401EnqueuesProbeNow walks the central
+// invariant of #257 end-to-end: an upstream 401 against a user-initiated
+// proxy request enqueues a one-shot probe-now task. We assert two
+// observable side-effects:
+//
+//  1. The throttle key is present in Redis — proves the SetNX ran (the
+//     synchronization point inside EnqueueProbeNow), which means the
+//     proxy's 401-detection branch fired and we reached the per-probe
+//     loop.
+//  2. The asynq queue contains a pending core:probe task for this
+//     connection — proves the enqueue actually happened.
+//
+// A subsequent call from the same connection within the throttle window
+// must NOT add a second task, demonstrating the throttle behavior.
+func TestApiKeyProbeAcceleration_401EnqueuesProbeNow(t *testing.T) {
+	const goodKey = "accel-good-key"
+
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: goodKey,
+	})
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	conn := helpers.NewApiKeyConnector(connectorID, "api-key-accel", helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+		ProbeURL:  stub.BaseURL + "/probe",
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:    helpers.ServiceTypeAPI,
+		Connectors: []sconfig.Connector{conn},
+	})
+	defer env.Cleanup()
+
+	// Drive to Ready with the good key. Subsequent proxy traffic uses
+	// this credential.
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": goodKey})
+	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	// Rotate the upstream so the stored key now 401s.
+	stub.RotateAcceptedKey("rotated")
+
+	// Snapshot pending task count before the user request so we can
+	// attribute newly-enqueued tasks to this proxy call.
+	pendingBefore := countPendingProbeTasksForConnection(t, env, connectionID)
+
+	// Issue a proxy request — upstream returns 401. The wrapped /_proxy
+	// endpoint always returns 200 with the upstream's status code carried
+	// in the response body; the side-effects we care about (probe-now
+	// enqueue + throttle key) fire regardless of how the body shape
+	// presents the upstream status to the customer.
+	resp := env.DoProxyRequest(t, connectionID, stub.BaseURL+"/something", "GET")
+	require.Equalf(t, http.StatusOK, resp.Code,
+		"wrapped /_proxy endpoint returns 200 with the upstream status in body; got %d body=%s",
+		resp.Code, resp.Body.String())
+
+	// The throttle key should now exist in Redis (proves the enqueue
+	// path executed).
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	throttleKey := probeNowThrottleKey(id, "verify-credential")
+	exists, err := env.DM.GetRedisClient().Exists(context.Background(), throttleKey).Result()
+	require.NoError(t, err)
+	require.Equalf(t, int64(1), exists,
+		"throttle key %q should exist in Redis after a 401-triggered enqueue", throttleKey)
+
+	// And the asynq queue should contain one new pending probe task.
+	pendingAfter := countPendingProbeTasksForConnection(t, env, connectionID)
+	require.Equalf(t, pendingBefore+1, pendingAfter,
+		"401 from upstream must enqueue exactly one new probe task; got %d → %d",
+		pendingBefore, pendingAfter)
+
+	// Issue a second user request while still in the throttle window.
+	// The proxy still fires the acceleration path, but SetNX returns
+	// false, so no new task is enqueued.
+	resp2 := env.DoProxyRequest(t, connectionID, stub.BaseURL+"/something-else", "GET")
+	require.Equal(t, http.StatusOK, resp2.Code, "wrapped /_proxy always returns 200")
+
+	pendingFinal := countPendingProbeTasksForConnection(t, env, connectionID)
+	assert.Equalf(t, pendingAfter, pendingFinal,
+		"second 401 within throttle window must not enqueue another task; got %d → %d",
+		pendingAfter, pendingFinal)
+}
+
+// TestApiKeyProbeAcceleration_2xxDoesNotEnqueue confirms the negative
+// invariant: a successful (200) proxied response must NOT trigger
+// probe-now, both because it would be wasted work and because the
+// per-probe throttle would silently absorb a real failure that arrived
+// later in the same window.
+func TestApiKeyProbeAcceleration_2xxDoesNotEnqueue(t *testing.T) {
+	const goodKey = "accel-2xx-key"
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: goodKey,
+	})
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	conn := helpers.NewApiKeyConnector(connectorID, "api-key-accel-2xx", helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+		ProbeURL:  stub.BaseURL + "/probe",
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:    helpers.ServiceTypeAPI,
+		Connectors: []sconfig.Connector{conn},
+	})
+	defer env.Cleanup()
+
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": goodKey})
+	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	pendingBefore := countPendingProbeTasksForConnection(t, env, connectionID)
+
+	// Proxy a successful request — upstream returns 200.
+	resp := env.DoProxyRequest(t, connectionID, stub.BaseURL+"/anything", "GET")
+	require.Equalf(t, http.StatusOK, resp.Code, "expected 200 on a request with the valid key; got %d", resp.Code)
+
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	throttleKey := probeNowThrottleKey(id, "verify-credential")
+	exists, err := env.DM.GetRedisClient().Exists(context.Background(), throttleKey).Result()
+	require.NoError(t, err)
+	assert.Equalf(t, int64(0), exists,
+		"throttle key %q must not exist after a 2xx response", throttleKey)
+
+	pendingAfter := countPendingProbeTasksForConnection(t, env, connectionID)
+	assert.Equalf(t, pendingBefore, pendingAfter,
+		"2xx response must not enqueue a probe task; got %d → %d", pendingBefore, pendingAfter)
+}
+
+// probeNowThrottleKey mirrors the production helper in
+// internal/core/service_probe_now.go. Duplicated here (rather than
+// imported) because the integration_tests module deliberately depends only
+// on iface — using the internal helper would couple test code to the core
+// package. The shape is short and stable enough that drift is unlikely.
+func probeNowThrottleKey(connectionId apid.ID, probeId string) string {
+	return "probe_now:throttle:" + connectionId.String() + ":" + probeId
+}
+
+// countPendingProbeTasksForConnection counts pending core:probe tasks for
+// the supplied connection in the default asynq queue. Filters by both task
+// type and payload so accumulated tasks from other test runs (the
+// integration Redis is shared across tests inside a `go test` invocation)
+// don't drown out the signal. A large page size avoids pagination
+// boundaries — the alternative of paging manually would compound the same
+// fragility.
+func countPendingProbeTasksForConnection(t *testing.T, env *helpers.IntegrationTestEnv, connectionID string) int {
+	t.Helper()
+	tasks, err := env.DM.GetAsyncInspector().ListPendingTasks("default", asynq.PageSize(10000))
+	if err != nil {
+		return 0
+	}
+	count := 0
+	needle := []byte(connectionID)
+	for _, ti := range tasks {
+		if ti.Type != "core:probe" {
+			continue
+		}
+		if !bytes.Contains(ti.Payload, needle) {
+			continue
+		}
+		count++
+	}
+	_ = database.ConnectionStateReady // keep import referenced
+	return count
+}

--- a/internal/core/connection_proxy.go
+++ b/internal/core/connection_proxy.go
@@ -34,7 +34,7 @@ func (c *connection) getProxyImpl() (iface.Proxy, error) {
 			return
 		}
 
-		c.proxyImpl = proxy.New(c.s.httpf, c, auth)
+		c.proxyImpl = proxy.New(c.s.httpf, c, auth, c.s)
 	})
 
 	return c.proxyImpl, c.proxyImplErr

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -120,6 +120,14 @@ type C interface {
 	// no longer in verify phase); other errors propagate unwrapped.
 	RunVerifyConnection(ctx context.Context, connectionId apid.ID) error
 
+	// EnqueueProbeNow schedules an immediate one-shot probe run for every probe configured on the
+	// connection. Used by the proxy's 401/403 detection path to cut detection lag from the
+	// configured probe interval to ~immediate when an upstream signals a credential failure on a
+	// user-initiated request. Per-(connection, probe) throttling caps the rate of enqueues so a
+	// 401 storm does not pile up tasks. Best-effort: errors are logged but do not surface to the
+	// caller, since the caller's response is already on its way.
+	EnqueueProbeNow(ctx context.Context, connectionId apid.ID) error
+
 	// RetryConnectionSetup resets a connection that is in the verify_failed terminal state so the user
 	// can try setup again — either restarting preconnect forms, or re-initiating OAuth if the connector
 	// has no preconnect steps. Returns the initial setup step response for the retry.

--- a/internal/core/service_probe_now.go
+++ b/internal/core/service_probe_now.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+)
+
+// DefaultProbeNowThrottleWindow caps how often the proxy's 401/403 detection
+// path can re-enqueue a probe-now task for the same (connection, probe). A
+// 60-second window is plenty for the typical incident shape — a single
+// rotation event triggers one probe-now per probe, the probe records its
+// outcome, and any further 401s are absorbed without piling up duplicate
+// tasks. Shorter windows risk task storms on misbehaving upstreams; longer
+// windows defeat the "detection lag → ~immediate" point of the feature.
+const DefaultProbeNowThrottleWindow = 60 * time.Second
+
+// probeNowThrottleKey returns the Redis key used by the SETNX-style throttle.
+// One key per (connection, probe) so probes on the same connection don't
+// throttle each other, and connections under load against the same connector
+// don't throttle each other either.
+func probeNowThrottleKey(connectionId apid.ID, probeId string) string {
+	return fmt.Sprintf("probe_now:throttle:%s:%s", connectionId.String(), probeId)
+}
+
+// EnqueueProbeNow enqueues an asynq probe task for every probe on the
+// connection, subject to per-(connection, probe) throttling. See the
+// iface.C.EnqueueProbeNow contract for the broader contract.
+//
+// Best-effort by design: any error from looking up the connection or
+// enqueueing is logged at warn-level and the function continues. The caller
+// is the proxy's 401/403 detection path, which has already sent the
+// upstream's response to the customer — failing to enqueue a probe-now is
+// not a customer-facing failure (the next scheduled probe will still detect
+// the credential problem; we just lose the latency win for this incident).
+func (s *service) EnqueueProbeNow(ctx context.Context, connectionId apid.ID) error {
+	logger := aplog.NewBuilder(s.logger).
+		WithCtx(ctx).
+		WithConnectionId(connectionId).
+		Build()
+
+	conn, err := s.getConnection(ctx, connectionId)
+	if err != nil {
+		logger.Warn("probe-now: failed to load connection", "error", err)
+		return err
+	}
+
+	probes := conn.GetProbes()
+	if len(probes) == 0 {
+		return nil
+	}
+
+	for _, probe := range probes {
+		key := probeNowThrottleKey(connectionId, probe.GetId())
+		ok, err := s.r.SetNX(ctx, key, "1", DefaultProbeNowThrottleWindow).Result()
+		if err != nil {
+			logger.Warn("probe-now: throttle check failed",
+				"probe_id", probe.GetId(),
+				"error", err,
+			)
+			continue
+		}
+		if !ok {
+			// Already enqueued within the throttle window — skip silently.
+			// Logging would be too noisy under sustained 401 traffic.
+			continue
+		}
+
+		task, err := newProbeTask(connectionId, probe.GetId())
+		if err != nil {
+			logger.Warn("probe-now: failed to build probe task",
+				"probe_id", probe.GetId(),
+				"error", err,
+			)
+			continue
+		}
+		if _, err := s.ac.EnqueueContext(ctx, task); err != nil {
+			logger.Warn("probe-now: failed to enqueue probe task",
+				"probe_id", probe.GetId(),
+				"error", err,
+			)
+			continue
+		}
+		logger.Info("probe-now: probe task enqueued", "probe_id", probe.GetId())
+	}
+	return nil
+}

--- a/internal/core/service_probe_now_test.go
+++ b/internal/core/service_probe_now_test.go
@@ -1,0 +1,236 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
+	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockRedisPkg "github.com/rmorlok/authproxy/internal/apredis/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnqueueProbeNow_EnqueuesEachProbeWhenThrottleAllows is the happy path:
+// SetNX returns true (key not yet present) for each probe → newProbeTask
+// + Enqueue for each.
+func TestEnqueueProbeNow_EnqueuesEachProbeWhenThrottleAllows(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-happy",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{Id: "p1", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"}},
+			{Id: "p2", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://y.example/health"}},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+	svc.r = mockRedisAllowingSetNX(ctrl, connectionId, []string{"p1", "p2"}, true)
+	svc.ac = mockAsynqExpectingEnqueues(ctrl, 2)
+
+	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
+}
+
+// TestEnqueueProbeNow_ThrottleSkipsEnqueue: SetNX returns false → throttled
+// → no Enqueue call. The mock asynq client EXPECT nothing — if Enqueue were
+// called, gomock's controller fails at Finish.
+func TestEnqueueProbeNow_ThrottleSkipsEnqueue(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-throttled",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{Id: "p1", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"}},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+	svc.r = mockRedisAllowingSetNX(ctrl, connectionId, []string{"p1"}, false)
+	// No Enqueue expectations — would fail at ctrl.Finish if called.
+	svc.ac = mockAsynqExpectingEnqueues(ctrl, 0)
+
+	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
+}
+
+// TestEnqueueProbeNow_MixedThrottle: two probes, one allowed and one
+// throttled — only the allowed one results in an Enqueue.
+func TestEnqueueProbeNow_MixedThrottle(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-mixed",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{Id: "p1", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"}},
+			{Id: "p2", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://y.example/health"}},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	r := mockRedisPkg.NewMockClient(ctrl)
+	r.EXPECT().
+		SetNX(gomock.Any(), probeNowThrottleKey(connectionId, "p1"), "1", DefaultProbeNowThrottleWindow).
+		Return(redis.NewBoolResult(true, nil))
+	r.EXPECT().
+		SetNX(gomock.Any(), probeNowThrottleKey(connectionId, "p2"), "1", DefaultProbeNowThrottleWindow).
+		Return(redis.NewBoolResult(false, nil))
+	svc.r = r
+
+	svc.ac = mockAsynqExpectingEnqueues(ctrl, 1)
+
+	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
+}
+
+// TestEnqueueProbeNow_NoProbesShortCircuits: connector without probes
+// returns nil without touching Redis or asynq.
+func TestEnqueueProbeNow_NoProbesShortCircuits(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-no-probes",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+	// No SetNX / Enqueue expectations — neither path should be touched.
+
+	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
+}
+
+// TestEnqueueProbeNow_RedisErrorIsSwallowedPerProbe: a Redis error from
+// SetNX must not abort the loop — other probes should still be considered.
+// And the error itself does not surface to the caller (best-effort
+// contract).
+func TestEnqueueProbeNow_RedisErrorIsSwallowedPerProbe(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-redis-err",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{Id: "p1", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"}},
+			{Id: "p2", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://y.example/health"}},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateReady,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	r := mockRedisPkg.NewMockClient(ctrl)
+	r.EXPECT().
+		SetNX(gomock.Any(), probeNowThrottleKey(connectionId, "p1"), "1", DefaultProbeNowThrottleWindow).
+		Return(redis.NewBoolResult(false, errors.New("redis down")))
+	r.EXPECT().
+		SetNX(gomock.Any(), probeNowThrottleKey(connectionId, "p2"), "1", DefaultProbeNowThrottleWindow).
+		Return(redis.NewBoolResult(true, nil))
+	svc.r = r
+
+	// p1 short-circuited by redis error → skipped; p2 succeeded → enqueued.
+	svc.ac = mockAsynqExpectingEnqueues(ctrl, 1)
+
+	err := svc.EnqueueProbeNow(context.Background(), connectionId)
+	assert.NoError(t, err, "redis errors are best-effort, should not surface")
+}
+
+// TestEnqueueProbeNow_ConnectionNotFoundSurfacesError: unlike the per-probe
+// errors that are best-effort, a missing connection is a structural
+// problem — the caller (the proxy 401 path) gets the error so it can log
+// it.
+func TestEnqueueProbeNow_ConnectionNotFoundSurfacesError(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	svc, db, _, _, _, _ := FullMockService(t, ctrl)
+	db.EXPECT().
+		GetConnection(gomock.Any(), connectionId).
+		Return(nil, database.ErrNotFound)
+
+	err := svc.EnqueueProbeNow(context.Background(), connectionId)
+	require.Error(t, err)
+}
+
+// mockRedisAllowingSetNX returns a redis mock where SetNX against each
+// probe key returns the supplied "allowed" result.
+func mockRedisAllowingSetNX(ctrl *gomock.Controller, connectionId apid.ID, probeIds []string, allowed bool) *mockRedisPkg.MockClient {
+	r := mockRedisPkg.NewMockClient(ctrl)
+	for _, pid := range probeIds {
+		r.EXPECT().
+			SetNX(gomock.Any(), probeNowThrottleKey(connectionId, pid), "1", DefaultProbeNowThrottleWindow).
+			Return(redis.NewBoolResult(allowed, nil))
+	}
+	return r
+}
+
+// mockAsynqExpectingEnqueues returns an asynq mock that expects exactly N
+// EnqueueContext calls. Each call returns a no-op TaskInfo so the
+// caller's path stays inside the success branch.
+func mockAsynqExpectingEnqueues(ctrl *gomock.Controller, n int) *mockAsynq.MockClient {
+	ac := mockAsynq.NewMockClient(ctrl)
+	if n > 0 {
+		ac.EXPECT().
+			EnqueueContext(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&asynq.TaskInfo{}, nil).
+			Times(n)
+	}
+	return ac
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -15,23 +15,60 @@ import (
 	"net/http"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/auth_methods"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	gentleman "gopkg.in/h2non/gentleman.v2"
 )
 
+// ProbeAccelerator is the subset of the core service the proxy relies on to
+// nudge probes when the upstream returns a credential-related failure. The
+// proxy only needs EnqueueProbeNow; keeping the surface narrow lets test
+// constructors pass a tiny fake instead of the full iface.C.
+type ProbeAccelerator interface {
+	EnqueueProbeNow(ctx context.Context, connectionId apid.ID) error
+}
+
 type proxy struct {
-	httpf httpf.F
-	conn  iface.Connection
-	auth  auth_methods.Authenticator
+	httpf       httpf.F
+	conn        iface.Connection
+	auth        auth_methods.Authenticator
+	accelerator ProbeAccelerator
 }
 
 // New constructs an iface.Proxy that orchestrates calls for a single
-// connection using the supplied Authenticator. One instance per
+// connection using the supplied Authenticator. The optional accelerator,
+// when non-nil, receives a fire-and-forget EnqueueProbeNow call on
+// upstream 401/403 responses so the probe-driven health signal can flip
+// without waiting for the next scheduled probe tick. One instance per
 // connection — held inside the connection's lazy proxy-impl cache.
-func New(h httpf.F, conn iface.Connection, auth auth_methods.Authenticator) iface.Proxy {
-	return &proxy{httpf: h, conn: conn, auth: auth}
+func New(h httpf.F, conn iface.Connection, auth auth_methods.Authenticator, accelerator ProbeAccelerator) iface.Proxy {
+	return &proxy{httpf: h, conn: conn, auth: auth, accelerator: accelerator}
+}
+
+// maybeAccelerateProbes fires a best-effort probe-now enqueue when the
+// upstream returns a credential-related status code on a user-initiated
+// request. Probe traffic itself is excluded — without that gate the
+// probe-now task's own 401 would re-enter this path and (even with the
+// per-probe throttle) waste an iteration of bookkeeping per failed probe.
+//
+// Errors from EnqueueProbeNow are intentionally swallowed: by the time
+// this runs, the customer's response is already on its way. Surfacing an
+// error would turn a layered optimisation into a brittle dependency on
+// the throttle store.
+func (p *proxy) maybeAccelerateProbes(ctx context.Context, reqType httpf.RequestType, statusCode int) {
+	if p.accelerator == nil {
+		return
+	}
+	if reqType == common.RequestTypeProbe {
+		return
+	}
+	if statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden {
+		return
+	}
+	_ = p.accelerator.EnqueueProbeNow(ctx, p.conn.GetId())
 }
 
 // ProxyRequest resolves credentials, sends the request, and on a 401
@@ -63,6 +100,13 @@ func (p *proxy) ProxyRequest(ctx context.Context, reqType httpf.RequestType, req
 			_ = recoverErr
 		}
 	}
+
+	// After the recover-and-retry dance has run its course, the final
+	// status code is what the customer will see. A persistent 401/403
+	// here means credentials are genuinely failing — accelerate probes
+	// so the probe-driven health signal flips without waiting for the
+	// next scheduled probe interval.
+	p.maybeAccelerateProbes(ctx, reqType, resp.StatusCode)
 
 	return iface.ProxyResponseFromGentlemen(resp)
 }
@@ -115,6 +159,10 @@ func (p *proxy) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, 
 			_ = recoverErr
 		}
 	}
+
+	// Same 401/403 acceleration as the wrapped path. See ProxyRequest's
+	// comment for the rationale.
+	p.maybeAccelerateProbes(ctx, reqType, resp.StatusCode)
 
 	return streamResponse(w, resp)
 }

--- a/internal/proxy/proxy_acceleration_test.go
+++ b/internal/proxy/proxy_acceleration_test.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/auth_methods"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubAccelerator records every EnqueueProbeNow call so tests can assert on
+// "fired" vs "not fired" for status codes without standing up the full
+// service + Redis + asynq stack.
+type stubAccelerator struct {
+	calls  atomic.Int32
+	lastId atomic.Value // apid.ID
+	retErr error
+}
+
+func (s *stubAccelerator) EnqueueProbeNow(ctx context.Context, id apid.ID) error {
+	s.calls.Add(1)
+	s.lastId.Store(id)
+	return s.retErr
+}
+
+// staticHandler returns a handler that always responds with the given status.
+// Body content is irrelevant — the proxy never inspects it for the
+// acceleration decision (only the status code matters).
+func staticHandler(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	})
+}
+
+// newTestProxyWithAcceleration builds a proxy wired to a stub accelerator
+// and a single-handler upstream. Mirrors newRawTestProxy but exposes the
+// accelerator so each test can read its call count, and returns the
+// upstream URL so the test can construct an outbound request that
+// resolves correctly through the stub httpf's client.
+func newTestProxyWithAcceleration(t *testing.T, h http.Handler, auth auth_methods.Authenticator) (iface.Proxy, *stubAccelerator, string) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	conn := &mockCore.Connection{
+		Id:        apid.New(apid.PrefixConnection),
+		Namespace: "root/",
+	}
+	acc := &stubAccelerator{}
+	p := New(&stubHttpf{client: srv.Client()}, conn, auth, acc)
+	return p, acc, srv.URL
+}
+
+// authNeverRecovers makes RecoverFrom401 always return ErrCannotRecover, so
+// a 401 upstream lands as a 401 to the customer without any retry loop —
+// the canonical api-key shape.
+func authNeverRecovers() *fakeAuth {
+	return &fakeAuth{maxRecover: 0}
+}
+
+// TestProxyRequestRaw_AccelerationOn401 — the central invariant of #257:
+// an upstream 401 on a user-initiated request fires EnqueueProbeNow.
+func TestProxyRequestRaw_AccelerationOn401(t *testing.T) {
+	p, acc, srvURL := newTestProxyWithAcceleration(t, staticHandler(http.StatusUnauthorized), authNeverRecovers())
+
+	req := mustNewRawRequest(t, srvURL+"/x")
+	w := httptest.NewRecorder()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProxy, &iface.RawProxyRequest{Outbound: req}, w))
+
+	assert.Equal(t, int32(1), acc.calls.Load(),
+		"401 on a proxied user request must enqueue a probe-now task")
+}
+
+// TestProxyRequestRaw_AccelerationOn403 — 403 is the other status the
+// issue spec calls out. Same observable: probe-now is enqueued.
+func TestProxyRequestRaw_AccelerationOn403(t *testing.T) {
+	p, acc, srvURL := newTestProxyWithAcceleration(t, staticHandler(http.StatusForbidden), authNeverRecovers())
+
+	req := mustNewRawRequest(t, srvURL+"/x")
+	w := httptest.NewRecorder()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProxy, &iface.RawProxyRequest{Outbound: req}, w))
+
+	assert.Equal(t, int32(1), acc.calls.Load(),
+		"403 on a proxied user request must enqueue a probe-now task")
+}
+
+// TestProxyRequestRaw_NoAccelerationOnSuccessOrOther4xx — only 401/403 are
+// "credential failed" signals. 200 obviously doesn't fire; 400/404/429
+// also must not fire — those are bad-request / not-found / rate-limit
+// signals where a probe-now would be wasted work.
+func TestProxyRequestRaw_NoAccelerationOnSuccessOrOther4xx(t *testing.T) {
+	cases := []int{
+		http.StatusOK,
+		http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	}
+	for _, status := range cases {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			p, acc, srvURL := newTestProxyWithAcceleration(t, staticHandler(status), authNeverRecovers())
+
+			req := mustNewRawRequest(t, srvURL+"/x")
+			w := httptest.NewRecorder()
+			require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProxy, &iface.RawProxyRequest{Outbound: req}, w))
+
+			assert.Equalf(t, int32(0), acc.calls.Load(),
+				"status %d (%q) must not enqueue a probe-now task", status, http.StatusText(status))
+		})
+	}
+}
+
+// TestProxyRequestRaw_NoAccelerationOnProbeTraffic — when the probe itself
+// receives a 401, the proxy must NOT re-enqueue probe-now. Even with
+// throttling, the recursion is wasteful (the probe outcome already feeds
+// the health signal directly).
+func TestProxyRequestRaw_NoAccelerationOnProbeTraffic(t *testing.T) {
+	p, acc, srvURL := newTestProxyWithAcceleration(t, staticHandler(http.StatusUnauthorized), authNeverRecovers())
+
+	req := mustNewRawRequest(t, srvURL+"/x")
+	w := httptest.NewRecorder()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProbe, &iface.RawProxyRequest{Outbound: req}, w))
+
+	assert.Equal(t, int32(0), acc.calls.Load(),
+		"probe-typed traffic must not trigger probe-now (would loop)")
+}
+
+// TestProxyRequestRaw_AccelerationToleratesAcceleratorErrors — the
+// accelerator's return error must not surface to the customer. The
+// upstream response (here: 401) is what they see; acceleration is a
+// background signal and failing it must not bleed into the user-facing
+// response path.
+func TestProxyRequestRaw_AccelerationToleratesAcceleratorErrors(t *testing.T) {
+	p, acc, srvURL := newTestProxyWithAcceleration(t, staticHandler(http.StatusUnauthorized), authNeverRecovers())
+	acc.retErr = assertErr("accelerator down")
+
+	req := mustNewRawRequest(t, srvURL+"/x")
+	w := httptest.NewRecorder()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProxy, &iface.RawProxyRequest{Outbound: req}, w),
+		"proxy response path must not surface an accelerator error to the customer")
+	assert.Equal(t, http.StatusUnauthorized, w.Code,
+		"the customer-visible status is the upstream's, unchanged by the accelerator")
+}
+
+// TestProxyRequestRaw_NoAcceleratorIsAllowed — a connection constructed
+// without an accelerator (e.g. legacy callers, or tests not exercising the
+// 401-acceleration path) must still pass through 401/403 cleanly.
+func TestProxyRequestRaw_NoAcceleratorIsAllowed(t *testing.T) {
+	srv := httptest.NewServer(staticHandler(http.StatusUnauthorized))
+	t.Cleanup(srv.Close)
+	conn := &mockCore.Connection{
+		Id:        apid.New(apid.PrefixConnection),
+		Namespace: "root/",
+	}
+	p := New(&stubHttpf{client: srv.Client()}, conn, authNeverRecovers(), nil)
+
+	req := mustNewRawRequest(t, srv.URL+"/x")
+	w := httptest.NewRecorder()
+	require.NoError(t, p.ProxyRequestRaw(context.Background(), common.RequestTypeProxy, &iface.RawProxyRequest{Outbound: req}, w))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// mustNewRawRequest builds an *http.Request for the raw-proxy path. The
+// URL must point at the httptest.Server backing the stubHttpf — otherwise
+// the request would try to actually dial that hostname.
+func mustNewRawRequest(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	return req
+}
+
+// assertErr is a tiny error helper to avoid importing errors-pkg gymnastics
+// for one synthetic value.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/internal/proxy/proxy_raw_test.go
+++ b/internal/proxy/proxy_raw_test.go
@@ -82,7 +82,7 @@ func newRawTestProxy(t *testing.T, h http.Handler, auth *fakeAuth) (iface.Proxy,
 		Id:        apid.New(apid.PrefixConnection),
 		Namespace: "root/",
 	}
-	p := New(&stubHttpf{client: srv.Client()}, conn, auth)
+	p := New(&stubHttpf{client: srv.Client()}, conn, auth, nil)
 	return p, srv
 }
 


### PR DESCRIPTION
## Summary

When the proxy receives a 401 or 403 from the upstream on a user-initiated request, enqueue a one-shot probe task for every probe on the connection. Cuts detection lag from the configured probe interval (potentially many minutes) to ~immediate. Probe outcomes still feed the existing probe-driven health counters from #255 — this is purely a latency optimization on top of that.

Closes #257. Completes the #243 api-key project.

## iface.C gains `EnqueueProbeNow`

Implementation in `internal/core/service_probe_now.go`:

- Loads the connection, iterates over its probes.
- Per-(connection, probe) throttle via Redis `SETNX` with a 60s TTL (`DefaultProbeNowThrottleWindow`). Sustained 401 traffic enqueues at most one probe-now per probe per window.
- Best-effort: per-probe Redis or `Enqueue` errors are logged and skipped, never surfaced to the caller (the proxy's response is already on its way).
- A missing connection is the one structural error that surfaces, so callers can log it.

## Proxy wiring (`internal/proxy/proxy.go`)

- New `ProbeAccelerator` interface — narrow surface the proxy depends on, lets tests pass a tiny stub instead of the full `iface.C`.
- `proxy.New` gains an accelerator parameter (nil-tolerant for legacy constructors and tests that don't exercise the acceleration path).
- Both `ProxyRequest` and `ProxyRequestRaw` call `maybeAccelerateProbes` after the recover-and-retry dance settles on a final status.
- **Gating**: only `RequestTypeProxy` traffic triggers; probe-typed traffic is excluded so a probe's own 401 doesn't loop into another probe-now enqueue.

## Test coverage

**Proxy unit tests** (`internal/proxy/proxy_acceleration_test.go`):
- `AccelerationOn401` / `AccelerationOn403` — fire.
- `NoAccelerationOnSuccessOrOther4xx` — 200/400/404/429/500 do not fire.
- `NoAccelerationOnProbeTraffic` — `RequestTypeProbe` excluded.
- `AccelerationToleratesAcceleratorErrors` — best-effort contract.
- `NoAcceleratorIsAllowed` — nil accelerator passes through 401/403 cleanly.

**Service unit tests** (`internal/core/service_probe_now_test.go`):
- `EnqueuesEachProbeWhenThrottleAllows` — both probes hit `Enqueue`.
- `ThrottleSkipsEnqueue` — `SetNX=false` → no `Enqueue`.
- `MixedThrottle` — partial throttle still enqueues the allowed probe.
- `NoProbesShortCircuits` — connector with no probes is a no-op.
- `RedisErrorIsSwallowedPerProbe` — one probe's error doesn't abort the loop.
- `ConnectionNotFoundSurfacesError` — structural error surfaces.

**Integration test** (`integration_tests/api_key/probe_acceleration_test.go`):
- `401EnqueuesProbeNow` — drives connection to Ready with a stub upstream, rotates the upstream's accepted key, proxies a request, verifies (a) the throttle key landed in Redis and (b) the asynq queue contains a new `core:probe` task with this connection's id in the payload. A second 401 within the window does not enqueue another task.
- `2xxDoesNotEnqueue` — successful proxy traffic neither writes a throttle key nor enqueues a probe task.

## Test plan

- [x] `go test ./internal/proxy/...`
- [x] `go test ./internal/core/...`
- [x] `go test -tags integration ./api_key/... ./probes/...`
- [x] Full non-integration `go test ./...`
- [x] `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)