### PR TITLE
Migrate vault retry transport to internal/util/retry (#358)

### DIFF
--- a/internal/schema/config/key_data_vault_retry.go
+++ b/internal/schema/config/key_data_vault_retry.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"context"
 	"math"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/rmorlok/authproxy/internal/util/retry"
 )
 
 const (
@@ -16,56 +19,74 @@ const (
 )
 
 // vaultRetryTransport wraps an http.RoundTripper to retry on 429 responses.
-// If a Retry-After header is present, it uses that duration; otherwise it
-// uses exponential backoff with jitter.
+// If a Retry-After header is present (numeric seconds), it overrides the
+// backoff; otherwise the exponential strategy is used.
+//
+// Transport errors are NOT retried — that mirrors the pre-consolidation
+// behavior and matches Vault's official client conventions (the SDK
+// classifies network failures as caller-handled).
 type vaultRetryTransport struct {
 	base http.RoundTripper
 }
 
 func (t *vaultRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	backoff := vaultRetryInitialBackoff
+	res, err := retry.Do(req.Context(), retry.Options[*http.Response]{
+		MaxAttempts: vaultRetryMaxAttempts,
+		Backoff:     newVaultBackoff(),
+		Classify: func(resp *http.Response, err error) bool {
+			// Only retry 429s; transport errors fall through unchanged.
+			return err == nil && resp != nil && resp.StatusCode == http.StatusTooManyRequests
+		},
+		OnRetry: func(_ int, resp *http.Response, _ error) {
+			// Drain + close so the connection can return to the pool
+			// before the next attempt opens a fresh one. The body of
+			// the final returned response is left intact for the caller.
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+		},
+		OnRetryWait: parseVaultRetryAfter,
+	}, func(_ context.Context) (*http.Response, error) {
+		return t.base.RoundTrip(req)
+	})
 
-	for attempt := 0; ; attempt++ {
-		resp, err := t.base.RoundTrip(req)
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode != http.StatusTooManyRequests || attempt >= vaultRetryMaxAttempts-1 {
-			return resp, nil
-		}
-
-		// Determine how long to wait before retrying.
-		wait := t.retryAfterDuration(resp, backoff)
-
-		// Drain and close the body so the connection can be reused.
-		resp.Body.Close()
-
-		select {
-		case <-req.Context().Done():
-			return nil, req.Context().Err()
-		case <-time.After(wait):
-		}
-
-		// Advance exponential backoff for next attempt.
-		backoff = time.Duration(float64(backoff) * vaultRetryMultiplier)
-		if backoff > vaultRetryMaxBackoff {
-			backoff = vaultRetryMaxBackoff
-		}
+	if err != nil {
+		return nil, err
 	}
+	return res.Value, nil
 }
 
-// retryAfterDuration parses the Retry-After header if present, otherwise
-// returns the given backoff duration with jitter.
-func (t *vaultRetryTransport) retryAfterDuration(resp *http.Response, backoff time.Duration) time.Duration {
-	if ra := resp.Header.Get("Retry-After"); ra != "" {
-		if seconds, err := strconv.ParseFloat(ra, 64); err == nil && seconds > 0 {
-			// Round up to nearest second, matching Vault v1.20.0 behavior.
-			return time.Duration(math.Ceil(seconds)) * time.Second
-		}
-	}
+// newVaultBackoff returns the exponential strategy used between attempts
+// when no Retry-After header is present. Parameters match the
+// pre-consolidation transport: 2s initial, double each step, capped at 60s.
+// The randomization factor (0.5) gives ~[interval/2, interval*1.5] jitter —
+// slightly wider than the prior hand-rolled "[backoff/2, backoff)" range, but
+// the overall back-off shape is preserved and there are no tests that depend
+// on the exact distribution.
+func newVaultBackoff() backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = vaultRetryInitialBackoff
+	b.MaxInterval = vaultRetryMaxBackoff
+	b.Multiplier = vaultRetryMultiplier
+	b.RandomizationFactor = 0.5
+	return b
+}
 
-	// Exponential backoff with jitter: [backoff/2, backoff)
-	jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
-	return backoff/2 + jitter
+// parseVaultRetryAfter returns the Retry-After header's duration if the
+// header is present and parses as a positive numeric-seconds value (rounded
+// up to the nearest second, matching Vault v1.20.0 behavior). Returns 0
+// otherwise so retry.Do falls through to the backoff strategy.
+func parseVaultRetryAfter(resp *http.Response, _ error) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return 0
+	}
+	seconds, err := strconv.ParseFloat(ra, 64)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(math.Ceil(seconds)) * time.Second
 }

