### PR TITLE
Add signing_proxy.port CLI config + templated .env URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,18 +10,19 @@ AUTHPROXY_CONFIG=./dev_config/default.yaml
 ## For clone N the offset from defaults is (N-1)*10, with authproxy0
 ## treated as the 10th slot (offset 90):
 ##
-##   authproxy1: 808x / 8083 / 5173 / 5174   (defaults — leave unset)
-##   authproxy2: 809x / 8093 / 5183 / 5184
-##   authproxy3: 810x / 8103 / 5193 / 5194
-##   authproxy4: 811x / 8113 / 5203 / 5204
-##   authproxy5: 812x / 8123 / 5213 / 5214
-##   authproxy6: 813x / 8133 / 5223 / 5224
-##   authproxy7: 814x / 8143 / 5233 / 5234
-##   authproxy8: 815x / 8153 / 5243 / 5244
-##   authproxy9: 816x / 8163 / 5253 / 5254
-##   authproxy0: 817x / 8173 / 5263 / 5264
+##   authproxy1: 808x / 8083 / 5173 / 5174 / 8888   (defaults — leave unset)
+##   authproxy2: 809x / 8093 / 5183 / 5184 / 8898
+##   authproxy3: 810x / 8103 / 5193 / 5194 / 8908
+##   authproxy4: 811x / 8113 / 5203 / 5204 / 8918
+##   authproxy5: 812x / 8123 / 5213 / 5214 / 8928
+##   authproxy6: 813x / 8133 / 5223 / 5224 / 8938
+##   authproxy7: 814x / 8143 / 5233 / 5234 / 8948
+##   authproxy8: 815x / 8153 / 5243 / 5244 / 8958
+##   authproxy9: 816x / 8163 / 5253 / 5254 / 8968
+##   authproxy0: 817x / 8173 / 5263 / 5264 / 8978
 ##
-## Columns: PUBLIC,API,ADMIN_API (808x) / WORKER_HEALTH / MARKETPLACE_UI / ADMIN_UI.
+## Columns: PUBLIC,API,ADMIN_API (808x) / WORKER_HEALTH / MARKETPLACE_UI /
+## ADMIN_UI / SIGNING_PROXY.
 ##
 ## Override in your local .env (gitignored). Defaults below match the
 ## values baked into dev_config/default.yaml + the per-package vite
@@ -33,19 +34,21 @@ AUTHPROXY_CONFIG=./dev_config/default.yaml
 #AUTHPROXY_WORKER_HEALTH_PORT=8083
 #AUTHPROXY_ADMIN_UI_PORT=5174
 #AUTHPROXY_MARKETPLACE_UI_PORT=5173
+#AUTHPROXY_SIGNING_PROXY_PORT=8888
 
 ##
-## URLs that embed the ports above. The server reads these so the CORS
-## allow list (the UI's origin) and the login redirect target match the
-## ports above. The Vite dev servers also forward any VITE_* values set
-## here into the bundle, overriding the per-package .env.development
-## defaults.
+## URLs that embed the ports above (CORS allow-list, login redirect,
+## Vite bundle). The ${VAR} expansion is supported by godotenv (Go
+## server + CLI) and dotenv-expand (Vite), so overriding a port also
+## updates these URLs without further edits. The signing-proxy port is
+## also picked up by `ap signing-proxy` via ~/.authproxy.yaml's
+## `signing_proxy.port.env_var: AUTHPROXY_SIGNING_PROXY_PORT`.
 ##
