### PR TITLE
Define ManifestSetupStep / flow types in core/iface (#362)

### DIFF
--- a/internal/core/iface/manifest_setup_step.go
+++ b/internal/core/iface/manifest_setup_step.go
@@ -1,0 +1,208 @@
+package iface
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+// ManifestStepType identifies the runtime kind of a setup step. The schema
+// distinguishes user-authored kinds (form vs. redirect) — those carry through
+// to the manifest unchanged, plus the auth-method-emitted steps that get one
+// or the other depending on what the method needs at that point in the flow
+// (api-key emits form steps for credential collection; OAuth2 emits a redirect
+// step for the authorize URL).
+type ManifestStepType string
+
+const (
+	ManifestStepTypeForm     ManifestStepType = "form"
+	ManifestStepTypeRedirect ManifestStepType = "redirect"
+)
+
+// Sentinel errors returned when a method is invoked on a step that doesn't
+// support it (e.g. calling OnSubmit on a redirect step). Callers should
+// dispatch by Type() before invoking the method; the sentinels exist so that
+// programmer errors fail loudly instead of silently misbehaving.
+var (
+	ErrSubmitNotSupported   = errors.New("step does not accept form submissions")
+	ErrRedirectNotSupported = errors.New("step is not a redirect step")
+)
+
+// RedirectInfo is the resolved redirect for a redirect-type step. The setup
+// flow returns this from RenderRedirect; the HTTP layer turns it into the
+// ConnectionSetupRedirect response. Single-field today; expandable when a
+// future step kind needs e.g. POST + body or additional headers.
+type RedirectInfo struct {
+	// URL is the fully-rendered URL the user should be redirected to. For
+	// schema-defined redirect steps this is the URL template with cfg + token
+	// substitution applied; for OAuth2-emitted redirect steps this is the
+	// freshly-minted authorize URL (state + PKCE already persisted).
+	URL string
+}
+
+// RenderRedirectOptions carries request-scoped inputs into a redirect step's
+// URL resolution. Threaded through the flow runner because the values are
+// known to the HTTP layer but not the step itself.
+type RenderRedirectOptions struct {
+	// ReturnToUrl is the marketplace URL the 3rd party should bounce the user
+	// back to after they complete the off-platform step. Empty when the
+	// caller does not have one — schema-defined redirect steps that use
+	// RETURN_ADVANCE/RETURN_ABORT tokens (see #367) read ReturnToUrl to
+	// embed in the signed token's claim payload; OAuth2 reads it to persist
+	// in the state record.
+	ReturnToUrl string
+}
+
+// ManifestSetupStep is a single, fully-resolved step in a connection's setup
+// flow. Owners (schema-defined steps from the connector YAML, auth-method-
+// emitted steps from the auth method's factory) construct ManifestSetupStep
+// values; core's flow runner dispatches against them without knowing where
+// they came from.
+//
+// All steps expose presentation metadata (Id, Title, Description, Type). Type
+// determines which of OnSubmit / RenderRedirect is meaningful — calling the
+// other returns the matching sentinel error.
+type ManifestSetupStep interface {
+	// Id is the step identifier. User-authored steps carry the id from the
+	// connector YAML; system-emitted steps use the apxy: prefix (e.g.
+	// "apxy:auth:oauth2_authorize", "apxy:verify_failed").
+	Id() string
+
+	// Title and Description are the human-readable strings the UI renders
+	// above the form / redirect notice. Both may be empty.
+	Title() string
+	Description() string
+
+	// Type selects the dispatch branch — form steps receive OnSubmit, redirect
+	// steps receive RenderRedirect.
+	Type() ManifestStepType
+
+	// JsonSchema and UiSchema are the JSONForms-shaped payloads for form
+	// steps. Both return nil for redirect steps.
+	JsonSchema() json.RawMessage
+	UiSchema() json.RawMessage
+
+	// OnSubmit handles a form submission for this step. Implementations:
+	//   - schema-defined form steps: validate against JsonSchema and merge
+	//     the allowed fields into the connection's EncryptedConfiguration.
+	//   - auth-method-emitted form steps (e.g. api-key credential
+	//     collection): hand the data to the auth method to persist as
+	//     credentials, then trigger HandleCredentialsEstablished.
+	//   - redirect steps: return ErrSubmitNotSupported.
+	OnSubmit(ctx context.Context, data json.RawMessage) error
+
+	// RenderRedirect returns the resolved redirect URL for redirect-type
+	// steps. Form steps return ErrRedirectNotSupported. The opts struct
+	// carries request-scoped values (ReturnToUrl) the step may need to mint
+	// the URL.
+	RenderRedirect(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
+}
+
+// ManifestSetupFlow is the ordered, fully-materialized setup flow for a
+// connection. Built by core (the flow builder lands in #366) from: preconnect
+// steps (schema) + auth-method-emitted steps (factory) + configure steps
+// (schema). Terminal failure pseudo-steps (apxy:verify_failed,
+// apxy:auth_failed) and the verify step (apxy:verify) are addressable by id
+// but not part of the linear order returned by Steps() / NextStep().
+type ManifestSetupFlow interface {
+	// Steps returns the ordered, linear steps a user walks through during
+	// setup. Implicit terminal steps (verify_failed, auth_failed) and the
+	// verify pseudo-step are not included; use StepById for those.
+	Steps() []ManifestSetupStep
+
+	// StepById returns the step with the given id, including implicit
+	// terminal/verify pseudo-steps. Returns false if the id is unknown.
+	StepById(id string) (ManifestSetupStep, bool)
+
+	// FirstStep returns the first step in the linear flow. Returns nil if
+	// the flow has no linear steps (a connector with no preconnect, no
+	// auth-emitted steps, and no configure — which means setup is already
+	// complete on initiate).
+	FirstStep() ManifestSetupStep
+
+	// NextStep returns the step that follows the step with the given id in
+	// the linear flow, or false when currentId is the final linear step.
+	// Pseudo-steps (verify, verify_failed, auth_failed) are not part of the
+	// linear successor relation.
+	NextStep(currentId string) (ManifestSetupStep, bool)
+}
+
+// FormStepConfig configures NewFormStep. All fields are optional except Id
+// and JsonSchema; OnSubmit is required for the step to handle submissions
+// (a nil submitter returns ErrSubmitNotSupported, which is correct for
+// purely-display intermediate steps if those ever exist).
+type FormStepConfig struct {
+	Id          string
+	Title       string
+	Description string
+	JsonSchema  json.RawMessage
+	UiSchema    json.RawMessage
+	OnSubmit    func(ctx context.Context, data json.RawMessage) error
+}
+
+// NewFormStep returns a form-type ManifestSetupStep backed by the supplied
+// configuration. The OnSubmit closure is what differs across owners (schema
+// merges into config; api-key persists credentials).
+func NewFormStep(cfg FormStepConfig) ManifestSetupStep {
+	return &formStep{cfg: cfg}
+}
+
+// RedirectStepConfig configures NewRedirectStep.
+type RedirectStepConfig struct {
+	Id          string
+	Title       string
+	Description string
+	// Render resolves the redirect URL when the flow runner reaches this
+	// step. Required.
+	Render func(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
+}
+
+// NewRedirectStep returns a redirect-type ManifestSetupStep backed by the
+// supplied configuration.
+func NewRedirectStep(cfg RedirectStepConfig) ManifestSetupStep {
+	return &redirectStep{cfg: cfg}
+}
+
+type formStep struct {
+	cfg FormStepConfig
+}
+
+func (s *formStep) Id() string                       { return s.cfg.Id }
+func (s *formStep) Title() string                    { return s.cfg.Title }
+func (s *formStep) Description() string              { return s.cfg.Description }
+func (s *formStep) Type() ManifestStepType           { return ManifestStepTypeForm }
+func (s *formStep) JsonSchema() json.RawMessage      { return s.cfg.JsonSchema }
+func (s *formStep) UiSchema() json.RawMessage        { return s.cfg.UiSchema }
+
+func (s *formStep) OnSubmit(ctx context.Context, data json.RawMessage) error {
+	if s.cfg.OnSubmit == nil {
+		return ErrSubmitNotSupported
+	}
+	return s.cfg.OnSubmit(ctx, data)
+}
+
+func (s *formStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
+	return RedirectInfo{}, ErrRedirectNotSupported
+}
+
+type redirectStep struct {
+	cfg RedirectStepConfig
+}
+
+func (s *redirectStep) Id() string                  { return s.cfg.Id }
+func (s *redirectStep) Title() string               { return s.cfg.Title }
+func (s *redirectStep) Description() string         { return s.cfg.Description }
+func (s *redirectStep) Type() ManifestStepType      { return ManifestStepTypeRedirect }
+func (s *redirectStep) JsonSchema() json.RawMessage { return nil }
+func (s *redirectStep) UiSchema() json.RawMessage   { return nil }
+
+func (s *redirectStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
+	return ErrSubmitNotSupported
+}
+
+func (s *redirectStep) RenderRedirect(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error) {
+	if s.cfg.Render == nil {
+		return RedirectInfo{}, ErrRedirectNotSupported
+	}
+	return s.cfg.Render(ctx, opts)
+}

--- a/internal/core/iface/manifest_setup_step_test.go
+++ b/internal/core/iface/manifest_setup_step_test.go
@@ -1,0 +1,110 @@
+package iface_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/internal/core/iface"
+)
+
+// TestFormStep_DispatchSurface verifies that NewFormStep produces a step
+// whose Type is form, whose OnSubmit invokes the supplied closure, and whose
+// RenderRedirect returns the sentinel for "wrong method." This is the core
+// dispatch contract callers rely on.
+func TestFormStep_DispatchSurface(t *testing.T) {
+	var captured json.RawMessage
+	step := iface.NewFormStep(iface.FormStepConfig{
+		Id:          "preconnect-0",
+		Title:       "Subdomain",
+		Description: "Enter your subdomain",
+		JsonSchema:  json.RawMessage(`{"type":"object"}`),
+		UiSchema:    json.RawMessage(`{"type":"VerticalLayout"}`),
+		OnSubmit: func(_ context.Context, data json.RawMessage) error {
+			captured = data
+			return nil
+		},
+	})
+
+	assert.Equal(t, "preconnect-0", step.Id())
+	assert.Equal(t, "Subdomain", step.Title())
+	assert.Equal(t, "Enter your subdomain", step.Description())
+	assert.Equal(t, iface.ManifestStepTypeForm, step.Type())
+	assert.JSONEq(t, `{"type":"object"}`, string(step.JsonSchema()))
+	assert.JSONEq(t, `{"type":"VerticalLayout"}`, string(step.UiSchema()))
+
+	payload := json.RawMessage(`{"subdomain":"acme"}`)
+	require.NoError(t, step.OnSubmit(context.Background(), payload))
+	assert.JSONEq(t, `{"subdomain":"acme"}`, string(captured))
+
+	_, err := step.RenderRedirect(context.Background(), iface.RenderRedirectOptions{})
+	assert.ErrorIs(t, err, iface.ErrRedirectNotSupported)
+}
+
+// TestFormStep_NilOnSubmitReturnsSentinel — a form step constructed without
+// an OnSubmit closure surfaces ErrSubmitNotSupported on call. Lets callers
+// distinguish "this step has no handler" from "the handler returned an error."
+func TestFormStep_NilOnSubmitReturnsSentinel(t *testing.T) {
+	step := iface.NewFormStep(iface.FormStepConfig{Id: "x"})
+	err := step.OnSubmit(context.Background(), json.RawMessage(`{}`))
+	assert.ErrorIs(t, err, iface.ErrSubmitNotSupported)
+}
+
+// TestFormStep_OnSubmitErrorPropagates — caller-side errors round-trip
+// unchanged (not wrapped in ErrSubmitNotSupported). Important so schema
+// validation failures and credential-persistence failures stay distinguishable.
+func TestFormStep_OnSubmitErrorPropagates(t *testing.T) {
+	sentinel := errors.New("schema validation failed: missing required field 'subdomain'")
+	step := iface.NewFormStep(iface.FormStepConfig{
+		Id: "x",
+		OnSubmit: func(_ context.Context, _ json.RawMessage) error {
+			return sentinel
+		},
+	})
+	err := step.OnSubmit(context.Background(), nil)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+// TestRedirectStep_DispatchSurface verifies that NewRedirectStep produces a
+// step whose Type is redirect, whose RenderRedirect invokes the supplied
+// closure with ReturnToUrl threaded through, and whose OnSubmit returns the
+// sentinel.
+func TestRedirectStep_DispatchSurface(t *testing.T) {
+	var capturedOpts iface.RenderRedirectOptions
+	step := iface.NewRedirectStep(iface.RedirectStepConfig{
+		Id:          "apxy:auth:oauth2_authorize",
+		Title:       "Authorize",
+		Description: "Sign in with your provider",
+		Render: func(_ context.Context, opts iface.RenderRedirectOptions) (iface.RedirectInfo, error) {
+			capturedOpts = opts
+			return iface.RedirectInfo{URL: "https://provider.example.com/authorize?state=abc"}, nil
+		},
+	})
+
+	assert.Equal(t, "apxy:auth:oauth2_authorize", step.Id())
+	assert.Equal(t, iface.ManifestStepTypeRedirect, step.Type())
+	assert.Nil(t, step.JsonSchema())
+	assert.Nil(t, step.UiSchema())
+
+	info, err := step.RenderRedirect(context.Background(), iface.RenderRedirectOptions{
+		ReturnToUrl: "https://marketplace.example.com/connections",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://provider.example.com/authorize?state=abc", info.URL)
+	assert.Equal(t, "https://marketplace.example.com/connections", capturedOpts.ReturnToUrl)
+
+	assert.ErrorIs(t, step.OnSubmit(context.Background(), nil), iface.ErrSubmitNotSupported)
+}
+
+// TestRedirectStep_NilRenderReturnsSentinel — a redirect step constructed
+// without a Render closure surfaces ErrRedirectNotSupported. Matches the
+// form-step nil-handler behavior.
+func TestRedirectStep_NilRenderReturnsSentinel(t *testing.T) {
+	step := iface.NewRedirectStep(iface.RedirectStepConfig{Id: "x"})
+	_, err := step.RenderRedirect(context.Background(), iface.RenderRedirectOptions{})
+	assert.ErrorIs(t, err, iface.ErrRedirectNotSupported)
+}


### PR DESCRIPTION
Closes #362. Part of #360.

## Summary

Introduces the runtime representation of a fully-materialized setup flow in ``internal/core/iface``. No callers yet — this is the type surface that #366 wires core to, and that auth-method factories will emit steps into.

- ``ManifestStepType`` (``form`` | ``redirect``).
- ``ManifestSetupStep`` — a single, fully-resolved step. Exposes ``Id`` / ``Title`` / ``Description`` / ``Type`` / ``JsonSchema`` / ``UiSchema`` for presentation, plus ``OnSubmit`` (form steps) and ``RenderRedirect`` (redirect steps) for dispatch. Calling the wrong method returns ``ErrSubmitNotSupported`` / ``ErrRedirectNotSupported`` sentinels.
- ``ManifestSetupFlow`` — ordered linear ``Steps()`` + ``StepById()`` lookup for terminal pseudo-steps (``apxy:verify_failed`` / ``apxy:auth_failed`` / ``apxy:verify``).
- ``RedirectInfo`` (resolved URL) and ``RenderRedirectOptions`` (carries ``ReturnToUrl`` request-scoped through to the step's URL resolver — needed by both schema-defined redirect steps with ``{{RETURN_ADVANCE}}`` tokens in #367 and the OAuth2-emitted redirect step in #368).
- ``NewFormStep`` / ``NewRedirectStep`` constructor helpers backed by closure-carrying concrete types so each owner (schema, api-key, OAuth2) builds steps without defining a per-kind struct.

## Test plan

- [x] New unit tests in ``manifest_setup_step_test.go`` cover the dispatch contract on each step kind (form / redirect), nil-handler sentinels, error propagation, and ``ReturnToUrl`` threading.
- [x] ``go test ./internal/core/... ./internal/auth_methods/...`` clean.
- [x] ``./scripts/preflight.sh`` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)