### PR TITLE
Centralize connection setup API DTOs

### DIFF
--- a/internal/core/iface/connection_initiate.go
+++ b/internal/core/iface/connection_initiate.go
@@ -1,155 +1,23 @@
 package iface
 
-import (
-	"encoding/json"
-	"fmt"
+import schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/rmorlok/authproxy/internal/apid"
-	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
-)
+type InitiateConnectionRequest = schemaapi.InitiateConnectionRequest
 
-type InitiateConnectionRequest struct {
-	// Id of the connector to initiate the connector for
-	ConnectorId apid.ID `json:"connector_id"`
-
-	// Version of the connector to initiate connection for; if not specified defaults to the primary version.
-	ConnectorVersion uint64 `json:"connector_version,omitempty"`
-
-	// The namespace to create the connection in. Must be the namespace of connector or a child namespace of that
-	// namespace. Defaults to the connector namespace if not specified.
-	IntoNamespace string `json:"into_namespace,omitempty"`
-
-	// The URL to return to after the connection is completed.
-	ReturnToUrl string `json:"return_to_url"`
-}
-
-func (icr *InitiateConnectionRequest) Validate() error {
-	result := &multierror.Error{}
-
-	if icr.ConnectorId == apid.Nil {
-		result = multierror.Append(result, fmt.Errorf("connector_id is required"))
-	}
-
-	if icr.HasIntoNamespace() {
-		if err := aschema.ValidateNamespacePath(icr.IntoNamespace); err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-
-	return result.ErrorOrNil()
-}
-
-func (icr *InitiateConnectionRequest) HasVersion() bool {
-	return icr.ConnectorVersion > 0
-}
-
-func (icr *InitiateConnectionRequest) HasIntoNamespace() bool {
-	return icr.IntoNamespace != ""
-}
-
-type ConnectionSetupResponseType string
+type ConnectionSetupResponseType = schemaapi.ConnectionSetupResponseType
 
 const (
-	ConnectionSetupResponseTypeRedirect  ConnectionSetupResponseType = "redirect"
-	ConnectionSetupResponseTypeForm      ConnectionSetupResponseType = "form"
-	ConnectionSetupResponseTypeComplete  ConnectionSetupResponseType = "complete"
-	ConnectionSetupResponseTypeVerifying ConnectionSetupResponseType = "verifying"
-	ConnectionSetupResponseTypeError     ConnectionSetupResponseType = "error"
+	ConnectionSetupResponseTypeRedirect  = schemaapi.ConnectionSetupResponseTypeRedirect
+	ConnectionSetupResponseTypeForm      = schemaapi.ConnectionSetupResponseTypeForm
+	ConnectionSetupResponseTypeComplete  = schemaapi.ConnectionSetupResponseTypeComplete
+	ConnectionSetupResponseTypeVerifying = schemaapi.ConnectionSetupResponseTypeVerifying
+	ConnectionSetupResponseTypeError     = schemaapi.ConnectionSetupResponseTypeError
 )
 
-type ConnectionSetupResponse interface {
-	GetId() apid.ID
-	GetType() ConnectionSetupResponseType
-}
-
-type ConnectionSetupRedirect struct {
-	Id          apid.ID                     `json:"id"`
-	Type        ConnectionSetupResponseType `json:"type"`
-	RedirectUrl string                      `json:"redirect_url"`
-}
-
-func (icr *ConnectionSetupRedirect) GetId() apid.ID {
-	return icr.Id
-}
-
-func (icr *ConnectionSetupRedirect) GetType() ConnectionSetupResponseType {
-	return icr.Type
-}
-
-type ConnectionSetupForm struct {
-	Id              apid.ID                     `json:"id"`
-	Type            ConnectionSetupResponseType `json:"type"`
-	StepId          string                      `json:"step_id"`
-	StepTitle       string                      `json:"step_title,omitempty"`
-	StepDescription string                      `json:"step_description,omitempty"`
-	CurrentStep     int                         `json:"current_step"`
-	TotalSteps      int                         `json:"total_steps"`
-	JsonSchema      json.RawMessage             `json:"json_schema"`
-	UiSchema        json.RawMessage             `json:"ui_schema"`
-}
-
-func (icf *ConnectionSetupForm) GetId() apid.ID {
-	return icf.Id
-}
-
-func (icf *ConnectionSetupForm) GetType() ConnectionSetupResponseType {
-	return icf.Type
-}
-
-type ConnectionSetupComplete struct {
-	Id   apid.ID                     `json:"id"`
-	Type ConnectionSetupResponseType `json:"type"`
-}
-
-func (icc *ConnectionSetupComplete) GetId() apid.ID {
-	return icc.Id
-}
-
-func (icc *ConnectionSetupComplete) GetType() ConnectionSetupResponseType {
-	return icc.Type
-}
-
-// ConnectionSetupVerifying indicates that probes are running in the background to verify
-// the credentials obtained during auth. The UI should poll /_setup_step to observe the outcome.
-type ConnectionSetupVerifying struct {
-	Id   apid.ID                     `json:"id"`
-	Type ConnectionSetupResponseType `json:"type"`
-}
-
-func (icv *ConnectionSetupVerifying) GetId() apid.ID {
-	return icv.Id
-}
-
-func (icv *ConnectionSetupVerifying) GetType() ConnectionSetupResponseType {
-	return icv.Type
-}
-
-// ConnectionSetupError is a terminal error response during setup, e.g. when probe verification
-// fails. The UI should show the error and offer retry (POST /_retry) or cancel (POST /_abort).
-type ConnectionSetupError struct {
-	Id       apid.ID                     `json:"id"`
-	Type     ConnectionSetupResponseType `json:"type"`
-	Error    string                      `json:"error"`
-	CanRetry bool                        `json:"can_retry"`
-}
-
-func (ice *ConnectionSetupError) GetId() apid.ID {
-	return ice.Id
-}
-
-func (ice *ConnectionSetupError) GetType() ConnectionSetupResponseType {
-	return ice.Type
-}
-
-type SubmitConnectionRequest struct {
-	// StepId is the id of the step being submitted. Must match the current setup step's id.
-	StepId string `json:"step_id"`
-
-	// Data is the form data submitted by the user for the current step.
-	Data json.RawMessage `json:"data"`
-
-	// ReturnToUrl is required when the next step after form submission is an auth redirect.
-	// The client should provide this so the OAuth callback knows where to return.
-	ReturnToUrl string `json:"return_to_url,omitempty"`
-}
+type ConnectionSetupResponse = schemaapi.ConnectionSetupResponse
+type ConnectionSetupRedirect = schemaapi.ConnectionSetupRedirect
+type ConnectionSetupForm = schemaapi.ConnectionSetupForm
+type ConnectionSetupComplete = schemaapi.ConnectionSetupComplete
+type ConnectionSetupVerifying = schemaapi.ConnectionSetupVerifying
+type ConnectionSetupError = schemaapi.ConnectionSetupError
+type SubmitConnectionRequest = schemaapi.SubmitConnectionRequest

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 )
 
 // ErrorResponse is the standardized error response format for authproxy API errors.
