### PR TITLE
Add app metrics resource snapshot worker

### DIFF
--- a/internal/app_metrics/task_resource_snapshot.go
+++ b/internal/app_metrics/task_resource_snapshot.go
@@ -1,0 +1,183 @@
+package app_metrics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+const (
+	taskTypeResourceSnapshot  = "app_metrics:resource_snapshot"
+	resourceSnapshotBatchSize = 1000
+)
+
+// ResourceSnapshotTaskHandler snapshots live resources into app_metrics storage.
+type ResourceSnapshotTaskHandler struct {
+	db     database.DB
+	store  ResourceSampleStore
+	cfg    *sconfig.AppMetrics
+	logger *slog.Logger
+}
+
+func NewResourceSnapshotTaskHandler(
+	db database.DB,
+	store ResourceSampleStore,
+	cfg *sconfig.AppMetrics,
+	logger *slog.Logger,
+) *ResourceSnapshotTaskHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &ResourceSnapshotTaskHandler{
+		db:     db,
+		store:  store,
+		cfg:    cfg,
+		logger: logger.With("component", "app_metrics_resource_snapshot"),
+	}
+}
+
+func NewResourceSnapshotTask() *asynq.Task {
+	return asynq.NewTask(taskTypeResourceSnapshot, nil)
+}
+
+func (h *ResourceSnapshotTaskHandler) RegisterTasks(mux *asynq.ServeMux) {
+	mux.HandleFunc(taskTypeResourceSnapshot, h.runResourceSnapshotTask)
+}
+
+func (h *ResourceSnapshotTaskHandler) GetCronTasks() []*asynq.PeriodicTaskConfig {
+	if h == nil || h.cfg == nil || h.cfg.Database == nil {
+		return nil
+	}
+
+	interval := h.cfg.GetResourceSnapshotInterval()
+	if interval <= 0 {
+		interval = (&sconfig.AppMetrics{}).GetResourceSnapshotInterval()
+	}
+
+	return []*asynq.PeriodicTaskConfig{{
+		Cronspec: fmt.Sprintf("@every %s", interval),
+		Task:     NewResourceSnapshotTask(),
+	}}
+}
+
+func (h *ResourceSnapshotTaskHandler) runResourceSnapshotTask(ctx context.Context, _ *asynq.Task) error {
+	now := apctx.GetClock(ctx).Now()
+	return h.SnapshotResources(ctx, now)
+}
+
+func (h *ResourceSnapshotTaskHandler) SnapshotResources(ctx context.Context, at time.Time) error {
+	if h == nil {
+		return fmt.Errorf("resource snapshot task handler is nil")
+	}
+	if h.db == nil {
+		return fmt.Errorf("resource snapshot database is required")
+	}
+	if h.store == nil {
+		return fmt.Errorf("resource snapshot store is required")
+	}
+
+	interval := h.cfg.GetResourceSnapshotInterval()
+	if interval <= 0 {
+		interval = (&sconfig.AppMetrics{}).GetResourceSnapshotInterval()
+	}
+	sampledAt := at.UTC().Truncate(interval)
+
+	start := time.Now()
+	logger := h.logger.With("sampled_at", sampledAt, "interval", interval)
+	logger.Info("starting app metrics resource snapshot")
+
+	connectionCount, err := h.snapshotConnections(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot connection resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
+	actorCount, err := h.snapshotActors(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot actor resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
+	logger.Info(
+		"completed app metrics resource snapshot",
+		"connections", connectionCount,
+		"actors", actorCount,
+		"duration", time.Since(start),
+	)
+	return nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotConnections(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListConnectionsBuilder().
+		WithDeletedHandling(database.DeletedHandlingExclude).
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[database.Connection]) (pagination.KeepGoing, error) {
+			samples := make([]*ConnectionResourceSample, 0, len(page.Results))
+			for _, conn := range page.Results {
+				conn := conn
+				samples = append(samples, &ConnectionResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeConnection,
+					ResourceID:        conn.Id,
+					Namespace:         conn.Namespace,
+					Labels:            conn.Labels,
+					State:             conn.State,
+					HealthState:       conn.HealthState,
+					ConnectorID:       conn.ConnectorId,
+					ConnectorVersion:  conn.ConnectorVersion,
+					ResourceCreatedAt: conn.CreatedAt,
+					ResourceUpdatedAt: conn.UpdatedAt,
+					ResourceDeletedAt: conn.DeletedAt,
+				})
+			}
+			if err := h.store.StoreConnectionResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate connection resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotActors(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListActorsBuilder().
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[*database.Actor]) (pagination.KeepGoing, error) {
+			samples := make([]*ActorResourceSample, 0, len(page.Results))
+			for _, actor := range page.Results {
+				samples = append(samples, &ActorResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeActor,
+					ResourceID:        actor.Id,
+					Namespace:         actor.Namespace,
+					Labels:            actor.Labels,
+					ExternalID:        actor.ExternalId,
+					ResourceCreatedAt: actor.CreatedAt,
+					ResourceUpdatedAt: actor.UpdatedAt,
+					ResourceDeletedAt: actor.DeletedAt,
+				})
+			}
+			if err := h.store.StoreActorResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate actor resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}

--- a/internal/app_metrics/task_resource_snapshot_test.go
+++ b/internal/app_metrics/task_resource_snapshot_test.go
@@ -1,0 +1,184 @@
+package app_metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	clock "k8s.io/utils/clock/testing"
+)
+
+func TestResourceSnapshotTask_CreatesSamplesAndIsIdempotent(t *testing.T) {
+	ctx, mainDB, store, retriever, handler := newResourceSnapshotTestHarness(t)
+	now := time.Date(2026, time.May, 29, 12, 7, 0, 0, time.UTC)
+	sampledAt := time.Date(2026, time.May, 29, 12, 0, 0, 0, time.UTC)
+	ctx = apctx.NewBuilder(ctx).WithClock(clock.NewFakeClock(now)).Build()
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, mainDB.CreateActor(ctx, &database.Actor{
+		Id:         actorID,
+		Namespace:  "root.metrics",
+		ExternalId: "user-123",
+		Labels:     database.Labels{"team": "platform"},
+	}))
+
+	connID := apid.New(apid.PrefixConnection)
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	require.NoError(t, mainDB.CreateConnection(ctx, &database.Connection{
+		Id:               connID,
+		Namespace:        "root.metrics",
+		ConnectorId:      connectorID,
+		ConnectorVersion: 2,
+		State:            database.ConnectionStateConfigured,
+		HealthState:      database.ConnectionHealthStateUnhealthy,
+		Labels:           database.Labels{"connector": "crm"},
+	}))
+
+	require.NoError(t, handler.runResourceSnapshotTask(ctx, asynq.NewTask(taskTypeResourceSnapshot, nil)))
+	require.NoError(t, handler.SnapshotResources(ctx, now))
+
+	connectionSamples := listConnectionSamples(t, retriever, ctx, sampledAt)
+	require.Len(t, connectionSamples, 1)
+	require.Equal(t, connID, connectionSamples[0].ResourceID)
+	require.Equal(t, sampledAt, connectionSamples[0].SampledAt)
+	require.Equal(t, "root.metrics", connectionSamples[0].Namespace)
+	require.Equal(t, database.ConnectionStateConfigured, connectionSamples[0].State)
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, connectionSamples[0].HealthState)
+	require.Equal(t, connectorID, connectionSamples[0].ConnectorID)
+	require.Equal(t, uint64(2), connectionSamples[0].ConnectorVersion)
+	require.Equal(t, "crm", connectionSamples[0].Labels["connector"])
+
+	actorSamples := listActorSamples(t, retriever, ctx, sampledAt)
+	require.Len(t, actorSamples, 1)
+	require.Equal(t, actorID, actorSamples[0].ResourceID)
+	require.Equal(t, sampledAt, actorSamples[0].SampledAt)
+	require.Equal(t, "root.metrics", actorSamples[0].Namespace)
+	require.Equal(t, "user-123", actorSamples[0].ExternalID)
+	require.Equal(t, "platform", actorSamples[0].Labels["team"])
+
+	require.NoError(t, store.StoreActorResourceSamples(ctx, nil), "empty stores remain no-ops")
+}
+
+func TestResourceSnapshotTask_DeletedResourcesDoNotAppearInLaterSlices(t *testing.T) {
+	ctx, mainDB, _, retriever, handler := newResourceSnapshotTestHarness(t)
+	firstClock := clock.NewFakeClock(time.Date(2026, time.May, 29, 12, 7, 0, 0, time.UTC))
+	ctx = apctx.NewBuilder(ctx).WithClock(firstClock).Build()
+	firstSampledAt := time.Date(2026, time.May, 29, 12, 0, 0, 0, time.UTC)
+	secondSampledAt := time.Date(2026, time.May, 29, 12, 15, 0, 0, time.UTC)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, mainDB.CreateActor(ctx, &database.Actor{
+		Id:         actorID,
+		Namespace:  "root.metrics",
+		ExternalId: "deleted-user",
+	}))
+
+	connID := apid.New(apid.PrefixConnection)
+	require.NoError(t, mainDB.CreateConnection(ctx, &database.Connection{
+		Id:               connID,
+		Namespace:        "root.metrics",
+		ConnectorId:      apid.New(apid.PrefixConnectorVersion),
+		ConnectorVersion: 1,
+		State:            database.ConnectionStateConfigured,
+	}))
+
+	require.NoError(t, handler.SnapshotResources(ctx, firstClock.Now()))
+
+	firstClock.SetTime(time.Date(2026, time.May, 29, 12, 16, 0, 0, time.UTC))
+	require.NoError(t, mainDB.DeleteActor(ctx, actorID))
+	require.NoError(t, mainDB.DeleteConnection(ctx, connID))
+	require.NoError(t, handler.SnapshotResources(ctx, firstClock.Now()))
+
+	firstConnectionSamples := listConnectionSamples(t, retriever, ctx, firstSampledAt)
+	require.Len(t, firstConnectionSamples, 1)
+	secondConnectionSamples := listConnectionSamples(t, retriever, ctx, secondSampledAt)
+	require.Empty(t, secondConnectionSamples)
+
+	firstActorSamples := listActorSamples(t, retriever, ctx, firstSampledAt)
+	require.Len(t, firstActorSamples, 1)
+	secondActorSamples := listActorSamples(t, retriever, ctx, secondSampledAt)
+	require.Empty(t, secondActorSamples)
+}
+
+func TestResourceSnapshotTask_CronUsesConfiguredInterval(t *testing.T) {
+	handler := NewResourceSnapshotTaskHandler(
+		nil,
+		nil,
+		&sconfig.AppMetrics{Database: &sconfig.Database{InnerVal: &sconfig.DatabaseSqlite{Path: "unused.db"}}},
+		test_utils.NewTestLogger(),
+	)
+
+	tasks := handler.GetCronTasks()
+	require.Len(t, tasks, 1)
+	require.Equal(t, "@every 15m0s", tasks[0].Cronspec)
+	require.Equal(t, taskTypeResourceSnapshot, tasks[0].Task.Type())
+
+	handler.cfg.ResourceSnapshotInterval = &sconfig.HumanDuration{Duration: 5 * time.Minute}
+	tasks = handler.GetCronTasks()
+	require.Len(t, tasks, 1)
+	require.Equal(t, "@every 5m0s", tasks[0].Cronspec)
+}
+
+func newResourceSnapshotTestHarness(t testing.TB) (
+	context.Context,
+	database.DB,
+	ResourceSampleStore,
+	ResourceSampleRetriever,
+	*ResourceSnapshotTaskHandler,
+) {
+	t.Helper()
+
+	_, mainDB := database.MustApplyBlankTestDbConfig(t, nil)
+	require.NoError(t, mainDB.EnsureNamespaceByPath(context.Background(), "root.metrics"))
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+	resourceRetriever := retriever.(ResourceSampleRetriever)
+	handler := NewResourceSnapshotTaskHandler(
+		mainDB,
+		resourceStore,
+		&sconfig.AppMetrics{
+			Database:                 &sconfig.Database{InnerVal: &sconfig.DatabaseSqlite{Path: "unused.db"}},
+			ResourceSnapshotInterval: &sconfig.HumanDuration{Duration: 15 * time.Minute},
+		},
+		test_utils.NewTestLogger(),
+	)
+
+	return context.Background(), mainDB, resourceStore, resourceRetriever, handler
+}
+
+func listConnectionSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*ConnectionResourceSample {
+	t.Helper()
+	samples, err := retriever.ListConnectionResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}
+
+func listActorSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*ActorResourceSample {
+	t.Helper()
+	samples, err := retriever.ListActorResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -15,6 +15,7 @@ import (
 	authSync "github.com/rmorlok/authproxy/internal/apauth/tasks"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/app_metrics"
 	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/config"
 	dbTasks "github.com/rmorlok/authproxy/internal/database/tasks"
@@ -167,6 +168,14 @@ func Serve(cfg config.C) {
 	)
 	dbTaskHandler.RegisterTasks(mux)
 
+	appMetricsTaskHandler := app_metrics.NewResourceSnapshotTaskHandler(
+		dm.GetDatabase(),
+		dm.GetAppMetricsService(),
+		dm.GetConfigRoot().AppMetrics,
+		logger,
+	)
+	appMetricsTaskHandler.RegisterTasks(mux)
+
 	var wg sync.WaitGroup
 
 	wg.Add(1)
@@ -191,7 +200,8 @@ func Serve(cfg config.C) {
 		addRegistrar(dm.GetCoreService()).
 		addRegistrar(adminSyncTaskHandler).
 		addRegistrar(encryptTaskHandler).
-		addRegistrar(dbTaskHandler)
+		addRegistrar(dbTaskHandler).
+		addRegistrar(appMetricsTaskHandler)
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
## Summary
- add an app metrics resource snapshot task and periodic registrar
- snapshot live connections and actors into app metrics samples on the configured cadence
- wire the task into the worker scheduler and asynq mux
- cover sample creation, deleted-resource behavior, idempotent reruns, and cadence registration

Closes #407

## Tests
- `env GOCACHE=/private/tmp/authproxy-go-cache AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=sqlite go test ./internal/app_metrics ./internal/service ./internal/service/worker`
- `./scripts/preflight.sh`

Note: `go test ./...` was attempted locally with SQLite selectors, but this sandbox blocks local listener creation and home-directory writes used by unrelated packages (httptest/miniredis/OTLP tests).