--- a/internal/schema/config/key_data_vault_retry_test.go
+++ b/internal/schema/config/key_data_vault_retry_test.go
@@ -1,0 +1,228 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tclock "k8s.io/utils/clock/testing"
+)
+
+// scriptedRoundTripper returns a sequence of canned responses (or errors)
+// across successive RoundTrip calls. attempts atomically tracks how many
+// times RoundTrip was invoked.
+type scriptedRoundTripper struct {
+	attempts atomic.Int32
+	steps    []rtStep
+}
+
+type rtStep struct {
+	resp *http.Response
+	err  error
+}
+
+func (rt *scriptedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := int(rt.attempts.Add(1)) - 1
+	if idx >= len(rt.steps) {
+		idx = len(rt.steps) - 1
+	}
+	s := rt.steps[idx]
+	if s.resp != nil && s.resp.Body == nil {
+		s.resp.Body = http.NoBody
+	}
+	return s.resp, s.err
+}
+
+func newResp(status int, retryAfter string) *http.Response {
+	h := http.Header{}
+	if retryAfter != "" {
+		h.Set("Retry-After", retryAfter)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       http.NoBody,
+	}
+}
+
+// fakeClkCtx returns a context whose clock is a FakeClock plus a goroutine
+// that steps it whenever the retry helper subscribes. Returns a stop func
+// to be called via defer.
+func fakeClkCtx(t *testing.T, parent context.Context) (context.Context, func()) {
+	t.Helper()
+	fakeClk := tclock.NewFakeClock(time.Now())
+	stepperCtx, stop := context.WithCancel(context.Background())
+	go func() {
+		for {
+			select {
+			case <-stepperCtx.Done():
+				return
+			default:
+			}
+			if fakeClk.HasWaiters() {
+				fakeClk.Step(time.Minute)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	return apctx.WithClock(parent, fakeClk), stop
+}
+
+func TestVaultRetryTransport_429ThenSuccess(t *testing.T) {
+	ctx, stop := fakeClkCtx(t, context.Background())
+	defer stop()
+
+	rt := &scriptedRoundTripper{steps: []rtStep{
+		{resp: newResp(http.StatusTooManyRequests, "")},
+		{resp: newResp(http.StatusTooManyRequests, "")},
+		{resp: newResp(http.StatusOK, "")},
+	}}
+	transport := &vaultRetryTransport{base: rt}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), rt.attempts.Load())
+}
+
+func TestVaultRetryTransport_429ExhaustedReturnsLastResp(t *testing.T) {
+	ctx, stop := fakeClkCtx(t, context.Background())
+	defer stop()
+
+	steps := make([]rtStep, vaultRetryMaxAttempts)
+	for i := range steps {
+		steps[i] = rtStep{resp: newResp(http.StatusTooManyRequests, "")}
+	}
+	rt := &scriptedRoundTripper{steps: steps}
+	transport := &vaultRetryTransport{base: rt}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err, "exhaustion returns the final 429 with nil err — caller decides")
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(vaultRetryMaxAttempts), rt.attempts.Load())
+}
+
+func TestVaultRetryTransport_TransportErrorNotRetried(t *testing.T) {
+	ctx, stop := fakeClkCtx(t, context.Background())
+	defer stop()
+
+	wantErr := errors.New("dial tcp: connection refused")
+	rt := &scriptedRoundTripper{steps: []rtStep{{err: wantErr}}}
+	transport := &vaultRetryTransport{base: rt}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.ErrorIs(t, err, wantErr, "transport errors must not be retried — they short-circuit")
+	assert.Nil(t, resp)
+	assert.Equal(t, int32(1), rt.attempts.Load())
+}
+
+func TestVaultRetryTransport_Non429StatusReturnedImmediately(t *testing.T) {
+	ctx, stop := fakeClkCtx(t, context.Background())
+	defer stop()
+
+	rt := &scriptedRoundTripper{steps: []rtStep{
+		{resp: newResp(http.StatusInternalServerError, "")},
+	}}
+	transport := &vaultRetryTransport{base: rt}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, int32(1), rt.attempts.Load(), "non-429 statuses are not retried — even 5xx")
+}
+
+func TestVaultRetryTransport_RetryAfterHonored(t *testing.T) {
+	// Drive the retry helper with a real clock and a Retry-After of 0.1s.
+	// We can't easily assert "waited exactly 100ms" without flakiness, but
+	// we can assert the request is retried (i.e. parseVaultRetryAfter
+	// produced a positive duration that the helper honored).
+	rt := &scriptedRoundTripper{steps: []rtStep{
+		{resp: newResp(http.StatusTooManyRequests, "0.1")},
+		{resp: newResp(http.StatusOK, "")},
+	}}
+	transport := &vaultRetryTransport{base: rt}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	resp, err := transport.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), rt.attempts.Load())
+	// parseVaultRetryAfter ceils to nearest second, so 0.1 → 1s wait.
+	assert.GreaterOrEqual(t, elapsed, 500*time.Millisecond,
+		"Retry-After ceils to 1s, so the helper should have waited at least ~1s (allow margin)")
+}
+
+func TestVaultRetryTransport_CtxCancelDuringBackoff(t *testing.T) {
+	// Don't install a clock stepper — backoff sleeps on a real clock and
+	// gets cancelled by ctx.
+	steps := make([]rtStep, vaultRetryMaxAttempts)
+	for i := range steps {
+		steps[i] = rtStep{resp: newResp(http.StatusTooManyRequests, "")}
+	}
+	rt := &scriptedRoundTripper{steps: steps}
+	transport := &vaultRetryTransport{base: rt}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Wait for one attempt then cancel.
+		for rt.attempts.Load() < 1 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context"),
+		"expected ctx cancel to surface; got %v", err)
+	assert.Nil(t, resp)
+}
+
+func TestParseVaultRetryAfter(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *http.Response
+		want time.Duration
+	}{
+		{"nil response", nil, 0},
+		{"no header", newResp(429, ""), 0},
+		{"valid integer", newResp(429, "5"), 5 * time.Second},
+		{"valid fractional rounds up", newResp(429, "0.1"), 1 * time.Second},
+		{"valid fractional rounds up (2.3)", newResp(429, "2.3"), 3 * time.Second},
+		{"zero is rejected", newResp(429, "0"), 0},
+		{"negative is rejected", newResp(429, "-1"), 0},
+		{"unparseable is rejected", newResp(429, "Wed, 21 Oct 2015 07:28:00 GMT"), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseVaultRetryAfter(tc.resp, nil))
+		})
+	}
+}

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -56,8 +56,21 @@ type Options[T any] struct {
 	// OnRetry, if non-nil, fires after each *retryable* failure that is
 	// not the last attempt in the budget — i.e. exactly when a retry is
 	// about to be scheduled. Use it to emit per-attempt structured logs
-	// without coupling those log strings into this package.
+	// without coupling those log strings into this package. Also a good
+	// spot to release per-attempt resources (e.g. closing an HTTP
+	// response body before the next iteration replaces it).
 	OnRetry func(attempt int, value T, err error)
+
+	// OnRetryWait, if non-nil, returns an override for the wait
+	// duration before the next attempt. Returning <= 0 falls through to
+	// the Backoff strategy. Called once per inter-attempt gap, between
+	// Classify (which decided to retry) and OnRetry; the Backoff is
+	// still advanced via NextBackOff so its progression is unchanged.
+	//
+	// Intended for callsites that need response-driven waits — e.g. a
+	// transport that honors HTTP Retry-After headers when present and
+	// falls back to exponential backoff otherwise.
+	OnRetryWait func(value T, err error) time.Duration
 }
 
 // Do runs op until it produces a non-retryable outcome, the attempt budget
