### PR TITLE
[A18] demos/shell: Go SSO host stand-in + React picker for demo env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY ui ui
 COPY sdks sdks
+# `demos/*/frontend` is declared as a workspace in the root package.json.
+# `yarn install --immutable` insists every declared workspace exists on
+# disk even when we won't build the demo image here (demos/shell ships
+# in its own image — see A19/#306). Copying the dir keeps yarn happy
+# without affecting any subsequent build steps.
+COPY demos demos
 
 RUN yarn install --immutable
 RUN yarn workspace @authproxy/admin build \

--- a/demos/shell/.gitignore
+++ b/demos/shell/.gitignore
@@ -1,0 +1,9 @@
+# Locally-generated demo admin keypair (never commit private keys).
+dev_keys/
+
+# Vite build output. `backend/embed/dist/.gitkeep` + `placeholder.html`
+# are committed so //go:embed always has at least one file on a fresh
+# checkout; everything else is build-time output.
+backend/embed/dist/*
+!backend/embed/dist/.gitkeep
+!backend/embed/dist/placeholder.html

--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -1,0 +1,123 @@
+# demos/shell — SSO stand-in host for the AuthProxy demo
+
+AuthProxy is normally embedded in a host application that handles user
+authentication. The demo environment needs a stand-in for that host —
+something with a "pick your demo identity" dropdown that mints a JWT
+vouching for the selected user and redirects them into the AuthProxy
+marketplace or admin UI.
+
+**Never ship this to customers.** It only lives in the demo environment.
+
+## Architecture
+
+```
+   ┌──────────────────────┐        POST /sso         ┌──────────────────────┐
+   │  Frontend (Vite)     │  ─────────────────────►  │  Backend (Go)         │
+   │  actor + destination │                          │  - signs JWT          │
+   │  dropdowns           │                          │  - 303 redirect       │
+   └──────────────────────┘                          └──────────┬───────────┘
+                                                                │
+                                                                ▼
+                            ┌──────────────────────────────────────────────────┐
+                            │  Marketplace or Admin UI                          │
+                            │  picks up ?auth_token=… → establishes session     │
+                            └──────────────────────────────────────────────────┘
+```
+
+The backend holds **one** admin private key. AuthProxy's auth model
+trusts an admin-signed JWT to bear any `actor_external_id` claim — so
+one key is enough to "be" any of the three demo identities.
+
+## Running locally
+
+Pre-requisites:
+- AuthProxy server running locally (`go run ./cmd/server serve --config=./dev_config/default.yaml all`)
+- A configured admin actor in your AuthProxy config that the demo shell can use as its signing identity
+- Node + Yarn pinned via Volta (see root `package.json`)
+
+### 1. Generate the demo admin keypair (one-time, local)
+
+```bash
+mkdir -p demos/shell/dev_keys
+openssl genrsa -out demos/shell/dev_keys/demo-shell 2048
+openssl rsa -in demos/shell/dev_keys/demo-shell -pubout -out demos/shell/dev_keys/demo-shell.pub
+```
+
+Add the public key as an admin actor in `dev_config/default.yaml`:
+
+```yaml
+system_auth:
+  actors:
+    - external_id: demo-shell
+      key:
+        public_key:
+          path: ./demos/shell/dev_keys/demo-shell.pub
+      permissions:
+        - namespace: "root.**"
+          resources: ["*"]
+          verbs: ["*"]
+```
+
+Restart the AuthProxy server so it picks up the new actor.
+
+### 2. Start the demo-shell frontend (vite dev for HMR)
+
+```bash
+yarn install                          # picks up demos/shell/frontend as @authproxy/demo-shell
+yarn workspace @authproxy/demo-shell dev
+# → listens on http://localhost:5175
+```
+
+### 3. Start the demo-shell backend
+
+```bash
+ADMIN_USERNAME=demo-shell \
+ADMIN_PRIVATE_KEY_PATH=./demos/shell/dev_keys/demo-shell \
+AUTHPROXY_ADMIN_UI_URL=http://localhost:5174 \
+AUTHPROXY_MARKETPLACE_URL=http://localhost:5173 \
+AUTHPROXY_AUTH_URL=http://localhost:8080 \
+DEV_FRONTEND_URL=http://localhost:5175 \
+go run ./demos/shell/backend
+# → listens on http://localhost:8888
+```
+
+`DEV_FRONTEND_URL` makes the backend's `GET /` redirect to the vite dev
+server so HMR works. Leave it unset in production — the backend serves
+the embedded build at the same root.
+
+### 4. Drive the flow
+
+Open <http://localhost:8888>. Pick `demo-admin` + Admin UI → submit →
+you're redirected to the AuthProxy admin UI as `demo-admin` with a fresh
+session. Pick `fresh-user` + Marketplace → empty marketplace, no
+connections.
+
+## Configuration reference
+
+The backend reads the following env vars:
+
+| Var                       | Required | Notes                                                                       |
+|---------------------------|----------|-----------------------------------------------------------------------------|
+| `ADMIN_USERNAME`          | ✅        | external_id of the admin actor whose key is mounted at `ADMIN_PRIVATE_KEY_PATH` |
+| `ADMIN_PRIVATE_KEY_PATH`  | ✅        | File path; PEM RSA or EC                                                    |
+| `AUTHPROXY_ADMIN_UI_URL`  | ✅        | Base URL of the admin SPA                                                   |
+| `AUTHPROXY_MARKETPLACE_URL` | ✅      | Base URL of the marketplace SPA                                             |
+| `AUTHPROXY_AUTH_URL`      | ⛔        | Optional today; kept for future routes that call back into AuthProxy        |
+| `DEV_FRONTEND_URL`        | ⛔        | If set, `GET /` redirects here instead of serving the embedded build        |
+| `PORT`                    | ⛔        | Default `8888`                                                              |
+
+## Why one signing key, not three
+
+It's tempting to give the demo shell one keypair per demo identity. The
+existing AuthProxy auth model already covers the multi-identity case via
+admin-actor vouching: an admin's JWT can bear any `actor_external_id`
+claim and AuthProxy will trust the user assignment. That's the same
+pattern `cmd/cli/sign-marketplace-login-url` uses, so the demo shell
+mirrors it.
+
+## Why this lives in `demos/`, not `cmd/` or `internal/`
+
+Top-level `demos/` lets future demo wrappers (each their own stand-in
+host) live next to this one without polluting the main service tree.
+Anything under `demos/` is allowed to import from `internal/` but the
+reverse is forbidden — main code never depends on demo code.

--- a/demos/shell/backend/embed/dist/placeholder.html
+++ b/demos/shell/backend/embed/dist/placeholder.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<!--
+  Placeholder so //go:embed all:dist has at least one file on a fresh
+  checkout. Replaced by `yarn workspace @authproxy/demo-shell build`
+  output. If you see this in production, the vite build didn't run.
+-->
+<html><body><pre>demo-shell frontend not yet built</pre></body></html>

--- a/demos/shell/backend/embed/embed.go
+++ b/demos/shell/backend/embed/embed.go
@@ -1,0 +1,24 @@
+// Package embed exposes the built demo-shell SPA as an embedded filesystem.
+//
+// The contents come from `vite build` (outDir=../backend/embed/dist).
+// A placeholder file + .gitkeep live in dist/ so the //go:embed directive
+// has at least one file on a fresh checkout — the real production build
+// overwrites them in CI / `make demo-shell`.
+package embed
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:dist
+var distFS embed.FS
+
+// FS returns a filesystem rooted at the built dist/ directory.
+func FS() fs.FS {
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}

--- a/demos/shell/backend/main.go
+++ b/demos/shell/backend/main.go
@@ -1,0 +1,209 @@
+// Command demo-shell is the SSO stand-in host application for the AuthProxy
+// demo environment.
+//
+// AuthProxy is normally embedded in a host application that handles user
+// authentication; the host signs a JWT vouching for the authenticated user
+// using an admin signing key registered with AuthProxy, then redirects the
+// user to the appropriate AuthProxy UI (marketplace or admin) with the JWT
+// as a query parameter. AuthProxy validates the signature against the
+// admin's stored public key and establishes a session.
+//
+// The demo shell short-circuits the "actual auth" step: it presents three
+// well-known demo actor identities as a dropdown and signs a JWT for the
+// picked one. **Not** something you'd ship to customers — lives only in
+// the demo environment.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rmorlok/authproxy/demos/shell/backend/embed"
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// demoActors enumerates the three identities the shell can sign JWTs for.
+// The same three are expected to exist as ConfiguredActors on the AuthProxy
+// side (the umbrella chart's seed job pre-creates them — see #A11).
+var demoActors = map[string]struct{}{
+	"demo-admin": {},
+	"demo-user":  {},
+	"fresh-user": {},
+}
+
+// demoDestinations maps the UI's `destination` form field to the env var
+// the backend reads to know where to redirect.
+var demoDestinations = map[string]string{
+	"admin":       "AUTHPROXY_ADMIN_UI_URL",
+	"marketplace": "AUTHPROXY_MARKETPLACE_URL",
+}
+
+type settings struct {
+	addr                string
+	adminPrivateKeyPath string
+	adminUsername       string
+	authUrl             string
+	destinationUrls     map[string]string
+	devFrontendUrl      string
+	tokenTtl            time.Duration
+}
+
+func mustGetenv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "missing required env var %s\n", key)
+		os.Exit(2)
+	}
+	return v
+}
+
+func loadSettings() settings {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8888"
+	}
+
+	destURLs := make(map[string]string, len(demoDestinations))
+	for dest, envKey := range demoDestinations {
+		destURLs[dest] = mustGetenv(envKey)
+	}
+
+	return settings{
+		addr:                ":" + port,
+		adminPrivateKeyPath: mustGetenv("ADMIN_PRIVATE_KEY_PATH"),
+		adminUsername:       mustGetenv("ADMIN_USERNAME"),
+		// AUTHPROXY_AUTH_URL isn't strictly required for the redirect itself
+		// (the destination URLs are what we redirect to) but it's kept here
+		// in case future routes need to call back into AuthProxy directly.
+		authUrl: os.Getenv("AUTHPROXY_AUTH_URL"),
+		// DEV_FRONTEND_URL=http://localhost:5175 makes GET / proxy to a
+		// running vite dev server for HMR. Empty in production — frontend
+		// is served from the embedded FS.
+		devFrontendUrl:  os.Getenv("DEV_FRONTEND_URL"),
+		destinationUrls: destURLs,
+		tokenTtl:        15 * time.Minute,
+	}
+}
+
+// signTokenFor mints a JWT signed by the admin keypair, claiming the
+// picked actor's external_id. AuthProxy validates the signature against
+// the admin's stored public key and — because the admin has trust to
+// vouch for arbitrary actors — establishes a session for that actor.
+func signTokenFor(s settings, actorExternalId string) (string, error) {
+	b := jwt.NewJwtTokenBuilder().
+		WithActorExternalId(actorExternalId).
+		WithActorSigned().
+		WithServiceIds(config.AllServiceIds()).
+		WithNonce().
+		WithExpiresIn(s.tokenTtl).
+		WithPrivateKeyPath(s.adminPrivateKeyPath)
+
+	return b.Token()
+}
+
+func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+
+		actor := strings.TrimSpace(r.FormValue("actor"))
+		destination := strings.TrimSpace(r.FormValue("destination"))
+
+		if _, ok := demoActors[actor]; !ok {
+			http.Error(w, "unknown actor", http.StatusBadRequest)
+			return
+		}
+		destURL, ok := s.destinationUrls[destination]
+		if !ok {
+			http.Error(w, "unknown destination", http.StatusBadRequest)
+			return
+		}
+
+		token, err := signTokenFor(s, actor)
+		if err != nil {
+			logger.Error("failed to sign token", "err", err, "actor", actor)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		parsed, err := url.Parse(destURL)
+		if err != nil {
+			logger.Error("invalid destination URL", "err", err, "destination", destination, "url", destURL)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		q := parsed.Query()
+		q.Set("auth_token", token)
+		parsed.RawQuery = q.Encode()
+
+		logger.Info("signed token, redirecting", "actor", actor, "destination", destination)
+		http.Redirect(w, r, parsed.String(), http.StatusSeeOther)
+	}
+}
+
+// frontendHandler serves the SPA. In production, it serves the embedded
+// build at embed/dist/. In dev (DEV_FRONTEND_URL set), it 302-redirects
+// to the vite dev server so HMR + source maps work.
+func frontendHandler(s settings) http.Handler {
+	if s.devFrontendUrl != "" {
+		base, err := url.Parse(s.devFrontendUrl)
+		if err != nil {
+			panic(fmt.Errorf("invalid DEV_FRONTEND_URL %q: %w", s.devFrontendUrl, err))
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			redirectURL := *base
+			redirectURL.Path = r.URL.Path
+			redirectURL.RawQuery = r.URL.RawQuery
+			http.Redirect(w, r, redirectURL.String(), http.StatusTemporaryRedirect)
+		})
+	}
+
+	root, err := fs.Sub(embed.FS(), ".")
+	if err != nil {
+		panic(err)
+	}
+	return http.FileServer(http.FS(root))
+}
+
+func main() {
+	flag.Parse()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	s := loadSettings()
+
+	mux := http.NewServeMux()
+	mux.Handle("POST /sso", ssoHandler(s, logger))
+	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	mux.Handle("/", frontendHandler(s))
+
+	srv := &http.Server{
+		Addr:              s.addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	logger.Info("demo-shell listening", "addr", s.addr, "dev_frontend", s.devFrontendUrl != "")
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("server exited", "err", err)
+		os.Exit(1)
+	}
+}

--- a/demos/shell/frontend/index.html
+++ b/demos/shell/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AuthProxy Demo · Sign-in</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demos/shell/frontend/package.json
+++ b/demos/shell/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@authproxy/demo-shell",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "preview": "vite preview",
+    "lint": "eslint --ext .ts,.tsx src"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}

--- a/demos/shell/frontend/src/App.tsx
+++ b/demos/shell/frontend/src/App.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+// Demo actor identities. The same three names are pre-created on the
+// AuthProxy side by the umbrella chart's seed job (A11 / #300); each maps
+// to a ConfiguredActor with namespace + permissions appropriate for the
+// scenario the dropdown label describes.
+const ACTORS: Array<{ id: string; label: string; description: string }> = [
+  {
+    id: 'demo-admin',
+    label: 'Demo admin',
+    description: 'Pre-configured admin actor with access to the admin UI.',
+  },
+  {
+    id: 'demo-user',
+    label: 'Demo user',
+    description: 'Pre-configured end user with a working connection to the demo connector.',
+  },
+  {
+    id: 'fresh-user',
+    label: 'Fresh user',
+    description: 'New user with no connections — lands on an empty marketplace.',
+  },
+];
+
+const DESTINATIONS: Array<{ id: 'admin' | 'marketplace'; label: string }> = [
+  { id: 'marketplace', label: 'Marketplace UI' },
+  { id: 'admin', label: 'Admin UI' },
+];
+
+export function App() {
+  const [actor, setActor] = useState(ACTORS[0]!.id);
+  const [destination, setDestination] = useState<'admin' | 'marketplace'>('marketplace');
+
+  const actorMeta = ACTORS.find((a) => a.id === actor)!;
+
+  return (
+    <div className="shell">
+      <h1>AuthProxy Demo Shell</h1>
+      <p className="lede">
+        Stand-in host application. Pick an actor identity + a destination and the
+        demo shell signs a JWT, redirects you in.
+      </p>
+
+      <form method="POST" action="/sso" className="card">
+        <label>
+          <span>Actor</span>
+          <select name="actor" value={actor} onChange={(e) => setActor(e.target.value)}>
+            {ACTORS.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.label}
+              </option>
+            ))}
+          </select>
+          <small>{actorMeta.description}</small>
+        </label>
+
+        <label>
+          <span>Destination</span>
+          <select
+            name="destination"
+            value={destination}
+            onChange={(e) => setDestination(e.target.value as 'admin' | 'marketplace')}
+          >
+            {DESTINATIONS.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button type="submit">Sign in</button>
+      </form>
+
+      <footer>
+        Demo environment only — never ship this shell to customers.
+      </footer>
+    </div>
+  );
+}

--- a/demos/shell/frontend/src/main.tsx
+++ b/demos/shell/frontend/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+if (!container) {
+  throw new Error('#root element missing from index.html');
+}
+createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/demos/shell/frontend/src/styles.css
+++ b/demos/shell/frontend/src/styles.css
@@ -1,0 +1,88 @@
+:root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1rem;
+  background: light-dark(#f5f5f7, #1a1a1c);
+  color: light-dark(#1a1a1c, #f5f5f7);
+}
+
+.shell {
+  width: 100%;
+  max-width: 480px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.lede {
+  margin: 0 0 1.5rem;
+  opacity: 0.75;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.card {
+  background: light-dark(#fff, #2a2a2e);
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+label > span {
+  font-weight: 600;
+}
+
+select {
+  font-size: 1rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid light-dark(#d0d0d4, #444);
+  background: light-dark(#fff, #1a1a1c);
+  color: inherit;
+}
+
+small {
+  opacity: 0.65;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+button[type='submit'] {
+  font-size: 1rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 0;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button[type='submit']:hover {
+  background: #1d4ed8;
+}
+
+footer {
+  margin-top: 2rem;
+  font-size: 0.8rem;
+  opacity: 0.55;
+  text-align: center;
+}

--- a/demos/shell/frontend/tsconfig.json
+++ b/demos/shell/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/demos/shell/frontend/vite.config.ts
+++ b/demos/shell/frontend/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = resolve(__dirname, '../../..');
+
+export default defineConfig(({ mode }) => {
+  // Same root-env override pattern as ui/marketplace — lets multi-clone
+  // setups (authproxy1, authproxy2, …) override port slots from one place.
+  const rootEnv = loadEnv(mode, monorepoRoot, '');
+  for (const [k, v] of Object.entries(rootEnv)) {
+    process.env[k] = v;
+  }
+
+  const port = Number(process.env.AUTHPROXY_DEMO_SHELL_UI_PORT) || 5175;
+  const base = process.env.VITE_BASE_URL || '/';
+
+  return {
+    base,
+    plugins: [react()],
+    server: {
+      port,
+      strictPort: true,
+    },
+    build: {
+      // Output into ../backend/embed/dist so the Go //go:embed directive in
+      // demos/shell/backend/embed/embed.go can pick the build up at compile
+      // time without copying files around.
+      outDir: '../backend/embed/dist',
+      emptyOutDir: false,
+    },
+  };
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "workspaces": [
     "ui/*",
-    "sdks/js"
+    "sdks/js",
+    "demos/*/frontend"
   ],
   "packageManager": "yarn@4.11.0",
   "volta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@authproxy/demo-shell@workspace:demos/shell/frontend":
