### PR TITLE
Move rate limit and encryption key DTOs into schema API

### DIFF
--- a/internal/routes/encryption_keys.go
+++ b/internal/routes/encryption_keys.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -17,33 +16,15 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
-	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
-type EncryptionKeyJson struct {
-	Id          apid.ID                     `json:"id"`
-	Namespace   string                      `json:"namespace"`
-	State       database.EncryptionKeyState `json:"state"`
-	Labels      map[string]string           `json:"labels,omitempty"`
-	Annotations map[string]string           `json:"annotations,omitempty"`
-	CreatedAt   time.Time                   `json:"created_at"`
-	UpdatedAt   time.Time                   `json:"updated_at"`
-}
-
-type CreateEncryptionKeyRequestJson struct {
-	Namespace   string             `json:"namespace"`
-	KeyData     *cfgschema.KeyData `json:"key_data,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-}
-
-type UpdateEncryptionKeyRequestJson struct {
-	State       *database.EncryptionKeyState `json:"state,omitempty"`
-	Labels      *map[string]string           `json:"labels,omitempty"`
-	Annotations *map[string]string           `json:"annotations,omitempty"`
-}
+type EncryptionKeyJson = schemaapi.EncryptionKeyJson
+type CreateEncryptionKeyRequestJson = schemaapi.CreateEncryptionKeyRequestJson
+type UpdateEncryptionKeyRequestJson = schemaapi.UpdateEncryptionKeyRequestJson
+type ListEncryptionKeysResponseJson = schemaapi.ListEncryptionKeysResponseJson
 
 type ListEncryptionKeysRequestQueryParams struct {
 	Cursor        *string                      `form:"cursor"`
@@ -54,16 +35,11 @@ type ListEncryptionKeysRequestQueryParams struct {
 	OrderByVal    *string                      `form:"order_by"`
 }
 
-type ListEncryptionKeysResponseJson struct {
-	Items  []EncryptionKeyJson `json:"items"`
-	Cursor string              `json:"cursor,omitempty"`
-}
-
 func EncryptionKeyToJson(ek coreIface.EncryptionKey) EncryptionKeyJson {
 	return EncryptionKeyJson{
 		Id:          ek.GetId(),
 		Namespace:   ek.GetNamespace(),
-		State:       ek.GetState(),
+		State:       schemaapi.EncryptionKeyState(ek.GetState()),
 		Labels:      ek.GetLabels(),
 		Annotations: ek.GetAnnotations(),
 		CreatedAt:   ek.GetCreatedAt(),
@@ -289,7 +265,7 @@ func (r *EncryptionKeysRoutes) list(gctx *gin.Context) {
 // @Accept			json
 // @Produce		json
 // @Param			id		path		string								true	"Encryption key ID"
-// @Param			request	body		UpdateEncryptionKeyRequestJson		true	"Update request"
+// @Param			request	body		SwaggerUpdateEncryptionKeyRequest		true	"Update request"
 // @Success		200		{object}	SwaggerEncryptionKeyJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
@@ -317,7 +293,7 @@ func (r *EncryptionKeysRoutes) update(gctx *gin.Context) {
 	}
 
 	// Validate state if provided
-	if req.State != nil && !database.IsValidEncryptionKeyState(*req.State) {
+	if req.State != nil && !database.IsValidEncryptionKeyState(string(*req.State)) {
 		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid state '%s'", *req.State))
 		val.MarkErrorReturn()
 		return
@@ -361,7 +337,7 @@ func (r *EncryptionKeysRoutes) update(gctx *gin.Context) {
 	}
 
 	if req.State != nil {
-		err = r.core.SetEncryptionKeyState(ctx, id, *req.State)
+		err = r.core.SetEncryptionKeyState(ctx, id, database.EncryptionKeyState(*req.State))
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				apgin.WriteError(gctx, nil, httperr.NotFound(fmt.Sprintf("encryption key '%s' not found", id), httperr.WithInternalErr(err)))

--- a/internal/routes/encryption_keys_test.go
+++ b/internal/routes/encryption_keys_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/httperr"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
@@ -178,7 +179,7 @@ func TestEncryptionKeys(t *testing.T) {
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, created.Id, resp.Id)
 			require.Equal(t, "root", resp.Namespace)
-			require.Equal(t, database.EncryptionKeyStateActive, resp.State)
+			require.Equal(t, schemaapi.EncryptionKeyStateActive, resp.State)
 			require.Equal(t, "test", resp.Labels["env"])
 		})
 
@@ -315,7 +316,7 @@ func TestEncryptionKeys(t *testing.T) {
 			created := createKey(t, tu, "root", map[string]string{"env": "prod", "team": "backend"})
 			require.True(t, created.Id.HasPrefix(apid.PrefixEncryptionKey))
 			require.Equal(t, "root", created.Namespace)
-			require.Equal(t, database.EncryptionKeyStateActive, created.State)
+			require.Equal(t, schemaapi.EncryptionKeyStateActive, created.State)
 			require.Equal(t, "prod", created.Labels["env"])
 			require.Equal(t, "backend", created.Labels["team"])
 		})
@@ -324,7 +325,7 @@ func TestEncryptionKeys(t *testing.T) {
 			created := createKey(t, tu, "root", nil)
 			require.True(t, created.Id.HasPrefix(apid.PrefixEncryptionKey))
 			require.Equal(t, "root", created.Namespace)
-			require.Equal(t, database.EncryptionKeyStateActive, created.State)
+			require.Equal(t, schemaapi.EncryptionKeyStateActive, created.State)
 		})
 	})
 
@@ -432,7 +433,7 @@ func TestEncryptionKeys(t *testing.T) {
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Len(t, resp.Items, 3)
 			for _, item := range resp.Items {
-				require.Equal(t, database.EncryptionKeyStateActive, item.State)
+				require.Equal(t, schemaapi.EncryptionKeyStateActive, item.State)
 			}
 		})
 
@@ -608,7 +609,7 @@ func TestEncryptionKeys(t *testing.T) {
 
 			var resp EncryptionKeyJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-			require.Equal(t, database.EncryptionKeyStateDisabled, resp.State)
+			require.Equal(t, schemaapi.EncryptionKeyStateDisabled, resp.State)
 
 			// Verify in database
 			got, err := tu.Db.GetEncryptionKey(context.Background(), created.Id)
@@ -677,7 +678,7 @@ func TestEncryptionKeys(t *testing.T) {
 
 			var resp EncryptionKeyJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-			require.Equal(t, database.EncryptionKeyStateActive, resp.State)
+			require.Equal(t, schemaapi.EncryptionKeyStateActive, resp.State)
 			respUser, _ := database.SplitUserAndApxyLabels(database.Labels(resp.Labels))
 			require.Equal(t, database.Labels{"new-label": "value"}, respUser)
 		})

--- a/internal/routes/rate_limits.go
+++ b/internal/routes/rate_limits.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -17,33 +16,20 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
-	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
-type RateLimitJson struct {
-	Id          apid.ID            `json:"id"`
-	Namespace   string             `json:"namespace"`
-	Definition  rlschema.RateLimit `json:"definition"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-	CreatedAt   time.Time          `json:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at"`
-}
-
-type CreateRateLimitRequestJson struct {
-	Namespace   string             `json:"namespace"`
-	Definition  rlschema.RateLimit `json:"definition"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-}
-
-type UpdateRateLimitRequestJson struct {
-	Definition  *rlschema.RateLimit `json:"definition,omitempty"`
-	Labels      *map[string]string  `json:"labels,omitempty"`
-	Annotations *map[string]string  `json:"annotations,omitempty"`
-}
+type RateLimitJson = schemaapi.RateLimitJson
+type CreateRateLimitRequestJson = schemaapi.CreateRateLimitRequestJson
+type UpdateRateLimitRequestJson = schemaapi.UpdateRateLimitRequestJson
+type ListRateLimitsResponseJson = schemaapi.ListRateLimitsResponseJson
+type DryRunRequestJson = schemaapi.DryRunRequestJson
+type DryRunContextJson = schemaapi.DryRunContextJson
+type DryRunResponseJson = schemaapi.DryRunResponseJson
+type DryRunMatchJson = schemaapi.DryRunMatchJson
+type DryRunNotMatchedJson = schemaapi.DryRunNotMatchedJson
 
 type ListRateLimitsRequestQueryParams struct {
 	Cursor        *string `form:"cursor"`
@@ -51,11 +37,6 @@ type ListRateLimitsRequestQueryParams struct {
 	NamespaceVal  *string `form:"namespace"`
 	LabelSelector *string `form:"label_selector"`
 	OrderByVal    *string `form:"order_by"`
-}
-
-type ListRateLimitsResponseJson struct {
-	Items  []RateLimitJson `json:"items"`
-	Cursor string          `json:"cursor,omitempty"`
 }
 
 func RateLimitToJson(r coreIface.RateLimit) RateLimitJson {
@@ -78,53 +59,18 @@ type RateLimitsRoutes struct {
 	annotsAdapter key_value.Adapter[apid.ID]
 }
 
-// DryRunRequestJson is the wire shape for POST /rate-limits/_dry_run.
-// Reuses iface.ProxyRequest for the request half — same shape as the
-// real /connections/{id}/_proxy endpoint, so a future "send this for
-// real" button can hand the same payload to that endpoint without
-// reshaping. RequestType + Context live alongside since the proxy
-// path takes request_type as a sibling param, not on the request.
-type DryRunRequestJson struct {
-	Request     coreIface.ProxyRequest `json:"request"`
-	RequestType string                 `json:"request_type"`
-	Context     DryRunContextJson      `json:"context"`
-}
-
-type DryRunContextJson struct {
-	ConnectionId *apid.ID `json:"connection_id,omitempty"`
-	ActorId      *apid.ID `json:"actor_id,omitempty"`
-	Namespace    *string  `json:"namespace,omitempty"`
-}
-
-type DryRunResponseJson struct {
-	RequestLabelSnapshot map[string]string      `json:"request_label_snapshot"`
-	Matched              []DryRunMatchJson      `json:"matched"`
-	NotMatched           []DryRunNotMatchedJson `json:"not_matched"`
-}
-
-type DryRunMatchJson struct {
-	RateLimitId      apid.ID `json:"rate_limit_id"`
-	Namespace        string  `json:"namespace"`
-	EffectiveMode    string  `json:"effective_mode"`
-	BucketKey        string  `json:"bucket_key"`
-	AlgorithmSummary string  `json:"algorithm_summary"`
-	WouldAllow       bool    `json:"would_allow"`
-	Remaining        int     `json:"remaining"`
-	RetryAfterMs     int64   `json:"retry_after_ms"`
-	PeekFailed       bool    `json:"peek_failed"`
-}
-
-type DryRunNotMatchedJson struct {
-	RateLimitId apid.ID `json:"rate_limit_id"`
-	Namespace   string  `json:"namespace"`
-	Reason      string  `json:"reason"`
-}
-
-// toCore translates the wire request to the structured input the core
+// dryRunRequestToCore translates the wire request to the structured input the core
 // service consumes. Nothing here does business logic — it's just shape.
-func (r DryRunRequestJson) toCore() coreIface.DryRunRateLimitRequest {
+func dryRunRequestToCore(r DryRunRequestJson) coreIface.DryRunRateLimitRequest {
 	return coreIface.DryRunRateLimitRequest{
-		Request:     r.Request,
+		Request: coreIface.ProxyRequest{
+			URL:      r.Request.URL,
+			Method:   r.Request.Method,
+			Headers:  r.Request.Headers,
+			Labels:   r.Request.Labels,
+			BodyRaw:  r.Request.BodyRaw,
+			BodyJson: r.Request.BodyJson,
+		},
 		RequestType: r.RequestType,
 		Context: coreIface.DryRunRequestContext{
 			ConnectionId: r.Context.ConnectionId,
@@ -213,7 +159,7 @@ func (r *RateLimitsRoutes) get(gctx *gin.Context) {
 // @Tags			rate_limits
 // @Accept			json
 // @Produce		json
-// @Param			request	body		CreateRateLimitRequestJson	true	"Rate limit creation request"
+// @Param			request	body		SwaggerCreateRateLimitRequest	true	"Rate limit creation request"
 // @Success		200		{object}	SwaggerRateLimitJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
@@ -364,7 +310,7 @@ func (r *RateLimitsRoutes) list(gctx *gin.Context) {
 // @Accept			json
 // @Produce		json
 // @Param			id		path		string							true	"Rate limit ID"
-// @Param			request	body		UpdateRateLimitRequestJson		true	"Update request"
+// @Param			request	body		SwaggerUpdateRateLimitRequest		true	"Update request"
 // @Success		200		{object}	SwaggerRateLimitJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
@@ -555,7 +501,7 @@ func (r *RateLimitsRoutes) dryRun(gctx *gin.Context) {
 		return
 	}
 
-	result, err := r.core.DryRunRateLimit(ctx, req.toCore())
+	result, err := r.core.DryRunRateLimit(ctx, dryRunRequestToCore(req))
 	if err != nil {
 		switch {
 		case errors.Is(err, core.ErrInvalidArgument):

--- a/internal/routes/swagger_models.go
+++ b/internal/routes/swagger_models.go
@@ -32,6 +32,15 @@ type SwaggerListConnectorVersionsResponse = schemaapiopenapi.ListConnectorVersio
 type SwaggerCreateConnectorRequest = schemaapiopenapi.CreateConnectorRequestJson
 type SwaggerUpdateConnectorRequest = schemaapiopenapi.UpdateConnectorRequestJson
 type SwaggerCreateConnectorVersionRequest = schemaapiopenapi.CreateConnectorVersionRequestJson
+type SwaggerEncryptionKeyJson = schemaapi.EncryptionKeyJson
+type SwaggerListEncryptionKeysResponse = schemaapiopenapi.ListEncryptionKeysResponseJson
+type SwaggerUpdateEncryptionKeyRequest = schemaapiopenapi.UpdateEncryptionKeyRequestJson
+type SwaggerRateLimitJson = schemaapiopenapi.RateLimitJson
+type SwaggerListRateLimitsResponse = schemaapiopenapi.ListRateLimitsResponseJson
+type SwaggerCreateRateLimitRequest = schemaapiopenapi.CreateRateLimitRequestJson
+type SwaggerUpdateRateLimitRequest = schemaapiopenapi.UpdateRateLimitRequestJson
+type SwaggerDryRunRequest = schemaapiopenapi.DryRunRequestJson
+type SwaggerDryRunResponse = schemaapiopenapi.DryRunResponseJson
 
 // ProxyRequest represents a request to proxy through a connection.
 //
@@ -147,114 +156,6 @@ type SwaggerDisconnectResponse struct {
 	TaskId string `json:"task_id"`
 	// Connection being disconnected
 	Connection SwaggerConnectionJson `json:"connection"`
-}
-
-// SwaggerEncryptionKeyJson is a simplified encryption key model for swagger documentation
-//
-//	@Description	Encryption key configuration
-type SwaggerEncryptionKeyJson struct {
-	// Encryption key ID
-	Id apid.ID `swaggertype:"string" json:"id" example:"ek_test550e8400abcde"`
-	// Namespace path
-	Namespace string `json:"namespace" example:"acme"`
-	// State (active, disabled)
-	State string `json:"state" example:"active"`
-	// Labels assigned to the encryption key
-	Labels map[string]string `json:"labels,omitempty"`
-	// Annotations assigned to the encryption key
-	Annotations map[string]string `json:"annotations,omitempty"`
-	// Creation timestamp
-	CreatedAt time.Time `json:"created_at"`
-	// Last update timestamp
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-// SwaggerListEncryptionKeysResponse is the response for list encryption keys
-//
-//	@Description	Paginated list of encryption keys
-type SwaggerListEncryptionKeysResponse struct {
-	// List of encryption keys
-	Items []SwaggerEncryptionKeyJson `json:"items"`
-	// Pagination cursor for next page
-	Cursor string `json:"cursor,omitempty"`
-}
-
-// SwaggerRateLimitJson is a simplified rate-limit model for swagger documentation.
-//
-//	@Description	Rate limit configuration
-type SwaggerRateLimitJson struct {
-	// Rate limit ID
-	Id apid.ID `swaggertype:"string" json:"id" example:"rl_test550e8400abcde"`
-	// Namespace path
-	Namespace string `json:"namespace" example:"acme"`
-	// JSON-serialised definition (mode, selector, bucket, algorithm)
-	Definition map[string]interface{} `json:"definition"`
-	// Labels assigned to the rate limit
-	Labels map[string]string `json:"labels,omitempty"`
-	// Annotations assigned to the rate limit
-	Annotations map[string]string `json:"annotations,omitempty"`
-	// Creation timestamp
-	CreatedAt time.Time `json:"created_at"`
-	// Last update timestamp
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-// SwaggerListRateLimitsResponse is the response for list rate limits.
-//
-//	@Description	Paginated list of rate limits
-type SwaggerListRateLimitsResponse struct {
-	// List of rate limits
-	Items []SwaggerRateLimitJson `json:"items"`
-	// Pagination cursor for next page
-	Cursor string `json:"cursor,omitempty"`
-}
-
-// SwaggerDryRunRequest is the input for the rate-limit dry-run endpoint.
-// Reuses ProxyRequest so the request body is identical to the shape the
-// real /connections/{id}/_proxy endpoint accepts.
-//
-//	@Description	Dry-run input: a proxy-shaped request + request type + the identity it runs under
-type SwaggerDryRunRequest struct {
-	Request     ProxyRequest         `json:"request"`
-	RequestType string               `json:"request_type" example:"proxy"`
-	Context     SwaggerDryRunContext `json:"context"`
-}
-
-// SwaggerDryRunContext is the actor + connection + namespace identity.
-// Labels live on Request now (matching ProxyRequest).
-//
-//	@Description	Identity the request runs under
-type SwaggerDryRunContext struct {
-	ConnectionId string `json:"connection_id,omitempty"`
-	ActorId      string `json:"actor_id,omitempty"`
-	Namespace    string `json:"namespace,omitempty"`
-}
-
-// SwaggerDryRunResponse is what the endpoint returns.
-//
-//	@Description	Per-rule match + peek-driven would-allow result
-type SwaggerDryRunResponse struct {
-	RequestLabelSnapshot map[string]string         `json:"request_label_snapshot"`
-	Matched              []SwaggerDryRunMatch      `json:"matched"`
-	NotMatched           []SwaggerDryRunNotMatched `json:"not_matched"`
-}
-
-type SwaggerDryRunMatch struct {
-	RateLimitId      string `json:"rate_limit_id" swaggertype:"string" example:"rl_test550e8400"`
-	Namespace        string `json:"namespace"`
-	EffectiveMode    string `json:"effective_mode" example:"enforce"`
-	BucketKey        string `json:"bucket_key" example:"actor=act_abc|labels/team=acme"`
-	AlgorithmSummary string `json:"algorithm_summary" example:"token bucket 60 @ 1/s"`
-	WouldAllow       bool   `json:"would_allow"`
-	Remaining        int    `json:"remaining"`
-	RetryAfterMs     int64  `json:"retry_after_ms"`
-	PeekFailed       bool   `json:"peek_failed"`
-}
-
-type SwaggerDryRunNotMatched struct {
-	RateLimitId string `json:"rate_limit_id" swaggertype:"string"`
-	Namespace   string `json:"namespace"`
-	Reason      string `json:"reason"`
 }
 
 // SwaggerListRequestEventsResponse is the response for listing request events

--- a/internal/schema/AGENTS.md
+++ b/internal/schema/AGENTS.md
@@ -7,8 +7,8 @@ This directory owns AuthProxy's public and internal data contracts. Keep schema 
 - `internal/schema/common` contains shared primitives used by multiple schemas, such as string values, images, durations, byte sizes, request types, and raw JSON helpers.
 - `internal/schema/config` contains YAML/JSON config-file syntax. It may reference common primitives, auth permissions, and resource definitions used in config.
 - `internal/schema/auth` contains auth/JWT-specific schema such as permissions. Namespace path and matcher helpers live in `internal/schema/resources/namespace`; the auth package only re-exports namespace helpers for compatibility.
-- `internal/schema/resources/...` contains REST-managed resource models. Use this tree for system resources such as connectors, namespaces, and rate limits.
-- `internal/schema/api` contains API request/response DTOs. Resource packages must not import it.
+- `internal/schema/resources/...` contains reusable resource definition models. Use this tree for system resources such as connectors, namespaces, and rate-limit definitions; do not put API envelopes, pagination responses, or dry-run request/response bodies here.
+- `internal/schema/api` contains API request/response DTOs. Route handlers should import these instead of defining local wire structs. Resource packages must not import it.
 
 ## Conventions
 

--- a/internal/schema/api/README.md
+++ b/internal/schema/api/README.md
@@ -4,4 +4,6 @@ This package contains API request and response DTOs. These types describe the wi
 
 API models may compose shared primitives from `internal/schema/common` and resource models from `internal/schema/resources/...`. Resource packages must not import this package.
 
+Rate-limit API envelopes, pagination responses, and dry-run DTOs live here while the reusable rate-limit definition remains in `internal/schema/resources/rate_limit`. Encryption-key API DTOs live here too; key material syntax composes `internal/schema/config.KeyData`, and the API exposes its own state enum rather than database storage types.
+
 OpenAPI-only generator adapters live under `internal/schema/api/openapi`. Keep those adapters thin: they may compose API DTOs for documentation, but runtime route request/response contracts should remain in this package.

--- a/internal/schema/api/encryption_keys.go
+++ b/internal/schema/api/encryption_keys.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// EncryptionKeyState is the API-visible lifecycle state of an encryption key.
+type EncryptionKeyState string
+
+const (
+	EncryptionKeyStateActive   EncryptionKeyState = "active"
+	EncryptionKeyStateDisabled EncryptionKeyState = "disabled"
+)
+
+// EncryptionKeyJson is the API envelope for a managed encryption key.
+//
+//	@Description	Encryption key API response
+type EncryptionKeyJson struct {
+	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"ek_test550e8400abcde"`
+	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
+	State       EncryptionKeyState `json:"state" yaml:"state" swaggertype:"string" example:"active"`
+	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time          `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time          `json:"updated_at" yaml:"updated_at"`
+}
+
+type ListEncryptionKeysResponseJson struct {
+	Items  []EncryptionKeyJson `json:"items" yaml:"items"`
+	Cursor string              `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+}
+
+// CreateEncryptionKeyRequestJson is the request body for POST /encryption-keys.
+//
+//	@Description	Request to create a new encryption key
+type CreateEncryptionKeyRequestJson struct {
+	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
+	KeyData     *cfgschema.KeyData `json:"key_data,omitempty" yaml:"key_data,omitempty"`
+	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// UpdateEncryptionKeyRequestJson is the request body for PATCH /encryption-keys/:id.
+//
+//	@Description	Request to update an encryption key
+type UpdateEncryptionKeyRequestJson struct {
+	State       *EncryptionKeyState `json:"state,omitempty" yaml:"state,omitempty"`
+	Labels      *map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -89,3 +89,118 @@ type CreateConnectorVersionRequestJson struct {
 	Labels      *map[string]string `json:"labels,omitempty"`
 	Annotations *map[string]string `json:"annotations,omitempty"`
 }
+
+// ListEncryptionKeysResponseJson documents the paginated encryption-key list response.
+//
+//	@Description	Paginated list of encryption keys
+type ListEncryptionKeysResponseJson struct {
+	Items  []schemaapi.EncryptionKeyJson `json:"items"`
+	Cursor string                        `json:"cursor,omitempty"`
+}
+
+// UpdateEncryptionKeyRequestJson documents the encryption-key update body.
+//
+//	@Description	Request to update an encryption key
+type UpdateEncryptionKeyRequestJson struct {
+	State       *string            `json:"state,omitempty" example:"disabled"`
+	Labels      *map[string]string `json:"labels,omitempty"`
+	Annotations *map[string]string `json:"annotations,omitempty"`
+}
+
+// RateLimitJson documents a rate-limit response while keeping the definition
+// opaque for swaggo.
+//
+//	@Description	Rate-limit API response
+type RateLimitJson struct {
+	Id          apid.ID           `json:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace   string            `json:"namespace" example:"root.acme"`
+	Definition  map[string]any    `json:"definition"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// ListRateLimitsResponseJson documents the paginated rate-limit list response.
+//
+//	@Description	Paginated list of rate limits
+type ListRateLimitsResponseJson struct {
+	Items  []interface{} `json:"items"`
+	Cursor string        `json:"cursor,omitempty"`
+}
+
+// CreateRateLimitRequestJson documents the rate-limit creation body.
+//
+//	@Description	Request to create a rate limit
+type CreateRateLimitRequestJson struct {
+	Namespace   string            `json:"namespace" example:"root.acme"`
+	Definition  map[string]any    `json:"definition"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// UpdateRateLimitRequestJson documents the rate-limit update body.
+//
+//	@Description	Request to update a rate limit
+type UpdateRateLimitRequestJson struct {
+	Definition  map[string]any     `json:"definition,omitempty"`
+	Labels      *map[string]string `json:"labels,omitempty"`
+	Annotations *map[string]string `json:"annotations,omitempty"`
+}
+
+// ProxyRequestJson documents the proxy-shaped request used by dry-run.
+//
+//	@Description	Request to simulate an HTTP request
+type ProxyRequestJson struct {
+	URL      string            `json:"url" example:"https://api.example.com/v1/users"`
+	Method   string            `json:"method" example:"POST"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+	BodyRaw  []byte            `json:"body_raw,omitempty"`
+	BodyJson interface{}       `json:"body_json,omitempty"`
+}
+
+// DryRunRequestJson documents the rate-limit dry-run request body.
+//
+//	@Description	Dry-run input: a proxy-shaped request + request type + the identity it runs under
+type DryRunRequestJson struct {
+	Request     interface{} `json:"request"`
+	RequestType string      `json:"request_type" example:"proxy"`
+	Context     interface{} `json:"context"`
+}
+
+// DryRunContextJson documents the dry-run identity context.
+//
+//	@Description	Identity the request runs under
+type DryRunContextJson struct {
+	ConnectionId string `json:"connection_id,omitempty"`
+	ActorId      string `json:"actor_id,omitempty"`
+	Namespace    string `json:"namespace,omitempty" example:"root.acme"`
+}
+
+// DryRunResponseJson documents the dry-run response.
+//
+//	@Description	Per-rule match + peek-driven would-allow result
+type DryRunResponseJson struct {
+	RequestLabelSnapshot map[string]string `json:"request_label_snapshot"`
+	Matched              []interface{}     `json:"matched"`
+	NotMatched           []interface{}     `json:"not_matched"`
+}
+
+type DryRunMatchJson struct {
+	RateLimitId      string `json:"rate_limit_id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace        string `json:"namespace" example:"root.acme"`
+	EffectiveMode    string `json:"effective_mode" example:"enforce"`
+	BucketKey        string `json:"bucket_key" example:"actor=act_abc|labels/team=acme"`
+	AlgorithmSummary string `json:"algorithm_summary" example:"token bucket 60 @ 1/s"`
+	WouldAllow       bool   `json:"would_allow"`
+	Remaining        int    `json:"remaining"`
+	RetryAfterMs     int64  `json:"retry_after_ms"`
+	PeekFailed       bool   `json:"peek_failed"`
+}
+
+type DryRunNotMatchedJson struct {
+	RateLimitId string `json:"rate_limit_id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace   string `json:"namespace" example:"root.acme"`
+	Reason      string `json:"reason"`
+}

--- a/internal/schema/api/rate_limits.go
+++ b/internal/schema/api/rate_limits.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+)
+
+// RateLimitJson is the API envelope around a rate-limit resource definition.
+//
+//	@Description	Rate-limit API response
+type RateLimitJson struct {
+	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Definition  rlschema.RateLimit `json:"definition" yaml:"definition"`
+	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time          `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time          `json:"updated_at" yaml:"updated_at"`
+}
+
+type ListRateLimitsResponseJson struct {
+	Items  []RateLimitJson `json:"items" yaml:"items"`
+	Cursor string          `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+}
+
+// CreateRateLimitRequestJson is the request body for POST /rate-limits.
+//
+//	@Description	Request to create a rate limit
+type CreateRateLimitRequestJson struct {
+	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Definition  rlschema.RateLimit `json:"definition" yaml:"definition"`
+	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// UpdateRateLimitRequestJson is the request body for PATCH /rate-limits/:id.
+//
+//	@Description	Request to update a rate limit
+type UpdateRateLimitRequestJson struct {
+	Definition  *rlschema.RateLimit `json:"definition,omitempty" yaml:"definition,omitempty"`
+	Labels      *map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// ProxyRequestJson is the wire shape used by API endpoints that accept a
+// synthetic proxy request, such as rate-limit dry-run.
+//
+//	@Description	Request to proxy or simulate an HTTP request
+type ProxyRequestJson struct {
+	URL      string            `json:"url" yaml:"url" example:"https://api.example.com/v1/users"`
+	Method   string            `json:"method" yaml:"method" example:"GET"`
+	Headers  map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	BodyRaw  []byte            `json:"body_raw,omitempty" yaml:"body_raw,omitempty"`
+	BodyJson interface{}       `json:"body_json,omitempty" yaml:"body_json,omitempty"`
+}
+
+// DryRunRequestJson is the request body for POST /rate-limits/_dry_run.
+//
+//	@Description	Request to simulate rate-limit matching
+type DryRunRequestJson struct {
+	Request     ProxyRequestJson  `json:"request" yaml:"request"`
+	RequestType string            `json:"request_type" yaml:"request_type" example:"proxy"`
+	Context     DryRunContextJson `json:"context" yaml:"context"`
+}
+
+type DryRunContextJson struct {
+	ConnectionId *apid.ID `json:"connection_id,omitempty" yaml:"connection_id,omitempty" swaggertype:"string"`
+	ActorId      *apid.ID `json:"actor_id,omitempty" yaml:"actor_id,omitempty" swaggertype:"string"`
+	Namespace    *string  `json:"namespace,omitempty" yaml:"namespace,omitempty" example:"root.acme"`
+}
+
+type DryRunResponseJson struct {
+	RequestLabelSnapshot map[string]string      `json:"request_label_snapshot" yaml:"request_label_snapshot"`
+	Matched              []DryRunMatchJson      `json:"matched" yaml:"matched"`
+	NotMatched           []DryRunNotMatchedJson `json:"not_matched" yaml:"not_matched"`
+}
+
+type DryRunMatchJson struct {
+	RateLimitId      apid.ID `json:"rate_limit_id" yaml:"rate_limit_id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace        string  `json:"namespace" yaml:"namespace" example:"root.acme"`
+	EffectiveMode    string  `json:"effective_mode" yaml:"effective_mode" example:"enforce"`
+	BucketKey        string  `json:"bucket_key" yaml:"bucket_key" example:"rate_limit:rl_test550e8400abcde:actor:act_test"`
+	AlgorithmSummary string  `json:"algorithm_summary" yaml:"algorithm_summary" example:"fixed_window window=1m limit=100"`
+	WouldAllow       bool    `json:"would_allow" yaml:"would_allow" example:"true"`
+	Remaining        int     `json:"remaining" yaml:"remaining" example:"99"`
+	RetryAfterMs     int64   `json:"retry_after_ms" yaml:"retry_after_ms" example:"0"`
+	PeekFailed       bool    `json:"peek_failed" yaml:"peek_failed" example:"false"`
+}
+
+type DryRunNotMatchedJson struct {
+	RateLimitId apid.ID `json:"rate_limit_id" yaml:"rate_limit_id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace   string  `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Reason      string  `json:"reason" yaml:"reason" example:"method did not match"`
+}

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -14,6 +14,10 @@
       "type": "string",
       "enum": ["draft", "primary", "active", "archived"]
     },
+    "EncryptionKeyState": {
+      "type": "string",
+      "enum": ["active", "disabled"]
+    },
     "StringMap": {
       "type": "object",
       "additionalProperties": {
@@ -355,6 +359,193 @@
       "type": "object",
       "properties": {
         "definition": { "$ref": "../resources/connectors/schema.json" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" }
+      },
+      "additionalProperties": false
+    },
+    "RateLimit": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "definition": { "$ref": "../resources/rate_limit/schema.json#/$defs/RateLimit" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": ["id", "namespace", "definition", "created_at", "updated_at"],
+      "additionalProperties": false
+    },
+    "ListRateLimitsResponse": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RateLimit" }
+        },
+        "cursor": { "type": "string" }
+      },
+      "required": ["items"],
+      "additionalProperties": false
+    },
+    "CreateRateLimitRequest": {
+      "type": "object",
+      "properties": {
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "definition": { "$ref": "../resources/rate_limit/schema.json#/$defs/RateLimit" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" }
+      },
+      "required": ["namespace", "definition"],
+      "additionalProperties": false
+    },
+    "UpdateRateLimitRequest": {
+      "type": "object",
+      "properties": {
+        "definition": { "$ref": "../resources/rate_limit/schema.json#/$defs/RateLimit" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" }
+      },
+      "additionalProperties": false
+    },
+    "ProxyRequest": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "method": { "$ref": "../resources/rate_limit/schema.json#/$defs/HttpMethod" },
+        "headers": { "$ref": "#/$defs/StringMap" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "body_raw": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "body_json": {}
+      },
+      "required": ["url", "method"],
+      "additionalProperties": false
+    },
+    "DryRunContext": {
+      "type": "object",
+      "properties": {
+        "connection_id": { "type": "string" },
+        "actor_id": { "type": "string" },
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+      },
+      "additionalProperties": false
+    },
+    "DryRunRequest": {
+      "type": "object",
+      "properties": {
+        "request": { "$ref": "#/$defs/ProxyRequest" },
+        "request_type": { "$ref": "../common/schema.json#/$defs/RequestType" },
+        "context": { "$ref": "#/$defs/DryRunContext" }
+      },
+      "required": ["request", "request_type", "context"],
+      "additionalProperties": false
+    },
+    "DryRunMatch": {
+      "type": "object",
+      "properties": {
+        "rate_limit_id": { "type": "string" },
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "effective_mode": { "$ref": "../resources/rate_limit/schema.json#/$defs/Mode" },
+        "bucket_key": { "type": "string" },
+        "algorithm_summary": { "type": "string" },
+        "would_allow": { "type": "boolean" },
+        "remaining": { "type": "integer" },
+        "retry_after_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "peek_failed": { "type": "boolean" }
+      },
+      "required": ["rate_limit_id", "namespace", "effective_mode", "bucket_key", "algorithm_summary", "would_allow", "remaining", "retry_after_ms", "peek_failed"],
+      "additionalProperties": false
+    },
+    "DryRunNotMatched": {
+      "type": "object",
+      "properties": {
+        "rate_limit_id": { "type": "string" },
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "reason": { "type": "string" }
+      },
+      "required": ["rate_limit_id", "namespace", "reason"],
+      "additionalProperties": false
+    },
+    "DryRunResponse": {
+      "type": "object",
+      "properties": {
+        "request_label_snapshot": { "$ref": "#/$defs/StringMap" },
+        "matched": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/DryRunMatch" }
+        },
+        "not_matched": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/DryRunNotMatched" }
+        }
+      },
+      "required": ["request_label_snapshot", "matched", "not_matched"],
+      "additionalProperties": false
+    },
+    "EncryptionKey": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "state": { "$ref": "#/$defs/EncryptionKeyState" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": ["id", "namespace", "state", "created_at", "updated_at"],
+      "additionalProperties": false
+    },
+    "ListEncryptionKeysResponse": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EncryptionKey" }
+        },
+        "cursor": { "type": "string" }
+      },
+      "required": ["items"],
+      "additionalProperties": false
+    },
+    "CreateEncryptionKeyRequest": {
+      "type": "object",
+      "properties": {
+        "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" },
+        "key_data": { "$ref": "../config/schema.json#/$defs/KeyData" },
+        "labels": { "$ref": "#/$defs/StringMap" },
+        "annotations": { "$ref": "#/$defs/StringMap" }
+      },
+      "required": ["namespace"],
+      "additionalProperties": false
+    },
+    "UpdateEncryptionKeyRequest": {
+      "type": "object",
+      "properties": {
+        "state": { "$ref": "#/$defs/EncryptionKeyState" },
         "labels": { "$ref": "#/$defs/StringMap" },
         "annotations": { "$ref": "#/$defs/StringMap" }
       },

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -32,9 +32,12 @@ func compileRefSchema(t *testing.T, ref string) *jsonschemav5.Schema {
 	c := jsonschemav5.NewCompiler()
 
 	_ = loadSchema(t, c, "../common/schema.json")
+	_ = loadSchema(t, c, "../auth/schema.json")
+	_ = loadSchema(t, c, "../config/schema.json")
 	_ = loadSchema(t, c, "../resources/namespace/schema.json")
 	_ = loadSchema(t, c, "../resources/connectors/schema-oauth.json")
 	_ = loadSchema(t, c, "../resources/connectors/schema.json")
+	_ = loadSchema(t, c, "../resources/rate_limit/schema.json")
 	sid := loadSchema(t, c, "./schema.json")
 	require.Equal(t, SchemaIdAPI, sid)
 
@@ -81,6 +84,16 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "create connector", ref: "./schema.json#/$defs/CreateConnectorRequest", file: "valid-create-connector.json"},
 		{name: "update connector", ref: "./schema.json#/$defs/UpdateConnectorRequest", file: "valid-update-connector.json"},
 		{name: "create connector version", ref: "./schema.json#/$defs/CreateConnectorVersionRequest", file: "valid-create-connector-version.json"},
+		{name: "rate limit", ref: "./schema.json#/$defs/RateLimit", file: "valid-rate-limit.json"},
+		{name: "list rate limits", ref: "./schema.json#/$defs/ListRateLimitsResponse", file: "valid-list-rate-limits.json"},
+		{name: "create rate limit", ref: "./schema.json#/$defs/CreateRateLimitRequest", file: "valid-create-rate-limit.json"},
+		{name: "update rate limit", ref: "./schema.json#/$defs/UpdateRateLimitRequest", file: "valid-update-rate-limit.json"},
+		{name: "dry-run request", ref: "./schema.json#/$defs/DryRunRequest", file: "valid-dry-run-request.json"},
+		{name: "dry-run response", ref: "./schema.json#/$defs/DryRunResponse", file: "valid-dry-run-response.json"},
+		{name: "encryption key", ref: "./schema.json#/$defs/EncryptionKey", file: "valid-encryption-key.json"},
+		{name: "list encryption keys", ref: "./schema.json#/$defs/ListEncryptionKeysResponse", file: "valid-list-encryption-keys.json"},
+		{name: "create encryption key", ref: "./schema.json#/$defs/CreateEncryptionKeyRequest", file: "valid-create-encryption-key.json"},
+		{name: "update encryption key", ref: "./schema.json#/$defs/UpdateEncryptionKeyRequest", file: "valid-update-encryption-key.json"},
 	}
 
 	for _, tt := range tests {

--- a/internal/schema/api/test_data/valid-create-encryption-key.json
+++ b/internal/schema/api/test_data/valid-create-encryption-key.json
@@ -1,0 +1,9 @@
+{
+  "namespace": "root.acme",
+  "key_data": {
+    "num_bytes": 32
+  },
+  "labels": {
+    "scope": "tenant"
+  }
+}

--- a/internal/schema/api/test_data/valid-create-rate-limit.json
+++ b/internal/schema/api/test_data/valid-create-rate-limit.json
@@ -1,0 +1,26 @@
+{
+  "namespace": "root.acme",
+  "definition": {
+    "mode": "enforce",
+    "selector": {
+      "methods": ["GET"],
+      "path_match": {
+        "kind": "glob",
+        "value": "/reports/*"
+      }
+    },
+    "bucket": {
+      "dimensions": ["connection"]
+    },
+    "algorithm": {
+      "sliding_window": {
+        "window": "5m",
+        "limit": 500,
+        "mode": "counter"
+      }
+    }
+  },
+  "labels": {
+    "team": "analytics"
+  }
+}

--- a/internal/schema/api/test_data/valid-dry-run-request.json
+++ b/internal/schema/api/test_data/valid-dry-run-request.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "url": "https://api.example.com/v1/users",
+    "method": "POST",
+    "headers": {
+      "content-type": "application/json"
+    },
+    "labels": {
+      "team": "payments"
+    },
+    "body_json": {
+      "name": "Ada"
+    }
+  },
+  "request_type": "proxy",
+  "context": {
+    "actor_id": "act_test550e8400abcde",
+    "namespace": "root.acme"
+  }
+}