@@ -16,73 +17,12 @@ type ErrorResponse struct {
 	StackTrace string `json:"stack_trace,omitempty"`
 }
 
-// InitiateConnectionRequest represents a request to initiate a connection to an external service.
-//
-//	@Description	Request to initiate a connection
-type InitiateConnectionRequest struct {
-	// ID of the connector to initiate the connection for
-	ConnectorId apid.ID `swaggertype:"string" json:"connector_id" example:"req_test550e8400abcde"`
-	// Version of the connector (optional, defaults to primary version)
-	ConnectorVersion uint64 `json:"connector_version,omitempty" example:"1"`
-	// Namespace to create the connection in (optional, defaults to connector namespace)
-	IntoNamespace string `json:"into_namespace,omitempty" example:"acme"`
-	// URL to return to after the connection is completed
-	ReturnToUrl string `json:"return_to_url" example:"https://example.com/callback"`
-}
-
-// ConnectionSetupRedirect represents the response when a connection requires a redirect for OAuth.
-//
-//	@Description	Redirect response for connection setup
-type ConnectionSetupRedirect struct {
-	// Connection UUID
-	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
-	// Response type (always "redirect")
-	Type string `json:"type" example:"redirect"`
-	// URL to redirect the user to
-	RedirectUrl string `json:"redirect_url" example:"https://oauth.provider.com/authorize?..."`
-}
-
-// ConnectionSetupForm represents the response when a connection requires form input.
-//
-//	@Description	Form response for connection setup
-type ConnectionSetupForm struct {
-	// Connection UUID
-	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
-	// Response type (always "form")
-	Type string `json:"type" example:"form"`
-	// JSON Schema defining the form fields
-	JsonSchema interface{} `json:"json_schema"`
-	// UI Schema for JSON Forms rendering
-	UiSchema interface{} `json:"ui_schema"`
-}
-
-// ConnectionSetupComplete represents the response when a connection setup is complete.
-//
-//	@Description	Completion response for connection setup
-type ConnectionSetupComplete struct {
-	// Connection UUID
-	Id apid.ID `swaggertype:"string" json:"id" example:"req_test550e8400abcde"`
-	// Response type (always "complete")
-	Type string `json:"type" example:"complete"`
-}
-
-// SubmitConnectionRequest represents a form data submission for a connection setup step.
-//
-//	@Description	Form submission data
-type SubmitConnectionRequest struct {
-	// Form data matching the JSON Schema provided in the form response
-	Data interface{} `json:"data"`
-}
-
-// DataSourceOptionJson represents a single option from a data source for populating form dropdowns.
-//
-//	@Description	Data source option for form select fields
-type DataSourceOptionJson struct {
-	// Option value
-	Value string `json:"value" example:"ws-123"`
-	// Human-readable label
-	Label string `json:"label" example:"My Workspace"`
-}
+type InitiateConnectionRequest = schemaapi.InitiateConnectionRequest
+type ConnectionSetupRedirect = schemaapi.ConnectionSetupRedirect
+type ConnectionSetupForm = schemaapi.ConnectionSetupForm
+type ConnectionSetupComplete = schemaapi.ConnectionSetupComplete
+type SubmitConnectionRequest = schemaapi.SubmitConnectionRequest
+type DataSourceOptionJson = schemaapi.DataSourceOptionJson
 
 // ProxyRequest represents a request to proxy through a connection.
 //

--- a/internal/schema/AGENTS.md
+++ b/internal/schema/AGENTS.md
@@ -8,7 +8,7 @@ This directory owns AuthProxy's public and internal data contracts. Keep schema 
 - `internal/schema/config` contains YAML/JSON config-file syntax. It may reference common primitives, auth permissions, and resource definitions used in config.
 - `internal/schema/auth` contains auth/JWT-specific schema such as permissions. Namespace path and matcher helpers live in `internal/schema/resources/namespace`; the auth package only re-exports namespace helpers for compatibility.
 - `internal/schema/resources/...` contains REST-managed resource models. Use this tree for system resources such as connectors, namespaces, and rate limits.
-- `internal/schema/api` is reserved for API request/response DTOs. Resource packages must not import it.
+- `internal/schema/api` contains API request/response DTOs. Resource packages must not import it.
 
 ## Conventions
 

--- a/internal/schema/README.md
+++ b/internal/schema/README.md
@@ -6,6 +6,6 @@
 - `config`: application configuration file syntax.
 - `auth`: authentication and authorization contract types.
 - `resources`: REST-managed resource models.
-- `api`: API request/response DTOs, added as the API contract consolidation continues.
+- `api`: API request/response DTOs.
 
 Resource packages are intentionally separate from API DTOs. API models can compose resources, but resources must not depend on API-specific request or response wrappers.

--- a/internal/schema/api/README.md
+++ b/internal/schema/api/README.md
@@ -1,0 +1,5 @@
+# API Schema
+
+This package contains API request and response DTOs. These types describe the wire contract at AuthProxy route boundaries.
+
+API models may compose shared primitives from `internal/schema/common` and resource models from `internal/schema/resources/...`. Resource packages must not import this package.

