### PR TITLE
deploy-demo: drop unused global.acmeEmail --set

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -26,7 +26,6 @@ name: Deploy Demo
 #       AWS_REGION    : e.g. us-east-1
 #       EKS_CLUSTER   : e.g. authproxy-eks
 #       DEMO_HOSTNAME : e.g. demo.authproxy.net
-#       ACME_EMAIL    : LE registration email
 
 on:
   push:
@@ -132,7 +131,6 @@ jobs:
             --namespace "${RELEASE_NS}" --create-namespace \
             --wait --timeout 10m \
             --set "global.hostname=${{ vars.DEMO_HOSTNAME }}" \
-            --set "global.acmeEmail=${{ vars.ACME_EMAIL }}" \
             --set "authproxy.image.tag=${{ steps.tag.outputs.tag }}" \
             --set "demoShell.image.tag=${{ steps.tag.outputs.tag }}" \
             --set "seed.image.tag=${{ steps.tag.outputs.tag }}"

--- a/deploy/docs/runbook.md
+++ b/deploy/docs/runbook.md
@@ -183,7 +183,10 @@ image tag pinned to that commit's `sha-<short>`. One-time setup:
    | `AWS_REGION`    | `us-east-1`      |
    | `EKS_CLUSTER`   | `authproxy-eks`  |
    | `DEMO_HOSTNAME` | `demo.authproxy.net` |
-   | `ACME_EMAIL`    | `you@example.com`|
+
+   (The Let's Encrypt email is configured on the bootstrap chart's
+   ClusterIssuer at install time — see Section 1.8 — and isn't
+   re-passed per deploy.)
 
    `AWS_ROLE_ARN` should already be set as a Secret from Section 1.6.
 


### PR DESCRIPTION
## Summary
Post-merge of the first-install fix, the next Deploy Demo run hit:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
authproxy-demo:
  - global: Additional property acmeEmail is not allowed
```

The umbrella's `values.schema.json` declares `global` with `additionalProperties: false` and only allows `hostname`, `clusterIssuer`, `ingressClassName`. The workflow was setting `global.acmeEmail` — a leftover from when I expected the umbrella to render its own ClusterIssuer. It doesn't: the LE-prod issuer lives in the bootstrap chart from A8, and the email is already baked into it at install time.

Drop the `--set` and the `ACME_EMAIL` repo variable from both the workflow and the runbook section.

## Test plan
- [x] YAML valid.
- [ ] **Post-merge**: re-run `Deploy Demo`. helm upgrade should now reach the rollout-wait step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)