### PR TITLE
Add app metrics resource sample storage

### DIFF
--- a/internal/app_metrics/migrations/clickhouse/000004_create_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/clickhouse/000004_create_resource_samples.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS app_metrics_actor_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connection_resource_samples;

--- a/internal/app_metrics/migrations/clickhouse/000004_create_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/clickhouse/000004_create_resource_samples.up.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connection_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'connection',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    state String,
+    health_state String,
+    connector_id String,
+    connector_version UInt64 DEFAULT 0,
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id);
+
+CREATE TABLE IF NOT EXISTS app_metrics_actor_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'actor',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    external_id String DEFAULT '',
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id);

--- a/internal/app_metrics/migrations/postgres/000004_create_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/postgres/000004_create_resource_samples.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS app_metrics_actor_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connection_resource_samples;

--- a/internal/app_metrics/migrations/postgres/000004_create_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/postgres/000004_create_resource_samples.up.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connection_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connection',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    health_state TEXT NOT NULL,
+    connector_id TEXT NOT NULL,
+    connector_version BIGINT NOT NULL DEFAULT 0,
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_namespace ON app_metrics_connection_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_sampled_at ON app_metrics_connection_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_connector ON app_metrics_connection_resource_samples (connector_id, connector_version);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_state ON app_metrics_connection_resource_samples (state, health_state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_actor_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'actor',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    external_id TEXT NOT NULL DEFAULT '',
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_namespace ON app_metrics_actor_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_sampled_at ON app_metrics_actor_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_external_id ON app_metrics_actor_resource_samples (external_id);

--- a/internal/app_metrics/migrations/sqlite/000004_create_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/sqlite/000004_create_resource_samples.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS app_metrics_actor_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connection_resource_samples;

--- a/internal/app_metrics/migrations/sqlite/000004_create_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/sqlite/000004_create_resource_samples.up.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connection_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connection',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    health_state TEXT NOT NULL,
+    connector_id TEXT NOT NULL,
+    connector_version INTEGER NOT NULL DEFAULT 0,
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_namespace ON app_metrics_connection_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_sampled_at ON app_metrics_connection_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_connector ON app_metrics_connection_resource_samples (connector_id, connector_version);
+CREATE INDEX IF NOT EXISTS idx_connection_resource_samples_state ON app_metrics_connection_resource_samples (state, health_state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_actor_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'actor',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    external_id TEXT NOT NULL DEFAULT '',
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_namespace ON app_metrics_actor_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_sampled_at ON app_metrics_actor_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_actor_resource_samples_external_id ON app_metrics_actor_resource_samples (external_id);

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -15,6 +15,12 @@ type RecordStore interface {
 	StoreRecords(ctx context.Context, records []*LogRecord) error
 }
 
+// ResourceSampleStore persists point-in-time resource samples for app metrics.
+type ResourceSampleStore interface {
+	StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error
+	StoreActorResourceSamples(ctx context.Context, samples []*ActorResourceSample) error
+}
+
 type migratable interface {
 	// Migrate runs any necessary schema migrations for the storage backend.
 	Migrate(ctx context.Context) error
@@ -38,4 +44,10 @@ type RecordRetriever interface {
 
 	// QueryRequestEventMetrics executes time-series metric queries over request events.
 	QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error)
+}
+
+// ResourceSampleRetriever queries point-in-time resource samples for app metrics.
+type ResourceSampleRetriever interface {
+	ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error)
+	ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error)
 }