+  version: 0.0.0-use.local
+  resolution: "@authproxy/demo-shell@workspace:demos/shell/frontend"
+  dependencies:
+    "@types/react": "npm:^18.3.12"
+    "@types/react-dom": "npm:^18.3.1"
+    "@vitejs/plugin-react": "npm:^4.3.4"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:^5.7.2"
+    vite: "npm:^5.4.11"
+  languageName: unknown
+  linkType: soft
+
 "@authproxy/marketplace@workspace:ui/marketplace":
   version: 0.0.0-use.local
   resolution: "@authproxy/marketplace@workspace:ui/marketplace"
@@ -3026,10 +3040,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:^15.7.15":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.15":
   version: 15.7.15
   resolution: "@types/prop-types@npm:15.7.15"
   checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.3.1":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: 10c0/8bd309e2c3d1604a28a736a24f96cbadf6c05d5288cfef8883b74f4054c961b6b3a5e997fd5686e492be903c8f3380dba5ec017eff3906b1256529cd2d39603e
   languageName: node
   linkType: hard
 
@@ -3048,6 +3071,16 @@ __metadata:
   peerDependencies:
     "@types/react": "*"
   checksum: 10c0/0441b8b47c69312c89ec0760ba477ba1a0808a10ceef8dc1c64b1013ed78517332c30f18681b0ec0b53542731f1ed015169fed1d127cc91222638ed955478ec7
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.3.12":
+  version: 18.3.29
+  resolution: "@types/react@npm:18.3.29"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/b582f5c3a034229b2e287f5e39aebf3988d6ce79e7fd81c8257dc55bee0e321ddf708d6014a44c5ceae8debea1e15a93326b207a4fec6a0170200a03d105adfb
   languageName: node
   linkType: hard
 