--- a/internal/schema/api/connection_setup.go
+++ b/internal/schema/api/connection_setup.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apid"
+	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+)
+
+// InitiateConnectionRequest represents a request to initiate a connection to an external service.
+//
+//	@Description	Request to initiate a connection
+type InitiateConnectionRequest struct {
+	// ID of the connector to initiate the connection for.
+	ConnectorId apid.ID `json:"connector_id" yaml:"connector_id" swaggertype:"string" example:"cxr_test550e8400abcde"`
+
+	// Version of the connector to initiate connection for; if not specified defaults to the primary version.
+	ConnectorVersion uint64 `json:"connector_version,omitempty" yaml:"connector_version,omitempty" example:"1"`
+
+	// The namespace to create the connection in. Must be the namespace of connector or a child namespace of that
+	// namespace. Defaults to the connector namespace if not specified.
+	IntoNamespace string `json:"into_namespace,omitempty" yaml:"into_namespace,omitempty" example:"root.acme"`
+
+	// The URL to return to after the connection is completed.
+	ReturnToUrl string `json:"return_to_url" yaml:"return_to_url" example:"https://example.com/callback"`
+}
+
+func (icr *InitiateConnectionRequest) Validate() error {
+	result := &multierror.Error{}
+
+	if icr.ConnectorId == apid.Nil {
+		result = multierror.Append(result, fmt.Errorf("connector_id is required"))
+	}
+
+	if icr.HasIntoNamespace() {
+		if err := nschema.ValidateNamespacePath(icr.IntoNamespace); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (icr *InitiateConnectionRequest) HasVersion() bool {
+	return icr.ConnectorVersion > 0
+}
+
+func (icr *InitiateConnectionRequest) HasIntoNamespace() bool {
+	return icr.IntoNamespace != ""
+}
+
+type ConnectionSetupResponseType string
+
+const (
+	ConnectionSetupResponseTypeRedirect  ConnectionSetupResponseType = "redirect"
+	ConnectionSetupResponseTypeForm      ConnectionSetupResponseType = "form"
+	ConnectionSetupResponseTypeComplete  ConnectionSetupResponseType = "complete"
+	ConnectionSetupResponseTypeVerifying ConnectionSetupResponseType = "verifying"
+	ConnectionSetupResponseTypeError     ConnectionSetupResponseType = "error"
+)
+
+type ConnectionSetupResponse interface {
+	GetId() apid.ID
+	GetType() ConnectionSetupResponseType
+}
+
+// ConnectionSetupRedirect represents the response when a connection requires a redirect for OAuth.
+//
+//	@Description	Redirect response for connection setup
+type ConnectionSetupRedirect struct {
+	// Connection UUID.
+	Id apid.ID `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
+
+	// Response type.
+	Type ConnectionSetupResponseType `json:"type" yaml:"type" swaggertype:"string" example:"redirect"`
+
+	// URL to redirect the user to.
+	RedirectUrl string `json:"redirect_url" yaml:"redirect_url" example:"https://oauth.provider.com/authorize?..."`
+}
+
+func (icr *ConnectionSetupRedirect) GetId() apid.ID {
+	return icr.Id
+}
+
+func (icr *ConnectionSetupRedirect) GetType() ConnectionSetupResponseType {
+	return icr.Type
+}
+
+// ConnectionSetupForm represents the response when a connection requires form input.
+//
+//	@Description	Form response for connection setup
+type ConnectionSetupForm struct {
+	// Connection UUID.
+	Id apid.ID `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
+
+	// Response type.
+	Type ConnectionSetupResponseType `json:"type" yaml:"type" swaggertype:"string" example:"form"`
+
+	// Step ID being submitted.
+	StepId string `json:"step_id" yaml:"step_id" example:"preconnect:0"`
+
+	// Step title.
+	StepTitle string `json:"step_title,omitempty" yaml:"step_title,omitempty" example:"Choose workspace"`
+
+	// Step description.
+	StepDescription string `json:"step_description,omitempty" yaml:"step_description,omitempty"`
+
+	// Current step number in the setup phase.
+	CurrentStep int `json:"current_step" yaml:"current_step" example:"1"`
+
+	// Total number of steps in the setup phase.
+	TotalSteps int `json:"total_steps" yaml:"total_steps" example:"2"`
+
+	// JSON Schema defining the form fields.
+	JsonSchema json.RawMessage `json:"json_schema" yaml:"json_schema" swaggertype:"object"`
+
+	// UI Schema for JSON Forms rendering.
+	UiSchema json.RawMessage `json:"ui_schema" yaml:"ui_schema" swaggertype:"object"`
+}
+
+func (icf *ConnectionSetupForm) GetId() apid.ID {
+	return icf.Id
+}
+
+func (icf *ConnectionSetupForm) GetType() ConnectionSetupResponseType {
+	return icf.Type
+}
+
+// ConnectionSetupComplete represents the response when a connection setup is complete.
+//
+//	@Description	Completion response for connection setup
+type ConnectionSetupComplete struct {
+	// Connection UUID.
+	Id apid.ID `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
+
+	// Response type.
+	Type ConnectionSetupResponseType `json:"type" yaml:"type" swaggertype:"string" example:"complete"`
+}
+
+func (icc *ConnectionSetupComplete) GetId() apid.ID {
+	return icc.Id
+}
+
+func (icc *ConnectionSetupComplete) GetType() ConnectionSetupResponseType {
+	return icc.Type
+}
+
+// ConnectionSetupVerifying indicates that probes are running in the background to verify
+// the credentials obtained during auth. The UI should poll /_setup_step to observe the outcome.
+type ConnectionSetupVerifying struct {
+	Id   apid.ID                     `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
+	Type ConnectionSetupResponseType `json:"type" yaml:"type" swaggertype:"string" example:"verifying"`
+}
+
+func (icv *ConnectionSetupVerifying) GetId() apid.ID {
+	return icv.Id
+}
+
+func (icv *ConnectionSetupVerifying) GetType() ConnectionSetupResponseType {
+	return icv.Type
+}
+
+// ConnectionSetupError is a terminal error response during setup, e.g. when probe verification
+// fails. The UI should show the error and offer retry (POST /_retry) or cancel (POST /_abort).
+type ConnectionSetupError struct {
+	Id       apid.ID                     `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
+	Type     ConnectionSetupResponseType `json:"type" yaml:"type" swaggertype:"string" example:"error"`
+	Error    string                      `json:"error" yaml:"error" example:"probe verification failed"`
+	CanRetry bool                        `json:"can_retry" yaml:"can_retry" example:"true"`
+}
+
+func (ice *ConnectionSetupError) GetId() apid.ID {
+	return ice.Id
+}
+
+func (ice *ConnectionSetupError) GetType() ConnectionSetupResponseType {
+	return ice.Type
+}
+
+// SubmitConnectionRequest represents a form data submission for a connection setup step.
+//
+//	@Description	Form submission data
+type SubmitConnectionRequest struct {
+	// StepId is the id of the step being submitted. Must match the current setup step's id.
+	StepId string `json:"step_id" yaml:"step_id" example:"preconnect:0"`
+
+	// Data is the form data submitted by the user for the current step.
+	Data json.RawMessage `json:"data" yaml:"data" swaggertype:"object"`
+
+	// ReturnToUrl is required when the next step after form submission is an auth redirect.
+	// The client should provide this so the OAuth callback knows where to return.
+	ReturnToUrl string `json:"return_to_url,omitempty" yaml:"return_to_url,omitempty" example:"https://example.com/callback"`
+}
+
+// DataSourceOptionJson represents a single option from a data source for populating form dropdowns.
+//
+//	@Description	Data source option for form select fields
+type DataSourceOptionJson struct {
+	// Option value.
+	Value string `json:"value" yaml:"value" example:"ws-123"`
+
+	// Human-readable label.
+	Label string `json:"label" yaml:"label" example:"My Workspace"`
+}

--- a/internal/schema/api/schema.go
+++ b/internal/schema/api/schema.go
@@ -1,0 +1,3 @@
+package api
+
+const SchemaIdAPI = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/schema.json"

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/schema.json",
+  "$defs": {
+    "ConnectionSetupResponseType": {
+      "type": "string",
+      "enum": ["redirect", "form", "complete", "verifying", "error"]
+    },
+    "InitiateConnectionRequest": {
+      "type": "object",
+      "properties": {
+        "connector_id": { "type": "string" },
+        "connector_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "into_namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "return_to_url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["connector_id", "return_to_url"],
+      "additionalProperties": false
+    },
+    "ConnectionSetupRedirect": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "const": "redirect" },
+        "redirect_url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["id", "type", "redirect_url"],
+      "additionalProperties": false
+    },
+    "ConnectionSetupForm": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "const": "form" },
+        "step_id": { "type": "string" },
+        "step_title": { "type": "string" },
+        "step_description": { "type": "string" },
+        "current_step": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_steps": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "json_schema": { "type": "object" },
+        "ui_schema": { "type": "object" }
+      },
+      "required": ["id", "type", "step_id", "current_step", "total_steps", "json_schema", "ui_schema"],
+      "additionalProperties": false
+    },
+    "ConnectionSetupComplete": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "const": "complete" }
+      },
+      "required": ["id", "type"],
+      "additionalProperties": false
+    },
+    "ConnectionSetupVerifying": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "const": "verifying" }
+      },
+      "required": ["id", "type"],
+      "additionalProperties": false
+    },
+    "ConnectionSetupError": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "const": "error" },
+        "error": { "type": "string" },
+        "can_retry": { "type": "boolean" }
+      },
+      "required": ["id", "type", "error", "can_retry"],
+      "additionalProperties": false
+    },
+    "SubmitConnectionRequest": {
+      "type": "object",
+      "properties": {
+        "step_id": { "type": "string" },
+        "data": {},
+        "return_to_url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["step_id", "data"],
+      "additionalProperties": false
+    },
+    "DataSourceOption": {
+      "type": "object",
+      "properties": {
+        "value": { "type": "string" },
+        "label": { "type": "string" }
+      },
+      "required": ["value", "label"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaID struct {
+	ID string `json:"$id"`
+}
+
+func loadSchema(t *testing.T, c *jsonschemav5.Compiler, path string) string {
+	schemaBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var id schemaID
+	require.NoError(t, json.Unmarshal(schemaBytes, &id))
+
+	require.NoError(t, c.AddResource(id.ID, bytes.NewReader(schemaBytes)))
+
+	return id.ID
+}
+
+func compileRefSchema(t *testing.T, ref string) *jsonschemav5.Schema {
+	c := jsonschemav5.NewCompiler()
+
+	_ = loadSchema(t, c, "../resources/namespace/schema.json")
+	sid := loadSchema(t, c, "./schema.json")
+	require.Equal(t, SchemaIdAPI, sid)
+
+	const testSchemaID = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/test.json"
+	require.NoError(t, c.AddResource(testSchemaID, strings.NewReader(strings.TrimSpace(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/test.json",
+  "$ref": "`+ref+`"
+}`))))
+
+	schema, err := c.Compile(testSchemaID)
+	require.NoError(t, err)
+	return schema
+}
+
+func TestSchemaSamples(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		file string
+	}{
+		{name: "initiate connection", ref: "./schema.json#/$defs/InitiateConnectionRequest", file: "valid-initiate-connection.json"},
+		{name: "setup redirect", ref: "./schema.json#/$defs/ConnectionSetupRedirect", file: "valid-connection-setup-redirect.json"},
+		{name: "setup form", ref: "./schema.json#/$defs/ConnectionSetupForm", file: "valid-connection-setup-form.json"},
+		{name: "setup complete", ref: "./schema.json#/$defs/ConnectionSetupComplete", file: "valid-connection-setup-complete.json"},
+		{name: "setup verifying", ref: "./schema.json#/$defs/ConnectionSetupVerifying", file: "valid-connection-setup-verifying.json"},
+		{name: "setup error", ref: "./schema.json#/$defs/ConnectionSetupError", file: "valid-connection-setup-error.json"},
+		{name: "submit connection", ref: "./schema.json#/$defs/SubmitConnectionRequest", file: "valid-submit-connection.json"},
+		{name: "data source option", ref: "./schema.json#/$defs/DataSourceOption", file: "valid-data-source-option.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := compileRefSchema(t, tt.ref)
+
+			data, err := os.ReadFile(filepath.Join("test_data", tt.file))
+			require.NoError(t, err)
+
+			var v any
+			require.NoError(t, json.Unmarshal(data, &v))
+			require.NoError(t, schema.Validate(v))
+		})
+	}
+}
+
+func TestInitiateConnectionRequestValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		req := InitiateConnectionRequest{
+			ConnectorId:   "cxr_test0000000000001",
+			IntoNamespace: "root.acme",
+			ReturnToUrl:   "https://example.com/callback",
+		}
+		require.NoError(t, req.Validate())
+		require.True(t, req.HasIntoNamespace())
+		require.False(t, req.HasVersion())
+	})
+
+	t.Run("requires connector id", func(t *testing.T) {
+		req := InitiateConnectionRequest{ReturnToUrl: "https://example.com/callback"}
+		require.ErrorContains(t, req.Validate(), "connector_id is required")
+	})
+
+	t.Run("validates namespace", func(t *testing.T) {
+		req := InitiateConnectionRequest{
+			ConnectorId:   "cxr_test0000000000001",
+			IntoNamespace: "not-rooted",
+			ReturnToUrl:   "https://example.com/callback",
+		}
+		require.Error(t, req.Validate())
+	})
+}