--- a/internal/app_metrics/provider_resource_samples_test.go
+++ b/internal/app_metrics/provider_resource_samples_test.go
@@ -1,0 +1,153 @@
+package app_metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceSamples_ConnectionSamples_IdempotentAndQueryable(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+	resourceRetriever := retriever.(ResourceSampleRetriever)
+
+	ctx := context.Background()
+	sampledAt := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	connID := apid.New(apid.PrefixConnection)
+	otherConnID := apid.New(apid.PrefixConnection)
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	createdAt := sampledAt.Add(-time.Hour)
+	updatedAt := sampledAt.Add(-time.Minute)
+
+	err := resourceStore.StoreConnectionResourceSamples(ctx, []*ConnectionResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        connID,
+			Namespace:         "root.acme.prod",
+			Labels:            database.Labels{"env": "prod", "tier": "silver"},
+			State:             database.ConnectionStateSetup,
+			HealthState:       database.ConnectionHealthStateHealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  1,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        otherConnID,
+			Namespace:         "root.other",
+			Labels:            database.Labels{"env": "prod", "tier": "gold"},
+			State:             database.ConnectionStateConfigured,
+			HealthState:       database.ConnectionHealthStateHealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  1,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	})
+	require.NoError(t, err)
+
+	err = resourceStore.StoreConnectionResourceSamples(ctx, []*ConnectionResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        connID,
+			Namespace:         "root.acme.prod",
+			Labels:            database.Labels{"env": "prod", "tier": "gold"},
+			State:             database.ConnectionStateConfigured,
+			HealthState:       database.ConnectionHealthStateUnhealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  2,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: sampledAt,
+		},
+	})
+	require.NoError(t, err)
+
+	start := sampledAt.Add(-time.Minute)
+	end := sampledAt.Add(time.Minute)
+	samples, err := resourceRetriever.ListConnectionResourceSamples(ctx, ResourceSampleQuery{
+		Start:             &start,
+		End:               &end,
+		NamespaceMatchers: []string{"root.acme.**"},
+		LabelSelector:     "tier=gold",
+	})
+	require.NoError(t, err)
+	require.Len(t, samples, 1)
+
+	got := samples[0]
+	require.Equal(t, ResourceTypeConnection, got.ResourceType)
+	require.Equal(t, connID, got.ResourceID)
+	require.Equal(t, "root.acme.prod", got.Namespace)
+	require.Equal(t, database.Labels{"env": "prod", "tier": "gold"}, got.Labels)
+	require.Equal(t, database.ConnectionStateConfigured, got.State)
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, got.HealthState)
+	require.Equal(t, connectorID, got.ConnectorID)
+	require.Equal(t, uint64(2), got.ConnectorVersion)
+	require.True(t, sampledAt.Equal(got.SampledAt))
+	require.True(t, createdAt.Equal(got.ResourceCreatedAt))
+	require.True(t, sampledAt.Equal(got.ResourceUpdatedAt))
+	require.Nil(t, got.ResourceDeletedAt)
+}
+
+func TestResourceSamples_ActorSamples_IdempotentAndQueryable(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+	resourceRetriever := retriever.(ResourceSampleRetriever)
+
+	ctx := context.Background()
+	sampledAt := time.Date(2026, 5, 25, 12, 15, 0, 0, time.UTC)
+	actorID := apid.New(apid.PrefixActor)
+	createdAt := sampledAt.Add(-2 * time.Hour)
+	updatedAt := sampledAt.Add(-time.Minute)
+	deletedAt := sampledAt.Add(time.Minute)
+
+	err := resourceStore.StoreActorResourceSamples(ctx, []*ActorResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        actorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"team": "ops"},
+			ExternalID:        "actor-1",
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	})
+	require.NoError(t, err)
+
+	err = resourceStore.StoreActorResourceSamples(ctx, []*ActorResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        actorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"team": "ops", "status": "deleted"},
+			ExternalID:        "actor-1-renamed",
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: sampledAt,
+			ResourceDeletedAt: &deletedAt,
+		},
+	})
+	require.NoError(t, err)
+
+	samples, err := resourceRetriever.ListActorResourceSamples(ctx, ResourceSampleQuery{
+		ResourceIDs:   []apid.ID{actorID},
+		LabelSelector: "status=deleted",
+	})
+	require.NoError(t, err)
+	require.Len(t, samples, 1)
+
+	got := samples[0]
+	require.Equal(t, ResourceTypeActor, got.ResourceType)
+	require.Equal(t, actorID, got.ResourceID)
+	require.Equal(t, "root.acme", got.Namespace)
+	require.Equal(t, database.Labels{"team": "ops", "status": "deleted"}, got.Labels)
+	require.Equal(t, "actor-1-renamed", got.ExternalID)
+	require.True(t, sampledAt.Equal(got.SampledAt))
+	require.True(t, createdAt.Equal(got.ResourceCreatedAt))
+	require.True(t, sampledAt.Equal(got.ResourceUpdatedAt))
+	require.NotNil(t, got.ResourceDeletedAt)
+	require.True(t, deletedAt.Equal(*got.ResourceDeletedAt))
+}