--- a/internal/schema/api/test_data/valid-dry-run-response.json
+++ b/internal/schema/api/test_data/valid-dry-run-response.json
@@ -1,0 +1,25 @@
+{
+  "request_label_snapshot": {
+    "team": "payments"
+  },
+  "matched": [
+    {
+      "rate_limit_id": "rl_test550e8400abcde",
+      "namespace": "root.acme",
+      "effective_mode": "enforce",
+      "bucket_key": "actor=act_test550e8400abcde|labels/team=payments",
+      "algorithm_summary": "fixed_window window=1m limit=100",
+      "would_allow": true,
+      "remaining": 99,
+      "retry_after_ms": 0,
+      "peek_failed": false
+    }
+  ],
+  "not_matched": [
+    {
+      "rate_limit_id": "rl_other550e8400abcde",
+      "namespace": "root.acme",
+      "reason": "method did not match"
+    }
+  ]
+}

--- a/internal/schema/api/test_data/valid-encryption-key.json
+++ b/internal/schema/api/test_data/valid-encryption-key.json
@@ -1,0 +1,13 @@
+{
+  "id": "ek_test550e8400abcde",
+  "namespace": "root.acme",
+  "state": "active",
+  "labels": {
+    "scope": "tenant"
+  },
+  "annotations": {
+    "owner": "security"
+  },
+  "created_at": "2026-01-02T03:04:05Z",
+  "updated_at": "2026-01-02T03:05:06Z"
+}