@@ -3402,7 +3435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^4.2.1":
+"@vitejs/plugin-react@npm:^4.2.1, @vitejs/plugin-react@npm:^4.3.4":
   version: 4.7.0
   resolution: "@vitejs/plugin-react@npm:4.7.0"
   dependencies:
@@ -4309,6 +4342,13 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
   languageName: node
   linkType: hard
 
@@ -6840,7 +6880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -8262,6 +8302,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    scheduler: "npm:^0.23.2"
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -8374,6 +8426,15 @@ __metadata:
   version: 19.2.0
   resolution: "react@npm:19.2.0"
   checksum: 10c0/1b6d64eacb9324725bfe1e7860cb7a6b8a34bc89a482920765ebff5c10578eb487e6b46b2f0df263bd27a25edbdae2c45e5ea5d81ae61404301c1a7192c38330
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
   languageName: node
   linkType: hard
 
@@ -8808,6 +8869,15 @@ __metadata:
   dependencies:
     xmlchars: "npm:^2.2.0"
   checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
   languageName: node
   linkType: hard
 
@@ -9565,7 +9635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.6.3, typescript@npm:latest":
+"typescript@npm:^5.6.3, typescript@npm:^5.7.2, typescript@npm:latest":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -9575,7 +9645,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3Alatest#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3Alatest#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -9815,7 +9885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0, vite@npm:^5.0.12":
+"vite@npm:^5.0.0, vite@npm:^5.0.12, vite@npm:^5.4.11":
   version: 5.4.21
   resolution: "vite@npm:5.4.21"
   dependencies:


