### PR TITLE
Add request event metrics queries

### DIFF
--- a/internal/app_metrics/interface.go
+++ b/internal/app_metrics/interface.go
@@ -13,4 +13,5 @@ type LogRetriever interface {
 	GetFullLog(ctx context.Context, id apid.ID) (*FullLog, error)
 	NewListRequestsBuilder() ListRequestBuilder
 	ListRequestsFromCursor(ctx context.Context, cursor string) (ListRequestExecutor, error)
+	QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error)
 }

--- a/internal/app_metrics/mock/service.go
+++ b/internal/app_metrics/mock/service.go
@@ -79,3 +79,18 @@ func (mr *MockLogRetrieverMockRecorder) NewListRequestsBuilder() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListRequestsBuilder", reflect.TypeOf((*MockLogRetriever)(nil).NewListRequestsBuilder))
 }
+
+// QueryRequestEventMetrics mocks base method.
+func (m *MockLogRetriever) QueryRequestEventMetrics(ctx context.Context, queries []app_metrics.RequestEventMetricsQuery) ([]app_metrics.RequestEventMetricSeries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryRequestEventMetrics", ctx, queries)
+	ret0, _ := ret[0].([]app_metrics.RequestEventMetricSeries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryRequestEventMetrics indicates an expected call of QueryRequestEventMetrics.
+func (mr *MockLogRetrieverMockRecorder) QueryRequestEventMetrics(ctx, queries interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRequestEventMetrics", reflect.TypeOf((*MockLogRetriever)(nil).QueryRequestEventMetrics), ctx, queries)
+}

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -35,4 +35,7 @@ type RecordRetriever interface {
 
 	// ListRequestsFromCursor resumes a paginated listing from a cursor string.
 	ListRequestsFromCursor(ctx context.Context, cursor string) (ListRequestExecutor, error)
+
+	// QueryRequestEventMetrics executes time-series metric queries over request events.
+	QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error)
 }

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -265,6 +265,12 @@ func (r *clickhouseRecordRetriever) ListRequestsFromCursor(ctx context.Context, 
 	return b.fromCursor(ctx, cursor)
 }
 
+func (r *clickhouseRecordRetriever) QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error) {
+	return executeRequestEventMetricsQueries(ctx, queries, func(ctx context.Context, query RequestEventMetricsQuery) ([]*LogRecord, error) {
+		return fetchRequestEventMetricRecords(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+	})
+}
+
 var _ RecordRetriever = (*clickhouseRecordRetriever)(nil)
 
 // --- ClickHouse ListRequestBuilder (wraps SQL builder) ---

--- a/internal/app_metrics/provider_record_test.go
+++ b/internal/app_metrics/provider_record_test.go
@@ -20,6 +20,7 @@ type recordOpts struct {
 	host             string
 	path             string
 	statusCode       int
+	duration         time.Duration
 	requestType      httpf.RequestType
 	correlationId    string
 	connectionId     apid.ID
@@ -54,13 +55,16 @@ func makeRecord(namespace string, o recordOpts) *LogRecord {
 	if o.requestType == "" {
 		o.requestType = httpf.RequestTypeProxy
 	}
+	if o.duration == 0 {
+		o.duration = 123 * time.Millisecond
+	}
 	return &LogRecord{
 		RequestId:           apid.New(apid.PrefixRequestEvents),
 		Namespace:           namespace,
 		Type:                o.requestType,
 		CorrelationId:       o.correlationId,
 		Timestamp:           o.timestamp,
-		MillisecondDuration: MillisecondDuration(123 * time.Millisecond),
+		MillisecondDuration: MillisecondDuration(o.duration),
 		ConnectionId:        o.connectionId,
 		ConnectorId:         o.connectorId,
 		ConnectorVersion:    o.connectorVersion,
@@ -416,10 +420,168 @@ func TestRequestEvents_List_Pagination_CursorRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRequestEvents_Metrics_CountAndEmptyBuckets(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, store.StoreRecords(ctx, []*LogRecord{
+		makeRecord("root", recordOpts{timestamp: base.Add(1 * time.Minute)}),
+		makeRecord("root", recordOpts{timestamp: base.Add(3 * time.Minute)}),
+		makeRecord("root", recordOpts{timestamp: base.Add(17 * time.Minute)}),
+		makeRecord("root", recordOpts{timestamp: base.Add(45 * time.Minute)}),
+	}))
+
+	series, err := retriever.QueryRequestEventMetrics(ctx, []RequestEventMetricsQuery{{
+		RefID:  "requests",
+		Metric: RequestEventMetricCount,
+		Start:  base,
+		End:    base.Add(45 * time.Minute),
+		Step:   15 * time.Minute,
+	}})
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	require.Equal(t, "requests", series[0].RefID)
+	require.Equal(t, []RequestEventMetricPoint{
+		{Timestamp: base, Value: 2},
+		{Timestamp: base.Add(15 * time.Minute), Value: 1},
+		{Timestamp: base.Add(30 * time.Minute), Value: 0},
+	}, series[0].Points)
+}
+
+func TestRequestEvents_Metrics_FiltersAndGroups(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	connectorA := apid.New(apid.PrefixConnectorVersion)
+	connectorB := apid.New(apid.PrefixConnectorVersion)
+	require.NoError(t, store.StoreRecords(ctx, []*LogRecord{
+		makeRecord("root.team", recordOpts{
+			timestamp:   base.Add(time.Minute),
+			method:      "GET",
+			connectorId: connectorA,
+			labels:      database.Labels{"env": "prod"},
+		}),
+		makeRecord("root.team", recordOpts{
+			timestamp:   base.Add(2 * time.Minute),
+			method:      "POST",
+			connectorId: connectorB,
+			labels:      database.Labels{"env": "prod"},
+		}),
+		makeRecord("root.team", recordOpts{
+			timestamp:   base.Add(3 * time.Minute),
+			method:      "GET",
+			connectorId: connectorA,
+			labels:      database.Labels{"env": "staging"},
+		}),
+		makeRecord("root.other", recordOpts{
+			timestamp:   base.Add(4 * time.Minute),
+			method:      "GET",
+			connectorId: connectorA,
+			labels:      database.Labels{"env": "prod"},
+		}),
+	}))
+
+	series, err := retriever.QueryRequestEventMetrics(ctx, []RequestEventMetricsQuery{{
+		RefID:             "by-method",
+		Metric:            RequestEventMetricCount,
+		Start:             base,
+		End:               base.Add(15 * time.Minute),
+		Step:              15 * time.Minute,
+		NamespaceMatchers: []string{"root.team"},
+		LabelSelector:     "env=prod",
+		GroupBy:           []RequestEventGroupBy{RequestEventGroupByMethod, RequestEventGroupByConnectorID},
+	}})
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	values := metricSeriesValuesByLabels(series)
+	require.Equal(t, 1.0, values["connector_id="+connectorA.String()+"\x00method=GET\x00"][0])
+	require.Equal(t, 1.0, values["connector_id="+connectorB.String()+"\x00method=POST\x00"][0])
+
+	series, err = retriever.QueryRequestEventMetrics(ctx, []RequestEventMetricsQuery{{
+		RefID:             "by-outcome",
+		Metric:            RequestEventMetricCount,
+		Start:             base,
+		End:               base.Add(15 * time.Minute),
+		Step:              15 * time.Minute,
+		NamespaceMatchers: []string{"root.team"},
+		GroupBy: []RequestEventGroupBy{
+			RequestEventGroupByType,
+			RequestEventGroupByResponseStatusCode,
+			RequestEventGroupByResponseSource,
+		},
+	}})
+	require.NoError(t, err)
+	values = metricSeriesValuesByLabels(series)
+	require.Equal(t, 3.0, values["response_source=upstream\x00response_status_code=200\x00type=proxy\x00"][0])
+}
+
+func TestRequestEvents_Metrics_ErrorsAndDurations(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, store.StoreRecords(ctx, []*LogRecord{
+		makeRecord("root", recordOpts{timestamp: base.Add(time.Minute), statusCode: 200, duration: 100 * time.Millisecond}),
+		makeRecord("root", recordOpts{timestamp: base.Add(2 * time.Minute), statusCode: 500, duration: 200 * time.Millisecond}),
+		makeRecord("root", recordOpts{timestamp: base.Add(3 * time.Minute), statusCode: 404, duration: 900 * time.Millisecond}),
+		makeRecord("root", recordOpts{timestamp: base.Add(20 * time.Minute), statusCode: 200, duration: 300 * time.Millisecond}),
+	}))
+
+	series, err := retriever.QueryRequestEventMetrics(ctx, []RequestEventMetricsQuery{
+		{
+			RefID:  "errors",
+			Metric: RequestEventMetricErrorsCount,
+			Start:  base,
+			End:    base.Add(30 * time.Minute),
+			Step:   15 * time.Minute,
+		},
+		{
+			RefID:  "avg",
+			Metric: RequestEventMetricDurationAvgMS,
+			Start:  base,
+			End:    base.Add(30 * time.Minute),
+			Step:   15 * time.Minute,
+		},
+		{
+			RefID:  "p95",
+			Metric: RequestEventMetricDurationP95MS,
+			Start:  base,
+			End:    base.Add(30 * time.Minute),
+			Step:   15 * time.Minute,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, series, 3)
+
+	byRef := map[string][]float64{}
+	for _, s := range series {
+		for _, point := range s.Points {
+			byRef[s.RefID] = append(byRef[s.RefID], point.Value)
+		}
+	}
+	require.Equal(t, []float64{2, 0}, byRef["errors"])
+	require.Equal(t, []float64{400, 300}, byRef["avg"])
+	require.Equal(t, []float64{900, 300}, byRef["p95"])
+}
+
 func collectIDs(records []*LogRecord) map[apid.ID]bool {
 	out := make(map[apid.ID]bool, len(records))
 	for _, r := range records {
 		out[r.RequestId] = true
+	}
+	return out
+}
+
+func metricSeriesValuesByLabels(series []RequestEventMetricSeries) map[string][]float64 {
+	out := map[string][]float64{}
+	for _, s := range series {
+		key := requestEventMetricGroupKey(s.Labels)
+		for _, point := range s.Points {
+			out[key] = append(out[key], point.Value)
+		}
 	}
 	return out
 }

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -339,6 +339,12 @@ func (r *sqlRecordRetriever) ListRequestsFromCursor(ctx context.Context, cursor 
 	return b.fromCursor(ctx, cursor)
 }
 
+func (r *sqlRecordRetriever) QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error) {
+	return executeRequestEventMetricsQueries(ctx, queries, func(ctx context.Context, query RequestEventMetricsQuery) ([]*LogRecord, error) {
+		return fetchRequestEventMetricRecords(ctx, r.db, r.placeholderFormat, r.provider, query)
+	})
+}
+
 var _ RecordRetriever = (*sqlRecordRetriever)(nil)
 
 // --- SQL ListRequestBuilder ---
@@ -498,6 +504,34 @@ func (l *sqlListRequestsBuilder) buildQuery() sq.SelectBuilder {
 		From(entryRecordsTable).
 		PlaceholderFormat(l.placeholderFormat)
 
+	builder = l.applyFilters(builder)
+
+	// Order by
+	orderColumn := "timestamp_ms"
+	orderDir := "DESC"
+
+	if l.OrderByFieldVal != nil {
+		if col, ok := sqlOrderByColumns[*l.OrderByFieldVal]; ok {
+			orderColumn = col
+		}
+	}
+	if l.OrderByVal != nil && *l.OrderByVal == pagination.OrderByAsc {
+		orderDir = "ASC"
+	}
+
+	builder = builder.OrderBy(orderColumn + " " + orderDir)
+
+	limit := l.LimitVal
+	if limit <= 0 {
+		limit = 100
+	}
+	builder = builder.Limit(uint64(limit + 1))
+	builder = builder.Offset(uint64(l.Offset))
+
+	return builder
+}
+
+func (l *sqlListRequestsBuilder) applyFilters(builder sq.SelectBuilder) sq.SelectBuilder {
 	if l.RequestType != nil {
 		builder = builder.Where(sq.Eq{"type": *l.RequestType})
 	}
@@ -585,28 +619,6 @@ func (l *sqlListRequestsBuilder) buildQuery() sq.SelectBuilder {
 	if l.RateLimitId != nil {
 		builder = builder.Where(sq.Eq{"rate_limit_id": l.RateLimitId.String()})
 	}
-
-	// Order by
-	orderColumn := "timestamp_ms"
-	orderDir := "DESC"
-
-	if l.OrderByFieldVal != nil {
-		if col, ok := sqlOrderByColumns[*l.OrderByFieldVal]; ok {
-			orderColumn = col
-		}
-	}
-	if l.OrderByVal != nil && *l.OrderByVal == pagination.OrderByAsc {
-		orderDir = "ASC"
-	}
-
-	builder = builder.OrderBy(orderColumn + " " + orderDir)
-
-	limit := l.LimitVal
-	if limit <= 0 {
-		limit = 100
-	}
-	builder = builder.Limit(uint64(limit + 1))
-	builder = builder.Offset(uint64(l.Offset))
 
 	return builder
 }
@@ -704,6 +716,49 @@ func (l *sqlListRequestsBuilder) Enumerate(ctx context.Context, callback paginat
 
 var _ ListRequestExecutor = (*sqlListRequestsBuilder)(nil)
 var _ ListRequestBuilder = (*sqlListRequestsBuilder)(nil)
+
+func fetchRequestEventMetricRecords(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query RequestEventMetricsQuery,
+) ([]*LogRecord, error) {
+	builder := &sqlListRequestsBuilder{
+		ListFilters:       requestEventMetricsFilters(query),
+		db:                db,
+		placeholderFormat: placeholderFormat,
+		provider:          provider,
+	}
+	selectBuilder := builder.applyFilters(sq.Select(entryRecordColumns...).
+		From(entryRecordsTable).
+		PlaceholderFormat(placeholderFormat)).
+		OrderBy("timestamp_ms ASC")
+
+	sqlQuery, args, err := selectBuilder.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request event metrics query: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request event metrics query: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]*LogRecord, 0)
+	for rows.Next() {
+		record, err := scanLogRecord(rows)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan request event metric record: %w", err)
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate request event metric records: %w", err)
+	}
+	return records, nil
+}
 
 // Suppress unused import warnings
 var _ = regexp.Compile

--- a/internal/app_metrics/request_event_metrics.go
+++ b/internal/app_metrics/request_event_metrics.go
@@ -1,0 +1,300 @@
+package app_metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+type RequestEventMetric string
+
+const (
+	RequestEventMetricCount         RequestEventMetric = "request_events.count"
+	RequestEventMetricErrorsCount   RequestEventMetric = "request_events.errors.count"
+	RequestEventMetricDurationAvgMS RequestEventMetric = "request_events.duration_ms.avg"
+	RequestEventMetricDurationP95MS RequestEventMetric = "request_events.duration_ms.p95"
+)
+
+type RequestEventGroupBy string
+
+const (
+	RequestEventGroupByType               RequestEventGroupBy = "type"
+	RequestEventGroupByMethod             RequestEventGroupBy = "method"
+	RequestEventGroupByResponseStatusCode RequestEventGroupBy = "response_status_code"
+	RequestEventGroupByResponseSource     RequestEventGroupBy = "response_source"
+	RequestEventGroupByConnectorID        RequestEventGroupBy = "connector_id"
+)
+
+type RequestEventMetricsQuery struct {
+	RefID             string
+	Metric            RequestEventMetric
+	Start             time.Time
+	End               time.Time
+	Step              time.Duration
+	NamespaceMatchers []string
+	LabelSelector     string
+	GroupBy           []RequestEventGroupBy
+}
+
+type RequestEventMetricPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     float64   `json:"value"`
+}
+
+type RequestEventMetricSeries struct {
+	RefID  string                    `json:"ref_id"`
+	Labels map[string]string         `json:"labels,omitempty"`
+	Points []RequestEventMetricPoint `json:"points"`
+}
+
+func validateRequestEventMetricsQuery(q RequestEventMetricsQuery) error {
+	if q.RefID == "" {
+		return errors.New("ref_id is required")
+	}
+	if !isValidRequestEventMetric(q.Metric) {
+		return fmt.Errorf("unsupported request event metric %q", q.Metric)
+	}
+	if q.Start.IsZero() || q.End.IsZero() {
+		return errors.New("start and end are required")
+	}
+	if !q.Start.Before(q.End) {
+		return errors.New("start must be before end")
+	}
+	if q.Step <= 0 {
+		return errors.New("step must be greater than zero")
+	}
+	for _, groupBy := range q.GroupBy {
+		if !isValidRequestEventGroupBy(groupBy) {
+			return fmt.Errorf("unsupported request event group_by dimension %q", groupBy)
+		}
+	}
+	if q.LabelSelector != "" {
+		if _, err := database.ParseLabelSelector(q.LabelSelector); err != nil {
+			return err
+		}
+	}
+	filters := ListFilters{}
+	if len(q.NamespaceMatchers) > 0 {
+		if err := filters.SetNamespaceMatchers(q.NamespaceMatchers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isValidRequestEventMetric(metric RequestEventMetric) bool {
+	switch metric {
+	case RequestEventMetricCount,
+		RequestEventMetricErrorsCount,
+		RequestEventMetricDurationAvgMS,
+		RequestEventMetricDurationP95MS:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidRequestEventGroupBy(groupBy RequestEventGroupBy) bool {
+	switch groupBy {
+	case RequestEventGroupByType,
+		RequestEventGroupByMethod,
+		RequestEventGroupByResponseStatusCode,
+		RequestEventGroupByResponseSource,
+		RequestEventGroupByConnectorID:
+		return true
+	default:
+		return false
+	}
+}
+
+type requestEventMetricAccumulator struct {
+	count     int
+	sum       float64
+	durations []float64
+}
+
+func (a *requestEventMetricAccumulator) add(metric RequestEventMetric, record *LogRecord) {
+	switch metric {
+	case RequestEventMetricCount:
+		a.count++
+	case RequestEventMetricErrorsCount:
+		if isRequestEventError(record) {
+			a.count++
+		}
+	case RequestEventMetricDurationAvgMS:
+		a.count++
+		a.sum += float64(record.MillisecondDuration.Duration().Milliseconds())
+	case RequestEventMetricDurationP95MS:
+		a.durations = append(a.durations, float64(record.MillisecondDuration.Duration().Milliseconds()))
+	}
+}
+
+func (a *requestEventMetricAccumulator) value(metric RequestEventMetric) float64 {
+	switch metric {
+	case RequestEventMetricCount, RequestEventMetricErrorsCount:
+		return float64(a.count)
+	case RequestEventMetricDurationAvgMS:
+		if a.count == 0 {
+			return 0
+		}
+		return a.sum / float64(a.count)
+	case RequestEventMetricDurationP95MS:
+		return percentileNearestRank(a.durations, 0.95)
+	default:
+		return 0
+	}
+}
+
+func isRequestEventError(record *LogRecord) bool {
+	return record.ResponseStatusCode >= 400 ||
+		record.ResponseError != "" ||
+		record.InternalTimeout ||
+		record.RequestCancelled
+}
+
+func executeRequestEventMetricsQueries(
+	ctx context.Context,
+	queries []RequestEventMetricsQuery,
+	fetch func(context.Context, RequestEventMetricsQuery) ([]*LogRecord, error),
+) ([]RequestEventMetricSeries, error) {
+	out := make([]RequestEventMetricSeries, 0)
+	for _, query := range queries {
+		if err := validateRequestEventMetricsQuery(query); err != nil {
+			return nil, err
+		}
+		records, err := fetch(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, buildRequestEventMetricSeries(query, records)...)
+	}
+	return out, nil
+}
+
+func buildRequestEventMetricSeries(query RequestEventMetricsQuery, records []*LogRecord) []RequestEventMetricSeries {
+	bucketCount := int(math.Ceil(float64(query.End.Sub(query.Start)) / float64(query.Step)))
+	if bucketCount < 1 {
+		bucketCount = 1
+	}
+
+	accumulators := map[string][]requestEventMetricAccumulator{}
+	labelsByKey := map[string]map[string]string{}
+
+	if len(query.GroupBy) == 0 {
+		key := requestEventMetricGroupKey(nil)
+		accumulators[key] = make([]requestEventMetricAccumulator, bucketCount)
+		labelsByKey[key] = map[string]string{}
+	}
+
+	for _, record := range records {
+		if record.Timestamp.Before(query.Start) || !record.Timestamp.Before(query.End) {
+			continue
+		}
+		bucketIdx := int(record.Timestamp.Sub(query.Start) / query.Step)
+		if bucketIdx < 0 || bucketIdx >= bucketCount {
+			continue
+		}
+		labels := requestEventMetricLabels(record, query.GroupBy)
+		key := requestEventMetricGroupKey(labels)
+		if _, ok := accumulators[key]; !ok {
+			accumulators[key] = make([]requestEventMetricAccumulator, bucketCount)
+			labelsByKey[key] = labels
+		}
+		accumulators[key][bucketIdx].add(query.Metric, record)
+	}
+
+	keys := make([]string, 0, len(accumulators))
+	for key := range accumulators {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	series := make([]RequestEventMetricSeries, 0, len(keys))
+	for _, key := range keys {
+		points := make([]RequestEventMetricPoint, bucketCount)
+		for i := range bucketCount {
+			points[i] = RequestEventMetricPoint{
+				Timestamp: query.Start.Add(time.Duration(i) * query.Step),
+				Value:     accumulators[key][i].value(query.Metric),
+			}
+		}
+		series = append(series, RequestEventMetricSeries{
+			RefID:  query.RefID,
+			Labels: labelsByKey[key],
+			Points: points,
+		})
+	}
+	return series
+}
+
+func requestEventMetricLabels(record *LogRecord, groupBy []RequestEventGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case RequestEventGroupByType:
+			labels[string(group)] = string(record.Type)
+		case RequestEventGroupByMethod:
+			labels[string(group)] = record.Method
+		case RequestEventGroupByResponseStatusCode:
+			labels[string(group)] = strconv.Itoa(record.ResponseStatusCode)
+		case RequestEventGroupByResponseSource:
+			source := record.ResponseSource
+			if source == "" {
+				source = ResponseSourceUpstream
+			}
+			labels[string(group)] = string(source)
+		case RequestEventGroupByConnectorID:
+			labels[string(group)] = record.ConnectorId.String()
+		}
+	}
+	return labels
+}
+
+func requestEventMetricGroupKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := ""
+	for _, key := range keys {
+		out += key + "=" + labels[key] + "\x00"
+	}
+	return out
+}
+
+func percentileNearestRank(values []float64, percentile float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	rank := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+func requestEventMetricsFilters(query RequestEventMetricsQuery) ListFilters {
+	filters := ListFilters{}
+	filters.SetTimestampRange(query.Start, query.End)
+	_ = filters.SetNamespaceMatchers(query.NamespaceMatchers)
+	if query.LabelSelector != "" {
+		filters.SetLabelSelector(query.LabelSelector)
+	}
+	return filters
+}

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -48,6 +48,11 @@ func (ss *StorageService) ListRequestsFromCursor(ctx context.Context, cursor str
 	return ss.retriever.ListRequestsFromCursor(ctx, cursor)
 }
 
+// QueryRequestEventMetrics executes time-series metric queries over request events.
+func (ss *StorageService) QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error) {
+	return ss.retriever.QueryRequestEventMetrics(ctx, queries)
+}
+
 func (ss *StorageService) GetFullLog(ctx context.Context, id apid.ID) (*FullLog, error) {
 	log, err := ss.GetRecord(ctx, id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add request-event metrics query types and execution through app_metrics storage/retriever
- support request count, error count, avg duration, p95 duration, time buckets, namespace matchers, label selectors, and the initial group-by dimensions
- cover bucket fill, filters, groupings, errors, and duration aggregations in provider tests

Closes #402
Refs #395

## Tests
- go test ./internal/app_metrics
- go test ./...
- ./scripts/preflight.sh