### PR TITLE
[A11] Seed demo actors via post-install hook Job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -36,6 +36,8 @@ jobs:
             dockerfile: Dockerfile
           - name: authproxy-demo-shell
             dockerfile: demos/shell/Dockerfile
+          - name: authproxy-demo-seed
+            dockerfile: demos/seed/Dockerfile
 
     steps:
       - uses: actions/checkout@v4

--- a/demos/seed/Dockerfile
+++ b/demos/seed/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for the demos/seed binary.
+#
+# Built from the repo root (`docker build -f demos/seed/Dockerfile .`)
+# because the Go binary imports `internal/apauth/jwt` and the schema
+# packages from the root module.
+#
+# No frontend stage — the seed binary is a one-shot CLI.
+
+FROM golang:1.24 AS builder
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# CGO not required — no C deps. Statically link for the minimal runtime image.
+RUN CGO_ENABLED=0 go build -o /demo-seed ./demos/seed/backend
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /demo-seed /app/demo-seed
+
+ENTRYPOINT ["/app/demo-seed"]

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -1,0 +1,177 @@
+// Command demo-seed bootstraps the demo environment's actors + connectors
+// against a running AuthProxy admin API. Run as a Helm post-install /
+// post-upgrade hook from the authproxy-demo umbrella chart.
+//
+// Idempotency model: for each desired entity, first GET it by
+// external_id; if AuthProxy returns 404, POST it. Re-running the seed
+// job is a no-op once the state matches.
+//
+// Auth: signs requests as the demo-shell admin actor using the same
+// keypair the demo-shell itself uses. AuthProxy already trusts that
+// actor to create/list other actors via the admin-api access scope.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"gopkg.in/yaml.v3"
+
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+// SeedConfig is the YAML shape the binary consumes.
+type SeedConfig struct {
+	Actors []ActorSeed `yaml:"actors"`
+}
+
+type ActorSeed struct {
+	ExternalId  string            `yaml:"external_id"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+type settings struct {
+	adminApiUrl         string
+	adminUsername       string
+	adminPrivateKeyPath string
+	configPath          string
+}
+
+func mustGetenv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "missing required env var %s\n", key)
+		os.Exit(2)
+	}
+	return v
+}
+
+func loadSettings() settings {
+	return settings{
+		adminApiUrl:         strings.TrimRight(mustGetenv("ADMIN_API_URL"), "/"),
+		adminUsername:       mustGetenv("ADMIN_USERNAME"),
+		adminPrivateKeyPath: mustGetenv("ADMIN_PRIVATE_KEY_PATH"),
+		configPath:          mustGetenv("SEED_CONFIG_PATH"),
+	}
+}
+
+func loadConfig(path string) (*SeedConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read seed config %q: %w", path, err)
+	}
+	var c SeedConfig
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse seed config %q: %w", path, err)
+	}
+	return &c, nil
+}
+
+// newSignedClient returns a resty client that injects an admin-signed
+// JWT on every request. Tokens are minted with a short TTL; the seed
+// job is a one-shot, no refresh logic needed.
+func newSignedClient(s settings) (*resty.Client, error) {
+	signer, err := jwt.NewJwtTokenBuilder().
+		WithActorExternalId(s.adminUsername).
+		WithActorSigned().
+		WithServiceIds(config.AllServiceIds()).
+		WithExpiresIn(5 * time.Minute).
+		WithPrivateKeyPath(s.adminPrivateKeyPath).
+		Signer()
+	if err != nil {
+		return nil, fmt.Errorf("build signer: %w", err)
+	}
+	c := resty.New().SetTimeout(30 * time.Second)
+	c.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
+		signer.SignRestyRequest(req)
+		return nil
+	})
+	return c, nil
+}
+
+// upsertActor creates the actor if it doesn't already exist by
+// external_id. Returns true when a create was performed, false on
+// no-op.
+func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, err error) {
+	// GET by external_id (with optional namespace).
+	getReq := c.R().SetHeader("Accept", "application/json")
+	if a.Namespace != "" {
+		getReq.SetQueryParam("namespace", a.Namespace)
+	}
+	getResp, err := getReq.Get(fmt.Sprintf("%s/api/v1/actors/external-id/%s", baseUrl, a.ExternalId))
+	if err != nil {
+		return false, fmt.Errorf("GET actor %q: %w", a.ExternalId, err)
+	}
+
+	switch getResp.StatusCode() {
+	case http.StatusOK:
+		return false, nil
+	case http.StatusNotFound:
+		// fall through to create
+	default:
+		return false, fmt.Errorf("GET actor %q returned %d: %s", a.ExternalId, getResp.StatusCode(), getResp.String())
+	}
+
+	body := api.CreateActorRequestJson{
+		ExternalId:  a.ExternalId,
+		Namespace:   a.Namespace,
+		Labels:      a.Labels,
+		Annotations: a.Annotations,
+	}
+	postResp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(fmt.Sprintf("%s/api/v1/actors", baseUrl))
+	if err != nil {
+		return false, fmt.Errorf("POST actor %q: %w", a.ExternalId, err)
+	}
+	if postResp.StatusCode() >= 400 {
+		return false, fmt.Errorf("POST actor %q returned %d: %s", a.ExternalId, postResp.StatusCode(), postResp.String())
+	}
+	return true, nil
+}
+
+func run(logger *slog.Logger) error {
+	s := loadSettings()
+	cfg, err := loadConfig(s.configPath)
+	if err != nil {
+		return err
+	}
+	client, err := newSignedClient(s)
+	if err != nil {
+		return err
+	}
+
+	for _, a := range cfg.Actors {
+		created, err := upsertActor(client, s.adminApiUrl, a)
+		if err != nil {
+			return err
+		}
+		if created {
+			logger.Info("actor created", "external_id", a.ExternalId, "namespace", a.Namespace)
+		} else {
+			logger.Info("actor already present", "external_id", a.ExternalId, "namespace", a.Namespace)
+		}
+	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	if err := run(logger); err != nil {
+		logger.Error("seed failed", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("seed complete")
+}

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -99,6 +99,29 @@ A Helm pre-install hook Job that generates the keypair Secrets is a
 reasonable follow-up — would unify the operator UX with the
 auto-generated random material above. Tracked separately.
 
+## Demo actors (seeded on every install/upgrade)
+
+A `post-install` + `post-upgrade` Helm hook Job runs the
+`authproxy-demo-seed` image, which calls the AuthProxy admin API to
+create the three demo identities the shell expects:
+
+| External ID  | Role     | Notes                                            |
+|--------------|----------|--------------------------------------------------|
+| `demo-admin` | admin    | Lands in the admin UI                            |
+| `demo-user`  | user     | Lands in the marketplace                         |
+| `fresh-user` | user     | Lands in the marketplace with no connections     |
+
+Idempotent: the seed binary GETs each actor by external_id and skips
+creation when AuthProxy returns 200. Re-running `helm upgrade` is a
+no-op once the state matches. Toggle off with `--set seed.enabled=false`
+or extend via `seed.actors[*]` to seed customer-specific identities
+alongside the defaults.
+
+> **Currently NOT seeded:** per-actor pre-existing connections + the
+> demo connector itself. The connector pattern needs a dedicated
+> connector-management admin API surface that isn't fully there yet;
+> tracked as a follow-up to A11.
+
 ## Sub-path routing
 
 The umbrella Ingress maps host paths to backend services:

--- a/deploy/charts/authproxy-demo/ci/all-disabled-values.yaml
+++ b/deploy/charts/authproxy-demo/ci/all-disabled-values.yaml
@@ -25,6 +25,9 @@ ingress:
 secrets:
   autoGenerate: false
 
+seed:
+  enabled: false
+
 authproxy:
   enabled: false
 

--- a/deploy/charts/authproxy-demo/templates/seed-job.yaml
+++ b/deploy/charts/authproxy-demo/templates/seed-job.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.seed.enabled }}
+# Post-install / post-upgrade hook Job that seeds the demo actors.
+#
+# Idempotency: the demo-seed binary GETs each actor by external_id
+# and skips creation when AuthProxy returns 200, so re-running on
+# every helm upgrade is a no-op once the state matches.
+#
+# Hook ordering: seed-job runs AFTER the inner authproxy chart is up
+# (helm sequences post-install hooks after the main release applies).
+# `--wait` on `helm install/upgrade` is still required so the
+# AuthProxy pods are Ready before the Job tries to talk to the admin
+# API; the Job's own retry loop handles short startup races.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-seed" .Release.Name }}
+  labels:
+    {{- include "authproxy-demo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo-seed
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: demo-seed
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: demo-seed
+          image: "{{ .Values.seed.image.repository }}:{{ default .Chart.AppVersion .Values.seed.image.tag }}"
+          imagePullPolicy: {{ .Values.seed.image.pullPolicy }}
+          env:
+            - name: ADMIN_API_URL
+              # In-cluster talking to the AuthProxy admin-api Service.
+              value: "http://{{ include "authproxy-demo.authproxy.serviceName" . }}:{{ .Values.seed.adminApiPort }}"
+            - name: ADMIN_USERNAME
+              value: "demo-shell"
+            - name: ADMIN_PRIVATE_KEY_PATH
+              value: "/etc/authproxy/demo-shell/private"
+            - name: SEED_CONFIG_PATH
+              value: "/etc/authproxy/seed/seed.yaml"
+          volumeMounts:
+            - name: admin-key
+              mountPath: /etc/authproxy/demo-shell
+              readOnly: true
+            - name: seed-config
+              mountPath: /etc/authproxy/seed
+              readOnly: true
+          resources:
+            {{- toYaml .Values.seed.resources | nindent 12 }}
+      volumes:
+        - name: admin-key
+          secret:
+            secretName: {{ printf "%s-demo-shell-key" .Release.Name | quote }}
+            items:
+              - key: private
+                path: private
+        - name: seed-config
+          configMap:
+            name: {{ printf "%s-seed-config" .Release.Name | quote }}
+---
+# ConfigMap with the actor list the Job reads. Rendered from
+# `.Values.seed.actors` so customers can extend or override it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-seed-config" .Release.Name }}
+  labels:
+    {{- include "authproxy-demo.labels" . | nindent 4 }}
+  annotations:
+    # Apply the ConfigMap BEFORE the Job hook runs.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation
+data:
+  seed.yaml: |
+    actors:
+{{- range .Values.seed.actors }}
+      - external_id: {{ .external_id | quote }}
+{{-   with .namespace }}
+        namespace: {{ . | quote }}
+{{-   end }}
+{{-   with .labels }}
+        labels:
+{{-     range $k, $v := . }}
+          {{ $k }}: {{ $v | quote }}
+{{-     end }}
+{{-   end }}
+{{-   with .annotations }}
+        annotations:
+{{-     range $k, $v := . }}
+          {{ $k }}: {{ $v | quote }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -50,6 +50,30 @@
       "properties": {
         "autoGenerate": { "type": "boolean" }
       }
+    },
+    "seed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":      { "type": "boolean" },
+        "image":        { "type": "object" },
+        "resources":    { "type": "object" },
+        "adminApiPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "actors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "external_id": { "type": "string", "minLength": 1 },
+              "namespace":   { "type": "string" },
+              "labels":      { "type": "object", "additionalProperties": { "type": "string" } },
+              "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "required": ["external_id"]
+          }
+        }
+      }
     }
   }
 }

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -61,11 +61,48 @@ ingress:
   tls: true
 
 secrets:
-  # -- When true, the chart auto-generates JWT signing keys + global AES
-  # key + demo-shell admin keypair the first time it's installed.
-  # Subsequent upgrades reuse the existing Secrets (via the `lookup`
-  # template helper) so sessions don't invalidate.
+  # -- When true, the chart auto-generates DB / Redis / MinIO passwords
+  # on first install via sprig random helpers. Subsequent upgrades
+  # reuse the existing Secrets (via the `lookup` template helper) so
+  # sessions don't invalidate. Keypair Secrets (JWT signing, demo-shell
+  # admin) need real openssl and must be operator-provided — see README.
   autoGenerate: true
+
+seed:
+  # -- When true, install a post-install/post-upgrade hook Job that
+  # creates the demo actors via the AuthProxy admin API. Idempotent —
+  # safe to leave on for every `helm upgrade`.
+  enabled: true
+  image:
+    repository: ghcr.io/rmorlok/authproxy-demo-seed
+    tag: ""               # falls back to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+  # -- Admin-api port to target. Matches the inner authproxy chart's
+  # default service port for the `adminApi` service.
+  adminApiPort: 8082
+  # -- Actors to seed. Each entry is the schema the demo-seed binary
+  # consumes — `external_id` is the only required field. Add or
+  # override via `--set` / values overlay to seed customer-specific
+  # actors alongside the defaults.
+  actors:
+    - external_id: demo-admin
+      labels:
+        demo: "true"
+        role: admin
+    - external_id: demo-user
+      labels:
+        demo: "true"
+        role: user
+    - external_id: fresh-user
+      labels:
+        demo: "true"
+        role: user
 
 # ---------------------------------------------------------------------------
 # Subchart passthroughs — see each upstream's values.yaml for the full


### PR DESCRIPTION
## Summary

Three pieces:

1. **`demos/seed/backend/`** — Go binary that reads a YAML actor list and idempotently creates each via the AuthProxy admin API. Authenticates as the demo-shell admin actor with the existing keypair. For each: GET by external_id first; POST only on 404. Re-running is a no-op.
2. **`demos/seed/Dockerfile`** + matrix entry in `build-image.yml` — single Go stage, statically linked, no UI. Ships as `ghcr.io/<owner>/authproxy-demo-seed`.
3. **`deploy/charts/authproxy-demo/templates/seed-job.yaml`** — post-install + post-upgrade Helm hook Job (`hook-weight: "20"` so it runs after main release applies). Mounts the demo-shell admin keypair, reads the actor list from a sibling ConfigMap (`hook-weight: "10"`). Extension point is `seed.actors` in values.yaml.

Closes #300 for the actor-seeding side. The pre-existing connection for `demo-user` and the demo connector itself need a connector-management admin API surface that isn't fully there yet — flagged in the chart README as a follow-up.

## Test plan
- [x] `go build ./demos/seed/backend/...` clean.
- [x] YAML / JSON validation for all chart files.
- [x] `./scripts/preflight.sh` clean.
- [ ] CI: helm chart lint passes; demo-seed image builds.
- [ ] **Post-merge manual**: install the umbrella against the cluster, verify the three actors land in AuthProxy's actors table, demo-shell mints sessions for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)