--- a/internal/schema/api/test_data/valid-connection-setup-complete.json
+++ b/internal/schema/api/test_data/valid-connection-setup-complete.json
@@ -1,0 +1,4 @@
+{
+  "id": "cxn_test0000000000002",
+  "type": "complete"
+}

--- a/internal/schema/api/test_data/valid-connection-setup-error.json
+++ b/internal/schema/api/test_data/valid-connection-setup-error.json
@@ -1,0 +1,6 @@
+{
+  "id": "cxn_test0000000000002",
+  "type": "error",
+  "error": "probe verification failed",
+  "can_retry": true
+}

--- a/internal/schema/api/test_data/valid-connection-setup-form.json
+++ b/internal/schema/api/test_data/valid-connection-setup-form.json
@@ -1,0 +1,21 @@
+{
+  "id": "cxn_test0000000000002",
+  "type": "form",
+  "step_id": "preconnect:0",
+  "step_title": "Choose workspace",
+  "current_step": 1,
+  "total_steps": 1,
+  "json_schema": {
+    "type": "object",
+    "properties": {
+      "workspace": {
+        "type": "string"
+      }
+    }
+  },
+  "ui_schema": {
+    "workspace": {
+      "ui:widget": "select"
+    }
+  }
+}

--- a/internal/schema/api/test_data/valid-connection-setup-redirect.json
+++ b/internal/schema/api/test_data/valid-connection-setup-redirect.json
@@ -1,0 +1,5 @@
+{
+  "id": "cxn_test0000000000002",
+  "type": "redirect",
+  "redirect_url": "https://oauth.provider.example/authorize"
+}