-#AUTHPROXY_ADMIN_UI_BASE_URL=http://localhost:5174
-#AUTHPROXY_MARKETPLACE_BASE_URL=http://localhost:5173
-#AUTHPROXY_HOST_APP_INITIATE_SESSION_URL=http://127.0.0.1:8888/login-redirect
-#VITE_ADMIN_BASE_URL=https://127.0.0.1:8082
-#VITE_PUBLIC_BASE_URL=https://127.0.0.1:8080
+#AUTHPROXY_ADMIN_UI_BASE_URL=http://localhost:${AUTHPROXY_ADMIN_UI_PORT}
+#AUTHPROXY_MARKETPLACE_BASE_URL=http://localhost:${AUTHPROXY_MARKETPLACE_UI_PORT}
+#AUTHPROXY_HOST_APP_INITIATE_SESSION_URL=http://127.0.0.1:${AUTHPROXY_SIGNING_PROXY_PORT}/login-redirect
+#VITE_ADMIN_BASE_URL=https://127.0.0.1:${AUTHPROXY_ADMIN_API_PORT}
+#VITE_PUBLIC_BASE_URL=https://127.0.0.1:${AUTHPROXY_PUBLIC_PORT}
 
 ##
 ## Uncomment to run tests with postgres

--- a/cmd/cli/config/resolver.go
+++ b/cmd/cli/config/resolver.go
@@ -260,3 +260,15 @@ func (j *Resolver) ResolveAdminUiUrl() (string, error) {
 
 	return root.AdminUiUrl(), nil
 }
+
+// ResolveSigningProxyPort returns the configured signing-proxy port from the
+// CLI config file, or 0 if unset. Callers should treat 0 as "fall back to the
+// command's own --port default."
+func (j *Resolver) ResolveSigningProxyPort() (int, error) {
+	root, err := j.resolveRoot()
+	if err != nil {
+		return 0, err
+	}
+
+	return root.SigningProxyPort()
+}

--- a/cmd/cli/config/root.go
+++ b/cmd/cli/config/root.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"strconv"
 
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"gopkg.in/yaml.v3"
@@ -18,6 +19,9 @@ type Root struct {
 		MarketplaceVal scommon.StringValue `json:"marketplace" yaml:"marketplace"`
 		AdminUiVal     scommon.StringValue `json:"admin_ui" yaml:"admin_ui"`
 	} `json:"server" yaml:"server"`