--- a/internal/schema/api/test_data/valid-list-encryption-keys.json
+++ b/internal/schema/api/test_data/valid-list-encryption-keys.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    {
+      "id": "ek_test550e8400abcde",
+      "namespace": "root.acme",
+      "state": "disabled",
+      "created_at": "2026-01-02T03:04:05Z",
+      "updated_at": "2026-01-02T03:05:06Z"
+    }
+  ],
+  "cursor": "next"
+}

--- a/internal/schema/api/test_data/valid-list-rate-limits.json
+++ b/internal/schema/api/test_data/valid-list-rate-limits.json
@@ -1,0 +1,22 @@
+{
+  "items": [
+    {
+      "id": "rl_test550e8400abcde",
+      "namespace": "root.acme",
+      "definition": {
+        "mode": "observe",
+        "selector": {},
+        "bucket": {},
+        "algorithm": {
+          "token_bucket": {
+            "capacity": 60,
+            "refill_rate": 1
+          }
+        }
+      },
+      "created_at": "2026-01-02T03:04:05Z",
+      "updated_at": "2026-01-02T03:05:06Z"
+    }
+  ],
+  "cursor": "next"
+}

--- a/internal/schema/api/test_data/valid-rate-limit.json
+++ b/internal/schema/api/test_data/valid-rate-limit.json
@@ -1,0 +1,33 @@
+{
+  "id": "rl_test550e8400abcde",
+  "namespace": "root.acme",
+  "definition": {
+    "mode": "enforce",
+    "selector": {
+      "methods": ["POST"],
+      "request_types": ["proxy"],
+      "label_selector": "team == payments",
+      "path_match": {
+        "kind": "prefix",
+        "value": "/v1/"
+      }
+    },
+    "bucket": {
+      "dimensions": ["actor", "labels/team"]
+    },
+    "algorithm": {
+      "fixed_window": {
+        "window": "1m",
+        "limit": 100
+      }
+    }
+  },
+  "labels": {
+    "team": "payments"
+  },
+  "annotations": {
+    "note": "protect write traffic"
+  },
+  "created_at": "2026-01-02T03:04:05Z",
+  "updated_at": "2026-01-02T03:05:06Z"
+}

