### PR TITLE
Migrate disconnect revoke loop to internal/util/retry (#359)

### DIFF
--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
-	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/util/retry"
 )
 
 const taskTypeDisconnectConnection = "core:disconnect_connection"
@@ -58,34 +58,41 @@ func (s *service) disconnectConnection(ctx context.Context, t *asynq.Task) error
 	revokeOps := conn.getRevokeCredentialsOperations()
 	if len(revokeOps) > 0 {
 		logger.Info("revoking credentials")
-		clk := apctx.GetClock(ctx)
 		for _, op := range revokeOps {
-			var lastErr error
-			for attempt := 1; attempt <= maxRevokeAttempts; attempt++ {
-				if ctxErr := ctx.Err(); ctxErr != nil {
-					return ctxErr
+			// The Warn is emitted inside the op so every failing attempt
+			// (including the terminal one) gets a log line — matching the
+			// pre-consolidation behavior here, which differs from the OAuth
+			// callsites that only log on retries.
+			attempt := 0
+			res, err := retry.Do(ctx, retry.Options[struct{}]{
+				MaxAttempts: maxRevokeAttempts,
+				Backoff:     &retry.LinearBackOff{Step: 1 * time.Second},
+			}, func(ctx context.Context) (struct{}, error) {
+				attempt++
+				err := op(ctx)
+				if err != nil {
+					logger.Warn(
+						"revoke attempt failed",
+						"error", err,
+						"attempt", attempt,
+						"max_attempts", maxRevokeAttempts,
+					)
 				}
-				lastErr = op(ctx)
-				if lastErr == nil {
-					break
+				return struct{}{}, err
+			})
+			if err != nil {
+				// ctx errors are terminal — surface them so the task can be
+				// retried by asynq rather than swallowed under a "proceeding
+				// with disconnect" log line that doesn't apply.
+				if ctx.Err() != nil {
+					return ctx.Err()
 				}
-				logger.Warn(
-					"revoke attempt failed",
-					"error", lastErr,
-					"attempt", attempt,
-					"max_attempts", maxRevokeAttempts,
-				)
-				if attempt < maxRevokeAttempts {
-					clk.Sleep(time.Duration(attempt) * time.Second)
-				}
-			}
-			if lastErr != nil {
-				// Proceed with the rest of the disconnect so the connection
-				// does not stay stuck in `disconnecting` forever.
+				// Otherwise: proceed with the rest of the disconnect so the
+				// connection does not stay stuck in `disconnecting` forever.
 				logger.Error(
 					"revocation failed after max attempts; proceeding with disconnect",
-					"error", lastErr,
-					"attempts", maxRevokeAttempts,
+					"error", err,
+					"attempts", res.Attempts,
 				)
 			}
 		}

--- a/internal/core/task_disconnect_connection_test.go
+++ b/internal/core/task_disconnect_connection_test.go
@@ -135,9 +135,27 @@ func TestTaskDisconnectConnection(t *testing.T) {
 		task, err := newDisconnectConnectionTask(connectionId)
 		require.NoError(t, err)
 
-		// Use a fake clock so the inter-attempt sleeps return immediately.
+		// Use a fake clock so the inter-attempt backoff doesn't burn real
+		// time. The retry helper sleeps via clk.After + select, which is not
+		// auto-stepped by FakeClock (unlike clk.Sleep), so a stepper
+		// goroutine advances the clock whenever the helper subscribes.
 		fakeClk := tclock.NewFakeClock(time.Now())
 		retryCtx := apctx.WithClock(ctx, fakeClk)
+		stepperCtx, stopStepper := context.WithCancel(context.Background())
+		defer stopStepper()
+		go func() {
+			for {
+				select {
+				case <-stepperCtx.Done():
+					return
+				default:
+				}
+				if fakeClk.HasWaiters() {
+					fakeClk.Step(time.Second)
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}()
 
 		err = svc.disconnectConnection(retryCtx, task)
 		assert.NoError(t, err, "disconnect should succeed even when revocation fails")


### PR DESCRIPTION
Closes #359. Phase 3 of #277.

## Summary
- `disconnectConnection`'s per-op retry loop in `internal/core/task_disconnect_connection.go` now runs through `retry.Do` with `LinearBackOff{Step: 1s}` — matching the prior `attempt × 1s` shape and `maxRevokeAttempts = 3` budget.
- The `Warn` log fires inside the op (every failing attempt, including the terminal one). This differs from the OAuth callsites migrated in #369, which only log on retries — preserving each site's pre-consolidation behavior was the goal of the consolidation.
- The `Error` "revocation failed after max attempts; proceeding with disconnect" summary still fires on exhaustion. ctx errors short-circuit and return up to asynq instead of being absorbed by that summary.
- Test update: the existing fake-clock test drove the prior code's `clk.Sleep` auto-step behavior. `retry.Do` uses `clk.After + select`, which `FakeClock` does not auto-step, so the test now runs a stepper goroutine to advance the clock while the helper is waiting.

## Test plan
- [x] `go test ./internal/core/... -count=1` — all `TestTaskDisconnectConnection` subcases pass.
- [x] `./scripts/preflight.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)