@@ -120,6 +133,11 @@ func Do[T any](
 		wait := opts.Backoff.NextBackOff()
 		if wait == backoff.Stop {
 			break
+		}
+		if opts.OnRetryWait != nil {
+			if override := opts.OnRetryWait(val, err); override > 0 {
+				wait = override
+			}
 		}
 
 		select {

--- a/internal/util/retry/retry_test.go
+++ b/internal/util/retry/retry_test.go
@@ -292,6 +292,67 @@ func TestDo_MaxAttemptsBelowOneCoercedToOne(t *testing.T) {
 	assert.Equal(t, 1, res.Attempts)
 }
 
+func TestDo_OnRetryWaitOverridesBackoff(t *testing.T) {
+	// Verifies that an OnRetryWait override takes precedence over the
+	// Backoff strategy's wait, while leaving the Backoff progression in
+	// place (it's still advanced via NextBackOff each iteration).
+	fakeClk := tclock.NewFakeClock(time.Now())
+	ctx := apctx.WithClock(context.Background(), fakeClk)
+
+	const huge = time.Hour      // Backoff returns this — would hang the test
+	const override = 7 * time.Second
+
+	calls := make(chan int, 5)
+	done := make(chan struct{}, 1)
+
+	go func() {
+		_, _ = Do(ctx, Options[string]{
+			MaxAttempts: 3,
+			Backoff:     &backoff.ConstantBackOff{Interval: huge},
+			OnRetryWait: func(_ string, _ error) time.Duration {
+				return override
+			},
+		}, func(ctx context.Context) (string, error) {
+			calls <- 1
+			return "", errors.New("transient")
+		})
+		done <- struct{}{}
+	}()
+
+	<-calls
+	require.Eventually(t, fakeClk.HasWaiters, time.Second, time.Millisecond)
+	// Step the override exactly — if OnRetryWait were ignored, the helper
+	// would still be waiting for the huge Backoff interval and the next
+	// call would not fire.
+	fakeClk.Step(override)
+	<-calls
+
+	require.Eventually(t, fakeClk.HasWaiters, time.Second, time.Millisecond)
+	fakeClk.Step(override)
+	<-calls
+
+	<-done
+}
+
+func TestDo_OnRetryWaitNonPositiveFallsBackToBackoff(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	_, err := Do(ctx, Options[string]{
+		MaxAttempts: 3,
+		Backoff:     &backoff.ConstantBackOff{Interval: 1 * time.Millisecond},
+		OnRetryWait: func(_ string, _ error) time.Duration {
+			return 0
+		},
+	}, func(ctx context.Context) (string, error) {
+		calls++
+		return "", errors.New("transient")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 3, calls, "OnRetryWait returning 0 must not short-circuit; Backoff still runs")
+}
+
 func TestLinearBackOff(t *testing.T) {
 	b := &LinearBackOff{Step: 100 * time.Millisecond}
 


### PR DESCRIPTION
Closes #358. Phase 2 of #277 — completes the retry consolidation.

## Summary
- `vaultRetryTransport.RoundTrip` now runs through `retry.Do`. The backoff math is `cenkalti/backoff/v5`'s `ExponentialBackOff` (2s init, 2× multiplier, 60s cap, 0.5 jitter); `Retry-After` is honored via a new `OnRetryWait` hook.
- Adds tests for the transport — there were none before. Six `TestVaultRetryTransport_*` cases (429-then-success, exhaustion, transport-error not retried, non-429 immediate, `Retry-After` honored, ctx cancel) plus a `TestParseVaultRetryAfter` table.

## API decision (resolves the open question from #277)

The vault transport needs a per-attempt wait override (the `Retry-After` header). I considered:

1. **Extend `Classifier` to return `(retry bool, waitOverride time.Duration)`** — would touch every Phase 1 callsite (`postRefreshWithRetry`, `postTokenExchangeWithRetry`, the disconnect revoke loop). Cleanest unified API but high churn for a hook only one callsite uses.
2. **Keep the outer loop in the transport** and use the helper only for backoff math. Smallest diff but doesn't really consolidate anything.
3. **Add `OnRetryWait` to `retry.Options`** — purely additive, existing callsites untouched. Returns `time.Duration`; `<= 0` falls through to the `Backoff` strategy. ← Chose this.

Option 3 keeps the orthogonality of the helper: `Classify` decides retryability, `OnRetry` is the per-attempt log/cleanup hook, `OnRetryWait` is the optional per-attempt wait override. The vault site is the only callsite that needs it, but the shape generalizes cleanly (anything that wants HTTP-aware backoff can use it).

## Response-body lifecycle
`OnRetry` closes the body between attempts — matching the pre-consolidation behavior, where the body of the **final** returned response is left open for the caller while intermediate retried bodies are drained for connection reuse.

## Test plan
- [x] `go test ./internal/util/retry/...` — new `TestDo_OnRetryWait*` cases plus the existing suite.
- [x] `go test ./internal/schema/config/...` — new `TestVaultRetryTransport_*` and `TestParseVaultRetryAfter` cases.
- [x] `go test ./internal/auth_methods/oauth2/... ./internal/core/...` — Phase 1 and Phase 3 callsites still green (no API change visible to them).
- [x] `./scripts/preflight.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)