### PR TITLE
Switch ClickHouse request-log store to golang-migrate (#260)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
+github.com/ClickHouse/clickhouse-go v1.4.3 h1:iAFMa2UrQdR5bHJ2/yaSLffZkxpcOYQMCUuKeNXGdqc=
+github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
@@ -97,6 +99,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
+github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=

--- a/internal/request_log/migrations/clickhouse/000001_create_entry_records.down.sql
+++ b/internal/request_log/migrations/clickhouse/000001_create_entry_records.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS http_log_entry_records;

--- a/internal/request_log/migrations/clickhouse/000001_create_entry_records.up.sql
+++ b/internal/request_log/migrations/clickhouse/000001_create_entry_records.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS http_log_entry_records (
+    request_id String,
+    namespace String,
+    type String,
+    correlation_id String DEFAULT '',
+    timestamp_ms Int64,
+    duration_ms Int64 DEFAULT 0,
+    connection_id String DEFAULT '',
+    connector_id String DEFAULT '',
+    connector_version UInt64 DEFAULT 0,
+    method String DEFAULT '',
+    host String DEFAULT '',
+    scheme String DEFAULT '',
+    path String DEFAULT '',
+    response_status_code Int32 DEFAULT 0,
+    response_error String DEFAULT '',
+    request_http_version String DEFAULT '',
+    request_size_bytes Int64 DEFAULT 0,
+    request_mime_type String DEFAULT '',
+    response_http_version String DEFAULT '',
+    response_size_bytes Int64 DEFAULT 0,
+    response_mime_type String DEFAULT '',
+    internal_timeout Bool DEFAULT false,
+    request_cancelled Bool DEFAULT false,
+    full_request_recorded Bool DEFAULT false,
+    labels String DEFAULT '{}'
+) ENGINE = MergeTree()
+ORDER BY (namespace, timestamp_ms, request_id);

--- a/internal/request_log/migrations/clickhouse/000002_add_response_source_and_rate_limit.down.sql
+++ b/internal/request_log/migrations/clickhouse/000002_add_response_source_and_rate_limit.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE http_log_entry_records
+    DROP COLUMN IF EXISTS rate_limit_matched,
+    DROP COLUMN IF EXISTS rate_limit_bucket,
+    DROP COLUMN IF EXISTS rate_limit_mode,
+    DROP COLUMN IF EXISTS rate_limit_id,
+    DROP COLUMN IF EXISTS response_source;

--- a/internal/request_log/migrations/clickhouse/000002_add_response_source_and_rate_limit.up.sql
+++ b/internal/request_log/migrations/clickhouse/000002_add_response_source_and_rate_limit.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE http_log_entry_records
+    ADD COLUMN IF NOT EXISTS response_source String DEFAULT 'upstream',
+    ADD COLUMN IF NOT EXISTS rate_limit_id String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS rate_limit_mode String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS rate_limit_bucket String DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS rate_limit_matched String DEFAULT '[]';

--- a/internal/request_log/migrations/clickhouse/000003_add_body_skipped.down.sql
+++ b/internal/request_log/migrations/clickhouse/000003_add_body_skipped.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE http_log_entry_records
+    DROP COLUMN IF EXISTS request_body_skipped,
+    DROP COLUMN IF EXISTS response_body_skipped;

--- a/internal/request_log/migrations/clickhouse/000003_add_body_skipped.up.sql
+++ b/internal/request_log/migrations/clickhouse/000003_add_body_skipped.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE http_log_entry_records
+    ADD COLUMN IF NOT EXISTS request_body_skipped String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS response_body_skipped String DEFAULT '';

--- a/internal/request_log/provider_clickhouse.go
+++ b/internal/request_log/provider_clickhouse.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	sq "github.com/Masterminds/squirrel"
+	"github.com/golang-migrate/migrate/v4"
+	chmigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
@@ -124,49 +127,48 @@ func (s *clickhouseRecordStore) StoreRecord(ctx context.Context, record *LogReco
 
 func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 	s.logger.Info("running clickhouse http log migrations")
+	defer s.logger.Info("clickhouse http log migrations complete")
 
-	ddl := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		request_id String,
-		namespace String,
-		type String,
-		correlation_id String,
-		timestamp_ms Int64,
-		duration_ms Int64,
-		connection_id String,
-		connector_id String,
-		connector_version UInt64,
-		method String,
-		host String,
-		scheme String,
-		path String,
-		response_status_code Int32,
-		response_error String,
-		request_http_version String,
-		request_size_bytes Int64,
-		request_mime_type String,
-		response_http_version String,
-		response_size_bytes Int64,
-		response_mime_type String,
-		internal_timeout Bool,
-		request_cancelled Bool,
-		full_request_recorded Bool,
-		labels String DEFAULT '{}',
-		response_source String DEFAULT 'upstream',
-		rate_limit_id String DEFAULT '',
-		rate_limit_mode String DEFAULT '',
-		rate_limit_bucket String DEFAULT '{}',
-		rate_limit_matched String DEFAULT '[]',
-		request_body_skipped String DEFAULT '',
-		response_body_skipped String DEFAULT ''
-	) ENGINE = MergeTree()
-	ORDER BY (namespace, timestamp_ms, request_id)`, entryRecordsTable)
-
-	_, err := s.db.ExecContext(ctx, ddl)
+	src, err := iofs.New(httpLogMigrationsFs, "migrations/clickhouse")
 	if err != nil {
-		return fmt.Errorf("failed to create clickhouse table: %w", err)
+		return fmt.Errorf("failed to load clickhouse http log migrations: %w", err)
 	}
 
-	s.logger.Info("clickhouse http log migrations complete")
+	var dbName string
+	if s.cfg.Database != nil {
+		dbName, err = s.cfg.Database.GetValue(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to resolve clickhouse database name: %w", err)
+		}
+	}
+
+	driver, err := chmigrate.WithInstance(s.db, &chmigrate.Config{
+		DatabaseName:          dbName,
+		MultiStatementEnabled: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to setup clickhouse http log migration driver: %w", err)
+	}
+
+	m, err := migrate.NewWithInstance("iofs", src, "clickhouse", driver)
+	if err != nil {
+		return fmt.Errorf("failed to setup clickhouse http log migrator: %w", err)
+	}
+	defer func() {
+		sourceErr, dbErr := m.Close()
+		if sourceErr != nil || dbErr != nil {
+			s.logger.Warn("failed to close clickhouse migrator", "source_err", sourceErr, "db_err", dbErr)
+		}
+	}()
+
+	if err := m.Up(); err != nil {
+		if errors.Is(err, migrate.ErrNoChange) {
+			s.logger.Info("no clickhouse http log migrations required")
+			return nil
+		}
+		return fmt.Errorf("failed to migrate clickhouse http log database: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Step 1 of #260. The request-log package supports three providers (sqlite, postgres, clickhouse) for the entry-records database, but ClickHouse was the odd one out: its schema was applied via inline DDL in `clickhouseRecordStore.Migrate`, while sqlite/postgres go through `golang-migrate` with embedded migration files. This PR brings ClickHouse in line so future schema changes follow one pattern across all three providers.

- New `internal/request_log/migrations/clickhouse/` tree mirroring the sqlite/postgres trees, with three up/down pairs:
  - `000001_create_entry_records` — `CREATE TABLE ... ENGINE = MergeTree() ORDER BY (namespace, timestamp_ms, request_id)` using ClickHouse types (`String`, `Int32`/`Int64`/`UInt64`, `Bool`).
  - `000002_add_response_source_and_rate_limit` — adds `response_source` + rate-limit columns via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`.
  - `000003_add_body_skipped` — adds `request_body_skipped` + `response_body_skipped`.
- `clickhouseRecordStore.Migrate` now uses `chmigrate.WithInstance` on the existing `*sql.DB`, with `MultiStatementEnabled: true`, applying migrations from the embedded `migrations/clickhouse` source — same `iofs` + `migrate.NewWithInstance` shape as `sqlRecordStore.Migrate`. Inline DDL is gone.
- `go.sum` picks up `github.com/golang-migrate/migrate/v4/database/clickhouse` and a transitive v1 clickhouse-go that the driver self-registers under the `clickhouse://` DSN scheme (harmless — we go through `WithInstance` so the v1 driver isn't used at runtime).

This unblocks step 2 (a three-provider test harness for `internal/request_log`), which lands in a follow-up PR.

## Test plan

- [x] `go build ./internal/request_log/...`
- [x] `go test ./internal/request_log/...` (default SQLite path — green)
- [x] `./scripts/preflight.sh`
- [ ] End-to-end ClickHouse `Migrate()` exercised once the step-2 test harness lands and the CI matrix runs request_log tests against ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)