--- a/internal/schema/api/test_data/valid-update-encryption-key.json
+++ b/internal/schema/api/test_data/valid-update-encryption-key.json
@@ -1,0 +1,6 @@
+{
+  "state": "disabled",
+  "annotations": {
+    "reason": "rotation complete"
+  }
+}

--- a/internal/schema/api/test_data/valid-update-rate-limit.json
+++ b/internal/schema/api/test_data/valid-update-rate-limit.json
@@ -1,0 +1,18 @@
+{
+  "definition": {
+    "mode": "observe",
+    "selector": {
+      "request_types": ["proxy", "probe"]
+    },
+    "bucket": {},
+    "algorithm": {
+      "fixed_window": {
+        "window": "10s",
+        "limit": 10
+      }
+    }
+  },
+  "annotations": {
+    "reason": "temporary observe mode"
+  }
+}

--- a/internal/schema/resources/rate_limit/README.md
+++ b/internal/schema/resources/rate_limit/README.md
@@ -2,4 +2,4 @@
 
 This package defines rate-limit resource configuration, including selectors, buckets, and algorithms.
 
-The resource shape here is shared by config, persistence-facing code, rate-limit matching/enforcement, and future API DTOs.
+The resource shape here is shared by config, persistence-facing code, rate-limit matching/enforcement, and API DTOs. Keep API envelopes, pagination responses, and dry-run request/response contracts in `internal/schema/api`; this package should only describe the reusable rate-limit definition.

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -4783,7 +4783,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateEncryptionKeyRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateEncryptionKeyRequest"
                         }
                     }
                 ],