--- a/internal/schema/api/test_data/valid-connection-setup-verifying.json
+++ b/internal/schema/api/test_data/valid-connection-setup-verifying.json
@@ -1,0 +1,4 @@
+{
+  "id": "cxn_test0000000000002",
+  "type": "verifying"
+}

--- a/internal/schema/api/test_data/valid-data-source-option.json
+++ b/internal/schema/api/test_data/valid-data-source-option.json
@@ -1,0 +1,4 @@
+{
+  "value": "ws-123",
+  "label": "My Workspace"
+}

--- a/internal/schema/api/test_data/valid-initiate-connection.json
+++ b/internal/schema/api/test_data/valid-initiate-connection.json
@@ -1,0 +1,6 @@
+{
+  "connector_id": "cxr_test0000000000001",
+  "connector_version": 1,
+  "into_namespace": "root.acme",
+  "return_to_url": "https://example.com/callback"
+}

--- a/internal/schema/api/test_data/valid-submit-connection.json
+++ b/internal/schema/api/test_data/valid-submit-connection.json
@@ -1,0 +1,7 @@
+{
+  "step_id": "preconnect:0",
+  "data": {
+    "workspace": "ws-123"
+  },
+  "return_to_url": "https://example.com/callback"
+}

--- a/internal/schema/reexport.go
+++ b/internal/schema/reexport.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
@@ -9,6 +10,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 )
 
+const SchemaIdAPI = api.SchemaIdAPI
 const SchemaIdAuth = auth.SchemaIdAuth
 const SchemaIdCommon = common.SchemaIdCommon
 const SchemaIdConfig = config.SchemaIdConfig