+	SigningProxyVal struct {
+		PortVal scommon.StringValue `json:"port" yaml:"port"`
+	} `json:"signing_proxy" yaml:"signing_proxy"`
 }
 
 func UnmarshallYamlRoot(data []byte) (*Root, error) {
@@ -123,4 +127,27 @@ func (r *Root) AdminUiUrl() string {
 	}
 
 	return ""
+}
+
+// SigningProxyPort returns the configured port for `ap signing-proxy`, or 0 if
+// unset. Returns an error only if the value is set but doesn't parse as an int.
+func (r *Root) SigningProxyPort() (int, error) {
+	if r == nil {
+		return 0, nil
+	}
+
+	if !r.SigningProxyVal.PortVal.HasValue(context.Background()) {
+		return 0, nil
+	}
+
+	val, err := r.SigningProxyVal.PortVal.GetValue(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	if val == "" {
+		return 0, nil
+	}
+
+	return strconv.Atoi(val)
 }

--- a/cmd/cli/config/root_test.go
+++ b/cmd/cli/config/root_test.go
@@ -124,6 +124,48 @@ server:
 		assert.Equal(t, "", root.AuthUrl())
 		assert.Equal(t, "", root.MarketplaceUrl())
 		assert.Equal(t, "", root.AdminUiUrl())
+
+		port, err := root.SigningProxyPort()
+		require.NoError(t, err)
+		assert.Equal(t, 0, port)
+	})
+
+	t.Run("signing_proxy port direct value", func(t *testing.T) {
+		data := []byte(`
+signing_proxy:
+  port: "8898"
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		port, err := root.SigningProxyPort()
+		require.NoError(t, err)
+		assert.Equal(t, 8898, port)
+	})
+
+	t.Run("signing_proxy port via env var", func(t *testing.T) {
+		t.Setenv("CLI_ROOT_TEST_SIGNING_PROXY_PORT", "8908")
+		data := []byte(`
+signing_proxy:
+  port:
+    env_var: CLI_ROOT_TEST_SIGNING_PROXY_PORT
+    default: "8888"
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		port, err := root.SigningProxyPort()
+		require.NoError(t, err)
+		assert.Equal(t, 8908, port)
+	})
+
+	t.Run("signing_proxy port invalid value returns error", func(t *testing.T) {
+		data := []byte(`
+signing_proxy:
+  port: "not-a-number"
+`)
+		root, err := UnmarshallYamlRoot(data)
+		require.NoError(t, err)
+		_, err = root.SigningProxyPort()
+		require.Error(t, err)
 	})
 
 	t.Run("malformed yaml returns error", func(t *testing.T) {
@@ -145,4 +187,8 @@ func TestRoot_NilReceiverSafety(t *testing.T) {
 	assert.Equal(t, "", r.AuthUrl())
 	assert.Equal(t, "", r.MarketplaceUrl())
 	assert.Equal(t, "", r.AdminUiUrl())
+
+	port, err := r.SigningProxyPort()
+	require.NoError(t, err)
+	assert.Equal(t, 0, port)
 }

--- a/cmd/cli/config/schema.json
+++ b/cmd/cli/config/schema.json
@@ -29,6 +29,17 @@
       "additionalProperties": false,
       "description": "URLs the CLI uses to reach the various AuthProxy services. Each may be a direct string or any of the StringValue variants (env var, file, etc.)."
     },
+    "SigningProxy": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "Default listen port for `ap signing-proxy`. Overridable per-invocation with --port."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Defaults for `ap signing-proxy`. Useful when running multiple AuthProxy clones on one machine so each clone's signing-proxy listens on its own port."
+    },
     "Root": {
       "type": "object",
       "properties": {
@@ -46,6 +57,9 @@
         },
         "server": {
           "$ref": "#/$defs/Server"
+        },
+        "signing_proxy": {
+          "$ref": "#/$defs/SigningProxy"
         }
       },
       "additionalProperties": false,

--- a/cmd/cli/config/schema_test.go
+++ b/cmd/cli/config/schema_test.go
@@ -104,6 +104,9 @@ func TestSchema(t *testing.T) {
 				{Name: "server with all fields", Valid: true, Data: `{"server": {"api": "http://localhost:8081", "admin_api": "http://localhost:8082", "auth": "http://localhost:8080", "marketplace": "http://localhost:5173", "admin_ui": "http://localhost:5174"}}`},
 				{Name: "server extra property rejected", Valid: false, Data: `{"server": {"api": "http://localhost:8081", "bogus": "x"}}`},
 				{Name: "server is not an object", Valid: false, Data: `{"server": "http://localhost"}`},
+				{Name: "signing_proxy with port string", Valid: true, Data: `{"signing_proxy": {"port": "8898"}}`},
+				{Name: "signing_proxy with port via env var", Valid: true, Data: `{"signing_proxy": {"port": {"env_var": "SP_PORT", "default": "8888"}}}`},
+				{Name: "signing_proxy extra property rejected", Valid: false, Data: `{"signing_proxy": {"port": "8898", "bogus": "x"}}`},
 				{Name: "admin_private_key_path as env var", Valid: true, Data: `{"admin_private_key_path": {"env_var": "ADMIN_KEY_PATH"}}`},
 				{Name: "admin_shared_key_path as path", Valid: true, Data: `{"admin_shared_key_path": {"path": "~/.authproxy/shared.key"}}`},
 				{Name: "admin_username inline bool coerced", Valid: true, Data: `{"admin_username": true}`},
@@ -123,6 +126,16 @@ func TestSchema(t *testing.T) {
 				{Name: "api inline bool coerced", Valid: true, Data: `{"api": true}`},
 				{Name: "api inline number coerced", Valid: true, Data: `{"api": 99}`},
 				{Name: "api object with mixed forms rejected", Valid: false, Data: `{"api": {"value": "x", "path": "/p"}}`},
+			},
+		},
+		{
+			Def: "SigningProxy",
+			Cases: []schemaTest{
+				{Name: "empty", Valid: true, Data: `{}`},
+				{Name: "port string", Valid: true, Data: `{"port": "8888"}`},
+				{Name: "port via env var with default", Valid: true, Data: `{"port": {"env_var": "AUTHPROXY_SIGNING_PROXY_PORT", "default": "8888"}}`},
+				{Name: "port inline number coerced", Valid: true, Data: `{"port": 8888}`},
+				{Name: "extra property rejected", Valid: false, Data: `{"port": "8888", "extra": "bogus"}`},
 			},
 		},
 	}