--- a/internal/app_metrics/provider_resources.go
+++ b/internal/app_metrics/provider_resources.go
@@ -1,0 +1,497 @@
+package app_metrics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+var connectionResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"state",
+	"health_state",
+	"connector_id",
+	"connector_version",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
+var actorResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"external_id",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
+func (s *sqlRecordStore) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(connectionResourceSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, connectionResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnection),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			string(sample.HealthState),
+			sample.ConnectorID.String(),
+			sample.ConnectorVersion,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		state = excluded.state,
+		health_state = excluded.health_state,
+		connector_id = excluded.connector_id,
+		connector_version = excluded.connector_version,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build connection resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert connection resource samples: %w", err)
+	}
+	return nil
+}
+
+func (s *sqlRecordStore) StoreActorResourceSamples(ctx context.Context, samples []*ActorResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(actorResourceSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, actorResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeActor),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			sample.ExternalID,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		external_id = excluded.external_id,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build actor resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert actor resource samples: %w", err)
+	}
+	return nil
+}
+
+func (s *clickhouseRecordStore) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		connectionResourceSamplesTable,
+		strings.Join(connectionResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnection),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			string(sample.HealthState),
+			sample.ConnectorID.String(),
+			sample.ConnectorVersion,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse connection resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *clickhouseRecordStore) StoreActorResourceSamples(ctx context.Context, samples []*ActorResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		actorResourceSamplesTable,
+		strings.Join(actorResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeActor),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			sample.ExternalID,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse actor resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *sqlRecordRetriever) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
+	return fetchConnectionResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *sqlRecordRetriever) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
+	return fetchActorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *clickhouseRecordRetriever) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
+	return fetchConnectionResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func (r *clickhouseRecordRetriever) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
+	return fetchActorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func fetchConnectionResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*ConnectionResourceSample, error) {
+	builder := sq.Select(connectionResourceSampleColumns...).
+		From(resourceSampleTableName(connectionResourceSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*ConnectionResourceSample
+	for rows.Next() {
+		sample, err := scanConnectionResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func fetchActorResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*ActorResourceSample, error) {
+	builder := sq.Select(actorResourceSampleColumns...).
+		From(resourceSampleTableName(actorResourceSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*ActorResourceSample
+	for rows.Next() {
+		sample, err := scanActorResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func applyResourceSampleQuery(builder sq.SelectBuilder, provider config.DatabaseProvider, query ResourceSampleQuery) (sq.SelectBuilder, error) {
+	if query.Start != nil {
+		builder = builder.Where(sq.GtOrEq{"sampled_at_ms": query.Start.UnixMilli()})
+	}
+	if query.End != nil {
+		builder = builder.Where(sq.LtOrEq{"sampled_at_ms": query.End.UnixMilli()})
+	}
+	if len(query.ResourceIDs) > 0 {
+		ids := make([]string, 0, len(query.ResourceIDs))
+		for _, id := range query.ResourceIDs {
+			ids = append(ids, id.String())
+		}
+		builder = builder.Where(sq.Eq{"resource_id": ids})
+	}
+	if len(query.NamespaceMatchers) > 0 {
+		for _, matcher := range query.NamespaceMatchers {
+			if err := aschema.ValidateNamespaceMatcher(matcher); err != nil {
+				return builder, err
+			}
+		}
+		builder = builder.Where(namespaceMatcherExpr(query.NamespaceMatchers))
+	}
+	if query.LabelSelector != "" {
+		selector, err := database.ParseLabelSelector(query.LabelSelector)
+		if err != nil {
+			return builder, err
+		}
+		if len(selector) > 0 {
+			builder = selector.ApplyToSqlBuilderWithProvider(builder, "labels", provider)
+		}
+	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+	}
+	return builder, nil
+}
+
+func queryResourceSamples(ctx context.Context, db *sql.DB, builder sq.SelectBuilder) (*sql.Rows, error) {
+	sqlQuery, args, err := builder.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build resource sample query: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query resource samples: %w", err)
+	}
+	return rows, nil
+}
+
+func scanConnectionResourceSample(row interface{ Scan(dest ...any) error }) (*ConnectionResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	var resourceID, connectorID string
+	sample := &ConnectionResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&resourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.State,
+		&sample.HealthState,
+		&connectorID,
+		&sample.ConnectorVersion,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan connection resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceID = apid.ID(resourceID)
+	sample.ConnectorID = apid.ID(connectorID)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func scanActorResourceSample(row interface{ Scan(dest ...any) error }) (*ActorResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	var resourceID string
+	sample := &ActorResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&resourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.ExternalID,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan actor resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceID = apid.ID(resourceID)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func labelsValue(labels database.Labels) (any, error) {
+	labelsVal, err := labels.Value()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource sample labels: %w", err)
+	}
+	if labelsVal == nil {
+		return "{}", nil
+	}
+	return labelsVal, nil
+}
+
+func defaultResourceType(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func nullableUnixMillis(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.UnixMilli()
+}
+
+func nullableTime(ms sql.NullInt64) *time.Time {
+	if !ms.Valid {
+		return nil
+	}
+	t := unixMillis(ms.Int64)
+	return &t
+}
+
+func unixMillis(ms int64) time.Time {
+	return time.Unix(0, ms*int64(time.Millisecond)).In(time.UTC)
+}
+
+func resourceSampleTableName(table string, provider config.DatabaseProvider) string {
+	if provider == config.DatabaseProviderClickhouse {
+		return table + " FINAL"
+	}
+	return table
+}
+
+func namespaceMatcherExpr(matchers []string) sq.Sqlizer {
+	or := sq.Or{}
+	for _, matcher := range matchers {
+		if strings.HasSuffix(matcher, ".**") {
+			coreNamespace := matcher[:len(matcher)-3]
+			or = append(or,
+				sq.Eq{"namespace": coreNamespace},
+				sq.Like{"namespace": coreNamespace + ".%"},
+			)
+		} else {
+			or = append(or, sq.Eq{"namespace": matcher})
+		}
+	}
+	return or
+}
+
+var _ ResourceSampleStore = (*sqlRecordStore)(nil)
+var _ ResourceSampleStore = (*clickhouseRecordStore)(nil)
+var _ ResourceSampleRetriever = (*sqlRecordRetriever)(nil)
+var _ ResourceSampleRetriever = (*clickhouseRecordRetriever)(nil)

--- a/internal/app_metrics/resource_samples.go
+++ b/internal/app_metrics/resource_samples.go
@@ -1,0 +1,58 @@
+package app_metrics
+
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+const (
+	connectionResourceSamplesTable = "app_metrics_connection_resource_samples"
+	actorResourceSamplesTable      = "app_metrics_actor_resource_samples"
+
+	ResourceTypeConnection = "connection"
+	ResourceTypeActor      = "actor"
+)
+
+// ResourceSampleQuery filters point-in-time resource samples.
+type ResourceSampleQuery struct {
+	Start             *time.Time
+	End               *time.Time
+	ResourceIDs       []apid.ID
+	NamespaceMatchers []string
+	LabelSelector     string
+	Limit             int
+}
+
+// ConnectionResourceSample is a point-in-time snapshot of a connection for
+// resource metrics. Samples are keyed by SampledAt + ResourceID so rerunning a
+// snapshot bucket is idempotent.
+type ConnectionResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        apid.ID
+	Namespace         string
+	Labels            database.Labels
+	State             database.ConnectionState
+	HealthState       database.ConnectionHealthState
+	ConnectorID       apid.ID
+	ConnectorVersion  uint64
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}
+
+// ActorResourceSample is a point-in-time snapshot of an actor for resource
+// metrics.
+type ActorResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        apid.ID
+	Namespace         string
+	Labels            database.Labels
+	ExternalID        string
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -53,6 +53,22 @@ func (ss *StorageService) QueryRequestEventMetrics(ctx context.Context, queries 
 	return ss.retriever.QueryRequestEventMetrics(ctx, queries)
 }
 
+func (ss *StorageService) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreConnectionResourceSamples(ctx, samples)
+}
+
+func (ss *StorageService) StoreActorResourceSamples(ctx context.Context, samples []*ActorResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreActorResourceSamples(ctx, samples)
+}
+
+func (ss *StorageService) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListConnectionResourceSamples(ctx, query)
+}
+
+func (ss *StorageService) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListActorResourceSamples(ctx, query)
+}
+
 func (ss *StorageService) GetFullLog(ctx context.Context, id apid.ID) (*FullLog, error) {
 	log, err := ss.GetRecord(ctx, id)
 	if err != nil {


### PR DESCRIPTION
Closes #404

## Summary
- Add app metrics resource sample tables for connection and actor snapshots across SQLite, Postgres, and ClickHouse migrations.
- Add resource sample DTOs plus provider store/retriever methods with idempotent SQL upserts and ClickHouse ReplacingMergeTree-backed reads.
- Add StorageService wrappers and tests for idempotent connection/actor samples, namespace filtering, label selectors, lifecycle fields, and resource dimensions.

## Tests
- go test ./internal/app_metrics
- env AUTH_PROXY_REQUEST_LOG_TEST_DATABASE_PROVIDER=postgres go test ./internal/app_metrics
- ./scripts/preflight.sh

ClickHouse note: attempted env AUTH_PROXY_REQUEST_LOG_TEST_DATABASE_PROVIDER=clickhouse go test ./internal/app_metrics, but the local ClickHouse server at localhost:8123 rejected the default credentials with HTTP 401, so I could not complete the ClickHouse runtime test locally.