@@ -17,6 +19,7 @@ const SchemaIdNamespace = namespace.SchemaIdNamespace
 const SchemaIdRateLimit = rate_limit.SchemaIdRateLimit
 
 var allSchemas = []string{
+	SchemaIdAPI,
 	SchemaIdAuth,
 	SchemaIdCommon,
 	SchemaIdConfig,

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -7488,12 +7488,12 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "type": {
-                    "description": "Response type (always \"complete\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "complete"
                 }
@@ -7503,21 +7503,47 @@ const docTemplateadmin_api = `{
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
+                "current_step": {
+                    "description": "Current step number in the setup phase.",
+                    "type": "integer",
+                    "example": 1
+                },
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "json_schema": {
-                    "description": "JSON Schema defining the form fields"
+                    "description": "JSON Schema defining the form fields.",
+                    "type": "object"
+                },
+                "step_description": {
+                    "description": "Step description.",
+                    "type": "string"
+                },
+                "step_id": {
+                    "description": "Step ID being submitted.",
+                    "type": "string",
+                    "example": "preconnect:0"
+                },
+                "step_title": {
+                    "description": "Step title.",
+                    "type": "string",
+                    "example": "Choose workspace"
+                },
+                "total_steps": {
+                    "description": "Total number of steps in the setup phase.",
+                    "type": "integer",
+                    "example": 2
                 },
                 "type": {
-                    "description": "Response type (always \"form\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "form"
                 },
                 "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
+                    "description": "UI Schema for JSON Forms rendering.",
+                    "type": "object"
                 }
             }
         },
@@ -7526,17 +7552,17 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "redirect_url": {
-                    "description": "URL to redirect the user to",
+                    "description": "URL to redirect the user to.",
                     "type": "string",
                     "example": "https://oauth.provider.com/authorize?..."
                 },
                 "type": {
-                    "description": "Response type (always \"redirect\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "redirect"
                 }
@@ -7616,12 +7642,12 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "label": {
-                    "description": "Human-readable label",
+                    "description": "Human-readable label.",
                     "type": "string",
                     "example": "My Workspace"
                 },
                 "value": {
-                    "description": "Option value",
+                    "description": "Option value.",
                     "type": "string",
                     "example": "ws-123"
                 }
@@ -7647,22 +7673,22 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "connector_id": {
-                    "description": "ID of the connector to initiate the connection for",
+                    "description": "ID of the connector to initiate the connection for.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxr_test550e8400abcde"
                 },
                 "connector_version": {
-                    "description": "Version of the connector (optional, defaults to primary version)",
+                    "description": "Version of the connector to initiate connection for; if not specified defaults to the primary version.",
                     "type": "integer",
                     "example": 1
                 },
                 "into_namespace": {
-                    "description": "Namespace to create the connection in (optional, defaults to connector namespace)",
+                    "description": "The namespace to create the connection in. Must be the namespace of connector or a child namespace of that\nnamespace. Defaults to the connector namespace if not specified.",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "return_to_url": {
-                    "description": "URL to return to after the connection is completed",
+                    "description": "The URL to return to after the connection is completed.",
                     "type": "string",
                     "example": "https://example.com/callback"
                 }
@@ -7796,7 +7822,18 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Form data matching the JSON Schema provided in the form response"
+                    "description": "Data is the form data submitted by the user for the current step.",
+                    "type": "object"
+                },
+                "return_to_url": {
+                    "description": "ReturnToUrl is required when the next step after form submission is an auth redirect.\nThe client should provide this so the OAuth callback knows where to return.",
+                    "type": "string",
+                    "example": "https://example.com/callback"
+                },
+                "step_id": {
+                    "description": "StepId is the id of the step being submitted. Must match the current setup step's id.",
+                    "type": "string",
+                    "example": "preconnect:0"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -7482,12 +7482,12 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "type": {
-                    "description": "Response type (always \"complete\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "complete"
                 }
@@ -7497,21 +7497,47 @@
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
+                "current_step": {
+                    "description": "Current step number in the setup phase.",
+                    "type": "integer",
+                    "example": 1
+                },
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "json_schema": {
-                    "description": "JSON Schema defining the form fields"
+                    "description": "JSON Schema defining the form fields.",
+                    "type": "object"
+                },
+                "step_description": {
+                    "description": "Step description.",
+                    "type": "string"
+                },
+                "step_id": {
+                    "description": "Step ID being submitted.",
+                    "type": "string",
+                    "example": "preconnect:0"
+                },
+                "step_title": {
+                    "description": "Step title.",
+                    "type": "string",
+                    "example": "Choose workspace"
+                },
+                "total_steps": {
+                    "description": "Total number of steps in the setup phase.",
+                    "type": "integer",
+                    "example": 2
                 },
                 "type": {
-                    "description": "Response type (always \"form\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "form"
                 },
                 "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
+                    "description": "UI Schema for JSON Forms rendering.",
+                    "type": "object"
                 }
             }
         },
@@ -7520,17 +7546,17 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "redirect_url": {
-                    "description": "URL to redirect the user to",
+                    "description": "URL to redirect the user to.",
                     "type": "string",
                     "example": "https://oauth.provider.com/authorize?..."
                 },
                 "type": {
-                    "description": "Response type (always \"redirect\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "redirect"
                 }
@@ -7610,12 +7636,12 @@
             "type": "object",
             "properties": {
                 "label": {
-                    "description": "Human-readable label",
+                    "description": "Human-readable label.",
                     "type": "string",
                     "example": "My Workspace"
                 },
                 "value": {
-                    "description": "Option value",
+                    "description": "Option value.",
                     "type": "string",
                     "example": "ws-123"
                 }
@@ -7641,22 +7667,22 @@
             "type": "object",
             "properties": {
                 "connector_id": {
-                    "description": "ID of the connector to initiate the connection for",
+                    "description": "ID of the connector to initiate the connection for.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxr_test550e8400abcde"
                 },
                 "connector_version": {
-                    "description": "Version of the connector (optional, defaults to primary version)",
+                    "description": "Version of the connector to initiate connection for; if not specified defaults to the primary version.",
                     "type": "integer",
                     "example": 1
                 },
                 "into_namespace": {
-                    "description": "Namespace to create the connection in (optional, defaults to connector namespace)",
+                    "description": "The namespace to create the connection in. Must be the namespace of connector or a child namespace of that\nnamespace. Defaults to the connector namespace if not specified.",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "return_to_url": {
-                    "description": "URL to return to after the connection is completed",
+                    "description": "The URL to return to after the connection is completed.",
                     "type": "string",
                     "example": "https://example.com/callback"
                 }
@@ -7790,7 +7816,18 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Form data matching the JSON Schema provided in the form response"
+                    "description": "Data is the form data submitted by the user for the current step.",
+                    "type": "object"
+                },
+                "return_to_url": {
+                    "description": "ReturnToUrl is required when the next step after form submission is an auth redirect.\nThe client should provide this so the OAuth callback knows where to return.",
+                    "type": "string",
+                    "example": "https://example.com/callback"
+                },
+                "step_id": {
+                    "description": "StepId is the id of the step being submitted. Must match the current setup step's id.",
+                    "type": "string",
+                    "example": "preconnect:0"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -40,43 +40,64 @@ definitions:
     description: Completion response for connection setup
     properties:
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       type:
-        description: Response type (always "complete")
+        description: Response type.
         example: complete
         type: string
     type: object
   routes.ConnectionSetupForm:
     description: Form response for connection setup
     properties:
+      current_step:
+        description: Current step number in the setup phase.
+        example: 1
+        type: integer
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       json_schema:
-        description: JSON Schema defining the form fields
+        description: JSON Schema defining the form fields.
+        type: object
+      step_description:
+        description: Step description.
+        type: string
+      step_id:
+        description: Step ID being submitted.
+        example: preconnect:0
+        type: string
+      step_title:
+        description: Step title.
+        example: Choose workspace
+        type: string
+      total_steps:
+        description: Total number of steps in the setup phase.
+        example: 2
+        type: integer
       type:
-        description: Response type (always "form")
+        description: Response type.
         example: form
         type: string
       ui_schema:
-        description: UI Schema for JSON Forms rendering
+        description: UI Schema for JSON Forms rendering.
+        type: object
     type: object
   routes.ConnectionSetupRedirect:
     description: Redirect response for connection setup
     properties:
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       redirect_url:
-        description: URL to redirect the user to
+        description: URL to redirect the user to.
         example: https://oauth.provider.com/authorize?...
         type: string
       type:
-        description: Response type (always "redirect")
+        description: Response type.
         example: redirect
         type: string
     type: object
@@ -129,11 +150,11 @@ definitions:
     description: Data source option for form select fields
     properties:
       label:
-        description: Human-readable label
+        description: Human-readable label.
         example: My Workspace
         type: string
       value:
-        description: Option value
+        description: Option value.
         example: ws-123
         type: string
     type: object
@@ -152,20 +173,22 @@ definitions:
     description: Request to initiate a connection
     properties:
       connector_id:
-        description: ID of the connector to initiate the connection for
-        example: req_test550e8400abcde
+        description: ID of the connector to initiate the connection for.
+        example: cxr_test550e8400abcde
         type: string
       connector_version:
-        description: Version of the connector (optional, defaults to primary version)
+        description: Version of the connector to initiate connection for; if not specified
+          defaults to the primary version.
         example: 1
         type: integer
       into_namespace:
-        description: Namespace to create the connection in (optional, defaults to
-          connector namespace)
-        example: acme
+        description: |-
+          The namespace to create the connection in. Must be the namespace of connector or a child namespace of that
+          namespace. Defaults to the connector namespace if not specified.
+        example: root.acme
         type: string
       return_to_url:
-        description: URL to return to after the connection is completed
+        description: The URL to return to after the connection is completed.
         example: https://example.com/callback
         type: string
     type: object
@@ -258,7 +281,19 @@ definitions:
     description: Form submission data
     properties:
       data:
-        description: Form data matching the JSON Schema provided in the form response
+        description: Data is the form data submitted by the user for the current step.
+        type: object
+      return_to_url:
+        description: |-
+          ReturnToUrl is required when the next step after form submission is an auth redirect.
+          The client should provide this so the OAuth callback knows where to return.
+        example: https://example.com/callback
+        type: string
+      step_id:
+        description: StepId is the id of the step being submitted. Must match the
+          current setup step's id.
+        example: preconnect:0
+        type: string
     type: object
   routes.SwaggerConnectionJson:
     description: Connection to an external service

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -7488,12 +7488,12 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "type": {
-                    "description": "Response type (always \"complete\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "complete"
                 }
@@ -7503,21 +7503,47 @@ const docTemplateApi = `{
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
+                "current_step": {
+                    "description": "Current step number in the setup phase.",
+                    "type": "integer",
+                    "example": 1
+                },
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "json_schema": {
-                    "description": "JSON Schema defining the form fields"
+                    "description": "JSON Schema defining the form fields.",
+                    "type": "object"
+                },
+                "step_description": {
+                    "description": "Step description.",
+                    "type": "string"
+                },
+                "step_id": {
+                    "description": "Step ID being submitted.",
+                    "type": "string",
+                    "example": "preconnect:0"
+                },
+                "step_title": {
+                    "description": "Step title.",
+                    "type": "string",
+                    "example": "Choose workspace"
+                },
+                "total_steps": {
+                    "description": "Total number of steps in the setup phase.",
+                    "type": "integer",
+                    "example": 2
                 },
                 "type": {
-                    "description": "Response type (always \"form\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "form"
                 },
                 "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
+                    "description": "UI Schema for JSON Forms rendering.",
+                    "type": "object"
                 }
             }
         },
