### PR TITLE
deploy-demo: tolerate first-install (no prior helm history)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -112,8 +112,15 @@ jobs:
         run: |
           set -euo pipefail
           # Pre-existing revision, or empty when this is the first install.
-          rev=$(helm history "${RELEASE_NAME}" -n "${RELEASE_NS}" -o json 2>/dev/null \
-                | jq -r '[.[] | select(.status=="deployed")] | last | .revision // empty')
+          # `helm history` exits non-zero when the release doesn't exist —
+          # with pipefail that aborts the whole step, so detect the
+          # missing-release case via `helm status` first.
+          if helm status "${RELEASE_NAME}" -n "${RELEASE_NS}" >/dev/null 2>&1; then
+            rev=$(helm history "${RELEASE_NAME}" -n "${RELEASE_NS}" -o json \
+                  | jq -r '[.[] | select(.status=="deployed")] | last | .revision // empty')
+          else
+            rev=""
+          fi
           echo "previous_revision=${rev}" >> "$GITHUB_OUTPUT"
           echo "Previous deployed revision: ${rev:-<none>}"
 


### PR DESCRIPTION
## Summary
The first dispatch of the Deploy Demo workflow against a fresh cluster failed at the **Capture pre-deploy revision** step:

```
rev=$(helm history "$RELEASE" -n "$RELEASE_NS" -o json 2>/dev/null | jq ...)
```

On an empty cluster the release doesn't exist; `helm history` exits 1 with "release: not found". `2>/dev/null` suppresses stderr but the non-zero exit still propagates through the pipe; combined with `set -euo pipefail` it aborts the step before any meaningful revision can be recorded.

Fix: probe with `helm status` first (which is the canonical "does this release exist" check). When it succeeds, run history; otherwise leave `rev=""` so the rollback step's `steps.pre.outputs.previous_revision != ''` guard skips on first install.

## Test plan
- [x] YAML valid.
- [ ] **Post-merge**: re-run `gh workflow run "Deploy Demo"`. First-install flow should now reach the helm-upgrade step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)