@@ -6469,7 +6469,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerCreateRateLimitRequest"
                         }
                     }
                 ],
@@ -6711,7 +6711,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateRateLimitRequest"
                         }
                     }
                 ],
@@ -7538,6 +7538,42 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson": {
+            "description": "Encryption key API response",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "ek_test550e8400abcde"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7609,9 +7645,6 @@ const docTemplateadmin_api = `{
             }
         },
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
-            "type": "object"
-        },
-        "github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit": {
             "type": "object"
         },
         "routes.ActorJson": {
@@ -7779,6 +7812,7 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.CreateEncryptionKeyRequestJson": {
+            "description": "Request to create a new encryption key",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -7797,7 +7831,8 @@ const docTemplateadmin_api = `{
                     }
                 },
                 "namespace": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "root.acme"
                 }
             }
         },
@@ -7822,9 +7857,6 @@ const docTemplateadmin_api = `{
                     "example": "root.acme"
                 }
             }
-        },
-        "routes.CreateRateLimitRequestJson": {
-            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -8230,6 +8262,32 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "routes.SwaggerCreateRateLimitRequest": {
+            "description": "Request to create a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
         "routes.SwaggerDisconnectResponse": {
             "description": "Response for disconnect operation",
             "type": "object",
@@ -8248,81 +8306,12 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.SwaggerDryRunContext": {
-            "description": "Identity the request runs under",
-            "type": "object",
-            "properties": {
-                "actor_id": {
-                    "type": "string"
-                },
-                "connection_id": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerDryRunMatch": {
-            "type": "object",
-            "properties": {
-                "algorithm_summary": {
-                    "type": "string",
-                    "example": "token bucket 60 @ 1/s"
-                },
-                "bucket_key": {
-                    "type": "string",
-                    "example": "actor=act_abc|labels/team=acme"
-                },
-                "effective_mode": {
-                    "type": "string",
-                    "example": "enforce"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "peek_failed": {
-                    "type": "boolean"
-                },
-                "rate_limit_id": {
-                    "type": "string",
-                    "example": "rl_test550e8400"
-                },
-                "remaining": {
-                    "type": "integer"
-                },
-                "retry_after_ms": {
-                    "type": "integer"
-                },
-                "would_allow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "routes.SwaggerDryRunNotMatched": {
-            "type": "object",
-            "properties": {
-                "namespace": {
-                    "type": "string"
-                },
-                "rate_limit_id": {
-                    "type": "string"
-                },
-                "reason": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.SwaggerDryRunRequest": {
             "description": "Dry-run input: a proxy-shaped request + request type + the identity it runs under",
             "type": "object",
             "properties": {
-                "context": {
-                    "$ref": "#/definitions/routes.SwaggerDryRunContext"
-                },
-                "request": {
-                    "$ref": "#/definitions/routes.ProxyRequest"
-                },
+                "context": {},
+                "request": {},
                 "request_type": {
                     "type": "string",
                     "example": "proxy"
@@ -8335,15 +8324,11 @@ const docTemplateadmin_api = `{
             "properties": {
                 "matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunMatch"
-                    }
+                    "items": {}
                 },
                 "not_matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunNotMatched"
-                    }
+                    "items": {}
                 },
                 "request_label_snapshot": {
                     "type": "object",
@@ -8354,44 +8339,37 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.SwaggerEncryptionKeyJson": {
-            "description": "Encryption key configuration",
+            "description": "Encryption key API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "id": {
-                    "description": "Encryption key ID",
                     "type": "string",
                     "example": "ek_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "state": {
-                    "description": "State (active, disabled)",
                     "type": "string",
                     "example": "active"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8488,14 +8466,12 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of encryption keys",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/routes.SwaggerEncryptionKeyJson"
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson"
                     }
                 }
             }
