### PR TITLE
Fix Vault integration workflow startup

### DIFF
--- a/.github/workflows/vault-integration.yml
+++ b/.github/workflows/vault-integration.yml
@@ -1,6 +1,9 @@
 # schema: https://json.schemastore.org/github-workflow.json
 name: HashiCorp Vault Integration Tests
 
+env:
+  VAULT_IMAGE: hashicorp/vault:1.20.4
+
 on:
   push:
     branches: [ "main" ]
@@ -76,11 +79,19 @@ jobs:
           -e VAULT_DEV_ROOT_TOKEN_ID=dev-only-token \
           -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
           -e SKIP_SETCAP=true \
-          hashicorp/vault:latest server -dev
+          "$VAULT_IMAGE" server -dev
         for i in $(seq 1 30); do
-          curl -sf http://localhost:8200/v1/sys/health && break
+          if curl -sf http://localhost:8200/v1/sys/health; then
+            exit 0
+          fi
+          if ! docker ps --format '{{.Names}}' | grep -qx vault; then
+            docker logs vault
+            exit 1
+          fi
           sleep 1
         done
+        docker logs vault
+        exit 1
 
     - name: HashiCorp Vault Integration Tests
       working-directory: integration_tests

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -115,7 +115,7 @@ Or start Vault ad hoc:
 ```bash
 docker run -d --name vault -p 8200:8200 --cap-add=IPC_LOCK \
   -e VAULT_DEV_ROOT_TOKEN_ID=dev-only-token \
-  hashicorp/vault:latest server -dev
+  hashicorp/vault:1.20.4 server -dev
 ```
 
 Notes:

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       "
 
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.20.4
     ports:
       - "8200:8200"
     environment:


### PR DESCRIPTION
## Summary
- Pin the Vault integration workflow to a known Vault image tag instead of floating latest
- Fail the Vault startup step immediately with container logs if Vault exits or never becomes healthy
- Keep local integration compose/docs aligned with the CI Vault image

## Tests
- go test -tags "integration,vault" ./encrypt/... (from integration_tests; Vault test skips unless AUTH_PROXY_VAULT_TEST=1)
- ./scripts/preflight.sh