### PR TITLE
CLI config: add JSON schema; common: add StringValueTemplatedEnvVars

### DIFF
--- a/cmd/cli/config/root.go
+++ b/cmd/cli/config/root.go
@@ -1,22 +1,23 @@
 package config
 
-import "gopkg.in/yaml.v3"
+import (
+	"context"
+
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	"gopkg.in/yaml.v3"
+)
 
 type Root struct {
-	AdminUsernameVal       string `json:"admin_username" yaml:"admin_username"`
-	AdminPrivateKeyPathVal string `json:"admin_private_key_path" yaml:"admin_private_key_path"`
-	AdminSharedKeyPathVal  string `json:"admin_shared_key_path" yaml:"admin_shared_key_path"`
+	AdminUsernameVal       scommon.StringValue `json:"admin_username" yaml:"admin_username"`
+	AdminPrivateKeyPathVal scommon.StringValue `json:"admin_private_key_path" yaml:"admin_private_key_path"`
+	AdminSharedKeyPathVal  scommon.StringValue `json:"admin_shared_key_path" yaml:"admin_shared_key_path"`
 	ServerVal              struct {
-		ApiVal         string `json:"api" yaml:"api"`
-		AdminApiVal    string `json:"admin_api" yaml:"admin_api"`
-		AuthVal        string `json:"auth" yaml:"auth"`
-		MarketplaceVal string `json:"marketplace" yaml:"marketplace"`
-		AdminUiVal     string `json:"admin_ui" yaml:"admin_ui"`
+		ApiVal         scommon.StringValue `json:"api" yaml:"api"`
+		AdminApiVal    scommon.StringValue `json:"admin_api" yaml:"admin_api"`
+		AuthVal        scommon.StringValue `json:"auth" yaml:"auth"`
+		MarketplaceVal scommon.StringValue `json:"marketplace" yaml:"marketplace"`
+		AdminUiVal     scommon.StringValue `json:"admin_ui" yaml:"admin_ui"`
 	} `json:"server" yaml:"server"`
-}
-
-func UnmarshallYamlRootString(data string) (*Root, error) {
-	return UnmarshallYamlRoot([]byte(data))
 }
 
 func UnmarshallYamlRoot(data []byte) (*Root, error) {
@@ -33,7 +34,11 @@ func (r *Root) AdminUsername() string {
 		return ""
 	}
 
-	return r.AdminUsernameVal
+	if val, err := r.AdminUsernameVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) AdminPrivateKeyPath() string {
@@ -41,7 +46,11 @@ func (r *Root) AdminPrivateKeyPath() string {
 		return ""
 	}
 
-	return r.AdminPrivateKeyPathVal
+	if val, err := r.AdminPrivateKeyPathVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) AdminSharedKeyPath() string {
@@ -49,7 +58,11 @@ func (r *Root) AdminSharedKeyPath() string {
 		return ""
 	}
 
-	return r.AdminSharedKeyPathVal
+	if val, err := r.AdminSharedKeyPathVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) ApiUrl() string {
@@ -57,7 +70,11 @@ func (r *Root) ApiUrl() string {
 		return ""
 	}
 
-	return r.ServerVal.ApiVal
+	if val, err := r.ServerVal.ApiVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) AdminApiUrl() string {
@@ -65,7 +82,11 @@ func (r *Root) AdminApiUrl() string {
 		return ""
 	}
 
-	return r.ServerVal.AdminApiVal
+	if val, err := r.ServerVal.AdminApiVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) AuthUrl() string {
@@ -73,7 +94,11 @@ func (r *Root) AuthUrl() string {
 		return ""
 	}
 
-	return r.ServerVal.AuthVal
+	if val, err := r.ServerVal.AuthVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) MarketplaceUrl() string {
@@ -81,7 +106,11 @@ func (r *Root) MarketplaceUrl() string {
 		return ""
 	}
 
-	return r.ServerVal.MarketplaceVal
+	if val, err := r.ServerVal.MarketplaceVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }
 
 func (r *Root) AdminUiUrl() string {
@@ -89,5 +118,9 @@ func (r *Root) AdminUiUrl() string {
 		return ""
 	}
 
-	return r.ServerVal.AdminUiVal
+	if val, err := r.ServerVal.AdminUiVal.GetValue(context.Background()); err == nil {
+		return val
+	}
+
+	return ""
 }