### PR DESCRIPTION
## Summary
Adds `demos/shell/` — the SSO stand-in host the demo environment needs because AuthProxy is normally embedded in a host that handles user auth.

- **`demos/shell/backend/`** — Go service. Holds one admin signing keypair, exposes `POST /sso` accepting `actor` + `destination` form fields, mints a JWT via `internal/apauth/jwt`, 303-redirects to the picked SPA with `?auth_token=…`. Serves the embedded frontend at `/`; falls back to a vite-dev redirect when `DEV_FRONTEND_URL` is set.
- **`demos/shell/frontend/`** — Vite + React. Dropdowns for actor (`demo-admin` / `demo-user` / `fresh-user`) × destination (admin / marketplace). Builds into `../backend/embed/dist` so `go:embed` picks it up.
- Top-level `demos/` is new — future demo wrappers (each their own stand-in host) live next to this one without polluting `cmd/` or `internal/`. Root `package.json` workspaces gains `demos/*/frontend`.

Auth model: AuthProxy already trusts an admin-signed JWT to bear any `actor_external_id` claim (same pattern `cmd/cli/sign-marketplace-login-url` uses), so the shell holds one keypair and "becomes" any of the three identities by varying the claim. The three demo actors themselves come from A11 (#300).

Closes #305.

## Local-dev story
Full procedure in `demos/shell/README.md`. TL;DR:

```bash
# Generate the demo admin keypair (one-time, local):
mkdir -p demos/shell/dev_keys && openssl genrsa -out demos/shell/dev_keys/demo-shell 2048 && openssl rsa -in demos/shell/dev_keys/demo-shell -pubout -out demos/shell/dev_keys/demo-shell.pub
# Add the actor to dev_config/default.yaml under system_auth.actors.
# Then:
yarn install && yarn workspace @authproxy/demo-shell dev   # http://localhost:5175
ADMIN_USERNAME=demo-shell \
  ADMIN_PRIVATE_KEY_PATH=./demos/shell/dev_keys/demo-shell \
  AUTHPROXY_ADMIN_UI_URL=http://localhost:5174 \
  AUTHPROXY_MARKETPLACE_URL=http://localhost:5173 \
  AUTHPROXY_AUTH_URL=http://localhost:8080 \
  DEV_FRONTEND_URL=http://localhost:5175 \
  go run ./demos/shell/backend
```

## Test plan
- [x] `go build ./demos/shell/backend/...` clean.
- [x] `./scripts/preflight.sh` passes.
- [ ] **Manual**: with a configured local dev admin actor, `demo-admin` + Admin UI lands you logged in to admin; `fresh-user` + Marketplace lands you on an empty marketplace. (Requires the actor to be added to dev_config — see README.)
- [ ] **A19 follow-up**: containerize and push to GHCR (#306).
- [ ] **A11 follow-up**: seed the three demo actors in the umbrella chart (#300).

## What's intentionally NOT here
- No tests yet. The Go is mostly env-plumbing + a thin signing wrapper; the JWT builder is already covered by `internal/apauth/jwt/token_builder_test.go`. The frontend is a single screen with no logic. Will add tests if review wants them or if A19's container build exercises behavior worth pinning.
- No containerization — that's A19 (#306).
- No umbrella chart wiring — that's A10 (#303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)