--- a/cmd/cli/config/test_data/valid-full.yaml
+++ b/cmd/cli/config/test_data/valid-full.yaml
@@ -9,3 +9,7 @@ server:
   auth: http://localhost:8080
   marketplace: http://localhost:5173
   admin_ui: http://localhost:5174
+signing_proxy:
+  port:
+    env_var: AUTHPROXY_SIGNING_PROXY_PORT
+    default: "8888"

--- a/cmd/cli/signing_proxy.go
+++ b/cmd/cli/signing_proxy.go
@@ -113,6 +113,17 @@ func cmdSigningProxy() *cobra.Command {
 				return err
 			}
 
+			// If --port was not explicitly set, fall back to the config file's
+			// signing_proxy.port value (if any). The flag's own default still
+			// wins if neither is set.
+			if !cmd.Flags().Changed("port") {
+				if cfgPort, err := resolver.ResolveSigningProxyPort(); err != nil {
+					return fmt.Errorf("invalid signing_proxy.port in config: %w", err)
+				} else if cfgPort != 0 {
+					port = cfgPort
+				}
+			}
+
 			baseUrl := ""
 			if strings.HasPrefix(proxyTo, "http") {
 				baseUrl = proxyTo

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,9 +39,18 @@ server:
   auth: http://localhost:8080
   marketplace: http://localhost:5173
   admin_ui: http://localhost:5174
+
+# Defaults for `ap signing-proxy`. Useful when several AuthProxy clones
+# share one machine — each clone's signing-proxy needs its own port. The
+# `env_var` form lets one shared ~/.authproxy.yaml pick up the per-clone
+# value from the clone's .env (AUTHPROXY_SIGNING_PROXY_PORT).
+signing_proxy:
+  port:
+    env_var: AUTHPROXY_SIGNING_PROXY_PORT
+    default: "8888"
 ```
 
-Every value here can be overridden per-invocation by the flag of the same shape (`--apiUrl`, `--privateKeyPath`, `--actorId`, etc.).
+Every value here can be overridden per-invocation by the flag of the same shape (`--apiUrl`, `--privateKeyPath`, `--actorId`, `--port`, etc.).
 
 ### Signing keys
 
@@ -102,6 +111,8 @@ ap signing-proxy --proxyTo=admin-api --enableLoginRedirect=true
 ```
 
 `--proxyTo` accepts a service id (`api`, `admin-api`, `public`) or an absolute URL. `--enableLoginRedirect` adds a `/login-redirect` handler that simulates the host application's session-initiation flow — wire `host_application.initiate_session_url` (or `admin_api.ui.initiate_session_url`) at the printed URL.
+
+`--port` defaults to `8888`. If the CLI config sets `signing_proxy.port`, that value is used instead when `--port` is not given on the command line. Multiple clones on one machine should set `AUTHPROXY_SIGNING_PROXY_PORT` per clone in their `.env` and reference it from a shared `~/.authproxy.yaml` via `signing_proxy.port.env_var`.
 
 ### `ap proxy` — connection-scoped streaming proxy
 
@@ -176,6 +187,34 @@ ap proxy --connection cxn_openai curl -N \
 ```
 
 The `-N` (`--no-buffer`) is curl's, not ours — it disables curl's own line buffering so the tokens print as they arrive.
+
+### Run several AuthProxy clones on one machine
+
+Each clone (`~/src/authproxy1`, `~/src/authproxy2`, …) needs its own port pool so they don't collide. The pool lives in each clone's `.env` (gitignored) — see [`.env.example`](../.env.example) for the slot table. The `AUTHPROXY_SIGNING_PROXY_PORT` slot picks the listen port for `ap signing-proxy`:
+
+| Clone | `AUTHPROXY_SIGNING_PROXY_PORT` |
+|---|---|
+| authproxy1 | 8888 (default) |
+| authproxy2 | 8898 |
+| authproxy3 | 8908 |
+| authproxy*N* | 8888 + (N−1)·10 |
+
+A single shared `~/.authproxy.yaml` picks up whichever clone you ran `ap` from by reading the env var loaded from that clone's `.env`:
+
+```yaml
+signing_proxy:
+  port:
+    env_var: AUTHPROXY_SIGNING_PROXY_PORT
+    default: "8888"
+```
+
+```bash
+cd ~/src/authproxy3 && ap signing-proxy --proxyTo=api   # listens on 8908
+cd ~/src/authproxy1 && ap signing-proxy --proxyTo=api   # listens on 8888
+ap signing-proxy --proxyTo=api --port 9000              # --port always wins
+```
+
+The matching `AUTHPROXY_HOST_APP_INITIATE_SESSION_URL` in each `.env` is templated `http://127.0.0.1:${AUTHPROXY_SIGNING_PROXY_PORT}/login-redirect`, so the server's session-initiation URL automatically matches the port the local signing-proxy listens on.
 
 ## See also
 

--- a/ui/admin/src/vite-env.d.ts
+++ b/ui/admin/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
     readonly VITE_APP_TITLE: string
     readonly VITE_APP_URL: string
-    readonly VITE_LOGIN_URL_TEMPLATE: string
     readonly VITE_ADMIN_BASE_URL: string
 }
 