--- a/cmd/cli/config/root_test.go
+++ b/cmd/cli/config/root_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshallYamlRoot(t *testing.T) {
+	t.Run("minimal config", func(t *testing.T) {
+		data := []byte(`
+admin_username: bobdole
+admin_private_key_path: /home/bob/.authproxy/admin.key
+server:
+  api: http://localhost:8081
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		require.NotNil(t, root)
+
+		assert.Equal(t, "bobdole", root.AdminUsername())
+		assert.Equal(t, "/home/bob/.authproxy/admin.key", root.AdminPrivateKeyPath())
+		assert.Equal(t, "", root.AdminSharedKeyPath())
+		assert.Equal(t, "http://localhost:8081", root.ApiUrl())
+		assert.Equal(t, "", root.AdminApiUrl())
+		assert.Equal(t, "", root.AuthUrl())
+		assert.Equal(t, "", root.MarketplaceUrl())
+		assert.Equal(t, "", root.AdminUiUrl())
+	})
+
+	t.Run("full config with all server urls", func(t *testing.T) {
+		data := []byte(`
+admin_username: bobdole
+admin_private_key_path: /home/bob/.authproxy/admin.key
+admin_shared_key_path: /home/bob/.authproxy/shared.key
+server:
+  api: http://localhost:8081
+  admin_api: http://localhost:8082
+  auth: http://localhost:8080
+  marketplace: http://localhost:5173
+  admin_ui: http://localhost:5174
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+
+		assert.Equal(t, "bobdole", root.AdminUsername())
+		assert.Equal(t, "/home/bob/.authproxy/admin.key", root.AdminPrivateKeyPath())
+		assert.Equal(t, "/home/bob/.authproxy/shared.key", root.AdminSharedKeyPath())
+		assert.Equal(t, "http://localhost:8081", root.ApiUrl())
+		assert.Equal(t, "http://localhost:8082", root.AdminApiUrl())
+		assert.Equal(t, "http://localhost:8080", root.AuthUrl())
+		assert.Equal(t, "http://localhost:5173", root.MarketplaceUrl())
+		assert.Equal(t, "http://localhost:5174", root.AdminUiUrl())
+	})
+
+	t.Run("admin_username via env var", func(t *testing.T) {
+		t.Setenv("CLI_ROOT_TEST_USERNAME", "alice")
+		data := []byte(`
+admin_username:
+  env_var: CLI_ROOT_TEST_USERNAME
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		assert.Equal(t, "alice", root.AdminUsername())
+	})
+
+	t.Run("admin_username via env var with default", func(t *testing.T) {
+		data := []byte(`
+admin_username:
+  env_var: CLI_ROOT_TEST_UNSET_USERNAME
+  default: defaultuser
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		assert.Equal(t, "defaultuser", root.AdminUsername())
+	})
+
+	t.Run("admin_username via env var unset returns empty (not error)", func(t *testing.T) {
+		data := []byte(`
+admin_username:
+  env_var: CLI_ROOT_TEST_UNSET_USERNAME_NO_DEFAULT
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		assert.Equal(t, "", root.AdminUsername())
+	})
+
+	t.Run("server api via templated env vars", func(t *testing.T) {
+		t.Setenv("CLI_ROOT_TEST_HOST", "ap.example.com")
+		t.Setenv("CLI_ROOT_TEST_PORT", "8081")
+		data := []byte(`
+server:
+  api:
+    template_env_vars: http://{{CLI_ROOT_TEST_HOST}}:{{CLI_ROOT_TEST_PORT}}
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		assert.Equal(t, "http://ap.example.com:8081", root.ApiUrl())
+	})
+
+	t.Run("server api via templated env vars falls back to default when missing", func(t *testing.T) {
+		data := []byte(`
+server:
+  api:
+    template_env_vars: http://{{CLI_ROOT_TEST_MISSING}}:8081
+    default: http://localhost:8081
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8081", root.ApiUrl())
+	})
+
+	t.Run("empty config yields empty values", func(t *testing.T) {
+		root, err := UnmarshallYamlRoot([]byte(`{}`))
+		require.NoError(t, err)
+		require.NotNil(t, root)
+
+		assert.Equal(t, "", root.AdminUsername())
+		assert.Equal(t, "", root.AdminPrivateKeyPath())
+		assert.Equal(t, "", root.AdminSharedKeyPath())
+		assert.Equal(t, "", root.ApiUrl())
+		assert.Equal(t, "", root.AdminApiUrl())
+		assert.Equal(t, "", root.AuthUrl())
+		assert.Equal(t, "", root.MarketplaceUrl())
+		assert.Equal(t, "", root.AdminUiUrl())
+	})
+
+	t.Run("malformed yaml returns error", func(t *testing.T) {
+		_, err := UnmarshallYamlRoot([]byte("admin_username: : :"))
+		require.Error(t, err)
+	})
+}
+
+func TestRoot_NilReceiverSafety(t *testing.T) {
+	// All accessors must tolerate a nil receiver; the resolver relies on this when no
+	// config file is present.
+	var r *Root
+
+	assert.Equal(t, "", r.AdminUsername())
+	assert.Equal(t, "", r.AdminPrivateKeyPath())
+	assert.Equal(t, "", r.AdminSharedKeyPath())
+	assert.Equal(t, "", r.ApiUrl())
+	assert.Equal(t, "", r.AdminApiUrl())
+	assert.Equal(t, "", r.AuthUrl())
+	assert.Equal(t, "", r.MarketplaceUrl())
+	assert.Equal(t, "", r.AdminUiUrl())
+}

--- a/cmd/cli/config/schema.go
+++ b/cmd/cli/config/schema.go
@@ -1,0 +1,3 @@
+package config
+
+const SchemaIdCliConfig = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/cli/schema.json"

--- a/cmd/cli/config/schema.json
+++ b/cmd/cli/config/schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/cli/schema.json",
+  "$defs": {
+    "Server": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Base URL of the AuthProxy API service (e.g. http://localhost:8081)."
+        },
+        "admin_api": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Base URL of the AuthProxy Admin API service (e.g. http://localhost:8082)."
+        },
+        "auth": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Base URL of the AuthProxy auth/public service (e.g. http://localhost:8080)."
+        },
+        "marketplace": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Base URL of the marketplace UI (e.g. http://localhost:5173)."
+        },
+        "admin_ui": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Base URL of the admin UI (e.g. http://localhost:5174)."
+        }
+      },
+      "additionalProperties": false,
+      "description": "URLs the CLI uses to reach the various AuthProxy services. Each may be a direct string or any of the StringValue variants (env var, file, etc.)."
+    },
+    "Root": {
+      "type": "object",
+      "properties": {
+        "admin_username": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Username/actor id used when signing admin JWTs."
+        },
+        "admin_private_key_path": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Path to the RSA/EC private key used to sign admin JWTs."
+        },
+        "admin_shared_key_path": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Path to the shared (HMAC) secret used to sign admin JWTs. Mutually exclusive with admin_private_key_path."
+        },
+        "server": {
+          "$ref": "#/$defs/Server"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Root of the CLI config file (typically ~/.authproxy.yaml)."
+    }
+  },
+  "type": "object",
+  "$ref": "#/$defs/Root"
+}

--- a/cmd/cli/config/schema_test.go
+++ b/cmd/cli/config/schema_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaId struct {
+	Id string `json:"$id"`
+}
+
+func loadSchema(t *testing.T, c *jsonschemav5.Compiler, path string) string {
+	t.Helper()
+	schemaBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var sid schemaId
+	err = json.Unmarshal(schemaBytes, &sid)
+	require.NoError(t, err)
+
+	err = c.AddResource(sid.Id, bytes.NewReader(schemaBytes))
+	require.NoError(t, err)
+
+	return sid.Id
+}
+
+// commonSchemaPath is the relative path from cmd/cli/config to the internal common schema.
+const commonSchemaPath = "../../../internal/schema/common/schema.json"
+
+func Test_SchemaAgainstRealData(t *testing.T) {
+	c := jsonschemav5.NewCompiler()
+
+	_ = loadSchema(t, c, commonSchemaPath)
+	sid := loadSchema(t, c, "./schema.json")
+
+	require.Equal(t, SchemaIdCliConfig, sid, "schema ID should match SchemaIdCliConfig constant")
+
+	schema, err := c.Compile(sid)
+	require.NoError(t, err)
+
+	files, err := filepath.Glob("test_data/*.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no test files found")
+
+	for _, cfgPath := range files {
+		name := strings.TrimSuffix(filepath.Base(cfgPath), ".yaml")
+		if !strings.HasPrefix(name, "valid") && !strings.HasPrefix(name, "invalid") {
+			t.Fatalf("invalid test file name: %s; must start with valid or invalid", name)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			b, err := os.ReadFile(cfgPath)
+			require.NoError(t, err)
+
+			data, err := util.YamlBytesToJSON(b)
+			require.NoError(t, err)
+
+			var v interface{}
+			require.NoError(t, json.Unmarshal(data, &v))
+
+			err = schema.Validate(v)
+			shouldBeValid := strings.HasPrefix(name, "valid")
+			if shouldBeValid {
+				require.NoErrorf(t, err, "%s should be valid against schema", cfgPath)
+			} else {
+				require.Errorf(t, err, "%s should not be valid against schema", cfgPath)
+			}
+		})
+	}
+}
+
+type schemaTest struct {
+	Name  string
+	Valid bool
+	Data  string
+}
+
+func TestSchema(t *testing.T) {
+	tests := []struct {
+		Def   string
+		Cases []schemaTest
+	}{
+		{
+			Def: "Root",
+			Cases: []schemaTest{
+				{Name: "empty object", Valid: true, Data: `{}`},
+				{Name: "string admin_username", Valid: true, Data: `{"admin_username": "bob"}`},
+				{Name: "object admin_username via env var", Valid: true, Data: `{"admin_username": {"env_var": "USER"}}`},
+				{Name: "object admin_username via env var with default", Valid: true, Data: `{"admin_username": {"env_var": "USER", "default": "bob"}}`},
+				{Name: "object admin_username via path", Valid: true, Data: `{"admin_username": {"path": "/etc/user"}}`},
+				{Name: "object admin_username via template_env_vars", Valid: true, Data: `{"admin_username": {"template_env_vars": "{{ENV}}-{{USER}}"}}`},
+				{Name: "extra root property", Valid: false, Data: `{"unknown": "value"}`},
+				{Name: "non-object root", Valid: false, Data: `"not an object"`},
+				{Name: "admin_username bad form", Valid: false, Data: `{"admin_username": {"unknown_form": "x"}}`},
+				{Name: "server present and well-formed", Valid: true, Data: `{"server": {"api": "http://localhost:8081"}}`},
+				{Name: "server with all fields", Valid: true, Data: `{"server": {"api": "http://localhost:8081", "admin_api": "http://localhost:8082", "auth": "http://localhost:8080", "marketplace": "http://localhost:5173", "admin_ui": "http://localhost:5174"}}`},
+				{Name: "server extra property rejected", Valid: false, Data: `{"server": {"api": "http://localhost:8081", "bogus": "x"}}`},
+				{Name: "server is not an object", Valid: false, Data: `{"server": "http://localhost"}`},
+				{Name: "admin_private_key_path as env var", Valid: true, Data: `{"admin_private_key_path": {"env_var": "ADMIN_KEY_PATH"}}`},
+				{Name: "admin_shared_key_path as path", Valid: true, Data: `{"admin_shared_key_path": {"path": "~/.authproxy/shared.key"}}`},
+				{Name: "admin_username inline bool coerced", Valid: true, Data: `{"admin_username": true}`},
+				{Name: "admin_username inline number coerced", Valid: true, Data: `{"admin_username": 99}`},
+				{Name: "admin_username object with both value and env_var rejected", Valid: false, Data: `{"admin_username": {"value": "x", "env_var": "Y"}}`},
+				{Name: "admin_username object with value and extra rejected", Valid: false, Data: `{"admin_username": {"value": "x", "extra": "y"}}`},
+			},
+		},
+		{
+			Def: "Server",
+			Cases: []schemaTest{
+				{Name: "empty", Valid: true, Data: `{}`},
+				{Name: "api only", Valid: true, Data: `{"api": "http://localhost:8081"}`},
+				{Name: "all urls", Valid: true, Data: `{"api": "http://localhost:8081", "admin_api": "http://localhost:8082", "auth": "http://localhost:8080", "marketplace": "http://localhost:5173", "admin_ui": "http://localhost:5174"}`},
+				{Name: "api as env var", Valid: true, Data: `{"api": {"env_var": "API_URL", "default": "http://localhost:8081"}}`},
+				{Name: "extra property rejected", Valid: false, Data: `{"api": "http://localhost:8081", "extra": "bogus"}`},
+				{Name: "api inline bool coerced", Valid: true, Data: `{"api": true}`},
+				{Name: "api inline number coerced", Valid: true, Data: `{"api": 99}`},
+				{Name: "api object with mixed forms rejected", Valid: false, Data: `{"api": {"value": "x", "path": "/p"}}`},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Def, func(t *testing.T) {
+			c := jsonschemav5.NewCompiler()
+
+			_ = loadSchema(t, c, commonSchemaPath)
+			sid := loadSchema(t, c, "./schema.json")
+			require.Equal(t, SchemaIdCliConfig, sid)
+
+			wrapperId := "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/cli/test-" + tc.Def + ".json"
+			wrapper := `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "` + wrapperId + `",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["test"],
+  "properties": {
+    "test": { "$ref": "./schema.json#/$defs/` + tc.Def + `" }
+  }
+}`
+			require.NoError(t, c.AddResource(wrapperId, strings.NewReader(wrapper)))
+
+			schema, err := c.Compile(wrapperId)
+			require.NoError(t, err)
+
+			for _, tt := range tc.Cases {
+				t.Run(tt.Name, func(t *testing.T) {
+					var v interface{}
+					require.NoError(t, json.Unmarshal([]byte(`{"test": `+tt.Data+`}`), &v))
+
+					err = schema.Validate(v)
+					if tt.Valid {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+				})
+			}
+		})
+	}
+}

--- a/cmd/cli/config/test_data/invalid-bad-string-value.yaml
+++ b/cmd/cli/config/test_data/invalid-bad-string-value.yaml
@@ -1,0 +1,4 @@
+# $schema: ../schema.json
+
+admin_username:
+  unknown_form: bobdole

--- a/cmd/cli/config/test_data/invalid-extra-root-property.yaml
+++ b/cmd/cli/config/test_data/invalid-extra-root-property.yaml
@@ -1,0 +1,4 @@
+# $schema: ../schema.json
+
+admin_username: bobdole
+extra_property_not_allowed: oops

--- a/cmd/cli/config/test_data/invalid-extra-server-property.yaml
+++ b/cmd/cli/config/test_data/invalid-extra-server-property.yaml
@@ -1,0 +1,6 @@
+# $schema: ../schema.json
+
+admin_username: bobdole
+server:
+  api: http://localhost:8081
+  bogus: http://localhost:9999

--- a/cmd/cli/config/test_data/valid-empty.yaml
+++ b/cmd/cli/config/test_data/valid-empty.yaml
@@ -1,0 +1,3 @@
+# $schema: ../schema.json
+
+{}

--- a/cmd/cli/config/test_data/valid-env-vars.yaml
+++ b/cmd/cli/config/test_data/valid-env-vars.yaml
@@ -1,0 +1,18 @@
+# $schema: ../schema.json
+
+admin_username:
+  env_var: AUTHPROXY_ADMIN_USERNAME
+  default: bobdole
+admin_private_key_path:
+  path: ~/.authproxy/admin.key
+server:
+  api:
+    env_var: AUTHPROXY_API_URL
+    default: http://localhost:8081
+  admin_api:
+    template_env_vars: http://{{AUTHPROXY_HOST}}:{{AUTHPROXY_ADMIN_API_PORT}}
+    default: http://localhost:8082
+  marketplace:
+    env_var: AUTHPROXY_MARKETPLACE_URL
+  admin_ui:
+    value: http://localhost:5174

--- a/cmd/cli/config/test_data/valid-full.yaml
+++ b/cmd/cli/config/test_data/valid-full.yaml
@@ -1,0 +1,11 @@
+# $schema: ../schema.json
+
+admin_username: bobdole
+admin_private_key_path: /home/bob/.authproxy/admin.key
+admin_shared_key_path: /home/bob/.authproxy/shared.key
+server:
+  api: http://localhost:8081
+  admin_api: http://localhost:8082
+  auth: http://localhost:8080
+  marketplace: http://localhost:5173
+  admin_ui: http://localhost:5174

--- a/cmd/cli/config/test_data/valid-minimal.yaml
+++ b/cmd/cli/config/test_data/valid-minimal.yaml
@@ -1,0 +1,6 @@
+# $schema: ../schema.json
+
+admin_username: bobdole
+admin_private_key_path: /home/bob/.authproxy/admin.key
+server:
+  api: http://localhost:8081

--- a/internal/schema/common/schema.json
+++ b/internal/schema/common/schema.json
@@ -174,6 +174,24 @@
       "additionalProperties": false,
       "description": "A string value used in configuration"
     },
+    "StringValueTemplatedEnvVars": {
+      "properties": {
+        "template_env_vars": {
+          "type": "string",
+          "description": "A mustache-style template (e.g. 'https://{{HOST}}/api/{{VERSION}}') whose {{...}} tokens are substituted with the values of the corresponding environment variables. The primary value is considered absent if any referenced environment variable is unset or empty."
+        },
+        "default": {
+          "type": "string",
+          "description": "An optional, default value to use if any of the templated environment variables are not set."
+        }
+      },
+      "type": "object",
+      "required": [
+        "template_env_vars"
+      ],
+      "additionalProperties": false,
+      "description": "A string value rendered from a mustache template whose variables are read from environment variables."
+    },
     "StringValue": {
       "oneOf": [
         { "$ref": "#/$defs/StringValueInlineString" },
@@ -183,6 +201,7 @@
         { "$ref": "#/$defs/StringValueBase64" },
         { "$ref": "#/$defs/StringValueEnvVar" },
         { "$ref": "#/$defs/StringValueEnvVarBase64" },
+        { "$ref": "#/$defs/StringValueTemplatedEnvVars" },
         { "$ref": "#/$defs/StringValueFile" }
       ],
       "description": "A string value used in configuration that can be expressed in on of several ways."
@@ -238,6 +257,7 @@
         { "$ref": "#/$defs/StringValueBase64" },
         { "$ref": "#/$defs/StringValueEnvVar" },
         { "$ref": "#/$defs/StringValueEnvVarBase64" },
+        { "$ref": "#/$defs/StringValueTemplatedEnvVars" },
         { "$ref": "#/$defs/StringValueFile" }
       ],
       "description": "A boolean value used in configuration that can be expressed in on of several ways. When taken from other sources, the string value is parsed as a bool."

--- a/internal/schema/common/schema_test.go
+++ b/internal/schema/common/schema_test.go
@@ -512,6 +512,31 @@ func TestSchema(t *testing.T) {
 					Data:  `{"test": {"env_var_base64": "SOME_ENV_VAR", "default": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=", "other": "value"}}`,
 				},
 				{
+					Name:  "templated env vars",
+					Valid: true,
+					Data:  `{"test": {"template_env_vars": "https://{{HOST}}.example.com/api"}}`,
+				},
+				{
+					Name:  "templated env vars - default",
+					Valid: true,
+					Data:  `{"test": {"template_env_vars": "https://{{HOST}}.example.com/api", "default": "https://default.example.com/api"}}`,
+				},
+				{
+					Name:  "templated env vars - default - doesn't coerce number to string",
+					Valid: false,
+					Data:  `{"test": {"template_env_vars": "https://{{HOST}}.example.com/api", "default": 8080}}`,
+				},
+				{
+					Name:  "templated env vars - default - doesn't coerce bool to string",
+					Valid: false,
+					Data:  `{"test": {"template_env_vars": "https://{{HOST}}.example.com/api", "default": true}}`,
+				},
+				{
+					Name:  "templated env vars - other attributes",
+					Valid: false,
+					Data:  `{"test": {"template_env_vars": "https://{{HOST}}.example.com/api", "default": "https://default.example.com/api", "other": "value"}}`,
+				},
+				{
 					Name:  "file",
 					Valid: true,
 					Data:  `{"test": {"path": "/path/to/file"}}`,
@@ -716,6 +741,21 @@ func TestSchema(t *testing.T) {
 					Name:  "env var base64 - other attributes",
 					Valid: false,
 					Data:  `{"test": {"env_var_base64": "SOME_ENV_VAR", "default": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=", "other": "value"}}`,
+				},
+				{
+					Name:  "templated env vars",
+					Valid: true,
+					Data:  `{"test": {"template_env_vars": "{{SOME_BOOL}}"}}`,
+				},
+				{
+					Name:  "templated env vars - default",
+					Valid: true,
+					Data:  `{"test": {"template_env_vars": "{{SOME_BOOL}}", "default": "false"}}`,
+				},
+				{
+					Name:  "templated env vars - other attributes",
+					Valid: false,
+					Data:  `{"test": {"template_env_vars": "{{SOME_BOOL}}", "default": "false", "other": "value"}}`,
 				},
 				{
 					Name:  "file",

--- a/internal/schema/common/string_value_base64_test.go
+++ b/internal/schema/common/string_value_base64_test.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValueBase64_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-empty base64", func(t *testing.T) {
+		v := &StringValueBase64{Base64: base64.StdEncoding.EncodeToString([]byte("hello"))}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("empty base64", func(t *testing.T) {
+		v := &StringValueBase64{Base64: ""}
+		assert.False(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueBase64_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("decodes valid base64", func(t *testing.T) {
+		encoded := base64.StdEncoding.EncodeToString([]byte("hello world"))
+		v := &StringValueBase64{Base64: encoded}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", got)
+	})
+
+	t.Run("invalid base64 returns error", func(t *testing.T) {
+		v := &StringValueBase64{Base64: "not!valid!base64!!"}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("empty base64 returns empty string", func(t *testing.T) {
+		v := &StringValueBase64{Base64: ""}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+}
+
+func TestStringValueBase64_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueBase64
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueBase64{Base64: "aGVsbG8="}
+		clone := orig.Clone().(*StringValueBase64)
+		assert.Equal(t, orig, clone)
+		clone.Base64 = "Y2hhbmdlZA=="
+		assert.NotEqual(t, orig.Base64, clone.Base64)
+	})
+}

--- a/internal/schema/common/string_value_direct_test.go
+++ b/internal/schema/common/string_value_direct_test.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValueDirect_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-empty value", func(t *testing.T) {
+		v := &StringValueDirect{Value: "hello"}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		v := &StringValueDirect{Value: ""}
+		assert.False(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueDirect_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns value", func(t *testing.T) {
+		v := &StringValueDirect{Value: "hello"}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", got)
+	})
+
+	t.Run("returns empty value without error", func(t *testing.T) {
+		v := &StringValueDirect{Value: ""}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+}
+
+func TestStringValueDirect_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueDirect
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueDirect{Value: "hello", IsDirect: true, IsNonString: true}
+		clone := orig.Clone().(*StringValueDirect)
+		assert.Equal(t, orig, clone)
+		clone.Value = "changed"
+		assert.NotEqual(t, orig.Value, clone.Value)
+	})
+}

--- a/internal/schema/common/string_value_env_var_base64_test.go
+++ b/internal/schema/common/string_value_env_var_base64_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValueEnvVarBase64_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("env var set", func(t *testing.T) {
+		t.Setenv("TEST_SV_EVB_HAS", base64.StdEncoding.EncodeToString([]byte("hi")))
+		v := &StringValueEnvVarBase64{EnvVar: "TEST_SV_EVB_HAS"}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var unset, no default", func(t *testing.T) {
+		v := &StringValueEnvVarBase64{EnvVar: "TEST_SV_EVB_UNSET_NO_DEFAULT"}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var unset, with default", func(t *testing.T) {
+		v := &StringValueEnvVarBase64{
+			EnvVar:  "TEST_SV_EVB_UNSET_WITH_DEFAULT",
+			Default: util.ToPtr(base64.StdEncoding.EncodeToString([]byte("default"))),
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueEnvVarBase64_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("env var set returns decoded value", func(t *testing.T) {
+		t.Setenv("TEST_SV_EVB_GET", base64.StdEncoding.EncodeToString([]byte("decoded")))
+		v := &StringValueEnvVarBase64{EnvVar: "TEST_SV_EVB_GET"}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "decoded", got)
+	})
+
+	t.Run("env var unset with default returns decoded default", func(t *testing.T) {
+		v := &StringValueEnvVarBase64{
+			EnvVar:  "TEST_SV_EVB_GET_UNSET",
+			Default: util.ToPtr(base64.StdEncoding.EncodeToString([]byte("default-val"))),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "default-val", got)
+	})
+
+	t.Run("env var unset without default returns error", func(t *testing.T) {
+		v := &StringValueEnvVarBase64{EnvVar: "TEST_SV_EVB_GET_UNSET_NO_DEFAULT"}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid base64 returns error", func(t *testing.T) {
+		t.Setenv("TEST_SV_EVB_INVALID", "not!valid!base64!")
+		v := &StringValueEnvVarBase64{EnvVar: "TEST_SV_EVB_INVALID"}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("env var takes precedence over default", func(t *testing.T) {
+		t.Setenv("TEST_SV_EVB_PRECEDENCE", base64.StdEncoding.EncodeToString([]byte("from-env")))
+		v := &StringValueEnvVarBase64{
+			EnvVar:  "TEST_SV_EVB_PRECEDENCE",
+			Default: util.ToPtr(base64.StdEncoding.EncodeToString([]byte("default-val"))),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", got)
+	})
+}
+
+func TestStringValueEnvVarBase64_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueEnvVarBase64
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueEnvVarBase64{
+			EnvVar:  "FOO",
+			Default: util.ToPtr("aGVsbG8="),
+		}
+		clone := orig.Clone().(*StringValueEnvVarBase64)
+		assert.Equal(t, orig, clone)
+		clone.EnvVar = "CHANGED"
+		assert.NotEqual(t, orig.EnvVar, clone.EnvVar)
+	})
+}

--- a/internal/schema/common/string_value_env_var_test.go
+++ b/internal/schema/common/string_value_env_var_test.go
@@ -1,0 +1,118 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValueEnvVar_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("env var set", func(t *testing.T) {
+		t.Setenv("TEST_SV_EV_HAS", "value")
+		v := &StringValueEnvVar{EnvVar: "TEST_SV_EV_HAS"}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var unset, no default", func(t *testing.T) {
+		v := &StringValueEnvVar{EnvVar: "TEST_SV_EV_UNSET_NO_DEFAULT"}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var unset, with default", func(t *testing.T) {
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_UNSET_WITH_DEFAULT",
+			Default: util.ToPtr("default-val"),
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var unset, with empty default", func(t *testing.T) {
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_UNSET_EMPTY_DEFAULT",
+			Default: util.ToPtr(""),
+		}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var set to empty string falls back to default", func(t *testing.T) {
+		t.Setenv("TEST_SV_EV_EMPTY", "")
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_EMPTY",
+			Default: util.ToPtr("default-val"),
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueEnvVar_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("env var set returns env value", func(t *testing.T) {
+		t.Setenv("TEST_SV_EV_GET", "the-value")
+		v := &StringValueEnvVar{EnvVar: "TEST_SV_EV_GET"}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "the-value", got)
+	})
+
+	t.Run("env var unset with default returns default", func(t *testing.T) {
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_GET_UNSET",
+			Default: util.ToPtr("default-val"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "default-val", got)
+	})
+
+	t.Run("env var unset without default returns error", func(t *testing.T) {
+		v := &StringValueEnvVar{EnvVar: "TEST_SV_EV_GET_UNSET_NO_DEFAULT"}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("env var set to empty string falls back to default", func(t *testing.T) {
+		t.Setenv("TEST_SV_EV_GET_EMPTY", "")
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_GET_EMPTY",
+			Default: util.ToPtr("default-val"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "default-val", got)
+	})
+
+	t.Run("env var takes precedence over default", func(t *testing.T) {
+		t.Setenv("TEST_SV_EV_PRECEDENCE", "from-env")
+		v := &StringValueEnvVar{
+			EnvVar:  "TEST_SV_EV_PRECEDENCE",
+			Default: util.ToPtr("default-val"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", got)
+	})
+}
+
+func TestStringValueEnvVar_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueEnvVar
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueEnvVar{
+			EnvVar:  "FOO",
+			Default: util.ToPtr("bar"),
+		}
+		clone := orig.Clone().(*StringValueEnvVar)
+		assert.Equal(t, orig, clone)
+		clone.EnvVar = "CHANGED"
+		assert.NotEqual(t, orig.EnvVar, clone.EnvVar)
+	})
+}

--- a/internal/schema/common/string_value_file_test.go
+++ b/internal/schema/common/string_value_file_test.go
@@ -1,0 +1,93 @@
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.txt")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0600))
+	return path
+}
+
+func TestStringValueFile_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("existing file", func(t *testing.T) {
+		path := writeTempFile(t, "hello")
+		v := &StringValueFile{Path: path}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		v := &StringValueFile{Path: "/nonexistent/path/should/not/exist.txt"}
+		assert.False(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueFile_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads file contents", func(t *testing.T) {
+		path := writeTempFile(t, "contents of the file")
+		v := &StringValueFile{Path: path}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "contents of the file", got)
+	})
+
+	t.Run("empty file returns empty string", func(t *testing.T) {
+		path := writeTempFile(t, "")
+		v := &StringValueFile{Path: path}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		v := &StringValueFile{Path: "/nonexistent/path/should/not/exist.txt"}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("expands home directory", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		tmp, err := os.CreateTemp(home, "string_value_file_*.txt")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+		_, err = tmp.WriteString("from home")
+		require.NoError(t, err)
+		require.NoError(t, tmp.Close())
+
+		rel := filepath.Join("~", filepath.Base(tmp.Name()))
+		v := &StringValueFile{Path: rel}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "from home", got)
+	})
+}
+
+func TestStringValueFile_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueFile
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueFile{Path: "/some/path"}
+		clone := orig.Clone().(*StringValueFile)
+		assert.Equal(t, orig, clone)
+		clone.Path = "/different"
+		assert.NotEqual(t, orig.Path, clone.Path)
+	})
+}

--- a/internal/schema/common/string_value_serialization_json.go
+++ b/internal/schema/common/string_value_serialization_json.go
@@ -62,10 +62,12 @@ func (sv *StringValue) UnmarshalJSON(data []byte) error {
 		svi = &StringValueEnvVar{}
 	} else if _, ok := valueMap["env_var_base64"]; ok {
 		svi = &StringValueEnvVarBase64{}
+	} else if _, ok := valueMap["template_env_vars"]; ok {
+		svi = &StringValueTemplatedEnvVars{}
 	} else if _, ok := valueMap["path"]; ok {
 		svi = &StringValueFile{}
 	} else {
-		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path")
+		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, template_env_vars, path")
 	}
 
 	if err := json.Unmarshal(data, svi); err != nil {

--- a/internal/schema/common/string_value_serialization_yaml.go
+++ b/internal/schema/common/string_value_serialization_yaml.go
@@ -69,6 +69,9 @@ fieldLoop:
 		case "env_var_base64":
 			keyData = &StringValueEnvVarBase64{}
 			break fieldLoop
+		case "template_env_vars":
+			keyData = &StringValueTemplatedEnvVars{}
+			break fieldLoop
 		case "path":
 			keyData = &StringValueFile{}
 			break fieldLoop
@@ -76,7 +79,7 @@ fieldLoop:
 	}
 
 	if keyData == nil {
-		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, file")
+		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, template_env_vars, path")
 	}
 
 	if err := value.Decode(keyData); err != nil {

--- a/internal/schema/common/string_value_templated_env_vars.go
+++ b/internal/schema/common/string_value_templated_env_vars.go
@@ -1,0 +1,91 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cbroglie/mustache"
+)
+
+// StringValueTemplatedEnvVars is a string value whose final value is produced by rendering a
+// mustache template, substituting any `{{VAR}}` tokens with the values of the named environment
+// variables. The primary value is considered "not present" if any of the referenced env vars
+// are unset or empty; in that case the optional Default is used. If neither the templated value
+// nor the default is available, HasValue returns false and GetValue returns an error.
+type StringValueTemplatedEnvVars struct {
+	Template string  `json:"template_env_vars" yaml:"template_env_vars"`
+	Default  *string `json:"default,omitempty" yaml:"default,omitempty"`
+}
+
+// resolveEnvVars walks the template and looks up each referenced variable in the environment.
+// Returns the lookup map, whether every variable resolved to a non-empty value, and any
+// template-parsing error encountered.
+func (t *StringValueTemplatedEnvVars) resolveEnvVars() (map[string]any, bool, error) {
+	tmpl, err := mustache.ParseString(t.Template)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid template: %w", err)
+	}
+
+	data := map[string]any{}
+	allPresent := true
+	seen := map[string]struct{}{}
+	for _, tag := range tmpl.Tags() {
+		if tag.Type() != mustache.Variable {
+			continue
+		}
+		name := tag.Name()
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		val, present := os.LookupEnv(name)
+		if !present || len(val) == 0 {
+			allPresent = false
+			continue
+		}
+		data[name] = val
+	}
+
+	return data, allPresent, nil
+}
+
+func (t *StringValueTemplatedEnvVars) HasValue(ctx context.Context) bool {
+	_, allPresent, err := t.resolveEnvVars()
+	if err == nil && allPresent && len(t.Template) > 0 {
+		return true
+	}
+	return t.Default != nil && len(*t.Default) > 0
+}
+
+func (t *StringValueTemplatedEnvVars) GetValue(ctx context.Context) (string, error) {
+	data, allPresent, err := t.resolveEnvVars()
+	if err != nil {
+		return "", err
+	}
+
+	if allPresent && len(t.Template) > 0 {
+		rendered, err := mustache.Render(t.Template, data)
+		if err != nil {
+			return "", fmt.Errorf("failed to render template: %w", err)
+		}
+		return rendered, nil
+	}
+
+	if t.Default != nil {
+		return *t.Default, nil
+	}
+	return "", fmt.Errorf("one or more environment variables referenced by template '%s' do not have a value", t.Template)
+}
+
+func (t *StringValueTemplatedEnvVars) Clone() StringValueType {
+	if t == nil {
+		return nil
+	}
+
+	clone := *t
+	return &clone
+}
+
+var _ StringValueType = (*StringValueTemplatedEnvVars)(nil)

--- a/internal/schema/common/string_value_templated_env_vars_test.go
+++ b/internal/schema/common/string_value_templated_env_vars_test.go
@@ -1,0 +1,205 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringValueTemplatedEnvVars_HasValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("all env vars set", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_HOST", "api")
+		t.Setenv("TEST_SV_TPL_VERSION", "v1")
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_HOST}}.example.com/{{TEST_SV_TPL_VERSION}}",
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("one env var missing, no default", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_HOST2", "api")
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_HOST2}}.example.com/{{TEST_SV_TPL_VERSION_MISSING}}",
+		}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var missing, with default", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_VAR_MISSING_A}}.example.com",
+			Default:  util.ToPtr("https://default.example.com"),
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var missing with empty default", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_VAR_MISSING_B}}.example.com",
+			Default:  util.ToPtr(""),
+		}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("env var set to empty string treated as missing", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_EMPTY", "")
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_EMPTY}}.example.com",
+			Default:  util.ToPtr("https://default.example.com"),
+		}
+		assert.True(t, v.HasValue(ctx))
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://default.example.com", got)
+	})
+
+	t.Run("template with no variables", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://example.com/api",
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+
+	t.Run("empty template with no default", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{Template: ""}
+		assert.False(t, v.HasValue(ctx))
+	})
+
+	t.Run("empty template with default", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "",
+			Default:  util.ToPtr("a default"),
+		}
+		assert.True(t, v.HasValue(ctx))
+	})
+}
+
+func TestStringValueTemplatedEnvVars_GetValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("all env vars set, renders template", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_GET_HOST", "api")
+		t.Setenv("TEST_SV_TPL_GET_VERSION", "v2")
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_GET_HOST}}.example.com/{{TEST_SV_TPL_GET_VERSION}}",
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com/v2", got)
+	})
+
+	t.Run("missing env var falls back to default", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_GET_MISSING_A}}.example.com",
+			Default:  util.ToPtr("https://default.example.com"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://default.example.com", got)
+	})
+
+	t.Run("missing env var with no default returns error", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://{{TEST_SV_TPL_GET_MISSING_B}}.example.com",
+		}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("partial set falls back to default", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_GET_PARTIAL_A", "set")
+		v := &StringValueTemplatedEnvVars{
+			Template: "{{TEST_SV_TPL_GET_PARTIAL_A}}/{{TEST_SV_TPL_GET_PARTIAL_MISSING}}",
+			Default:  util.ToPtr("the-default"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "the-default", got)
+	})
+
+	t.Run("template with no variables returns template directly", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "https://example.com/api",
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/api", got)
+	})
+
+	t.Run("repeated variable resolves once", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_GET_REPEAT", "abc")
+		v := &StringValueTemplatedEnvVars{
+			Template: "{{TEST_SV_TPL_GET_REPEAT}}-{{TEST_SV_TPL_GET_REPEAT}}",
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "abc-abc", got)
+	})
+
+	t.Run("env var takes precedence over default when set", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_GET_PRECEDENCE", "from-env")
+		v := &StringValueTemplatedEnvVars{
+			Template: "{{TEST_SV_TPL_GET_PRECEDENCE}}",
+			Default:  util.ToPtr("default-val"),
+		}
+		got, err := v.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", got)
+	})
+
+	t.Run("malformed template returns error", func(t *testing.T) {
+		v := &StringValueTemplatedEnvVars{
+			Template: "{{unclosed",
+		}
+		_, err := v.GetValue(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestStringValueTemplatedEnvVars_Clone(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var v *StringValueTemplatedEnvVars
+		assert.Nil(t, v.Clone())
+	})
+
+	t.Run("clone is independent copy", func(t *testing.T) {
+		orig := &StringValueTemplatedEnvVars{
+			Template: "https://{{HOST}}.example.com",
+			Default:  util.ToPtr("https://default.example.com"),
+		}
+		clone := orig.Clone().(*StringValueTemplatedEnvVars)
+		assert.Equal(t, orig, clone)
+		clone.Template = "changed"
+		assert.NotEqual(t, orig.Template, clone.Template)
+	})
+}
+
+func TestStringValueTemplatedEnvVars_StringValueIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("HasValue routes through StringValue wrapper", func(t *testing.T) {
+		t.Setenv("TEST_SV_TPL_INT_A", "x")
+		sv := &StringValue{InnerVal: &StringValueTemplatedEnvVars{
+			Template: "{{TEST_SV_TPL_INT_A}}",
+		}}
+		assert.True(t, sv.HasValue(ctx))
+
+		got, err := sv.GetValue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "x", got)
+	})
+
+	t.Run("CloneValue produces equal wrapper", func(t *testing.T) {
+		sv := &StringValue{InnerVal: &StringValueTemplatedEnvVars{
+			Template: "{{HOST}}",
+			Default:  util.ToPtr("default"),
+		}}
+		clone := sv.CloneValue()
+		require.NotNil(t, clone)
+		assert.Equal(t, sv, clone)
+	})
+}