@@ -8505,15 +8481,11 @@ const docTemplateadmin_api = `{
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of rate limits",
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
-                    }
+                    "items": {}
                 }
             }
         },
@@ -8586,44 +8558,37 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.SwaggerRateLimitJson": {
-            "description": "Rate limit configuration",
+            "description": "Rate-limit API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "definition": {
-                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                 },
                 "id": {
-                    "description": "Rate limit ID",
                     "type": "string",
                     "example": "rl_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8745,6 +8710,50 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "routes.SwaggerUpdateEncryptionKeyRequest": {
+            "description": "Request to update an encryption key",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "state": {
+                    "type": "string",
+                    "example": "disabled"
+                }
+            }
+        },
+        "routes.SwaggerUpdateRateLimitRequest": {
+            "description": "Request to update a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.TaskInfoJson": {
             "type": "object",
             "properties": {
@@ -8791,26 +8800,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.UpdateEncryptionKeyRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.UpdateNamespaceRequestJson": {
             "description": "Namespace update request",
             "type": "object",
@@ -8820,26 +8809,6 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "routes.UpdateRateLimitRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {
-                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -4777,7 +4777,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateEncryptionKeyRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateEncryptionKeyRequest"
                         }
                     }
                 ],
@@ -6463,7 +6463,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerCreateRateLimitRequest"
                         }
                     }
                 ],
@@ -6705,7 +6705,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateRateLimitRequest"
                         }
                     }
                 ],
@@ -7532,6 +7532,42 @@
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson": {
+            "description": "Encryption key API response",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "ek_test550e8400abcde"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7603,9 +7639,6 @@
             }
         },
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
-            "type": "object"
-        },
-        "github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit": {
             "type": "object"
         },
         "routes.ActorJson": {
@@ -7773,6 +7806,7 @@
             }
         },
         "routes.CreateEncryptionKeyRequestJson": {
+            "description": "Request to create a new encryption key",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -7791,7 +7825,8 @@
                     }
                 },
                 "namespace": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "root.acme"
                 }
             }
         },
@@ -7816,9 +7851,6 @@
                     "example": "root.acme"
                 }
             }
-        },
-        "routes.CreateRateLimitRequestJson": {
-            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -8224,6 +8256,32 @@
                 }
             }
         },
+        "routes.SwaggerCreateRateLimitRequest": {
+            "description": "Request to create a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
         "routes.SwaggerDisconnectResponse": {
             "description": "Response for disconnect operation",
             "type": "object",
@@ -8242,81 +8300,12 @@
                 }
             }
         },
-        "routes.SwaggerDryRunContext": {
-            "description": "Identity the request runs under",
-            "type": "object",
-            "properties": {
-                "actor_id": {
-                    "type": "string"
-                },
-                "connection_id": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerDryRunMatch": {
-            "type": "object",
-            "properties": {
-                "algorithm_summary": {
-                    "type": "string",
-                    "example": "token bucket 60 @ 1/s"
-                },
-                "bucket_key": {
-                    "type": "string",
-                    "example": "actor=act_abc|labels/team=acme"
-                },
-                "effective_mode": {
-                    "type": "string",
-                    "example": "enforce"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "peek_failed": {
-                    "type": "boolean"
-                },
-                "rate_limit_id": {
-                    "type": "string",
-                    "example": "rl_test550e8400"
-                },
-                "remaining": {
-                    "type": "integer"
-                },
-                "retry_after_ms": {
-                    "type": "integer"
-                },
-                "would_allow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "routes.SwaggerDryRunNotMatched": {
-            "type": "object",
-            "properties": {
-                "namespace": {
-                    "type": "string"
-                },
-                "rate_limit_id": {
-                    "type": "string"
-                },
-                "reason": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.SwaggerDryRunRequest": {
             "description": "Dry-run input: a proxy-shaped request + request type + the identity it runs under",
             "type": "object",
             "properties": {
-                "context": {
-                    "$ref": "#/definitions/routes.SwaggerDryRunContext"
-                },
-                "request": {
-                    "$ref": "#/definitions/routes.ProxyRequest"
-                },
+                "context": {},
+                "request": {},
                 "request_type": {
                     "type": "string",
                     "example": "proxy"
@@ -8329,15 +8318,11 @@
             "properties": {
                 "matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunMatch"
-                    }
+                    "items": {}
                 },
                 "not_matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunNotMatched"
-                    }
+                    "items": {}
                 },
                 "request_label_snapshot": {
                     "type": "object",
@@ -8348,44 +8333,37 @@
             }
         },
         "routes.SwaggerEncryptionKeyJson": {
-            "description": "Encryption key configuration",
+            "description": "Encryption key API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "id": {
-                    "description": "Encryption key ID",
                     "type": "string",
                     "example": "ek_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "state": {
-                    "description": "State (active, disabled)",
                     "type": "string",
                     "example": "active"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8482,14 +8460,12 @@
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of encryption keys",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/routes.SwaggerEncryptionKeyJson"
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson"
                     }
                 }
             }
@@ -8499,15 +8475,11 @@
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of rate limits",
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
-                    }
+                    "items": {}
                 }
             }
         },
@@ -8580,44 +8552,37 @@
             }
         },
         "routes.SwaggerRateLimitJson": {
-            "description": "Rate limit configuration",
+            "description": "Rate-limit API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "definition": {
-                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                 },
                 "id": {
-                    "description": "Rate limit ID",
                     "type": "string",
                     "example": "rl_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8739,6 +8704,50 @@
                 }
             }
         },
+        "routes.SwaggerUpdateEncryptionKeyRequest": {
+            "description": "Request to update an encryption key",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "state": {
+                    "type": "string",
+                    "example": "disabled"
+                }
+            }
+        },
+        "routes.SwaggerUpdateRateLimitRequest": {
+            "description": "Request to update a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.TaskInfoJson": {
             "type": "object",
             "properties": {
@@ -8785,26 +8794,6 @@
                 }
             }
         },
-        "routes.UpdateEncryptionKeyRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.UpdateNamespaceRequestJson": {
             "description": "Namespace update request",
             "type": "object",
@@ -8814,26 +8803,6 @@
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "routes.UpdateRateLimitRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {
-                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -78,6 +78,31 @@ definitions:
         example: 2
         type: integer
     type: object
+  github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson:
+    description: Encryption key API response
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      created_at:
+        type: string
+      id:
+        example: ek_test550e8400abcde
+        type: string
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      namespace:
+        example: root.acme
+        type: string
+      state:
+        example: active
+        type: string
+      updated_at:
+        type: string
+    type: object
   github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -128,8 +153,6 @@ definitions:
         type: array
     type: object
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
-    type: object
-  github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit:
     type: object
   routes.ActorJson:
     description: Actor identity within a namespace
@@ -251,6 +274,7 @@ definitions:
         type: string
     type: object
   routes.CreateEncryptionKeyRequestJson:
+    description: Request to create a new encryption key
     properties:
       annotations:
         additionalProperties:
@@ -263,6 +287,7 @@ definitions:
           type: string
         type: object
       namespace:
+        example: root.acme
         type: string
     type: object
   routes.CreateNamespaceRequestJson:
@@ -279,8 +304,6 @@ definitions:
       path:
         example: root.acme
         type: string
-    type: object
-  routes.CreateRateLimitRequestJson:
     type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
@@ -582,6 +605,24 @@ definitions:
           type: string
         type: object
     type: object
+  routes.SwaggerCreateRateLimitRequest:
+    description: Request to create a rate limit
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        additionalProperties: {}
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      namespace:
+        example: root.acme
+        type: string
+    type: object
   routes.SwaggerDisconnectResponse:
     description: Response for disconnect operation
     properties:
@@ -593,58 +634,12 @@ definitions:
         description: Task ID for tracking the disconnect operation
         type: string
     type: object
-  routes.SwaggerDryRunContext:
-    description: Identity the request runs under
-    properties:
-      actor_id:
-        type: string
-      connection_id:
-        type: string
-      namespace:
-        type: string
-    type: object
-  routes.SwaggerDryRunMatch:
-    properties:
-      algorithm_summary:
-        example: token bucket 60 @ 1/s
-        type: string
-      bucket_key:
-        example: actor=act_abc|labels/team=acme
-        type: string
-      effective_mode:
-        example: enforce
-        type: string
-      namespace:
-        type: string
-      peek_failed:
-        type: boolean
-      rate_limit_id:
-        example: rl_test550e8400
-        type: string
-      remaining:
-        type: integer
-      retry_after_ms:
-        type: integer
-      would_allow:
-        type: boolean
-    type: object
-  routes.SwaggerDryRunNotMatched:
-    properties:
-      namespace:
-        type: string
-      rate_limit_id:
-        type: string
-      reason:
-        type: string
-    type: object
   routes.SwaggerDryRunRequest:
     description: 'Dry-run input: a proxy-shaped request + request type + the identity
       it runs under'
     properties:
-      context:
-        $ref: '#/definitions/routes.SwaggerDryRunContext'
-      request:
-        $ref: '#/definitions/routes.ProxyRequest'
+      context: {}
+      request: {}
       request_type:
         example: proxy
         type: string
@@ -653,12 +648,10 @@ definitions:
     description: Per-rule match + peek-driven would-allow result
     properties:
       matched:
-        items:
-          $ref: '#/definitions/routes.SwaggerDryRunMatch'
+        items: {}
         type: array
       not_matched:
-        items:
-          $ref: '#/definitions/routes.SwaggerDryRunNotMatched'
+        items: {}
         type: array
       request_label_snapshot:
         additionalProperties:
@@ -666,35 +659,28 @@ definitions:
         type: object
     type: object
   routes.SwaggerEncryptionKeyJson:
-    description: Encryption key configuration
+    description: Encryption key API response
     properties:
       annotations:
         additionalProperties:
           type: string
-        description: Annotations assigned to the encryption key
         type: object
       created_at:
-        description: Creation timestamp
         type: string
       id:
-        description: Encryption key ID
         example: ek_test550e8400abcde
         type: string
       labels:
         additionalProperties:
           type: string
-        description: Labels assigned to the encryption key
         type: object
       namespace:
-        description: Namespace path
-        example: acme
+        example: root.acme
         type: string
       state:
-        description: State (active, disabled)
         example: active
         type: string
       updated_at:
-        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerForceConnectorVersionStateRequest:
@@ -765,24 +751,19 @@ definitions:
     description: Paginated list of encryption keys
     properties:
       cursor:
-        description: Pagination cursor for next page
         type: string
       items:
-        description: List of encryption keys
         items:
-          $ref: '#/definitions/routes.SwaggerEncryptionKeyJson'
+          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson'
         type: array
     type: object
   routes.SwaggerListRateLimitsResponse:
     description: Paginated list of rate limits
     properties:
       cursor:
-        description: Pagination cursor for next page
         type: string
       items:
-        description: List of rate limits
-        items:
-          $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        items: {}
         type: array
     type: object
   routes.SwaggerListRequestEventsResponse:
@@ -834,35 +815,28 @@ definitions:
         type: string
     type: object
   routes.SwaggerRateLimitJson:
-    description: Rate limit configuration
+    description: Rate-limit API response
     properties:
       annotations:
         additionalProperties:
           type: string
-        description: Annotations assigned to the rate limit
         type: object
       created_at:
-        description: Creation timestamp
         type: string
       definition:
-        additionalProperties: true
-        description: JSON-serialised definition (mode, selector, bucket, algorithm)
+        additionalProperties: {}
         type: object
       id:
-        description: Rate limit ID
         example: rl_test550e8400abcde
         type: string
       labels:
         additionalProperties:
           type: string
-        description: Labels assigned to the rate limit
         type: object
       namespace:
-        description: Namespace path
-        example: acme
+        example: root.acme
         type: string
       updated_at:
-        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerRequestEventsEntry:
@@ -953,6 +927,36 @@ definitions:
           type: string
         type: object
     type: object
+  routes.SwaggerUpdateEncryptionKeyRequest:
+    description: Request to update an encryption key
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      state:
+        example: disabled
+        type: string
+    type: object
+  routes.SwaggerUpdateRateLimitRequest:
+    description: Request to update a rate limit
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        additionalProperties: {}
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
   routes.TaskInfoJson:
     properties:
       id:
@@ -984,19 +988,6 @@ definitions:
           type: string
         type: object
     type: object
-  routes.UpdateEncryptionKeyRequestJson:
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      state:
-        type: string
-    type: object
   routes.UpdateNamespaceRequestJson:
     description: Namespace update request
     properties:
@@ -1004,19 +995,6 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  routes.UpdateRateLimitRequestJson:
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition:
-        $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit'
       labels:
         additionalProperties:
           type: string
@@ -4136,7 +4114,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.UpdateEncryptionKeyRequestJson'
+          $ref: '#/definitions/routes.SwaggerUpdateEncryptionKeyRequest'
       produces:
       - application/json
       responses:
@@ -5227,7 +5205,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.CreateRateLimitRequestJson'
+          $ref: '#/definitions/routes.SwaggerCreateRateLimitRequest'
       produces:
       - application/json
       responses:
@@ -5385,7 +5363,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.UpdateRateLimitRequestJson'
+          $ref: '#/definitions/routes.SwaggerUpdateRateLimitRequest'
       produces:
       - application/json
       responses:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -4783,7 +4783,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateEncryptionKeyRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateEncryptionKeyRequest"
                         }
                     }
                 ],
@@ -6469,7 +6469,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerCreateRateLimitRequest"
                         }
                     }
                 ],
@@ -6711,7 +6711,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateRateLimitRequest"
                         }
                     }
                 ],
@@ -7538,6 +7538,42 @@ const docTemplateApi = `{
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson": {
+            "description": "Encryption key API response",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "ek_test550e8400abcde"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7609,9 +7645,6 @@ const docTemplateApi = `{
             }
         },
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
-            "type": "object"
-        },
-        "github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit": {
             "type": "object"
         },
         "routes.ActorJson": {
@@ -7779,6 +7812,7 @@ const docTemplateApi = `{
             }
         },
         "routes.CreateEncryptionKeyRequestJson": {
+            "description": "Request to create a new encryption key",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -7797,7 +7831,8 @@ const docTemplateApi = `{
                     }
                 },
                 "namespace": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "root.acme"
                 }
             }
         },
@@ -7822,9 +7857,6 @@ const docTemplateApi = `{
                     "example": "root.acme"
                 }
             }
