### PR TITLE
Rename setup_step → setup_step_id; ID-based step encoding; drop SetupStepPhase (#365)

### DIFF
--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -40,11 +40,11 @@ func TestConnectionGetSetupStep(t *testing.T) {
 
 	t.Run("returns the setup step value", func(t *testing.T) {
 		conn := newTestConnection(cschema.Connector{})
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("step_a")
 		conn.SetupStep = &step
 		result := conn.GetSetupStep()
 		require.NotNil(t, result)
-		assert.Equal(t, "preconnect:0", result.String())
+		assert.Equal(t, "step_a", result.String())
 	})
 }
 
@@ -56,13 +56,13 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
+		step := cschema.MustNewSetupStep("step_b")
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
 
 		err := conn.SetSetupStep(context.Background(), &step)
 		require.NoError(t, err)
 		require.NotNil(t, conn.SetupStep)
-		assert.Equal(t, "configure:1", conn.SetupStep.String())
+		assert.Equal(t, "step_b", conn.SetupStep.String())
 	})
 
 	t.Run("clears setup step when nil", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestConnectionSetSetupStep(t *testing.T) {
 
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
-		existing := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		existing := cschema.MustNewSetupStep("step_a")
 		conn.SetupStep = &existing
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
@@ -88,7 +88,7 @@ func TestConnectionSetSetupStep(t *testing.T) {
 		s, db, _, _, _, _ := FullMockService(t, ctrl)
 		conn := newTestConnectionWithService(s)
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("step_a")
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(database.ErrNotFound)
 
 		err := conn.SetSetupStep(context.Background(), &step)

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 // GetDataSource fetches data from an external API through the connection's authenticated proxy,
@@ -20,13 +19,13 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("connection has no active setup step")
 	}
 
-	if setupStep.Phase() != cschema.SetupPhaseConfigure {
-		return nil, httperr.BadRequest("data sources are only available during configure steps")
-	}
-
 	connector := c.cv.GetDefinition()
 	if connector == nil || connector.SetupFlow == nil {
 		return nil, httperr.BadRequest("connector has no setup flow")
+	}
+
+	if !connector.SetupFlow.IsConfigureStep(*setupStep) {
+		return nil, httperr.BadRequest("data sources are only available during configure steps")
 	}
 
 	step, _, err := connector.SetupFlow.GetStepBySetupStep(*setupStep)

--- a/internal/core/connection_data_source_test.go
+++ b/internal/core/connection_data_source_test.go
@@ -52,7 +52,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "some_source")
@@ -84,7 +84,7 @@ func TestGetDataSource(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, nil)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "workspaces")
@@ -111,7 +111,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "nonexistent")
@@ -143,7 +143,7 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "workspaces")

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -32,9 +32,9 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	if connectorDef.SetupFlow.HasConfigure() {
-		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		first := cschema.MustNewSetupStep(connectorDef.SetupFlow.Configure.Steps[0].Id)
 		if err := c.SetSetupStep(ctx, &first); err != nil {
-			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to configure:0: %w", err)
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to set setup step to first configure step: %w", err)
 		}
 		return iface.PostAuthOutcome{SetupPending: true}, nil
 	}

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -34,7 +34,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		assert.Equal(t, cschema.SetupStepVerify, *conn.GetSetupStep())
 	})
 
-	t.Run("enters configure:0 when connector has configure but no probes", func(t *testing.T) {
+	t.Run("enters first configure when connector has configure but no probes", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -46,13 +46,13 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 			},
 		})
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)
 		assert.True(t, outcome.SetupPending)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, "configure:0", conn.GetSetupStep().String())
+		assert.Equal(t, "workspace", conn.GetSetupStep().String())
 	})
 
 	t.Run("clears setup step and marks ready when connector has neither probes nor configure", func(t *testing.T) {

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestOnVerifyPassed(t *testing.T) {
-	t.Run("advances to configure:0 when configure exists", func(t *testing.T) {
+	t.Run("advances to first configure when configure exists", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -25,12 +25,12 @@ func TestOnVerifyPassed(t *testing.T) {
 			},
 		})
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, conn.GetSetupStep())
-		assert.Equal(t, "configure:0", conn.GetSetupStep().String())
+		assert.Equal(t, "workspace", conn.GetSetupStep().String())
 	})
 
 	t.Run("clears setup step and marks ready when no further steps", func(t *testing.T) {

--- a/internal/core/service_connection_abort_test.go
+++ b/internal/core/service_connection_abort_test.go
@@ -50,7 +50,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Preconnect: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{
@@ -90,7 +90,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Configure: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{

--- a/internal/core/service_connection_cancel_setup_test.go
+++ b/internal/core/service_connection_cancel_setup_test.go
@@ -22,7 +22,7 @@ func TestCancelSetup(t *testing.T) {
 			},
 		})
 		conn.State = database.ConnectionStateConfigured
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 		errMsg := "stale"
 		conn.SetupError = &errMsg

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -89,7 +89,7 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 	// touching the auth phase or the credentials phase.
 	if connector.SetupFlow.HasPreconnect() {
 		firstStep := connector.SetupFlow.Preconnect.Steps[0]
-		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		first := cschema.MustNewSetupStep(firstStep.Id)
 		if err := connection.SetSetupStep(ctx, &first); err != nil {
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
@@ -113,7 +113,7 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 	// data to the auth method instead of merging it into the connection config.
 	if connector.SetupFlow.HasCredentials() {
 		firstStep := connector.SetupFlow.Credentials.Steps[0]
-		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+		first := cschema.MustNewSetupStep(firstStep.Id)
 		if err := connection.SetSetupStep(ctx, &first); err != nil {
 			val.MarkErrorReturn()
 			return nil, httperr.InternalServerError(httperr.WithInternalErr(err))

--- a/internal/core/service_connection_reauth.go
+++ b/internal/core/service_connection_reauth.go
@@ -62,11 +62,11 @@ func (s *service) ReauthConnection(ctx context.Context, id apid.ID, returnToUrl 
 		if !connector.SetupFlow.HasCredentials() {
 			return nil, httperr.InternalServerErrorMsg("api-key connector has no credentials step")
 		}
-		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+		first := cschema.MustNewSetupStep(connector.SetupFlow.Credentials.Steps[0].Id)
 		return conn.buildFormResponse(ctx, first, connector.SetupFlow)
 	case *config.AuthOAuth2:
 		if connector.SetupFlow.HasPreconnect() {
-			first := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+			first := cschema.MustNewSetupStep(connector.SetupFlow.Preconnect.Steps[0].Id)
 			return conn.buildFormResponse(ctx, first, connector.SetupFlow)
 		}
 		return conn.initiateAuthStep(ctx, returnToUrl, connector)

--- a/internal/core/service_connection_reauth_test.go
+++ b/internal/core/service_connection_reauth_test.go
@@ -65,7 +65,7 @@ func TestReauthConnection(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId))).Return(nil)
 
 		resp, err := conn.s.ReauthConnection(context.Background(), conn.Id, "")
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestReauthConnection(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId))).Return(nil)
 
 		resp, err := conn.s.ReauthConnection(context.Background(), conn.Id, "")
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestReauthConnection(t *testing.T) {
 
 		// Expect setup_error nil-write.
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId))).Return(nil)
 
 		// gomock validates the (*string)(nil) write happened — the in-memory
 		// `conn` is not the same instance ReauthConnection operates on (the
@@ -192,7 +192,7 @@ func TestReauthConnection(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("tenant"))).Return(nil)
 
 		resp, err := s.ReauthConnection(context.Background(), conn.Id, "")
 		require.NoError(t, err)

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -22,6 +22,6 @@ func (c *connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResp
 		return nil, httperr.BadRequest("connector has no configure steps to reconfigure")
 	}
 
-	first := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+	first := cschema.MustNewSetupStep(connector.SetupFlow.Configure.Steps[0].Id)
 	return c.buildFormResponse(ctx, first, connector.SetupFlow)
 }

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -74,7 +74,7 @@ func TestReconfigure(t *testing.T) {
 		})
 		conn.State = database.ConnectionStateConfigured
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestReconfigure(t *testing.T) {
 		})
 		conn.State = database.ConnectionStateConfigured
 
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		resp, err := conn.Reconfigure(context.Background())
 		require.NoError(t, err)

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -36,7 +36,7 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	if connector.SetupFlow.HasPreconnect() {
-		first := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		first := cschema.MustNewSetupStep(connector.SetupFlow.Preconnect.Steps[0].Id)
 		return conn.buildFormResponse(ctx, first, connector.SetupFlow)
 	}
 

--- a/internal/core/service_connection_retry_test.go
+++ b/internal/core/service_connection_retry_test.go
@@ -25,7 +25,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
 
@@ -72,7 +72,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("tenant"))).Return(nil)
 
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestRetryConnectionSetup(t *testing.T) {
 		}, nil).AnyTimes()
 
 		db.EXPECT().SetConnectionSetupError(gomock.Any(), conn.Id, (*string)(nil)).Return(nil)
-		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0))).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("tenant"))).Return(nil)
 
 		resp, err := conn.s.RetryConnectionSetup(context.Background(), conn.Id, "")
 		require.NoError(t, err)

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -34,9 +34,9 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 
 	currentSetupStep := *setupStep
 
-	// Only the indexed phases (preconnect, credentials, configure) accept form submissions.
-	if !currentSetupStep.Phase().IsIndexed() {
-		return nil, httperr.BadRequestf("cannot submit form for phase %q", currentSetupStep.Phase())
+	// Only schema-defined steps (preconnect, credentials, configure) accept form submissions.
+	if !connector.SetupFlow.IsSchemaStep(currentSetupStep) {
+		return nil, httperr.BadRequestf("cannot submit form for step %q", currentSetupStep.String())
 	}
 
 	// Look up the current step definition
@@ -47,7 +47,7 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 
 	// Credential submissions are dispatched to the auth method — no merge into
 	// the general config blob, no risk of field-name collisions with preconnect.
-	if currentSetupStep.Phase() == cschema.SetupPhaseCredentials {
+	if connector.SetupFlow.IsCredentialsStep(currentSetupStep) {
 		return c.submitCredentialsStep(ctx, req, currentStep, connector)
 	}
 
@@ -93,10 +93,8 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 	}
 
 	// Next step is a form step (could be another preconnect, the credentials
-	// phase, or a configure step).
-	if nextStep.Phase() == cschema.SetupPhaseCredentials && req.ReturnToUrl == "" {
-		// Credential steps don't need a returnTo, but log nothing — just build the form.
-	}
+	// phase, or a configure step). Credential steps don't need a returnTo;
+	// just build the form.
 	return c.buildFormResponse(ctx, nextStep, connector.SetupFlow)
 }
 