--- a/internal/schema/common/string_value_test.go
+++ b/internal/schema/common/string_value_test.go
@@ -63,6 +63,19 @@ func TestStringValue(t *testing.T) {
 				},
 			},
 			{
+				name: "templated env vars",
+				Val: &StringValueTemplatedEnvVars{
+					Template: "https://{{HOST}}.example.com/{{VERSION}}/api",
+				},
+			},
+			{
+				name: "templated env vars - default",
+				Val: &StringValueTemplatedEnvVars{
+					Template: "https://{{HOST}}.example.com/{{VERSION}}/api",
+					Default:  util.ToPtr("https://default.example.com/v1/api"),
+				},
+			},
+			{
 				name: "file",
 				Val: &StringValueFile{
 					Path: "/some/file",
@@ -146,6 +159,26 @@ value: some value
 					},
 					data: `
 base64: ywAAAAAAQABAAACAUwAOw==
+`,
+				},
+				{
+					name: "templated env vars",
+					expected: &StringValueTemplatedEnvVars{
+						Template: "https://{{HOST}}.example.com/api",
+					},
+					data: `
+template_env_vars: https://{{HOST}}.example.com/api
+`,
+				},
+				{
+					name: "templated env vars - default",
+					expected: &StringValueTemplatedEnvVars{
+						Template: "https://{{HOST}}.example.com/api",
+						Default:  util.ToPtr("https://default.example.com/api"),
+					},
+					data: `
+template_env_vars: https://{{HOST}}.example.com/api
+default: https://default.example.com/api
 `,
 				},
 			}