@@ -7526,17 +7552,17 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "redirect_url": {
-                    "description": "URL to redirect the user to",
+                    "description": "URL to redirect the user to.",
                     "type": "string",
                     "example": "https://oauth.provider.com/authorize?..."
                 },
                 "type": {
-                    "description": "Response type (always \"redirect\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "redirect"
                 }
@@ -7616,12 +7642,12 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "label": {
-                    "description": "Human-readable label",
+                    "description": "Human-readable label.",
                     "type": "string",
                     "example": "My Workspace"
                 },
                 "value": {
-                    "description": "Option value",
+                    "description": "Option value.",
                     "type": "string",
                     "example": "ws-123"
                 }
@@ -7647,22 +7673,22 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "connector_id": {
-                    "description": "ID of the connector to initiate the connection for",
+                    "description": "ID of the connector to initiate the connection for.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxr_test550e8400abcde"
                 },
                 "connector_version": {
-                    "description": "Version of the connector (optional, defaults to primary version)",
+                    "description": "Version of the connector to initiate connection for; if not specified defaults to the primary version.",
                     "type": "integer",
                     "example": 1
                 },
                 "into_namespace": {
-                    "description": "Namespace to create the connection in (optional, defaults to connector namespace)",
+                    "description": "The namespace to create the connection in. Must be the namespace of connector or a child namespace of that\nnamespace. Defaults to the connector namespace if not specified.",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "return_to_url": {
-                    "description": "URL to return to after the connection is completed",
+                    "description": "The URL to return to after the connection is completed.",
                     "type": "string",
                     "example": "https://example.com/callback"
                 }
@@ -7796,7 +7822,18 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Form data matching the JSON Schema provided in the form response"
+                    "description": "Data is the form data submitted by the user for the current step.",
+                    "type": "object"
+                },
+                "return_to_url": {
+                    "description": "ReturnToUrl is required when the next step after form submission is an auth redirect.\nThe client should provide this so the OAuth callback knows where to return.",
+                    "type": "string",
+                    "example": "https://example.com/callback"
+                },
+                "step_id": {
+                    "description": "StepId is the id of the step being submitted. Must match the current setup step's id.",
+                    "type": "string",
+                    "example": "preconnect:0"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -7482,12 +7482,12 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "type": {
-                    "description": "Response type (always \"complete\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "complete"
                 }
@@ -7497,21 +7497,47 @@
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
+                "current_step": {
+                    "description": "Current step number in the setup phase.",
+                    "type": "integer",
+                    "example": 1
+                },
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "json_schema": {
-                    "description": "JSON Schema defining the form fields"
+                    "description": "JSON Schema defining the form fields.",
+                    "type": "object"
+                },
+                "step_description": {
+                    "description": "Step description.",
+                    "type": "string"
+                },
+                "step_id": {
+                    "description": "Step ID being submitted.",
+                    "type": "string",
+                    "example": "preconnect:0"
+                },
+                "step_title": {
+                    "description": "Step title.",
+                    "type": "string",
+                    "example": "Choose workspace"
+                },
+                "total_steps": {
+                    "description": "Total number of steps in the setup phase.",
+                    "type": "integer",
+                    "example": 2
                 },
                 "type": {
-                    "description": "Response type (always \"form\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "form"
                 },
                 "ui_schema": {
-                    "description": "UI Schema for JSON Forms rendering"
+                    "description": "UI Schema for JSON Forms rendering.",
+                    "type": "object"
                 }
             }
         },
@@ -7520,17 +7546,17 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "Connection UUID",
+                    "description": "Connection UUID.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxn_test550e8400abcde"
                 },
                 "redirect_url": {
-                    "description": "URL to redirect the user to",
+                    "description": "URL to redirect the user to.",
                     "type": "string",
                     "example": "https://oauth.provider.com/authorize?..."
                 },
                 "type": {
-                    "description": "Response type (always \"redirect\")",
+                    "description": "Response type.",
                     "type": "string",
                     "example": "redirect"
                 }