@@ -268,19 +266,19 @@ func (c *connection) GetCurrentSetupStepResponse(ctx context.Context) (iface.Con
 
 	parsed := *setupStep
 
-	switch parsed.Phase() {
-	case cschema.SetupPhaseAuth:
+	switch {
+	case parsed.Equals(cschema.SetupStepAuth):
 		// The connection is waiting for the OAuth callback — tell the UI
 		return &iface.ConnectionSetupRedirect{
 			Id:   c.GetId(),
 			Type: iface.ConnectionSetupResponseTypeRedirect,
 		}, nil
-	case cschema.SetupPhaseVerify:
+	case parsed.Equals(cschema.SetupStepVerify):
 		return &iface.ConnectionSetupVerifying{
 			Id:   c.GetId(),
 			Type: iface.ConnectionSetupResponseTypeVerifying,
 		}, nil
-	case cschema.SetupPhaseVerifyFailed, cschema.SetupPhaseAuthFailed:
+	case parsed.IsTerminalFailure():
 		msg := ""
 		if e := c.GetSetupError(); e != nil {
 			msg = *e

--- a/internal/core/service_connection_submit_api_key_test.go
+++ b/internal/core/service_connection_submit_api_key_test.go
@@ -92,7 +92,7 @@ func TestApiKeySubmit_BearerPersistsCredentialAndAdvancesToReady(t *testing.T) {
 		Type: cschema.ApiKeyPlacementBearer,
 	}, nil)
 
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	credCap := &captureEncCredential{}
@@ -132,7 +132,7 @@ func TestApiKeySubmit_BasicPersistsBothCredentialFields(t *testing.T) {
 		UsernameField: "account_id",
 	}, nil)
 
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	credCap := &captureEncCredential{}
@@ -167,7 +167,7 @@ func TestApiKeySubmit_TransitionsToVerifyWhenProbesPresent(t *testing.T) {
 			{Id: "ping", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://example.com/ping"}},
 		},
 	)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	ctx, actorId := contextWithActor(t)
@@ -194,7 +194,7 @@ func TestApiKeySubmit_NoReplay_PriorCredentialNeverDecryptedIntoForm(t *testing.
 	conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 		Type: cschema.ApiKeyPlacementBearer,
 	}, nil)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	ctx, actorId := contextWithActor(t)
@@ -266,7 +266,7 @@ func TestApiKeySubmit_PreconnectFieldNamedApiKeyIsNotTreatedAsCredential(t *test
 		logger: aplog.NewNoopLogger(),
 	}
 
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+	step := cschema.MustNewSetupStep("tenant")
 	conn.SetupStep = &step
 
 	// Critical invariants:
@@ -285,7 +285,7 @@ func TestApiKeySubmit_PreconnectFieldNamedApiKeyIsNotTreatedAsCredential(t *test
 		})
 	// After preconnect completes the next step is the synthesized credentials step,
 	// so SubmitForm returns that form (not complete).
-	credsStep := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	credsStep := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &credsStep).Return(nil)
 
 	ctx, _ := contextWithActor(t)
@@ -338,11 +338,11 @@ func TestApiKeySubmit_TransitionsToConfigureWhenNoProbes(t *testing.T) {
 		logger: aplog.NewNoopLogger(),
 	}
 
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	ctx, actorId := contextWithActor(t)
-	configureFirst := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+	configureFirst := cschema.MustNewSetupStep("workspace")
 	db.EXPECT().
 		InsertApiKeyCredential(gomock.Any(), conn.Id, gomock.Any(), gomock.Any(), &actorId).
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
@@ -371,7 +371,7 @@ func TestApiKeySubmit_RejectsMismatchedStepId(t *testing.T) {
 	conn, _, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 		Type: cschema.ApiKeyPlacementBearer,
 	}, nil)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	// No InsertApiKeyCredential expected — submit should error before that.
@@ -394,7 +394,7 @@ func TestApiKeySubmit_RejectsSchemaViolation(t *testing.T) {
 	conn, _, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 		Type: cschema.ApiKeyPlacementBearer,
 	}, nil)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	// No InsertApiKeyCredential expected.
@@ -418,7 +418,7 @@ func TestApiKeySubmit_RejectsBasicMissingUsername(t *testing.T) {
 		Type:          cschema.ApiKeyPlacementBasic,
 		UsernameField: "account_id",
 	}, nil)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	// No InsertApiKeyCredential expected.
@@ -467,7 +467,7 @@ func TestApiKeySubmit_RejectsUnknownAuthTypeOnCredentialsPhase(t *testing.T) {
 		cv:     cv,
 		logger: aplog.NewNoopLogger(),
 	}
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep("creds")
 	conn.SetupStep = &step
 
 	ctx, _ := contextWithActor(t)
@@ -489,7 +489,7 @@ func TestApiKeySubmit_DBErrorSurfacesUnchanged(t *testing.T) {
 	conn, db, _ := newTestApiKeyConnection(t, ctrl, &cschema.ApiKeyPlacement{
 		Type: cschema.ApiKeyPlacementBearer,
 	}, nil)
-	step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseCredentials, 0)
+	step := cschema.MustNewSetupStep(cschema.SynthesizedApiKeyCredentialsStepId)
 	conn.SetupStep = &step
 
 	ctx, actorId := contextWithActor(t)

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -98,7 +98,7 @@ func TestSubmitForm(t *testing.T) {
 		defer ctrl.Finish()
 
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, nil)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 
 		_, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -123,11 +123,11 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		nextStep := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 1)