--- a/ui/marketplace/src/vite-env.d.ts
+++ b/ui/marketplace/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
     readonly VITE_APP_TITLE: string
     readonly VITE_APP_URL: string
-    readonly VITE_LOGIN_URL_TEMPLATE: string
     readonly VITE_PUBLIC_BASE_URL: string
 }
 


### PR DESCRIPTION
## Summary

- `ap signing-proxy` learns a `signing_proxy.port` config block in `~/.authproxy.yaml`. A `--port` flag still wins; otherwise the config value (typically `env_var: AUTHPROXY_SIGNING_PROXY_PORT`) does; otherwise the existing `8888` default.
- `.env.example` switches its URL block to `${...}` expansion (works with both godotenv on the Go side and Vite's bundled dotenv-expand on the UI side), and the per-clone port slot table grows an `AUTHPROXY_SIGNING_PROXY_PORT` column (slot N → `8888 + (N−1)·10`).
- Drops a dangling `VITE_LOGIN_URL_TEMPLATE` declaration from both `ui/admin` and `ui/marketplace` `vite-env.d.ts` — the env var itself was already gone, this just removes the type entry.

## Why

Several AuthProxy clones share one machine here (`~/src/authproxy[1-5]`). Before this change, getting each clone's `ap signing-proxy` onto its own port meant either passing `--port` on every invocation or rewriting the shared `~/.authproxy.yaml` when switching clones. The `env_var` indirection means a single shared CLI config reads each clone's `.env` automatically.

The templating in `.env` cuts down on the cluster of hardcoded ports that have to be kept in sync per slot — change the port once, the URLs follow.

## Test plan

- [x] `go test ./cmd/cli/...` passes (new cases in `root_test.go` and `schema_test.go` cover direct value, env-var, and invalid-int paths)
- [x] `./scripts/preflight.sh` passes
- [x] Verified `${VAR}` expansion against godotenv@v1.5.1 with a small repro (`URL=http://localhost:${PORT}` resolves correctly)
- [x] Verified `cmd.Flags().Changed("port")` semantics — `--port` always overrides the config value
- [ ] Manually exercise `cd ~/src/authproxy2 && ap signing-proxy --proxyTo=api` and confirm it listens on the slot-2 port (8898)

## Notes on UI changes

The `vite-env.d.ts` edits are type-declaration cleanup only — no runtime/UI behavior changes, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)