### PR TITLE
Execute resource app metrics queries

### DIFF
--- a/internal/app_metrics/interface.go
+++ b/internal/app_metrics/interface.go
@@ -14,4 +14,5 @@ type LogRetriever interface {
 	NewListRequestsBuilder() ListRequestBuilder
 	ListRequestsFromCursor(ctx context.Context, cursor string) (ListRequestExecutor, error)
 	QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error)
+	QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error)
 }

--- a/internal/app_metrics/mock/service.go
+++ b/internal/app_metrics/mock/service.go
@@ -94,3 +94,18 @@ func (mr *MockLogRetrieverMockRecorder) QueryRequestEventMetrics(ctx, queries in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRequestEventMetrics", reflect.TypeOf((*MockLogRetriever)(nil).QueryRequestEventMetrics), ctx, queries)
 }
+
+// QueryResourceMetrics mocks base method.
+func (m *MockLogRetriever) QueryResourceMetrics(ctx context.Context, queries []app_metrics.ResourceMetricsQuery) ([]app_metrics.ResourceMetricSeries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryResourceMetrics", ctx, queries)
+	ret0, _ := ret[0].([]app_metrics.ResourceMetricSeries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryResourceMetrics indicates an expected call of QueryResourceMetrics.
+func (mr *MockLogRetrieverMockRecorder) QueryResourceMetrics(ctx, queries interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryResourceMetrics", reflect.TypeOf((*MockLogRetriever)(nil).QueryResourceMetrics), ctx, queries)
+}

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -44,6 +44,9 @@ type RecordRetriever interface {
 
 	// QueryRequestEventMetrics executes time-series metric queries over request events.
 	QueryRequestEventMetrics(ctx context.Context, queries []RequestEventMetricsQuery) ([]RequestEventMetricSeries, error)
+
+	// QueryResourceMetrics executes time-series metric queries over resource samples.
+	QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error)
 }
 
 // ResourceSampleRetriever queries point-in-time resource samples for app metrics.

--- a/internal/app_metrics/provider_resource_metrics_test.go
+++ b/internal/app_metrics/provider_resource_metrics_test.go
@@ -1,0 +1,191 @@
+package app_metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceMetrics_ConnectionCountsUseStoredSamples(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+
+	ctx := context.Background()
+	start := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	connID := apid.New(apid.PrefixConnection)
+	otherConnID := apid.New(apid.PrefixConnection)
+	excludedConnID := apid.New(apid.PrefixConnection)
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+
+	err := resourceStore.StoreConnectionResourceSamples(ctx, []*ConnectionResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        connID,
+			Namespace:         "root.acme.prod",
+			Labels:            database.Labels{"env": "prod", "team": "api"},
+			State:             database.ConnectionStateConfigured,
+			HealthState:       database.ConnectionHealthStateHealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  1,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+		{
+			SampledAt:         start,
+			ResourceID:        otherConnID,
+			Namespace:         "root.acme.prod",
+			Labels:            database.Labels{"env": "prod", "team": "api"},
+			State:             database.ConnectionStateSetup,
+			HealthState:       database.ConnectionHealthStateUnhealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  2,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+		{
+			SampledAt:         start,
+			ResourceID:        excludedConnID,
+			Namespace:         "root.other",
+			Labels:            database.Labels{"env": "prod", "team": "api"},
+			State:             database.ConnectionStateConfigured,
+			HealthState:       database.ConnectionHealthStateHealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  1,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+		{
+			SampledAt:         start.Add(5 * time.Minute),
+			ResourceID:        connID,
+			Namespace:         "root.acme.prod",
+			Labels:            database.Labels{"env": "prod", "team": "api"},
+			State:             database.ConnectionStateConfigured,
+			HealthState:       database.ConnectionHealthStateHealthy,
+			ConnectorID:       connectorID,
+			ConnectorVersion:  1,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start.Add(5 * time.Minute),
+		},
+	})
+	require.NoError(t, err)
+
+	series, err := retriever.QueryResourceMetrics(ctx, []ResourceMetricsQuery{{
+		RefID:             "connections",
+		Metric:            ResourceMetricConnectionsCount,
+		Start:             start,
+		End:               start.Add(30 * time.Minute),
+		Step:              15 * time.Minute,
+		NamespaceMatchers: []string{"root.acme.**"},
+		LabelSelector:     "env=prod",
+		GroupBy:           []ResourceGroupBy{ResourceGroupByState, ResourceGroupByHealthState, ResourceGroupByConnectorVersion},
+	}})
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	require.Equal(t, "connections", series[0].RefID)
+	require.Equal(t, map[string]string{
+		"connector_version": "1",
+		"health_state":      string(database.ConnectionHealthStateHealthy),
+		"state":             string(database.ConnectionStateConfigured),
+	}, series[0].Labels)
+	require.Equal(t, []ResourceMetricPoint{
+		{Timestamp: start, Value: 1},
+		{Timestamp: start.Add(15 * time.Minute), Value: 0},
+	}, series[0].Points)
+
+	require.Equal(t, map[string]string{
+		"connector_version": "2",
+		"health_state":      string(database.ConnectionHealthStateUnhealthy),
+		"state":             string(database.ConnectionStateSetup),
+	}, series[1].Labels)
+	require.Equal(t, []ResourceMetricPoint{
+		{Timestamp: start, Value: 1},
+		{Timestamp: start.Add(15 * time.Minute), Value: 0},
+	}, series[1].Points)
+}
+
+func TestResourceMetrics_ActorCountsByNamespace(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+
+	ctx := context.Background()
+	start := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	actorID := apid.New(apid.PrefixActor)
+	otherActorID := apid.New(apid.PrefixActor)
+	excludedActorID := apid.New(apid.PrefixActor)
+
+	err := resourceStore.StoreActorResourceSamples(ctx, []*ActorResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        actorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod"},
+			ExternalID:        "actor-1",
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+		{
+			SampledAt:         start,
+			ResourceID:        otherActorID,
+			Namespace:         "root.acme.ops",
+			Labels:            database.Labels{"env": "prod"},
+			ExternalID:        "actor-2",
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+		{
+			SampledAt:         start,
+			ResourceID:        excludedActorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "dev"},
+			ExternalID:        "actor-3",
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+	})
+	require.NoError(t, err)
+
+	series, err := retriever.QueryResourceMetrics(ctx, []ResourceMetricsQuery{{
+		RefID:             "actors",
+		Metric:            ResourceMetricActorsCount,
+		Start:             start,
+		End:               start.Add(30 * time.Minute),
+		Step:              15 * time.Minute,
+		NamespaceMatchers: []string{"root.acme.**"},
+		LabelSelector:     "env=prod",
+		GroupBy:           []ResourceGroupBy{ResourceGroupByNamespace},
+	}})
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	require.Equal(t, map[string]string{"namespace": "root.acme"}, series[0].Labels)
+	require.Equal(t, []ResourceMetricPoint{
+		{Timestamp: start, Value: 1},
+		{Timestamp: start.Add(15 * time.Minute), Value: 0},
+	}, series[0].Points)
+
+	require.Equal(t, map[string]string{"namespace": "root.acme.ops"}, series[1].Labels)
+	require.Equal(t, []ResourceMetricPoint{
+		{Timestamp: start, Value: 1},
+		{Timestamp: start.Add(15 * time.Minute), Value: 0},
+	}, series[1].Points)
+}
+
+func TestResourceMetrics_InvalidGroupBy(t *testing.T) {
+	_, retriever, _ := MustNewBlankRequestEventsStore(t)
+	start := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	_, err := retriever.QueryResourceMetrics(context.Background(), []ResourceMetricsQuery{{
+		RefID:   "actors",
+		Metric:  ResourceMetricActorsCount,
+		Start:   start,
+		End:     start.Add(15 * time.Minute),
+		Step:    15 * time.Minute,
+		GroupBy: []ResourceGroupBy{ResourceGroupByState},
+	}})
+	require.Error(t, err)
+}

--- a/internal/app_metrics/provider_resources.go
+++ b/internal/app_metrics/provider_resources.go
@@ -248,12 +248,34 @@ func (r *sqlRecordRetriever) ListActorResourceSamples(ctx context.Context, query
 	return fetchActorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
 }
 
+func (r *sqlRecordRetriever) QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error) {
+	return executeResourceMetricsQueries(ctx, queries,
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectionResourceSample, error) {
+			return fetchConnectionResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ActorResourceSample, error) {
+			return fetchActorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+	)
+}
+
 func (r *clickhouseRecordRetriever) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
 	return fetchConnectionResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
 }
 
 func (r *clickhouseRecordRetriever) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
 	return fetchActorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func (r *clickhouseRecordRetriever) QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error) {
+	return executeResourceMetricsQueries(ctx, queries,
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectionResourceSample, error) {
+			return fetchConnectionResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ActorResourceSample, error) {
+			return fetchActorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+	)
 }
 
 func fetchConnectionResourceSamples(

--- a/internal/app_metrics/resource_metrics.go
+++ b/internal/app_metrics/resource_metrics.go
@@ -97,6 +97,10 @@ func isValidResourceMetric(metric ResourceMetric) bool {
 }
 
 func isValidResourceGroupBy(metric ResourceMetric, groupBy ResourceGroupBy) bool {
+	return IsValidResourceGroupBy(metric, groupBy)
+}
+
+func IsValidResourceGroupBy(metric ResourceMetric, groupBy ResourceGroupBy) bool {
 	switch metric {
 	case ResourceMetricConnectionsCount:
 		switch groupBy {

--- a/internal/app_metrics/resource_metrics.go
+++ b/internal/app_metrics/resource_metrics.go
@@ -1,0 +1,289 @@
+package app_metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+type ResourceMetric string
+
+const (
+	ResourceMetricConnectionsCount ResourceMetric = "resources.connections.count"
+	ResourceMetricActorsCount      ResourceMetric = "resources.actors.count"
+)
+
+type ResourceGroupBy string
+
+const (
+	ResourceGroupByState            ResourceGroupBy = "state"
+	ResourceGroupByHealthState      ResourceGroupBy = "health_state"
+	ResourceGroupByConnectorID      ResourceGroupBy = "connector_id"
+	ResourceGroupByConnectorVersion ResourceGroupBy = "connector_version"
+	ResourceGroupByNamespace        ResourceGroupBy = "namespace"
+)
+
+type ResourceMetricsQuery struct {
+	RefID             string
+	Metric            ResourceMetric
+	Start             time.Time
+	End               time.Time
+	Step              time.Duration
+	NamespaceMatchers []string
+	LabelSelector     string
+	GroupBy           []ResourceGroupBy
+}
+
+type ResourceMetricPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     float64   `json:"value"`
+}
+
+type ResourceMetricSeries struct {
+	RefID  string                `json:"ref_id"`
+	Labels map[string]string     `json:"labels,omitempty"`
+	Points []ResourceMetricPoint `json:"points"`
+}
+
+func validateResourceMetricsQuery(q ResourceMetricsQuery) error {
+	if q.RefID == "" {
+		return errors.New("ref_id is required")
+	}
+	if !isValidResourceMetric(q.Metric) {
+		return fmt.Errorf("unsupported resource metric %q", q.Metric)
+	}
+	if q.Start.IsZero() || q.End.IsZero() {
+		return errors.New("start and end are required")
+	}
+	if !q.Start.Before(q.End) {
+		return errors.New("start must be before end")
+	}
+	if q.Step <= 0 {
+		return errors.New("step must be greater than zero")
+	}
+	for _, groupBy := range q.GroupBy {
+		if !isValidResourceGroupBy(q.Metric, groupBy) {
+			return fmt.Errorf("unsupported resource group_by dimension %q for metric %q", groupBy, q.Metric)
+		}
+	}
+	if q.LabelSelector != "" {
+		if _, err := database.ParseLabelSelector(q.LabelSelector); err != nil {
+			return err
+		}
+	}
+	filters := ListFilters{}
+	if len(q.NamespaceMatchers) > 0 {
+		if err := filters.SetNamespaceMatchers(q.NamespaceMatchers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isValidResourceMetric(metric ResourceMetric) bool {
+	switch metric {
+	case ResourceMetricConnectionsCount, ResourceMetricActorsCount:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidResourceGroupBy(metric ResourceMetric, groupBy ResourceGroupBy) bool {
+	switch metric {
+	case ResourceMetricConnectionsCount:
+		switch groupBy {
+		case ResourceGroupByState,
+			ResourceGroupByHealthState,
+			ResourceGroupByConnectorID,
+			ResourceGroupByConnectorVersion:
+			return true
+		}
+	case ResourceMetricActorsCount:
+		return groupBy == ResourceGroupByNamespace
+	}
+	return false
+}
+
+func executeResourceMetricsQueries(
+	ctx context.Context,
+	queries []ResourceMetricsQuery,
+	fetchConnections func(context.Context, ResourceMetricsQuery) ([]*ConnectionResourceSample, error),
+	fetchActors func(context.Context, ResourceMetricsQuery) ([]*ActorResourceSample, error),
+) ([]ResourceMetricSeries, error) {
+	out := make([]ResourceMetricSeries, 0)
+	for _, query := range queries {
+		if err := validateResourceMetricsQuery(query); err != nil {
+			return nil, err
+		}
+		switch query.Metric {
+		case ResourceMetricConnectionsCount:
+			samples, err := fetchConnections(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildConnectionResourceMetricSeries(query, samples)...)
+		case ResourceMetricActorsCount:
+			samples, err := fetchActors(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildActorResourceMetricSeries(query, samples)...)
+		default:
+			return nil, fmt.Errorf("unsupported resource metric %q", query.Metric)
+		}
+	}
+	return out, nil
+}
+
+func buildConnectionResourceMetricSeries(query ResourceMetricsQuery, samples []*ConnectionResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *ConnectionResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *ConnectionResourceSample) apid.ID {
+		return sample.ResourceID
+	}, func(sample *ConnectionResourceSample) map[string]string {
+		return connectionResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildActorResourceMetricSeries(query ResourceMetricsQuery, samples []*ActorResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *ActorResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *ActorResourceSample) apid.ID {
+		return sample.ResourceID
+	}, func(sample *ActorResourceSample) map[string]string {
+		return actorResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildResourceMetricSeries[T any](
+	query ResourceMetricsQuery,
+	samples []*T,
+	sampledAt func(*T) time.Time,
+	resourceID func(*T) apid.ID,
+	labelsFor func(*T) map[string]string,
+) []ResourceMetricSeries {
+	bucketCount := int(math.Ceil(float64(query.End.Sub(query.Start)) / float64(query.Step)))
+	if bucketCount < 1 {
+		bucketCount = 1
+	}
+
+	seenByGroup := map[string][]map[apid.ID]struct{}{}
+	labelsByKey := map[string]map[string]string{}
+
+	if len(query.GroupBy) == 0 {
+		key := resourceMetricGroupKey(nil)
+		seenByGroup[key] = makeResourceMetricBuckets(bucketCount)
+		labelsByKey[key] = map[string]string{}
+	}
+
+	for _, sample := range samples {
+		ts := sampledAt(sample)
+		if ts.Before(query.Start) || !ts.Before(query.End) {
+			continue
+		}
+		bucketIdx := int(ts.Sub(query.Start) / query.Step)
+		if bucketIdx < 0 || bucketIdx >= bucketCount {
+			continue
+		}
+
+		labels := labelsFor(sample)
+		key := resourceMetricGroupKey(labels)
+		if _, ok := seenByGroup[key]; !ok {
+			seenByGroup[key] = makeResourceMetricBuckets(bucketCount)
+			labelsByKey[key] = labels
+		}
+		seenByGroup[key][bucketIdx][resourceID(sample)] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(seenByGroup))
+	for key := range seenByGroup {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	series := make([]ResourceMetricSeries, 0, len(keys))
+	for _, key := range keys {
+		points := make([]ResourceMetricPoint, bucketCount)
+		for i := range bucketCount {
+			points[i] = ResourceMetricPoint{
+				Timestamp: query.Start.Add(time.Duration(i) * query.Step),
+				Value:     float64(len(seenByGroup[key][i])),
+			}
+		}
+		series = append(series, ResourceMetricSeries{
+			RefID:  query.RefID,
+			Labels: labelsByKey[key],
+			Points: points,
+		})
+	}
+	return series
+}
+
+func makeResourceMetricBuckets(bucketCount int) []map[apid.ID]struct{} {
+	buckets := make([]map[apid.ID]struct{}, bucketCount)
+	for i := range buckets {
+		buckets[i] = map[apid.ID]struct{}{}
+	}
+	return buckets
+}
+
+func connectionResourceMetricLabels(sample *ConnectionResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case ResourceGroupByState:
+			labels[string(group)] = string(sample.State)
+		case ResourceGroupByHealthState:
+			labels[string(group)] = string(sample.HealthState)
+		case ResourceGroupByConnectorID:
+			labels[string(group)] = sample.ConnectorID.String()
+		case ResourceGroupByConnectorVersion:
+			labels[string(group)] = strconv.FormatUint(sample.ConnectorVersion, 10)
+		}
+	}
+	return labels
+}
+
+func actorResourceMetricLabels(sample *ActorResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		if group == ResourceGroupByNamespace {
+			labels[string(group)] = sample.Namespace
+		}
+	}
+	return labels
+}
+
+func resourceMetricGroupKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := ""
+	for _, key := range keys {
+		out += key + "=" + labels[key] + "\x00"
+	}
+	return out
+}
+
+func resourceMetricsSampleQuery(query ResourceMetricsQuery) ResourceSampleQuery {
+	return ResourceSampleQuery{
+		Start:             &query.Start,
+		End:               &query.End,
+		NamespaceMatchers: query.NamespaceMatchers,
+		LabelSelector:     query.LabelSelector,
+	}
+}

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -54,6 +54,11 @@ func (ss *StorageService) QueryRequestEventMetrics(ctx context.Context, queries 
 	return ss.retriever.QueryRequestEventMetrics(ctx, queries)
 }
 
+// QueryResourceMetrics executes time-series metric queries over resource samples.
+func (ss *StorageService) QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error) {
+	return ss.retriever.QueryResourceMetrics(ctx, queries)
+}
+
 func (ss *StorageService) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
 	return ss.store.(ResourceSampleStore).StoreConnectionResourceSamples(ctx, samples)
 }

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -275,23 +275,10 @@ func metricsQueryToResourceQuery(
 	groupBy := make([]app_metrics.ResourceGroupBy, 0, len(ref.GroupBy))
 	for _, raw := range ref.GroupBy {
 		gb := app_metrics.ResourceGroupBy(raw)
-		switch metric {
-		case app_metrics.ResourceMetricConnectionsCount:
-			switch gb {
-			case app_metrics.ResourceGroupByState,
-				app_metrics.ResourceGroupByHealthState,
-				app_metrics.ResourceGroupByConnectorID,
-				app_metrics.ResourceGroupByConnectorVersion:
-				groupBy = append(groupBy, gb)
-			default:
-				return app_metrics.ResourceMetricsQuery{}, httperr.BadRequestf("invalid group_by %q", raw)
-			}
-		case app_metrics.ResourceMetricActorsCount:
-			if gb != app_metrics.ResourceGroupByNamespace {
-				return app_metrics.ResourceMetricsQuery{}, httperr.BadRequestf("invalid group_by %q", raw)
-			}
-			groupBy = append(groupBy, gb)
+		if !app_metrics.IsValidResourceGroupBy(metric, gb) {
+			return app_metrics.ResourceMetricsQuery{}, httperr.BadRequestf("invalid group_by %q", raw)
 		}
+		groupBy = append(groupBy, gb)
 	}
 
 	query := app_metrics.ResourceMetricsQuery{

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"errors"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -260,17 +261,77 @@ func requestEventMetricFromAPI(metric, aggregation string) (app_metrics.RequestE
 	return "", httperr.BadRequestf("unsupported metric aggregation %q/%q", metric, aggregation)
 }
 
-func metricsResponseFromAPIRequest(req sapi.MetricsQueryRequestJson, series []app_metrics.RequestEventMetricSeries) sapi.MetricsQueryResponseJson {
-	refsByID := make(map[string]sapi.MetricsQueryRefJson, len(req.Queries))
-	for _, ref := range req.Queries {
-		refsByID[ref.RefID] = ref
+func metricsQueryToResourceQuery(
+	req sapi.MetricsQueryRequestJson,
+	ref sapi.MetricsQueryRefJson,
+	effectiveNamespaceMatchers []string,
+	step time.Duration,
+) (app_metrics.ResourceMetricsQuery, error) {
+	metric, err := resourceMetricFromAPI(ref.Metric, ref.Aggregation)
+	if err != nil {
+		return app_metrics.ResourceMetricsQuery{}, err
 	}
 
-	out := sapi.MetricsQueryResponseJson{
-		Series: make([]sapi.MetricsSeriesJson, 0, len(series)),
+	groupBy := make([]app_metrics.ResourceGroupBy, 0, len(ref.GroupBy))
+	for _, raw := range ref.GroupBy {
+		gb := app_metrics.ResourceGroupBy(raw)
+		switch metric {
+		case app_metrics.ResourceMetricConnectionsCount:
+			switch gb {
+			case app_metrics.ResourceGroupByState,
+				app_metrics.ResourceGroupByHealthState,
+				app_metrics.ResourceGroupByConnectorID,
+				app_metrics.ResourceGroupByConnectorVersion:
+				groupBy = append(groupBy, gb)
+			default:
+				return app_metrics.ResourceMetricsQuery{}, httperr.BadRequestf("invalid group_by %q", raw)
+			}
+		case app_metrics.ResourceMetricActorsCount:
+			if gb != app_metrics.ResourceGroupByNamespace {
+				return app_metrics.ResourceMetricsQuery{}, httperr.BadRequestf("invalid group_by %q", raw)
+			}
+			groupBy = append(groupBy, gb)
+		}
 	}
+
+	query := app_metrics.ResourceMetricsQuery{
+		RefID:             ref.RefID,
+		Metric:            metric,
+		Start:             req.Range.Start,
+		End:               req.Range.End,
+		Step:              step,
+		NamespaceMatchers: effectiveNamespaceMatchers,
+		GroupBy:           groupBy,
+	}
+	if req.LabelSelector != nil {
+		query.LabelSelector = *req.LabelSelector
+	}
+	return query, nil
+}
+
+func resourceMetricFromAPI(metric, aggregation string) (app_metrics.ResourceMetric, error) {
+	switch metric {
+	case "resources.connections":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricConnectionsCount, nil
+		}
+	case "resources.actors":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricActorsCount, nil
+		}
+	}
+	return "", httperr.BadRequestf("unsupported metric aggregation %q/%q", metric, aggregation)
+}
+
+type metricsResponseSeries struct {
+	RefID  string
+	Labels map[string]string
+	Points []sapi.MetricsPointJson
+}
+
+func requestEventMetricsResponseSeries(series []app_metrics.RequestEventMetricSeries) []metricsResponseSeries {
+	out := make([]metricsResponseSeries, 0, len(series))
 	for _, s := range series {
-		ref := refsByID[s.RefID]
 		points := make([]sapi.MetricsPointJson, 0, len(s.Points))
 		for _, p := range s.Points {
 			points = append(points, sapi.MetricsPointJson{
@@ -278,13 +339,79 @@ func metricsResponseFromAPIRequest(req sapi.MetricsQueryRequestJson, series []ap
 				Value:     p.Value,
 			})
 		}
+		out = append(out, metricsResponseSeries{
+			RefID:  s.RefID,
+			Labels: s.Labels,
+			Points: points,
+		})
+	}
+	return out
+}
+
+func resourceMetricsResponseSeries(series []app_metrics.ResourceMetricSeries) []metricsResponseSeries {
+	out := make([]metricsResponseSeries, 0, len(series))
+	for _, s := range series {
+		points := make([]sapi.MetricsPointJson, 0, len(s.Points))
+		for _, p := range s.Points {
+			points = append(points, sapi.MetricsPointJson{
+				Timestamp: p.Timestamp,
+				Value:     p.Value,
+			})
+		}
+		out = append(out, metricsResponseSeries{
+			RefID:  s.RefID,
+			Labels: s.Labels,
+			Points: points,
+		})
+	}
+	return out
+}
+
+func metricsResponseFromAPIRequest(req sapi.MetricsQueryRequestJson, series []metricsResponseSeries) sapi.MetricsQueryResponseJson {
+	refsByID := make(map[string]sapi.MetricsQueryRefJson, len(req.Queries))
+	refOrder := make(map[string]int, len(req.Queries))
+	for i, ref := range req.Queries {
+		refsByID[ref.RefID] = ref
+		refOrder[ref.RefID] = i
+	}
+	sort.SliceStable(series, func(i, j int) bool {
+		leftOrder := refOrder[series[i].RefID]
+		rightOrder := refOrder[series[j].RefID]
+		if leftOrder != rightOrder {
+			return leftOrder < rightOrder
+		}
+		return metricsSeriesGroupKey(series[i].Labels) < metricsSeriesGroupKey(series[j].Labels)
+	})
+
+	out := sapi.MetricsQueryResponseJson{
+		Series: make([]sapi.MetricsSeriesJson, 0, len(series)),
+	}
+	for _, s := range series {
+		ref := refsByID[s.RefID]
 		out.Series = append(out.Series, sapi.MetricsSeriesJson{
 			RefID:       s.RefID,
 			Metric:      ref.Metric,
 			Aggregation: ref.Aggregation,
 			Labels:      s.Labels,
-			Points:      points,
+			Points:      s.Points,
 		})
+	}
+	return out
+}
+
+func metricsSeriesGroupKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := ""
+	for _, key := range keys {
+		out += key + "=" + labels[key] + "\x00"
 	}
 	return out
 }
@@ -516,24 +643,56 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 
 	effectiveNamespaceMatchers := val.GetEffectiveNamespaceMatchers(req.Namespace)
 	requestEventQueries := make([]app_metrics.RequestEventMetricsQuery, 0, len(req.Queries))
+	resourceQueries := make([]app_metrics.ResourceMetricsQuery, 0, len(req.Queries))
 	for _, ref := range req.Queries {
-		q, err := metricsQueryToRequestEventQuery(req, ref, effectiveNamespaceMatchers, step)
-		if err != nil {
-			apgin.WriteErr(gctx, nil, err)
-			val.MarkErrorReturn()
-			return
+		if _, err := requestEventMetricFromAPI(ref.Metric, ref.Aggregation); err == nil {
+			q, err := metricsQueryToRequestEventQuery(req, ref, effectiveNamespaceMatchers, step)
+			if err != nil {
+				apgin.WriteErr(gctx, nil, err)
+				val.MarkErrorReturn()
+				return
+			}
+			requestEventQueries = append(requestEventQueries, q)
+			continue
 		}
-		requestEventQueries = append(requestEventQueries, q)
-	}
 
-	series, err := r.rl.QueryRequestEventMetrics(ctx, requestEventQueries)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid metrics query", httperr.WithInternalErr(err)))
+		if _, err := resourceMetricFromAPI(ref.Metric, ref.Aggregation); err == nil {
+			q, err := metricsQueryToResourceQuery(req, ref, effectiveNamespaceMatchers, step)
+			if err != nil {
+				apgin.WriteErr(gctx, nil, err)
+				val.MarkErrorReturn()
+				return
+			}
+			resourceQueries = append(resourceQueries, q)
+			continue
+		}
+
+		apgin.WriteError(gctx, nil, httperr.BadRequestf("unsupported metric aggregation %q/%q", ref.Metric, ref.Aggregation))
 		val.MarkErrorReturn()
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, series))
+	responseSeries := make([]metricsResponseSeries, 0)
+	if len(requestEventQueries) > 0 {
+		series, err := r.rl.QueryRequestEventMetrics(ctx, requestEventQueries)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("invalid metrics query", httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		responseSeries = append(responseSeries, requestEventMetricsResponseSeries(series)...)
+	}
+	if len(resourceQueries) > 0 {
+		series, err := r.rl.QueryResourceMetrics(ctx, resourceQueries)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("invalid metrics query", httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		responseSeries = append(responseSeries, resourceMetricsResponseSeries(series)...)
+	}
+
+	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
 }
 
 func (r *RequestEventsRoutes) Register(g gin.IRouter) {

--- a/internal/routes/request_events_test.go
+++ b/internal/routes/request_events_test.go
@@ -630,6 +630,51 @@ func TestRequestEventsRoutes(t *testing.T) {
 			require.Equal(t, 3.0, resp.Series[0].Points[0].Value)
 		})
 
+		t.Run("executes resource query", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newMetricsRequest(t, validBody(map[string]any{"queries": []map[string]any{
+				{
+					"ref_id":      "connections",
+					"metric":      "resources.connections",
+					"aggregation": "count",
+					"group_by":    []string{"state", "health_state"},
+				},
+			}}), aschema.PermissionsSingle("root.**", "request-events", "list"))
+
+			tu.MockRetriever.EXPECT().
+				QueryResourceMetrics(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, queries []app_metrics.ResourceMetricsQuery) ([]app_metrics.ResourceMetricSeries, error) {
+					require.Len(t, queries, 1)
+					require.Equal(t, "connections", queries[0].RefID)
+					require.Equal(t, app_metrics.ResourceMetricConnectionsCount, queries[0].Metric)
+					require.Equal(t, start, queries[0].Start)
+					require.Equal(t, end, queries[0].End)
+					require.Equal(t, 15*time.Minute, queries[0].Step)
+					require.Equal(t, []string{"root.tenant.**"}, queries[0].NamespaceMatchers)
+					require.Equal(t, "env=prod", queries[0].LabelSelector)
+					require.Equal(t, []app_metrics.ResourceGroupBy{app_metrics.ResourceGroupByState, app_metrics.ResourceGroupByHealthState}, queries[0].GroupBy)
+					return []app_metrics.ResourceMetricSeries{
+						{
+							RefID:  "connections",
+							Labels: map[string]string{"state": "configured", "health_state": "healthy"},
+							Points: []app_metrics.ResourceMetricPoint{{Timestamp: start, Value: 2}},
+						},
+					}, nil
+				})
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp sapi.MetricsQueryResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Series, 1)
+			require.Equal(t, "connections", resp.Series[0].RefID)
+			require.Equal(t, "resources.connections", resp.Series[0].Metric)
+			require.Equal(t, "count", resp.Series[0].Aggregation)
+			require.Equal(t, map[string]string{"state": "configured", "health_state": "healthy"}, resp.Series[0].Labels)
+			require.Equal(t, 2.0, resp.Series[0].Points[0].Value)
+		})
+
 		t.Run("namespace is constrained by actor permissions", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newMetricsRequest(t, validBody(map[string]any{"namespace": "root.**"}), aschema.PermissionsSingle("root.tenant.**", "request-events", "list"))
@@ -670,6 +715,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 			{name: "invalid metric", body: validBody(map[string]any{"queries": []map[string]any{{"ref_id": "x", "metric": "nope", "aggregation": "count"}}})},
 			{name: "invalid aggregation", body: validBody(map[string]any{"queries": []map[string]any{{"ref_id": "x", "metric": "request_events", "aggregation": "avg"}}})},
 			{name: "invalid group_by", body: validBody(map[string]any{"queries": []map[string]any{{"ref_id": "x", "metric": "request_events", "aggregation": "count", "group_by": []string{"path"}}}})},
+			{name: "invalid resource group_by", body: validBody(map[string]any{"queries": []map[string]any{{"ref_id": "x", "metric": "resources.actors", "aggregation": "count", "group_by": []string{"state"}}}})},
 			{name: "empty queries", body: validBody(map[string]any{"queries": []map[string]any{}})},
 		}
 


### PR DESCRIPTION
## Summary
- adds resource metrics query execution for connection and actor counts over app metrics samples
- wires /metrics/query to dispatch request-event and resource metric refs through the shared API response shape
- covers namespace/label filters, stable grouped series, distinct resource counting, and historical buckets from stored samples

Closes #409

## Tests
- env GOCACHE=/private/tmp/authproxy-go-cache AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=sqlite go test ./internal/app_metrics ./internal/routes
- ./scripts/preflight.sh