-        },
-        "routes.CreateRateLimitRequestJson": {
-            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -8230,6 +8262,32 @@ const docTemplateApi = `{
                 }
             }
         },
+        "routes.SwaggerCreateRateLimitRequest": {
+            "description": "Request to create a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
         "routes.SwaggerDisconnectResponse": {
             "description": "Response for disconnect operation",
             "type": "object",
@@ -8248,81 +8306,12 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.SwaggerDryRunContext": {
-            "description": "Identity the request runs under",
-            "type": "object",
-            "properties": {
-                "actor_id": {
-                    "type": "string"
-                },
-                "connection_id": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerDryRunMatch": {
-            "type": "object",
-            "properties": {
-                "algorithm_summary": {
-                    "type": "string",
-                    "example": "token bucket 60 @ 1/s"
-                },
-                "bucket_key": {
-                    "type": "string",
-                    "example": "actor=act_abc|labels/team=acme"
-                },
-                "effective_mode": {
-                    "type": "string",
-                    "example": "enforce"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "peek_failed": {
-                    "type": "boolean"
-                },
-                "rate_limit_id": {
-                    "type": "string",
-                    "example": "rl_test550e8400"
-                },
-                "remaining": {
-                    "type": "integer"
-                },
-                "retry_after_ms": {
-                    "type": "integer"
-                },
-                "would_allow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "routes.SwaggerDryRunNotMatched": {
-            "type": "object",
-            "properties": {
-                "namespace": {
-                    "type": "string"
-                },
-                "rate_limit_id": {
-                    "type": "string"
-                },
-                "reason": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.SwaggerDryRunRequest": {
             "description": "Dry-run input: a proxy-shaped request + request type + the identity it runs under",
             "type": "object",
             "properties": {
-                "context": {
-                    "$ref": "#/definitions/routes.SwaggerDryRunContext"
-                },
-                "request": {
-                    "$ref": "#/definitions/routes.ProxyRequest"
-                },
+                "context": {},
+                "request": {},
                 "request_type": {
                     "type": "string",
                     "example": "proxy"
@@ -8335,15 +8324,11 @@ const docTemplateApi = `{
             "properties": {
                 "matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunMatch"
-                    }
+                    "items": {}
                 },
                 "not_matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunNotMatched"
-                    }
+                    "items": {}
                 },
                 "request_label_snapshot": {
                     "type": "object",
@@ -8354,44 +8339,37 @@ const docTemplateApi = `{
             }
         },
         "routes.SwaggerEncryptionKeyJson": {
-            "description": "Encryption key configuration",
+            "description": "Encryption key API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "id": {
-                    "description": "Encryption key ID",
                     "type": "string",
                     "example": "ek_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "state": {
-                    "description": "State (active, disabled)",
                     "type": "string",
                     "example": "active"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8488,14 +8466,12 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of encryption keys",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/routes.SwaggerEncryptionKeyJson"
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson"
                     }
                 }
             }
@@ -8505,15 +8481,11 @@ const docTemplateApi = `{
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of rate limits",
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
-                    }
+                    "items": {}
                 }
             }
         },
@@ -8586,44 +8558,37 @@ const docTemplateApi = `{
             }
         },
         "routes.SwaggerRateLimitJson": {
-            "description": "Rate limit configuration",
+            "description": "Rate-limit API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "definition": {
-                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                 },
                 "id": {
-                    "description": "Rate limit ID",
                     "type": "string",
                     "example": "rl_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8745,6 +8710,50 @@ const docTemplateApi = `{
                 }
             }
         },
+        "routes.SwaggerUpdateEncryptionKeyRequest": {
+            "description": "Request to update an encryption key",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "state": {
+                    "type": "string",
+                    "example": "disabled"
+                }
+            }
+        },
+        "routes.SwaggerUpdateRateLimitRequest": {
+            "description": "Request to update a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.TaskInfoJson": {
             "type": "object",
             "properties": {
@@ -8791,26 +8800,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.UpdateEncryptionKeyRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.UpdateNamespaceRequestJson": {
             "description": "Namespace update request",
             "type": "object",
@@ -8820,26 +8809,6 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "routes.UpdateRateLimitRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {
-                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -4777,7 +4777,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateEncryptionKeyRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateEncryptionKeyRequest"
                         }
                     }
                 ],
@@ -6463,7 +6463,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.CreateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerCreateRateLimitRequest"
                         }
                     }
                 ],
@@ -6705,7 +6705,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.UpdateRateLimitRequestJson"
+                            "$ref": "#/definitions/routes.SwaggerUpdateRateLimitRequest"
                         }
                     }
                 ],
@@ -7532,6 +7532,42 @@
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson": {
+            "description": "Encryption key API response",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "ek_test550e8400abcde"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -7603,9 +7639,6 @@
             }
         },
         "github_com_rmorlok_authproxy_internal_schema_config.KeyData": {
-            "type": "object"
-        },
-        "github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit": {
             "type": "object"
         },
         "routes.ActorJson": {
@@ -7773,6 +7806,7 @@
             }
         },
         "routes.CreateEncryptionKeyRequestJson": {
+            "description": "Request to create a new encryption key",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -7791,7 +7825,8 @@
                     }
                 },
                 "namespace": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "root.acme"
                 }
             }
         },
@@ -7816,9 +7851,6 @@
                     "example": "root.acme"
                 }
             }
-        },
-        "routes.CreateRateLimitRequestJson": {
-            "type": "object"
         },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
@@ -8224,6 +8256,32 @@
                 }
             }
         },
+        "routes.SwaggerCreateRateLimitRequest": {
+            "description": "Request to create a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
         "routes.SwaggerDisconnectResponse": {
             "description": "Response for disconnect operation",
             "type": "object",
@@ -8242,81 +8300,12 @@
                 }
             }
         },
-        "routes.SwaggerDryRunContext": {
-            "description": "Identity the request runs under",
-            "type": "object",
-            "properties": {
-                "actor_id": {
-                    "type": "string"
-                },
-                "connection_id": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                }
-            }
-        },
-        "routes.SwaggerDryRunMatch": {
-            "type": "object",
-            "properties": {
-                "algorithm_summary": {
-                    "type": "string",
-                    "example": "token bucket 60 @ 1/s"
-                },
-                "bucket_key": {
-                    "type": "string",
-                    "example": "actor=act_abc|labels/team=acme"
-                },
-                "effective_mode": {
-                    "type": "string",
-                    "example": "enforce"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "peek_failed": {
-                    "type": "boolean"
-                },
-                "rate_limit_id": {
-                    "type": "string",
-                    "example": "rl_test550e8400"
-                },
-                "remaining": {
-                    "type": "integer"
-                },
-                "retry_after_ms": {
-                    "type": "integer"
-                },
-                "would_allow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "routes.SwaggerDryRunNotMatched": {
-            "type": "object",
-            "properties": {
-                "namespace": {
-                    "type": "string"
-                },
-                "rate_limit_id": {
-                    "type": "string"
-                },
-                "reason": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.SwaggerDryRunRequest": {
             "description": "Dry-run input: a proxy-shaped request + request type + the identity it runs under",
             "type": "object",
             "properties": {
-                "context": {
-                    "$ref": "#/definitions/routes.SwaggerDryRunContext"
-                },
-                "request": {
-                    "$ref": "#/definitions/routes.ProxyRequest"
-                },
+                "context": {},
+                "request": {},
                 "request_type": {
                     "type": "string",
                     "example": "proxy"
@@ -8329,15 +8318,11 @@
             "properties": {
                 "matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunMatch"
-                    }
+                    "items": {}
                 },
                 "not_matched": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerDryRunNotMatched"
-                    }
+                    "items": {}
                 },
                 "request_label_snapshot": {
                     "type": "object",
@@ -8348,44 +8333,37 @@
             }
         },
         "routes.SwaggerEncryptionKeyJson": {
-            "description": "Encryption key configuration",
+            "description": "Encryption key API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "id": {
-                    "description": "Encryption key ID",
                     "type": "string",
                     "example": "ek_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the encryption key",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "state": {
-                    "description": "State (active, disabled)",
                     "type": "string",
                     "example": "active"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8482,14 +8460,12 @@
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of encryption keys",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/routes.SwaggerEncryptionKeyJson"
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson"
                     }
                 }
             }
@@ -8499,15 +8475,11 @@
             "type": "object",
             "properties": {
                 "cursor": {
-                    "description": "Pagination cursor for next page",
                     "type": "string"
                 },
                 "items": {
-                    "description": "List of rate limits",
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/routes.SwaggerRateLimitJson"
-                    }
+                    "items": {}
                 }
             }
         },
