### PR TITLE
Fix config connector ID reuse for explicit versions

### DIFF
--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -478,6 +478,42 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 				return fmt.Errorf("connector %s currently has namespace path '%s' and cannot be changed to '%s'", configConnector.Id, results[0].Namespace, configConnector.GetNamespace())
 			}
 		}
+
+		if configConnector.HasVersion() {
+			existingVersion, err := s.db.GetConnectorVersionForLabelsAndVersion(ctx, labelSelector, configConnector.Version)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return fmt.Errorf("failed to check for existing connector version for precheck: %w", err)
+			}
+
+			if errors.Is(err, database.ErrNotFound) {
+				if len(results) == 0 {
+					if configConnector.Version != 1 {
+						return fmt.Errorf("connector with identifying labels %s does not have previous versions and must start with version 1", labelSelector)
+					}
+				} else {
+					newestVersion, err := s.db.NewestConnectorVersionForId(ctx, results[0].Id)
+					if err != nil && !errors.Is(err, database.ErrNotFound) {
+						return fmt.Errorf("failed to get newest version of connector for precheck: %w", err)
+					}
+					if newestVersion != nil && newestVersion.Version+1 != configConnector.Version {
+						return fmt.Errorf("connector with identifying labels %s currently has version %d and cannot be incremented to %d", labelSelector, newestVersion.Version, configConnector.Version)
+					}
+				}
+			} else {
+				if configConnector.State == "" {
+					// Unless specified, this is trying to be the primary version; important for hash
+					configConnector.State = string(database.ConnectorVersionStatePrimary)
+				}
+
+				if existingVersion.Namespace != configConnector.GetNamespace() {
+					return fmt.Errorf("connector with identifying labels %s currently has namespace '%s' and cannot be changed to %s", labelSelector, existingVersion.Namespace, configConnector.GetNamespace())
+				}
+
+				if existingVersion.State != database.ConnectorVersionStateDraft && existingVersion.Hash != configConnector.Hash() {
+					return fmt.Errorf("connector with identifying labels %s version %d has been published and cannot be modified", labelSelector, configConnector.Version)
+				}
+			}
+		}
 	}
 
 	return nil
@@ -553,7 +589,7 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 		// Pattern C: version only, no ID - use label-based lookup
 		labelValues := configConnector.GetIdentifyingLabelValues(identifyingLabels)
 		labelSelector := database.BuildLabelSelectorFromMap(labelValues)
-		existingVersion, err := s.db.GetConnectorVersionForLabelsAndVersion(ctx, labelSelector, configConnector.Version)
+		existingVersion, err = s.db.GetConnectorVersionForLabelsAndVersion(ctx, labelSelector, configConnector.Version)
 		if err != nil && !errors.Is(err, database.ErrNotFound) {
 			return apid.Nil, fmt.Errorf("failed to get connector version for labels/version: %w", err)
 		}
@@ -571,6 +607,15 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 			if err == nil && cv.Hash == existingVersion.Hash {
 				// No update required
 				return id, nil
+			}
+		} else {
+			existingVersion, err = s.db.GetConnectorVersionForLabels(ctx, labelSelector)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return apid.Nil, fmt.Errorf("failed to get connector version for labels: %w", err)
+			}
+
+			if existingVersion != nil {
+				id = existingVersion.Id
 			}
 		}
 	} else {

--- a/internal/core/service_migration_test.go
+++ b/internal/core/service_migration_test.go
@@ -922,6 +922,128 @@ func TestMigration(t *testing.T) {
 			})
 		})
 
+		t.Run("type and version", func(t *testing.T) {
+			t.Run("changed once preserves generated id", func(t *testing.T) {
+				cleanup := setup(t, []cschema.Connector{
+					{
+						Version:     1,
+						Labels:      map[string]string{"type": "fake"},
+						DisplayName: "initial",
+					},
+				})
+				defer cleanup()
+
+				err := service.MigrateConnectors(context.Background())
+				require.NoError(t, err)
+
+				cfg.GetRoot().Connectors.LoadFromList[0].Version = 2
+				cfg.GetRoot().Connectors.LoadFromList[0].DisplayName = "changed"
+
+				err = service.MigrateConnectors(context.Background())
+				require.NoError(t, err)
+
+				type connectorResult struct {
+					Id          string
+					Version     int64
+					State       string
+					DisplayName string
+				}
+
+				rows, err := rawDb.Query(withDisplayNameExpr(cfg, `
+			SELECT id, version, state, DISPLAY_NAME_EXPR as display_name
+			FROM connector_versions
+			WHERE deleted_at IS NULL
+			ORDER BY version;
+		`))
+				require.NoError(t, err)
+				defer rows.Close()
+
+				var results []connectorResult
+				for rows.Next() {
+					var result connectorResult
+					require.NoError(t, rows.Scan(&result.Id, &result.Version, &result.State, &result.DisplayName))
+					results = append(results, result)
+				}
+				require.NoError(t, rows.Err())
+				require.Len(t, results, 2)
+				require.Equal(t, results[0].Id, results[1].Id)
+				require.Equal(t, connectorResult{
+					Id:          results[0].Id,
+					Version:     1,
+					State:       "active",
+					DisplayName: "initial",
+				}, results[0])
+				require.Equal(t, connectorResult{
+					Id:          results[0].Id,
+					Version:     2,
+					State:       "primary",
+					DisplayName: "changed",
+				}, results[1])
+			})
+
+			t.Run("initial version must start at one", func(t *testing.T) {
+				cleanup := setup(t, []cschema.Connector{
+					{
+						Version:     2,
+						Labels:      map[string]string{"type": "fake"},
+						DisplayName: "initial",
+					},
+				})
+				defer cleanup()
+
+				err := service.MigrateConnectors(context.Background())
+				require.Error(t, err)
+
+				type connectorResult struct {
+					Id      string
+					Version int64
+					State   string
+				}
+
+				assertSqlWithDisplayName(t, rawDb, cfg, `
+			SELECT id, version, state FROM connector_versions WHERE deleted_at IS NULL;
+		`, []connectorResult{})
+			})
+
+			t.Run("cannot change published version", func(t *testing.T) {
+				cleanup := setup(t, []cschema.Connector{
+					{
+						Version:     1,
+						Labels:      map[string]string{"type": "fake"},
+						DisplayName: "initial",
+					},
+				})
+				defer cleanup()
+
+				err := service.MigrateConnectors(context.Background())
+				require.NoError(t, err)
+
+				cfg.GetRoot().Connectors.LoadFromList[0].DisplayName = "changed"
+
+				err = service.MigrateConnectors(context.Background())
+				require.Error(t, err)
+
+				type connectorResult struct {
+					Version     int64
+					State       string
+					DisplayName string
+				}
+
+				assertSqlWithDisplayName(t, rawDb, cfg, `
+			SELECT version, state, DISPLAY_NAME_EXPR as display_name
+			FROM connector_versions
+			WHERE deleted_at IS NULL
+			ORDER BY version;
+		`, []connectorResult{
+					{
+						Version:     1,
+						State:       "primary",
+						DisplayName: "initial",
+					},
+				})
+			})
+		})
+
 		t.Run("type only", func(t *testing.T) {
 			t.Run("single initial", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{


### PR DESCRIPTION
## Summary
- Reuse the existing connector ID when a config-defined connector has identifying labels plus an explicit new version but no explicit ID.
- Add precheck coverage for version-only configs, including sequential versioning and published-version immutability.
- Add regression coverage for the v1 to v2 config migration path.

Closes #2

## Tests
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -run TestMigration -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -count=1
- ./scripts/preflight.sh