@@ -7610,12 +7636,12 @@
             "type": "object",
             "properties": {
                 "label": {
-                    "description": "Human-readable label",
+                    "description": "Human-readable label.",
                     "type": "string",
                     "example": "My Workspace"
                 },
                 "value": {
-                    "description": "Option value",
+                    "description": "Option value.",
                     "type": "string",
                     "example": "ws-123"
                 }
@@ -7641,22 +7667,22 @@
             "type": "object",
             "properties": {
                 "connector_id": {
-                    "description": "ID of the connector to initiate the connection for",
+                    "description": "ID of the connector to initiate the connection for.",
                     "type": "string",
-                    "example": "req_test550e8400abcde"
+                    "example": "cxr_test550e8400abcde"
                 },
                 "connector_version": {
-                    "description": "Version of the connector (optional, defaults to primary version)",
+                    "description": "Version of the connector to initiate connection for; if not specified defaults to the primary version.",
                     "type": "integer",
                     "example": 1
                 },
                 "into_namespace": {
-                    "description": "Namespace to create the connection in (optional, defaults to connector namespace)",
+                    "description": "The namespace to create the connection in. Must be the namespace of connector or a child namespace of that\nnamespace. Defaults to the connector namespace if not specified.",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "return_to_url": {
-                    "description": "URL to return to after the connection is completed",
+                    "description": "The URL to return to after the connection is completed.",
                     "type": "string",
                     "example": "https://example.com/callback"
                 }
@@ -7790,7 +7816,18 @@
             "type": "object",
             "properties": {
                 "data": {
-                    "description": "Form data matching the JSON Schema provided in the form response"
+                    "description": "Data is the form data submitted by the user for the current step.",
+                    "type": "object"
+                },
+                "return_to_url": {
+                    "description": "ReturnToUrl is required when the next step after form submission is an auth redirect.\nThe client should provide this so the OAuth callback knows where to return.",
+                    "type": "string",
+                    "example": "https://example.com/callback"
+                },
+                "step_id": {
+                    "description": "StepId is the id of the step being submitted. Must match the current setup step's id.",
+                    "type": "string",
+                    "example": "preconnect:0"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -40,43 +40,64 @@ definitions:
     description: Completion response for connection setup
     properties:
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       type:
-        description: Response type (always "complete")
+        description: Response type.
         example: complete
         type: string
     type: object
   routes.ConnectionSetupForm:
     description: Form response for connection setup
     properties:
+      current_step:
+        description: Current step number in the setup phase.
+        example: 1
+        type: integer
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       json_schema:
-        description: JSON Schema defining the form fields
+        description: JSON Schema defining the form fields.
+        type: object
+      step_description:
+        description: Step description.
+        type: string
+      step_id:
+        description: Step ID being submitted.
+        example: preconnect:0
+        type: string
+      step_title:
+        description: Step title.
+        example: Choose workspace
+        type: string
+      total_steps:
+        description: Total number of steps in the setup phase.
+        example: 2
+        type: integer
       type:
-        description: Response type (always "form")
+        description: Response type.
         example: form
         type: string
       ui_schema:
-        description: UI Schema for JSON Forms rendering
+        description: UI Schema for JSON Forms rendering.
+        type: object
     type: object
   routes.ConnectionSetupRedirect:
     description: Redirect response for connection setup
     properties:
       id:
-        description: Connection UUID
-        example: req_test550e8400abcde
+        description: Connection UUID.
+        example: cxn_test550e8400abcde
         type: string
       redirect_url:
-        description: URL to redirect the user to
+        description: URL to redirect the user to.
         example: https://oauth.provider.com/authorize?...
         type: string
       type:
-        description: Response type (always "redirect")
+        description: Response type.
         example: redirect
         type: string
     type: object
@@ -129,11 +150,11 @@ definitions:
     description: Data source option for form select fields
     properties:
       label:
-        description: Human-readable label
+        description: Human-readable label.
         example: My Workspace
         type: string
       value:
-        description: Option value
+        description: Option value.
         example: ws-123
         type: string
     type: object
@@ -152,20 +173,22 @@ definitions:
     description: Request to initiate a connection
     properties:
       connector_id:
-        description: ID of the connector to initiate the connection for
-        example: req_test550e8400abcde
+        description: ID of the connector to initiate the connection for.
+        example: cxr_test550e8400abcde
         type: string
       connector_version:
-        description: Version of the connector (optional, defaults to primary version)
+        description: Version of the connector to initiate connection for; if not specified
+          defaults to the primary version.
         example: 1
         type: integer
       into_namespace:
-        description: Namespace to create the connection in (optional, defaults to
-          connector namespace)
-        example: acme
+        description: |-
+          The namespace to create the connection in. Must be the namespace of connector or a child namespace of that
+          namespace. Defaults to the connector namespace if not specified.
+        example: root.acme
         type: string
       return_to_url:
-        description: URL to return to after the connection is completed
+        description: The URL to return to after the connection is completed.
         example: https://example.com/callback
         type: string
     type: object
@@ -258,7 +281,19 @@ definitions:
     description: Form submission data
     properties:
       data:
-        description: Form data matching the JSON Schema provided in the form response
+        description: Data is the form data submitted by the user for the current step.
+        type: object
+      return_to_url:
+        description: |-
+          ReturnToUrl is required when the next step after form submission is an auth redirect.
+          The client should provide this so the OAuth callback knows where to return.
+        example: https://example.com/callback
+        type: string
+      step_id:
+        description: StepId is the id of the step being submitted. Must match the
+          current setup step's id.
+        example: preconnect:0
+        type: string
     type: object
   routes.SwaggerConnectionJson:
     description: Connection to an external service


### PR DESCRIPTION
## Summary
- Add internal/schema/api as the canonical package for connection setup API request/response DTOs.
- Re-export the API schema and add schema samples/tests for initiate, submit, response variants, and data-source options.
- Replace core iface and route Swagger model definitions with aliases over schema/api, then regenerate API/admin Swagger docs.

Closes #386

## Tests
- go test ./internal/schema/...
- go test ./internal/... -run '^$'
- (cd integration_tests && go test ./... -run '^$')
- ./scripts/preflight.sh