@@ -8580,44 +8552,37 @@
             }
         },
         "routes.SwaggerRateLimitJson": {
-            "description": "Rate limit configuration",
+            "description": "Rate-limit API response",
             "type": "object",
             "properties": {
                 "annotations": {
-                    "description": "Annotations assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "created_at": {
-                    "description": "Creation timestamp",
                     "type": "string"
                 },
                 "definition": {
-                    "description": "JSON-serialised definition (mode, selector, bucket, algorithm)",
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                 },
                 "id": {
-                    "description": "Rate limit ID",
                     "type": "string",
                     "example": "rl_test550e8400abcde"
                 },
                 "labels": {
-                    "description": "Labels assigned to the rate limit",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "namespace": {
-                    "description": "Namespace path",
                     "type": "string",
-                    "example": "acme"
+                    "example": "root.acme"
                 },
                 "updated_at": {
-                    "description": "Last update timestamp",
                     "type": "string"
                 }
             }
@@ -8739,6 +8704,50 @@
                 }
             }
         },
+        "routes.SwaggerUpdateEncryptionKeyRequest": {
+            "description": "Request to update an encryption key",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "state": {
+                    "type": "string",
+                    "example": "disabled"
+                }
+            }
+        },
+        "routes.SwaggerUpdateRateLimitRequest": {
+            "description": "Request to update a rate limit",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.TaskInfoJson": {
             "type": "object",
             "properties": {
@@ -8785,26 +8794,6 @@
                 }
             }
         },
-        "routes.UpdateEncryptionKeyRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
         "routes.UpdateNamespaceRequestJson": {
             "description": "Namespace update request",
             "type": "object",
@@ -8814,26 +8803,6 @@
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "routes.UpdateRateLimitRequestJson": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {
-                    "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -78,6 +78,31 @@ definitions:
         example: 2
         type: integer
     type: object
+  github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson:
+    description: Encryption key API response
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      created_at:
+        type: string
+      id:
+        example: ek_test550e8400abcde
+        type: string
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      namespace:
+        example: root.acme
+        type: string
+      state:
+        example: active
+        type: string
+      updated_at:
+        type: string
+    type: object
   github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -128,8 +153,6 @@ definitions:
         type: array
     type: object
   github_com_rmorlok_authproxy_internal_schema_config.KeyData:
-    type: object
-  github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit:
     type: object
   routes.ActorJson:
     description: Actor identity within a namespace
@@ -251,6 +274,7 @@ definitions:
         type: string
     type: object
   routes.CreateEncryptionKeyRequestJson:
+    description: Request to create a new encryption key
     properties:
       annotations:
         additionalProperties:
@@ -263,6 +287,7 @@ definitions:
           type: string
         type: object
       namespace:
+        example: root.acme
         type: string
     type: object
   routes.CreateNamespaceRequestJson:
@@ -279,8 +304,6 @@ definitions:
       path:
         example: root.acme
         type: string
-    type: object
-  routes.CreateRateLimitRequestJson:
     type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
@@ -582,6 +605,24 @@ definitions:
           type: string
         type: object
     type: object
+  routes.SwaggerCreateRateLimitRequest:
+    description: Request to create a rate limit
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        additionalProperties: {}
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      namespace:
+        example: root.acme
+        type: string
+    type: object
   routes.SwaggerDisconnectResponse:
     description: Response for disconnect operation
     properties:
@@ -593,58 +634,12 @@ definitions:
         description: Task ID for tracking the disconnect operation
         type: string
     type: object
-  routes.SwaggerDryRunContext:
-    description: Identity the request runs under
-    properties:
-      actor_id:
-        type: string
-      connection_id:
-        type: string
-      namespace:
-        type: string
-    type: object
-  routes.SwaggerDryRunMatch:
-    properties:
-      algorithm_summary:
-        example: token bucket 60 @ 1/s
-        type: string
-      bucket_key:
-        example: actor=act_abc|labels/team=acme
-        type: string
-      effective_mode:
-        example: enforce
-        type: string
-      namespace:
-        type: string
-      peek_failed:
-        type: boolean
-      rate_limit_id:
-        example: rl_test550e8400
-        type: string
-      remaining:
-        type: integer
-      retry_after_ms:
-        type: integer
-      would_allow:
-        type: boolean
-    type: object
-  routes.SwaggerDryRunNotMatched:
-    properties:
-      namespace:
-        type: string
-      rate_limit_id:
-        type: string
-      reason:
-        type: string
-    type: object
   routes.SwaggerDryRunRequest:
     description: 'Dry-run input: a proxy-shaped request + request type + the identity
       it runs under'
     properties:
-      context:
-        $ref: '#/definitions/routes.SwaggerDryRunContext'
-      request:
-        $ref: '#/definitions/routes.ProxyRequest'
+      context: {}
+      request: {}
       request_type:
         example: proxy
         type: string
@@ -653,12 +648,10 @@ definitions:
     description: Per-rule match + peek-driven would-allow result
     properties:
       matched:
-        items:
-          $ref: '#/definitions/routes.SwaggerDryRunMatch'
+        items: {}
         type: array
       not_matched:
-        items:
-          $ref: '#/definitions/routes.SwaggerDryRunNotMatched'
+        items: {}
         type: array
       request_label_snapshot:
         additionalProperties:
@@ -666,35 +659,28 @@ definitions:
         type: object
     type: object
   routes.SwaggerEncryptionKeyJson:
-    description: Encryption key configuration
+    description: Encryption key API response
     properties:
       annotations:
         additionalProperties:
           type: string
-        description: Annotations assigned to the encryption key
         type: object
       created_at:
-        description: Creation timestamp
         type: string
       id:
-        description: Encryption key ID
         example: ek_test550e8400abcde
         type: string
       labels:
         additionalProperties:
           type: string
-        description: Labels assigned to the encryption key
         type: object
       namespace:
-        description: Namespace path
-        example: acme
+        example: root.acme
         type: string
       state:
-        description: State (active, disabled)
         example: active
         type: string
       updated_at:
-        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerForceConnectorVersionStateRequest:
@@ -765,24 +751,19 @@ definitions:
     description: Paginated list of encryption keys
     properties:
       cursor:
-        description: Pagination cursor for next page
         type: string
       items:
-        description: List of encryption keys
         items:
-          $ref: '#/definitions/routes.SwaggerEncryptionKeyJson'
+          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.EncryptionKeyJson'
         type: array
     type: object
   routes.SwaggerListRateLimitsResponse:
     description: Paginated list of rate limits
     properties:
       cursor:
-        description: Pagination cursor for next page
         type: string
       items:
-        description: List of rate limits
-        items:
-          $ref: '#/definitions/routes.SwaggerRateLimitJson'
+        items: {}
         type: array
     type: object
   routes.SwaggerListRequestEventsResponse:
@@ -834,35 +815,28 @@ definitions:
         type: string
     type: object
   routes.SwaggerRateLimitJson:
-    description: Rate limit configuration
+    description: Rate-limit API response
     properties:
       annotations:
         additionalProperties:
           type: string
-        description: Annotations assigned to the rate limit
         type: object
       created_at:
-        description: Creation timestamp
         type: string
       definition:
-        additionalProperties: true
-        description: JSON-serialised definition (mode, selector, bucket, algorithm)
+        additionalProperties: {}
         type: object
       id:
-        description: Rate limit ID
         example: rl_test550e8400abcde
         type: string
       labels:
         additionalProperties:
           type: string
-        description: Labels assigned to the rate limit
         type: object
       namespace:
-        description: Namespace path
-        example: acme
+        example: root.acme
         type: string
       updated_at:
-        description: Last update timestamp
         type: string
     type: object
   routes.SwaggerRequestEventsEntry:
@@ -953,6 +927,36 @@ definitions:
           type: string
         type: object
     type: object
+  routes.SwaggerUpdateEncryptionKeyRequest:
+    description: Request to update an encryption key
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      state:
+        example: disabled
+        type: string
+    type: object
+  routes.SwaggerUpdateRateLimitRequest:
+    description: Request to update a rate limit
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition:
+        additionalProperties: {}
+        type: object
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
   routes.TaskInfoJson:
     properties:
       id:
@@ -984,19 +988,6 @@ definitions:
           type: string
         type: object
     type: object
-  routes.UpdateEncryptionKeyRequestJson:
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      state:
-        type: string
-    type: object
   routes.UpdateNamespaceRequestJson:
     description: Namespace update request
     properties:
@@ -1004,19 +995,6 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  routes.UpdateRateLimitRequestJson:
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition:
-        $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_resources_rate_limit.RateLimit'
       labels:
         additionalProperties:
           type: string
@@ -4136,7 +4114,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.UpdateEncryptionKeyRequestJson'
+          $ref: '#/definitions/routes.SwaggerUpdateEncryptionKeyRequest'
       produces:
       - application/json
       responses:
@@ -5227,7 +5205,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.CreateRateLimitRequestJson'
+          $ref: '#/definitions/routes.SwaggerCreateRateLimitRequest'
       produces:
       - application/json
       responses:
@@ -5385,7 +5363,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.UpdateRateLimitRequestJson'
+          $ref: '#/definitions/routes.SwaggerUpdateRateLimitRequest'
       produces:
       - application/json
       responses:


### PR DESCRIPTION
## Summary
- Move rate-limit, dry-run, and encryption-key wire DTOs into internal/schema/api
- Add JSON Schema definitions and sample payload validation for those API contracts
- Keep swaggo centralized with thin internal/schema/api/openapi adapters where the generator cannot parse resource-backed runtime types

Closes #387

## Tests
- ./scripts/preflight.sh
- go test ./internal/schema/...
- go test ./internal/routes -run 'TestEncryption|TestRateLimit' -count=1