+		nextStep := cschema.MustNewSetupStep("region")
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &nextStep).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -157,7 +157,7 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
@@ -183,7 +183,7 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
@@ -226,12 +226,12 @@ func TestSubmitForm(t *testing.T) {
 		}
 
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("step1")
 		conn.SetupStep = &step
 
 		// First submit — sets config with tenant
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
-		nextStep := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 1)
+		nextStep := cschema.MustNewSetupStep("step2")
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &nextStep).Return(nil)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
@@ -285,7 +285,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 			},
 		}
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("tenant")
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)
@@ -332,7 +332,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 			},
 		}
 		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &step).Return(nil)

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -112,7 +112,7 @@ func (c *Connection) cols() []string {
 		"annotations",
 		"encrypted_configuration",
 		"encrypted_at",
-		"setup_step",
+		"setup_step_id",
 		"setup_error",
 		"created_at",
 		"updated_at",
@@ -440,7 +440,7 @@ func (s *service) SetConnectionSetupStep(ctx context.Context, id apid.ID, setupS
 	dbResult, err := s.sq.
 		Update(ConnectionsTable).
 		Set("updated_at", now).
-		Set("setup_step", setupStep).
+		Set("setup_step_id", setupStep).
 		Where(sq.Eq{"id": id, "deleted_at": nil}).
 		RunWith(s.db).
 		Exec()
@@ -726,7 +726,7 @@ func (l *listConnectionsFilters) applyRestrictions(ctx context.Context) sq.Selec
 	}
 
 	if l.SetupStepNotNullVal {
-		q = q.Where(sq.NotEq{"setup_step": nil})
+		q = q.Where(sq.NotEq{"setup_step_id": nil})
 	}
 
 	if l.UpdatedBeforeVal != nil {

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -925,9 +925,9 @@ func TestConnections(t *testing.T) {
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
 		type connectionResult struct {
-			Id        string
-			SetupStep *string
-			UpdatedAt time.Time
+			Id          string
+			SetupStepId *string
+			UpdatedAt   time.Time
 		}
 
 		u := apid.New(apid.PrefixConnection)
@@ -949,18 +949,18 @@ func TestConnections(t *testing.T) {
 		newNow := time.Date(1955, time.November, 6, 6, 29, 0, 0, time.UTC)
 		ctx = apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(newNow)).Build()
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("preconnect_0")
 		err = db.SetConnectionSetupStep(ctx, u, &step)
 		require.NoError(t, err)
 
 		stepStr := step.String()
 		test_utils.AssertSql(t, rawDb, `
-			SELECT id, setup_step, updated_at FROM connections;
+			SELECT id, setup_step_id, updated_at FROM connections;
 		`, []connectionResult{
 			{
-				Id:        u.String(),
-				SetupStep: &stepStr,
-				UpdatedAt: newNow,
+				Id:          u.String(),
+				SetupStepId: &stepStr,
+				UpdatedAt:   newNow,
 			},
 		})
 
@@ -968,17 +968,17 @@ func TestConnections(t *testing.T) {
 		c, err = db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "preconnect:0", c.SetupStep.String())
+		assert.Equal(t, "preconnect_0", c.SetupStep.String())
 
 		// Update to a different step
-		step2 := cschema.MustNewIndexedSetupStep(cschema.SetupPhaseConfigure, 0)
+		step2 := cschema.MustNewSetupStep("configure_0")
 		err = db.SetConnectionSetupStep(ctx, u, &step2)
 		require.NoError(t, err)
 
 		c, err = db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "configure:0", c.SetupStep.String())
+		assert.Equal(t, "configure_0", c.SetupStep.String())
 
 		// Clear setup step (set to nil)
 		err = db.SetConnectionSetupStep(ctx, u, nil)
@@ -994,7 +994,7 @@ func TestConnections(t *testing.T) {
 		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("preconnect_0")
 		err := db.SetConnectionSetupStep(ctx, apid.New(apid.PrefixConnection), &step)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
@@ -1017,7 +1017,7 @@ func TestConnections(t *testing.T) {
 		err = db.DeleteConnection(ctx, u)
 		require.NoError(t, err)
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("preconnect_0")
 		err = db.SetConnectionSetupStep(ctx, u, &step)
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
@@ -1089,7 +1089,7 @@ func TestConnections(t *testing.T) {
 		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		step := cschema.MustNewIndexedSetupStep(cschema.SetupPhasePreconnect, 0)
+		step := cschema.MustNewSetupStep("preconnect_0")
 		ef := encfield.EncryptedField{ID: "ekv_test1234", Data: "encrypted-config-data"}
 		u := apid.New(apid.PrefixConnection)
 		err := db.CreateConnection(ctx, &Connection{
@@ -1107,7 +1107,7 @@ func TestConnections(t *testing.T) {
 		c, err := db.GetConnection(ctx, u)
 		require.NoError(t, err)
 		require.NotNil(t, c.SetupStep)
-		assert.Equal(t, "preconnect:0", c.SetupStep.String())
+		assert.Equal(t, "preconnect_0", c.SetupStep.String())
 		require.NotNil(t, c.EncryptedConfiguration)
 		assert.Equal(t, apid.ID("ekv_test1234"), c.EncryptedConfiguration.ID)
 		assert.Equal(t, "encrypted-config-data", c.EncryptedConfiguration.Data)

--- a/internal/database/migrations/postgres/000010_rename_setup_step_column.down.sql
+++ b/internal/database/migrations/postgres/000010_rename_setup_step_column.down.sql
@@ -1,0 +1,2 @@
+alter table connections
+    rename column setup_step_id to setup_step;

--- a/internal/database/migrations/postgres/000010_rename_setup_step_column.up.sql
+++ b/internal/database/migrations/postgres/000010_rename_setup_step_column.up.sql
@@ -1,0 +1,5 @@
+-- Rename connections.setup_step -> connections.setup_step_id to reflect that
+-- the column now stores a raw step identifier (the user-authored YAML step id
+-- or an apxy:* pseudo-step id) rather than the prior "phase:index" encoding.
+alter table connections
+    rename column setup_step to setup_step_id;

--- a/internal/database/migrations/sqlite/000010_rename_setup_step_column.down.sql
+++ b/internal/database/migrations/sqlite/000010_rename_setup_step_column.down.sql
@@ -1,0 +1,2 @@
+alter table connections
+    rename column setup_step_id to setup_step;

--- a/internal/database/migrations/sqlite/000010_rename_setup_step_column.up.sql
+++ b/internal/database/migrations/sqlite/000010_rename_setup_step_column.up.sql
@@ -1,0 +1,5 @@
+-- Rename connections.setup_step -> connections.setup_step_id to reflect that
+-- the column now stores a raw step identifier (the user-authored YAML step id
+-- or an apxy:* pseudo-step id) rather than the prior "phase:index" encoding.
+alter table connections
+    rename column setup_step to setup_step_id;

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -255,7 +255,7 @@ type ConnectionJson struct {
 	Annotations map[string]string              `json:"annotations,omitempty"`
 	State       database.ConnectionState       `json:"state"`
 	HealthState database.ConnectionHealthState `json:"health_state"`
-	SetupStep   *cschema.SetupStep             `json:"setup_step,omitempty" swaggertype:"string"`
+	SetupStep   *cschema.SetupStep             `json:"setup_step_id,omitempty" swaggertype:"string"`
 	SetupError  *string                        `json:"setup_error,omitempty"`
 	Connector   ConnectorJson                  `json:"connector"`
 	CreatedAt   time.Time                      `json:"created_at"`

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -73,8 +73,9 @@ type SwaggerConnectionJson struct {
 	// Operational health signal (healthy, unhealthy). Distinct from State: a Ready connection
 	// whose credentials have stopped working flips to unhealthy without changing State.
 	HealthState string `json:"health_state" example:"healthy"`
-	// Current setup step if connection setup is in progress
-	SetupStep *string `json:"setup_step,omitempty" example:"preconnect:0"`
+	// Current setup step if connection setup is in progress. Either a user-authored step id from
+	// the connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).
+	SetupStep *string `json:"setup_step_id,omitempty" example:"tenant"`
 	// Connector information
 	Connector SwaggerConnectorJson `json:"connector"`
 	// Creation timestamp

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -102,121 +101,80 @@ func (sf *SetupFlow) TotalSteps() int {
 	return total
 }
 
-// SetupStepPhase identifies which phase of the setup flow a step belongs to. The indexed
-// phases (preconnect, configure) carry an integer index in their canonical setup-step form;
-// the others are singleton pseudo-steps with no index.
-type SetupStepPhase string
+// ApxyStepPrefix is the reserved prefix for system-emitted step ids. User-
+// authored step ids must not start with this prefix. The auth-method-emitted
+// steps that #366 introduces use "apxy:auth:<val>"; terminal pseudo-steps use
+// "apxy:verify_failed" / "apxy:auth_failed"; the verify pseudo-step is
+// "apxy:verify". The placeholder "apxy:auth" is the OAuth2-only wait state
+// until #366 replaces it with the auth-method-emitted redirect step.
+const ApxyStepPrefix = "apxy:"
 
-const (
-	SetupPhasePreconnect   SetupStepPhase = "preconnect"
-	SetupPhaseCredentials  SetupStepPhase = "credentials"
-	SetupPhaseAuth         SetupStepPhase = "auth"
-	SetupPhaseVerify       SetupStepPhase = "verify"
-	SetupPhaseConfigure    SetupStepPhase = "configure"
-	SetupPhaseVerifyFailed SetupStepPhase = "verify_failed"
-	SetupPhaseAuthFailed   SetupStepPhase = "auth_failed"
-)
-
-// String returns the underlying phase identifier.
-func (p SetupStepPhase) String() string { return string(p) }
-
-// IsIndexed reports whether the phase carries a 0-based step index in its canonical form
-// (preconnect, credentials, configure). Singleton pseudo-steps return false.
-func (p SetupStepPhase) IsIndexed() bool {
-	return p == SetupPhasePreconnect || p == SetupPhaseCredentials || p == SetupPhaseConfigure
-}
-
-// IsTerminalFailure reports whether the phase represents a terminal failure pseudo-step
-// (verify_failed, auth_failed). Connections in this phase are retryable via the retry endpoint.
-func (p SetupStepPhase) IsTerminalFailure() bool {
-	return p == SetupPhaseVerifyFailed || p == SetupPhaseAuthFailed
-}
-
-// IsValid reports whether p is one of the recognized phases.
-func (p SetupStepPhase) IsValid() bool {
-	switch p {
-	case SetupPhasePreconnect, SetupPhaseCredentials, SetupPhaseAuth, SetupPhaseVerify, SetupPhaseConfigure,
-		SetupPhaseVerifyFailed, SetupPhaseAuthFailed:
-		return true
-	}
-	return false
-}
-
-// SetupStep is a typed representation of a setup-flow step. It captures the phase and, for
-// indexed phases, the 0-based step index. The zero SetupStep is invalid; use ParseSetupStep,
-// NewSetupStep, or NewIndexedSetupStep to construct one.
+// SetupStep is the typed identifier for a step within a connection's setup
+// flow. It is the value stored in connections.setup_step_id and threaded
+// through the API surface. User-authored steps carry the id from the
+// connector YAML; system-emitted steps use the apxy: prefix.
 type SetupStep struct {
-	phase SetupStepPhase
-	index int
+	id string
 }
 
-// NewSetupStep returns a SetupStep for a singleton (non-indexed) phase.
-// Returns an error if phase is indexed or unknown.
-func NewSetupStep(phase SetupStepPhase) (SetupStep, error) {
-	if !phase.IsValid() {
-		return SetupStep{}, fmt.Errorf("unknown setup phase %q", phase)
+// NewSetupStep constructs a SetupStep from an id string. The empty id is
+// rejected; use the zero SetupStep (i.e. omit the field) for "no active step."
+func NewSetupStep(id string) (SetupStep, error) {
+	if id == "" {
+		return SetupStep{}, fmt.Errorf("setup step id is required")
 	}
-	if phase.IsIndexed() {
-		return SetupStep{}, fmt.Errorf("phase %q is indexed; use NewIndexedSetupStep", phase)
-	}
-	return SetupStep{phase: phase}, nil
+	return SetupStep{id: id}, nil
 }
 
-// NewIndexedSetupStep returns a SetupStep for an indexed phase (preconnect, configure).
-// Returns an error if phase is not indexed or index is negative.
-func NewIndexedSetupStep(phase SetupStepPhase, index int) (SetupStep, error) {
-	if !phase.IsIndexed() {
-		return SetupStep{}, fmt.Errorf("phase %q is not indexed", phase)
-	}
-	if index < 0 {
-		return SetupStep{}, fmt.Errorf("setup step index must be non-negative, got %d", index)
-	}
-	return SetupStep{phase: phase, index: index}, nil
-}
-
-// MustNewIndexedSetupStep is like NewIndexedSetupStep but panics on error.
-func MustNewIndexedSetupStep(phase SetupStepPhase, index int) SetupStep {
-	step, err := NewIndexedSetupStep(phase, index)
+// MustNewSetupStep is like NewSetupStep but panics on error. Useful for
+// constructing predefined singleton steps at package init time.
+func MustNewSetupStep(id string) SetupStep {
+	step, err := NewSetupStep(id)
 	if err != nil {
 		panic(err)
 	}
 	return step
 }
 
-// Predefined SetupSteps for the singleton phases.
+// Predefined SetupSteps for the system-emitted pseudo-steps.
+//
+//   - SetupStepAuth is the OAuth2-only "waiting for callback" placeholder.
+//     #366 replaces direct use of this with auth-method-emitted redirect
+//     steps whose ids are method-specific (e.g. apxy:auth:oauth2_authorize).
+//   - SetupStepVerify is the post-auth "probes running" pseudo-step.
+//   - SetupStepVerifyFailed and SetupStepAuthFailed are terminal failure
+//     pseudo-steps; connections in these are retryable via the retry endpoint.
 var (
-	SetupStepAuth         = SetupStep{phase: SetupPhaseAuth}
-	SetupStepVerify       = SetupStep{phase: SetupPhaseVerify}
-	SetupStepVerifyFailed = SetupStep{phase: SetupPhaseVerifyFailed}
-	SetupStepAuthFailed   = SetupStep{phase: SetupPhaseAuthFailed}
+	SetupStepAuth         = MustNewSetupStep(ApxyStepPrefix + "auth")
+	SetupStepVerify       = MustNewSetupStep(ApxyStepPrefix + "verify")
+	SetupStepVerifyFailed = MustNewSetupStep(ApxyStepPrefix + "verify_failed")
+	SetupStepAuthFailed   = MustNewSetupStep(ApxyStepPrefix + "auth_failed")
 )
 
-// Phase returns the step's phase.
-func (s SetupStep) Phase() SetupStepPhase { return s.phase }
+// Id returns the underlying id string.
+func (s SetupStep) Id() string { return s.id }
 
-// Index returns the 0-based index for indexed phases. Returns 0 for singleton phases.
-func (s SetupStep) Index() int { return s.index }
+// String renders the step id. The zero SetupStep returns "".
+func (s SetupStep) String() string { return s.id }
 
-// String renders the canonical setup-step form: "phase:index" for indexed phases, "phase"
-// for singletons. The zero SetupStep returns "".
-func (s SetupStep) String() string {
-	if s.phase == "" {
-		return ""
-	}
-	if s.phase.IsIndexed() {
-		return fmt.Sprintf("%s:%d", s.phase, s.index)
-	}
-	return string(s.phase)
-}
-
-// IsZero reports whether s is the zero SetupStep (no phase set).
-func (s SetupStep) IsZero() bool { return s.phase == "" }
+// IsZero reports whether s is the zero SetupStep (no id set).
+func (s SetupStep) IsZero() bool { return s.id == "" }
 
 // Equals reports whether s and other are identical.
-func (s SetupStep) Equals(other SetupStep) bool { return s == other }
+func (s SetupStep) Equals(other SetupStep) bool { return s.id == other.id }
 
-// IsTerminalFailure reports whether the step is in a terminal failure phase.
-func (s SetupStep) IsTerminalFailure() bool { return s.phase.IsTerminalFailure() }
+// IsTerminalFailure reports whether the step is in a terminal failure state
+// (verify_failed or auth_failed) — connections in this state are retryable
+// via the retry endpoint.
+func (s SetupStep) IsTerminalFailure() bool {
+	return s.Equals(SetupStepVerifyFailed) || s.Equals(SetupStepAuthFailed)
+}
+
+// IsApxyEmitted reports whether the step id is system-emitted (i.e. carries
+// the reserved apxy: prefix). User-authored steps return false.
+func (s SetupStep) IsApxyEmitted() bool {
+	return strings.HasPrefix(s.id, ApxyStepPrefix)
+}
 
 // Value implements driver.Valuer so SetupStep can be stored as a database column.
 // The zero SetupStep round-trips as SQL NULL.
@@ -224,7 +182,7 @@ func (s SetupStep) Value() (driver.Value, error) {
 	if s.IsZero() {
 		return nil, nil
 	}
-	return s.String(), nil
+	return s.id, nil
 }
 
 // Scan implements sql.Scanner so SetupStep can be read from a database column.
@@ -245,27 +203,18 @@ func (s *SetupStep) Scan(value interface{}) error {
 		return fmt.Errorf("cannot scan %T into SetupStep", value)
 	}
 
-	if str == "" {
-		*s = SetupStep{}
-		return nil
-	}
-
-	parsed, err := ParseSetupStep(str)
-	if err != nil {
-		return err
-	}
-	*s = parsed
+	*s = SetupStep{id: str}
 	return nil
 }
 
-// MarshalJSON renders SetupStep as the canonical setup-step string. The zero
-// SetupStep marshals as JSON null so it round-trips cleanly with omitempty
-// pointer fields and database NULL.
+// MarshalJSON renders SetupStep as the step id string. The zero SetupStep
+// marshals as JSON null so it round-trips cleanly with omitempty pointer
+// fields and database NULL.
 func (s SetupStep) MarshalJSON() ([]byte, error) {
 	if s.IsZero() {
 		return []byte("null"), nil
 	}
-	return json.Marshal(s.String())
+	return json.Marshal(s.id)
 }
 
 // UnmarshalJSON parses a SetupStep from a JSON string, accepting null and the
@@ -281,26 +230,17 @@ func (s *SetupStep) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("setup step must be a JSON string: %w", err)
 	}
 
-	if str == "" {
-		*s = SetupStep{}
-		return nil
-	}
-
-	parsed, err := ParseSetupStep(str)
-	if err != nil {
-		return err
-	}
-	*s = parsed
+	*s = SetupStep{id: str}
 	return nil
 }
 
-// MarshalYAML renders SetupStep as the canonical setup-step string. The zero
-// SetupStep marshals as YAML null.
+// MarshalYAML renders SetupStep as the step id string. The zero SetupStep
+// marshals as YAML null.
 func (s SetupStep) MarshalYAML() (interface{}, error) {
 	if s.IsZero() {
 		return nil, nil
 	}
-	return s.String(), nil
+	return s.id, nil
 }
 
 // UnmarshalYAML parses a SetupStep from a YAML scalar, accepting null and the
@@ -316,158 +256,236 @@ func (s *SetupStep) UnmarshalYAML(value *yaml.Node) error {
 		return fmt.Errorf("setup step must be a YAML string: %w", err)
 	}
 
-	if str == "" {
-		*s = SetupStep{}
-		return nil
-	}
-
-	parsed, err := ParseSetupStep(str)
-	if err != nil {
-		return err
-	}
-	*s = parsed
+	*s = SetupStep{id: str}
 	return nil
 }
 
-// ParseSetupStep parses a setup-step string into a SetupStep. Indexed forms must be
-// "phase:index" (e.g. "preconnect:0", "configure:3"); singleton phases ("auth", "verify",
-// "verify_failed", "auth_failed") parse as a SetupStep with index 0.
+// ParseSetupStep parses a setup-step string into a SetupStep. The empty
+// string returns the zero SetupStep.
 func ParseSetupStep(setupStep string) (SetupStep, error) {
-	phase := SetupStepPhase(setupStep)
-	if phase.IsValid() && !phase.IsIndexed() {
-		return SetupStep{phase: phase}, nil
+	if setupStep == "" {
+		return SetupStep{}, nil
 	}
-
-	parts := strings.SplitN(setupStep, ":", 2)
-	if len(parts) != 2 {
-		return SetupStep{}, fmt.Errorf("invalid setup step format %q", setupStep)
-	}
-
-	phase = SetupStepPhase(parts[0])
-	if !phase.IsIndexed() {
-		return SetupStep{}, fmt.Errorf("invalid setup step phase %q", phase)
-	}
-
-	index, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return SetupStep{}, fmt.Errorf("invalid setup step index %q: %w", parts[1], err)
-	}
-
-	if index < 0 {
-		return SetupStep{}, fmt.Errorf("setup step index must be non-negative, got %d", index)
-	}
-
-	return SetupStep{phase: phase, index: index}, nil
+	return SetupStep{id: setupStep}, nil
 }
 
-// GetStepBySetupStep returns the step definition and its 0-based global index for the given
-// setup step. Returns an error if step is not an indexed phase or its index is out of range.
+// IsConfigureStep returns true when the supplied step belongs to the
+// schema's configure phase. Data sources are only available during configure
+// steps (preconnect cannot use them because credentials are not yet
+// established); callers use this to gate proxy-driven data-source requests.
+func (sf *SetupFlow) IsConfigureStep(step SetupStep) bool {
+	return phaseContainsId(sf.configurePhase(), step.id)
+}
+
+// IsCredentialsStep returns true when the supplied step belongs to the
+// schema's credentials phase. The credentials phase is owned by an auth
+// method (currently AuthApiKey); submissions to it are routed to the auth
+// method instead of merged into the connection's config.
+func (sf *SetupFlow) IsCredentialsStep(step SetupStep) bool {
+	return phaseContainsId(sf.credentialsPhase(), step.id)
+}
+
+// IsSchemaStep returns true when the supplied step is a user-authored step
+// from preconnect, credentials, or configure — i.e. one that accepts form
+// submissions. Apxy-emitted pseudo-steps return false.
+func (sf *SetupFlow) IsSchemaStep(step SetupStep) bool {
+	_, _, ok := sf.findStepById(step.id)
+	return ok
+}
+
+func (sf *SetupFlow) credentialsPhase() *SetupFlowPhase {
+	if sf == nil {
+		return nil
+	}
+	return sf.Credentials
+}
+
+func (sf *SetupFlow) configurePhase() *SetupFlowPhase {
+	if sf == nil {
+		return nil
+	}
+	return sf.Configure
+}
+
+func phaseContainsId(phase *SetupFlowPhase, id string) bool {
+	if phase == nil || id == "" {
+		return false
+	}
+	for i := range phase.Steps {
+		if phase.Steps[i].Id == id {
+			return true
+		}
+	}
+	return false
+}
+
+// findStepById walks the schema-defined arrays (preconnect, credentials,
+// configure) and returns the array slot the id lives in. ok=false if the id
+// is not user-authored (e.g. an apxy:* pseudo-step or unknown id).
+func (sf *SetupFlow) findStepById(id string) (step *SetupFlowStep, globalIndex int, ok bool) {
+	if sf == nil || id == "" {
+		return nil, 0, false
+	}
+	idx := 0
+	if sf.Preconnect != nil {
+		for i := range sf.Preconnect.Steps {
+			if sf.Preconnect.Steps[i].Id == id {
+				return &sf.Preconnect.Steps[i], idx, true
+			}
+			idx++
+		}
+	}
+	if sf.Credentials != nil {
+		for i := range sf.Credentials.Steps {
+			if sf.Credentials.Steps[i].Id == id {
+				return &sf.Credentials.Steps[i], idx, true
+			}
+			idx++
+		}
+	}
+	if sf.Configure != nil {
+		for i := range sf.Configure.Steps {
+			if sf.Configure.Steps[i].Id == id {
+				return &sf.Configure.Steps[i], idx, true
+			}
+			idx++
+		}
+	}
+	return nil, 0, false
+}
+
+// GetStepBySetupStep returns the step definition and its 0-based global index
+// (across preconnect + credentials + configure) for the given setup step.
+// Returns an error if the step id is not a user-authored schema step (e.g.
+// an apxy:* pseudo-step) or is unknown.
+//
+// DEPRECATED: #366 replaces direct callers with ManifestSetupFlow.StepById.
+// Kept transitional so the pre-#366 dispatch path keeps compiling.
 func (sf *SetupFlow) GetStepBySetupStep(step SetupStep) (*SetupFlowStep, int, error) {
-	switch step.phase {
-	case SetupPhasePreconnect:
-		if sf.Preconnect == nil || step.index >= len(sf.Preconnect.Steps) {
-			return nil, 0, fmt.Errorf("preconnect step index %d out of range", step.index)
-		}
-		return &sf.Preconnect.Steps[step.index], step.index, nil
-	case SetupPhaseCredentials:
-		if sf.Credentials == nil || step.index >= len(sf.Credentials.Steps) {
-			return nil, 0, fmt.Errorf("credentials step index %d out of range", step.index)
-		}
-		globalIndex := step.index
-		if sf.Preconnect != nil {
-			globalIndex += len(sf.Preconnect.Steps)
-		}
-		return &sf.Credentials.Steps[step.index], globalIndex, nil
-	case SetupPhaseConfigure:
-		if sf.Configure == nil || step.index >= len(sf.Configure.Steps) {
-			return nil, 0, fmt.Errorf("configure step index %d out of range", step.index)
-		}
-		globalIndex := step.index
-		if sf.Preconnect != nil {
-			globalIndex += len(sf.Preconnect.Steps)
-		}
-		if sf.Credentials != nil {
-			globalIndex += len(sf.Credentials.Steps)
-		}
-		return &sf.Configure.Steps[step.index], globalIndex, nil
-	default:
-		return nil, 0, fmt.Errorf("phase %q does not have indexed steps", step.phase)
+	found, idx, ok := sf.findStepById(step.id)
+	if !ok {
+		return nil, 0, fmt.Errorf("step %q is not a schema-defined step", step.id)
 	}
+	return found, idx, nil
 }
 
-// FirstSetupStep returns the first step in the flow. Returns the zero SetupStep when the
-// flow has no steps (caller should check IsZero).
+// FirstSetupStep returns the first step in the flow. Returns the zero
+// SetupStep when the flow has no steps (caller should check IsZero).
+//
+// DEPRECATED: #366 replaces direct callers with ManifestSetupFlow.FirstStep.
 func (sf *SetupFlow) FirstSetupStep() SetupStep {
 	if sf == nil {
 		return SetupStep{}
 	}
 	if sf.HasPreconnect() {
-		return SetupStep{phase: SetupPhasePreconnect}
+		return SetupStep{id: sf.Preconnect.Steps[0].Id}
 	}
 	if sf.HasCredentials() {
-		return SetupStep{phase: SetupPhaseCredentials}
+		return SetupStep{id: sf.Credentials.Steps[0].Id}
 	}
 	if sf.HasConfigure() {
-		return SetupStep{phase: SetupPhaseConfigure}
+		return SetupStep{id: sf.Configure.Steps[0].Id}
 	}
 	return SetupStep{}
 }
 
-// NextSetupStep returns the step that follows current.
+// NextSetupStep returns the step that follows current in the linear flow.
 //
-// The credentials phase is owned by an auth method (currently AuthApiKey): when
-// the setup flow has a credentials phase, preconnect transitions there before
-// any auth phase. When it doesn't, preconnect transitions directly to the
-// OAuth2-style auth phase (which OAuth2 connectors use to redirect+wait).
+// Navigation rules (same as the prior phase-based encoding, just keyed by id):
+//   - Within preconnect / credentials / configure arrays: advance to the
+//     next entry of the same array.
+//   - End of preconnect: jump to credentials:0 if present, else SetupStepAuth.
+//   - End of credentials: jump to SetupStepVerify if hasProbes, else configure:0,
+//     else done.
+//   - SetupStepAuth: jump to SetupStepVerify if hasProbes, else configure:0,
+//     else done.
+//   - SetupStepVerify: jump to configure:0 if present, else done.
+//   - End of configure: done.
 //
-// When the connector has probes, a verify phase runs between credential
-// establishment and configure. Returns the zero SetupStep (IsZero) when current
-// is the final step.
+// DEPRECATED: #366 replaces direct callers with ManifestSetupFlow.NextStep.
+// Kept transitional so the pre-#366 dispatch path keeps compiling.
 func (sf *SetupFlow) NextSetupStep(current SetupStep, hasProbes bool) (SetupStep, error) {
-	switch current.phase {
-	case SetupPhasePreconnect:
-		if sf.Preconnect != nil && current.index+1 < len(sf.Preconnect.Steps) {
-			return SetupStep{phase: SetupPhasePreconnect, index: current.index + 1}, nil
-		}
-		if sf.HasCredentials() {
-			return SetupStep{phase: SetupPhaseCredentials}, nil
-		}
-		// No credentials phase — fall through to the auth phase (OAuth2's redirect step).
-		return SetupStepAuth, nil
-	case SetupPhaseCredentials:
-		if sf.Credentials != nil && current.index+1 < len(sf.Credentials.Steps) {
-			return SetupStep{phase: SetupPhaseCredentials, index: current.index + 1}, nil
-		}
-		// Credentials done — credentials phase replaces the auth phase for its
-		// auth method, so we go straight to verify / configure / ready.
-		if hasProbes {
-			return SetupStepVerify, nil
-		}
-		if sf.HasConfigure() {
-			return SetupStep{phase: SetupPhaseConfigure}, nil
-		}
-		return SetupStep{}, nil // Complete
-	case SetupPhaseAuth:
-		if hasProbes {
-			return SetupStepVerify, nil
-		}
-		if sf.HasConfigure() {
-			return SetupStep{phase: SetupPhaseConfigure}, nil
-		}
-		return SetupStep{}, nil // Complete
-	case SetupPhaseVerify:
-		if sf.HasConfigure() {
-			return SetupStep{phase: SetupPhaseConfigure}, nil
-		}
-		return SetupStep{}, nil // Complete
-	case SetupPhaseConfigure:
-		if sf.Configure != nil && current.index+1 < len(sf.Configure.Steps) {
-			return SetupStep{phase: SetupPhaseConfigure, index: current.index + 1}, nil
-		}
-		return SetupStep{}, nil // Complete
-	default:
-		return SetupStep{}, fmt.Errorf("no successor defined for phase %q", current.phase)
+	if current.IsZero() {
+		return SetupStep{}, fmt.Errorf("cannot compute next from zero SetupStep")
 	}
+
+	// Pseudo-steps: explicit transitions.
+	if current.Equals(SetupStepAuth) {
+		return sf.afterCredentialsEstablished(hasProbes), nil
+	}
+	if current.Equals(SetupStepVerify) {
+		if sf.HasConfigure() {
+			return SetupStep{id: sf.Configure.Steps[0].Id}, nil
+		}
+		return SetupStep{}, nil
+	}
+	if current.IsApxyEmitted() {
+		return SetupStep{}, fmt.Errorf("no successor defined for pseudo-step %q", current.id)
+	}
+
+	// Schema-defined step: locate which array it lives in and advance.
+	if sf.HasPreconnect() {
+		if next, ok := nextInArray(sf.Preconnect.Steps, current.id); ok {
+			return next, nil
+		}
+		if sf.isLastInArray(sf.Preconnect.Steps, current.id) {
+			if sf.HasCredentials() {
+				return SetupStep{id: sf.Credentials.Steps[0].Id}, nil
+			}
+			return SetupStepAuth, nil
+		}
+	}
+	if sf.HasCredentials() {
+		if next, ok := nextInArray(sf.Credentials.Steps, current.id); ok {
+			return next, nil
+		}
+		if sf.isLastInArray(sf.Credentials.Steps, current.id) {
+			return sf.afterCredentialsEstablished(hasProbes), nil
+		}
+	}
+	if sf.HasConfigure() {
+		if next, ok := nextInArray(sf.Configure.Steps, current.id); ok {
+			return next, nil
+		}
+		if sf.isLastInArray(sf.Configure.Steps, current.id) {
+			return SetupStep{}, nil
+		}
+	}
+	return SetupStep{}, fmt.Errorf("unknown step id %q", current.id)
+}
+
+// afterCredentialsEstablished returns the step that follows credential
+// establishment (end of credentials phase, or OAuth2 auth phase).
+func (sf *SetupFlow) afterCredentialsEstablished(hasProbes bool) SetupStep {
+	if hasProbes {
+		return SetupStepVerify
+	}
+	if sf.HasConfigure() {
+		return SetupStep{id: sf.Configure.Steps[0].Id}
+	}
+	return SetupStep{} // Complete
+}
+
+// nextInArray returns the successor id within a single array, ok=false when
+// id is not present in the array or is the last entry.
+func nextInArray(steps []SetupFlowStep, id string) (SetupStep, bool) {
+	for i := range steps {
+		if steps[i].Id == id {
+			if i+1 < len(steps) {
+				return SetupStep{id: steps[i+1].Id}, true
+			}
+			return SetupStep{}, false
+		}
+	}
+	return SetupStep{}, false
+}
+
+// isLastInArray returns true when id is the last entry of the supplied array.
+func (sf *SetupFlow) isLastInArray(steps []SetupFlowStep, id string) bool {
+	if len(steps) == 0 {
+		return false
+	}
+	return steps[len(steps)-1].Id == id
 }
 
 // SetupFlowPhase is a sequential list of form steps within a phase (preconnect or configure).
@@ -500,6 +518,8 @@ func (p *SetupFlowPhase) Validate(vc *common.ValidationContext, seenIds map[stri
 // SetupFlowStep defines a single form step in the setup flow.
 type SetupFlowStep struct {
 	// Id is a unique identifier for this step within the connector's setup flow.
+	// Must not start with the apxy: prefix, which is reserved for system-emitted
+	// steps.
 	Id string `json:"id" yaml:"id"`
 
 	// Title is the human-readable title shown above the form.
@@ -524,6 +544,8 @@ func (s *SetupFlowStep) Validate(vc *common.ValidationContext, seenIds map[strin
 
 	if s.Id == "" {
 		result = multierror.Append(result, vc.NewErrorfForField("id", "step id is required"))
+	} else if strings.HasPrefix(s.Id, ApxyStepPrefix) {
+		result = multierror.Append(result, vc.NewErrorfForField("id", "step id %q must not start with reserved prefix %q", s.Id, ApxyStepPrefix))
 	} else if seenIds[s.Id] {
 		result = multierror.Append(result, vc.NewErrorfForField("id", "duplicate step id %q", s.Id))
 	} else {

--- a/internal/schema/resources/connectors/setup_flow_test.go
+++ b/internal/schema/resources/connectors/setup_flow_test.go
@@ -348,150 +348,74 @@ func TestSetupFlowHelpers(t *testing.T) {
 }
 
 func TestParseSetupStep(t *testing.T) {
-	t.Run("valid preconnect", func(t *testing.T) {
-		s, err := ParseSetupStep("preconnect:0")
+	t.Run("user-authored id", func(t *testing.T) {
+		s, err := ParseSetupStep("tenant")
 		require.NoError(t, err)
-		assert.Equal(t, SetupPhasePreconnect, s.Phase())
-		assert.Equal(t, 0, s.Index())
+		assert.Equal(t, "tenant", s.Id())
 	})
 
-	t.Run("valid configure with higher index", func(t *testing.T) {
-		s, err := ParseSetupStep("configure:3")
+	t.Run("apxy-emitted pseudo-step", func(t *testing.T) {
+		s, err := ParseSetupStep("apxy:auth")
 		require.NoError(t, err)
-		assert.Equal(t, SetupPhaseConfigure, s.Phase())
-		assert.Equal(t, 3, s.Index())
-	})
-
-	t.Run("auth phase", func(t *testing.T) {
-		s, err := ParseSetupStep("auth")
-		require.NoError(t, err)
-		assert.Equal(t, SetupPhaseAuth, s.Phase())
-		assert.Equal(t, 0, s.Index())
 		assert.True(t, s.Equals(SetupStepAuth))
+		assert.True(t, s.IsApxyEmitted())
 	})
 
-	t.Run("verify phase", func(t *testing.T) {
-		s, err := ParseSetupStep("verify")
-		require.NoError(t, err)
-		assert.True(t, s.Equals(SetupStepVerify))
-	})
-
-	t.Run("verify_failed phase", func(t *testing.T) {
-		s, err := ParseSetupStep("verify_failed")
+	t.Run("verify_failed terminal", func(t *testing.T) {
+		s, err := ParseSetupStep("apxy:verify_failed")
 		require.NoError(t, err)
 		assert.True(t, s.Equals(SetupStepVerifyFailed))
 		assert.True(t, s.IsTerminalFailure())
 	})
 
-	t.Run("auth_failed phase", func(t *testing.T) {
-		s, err := ParseSetupStep("auth_failed")
+	t.Run("auth_failed terminal", func(t *testing.T) {
+		s, err := ParseSetupStep("apxy:auth_failed")
 		require.NoError(t, err)
 		assert.True(t, s.Equals(SetupStepAuthFailed))
 		assert.True(t, s.IsTerminalFailure())
 	})
 
-	t.Run("invalid format", func(t *testing.T) {
-		_, err := ParseSetupStep("bad")
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid phase", func(t *testing.T) {
-		_, err := ParseSetupStep("unknown:0")
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid index", func(t *testing.T) {
-		_, err := ParseSetupStep("preconnect:abc")
-		assert.Error(t, err)
-	})
-
-	t.Run("negative index", func(t *testing.T) {
-		_, err := ParseSetupStep("preconnect:-1")
-		assert.Error(t, err)
-	})
-
-	t.Run("singleton with index suffix is rejected", func(t *testing.T) {
-		_, err := ParseSetupStep("auth:0")
-		assert.Error(t, err)
+	t.Run("empty string produces zero", func(t *testing.T) {
+		s, err := ParseSetupStep("")
+		require.NoError(t, err)
+		assert.True(t, s.IsZero())
 	})
 }
 
 func TestSetupStepRoundTrip(t *testing.T) {
-	cases := []string{"preconnect:0", "preconnect:7", "configure:0", "configure:2", "auth", "verify", "verify_failed", "auth_failed"}
+	cases := []string{"tenant", "select_workspace", "apxy:auth", "apxy:verify", "apxy:verify_failed", "apxy:auth_failed", "apxy:auth:oauth2_authorize"}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
 			s, err := ParseSetupStep(c)
 			require.NoError(t, err)
 			assert.Equal(t, c, s.String())
+			assert.Equal(t, c, s.Id())
 		})
 	}
 }
 
 func TestSetupStepConstructors(t *testing.T) {
-	t.Run("NewSetupStep accepts singleton phases", func(t *testing.T) {
-		s, err := NewSetupStep(SetupPhaseAuth)
+	t.Run("NewSetupStep accepts user-authored id", func(t *testing.T) {
+		s, err := NewSetupStep("tenant")
 		require.NoError(t, err)
-		assert.Equal(t, "auth", s.String())
+		assert.Equal(t, "tenant", s.String())
+		assert.False(t, s.IsApxyEmitted())
 	})
 
-	t.Run("NewSetupStep rejects indexed phase", func(t *testing.T) {
-		_, err := NewSetupStep(SetupPhasePreconnect)
-		assert.Error(t, err)
-	})
-
-	t.Run("NewSetupStep rejects unknown phase", func(t *testing.T) {
-		_, err := NewSetupStep(SetupStepPhase("nope"))
-		assert.Error(t, err)
-	})
-
-	t.Run("NewIndexedSetupStep accepts indexed phase", func(t *testing.T) {
-		s, err := NewIndexedSetupStep(SetupPhaseConfigure, 4)
+	t.Run("NewSetupStep accepts apxy-prefixed id", func(t *testing.T) {
+		s, err := NewSetupStep("apxy:auth:oauth2_authorize")
 		require.NoError(t, err)
-		assert.Equal(t, "configure:4", s.String())
+		assert.Equal(t, "apxy:auth:oauth2_authorize", s.String())
+		assert.True(t, s.IsApxyEmitted())
 	})
 
-	t.Run("NewIndexedSetupStep rejects singleton phase", func(t *testing.T) {
-		_, err := NewIndexedSetupStep(SetupPhaseAuth, 0)
+	t.Run("NewSetupStep rejects empty id", func(t *testing.T) {
+		_, err := NewSetupStep("")
 		assert.Error(t, err)
 	})
 
-	t.Run("NewIndexedSetupStep rejects negative index", func(t *testing.T) {
-		_, err := NewIndexedSetupStep(SetupPhasePreconnect, -1)
-		assert.Error(t, err)
-	})
-}
-
-func TestMustNewIndexedSetupStep(t *testing.T) {
-	t.Run("returns step for valid indexed phase", func(t *testing.T) {
-		s := MustNewIndexedSetupStep(SetupPhaseConfigure, 0)
-		assert.Equal(t, SetupPhaseConfigure, s.Phase())
-		assert.Equal(t, 0, s.Index())
-		assert.Equal(t, "configure:0", s.String())
-	})
-
-	t.Run("returns step for preconnect with non-zero index", func(t *testing.T) {
-		s := MustNewIndexedSetupStep(SetupPhasePreconnect, 3)
-		assert.Equal(t, SetupPhasePreconnect, s.Phase())
-		assert.Equal(t, 3, s.Index())
-		assert.Equal(t, "preconnect:3", s.String())
-	})
-
-	t.Run("panics on singleton phase", func(t *testing.T) {
-		assert.Panics(t, func() {
-			MustNewIndexedSetupStep(SetupPhaseAuth, 0)
-		})
-	})
-
-	t.Run("panics on negative index", func(t *testing.T) {
-		assert.Panics(t, func() {
-			MustNewIndexedSetupStep(SetupPhasePreconnect, -1)
-		})
-	})
-
-	t.Run("panics on unknown phase", func(t *testing.T) {
-		assert.Panics(t, func() {
-			MustNewIndexedSetupStep(SetupStepPhase("nope"), 0)
-		})
+	t.Run("MustNewSetupStep panics on empty id", func(t *testing.T) {
+		assert.Panics(t, func() { MustNewSetupStep("") })
 	})
 }
 
@@ -502,17 +426,17 @@ func TestSetupStepZero(t *testing.T) {
 }
 
 func TestSetupStepJSONMarshal(t *testing.T) {
-	t.Run("indexed phase marshals as canonical string", func(t *testing.T) {
-		s := MustNewIndexedSetupStep(SetupPhaseConfigure, 2)
+	t.Run("user-authored id marshals as JSON string", func(t *testing.T) {
+		s := MustNewSetupStep("tenant")
 		b, err := json.Marshal(s)
 		require.NoError(t, err)
-		assert.Equal(t, `"configure:2"`, string(b))
+		assert.Equal(t, `"tenant"`, string(b))
 	})
 
-	t.Run("singleton phase marshals as canonical string", func(t *testing.T) {
+	t.Run("apxy-emitted id marshals as JSON string", func(t *testing.T) {
 		b, err := json.Marshal(SetupStepAuth)
 		require.NoError(t, err)
-		assert.Equal(t, `"auth"`, string(b))
+		assert.Equal(t, `"apxy:auth"`, string(b))
 	})
 
 	t.Run("zero value marshals as null", func(t *testing.T) {
@@ -535,15 +459,15 @@ func TestSetupStepJSONMarshal(t *testing.T) {
 		type wrapper struct {
 			Step *SetupStep `json:"step,omitempty"`
 		}
-		s := MustNewIndexedSetupStep(SetupPhasePreconnect, 0)
+		s := MustNewSetupStep("tenant")
 		b, err := json.Marshal(wrapper{Step: &s})
 		require.NoError(t, err)
-		assert.Equal(t, `{"step":"preconnect:0"}`, string(b))
+		assert.Equal(t, `{"step":"tenant"}`, string(b))
 	})
 }
 
 func TestSetupStepJSONUnmarshal(t *testing.T) {
-	cases := []string{"preconnect:0", "preconnect:7", "configure:0", "configure:2", "auth", "verify", "verify_failed", "auth_failed"}
+	cases := []string{"tenant", "select_workspace", "apxy:auth", "apxy:verify", "apxy:verify_failed", "apxy:auth_failed"}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
 			input := []byte(`"` + c + `"`)
@@ -551,7 +475,6 @@ func TestSetupStepJSONUnmarshal(t *testing.T) {
 			require.NoError(t, json.Unmarshal(input, &s))
 			assert.Equal(t, c, s.String())
 
-			// And round-trip
 			b, err := json.Marshal(s)
 			require.NoError(t, err)
 			assert.Equal(t, string(input), string(b))
@@ -570,12 +493,6 @@ func TestSetupStepJSONUnmarshal(t *testing.T) {
 		assert.True(t, s.IsZero())
 	})
 
-	t.Run("invalid string returns error", func(t *testing.T) {
-		var s SetupStep
-		err := json.Unmarshal([]byte(`"unknown:0"`), &s)
-		assert.Error(t, err)
-	})
-
 	t.Run("non-string value returns error", func(t *testing.T) {
 		var s SetupStep
 		err := json.Unmarshal([]byte(`123`), &s)
@@ -584,7 +501,7 @@ func TestSetupStepJSONUnmarshal(t *testing.T) {
 }
 
 func TestSetupStepYAMLRoundTrip(t *testing.T) {
-	cases := []string{"preconnect:0", "configure:2", "auth", "verify_failed"}
+	cases := []string{"tenant", "apxy:auth", "apxy:verify_failed"}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
 			parsed, err := ParseSetupStep(c)
@@ -610,27 +527,38 @@ func TestSetupStepYAMLRoundTrip(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal([]byte(`""`), &s))
 		assert.True(t, s.IsZero())
 	})
-
-	t.Run("invalid string returns error", func(t *testing.T) {
-		var s SetupStep
-		err := yaml.Unmarshal([]byte(`unknown:0`), &s)
-		assert.Error(t, err)
-	})
 }
 
-func TestSetupStepPhaseHelpers(t *testing.T) {
-	assert.True(t, SetupPhasePreconnect.IsIndexed())
-	assert.True(t, SetupPhaseConfigure.IsIndexed())
-	assert.False(t, SetupPhaseAuth.IsIndexed())
-	assert.False(t, SetupPhaseVerify.IsIndexed())
+func TestSetupStepIsApxyEmitted(t *testing.T) {
+	assert.True(t, SetupStepAuth.IsApxyEmitted())
+	assert.True(t, SetupStepVerify.IsApxyEmitted())
+	assert.True(t, SetupStepVerifyFailed.IsApxyEmitted())
+	assert.True(t, SetupStepAuthFailed.IsApxyEmitted())
+	assert.False(t, MustNewSetupStep("tenant").IsApxyEmitted())
+}
 
-	assert.True(t, SetupPhaseVerifyFailed.IsTerminalFailure())
-	assert.True(t, SetupPhaseAuthFailed.IsTerminalFailure())
-	assert.False(t, SetupPhaseAuth.IsTerminalFailure())
-	assert.False(t, SetupPhasePreconnect.IsTerminalFailure())
+func TestSetupStepIsTerminalFailure(t *testing.T) {
+	assert.True(t, SetupStepVerifyFailed.IsTerminalFailure())
+	assert.True(t, SetupStepAuthFailed.IsTerminalFailure())
+	assert.False(t, SetupStepAuth.IsTerminalFailure())
+	assert.False(t, SetupStepVerify.IsTerminalFailure())
+	assert.False(t, MustNewSetupStep("tenant").IsTerminalFailure())
+}
 
-	assert.False(t, SetupStepPhase("garbage").IsValid())
-	assert.True(t, SetupPhaseAuth.IsValid())
+// TestSetupFlowStep_RejectsApxyPrefix — user-authored step ids must not start
+// with the reserved apxy: prefix (which is for system-emitted steps).
+func TestSetupFlowStep_RejectsApxyPrefix(t *testing.T) {
+	sf := &SetupFlow{
+		Preconnect: &SetupFlowPhase{
+			Steps: []SetupFlowStep{{
+				Id:         "apxy:my_step",
+				JsonSchema: common.RawJSON(`{"type":"object"}`),
+			}},
+		},
+	}
+	err := sf.Validate(&common.ValidationContext{Path: "setup_flow"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved prefix")
 }
 
 func TestSetupFlowTotalSteps(t *testing.T) {
@@ -653,95 +581,100 @@ func TestSetupFlowFirstSetupStep(t *testing.T) {
 
 	t.Run("preconnect first", func(t *testing.T) {
 		sf := &SetupFlow{
-			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
-			Configure:  &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "b"}}},
+			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "tenant"}}},
+			Configure:  &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "workspace"}}},
 		}
-		assert.Equal(t, "preconnect:0", sf.FirstSetupStep().String())
+		assert.Equal(t, "tenant", sf.FirstSetupStep().String())
 	})
 
 	t.Run("configure only", func(t *testing.T) {
 		sf := &SetupFlow{
-			Configure: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
+			Configure: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "workspace"}}},
 		}
-		assert.Equal(t, "configure:0", sf.FirstSetupStep().String())
+		assert.Equal(t, "workspace", sf.FirstSetupStep().String())
+	})
+
+	t.Run("credentials when no preconnect", func(t *testing.T) {
+		sf := &SetupFlow{
+			Credentials: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "api_key_step"}}},
+		}
+		assert.Equal(t, "api_key_step", sf.FirstSetupStep().String())
 	})
 }
 
 func TestSetupFlowNextSetupStep(t *testing.T) {
 	sf := &SetupFlow{
 		Preconnect: &SetupFlowPhase{
-			Steps: []SetupFlowStep{{Id: "a"}, {Id: "b"}},
+			Steps: []SetupFlowStep{{Id: "tenant"}, {Id: "region"}},
 		},
 		Configure: &SetupFlowPhase{
-			Steps: []SetupFlowStep{{Id: "c"}, {Id: "d"}},
+			Steps: []SetupFlowStep{{Id: "workspace"}, {Id: "sync"}},
 		},
 	}
 
-	mustParse := func(t *testing.T, s string) SetupStep {
-		t.Helper()
-		v, err := ParseSetupStep(s)
+	t.Run("preconnect[0] -> preconnect[1]", func(t *testing.T) {
+		next, err := sf.NextSetupStep(MustNewSetupStep("tenant"), false)
 		require.NoError(t, err)
-		return v
-	}
-
-	t.Run("preconnect:0 -> preconnect:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep(mustParse(t, "preconnect:0"), false)
-		require.NoError(t, err)
-		assert.Equal(t, "preconnect:1", next.String())
+		assert.Equal(t, "region", next.String())
 	})
 
-	t.Run("preconnect:1 -> auth", func(t *testing.T) {
-		next, err := sf.NextSetupStep(mustParse(t, "preconnect:1"), false)
+	t.Run("last preconnect -> apxy:auth", func(t *testing.T) {
+		next, err := sf.NextSetupStep(MustNewSetupStep("region"), false)
 		require.NoError(t, err)
 		assert.True(t, next.Equals(SetupStepAuth))
 	})
 
-	t.Run("auth -> configure:0", func(t *testing.T) {
+	t.Run("apxy:auth -> first configure", func(t *testing.T) {
 		next, err := sf.NextSetupStep(SetupStepAuth, false)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:0", next.String())
+		assert.Equal(t, "workspace", next.String())
 	})
 
-	t.Run("auth -> verify when probes present", func(t *testing.T) {
+	t.Run("apxy:auth with probes -> apxy:verify", func(t *testing.T) {
 		next, err := sf.NextSetupStep(SetupStepAuth, true)
 		require.NoError(t, err)
 		assert.True(t, next.Equals(SetupStepVerify))
 	})
 
-	t.Run("verify -> configure:0", func(t *testing.T) {
+	t.Run("apxy:verify -> first configure", func(t *testing.T) {
 		next, err := sf.NextSetupStep(SetupStepVerify, true)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:0", next.String())
+		assert.Equal(t, "workspace", next.String())
 	})
 
-	t.Run("verify with no configure -> zero (complete)", func(t *testing.T) {
+	t.Run("apxy:verify with no configure -> zero", func(t *testing.T) {
 		sfNoConfig := &SetupFlow{
-			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
+			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "tenant"}}},
 		}
 		next, err := sfNoConfig.NextSetupStep(SetupStepVerify, true)
 		require.NoError(t, err)
 		assert.True(t, next.IsZero())
 	})
 
-	t.Run("configure:0 -> configure:1", func(t *testing.T) {
-		next, err := sf.NextSetupStep(mustParse(t, "configure:0"), false)
+	t.Run("configure[0] -> configure[1]", func(t *testing.T) {
+		next, err := sf.NextSetupStep(MustNewSetupStep("workspace"), false)
 		require.NoError(t, err)
-		assert.Equal(t, "configure:1", next.String())
+		assert.Equal(t, "sync", next.String())
 	})
 
-	t.Run("configure:1 -> zero (complete)", func(t *testing.T) {
-		next, err := sf.NextSetupStep(mustParse(t, "configure:1"), false)
+	t.Run("last configure -> zero (complete)", func(t *testing.T) {
+		next, err := sf.NextSetupStep(MustNewSetupStep("sync"), false)
 		require.NoError(t, err)
 		assert.True(t, next.IsZero())
 	})
 
-	t.Run("auth with no configure -> zero (complete)", func(t *testing.T) {
+	t.Run("apxy:auth with no configure -> zero", func(t *testing.T) {
 		sfNoConfig := &SetupFlow{
-			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "a"}}},
+			Preconnect: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "tenant"}}},
 		}
 		next, err := sfNoConfig.NextSetupStep(SetupStepAuth, false)
 		require.NoError(t, err)
 		assert.True(t, next.IsZero())
+	})
+
+	t.Run("unknown id returns error", func(t *testing.T) {
+		_, err := sf.NextSetupStep(MustNewSetupStep("unknown"), false)
+		assert.Error(t, err)
 	})
 }
 
@@ -755,42 +688,68 @@ func TestSetupFlowGetStepBySetupStep(t *testing.T) {
 		},
 	}
 
-	mustParse := func(t *testing.T, s string) SetupStep {
-		t.Helper()
-		v, err := ParseSetupStep(s)
-		require.NoError(t, err)
-		return v
-	}
-
-	t.Run("preconnect:0", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:0"))
+	t.Run("first preconnect", func(t *testing.T) {
+		step, idx, err := sf.GetStepBySetupStep(MustNewSetupStep("tenant"))
 		require.NoError(t, err)
 		assert.Equal(t, "tenant", step.Id)
 		assert.Equal(t, 0, idx)
 	})
 
-	t.Run("preconnect:1", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:1"))
+	t.Run("second preconnect", func(t *testing.T) {
+		step, idx, err := sf.GetStepBySetupStep(MustNewSetupStep("region"))
 		require.NoError(t, err)
 		assert.Equal(t, "region", step.Id)
 		assert.Equal(t, 1, idx)
 	})
 
-	t.Run("configure:0 global index includes preconnect", func(t *testing.T) {
-		step, idx, err := sf.GetStepBySetupStep(mustParse(t, "configure:0"))
+	t.Run("configure step has global index including preconnect", func(t *testing.T) {
+		step, idx, err := sf.GetStepBySetupStep(MustNewSetupStep("workspace"))
 		require.NoError(t, err)
 		assert.Equal(t, "workspace", step.Id)
 		assert.Equal(t, 2, idx) // 2 preconnect steps before this
 	})
 
-	t.Run("out of range", func(t *testing.T) {
-		_, _, err := sf.GetStepBySetupStep(mustParse(t, "preconnect:5"))
+	t.Run("unknown id returns error", func(t *testing.T) {
+		_, _, err := sf.GetStepBySetupStep(MustNewSetupStep("nope"))
 		assert.Error(t, err)
 	})
 
-	t.Run("rejects singleton phase", func(t *testing.T) {
+	t.Run("rejects pseudo-step", func(t *testing.T) {
 		_, _, err := sf.GetStepBySetupStep(SetupStepAuth)
 		assert.Error(t, err)
+	})
+}
+
+func TestSetupFlow_IsSchemaStep_IsConfigureStep_IsCredentialsStep(t *testing.T) {
+	sf := &SetupFlow{
+		Preconnect:  &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "tenant"}}},
+		Credentials: &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "cred"}}},
+		Configure:   &SetupFlowPhase{Steps: []SetupFlowStep{{Id: "workspace"}}},
+	}
+
+	t.Run("IsSchemaStep accepts preconnect/credentials/configure", func(t *testing.T) {
+		assert.True(t, sf.IsSchemaStep(MustNewSetupStep("tenant")))
+		assert.True(t, sf.IsSchemaStep(MustNewSetupStep("cred")))
+		assert.True(t, sf.IsSchemaStep(MustNewSetupStep("workspace")))
+	})
+
+	t.Run("IsSchemaStep rejects pseudo-steps and unknown ids", func(t *testing.T) {
+		assert.False(t, sf.IsSchemaStep(SetupStepAuth))
+		assert.False(t, sf.IsSchemaStep(SetupStepVerify))
+		assert.False(t, sf.IsSchemaStep(MustNewSetupStep("nope")))
+	})
+
+	t.Run("IsConfigureStep only true for configure-array entries", func(t *testing.T) {
+		assert.False(t, sf.IsConfigureStep(MustNewSetupStep("tenant")))
+		assert.False(t, sf.IsConfigureStep(MustNewSetupStep("cred")))
+		assert.True(t, sf.IsConfigureStep(MustNewSetupStep("workspace")))
+		assert.False(t, sf.IsConfigureStep(SetupStepAuth))
+	})
+
+	t.Run("IsCredentialsStep only true for credentials-array entries", func(t *testing.T) {
+		assert.False(t, sf.IsCredentialsStep(MustNewSetupStep("tenant")))
+		assert.True(t, sf.IsCredentialsStep(MustNewSetupStep("cred")))
+		assert.False(t, sf.IsCredentialsStep(MustNewSetupStep("workspace")))
 	})
 }
 

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -7882,10 +7882,10 @@ const docTemplateadmin_api = `{
                     "type": "string",
                     "example": "acme"
                 },
-                "setup_step": {
-                    "description": "Current setup step if connection setup is in progress",
+                "setup_step_id": {
+                    "description": "Current setup step if connection setup is in progress. Either a user-authored step id from\nthe connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).",
                     "type": "string",
-                    "example": "preconnect:0"
+                    "example": "tenant"
                 },
                 "state": {
                     "description": "Connection state (pending, connected, disconnecting, disconnected, error)",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -7876,10 +7876,10 @@
                     "type": "string",
                     "example": "acme"
                 },
-                "setup_step": {
-                    "description": "Current setup step if connection setup is in progress",
+                "setup_step_id": {
+                    "description": "Current setup step if connection setup is in progress. Either a user-authored step id from\nthe connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).",
                     "type": "string",
-                    "example": "preconnect:0"
+                    "example": "tenant"
                 },
                 "state": {
                     "description": "Connection state (pending, connected, disconnecting, disconnected, error)",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -329,9 +329,11 @@ definitions:
         description: Namespace path
         example: acme
         type: string
-      setup_step:
-        description: Current setup step if connection setup is in progress
-        example: preconnect:0
+      setup_step_id:
+        description: |-
+          Current setup step if connection setup is in progress. Either a user-authored step id from
+          the connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).
+        example: tenant
         type: string
       state:
         description: Connection state (pending, connected, disconnecting, disconnected,

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -7882,10 +7882,10 @@ const docTemplateApi = `{
                     "type": "string",
                     "example": "acme"
                 },
-                "setup_step": {
-                    "description": "Current setup step if connection setup is in progress",
+                "setup_step_id": {
+                    "description": "Current setup step if connection setup is in progress. Either a user-authored step id from\nthe connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).",
                     "type": "string",
-                    "example": "preconnect:0"
+                    "example": "tenant"
                 },
                 "state": {
                     "description": "Connection state (pending, connected, disconnecting, disconnected, error)",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -7876,10 +7876,10 @@
                     "type": "string",
                     "example": "acme"
                 },
-                "setup_step": {
-                    "description": "Current setup step if connection setup is in progress",
+                "setup_step_id": {
+                    "description": "Current setup step if connection setup is in progress. Either a user-authored step id from\nthe connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).",
                     "type": "string",
-                    "example": "preconnect:0"
+                    "example": "tenant"
                 },
                 "state": {
                     "description": "Connection state (pending, connected, disconnecting, disconnected, error)",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -329,9 +329,11 @@ definitions:
         description: Namespace path
         example: acme
         type: string
-      setup_step:
-        description: Current setup step if connection setup is in progress
-        example: preconnect:0
+      setup_step_id:
+        description: |-
+          Current setup step if connection setup is in progress. Either a user-authored step id from
+          the connector definition or an apxy:* pseudo-step (e.g. apxy:verify, apxy:auth_failed).
+        example: tenant
         type: string
       state:
         description: Connection state (pending, connected, disconnecting, disconnected,

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -53,7 +53,7 @@ export interface Connection {
     connector: Connector;
     state: ConnectionState;
     health_state: ConnectionHealthState;
-    setup_step?: string;
+    setup_step_id?: string;
     setup_error?: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
@@ -338,7 +338,7 @@ export const reconfigureConnection = (id: string) => {
 };
 
 /**
- * Cancel an in-flight reconfigure on a ready connection by clearing setup_step and setup_error.
+ * Cancel an in-flight reconfigure on a ready connection by clearing setup_step_id and setup_error.
  * The connection remains ready and its previously stored configuration continues to apply.
  */
 export const cancelSetupConnection = (id: string) => {

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -116,7 +116,7 @@ const ConnectionList: React.FC = () => {
       ? connections.find((c) => c.id === connectionId)
       : undefined;
     // If the connection is already ready, the form is from a reconfigure flow.
-    // Clearing the form step alone leaves setup_step=configure:0 on the server,
+    // Clearing the form step alone leaves setup_step_id set on the server,
     // so the dialog reappears on next load — call cancel_setup to clear it server-side.
     if (conn && conn.state === ConnectionState.CONFIGURED) {
       dispatch(cancelSetupConnectionAsync(conn.id));

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -288,7 +288,7 @@ export const connectionsSlice = createSlice({
                 if (idx !== -1) {
                     state.items[idx] = {
                         ...state.items[idx],
-                        setup_step: undefined,
+                        setup_step_id: undefined,
                         setup_error: undefined,
                     };
                 }


### PR DESCRIPTION
Closes #365. Part of #360.

## Summary

``SetupStep`` is now a thin wrapper around a string id rather than a ``(phase, index)`` tuple. The DB column is renamed from ``setup_step`` to ``setup_step_id`` to reflect the new payload, and the JSON serialization on the connection API follows. The schema reserves the ``apxy:`` prefix for system-emitted step ids (``apxy:auth``, ``apxy:verify``, ``apxy:verify_failed``, ``apxy:auth_failed``); user-authored step ids in connector YAML must not collide with that prefix.

## Scope

- **``internal/schema/resources/connectors/setup_flow.go``**: replace the ``(phase, index)`` ``SetupStep`` with ``{id string}``. Drop ``SetupStepPhase``, the phase constants, ``NewIndexedSetupStep`` / ``MustNewIndexedSetupStep``, and the phase parsing in ``ParseSetupStep``. Add ``NewSetupStep`` / ``MustNewSetupStep``. The predefined singletons now carry ``apxy:``-prefixed ids. New ``IsConfigureStep`` / ``IsCredentialsStep`` / ``IsSchemaStep`` helpers replace the phase-aware routing.
  - ``GetStepBySetupStep`` / ``NextSetupStep`` / ``FirstSetupStep`` are kept (marked ``DEPRECATED``) and rewritten to navigate by id; #366 replaces them with the runtime manifest in ``core/iface``.
- **``internal/core/*``**: every ``MustNewIndexedSetupStep`` call site uses ``MustNewSetupStep(<step id>)``. ``service_connection_submit`` gates submissions via ``IsSchemaStep`` / ``IsCredentialsStep`` instead of phase predicates, and the resume-response switch keys off ``step.Equals`` + ``IsTerminalFailure`` rather than ``Phase()``.
- **``internal/database``**: column rename ``setup_step`` → ``setup_step_id`` + migration ``000010_rename_setup_step_column`` (pure ``ALTER TABLE RENAME``; per the project's accept-data-loss decision, pre-existing rows with the old ``phase:index`` payload are tolerated as scan errors in dev).
- **``internal/routes`` + swagger**: JSON tag becomes ``setup_step_id``; regenerated swagger docs reflect the rename.
- **``sdks/js`` + ``ui/marketplace``**: TypeScript field renamed; store + components updated.

## Test plan

- [x] ``go test ./...`` clean (postgres + redis running locally).
- [x] ``yarn workspace @authproxy/marketplace test`` passes.
- [x] TypeScript type-check clean (``tsc --noEmit``) for ``sdks/js``, ``ui/marketplace``, ``ui/admin``.
- [x] Integration: ``go test -tags integration ./api_key/`` and ``./probes/`` pass against the local OAuth2 test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)