### PR TITLE
Rename ConnectionState: Created→Setup, Ready→Configured (#363)

### DIFF
--- a/integration_tests/api_key/auto_reauth_test.go
+++ b/integration_tests/api_key/auto_reauth_test.go
@@ -65,7 +65,7 @@ func TestApiKeyAutoReauth(t *testing.T) {
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
 	cReady := env.GetConnection(t, connectionID)
-	require.Equal(t, database.ConnectionStateReady, cReady.State)
+	require.Equal(t, database.ConnectionStateConfigured, cReady.State)
 	require.Equal(t, database.ConnectionHealthStateHealthy, cReady.HealthState,
 		"connection should be healthy after a successful verify")
 
@@ -78,7 +78,7 @@ func TestApiKeyAutoReauth(t *testing.T) {
 		"probe should fail after upstream rotation invalidated the stored key")
 
 	cUnhealthy := env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, cUnhealthy.State,
+	assert.Equal(t, database.ConnectionStateConfigured, cUnhealthy.State,
 		"state should still be Ready — only health_state flips")
 	require.Equal(t, database.ConnectionHealthStateUnhealthy, cUnhealthy.HealthState,
 		"connection should be unhealthy after one failed probe (threshold=1)")
@@ -101,7 +101,7 @@ func TestApiKeyAutoReauth(t *testing.T) {
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
 	cRecovered := env.GetConnection(t, connectionID)
-	require.Equal(t, database.ConnectionStateReady, cRecovered.State)
+	require.Equal(t, database.ConnectionStateConfigured, cRecovered.State)
 	require.Equal(t, database.ConnectionHealthStateHealthy, cRecovered.HealthState,
 		"connection should be healthy again after submitting the new key")
 

--- a/integration_tests/api_key/initiate_flow_test.go
+++ b/integration_tests/api_key/initiate_flow_test.go
@@ -157,7 +157,7 @@ func runPerPlacementLifecycle(
 	require.NoError(t, env.RunVerifyConnection(t, connectionID), "verify should succeed against stub upstream")
 
 	conn2 := env.GetConnection(t, connectionID)
-	require.Equalf(t, database.ConnectionStateReady, conn2.State,
+	require.Equalf(t, database.ConnectionStateConfigured, conn2.State,
 		"connection should be Ready after submit + verify; got %s (setup_step=%v, setup_error=%v)",
 		conn2.State, conn2.SetupStep, conn2.SetupError)
 	assert.Equal(t, database.ConnectionHealthStateHealthy, conn2.HealthState,

--- a/integration_tests/api_key/probe_acceleration_test.go
+++ b/integration_tests/api_key/probe_acceleration_test.go
@@ -185,6 +185,6 @@ func countPendingProbeTasksForConnection(t *testing.T, env *helpers.IntegrationT
 		}
 		count++
 	}
-	_ = database.ConnectionStateReady // keep import referenced
+	_ = database.ConnectionStateConfigured // keep import referenced
 	return count
 }

--- a/integration_tests/api_key/rotation_test.go
+++ b/integration_tests/api_key/rotation_test.go
@@ -52,7 +52,7 @@ func TestApiKeyManualRotation(t *testing.T) {
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
 	cReady := env.GetConnection(t, connectionID)
-	require.Equal(t, database.ConnectionStateReady, cReady.State)
+	require.Equal(t, database.ConnectionStateConfigured, cReady.State)
 
 	// Snapshot the active credential row before rotation so we can confirm
 	// the row id changes (i.e. a new row was inserted, not the old one
@@ -98,7 +98,7 @@ func TestApiKeyManualRotation(t *testing.T) {
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
 	cAfter := env.GetConnection(t, connectionID)
-	require.Equal(t, database.ConnectionStateReady, cAfter.State)
+	require.Equal(t, database.ConnectionStateConfigured, cAfter.State)
 	assert.Equal(t, database.ConnectionHealthStateHealthy, cAfter.HealthState)
 
 	// 5. Active credential row was replaced — different id, different

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -635,7 +635,7 @@ func (env *IntegrationTestEnv) CreateConnection(t *testing.T, connectorID apid.I
 		Namespace:        sconfig.RootNamespace,
 		ConnectorId:      connectorID,
 		ConnectorVersion: connectorVersion,
-		State:            database.ConnectionStateCreated,
+		State:            database.ConnectionStateSetup,
 	})
 	require.NoError(t, err)
 

--- a/integration_tests/oauth2/callback_actor_mismatch_test.go
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.go
@@ -156,7 +156,7 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 
 	// 7. Connection still in `created`, no setup_step transition.
 	conn := env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection state should remain `created` after a rejected callback")
 	assert.Nil(t, conn.SetupStep, "no setup_step should be recorded on a rejected callback")
 	assert.Nil(t, conn.SetupError, "no setup_error should be recorded on a rejected callback")

--- a/integration_tests/oauth2/callback_cross_namespace_test.go
+++ b/integration_tests/oauth2/callback_cross_namespace_test.go
@@ -166,7 +166,7 @@ func TestCallbackRejection_CrossNamespace(t *testing.T) {
 	require.Nil(t, env.GetOAuth2Token(t, connID), "no oauth2_token row should exist for the rejected callback")
 
 	conn := env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection state should remain `created` after a rejected callback")
 	assert.Nil(t, conn.SetupStep, "no setup_step should be recorded on a rejected callback")
 	assert.Nil(t, conn.SetupError, "no setup_error should be recorded on a rejected callback")

--- a/integration_tests/oauth2/callback_namespace_mismatch_test.go
+++ b/integration_tests/oauth2/callback_namespace_mismatch_test.go
@@ -115,7 +115,7 @@ func TestCallbackRejection_NamespaceMismatchActor(t *testing.T) {
 	// rejected callback never reached the token exchange.
 	require.Nil(t, env.GetOAuth2Token(t, connID))
 	connAfter := env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateCreated, connAfter.State)
+	assert.Equal(t, database.ConnectionStateSetup, connAfter.State)
 
 	tokenReqs := provider.Requests(helpers.RequestsFilter{
 		Endpoint: helpers.EndpointToken,
@@ -227,7 +227,7 @@ func TestCallbackRejection_NamespaceMismatchConnection(t *testing.T) {
 	require.Nil(t, env.GetOAuth2Token(t, bobConnID),
 		"bob's connection must not have a token attached after a rejected forgery")
 	bobConnAfter := env.GetConnection(t, bobConnID)
-	assert.Equal(t, database.ConnectionStateCreated, bobConnAfter.State,
+	assert.Equal(t, database.ConnectionStateSetup, bobConnAfter.State,
 		"bob's connection state should remain `created`")
 	assert.Nil(t, bobConnAfter.SetupStep)
 	assert.Nil(t, bobConnAfter.SetupError)

--- a/integration_tests/oauth2/callback_state_security_test.go
+++ b/integration_tests/oauth2/callback_state_security_test.go
@@ -130,7 +130,7 @@ func (r *callbackStateSecurityRig) requireNoToken(t *testing.T, connectionID str
 func (r *callbackStateSecurityRig) requireConnectionUnchanged(t *testing.T, connectionID string) {
 	t.Helper()
 	conn := r.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection state should remain `created` after a rejected callback")
 	assert.Nil(t, conn.SetupStep, "no setup_step should be recorded on a rejected callback")
 	assert.Nil(t, conn.SetupError, "no setup_error should be recorded on a rejected callback")

--- a/integration_tests/oauth2/callback_token_exchange_failure_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_failure_test.go
@@ -147,7 +147,7 @@ func (r *tokenExchangeFailureRig) requireOneFailureEvent(t *testing.T, category 
 func (r *tokenExchangeFailureRig) requireAuthFailedConnection(t *testing.T, connectionID, errorSubstring string) {
 	t.Helper()
 	conn := r.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection state should remain `created` on token-exchange failure")
 	require.NotNilf(t, conn.SetupStep, "auth-failed connection should have a setup_step recorded")
 	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),

--- a/integration_tests/oauth2/callback_token_exchange_malformed_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_malformed_test.go
@@ -268,7 +268,7 @@ func TestTokenExchangeMalformed_CurrentlyAccepted(t *testing.T) {
 
 			// Connection advanced to Ready, no auth_failed setup_step.
 			conn := rig.env.GetConnection(t, connID)
-			assert.Equalf(t, database.ConnectionStateReady, conn.State,
+			assert.Equalf(t, database.ConnectionStateConfigured, conn.State,
 				"%s (%s): accepted exchange should transition to Ready", tc.name, tc.note)
 			assert.Nilf(t, conn.SetupStep,
 				"%s (%s): accepted exchange must not record an auth_failed setup_step", tc.name, tc.note)

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.go
@@ -148,7 +148,7 @@ func TestTokenExchange_TransientRetrySucceeds(t *testing.T) {
 		"successful retry should land on return_to_url; got %q", loc)
 
 	conn := rig.env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"retried success must transition the connection to ready")
 	assert.Nil(t, conn.SetupStep, "successful retry must not record an auth_failed setup_step")
 	assert.Nil(t, conn.SetupError, "successful retry must not record a setup_error")
@@ -212,7 +212,7 @@ func TestTokenExchange_TransientRetryExhausted(t *testing.T) {
 	require.Nil(t, rig.env.GetOAuth2Token(t, connID))
 
 	conn := rig.env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State)
+	assert.Equal(t, database.ConnectionStateSetup, conn.State)
 	require.NotNil(t, conn.SetupStep)
 	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
 		"exhausted retry should land in auth_failed; got %q", conn.SetupStep.String())

--- a/integration_tests/oauth2/pkce_test.go
+++ b/integration_tests/oauth2/pkce_test.go
@@ -212,7 +212,7 @@ func TestPKCE_HappyPath_S256(t *testing.T) {
 		"PKCE success path token should not be pre-expired (expires_at=%s)", token.AccessTokenExpiresAt)
 
 	conn := env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"PKCE success path should land the connection in ready")
 
 	// Provider must have observed a /token POST carrying code_verifier.
@@ -438,7 +438,7 @@ func TestPKCE_TokenExchangeRejected(t *testing.T) {
 			// stays `created` because the connection never reached the
 			// credentials-established transition.
 			connAfter := env.GetConnection(t, connID)
-			assert.Equal(t, database.ConnectionStateCreated, connAfter.State,
+			assert.Equal(t, database.ConnectionStateSetup, connAfter.State,
 				"connection state should remain `created` on PKCE rejection")
 			require.NotNilf(t, connAfter.SetupStep,
 				"PKCE-rejected connection should have a setup_step recorded")

--- a/integration_tests/oauth2/provider_timeouts_test.go
+++ b/integration_tests/oauth2/provider_timeouts_test.go
@@ -113,7 +113,7 @@ func TestTokenExchangeTimeout_RetriesAndExhausts(t *testing.T) {
 
 	// Connection in auth_failed terminal state.
 	conn := rig.env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State)
+	assert.Equal(t, database.ConnectionStateSetup, conn.State)
 	require.NotNil(t, conn.SetupStep)
 	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
 		"exhausted timeout should land in auth_failed; got %q", conn.SetupStep.String())
@@ -276,7 +276,7 @@ func TestUpstreamApiTimeout_SurfacedToCaller(t *testing.T) {
 	// is not a credential problem; flipping unhealthy here would
 	// paint a working connection broken.
 	conn := rig.env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"upstream transport failure must not change the connection state")
 	assert.Equalf(t, database.ConnectionHealthStateHealthy, conn.HealthState,
 		"upstream transport failure must not flip the connection unhealthy; got %q", conn.HealthState)

--- a/integration_tests/oauth2/scope_mismatch_test.go
+++ b/integration_tests/oauth2/scope_mismatch_test.go
@@ -206,7 +206,7 @@ func TestScopeMismatch_RequiredMissing(t *testing.T) {
 	connectionID := s.driveApprovalAndGetConnectionId(t)
 
 	conn := s.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection should remain in created state when required scopes are missing")
 	require.NotNilf(t, conn.SetupStep, "auth-failed connection should have a setup_step")
 	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
@@ -240,7 +240,7 @@ func TestScopeMismatch_OptionalMissing(t *testing.T) {
 	connectionID := s.driveApprovalAndGetConnectionId(t)
 
 	conn := s.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"missing-optional should not block the connection from going ready")
 
 	token := s.env.GetOAuth2Token(t, connectionID)
@@ -269,7 +269,7 @@ func TestScopeMismatch_AllScopesGranted(t *testing.T) {
 	connectionID := s.driveApprovalAndGetConnectionId(t)
 
 	conn := s.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State)
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State)
 
 	token := s.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, token)
@@ -298,7 +298,7 @@ func TestScopeMismatch_ExtraGranted(t *testing.T) {
 	connectionID := s.driveApprovalAndGetConnectionId(t)
 
 	conn := s.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"extra scopes should not block the connection from going ready")
 
 	token := s.env.GetOAuth2Token(t, connectionID)
@@ -332,7 +332,7 @@ func TestScopeMismatch_ProviderOmitsScope(t *testing.T) {
 	connectionID := s.driveApprovalAndGetConnectionId(t)
 
 	conn := s.env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State)
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State)
 
 	token := s.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, token)

--- a/integration_tests/oauth2/standard_flow_test.go
+++ b/integration_tests/oauth2/standard_flow_test.go
@@ -150,7 +150,7 @@ func TestStandardAuthorizationCodeFlow(t *testing.T) {
 
 	// 7. Connection lands in `ready` (no probes/configure on this connector).
 	conn := env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"connection should be ready after a successful flow with no probes/configure steps")
 
 	// 8. Proxy a request to the provider's resource endpoint and expect 200.

--- a/integration_tests/oauth2/user_denial_test.go
+++ b/integration_tests/oauth2/user_denial_test.go
@@ -143,7 +143,7 @@ func TestUserDenialFlow(t *testing.T) {
 	// 5. Connection sits in the auth_failed setup phase, retryable. State stays
 	//    at `created` because we never reached HandleCredentialsEstablished.
 	conn := env.GetConnection(t, connectionID)
-	assert.Equal(t, database.ConnectionStateCreated, conn.State,
+	assert.Equal(t, database.ConnectionStateSetup, conn.State,
 		"connection should remain in created state when authorization was denied")
 	require.NotNilf(t, conn.SetupStep, "denied connection should have a setup_step recorded")
 	assert.Truef(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),

--- a/integration_tests/probes/oauth2_probe_health_test.go
+++ b/integration_tests/probes/oauth2_probe_health_test.go
@@ -120,7 +120,7 @@ func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
 	require.NoError(t, env.RunVerifyConnection(t, connID))
 
 	conn := env.GetConnection(t, connID)
-	require.Equal(t, database.ConnectionStateReady, conn.State,
+	require.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"connection should land Ready after a successful verify")
 	require.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState,
 		"healthy is the baseline after a successful initial verify")
@@ -142,7 +142,7 @@ func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
 	require.Error(t, probeErr, "probe must surface upstream 401 as a failure outcome")
 
 	conn = env.GetConnection(t, connID)
-	assert.Equal(t, database.ConnectionStateReady, conn.State,
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
 		"state should still be Ready — only health_state flips on probe failures")
 	require.Equal(t, database.ConnectionHealthStateUnhealthy, conn.HealthState,
 		"failure_threshold=1: a single failed probe must flip health to unhealthy")

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -22,7 +22,7 @@ func newTestConnectionWithService(s *service) *connection {
 		Connection: database.Connection{
 			Id:               connId,
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
 		},

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -44,8 +44,8 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to clear setup step: %w", err)
 		}
 	}
-	if c.GetState() != database.ConnectionStateReady {
-		if err := c.SetState(ctx, database.ConnectionStateReady); err != nil {
+	if c.GetState() != database.ConnectionStateConfigured {
+		if err := c.SetState(ctx, database.ConnectionStateConfigured); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set connection ready: %w", err)
 		}
 	}

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -64,13 +64,13 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		conn.SetupStep = &authStep
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.False(t, outcome.SetupPending)
 		assert.Nil(t, conn.GetSetupStep())
-		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+		assert.Equal(t, database.ConnectionStateConfigured, conn.GetState())
 	})
 
 	t.Run("marks ready when no setup step and no probes/configure", func(t *testing.T) {
@@ -79,13 +79,13 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
 
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.False(t, outcome.SetupPending)
 		assert.Nil(t, conn.GetSetupStep())
-		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+		assert.Equal(t, database.ConnectionStateConfigured, conn.GetState())
 	})
 }
 

--- a/internal/core/connection_probe_health_test.go
+++ b/internal/core/connection_probe_health_test.go
@@ -76,7 +76,7 @@ func newProbeHealthTestConn(
 		Connection: database.Connection{
 			Id:               connId,
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      initialHealth,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -325,7 +325,7 @@ func TestRecordPeriodicProbeOutcome_ApiKeyStampsLastValidatedAt(t *testing.T) {
 		Connection: database.Connection{
 			Id:               connId,
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -368,7 +368,7 @@ func TestRecordPeriodicProbeOutcome_OAuth2SkipsLastValidatedAt(t *testing.T) {
 		Connection: database.Connection{
 			Id:               connId,
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),

--- a/internal/core/connection_test.go
+++ b/internal/core/connection_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newTestConnection(c cschema.Connector) *connection {
-	return newTestConnectionWithDetails(apid.New(apid.PrefixActor), database.ConnectionStateReady, c)
+	return newTestConnectionWithDetails(apid.New(apid.PrefixActor), database.ConnectionStateConfigured, c)
 }
 
 func newTestConnectionWithDetails(u apid.ID, s database.ConnectionState, c cschema.Connector) *connection {

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -36,7 +36,7 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 		if err := c.SetSetupStep(ctx, nil); err != nil {
 			return fmt.Errorf("failed to clear setup step after verify: %w", err)
 		}
-		if err := c.SetState(ctx, database.ConnectionStateReady); err != nil {
+		if err := c.SetState(ctx, database.ConnectionStateConfigured); err != nil {
 			return fmt.Errorf("failed to set connection ready after verify: %w", err)
 		}
 		return nil

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -40,12 +40,12 @@ func TestOnVerifyPassed(t *testing.T) {
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)
 		assert.Nil(t, conn.GetSetupStep())
-		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+		assert.Equal(t, database.ConnectionStateConfigured, conn.GetState())
 	})
 
 	t.Run("flips health back to healthy when previously unhealthy", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestOnVerifyPassed(t *testing.T) {
 
 		db.EXPECT().SetConnectionHealthState(gomock.Any(), conn.Id, database.ConnectionHealthStateHealthy).Return(nil)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -179,7 +179,7 @@ func (m *Connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResp
 }
 
 func (m *Connection) CancelSetup(ctx context.Context) error {
-	if m.State != database.ConnectionStateReady {
+	if m.State != database.ConnectionStateConfigured {
 		return fmt.Errorf("connection is not in a state that can cancel setup")
 	}
 	m.SetupStep = nil

--- a/internal/core/mock/setup.go
+++ b/internal/core/mock/setup.go
@@ -24,7 +24,7 @@ func MockConnectionRetrieval(ctx context.Context, dbMock *mockDb.MockDB, e *mock
 		GetConnection(gomock.Any(), connUuuid).
 		Return(&database.Connection{
 			Id:               connUuuid,
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			ConnectorId:      c.Id,
 			ConnectorVersion: c.Version,
 			CreatedAt:        clock.Now(),

--- a/internal/core/probe_http_test.go
+++ b/internal/core/probe_http_test.go
@@ -50,7 +50,7 @@ func newProbeTestConnection(t *testing.T, ctrl *gomock.Controller, def cschema.C
 		Connection: database.Connection{
 			Id:               apid.New(apid.PrefixConnection),
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -210,7 +210,7 @@ func TestProbeHttp_RawHttp_Success(t *testing.T) {
 		Connection: database.Connection{
 			Id:               apid.New(apid.PrefixConnection),
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -250,7 +250,7 @@ func TestProbeHttp_RawHttp_Non2xxIsFailure(t *testing.T) {
 		Connection: database.Connection{
 			Id:               apid.New(apid.PrefixConnection),
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),

--- a/internal/core/probe_no_op_test.go
+++ b/internal/core/probe_no_op_test.go
@@ -29,7 +29,7 @@ func TestProbeNoOp_Invoke(t *testing.T) {
 		Connection: database.Connection{
 			Id:               apid.New(apid.PrefixConnection),
 			Namespace:        "root",
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),

--- a/internal/core/service_connection_cancel_setup.go
+++ b/internal/core/service_connection_cancel_setup.go
@@ -13,7 +13,7 @@ import (
 // is already ready — abandoning setup mid-creation should use AbortConnection, which
 // also revokes credentials and removes the connection.
 func (c *connection) CancelSetup(ctx context.Context) error {
-	if c.GetState() != database.ConnectionStateReady {
+	if c.GetState() != database.ConnectionStateConfigured {
 		return httperr.BadRequest("connection is not in a state that can cancel setup")
 	}
 

--- a/internal/core/service_connection_cancel_setup_test.go
+++ b/internal/core/service_connection_cancel_setup_test.go
@@ -21,7 +21,7 @@ func TestCancelSetup(t *testing.T) {
 				Steps: []cschema.SetupFlowStep{{Id: "x", JsonSchema: workspaceSchema}},
 			},
 		})
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
 		conn.SetupStep = &step
 		errMsg := "stale"
@@ -33,7 +33,7 @@ func TestCancelSetup(t *testing.T) {
 		require.NoError(t, conn.CancelSetup(context.Background()))
 		assert.Nil(t, conn.GetSetupStep())
 		assert.Nil(t, conn.GetSetupError())
-		assert.Equal(t, database.ConnectionStateReady, conn.GetState())
+		assert.Equal(t, database.ConnectionStateConfigured, conn.GetState())
 	})
 
 	t.Run("no-op when ready and nothing to clear", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestCancelSetup(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 
 		require.NoError(t, conn.CancelSetup(context.Background()))
 	})
@@ -51,7 +51,7 @@ func TestCancelSetup(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-		conn.State = database.ConnectionStateCreated
+		conn.State = database.ConnectionStateSetup
 
 		err := conn.CancelSetup(context.Background())
 		require.Error(t, err)

--- a/internal/core/service_connection_create.go
+++ b/internal/core/service_connection_create.go
@@ -39,7 +39,7 @@ func (s *service) CreateConnection(
 		ConnectorVersion: cv.GetVersion(),
 		CreatedAt:        now,
 		UpdatedAt:        now,
-		State:            database.ConnectionStateCreated,
+		State:            database.ConnectionStateSetup,
 	}
 
 	err = s.db.CreateConnection(ctx, &dbConn)

--- a/internal/core/service_connection_reauth.go
+++ b/internal/core/service_connection_reauth.go
@@ -38,7 +38,7 @@ func (s *service) ReauthConnection(ctx context.Context, id apid.ID, returnToUrl 
 		return nil, err
 	}
 
-	if conn.GetState() != database.ConnectionStateReady {
+	if conn.GetState() != database.ConnectionStateConfigured {
 		return nil, httperr.BadRequest("connection is not in a reauthable state")
 	}
 

--- a/internal/core/service_connection_reauth_test.go
+++ b/internal/core/service_connection_reauth_test.go
@@ -24,7 +24,7 @@ func TestReauthConnection(t *testing.T) {
 		conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 			Type: cschema.ApiKeyPlacementBearer,
 		}, nil)
-		conn.State = database.ConnectionStateCreated
+		conn.State = database.ConnectionStateSetup
 
 		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
 		db.EXPECT().GetConnectorVersion(gomock.Any(), conn.cv.Id, conn.cv.Version).Return(&database.ConnectorVersion{
@@ -51,7 +51,7 @@ func TestReauthConnection(t *testing.T) {
 		conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 			Type: cschema.ApiKeyPlacementBearer,
 		}, nil)
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
 
 		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
@@ -93,7 +93,7 @@ func TestReauthConnection(t *testing.T) {
 		conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 			Type: cschema.ApiKeyPlacementBearer,
 		}, nil)
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 		conn.HealthState = database.ConnectionHealthStateUnhealthy
 
 		db.EXPECT().GetConnection(gomock.Any(), conn.Id).Return(&conn.Connection, nil).AnyTimes()
@@ -122,7 +122,7 @@ func TestReauthConnection(t *testing.T) {
 		conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 			Type: cschema.ApiKeyPlacementBearer,
 		}, nil)
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 		priorErr := "earlier verify error that should be wiped"
 		conn.SetupError = &priorErr
 
@@ -171,7 +171,7 @@ func TestReauthConnection(t *testing.T) {
 			Connection: database.Connection{
 				Id:               "cxn_test1111111111aa",
 				Namespace:        "root",
-				State:            database.ConnectionStateReady,
+				State:            database.ConnectionStateConfigured,
 				HealthState:      database.ConnectionHealthStateUnhealthy,
 				ConnectorId:      cv.GetId(),
 				ConnectorVersion: cv.GetVersion(),
@@ -224,7 +224,7 @@ func TestReauthConnection(t *testing.T) {
 			Connection: database.Connection{
 				Id:               "cxn_test1111111111aa",
 				Namespace:        "root",
-				State:            database.ConnectionStateReady,
+				State:            database.ConnectionStateConfigured,
 				HealthState:      database.ConnectionHealthStateHealthy,
 				ConnectorId:      cv.GetId(),
 				ConnectorVersion: cv.GetVersion(),

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -13,7 +13,7 @@ import (
 // its setup step to the first configure step. The connection must be in the ready
 // state and its connector must have configure steps defined.
 func (c *connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResponse, error) {
-	if c.GetState() != database.ConnectionStateReady {
+	if c.GetState() != database.ConnectionStateConfigured {
 		return nil, httperr.BadRequest("connection must be in ready state to reconfigure")
 	}
 

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -24,7 +24,7 @@ func TestReconfigure(t *testing.T) {
 				},
 			},
 		})
-		conn.State = database.ConnectionStateCreated
+		conn.State = database.ConnectionStateSetup
 
 		_, err := conn.Reconfigure(context.Background())
 		require.Error(t, err)
@@ -42,7 +42,7 @@ func TestReconfigure(t *testing.T) {
 				},
 			},
 		})
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 
 		_, err := conn.Reconfigure(context.Background())
 		require.Error(t, err)
@@ -54,7 +54,7 @@ func TestReconfigure(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, nil)
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 
 		_, err := conn.Reconfigure(context.Background())
 		require.Error(t, err)
@@ -72,7 +72,7 @@ func TestReconfigure(t *testing.T) {
 				},
 			},
 		})
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 
@@ -99,7 +99,7 @@ func TestReconfigure(t *testing.T) {
 				},
 			},
 		})
-		conn.State = database.ConnectionStateReady
+		conn.State = database.ConnectionStateConfigured
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
 

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -77,7 +77,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		if err := c.SetSetupStep(ctx, nil); err != nil {
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to clear setup step: %w", err))
 		}
-		if err := c.SetState(ctx, database.ConnectionStateReady); err != nil {
+		if err := c.SetState(ctx, database.ConnectionStateConfigured); err != nil {
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to set connection state to ready: %w", err))
 		}
 		return &iface.ConnectionSetupComplete{

--- a/internal/core/service_connection_submit_api_key_test.go
+++ b/internal/core/service_connection_submit_api_key_test.go
@@ -49,7 +49,7 @@ func newTestApiKeyConnection(
 		Connection: database.Connection{
 			Id:               "cxn_test1111111111aa",
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -107,7 +107,7 @@ func TestApiKeySubmit_BearerPersistsCredentialAndAdvancesToReady(t *testing.T) {
 		InsertApiKeyCredential(gomock.Any(), conn.Id, credCap, gomock.AssignableToTypeOf(&cschema.ApiKeyPlacement{}), &actorId).
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 	resp, err := conn.SubmitForm(ctx, iface.SubmitConnectionRequest{
 		StepId: cschema.SynthesizedApiKeyCredentialsStepId,
@@ -142,7 +142,7 @@ func TestApiKeySubmit_BasicPersistsBothCredentialFields(t *testing.T) {
 		InsertApiKeyCredential(gomock.Any(), conn.Id, credCap, gomock.AssignableToTypeOf(&cschema.ApiKeyPlacement{}), &actorId).
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 	resp, err := conn.SubmitForm(ctx, iface.SubmitConnectionRequest{
 		StepId: cschema.SynthesizedApiKeyCredentialsStepId,
@@ -202,7 +202,7 @@ func TestApiKeySubmit_NoReplay_PriorCredentialNeverDecryptedIntoForm(t *testing.
 		InsertApiKeyCredential(gomock.Any(), conn.Id, gomock.Any(), gomock.Any(), &actorId).
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 	// CRITICAL: GetActiveApiKeyCredential must NOT be called during submit.
 	// gomock fails ctrl.Finish() if submit reads the prior credential.
@@ -257,7 +257,7 @@ func TestApiKeySubmit_PreconnectFieldNamedApiKeyIsNotTreatedAsCredential(t *test
 		Connection: database.Connection{
 			Id:               "cxn_test2222222222aa",
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
 		},
@@ -329,7 +329,7 @@ func TestApiKeySubmit_TransitionsToConfigureWhenNoProbes(t *testing.T) {
 		Connection: database.Connection{
 			Id:               "cxn_test3333333333aa",
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
 		},
@@ -459,7 +459,7 @@ func TestApiKeySubmit_RejectsUnknownAuthTypeOnCredentialsPhase(t *testing.T) {
 		Connection: database.Connection{
 			Id:               "cxn_test4444444444aa",
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
 		},

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -59,7 +59,7 @@ func newTestConnectionWithSetupFlowAndAsynq(t *testing.T, ctrl *gomock.Controlle
 		Connection: database.Connection{
 			Id:               "cxn_test1111111111aa",
 			Namespace:        "root",
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			HealthState:      database.ConnectionHealthStateHealthy,
 			ConnectorId:      cv.GetId(),
 			ConnectorVersion: cv.GetVersion(),
@@ -188,7 +188,7 @@ func TestSubmitForm(t *testing.T) {
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
 			StepId: "workspace",
@@ -244,7 +244,7 @@ func TestSubmitForm(t *testing.T) {
 		// Second submit — merges workspace into existing config
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateReady).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
 
 		resp, err = conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
 			StepId: "step2",

--- a/internal/core/service_migration_test.go
+++ b/internal/core/service_migration_test.go
@@ -1655,7 +1655,7 @@ func TestMigration(t *testing.T) {
 					Namespace:        "root",
 					ConnectorId:      apid.MustParse("cxr_test0000000000002"),
 					ConnectorVersion: 1,
-					State:            database.ConnectionStateReady,
+					State:            database.ConnectionStateConfigured,
 				})
 				require.NoError(t, err)
 

--- a/internal/core/service_probe_now_test.go
+++ b/internal/core/service_probe_now_test.go
@@ -35,7 +35,7 @@ func TestEnqueueProbeNow_EnqueuesEachProbeWhenThrottleAllows(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -66,7 +66,7 @@ func TestEnqueueProbeNow_ThrottleSkipsEnqueue(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -98,7 +98,7 @@ func TestEnqueueProbeNow_MixedThrottle(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -134,7 +134,7 @@ func TestEnqueueProbeNow_NoProbesShortCircuits(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -166,7 +166,7 @@ func TestEnqueueProbeNow_RedisErrorIsSwallowedPerProbe(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,

--- a/internal/core/service_tasks.go
+++ b/internal/core/service_tasks.go
@@ -29,8 +29,8 @@ func (s *service) GetCronTasks() []*asynq.PeriodicTaskConfig {
 	err := s.db.ListConnectionsBuilder().
 		WithDeletedHandling(database.DeletedHandlingExclude).
 		ForStates([]database.ConnectionState{
-			database.ConnectionStateCreated,
-			database.ConnectionStateReady,
+			database.ConnectionStateSetup,
+			database.ConnectionStateConfigured,
 		}).
 		Enumerate(
 			context.Background(),

--- a/internal/core/task_probe_test.go
+++ b/internal/core/task_probe_test.go
@@ -40,7 +40,7 @@ func TestRunProbe_Success(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -91,7 +91,7 @@ func TestRunProbe_FailureBelowThreshold(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -144,7 +144,7 @@ func TestRunProbe_FailureCrossesThreshold(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -187,7 +187,7 @@ func TestRunProbe_ProbeNotFound(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,

--- a/internal/core/task_verify_connection_test.go
+++ b/internal/core/task_verify_connection_test.go
@@ -86,7 +86,7 @@ func TestRunVerifyConnection_NoProbes_AdvancesToReady(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateCreated,
+		State:            database.ConnectionStateSetup,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -102,7 +102,7 @@ func TestRunVerifyConnection_NoProbes_AdvancesToReady(t *testing.T) {
 		SetConnectionSetupStep(gomock.Any(), connectionId, (*cschema.SetupStep)(nil)).
 		Return(nil)
 	db.EXPECT().
-		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateReady).
+		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
 		Return(nil)
 
 	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
@@ -123,7 +123,7 @@ func TestRunVerifyConnection_StalePhase_SkipsCleanly(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,
@@ -184,7 +184,7 @@ func TestRunVerifyConnection_ProbeFailure(t *testing.T) {
 	conn := &database.Connection{
 		Id:               connectionId,
 		Namespace:        "root",
-		State:            database.ConnectionStateCreated,
+		State:            database.ConnectionStateSetup,
 		HealthState:      database.ConnectionHealthStateHealthy,
 		ConnectorId:      connector.Id,
 		ConnectorVersion: connector.Version,

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -29,8 +29,15 @@ func init() {
 type ConnectionState string
 
 const (
-	ConnectionStateCreated       ConnectionState = "created"
-	ConnectionStateReady         ConnectionState = "ready"
+	// ConnectionStateSetup is the initial state — a connection in setup
+	// has been persisted and has one or more setup steps in progress.
+	ConnectionStateSetup ConnectionState = "setup"
+	// ConnectionStateConfigured means setup is complete. The connection
+	// may or may not be currently usable; whether the credentials still
+	// work is the orthogonal ConnectionHealthState axis (e.g. an OAuth2
+	// connection with a revoked refresh token stays Configured but flips
+	// unhealthy until reauth).
+	ConnectionStateConfigured    ConnectionState = "configured"
 	ConnectionStateDisabled      ConnectionState = "disabled"
 	ConnectionStateDisconnecting ConnectionState = "disconnecting"
 	ConnectionStateDisconnected  ConnectionState = "disconnected"
@@ -38,8 +45,8 @@ const (
 
 func IsValidConnectionState[T string | ConnectionState](state T) bool {
 	switch ConnectionState(state) {
-	case ConnectionStateCreated,
-		ConnectionStateReady,
+	case ConnectionStateSetup,
+		ConnectionStateConfigured,
 		ConnectionStateDisabled,
 		ConnectionStateDisconnecting,
 		ConnectionStateDisconnected:
@@ -50,11 +57,12 @@ func IsValidConnectionState[T string | ConnectionState](state T) bool {
 }
 
 // ConnectionHealthState is the operational health signal for a connection,
-// distinct from its lifecycle state. A connection can be Ready and unhealthy
-// simultaneously — for example, an OAuth2 connection whose refresh token has
-// been revoked stays in ConnectionStateReady but flips to unhealthy until the
-// user re-authenticates. Probe-driven and refresh-driven signals both write
-// to this field; UI surfaces it to drive the unified reauth action.
+// distinct from its lifecycle state. A connection can be Configured and
+// unhealthy simultaneously — for example, an OAuth2 connection whose refresh
+// token has been revoked stays in ConnectionStateConfigured but flips to
+// unhealthy until the user re-authenticates. Probe-driven and refresh-driven
+// signals both write to this field; UI surfaces it to drive the unified
+// reauth action.
 type ConnectionHealthState string
 
 const (

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -23,7 +23,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		}
 		assert.Error(t, c.Validate())
 	})
@@ -33,7 +33,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root",
 			ConnectorId:      apid.New(apid.PrefixActor), // wrong prefix
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		}
 		assert.Error(t, c.Validate())
 	})
@@ -48,7 +48,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		assert.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestConnections(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, c)
 		assert.Equal(t, c.Id, u)
-		assert.Equal(t, c.State, ConnectionStateCreated)
+		assert.Equal(t, c.State, ConnectionStateSetup)
 		assert.True(t, c.CreatedAt.Equal(now))
 		assert.True(t, c.UpdatedAt.Equal(now))
 	})
@@ -75,7 +75,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Labels:           labels,
 		})
 		assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated})
+			State:            ConnectionStateSetup})
 		assert.NoError(t, err)
 
 		test_utils.AssertSql(t, rawDb, `
@@ -119,7 +119,7 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateCreated),
+				State:     string(ConnectionStateSetup),
 				DeletedAt: nil,
 			},
 		})
@@ -134,7 +134,7 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateCreated),
+				State:     string(ConnectionStateSetup),
 				DeletedAt: nil,
 			},
 		})
@@ -147,7 +147,7 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateCreated),
+				State:     string(ConnectionStateSetup),
 				DeletedAt: &now,
 			},
 		})
@@ -174,7 +174,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		assert.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateCreated),
+				State:     string(ConnectionStateSetup),
 				UpdatedAt: now,
 			},
 		})
@@ -192,7 +192,7 @@ func TestConnections(t *testing.T) {
 		ctx = apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(newNow)).Build()
 
 		// Attempt update for connection that does not exist
-		err = db.SetConnectionState(ctx, apid.New(apid.PrefixConnection), ConnectionStateReady)
+		err = db.SetConnectionState(ctx, apid.New(apid.PrefixConnection), ConnectionStateConfigured)
 		assert.ErrorIs(t, err, ErrNotFound)
 
 		// Unchanged
@@ -201,12 +201,12 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateCreated),
+				State:     string(ConnectionStateSetup),
 				UpdatedAt: now,
 			},
 		})
 
-		err = db.SetConnectionState(ctx, u, ConnectionStateReady)
+		err = db.SetConnectionState(ctx, u, ConnectionStateConfigured)
 		assert.NoError(t, err)
 
 		test_utils.AssertSql(t, rawDb, `
@@ -214,7 +214,7 @@ func TestConnections(t *testing.T) {
 		`, []connectionResult{
 			{
 				Id:        u.String(),
-				State:     string(ConnectionStateReady),
+				State:     string(ConnectionStateConfigured),
 				UpdatedAt: newNow,
 			},
 		})
@@ -230,7 +230,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		assert.NoError(t, err)
 
@@ -239,7 +239,7 @@ func TestConnections(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Attempting to set state on a soft-deleted connection should return ErrNotFound
-		err = db.SetConnectionState(ctx, u, ConnectionStateReady)
+		err = db.SetConnectionState(ctx, u, ConnectionStateConfigured)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
 
@@ -260,9 +260,9 @@ func TestConnections(t *testing.T) {
 			}
 			lastUuid = u
 
-			state := ConnectionStateCreated
+			state := ConnectionStateSetup
 			if i%2 == 1 {
-				state = ConnectionStateReady
+				state = ConnectionStateConfigured
 			}
 
 			err := db.CreateConnection(ctx, &Connection{
@@ -365,7 +365,7 @@ func TestConnections(t *testing.T) {
 		t.Run("filter by state", func(t *testing.T) {
 			total := 0
 
-			q := db.ListConnectionsBuilder().Limit(10).ForState(ConnectionStateReady)
+			q := db.ListConnectionsBuilder().Limit(10).ForState(ConnectionStateConfigured)
 			for {
 				result := q.FetchPage(ctx)
 				assert.NoError(t, result.Error)
@@ -418,7 +418,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        "root",
 				ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 				ConnectorVersion: 1,
-				State:            ConnectionStateCreated,
+				State:            ConnectionStateSetup,
 				Labels:           conn.labels,
 			})
 			assert.NoError(t, err)
@@ -495,7 +495,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Labels:           Labels{"existing": "value"},
 		})
 		assert.NoError(t, err)
@@ -547,7 +547,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Labels:           Labels{"env": "prod", "team": "backend", "version": "v1"},
 		})
 		assert.NoError(t, err)
@@ -600,7 +600,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Labels:           Labels{"old": "value", "other": "data"},
 		})
 		assert.NoError(t, err)
@@ -661,7 +661,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Annotations:      Annotations{"existing": "value"},
 		})
 		assert.NoError(t, err)
@@ -713,7 +713,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Annotations:      Annotations{"env": "prod", "team": "backend", "version": "v1"},
 		})
 		assert.NoError(t, err)
@@ -766,7 +766,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      connectorId,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Annotations:      Annotations{"old": "value", "other": "data"},
 		})
 		assert.NoError(t, err)
@@ -821,9 +821,9 @@ func TestConnections(t *testing.T) {
 
 			u := apid.New(apid.PrefixConnection)
 
-			state := ConnectionStateCreated
+			state := ConnectionStateSetup
 			if i%2 == 1 {
-				state = ConnectionStateReady
+				state = ConnectionStateConfigured
 			}
 
 			err := db.CreateConnection(ctx, &Connection{
@@ -894,7 +894,7 @@ func TestConnections(t *testing.T) {
 			total := 0
 			err := db.
 				ListConnectionsBuilder().
-				ForStates([]ConnectionState{ConnectionStateCreated, ConnectionStateReady}).
+				ForStates([]ConnectionState{ConnectionStateSetup, ConnectionStateConfigured}).
 				WithDeletedHandling(DeletedHandlingExclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
@@ -907,7 +907,7 @@ func TestConnections(t *testing.T) {
 			total := 0
 			err := db.
 				ListConnectionsBuilder().
-				ForStates([]ConnectionState{ConnectionStateReady}).
+				ForStates([]ConnectionState{ConnectionStateConfigured}).
 				WithDeletedHandling(DeletedHandlingExclude).
 				Enumerate(ctx, func(pr pagination.PageResult[Connection]) (keepGoing pagination.KeepGoing, err error) {
 					total += len(pr.Results)
@@ -936,7 +936,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1010,7 +1010,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1034,7 +1034,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.some-namespace",
 			ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1097,7 +1097,7 @@ func TestConnections(t *testing.T) {
 			Namespace:              "root.some-namespace",
 			ConnectorId:            apid.New(apid.PrefixConnectorVersion),
 			ConnectorVersion:       1,
-			State:                  ConnectionStateCreated,
+			State:                  ConnectionStateSetup,
 			SetupStep:              &step,
 			EncryptedConfiguration: &ef,
 			EncryptedAt:            &now,
@@ -1146,7 +1146,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.tenant-a",
 			ConnectorId:      connectorID,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			Labels:           Labels{"subscription": "gold"},
 		}))
 
@@ -1213,14 +1213,14 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.sel",
 			ConnectorId:      cvDrive,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		}))
 		require.NoError(t, db.CreateConnection(ctx, &Connection{
 			Id:               apid.New(apid.PrefixConnection),
 			Namespace:        "root.sel",
 			ConnectorId:      cvSlack,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		}))
 
 		// Filter connections by the parent connector version's user label —

--- a/internal/database/migrations/postgres/000009_rename_connection_state_values.down.sql
+++ b/internal/database/migrations/postgres/000009_rename_connection_state_values.down.sql
@@ -1,0 +1,8 @@
+-- Reverse the value rewrite from the up migration.
+update connections
+set state = 'created'
+where state = 'setup';
+
+update connections
+set state = 'ready'
+where state = 'configured';

--- a/internal/database/migrations/postgres/000009_rename_connection_state_values.up.sql
+++ b/internal/database/migrations/postgres/000009_rename_connection_state_values.up.sql
@@ -1,0 +1,10 @@
+-- Rename ConnectionState values: 'created' -> 'setup', 'ready' -> 'configured'.
+-- Free-text column, no CHECK constraints — this is purely a value rewrite so
+-- existing rows continue to load correctly via IsValidConnectionState.
+update connections
+set state = 'setup'
+where state = 'created';
+
+update connections
+set state = 'configured'
+where state = 'ready';

--- a/internal/database/migrations/sqlite/000009_rename_connection_state_values.down.sql
+++ b/internal/database/migrations/sqlite/000009_rename_connection_state_values.down.sql
@@ -1,0 +1,8 @@
+-- Reverse the value rewrite from the up migration.
+update connections
+set state = 'created'
+where state = 'setup';
+
+update connections
+set state = 'ready'
+where state = 'configured';

--- a/internal/database/migrations/sqlite/000009_rename_connection_state_values.up.sql
+++ b/internal/database/migrations/sqlite/000009_rename_connection_state_values.up.sql
@@ -1,0 +1,10 @@
+-- Rename ConnectionState values: 'created' -> 'setup', 'ready' -> 'configured'.
+-- Free-text column, no CHECK constraints — this is purely a value rewrite so
+-- existing rows continue to load correctly via IsValidConnectionState.
+update connections
+set state = 'setup'
+where state = 'created';
+
+update connections
+set state = 'configured'
+where state = 'ready';

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -2162,7 +2162,7 @@ func TestConnectorVersionLabelChangePropagation(t *testing.T) {
 			Namespace:        "root.cv",
 			ConnectorId:      cvID,
 			ConnectorVersion: 1,
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 		}))
 
 		c, err := db.GetConnection(ctx, connID)
@@ -2208,7 +2208,7 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 		connID := apid.New(apid.PrefixConnection)
 		require.NoError(t, db.CreateConnection(ctx, &Connection{
 			Id: connID, Namespace: "root.recon", ConnectorId: cvID, ConnectorVersion: 1,
-			State: ConnectionStateCreated,
+			State: ConnectionStateSetup,
 		}))
 		require.NoError(t, db.CreateEncryptionKey(ctx, &EncryptionKey{
 			Id: apid.New(apid.PrefixEncryptionKey), Namespace: "root.recon", State: EncryptionKeyStateActive,

--- a/internal/database/oauth2_token.go
+++ b/internal/database/oauth2_token.go
@@ -347,7 +347,7 @@ func (s *service) EnumerateOAuth2TokensExpiringWithin(
 			Where(sq.Eq{
 				"t.deleted_at": nil,
 				"c.deleted_at": nil,
-				"c.state":      ConnectionStateReady,
+				"c.state":      ConnectionStateConfigured,
 			}).
 			Where("t.access_token_expires_at <= ?", expirationThreshold).
 			OrderBy("t.created_at DESC").

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -444,7 +444,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 
 		createdConnection := Connection{
 			Id:               apid.MustParse("cxn_test0000000000001"),
-			State:            ConnectionStateCreated,
+			State:            ConnectionStateSetup,
 			ConnectorId:      apid.MustParse("cxr_test0000000000001"),
 			ConnectorVersion: 1,
 			CreatedAt:        apctx.GetClock(ctx).Now().Add(-1 * time.Hour),
@@ -453,7 +453,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 
 		readyConnection1 := Connection{
 			Id:               apid.MustParse("cxn_test0000000000002"),
-			State:            ConnectionStateReady,
+			State:            ConnectionStateConfigured,
 			ConnectorId:      apid.MustParse("cxr_test0000000000001"),
 			ConnectorVersion: 1,
 			CreatedAt:        apctx.GetClock(ctx).Now().Add(-1 * time.Hour),
@@ -462,7 +462,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 
 		readyConnection2 := Connection{
 			Id:               apid.MustParse("cxn_test0000000000003"),
-			State:            ConnectionStateReady,
+			State:            ConnectionStateConfigured,
 			ConnectorId:      apid.MustParse("cxr_test0000000000001"),
 			ConnectorVersion: 1,
 			CreatedAt:        apctx.GetClock(ctx).Now().Add(-1 * time.Hour),
@@ -480,7 +480,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 
 		deletedConnection := Connection{
 			Id:               apid.MustParse("cxn_test0000000000005"),
-			State:            ConnectionStateReady,
+			State:            ConnectionStateConfigured,
 			ConnectorId:      apid.MustParse("cxr_test0000000000001"),
 			ConnectorVersion: 1,
 			CreatedAt:        apctx.GetClock(ctx).Now().Add(-1 * time.Hour),
@@ -492,7 +492,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 		for i := 0; i < 200; i++ {
 			manyReadyConnections = append(manyReadyConnections, Connection{
 				Id:               apid.New(apid.PrefixConnection),
-				State:            ConnectionStateReady,
+				State:            ConnectionStateConfigured,
 				ConnectorId:      apid.MustParse("cxr_test0000000000001"),
 				ConnectorVersion: 1,
 				CreatedAt:        apctx.GetClock(ctx).Now().Add(-1 * time.Hour),

--- a/internal/database/tasks/task_cleanup_stale_connections.go
+++ b/internal/database/tasks/task_cleanup_stale_connections.go
@@ -20,7 +20,7 @@ func (th *taskHandler) cleanupStaleConnections(ctx context.Context, t *asynq.Tas
 	var cleaned int
 	err := th.db.ListConnectionsBuilder().
 		WithDeletedHandling(database.DeletedHandlingExclude).
-		ForStates([]database.ConnectionState{database.ConnectionStateCreated}).
+		ForStates([]database.ConnectionState{database.ConnectionStateSetup}).
 		WithSetupStepNotNull().
 		UpdatedBefore(cutoff).
 		Enumerate(ctx, func(pr pagination.PageResult[database.Connection]) (pagination.KeepGoing, error) {

--- a/internal/encrypt/fake_service_test.go
+++ b/internal/encrypt/fake_service_test.go
@@ -45,7 +45,7 @@ func TestFakeService(t *testing.T) {
 				Namespace:        "root.some-namespace",
 				ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 				ConnectorVersion: 1,
-				State:            database.ConnectionStateReady,
+				State:            database.ConnectionStateConfigured,
 			}
 			require.NoError(t, db.CreateConnection(context.Background(), &connection))
 

--- a/internal/encrypt/service_test.go
+++ b/internal/encrypt/service_test.go
@@ -65,7 +65,7 @@ func TestService(t *testing.T) {
 		Namespace:        "root.some-namespace",
 		ConnectorId:      apid.New(apid.PrefixConnectorVersion),
 		ConnectorVersion: 1,
-		State:            database.ConnectionStateReady,
+		State:            database.ConnectionStateConfigured,
 	}
 	require.NoError(t, db.CreateConnection(context.Background(), &connection))
 

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -103,7 +103,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestConnections(t *testing.T) {
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, u, resp.Id)
-			require.Equal(t, database.ConnectionStateCreated, resp.State)
+			require.Equal(t, database.ConnectionStateSetup, resp.State)
 		})
 
 		t.Run("allowed with matching resource id permission", func(t *testing.T) {
@@ -231,7 +231,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root",
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -242,7 +242,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.child",
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.child",
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -264,7 +264,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        "root.child.grandchild",
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -350,7 +350,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        "root",
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 				Labels:           database.Labels{"env": "test-label-conn"},
 			})
 			require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 		})
 		require.NoError(t, err)
 
@@ -473,7 +473,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Labels:           database.Labels{"existing": "value"},
 		})
 		require.NoError(t, err)
@@ -635,7 +635,7 @@ func TestConnections(t *testing.T) {
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, u, resp.Id)
-			require.Equal(t, database.ConnectionStateCreated, resp.State)
+			require.Equal(t, database.ConnectionStateSetup, resp.State)
 		})
 	})
 
@@ -648,7 +648,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Labels:           database.Labels{"env": "prod", "team": "backend"},
 		})
 		require.NoError(t, err)
@@ -723,7 +723,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 			})
 			require.NoError(t, err)
 
@@ -758,7 +758,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Labels:           database.Labels{"env": "staging"},
 		})
 		require.NoError(t, err)
@@ -852,7 +852,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1023,7 +1023,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Labels:           database.Labels{"env": "prod", "team": "backend"},
 		})
 		require.NoError(t, err)
@@ -1110,7 +1110,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 				Labels:           database.Labels{"to-delete": "value", "to-keep": "value2"},
 			})
 			require.NoError(t, err)
@@ -1145,7 +1145,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 				Labels:           database.Labels{"label": "value"},
 			})
 			require.NoError(t, err)
@@ -1184,7 +1184,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1253,7 +1253,7 @@ func TestConnections(t *testing.T) {
 
 		t.Run("allowed with matching resource id permission", func(t *testing.T) {
 			// Reset state first
-			err := tu.Db.SetConnectionState(context.Background(), u, database.ConnectionStateCreated)
+			err := tu.Db.SetConnectionState(context.Background(), u, database.ConnectionStateSetup)
 			require.NoError(t, err)
 
 			w := httptest.NewRecorder()
@@ -1283,7 +1283,7 @@ func TestConnections(t *testing.T) {
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 				http.MethodPut,
 				"/connections/"+u.String()+"/_force_state",
-				util.JsonToReader(ForceStateRequestJson{State: database.ConnectionStateReady}),
+				util.JsonToReader(ForceStateRequestJson{State: database.ConnectionStateConfigured}),
 				"root",
 				"some-actor",
 				aschema.PermissionsSingleWithResourceIds("root.**", "connections", "force_state", otherResourceId.String()),
@@ -1304,7 +1304,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Annotations:      database.Annotations{"note": "important", "owner": "team-a"},
 		})
 		require.NoError(t, err)
@@ -1363,7 +1363,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 			})
 			require.NoError(t, err)
 
@@ -1397,7 +1397,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Annotations:      database.Annotations{"note": "important"},
 		})
 		require.NoError(t, err)
@@ -1475,7 +1475,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1606,7 +1606,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 			Annotations:      database.Annotations{"note": "important", "owner": "team-a"},
 		})
 		require.NoError(t, err)
@@ -1661,7 +1661,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      connectorId,
 				ConnectorVersion: connectorVersion,
-				State:            database.ConnectionStateCreated,
+				State:            database.ConnectionStateSetup,
 				Annotations:      database.Annotations{"to-delete": "value", "to-keep": "value2"},
 			})
 			require.NoError(t, err)
@@ -1699,7 +1699,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1818,7 +1818,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1871,7 +1871,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1923,7 +1923,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateCreated,
+			State:            database.ConnectionStateSetup,
 		})
 		require.NoError(t, err)
 
@@ -1977,7 +1977,7 @@ func TestConnections(t *testing.T) {
 			Namespace:        sconfig.RootNamespace,
 			ConnectorId:      connectorId,
 			ConnectorVersion: connectorVersion,
-			State:            database.ConnectionStateReady,
+			State:            database.ConnectionStateConfigured,
 		})
 		require.NoError(t, err)
 
@@ -2045,7 +2045,7 @@ func TestConnections(t *testing.T) {
 				Namespace:        sconfig.RootNamespace,
 				ConnectorId:      oauthConnectorId,
 				ConnectorVersion: oauthConnectorVersion,
-				State:            database.ConnectionStateReady,
+				State:            database.ConnectionStateConfigured,
 			})
 			require.NoError(t, err)
 

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -3,18 +3,22 @@ import {Connector} from './connectors';
 import {ListResponse} from './common';
 
 // Connection models
+//
+// SETUP: connection is persisted and one or more setup steps are in progress.
+// CONFIGURED: setup is complete. The connection may or may not be currently
+// usable; the orthogonal ConnectionHealthState axis carries that signal.
 export enum ConnectionState {
-    CREATED = 'created',
-    READY = 'ready',
+    SETUP = 'setup',
+    CONFIGURED = 'configured',
     DISABLED = 'disabled',
     DISCONNECTING = 'disconnecting',
     DISCONNECTED = 'disconnected',
 }
 
 // Operational health signal for a connection. Distinct from ConnectionState:
-// a Ready connection whose credentials have stopped working flips to UNHEALTHY
-// without leaving the Ready lifecycle state. UIs surface this to drive the
-// unified re-authentication action.
+// a Configured connection whose credentials have stopped working flips to
+// UNHEALTHY without leaving the Configured lifecycle state. UIs surface this
+// to drive the unified re-authentication action.
 export enum ConnectionHealthState {
     HEALTHY = 'healthy',
     UNHEALTHY = 'unhealthy',

--- a/ui/admin/src/components/ConnectionDetail.tsx
+++ b/ui/admin/src/components/ConnectionDetail.tsx
@@ -29,8 +29,8 @@ import AnnotationsEditor from "./AnnotationsEditor";
 
 function StateChip({state}: { state: ConnectionState }) {
   const colors: Record<ConnectionState, "default" | "success" | "error" | "info" | "warning" | "primary" | "secondary"> = {
-    [ConnectionState.CREATED]: 'primary',
-    [ConnectionState.READY]: 'success',
+    [ConnectionState.SETUP]: 'primary',
+    [ConnectionState.CONFIGURED]: 'success',
     [ConnectionState.DISABLED]: 'error',
     [ConnectionState.DISCONNECTING]: 'warning',
     [ConnectionState.DISCONNECTED]: 'default',

--- a/ui/admin/src/pages/Connections.tsx
+++ b/ui/admin/src/pages/Connections.tsx
@@ -26,8 +26,8 @@ import {selectCurrentNamespacePath} from "../store/namespacesSlice";
 
 function renderState(state: ConnectionState) {
     const colors: Record<ConnectionState, "default" | "success" | "error" | "info" | "warning" | "primary" | "secondary"> = {
-        [ConnectionState.CREATED]: 'primary',
-        [ConnectionState.READY]: 'success',
+        [ConnectionState.SETUP]: 'primary',
+        [ConnectionState.CONFIGURED]: 'success',
         [ConnectionState.DISABLED]: 'error',
         [ConnectionState.DISCONNECTING]: 'warning',
         [ConnectionState.DISCONNECTED]: 'default'
@@ -123,8 +123,8 @@ export default function Connections() {
     const defaultPageSize = 20;
     const stateOptions = useMemo(() => [
         { label: 'All', value: '' },
-        { label: 'Created', value: ConnectionState.CREATED },
-        { label: 'Ready', value: ConnectionState.READY },
+        { label: 'Created', value: ConnectionState.SETUP },
+        { label: 'Ready', value: ConnectionState.CONFIGURED },
         { label: 'Disabled', value: ConnectionState.DISABLED },
         { label: 'Disconnecting', value: ConnectionState.DISCONNECTING },
         { label: 'Disconnected', value: ConnectionState.DISCONNECTED },

--- a/ui/marketplace/src/components/ConnectionCard.tsx
+++ b/ui/marketplace/src/components/ConnectionCard.tsx
@@ -60,13 +60,13 @@ const ConnectionCard: React.FC<ConnectionCardProps> = ({ connection }) => {
   // Determine the status color
   let statusColor: 'success' | 'error' | 'warning' | 'default' = 'default';
   switch (connection.state) {
-    case ConnectionState.READY:
+    case ConnectionState.CONFIGURED:
       statusColor = 'success';
       break;
     case ConnectionState.DISABLED:
       statusColor = 'error';
       break;
-    case ConnectionState.CREATED:
+    case ConnectionState.SETUP:
       statusColor = 'warning';
       break;
     case ConnectionState.DISCONNECTING:
@@ -98,10 +98,10 @@ const ConnectionCard: React.FC<ConnectionCardProps> = ({ connection }) => {
     });
   };
 
-  // Reauth is meaningful only on Ready connections (any state earlier is still
+  // Reauth is meaningful only on Configured connections (any state earlier is still
   // in initial setup; later states are tearing down). Visibility itself is the
   // signal — when health is unhealthy the button is emphasized.
-  const canReauth = connection.state === ConnectionState.READY;
+  const canReauth = connection.state === ConnectionState.CONFIGURED;
   const isUnhealthy = connection.health_state === ConnectionHealthState.UNHEALTHY;
 
   // Handle disconnect button click
@@ -228,7 +228,7 @@ const ConnectionCard: React.FC<ConnectionCardProps> = ({ connection }) => {
               Re-authenticate
             </Button>
           )}
-          {connection.state === ConnectionState.READY && connector?.has_configure && (
+          {connection.state === ConnectionState.CONFIGURED && connector?.has_configure && (
             <Button
               size="small"
               startIcon={<SettingsIcon />}

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -118,7 +118,7 @@ const ConnectionList: React.FC = () => {
     // If the connection is already ready, the form is from a reconfigure flow.
     // Clearing the form step alone leaves setup_step=configure:0 on the server,
     // so the dialog reappears on next load — call cancel_setup to clear it server-side.
-    if (conn && conn.state === ConnectionState.READY) {
+    if (conn && conn.state === ConnectionState.CONFIGURED) {
       dispatch(cancelSetupConnectionAsync(conn.id));
     }
     dispatch(clearFormStep());

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -386,6 +386,6 @@ export const selectRetryingConnection = (state: RootState) => state.connections.
 
 // Helper selectors
 export const selectActiveConnections = (state: RootState) =>
-    state.connections.items.filter(conn => conn.state === ConnectionState.READY);
+    state.connections.items.filter(conn => conn.state === ConnectionState.CONFIGURED);
 
 export default connectionsSlice.reducer;

--- a/ui/marketplace/src/stories/ConnectionCard.stories.tsx
+++ b/ui/marketplace/src/stories/ConnectionCard.stories.tsx
@@ -71,7 +71,7 @@ const mockConnection: Connection = {
       description: "A google calendar connector",
       logo: "https://upload.wikimedia.org/wikipedia/commons/a/a5/Google_Calendar_icon_%282020%29.svg"
   },
-  state: ConnectionState.READY,
+  state: ConnectionState.CONFIGURED,
   health_state: ConnectionHealthState.HEALTHY,
   created_at: '2023-04-01T12:00:00Z',
   updated_at: '2023-04-01T12:00:00Z',
@@ -96,7 +96,7 @@ export const Created: Story = {
   args: {
     connection: {
       ...mockConnection,
-      state: ConnectionState.CREATED,
+      state: ConnectionState.SETUP,
     },
   },
 };

--- a/ui/marketplace/src/tests/ConnectionCard.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionCard.test.tsx
@@ -61,7 +61,7 @@ describe('ConnectionCard', () => {
         id: '123e4567-e89b-12d3-a456-426614174000',
         namespace: 'root',
         connector: mockConnector,
-        state: ConnectionState.READY,
+        state: ConnectionState.CONFIGURED,
         health_state: ConnectionHealthState.HEALTHY,
         created_at: '2023-04-01T12:00:00Z',
         updated_at: '2023-04-01T12:00:00Z',
@@ -83,7 +83,7 @@ describe('ConnectionCard', () => {
         expect(screen.getByText(/Connected on/)).toBeInTheDocument();
 
         // Check if the status chip label is displayed (state string)
-        expect(screen.getByText('ready')).toBeInTheDocument();
+        expect(screen.getByText('configured')).toBeInTheDocument();
     });
 
     test('renders with unknown connector fallback when connector missing', () => {
@@ -102,8 +102,8 @@ describe('ConnectionCard', () => {
 
     test('renders different status labels based on connection state', () => {
         const states = [
-            {state: ConnectionState.READY, label: 'ready'},
-            {state: ConnectionState.CREATED, label: 'created'},
+            {state: ConnectionState.CONFIGURED, label: 'configured'},
+            {state: ConnectionState.SETUP, label: 'setup'},
             {state: ConnectionState.DISABLED, label: 'disabled'},
             {state: ConnectionState.DISCONNECTED, label: 'disconnected'},
         ];

--- a/ui/marketplace/src/tests/ConnectionList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionList.test.tsx
@@ -44,7 +44,7 @@ const makeConnection = (overrides: Partial<Connection> = {}): Connection => ({
     id: 'c-1',
     namespace: 'root',
     connector: connector,
-    state: ConnectionState.READY,
+    state: ConnectionState.CONFIGURED,
     health_state: ConnectionHealthState.HEALTHY,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',


### PR DESCRIPTION
Closes #363. Part of #360.

## Summary

- ``ConnectionStateCreated`` → ``ConnectionStateSetup`` (value ``"created"`` → ``"setup"``)
- ``ConnectionStateReady`` → ``ConnectionStateConfigured`` (value ``"ready"`` → ``"configured"``)

"Created" was misleading — a connection in this state has already been persisted and has setup steps in progress. "Ready" implied the connection was currently usable, but usability is governed by the orthogonal ``ConnectionHealthState`` axis (e.g. an OAuth2 connection with a revoked refresh token stays Configured but flips unhealthy until reauth). The rename lets the lifecycle state carry "setup is done" and ``health_state`` carry "currently usable."

## Scope

- Go: ``internal/database/connection.go`` constants + ``IsValid`` switch + all ~30 callers updated.
- TypeScript: ``sdks/js`` enum, marketplace + admin UI usages, tests, stories.
- DB migration ``000009_rename_connection_state_values.{up,down}.sql`` for sqlite + postgres: ``UPDATE`` existing rows (free-text column, no CHECK constraints to alter). Down reverses.

## Test plan

- [x] ``go test -count=1 ./internal/...`` clean (with Docker postgres + redis running).
- [x] ``./scripts/preflight.sh`` clean.
- [x] ``yarn workspace @authproxy/marketplace test`` and ``yarn workspace @authproxy/admin test`` pass; both type-check.
- [x] ``go test -tags integration ./api_key/`` and ``./probes/`` integration tests pass against the local OAuth2 test server. ``./oauth2/`` integration tests have a pre-existing flake (``TestScopeMismatch_*``) that reproduces on ``main`` unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)