@@ -314,6 +347,21 @@ base64: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/1J8
 						Base64: "ywAAAAAAQABAAACAUwAOw==",
 					},
 					data: `{"base64":"ywAAAAAAQABAAACAUwAOw=="}`,
+				},
+				{
+					name: "templated env vars",
+					expected: &StringValueTemplatedEnvVars{
+						Template: "https://{{HOST}}.example.com/api",
+					},
+					data: `{"template_env_vars":"https://{{HOST}}.example.com/api"}`,
+				},
+				{
+					name: "templated env vars - default",
+					expected: &StringValueTemplatedEnvVars{
+						Template: "https://{{HOST}}.example.com/api",
+						Default:  util.ToPtr("https://default.example.com/api"),
+					},
+					data: `{"template_env_vars":"https://{{HOST}}.example.com/api","default":"https://default.example.com/api"}`,
 				},
 			}
 


### PR DESCRIPTION
## Summary

Two interlocking pieces shipped together because the second depends on the first:

- **`internal/schema/common` — new `StringValueTemplatedEnvVars` variant.** A `StringValue` can now be a mustache template (e.g. `https://{{HOST}}.example.com/{{VERSION}}`) whose `{{VAR}}` tokens are resolved against the environment. The primary value is treated as *absent* if any referenced env var is unset/empty (or renders to empty); the optional `default` is used in that case. Wired into the JSON + YAML discriminator dispatchers and added to the `StringValue` / `StringValueBool` `oneOf` lists.
- **`cmd/cli/config` — JSON schema for `~/.authproxy.yaml`.** Mirrors the `internal/schema/<pkg>` per-package layout (`schema.go` + `schema.json` + `schema_test.go` + `test_data/*.yaml`). Now that `Root`'s fields are `scommon.StringValue`, the CLI config file accepts every `StringValue` form — including the new `template_env_vars`.

Also fills in previously-missing `HasValue` / `GetValue` / `Clone` unit tests for `StringValueDirect` / `Base64` / `EnvVar` / `EnvVarBase64` / `File`.

The CLI config schema is self-contained in `cmd/cli/config` (not registered in the `internal/schema` global compiler) because that package's `embed.FS` walks only its own subtree and the CLI config has no cross-package consumers needing global lookup.

## Test plan

- [x] `go test ./internal/schema/common/...` passes
- [x] `go test ./cmd/cli/config/...` passes (including the `Test_SchemaAgainstRealData` runner over `test_data/`)
- [x] `./scripts/preflight.sh` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)