### PR TITLE
Extend app metrics resource samples

### DIFF
--- a/internal/app_metrics/migrations/clickhouse/000005_create_additional_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/clickhouse/000005_create_additional_resource_samples.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS app_metrics_rate_limit_resource_samples;
+DROP TABLE IF EXISTS app_metrics_namespace_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_version_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_resource_samples;

--- a/internal/app_metrics/migrations/clickhouse/000005_create_additional_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/clickhouse/000005_create_additional_resource_samples.up.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connector_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'connector',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    state String,
+    connector_version UInt64 DEFAULT 0,
+    total_versions Int64 DEFAULT 0,
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id);
+
+CREATE TABLE IF NOT EXISTS app_metrics_connector_version_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'connector_version',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    state String,
+    connector_version UInt64 DEFAULT 0,
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id, connector_version);
+
+CREATE TABLE IF NOT EXISTS app_metrics_namespace_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'namespace',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    state String,
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id);
+
+CREATE TABLE IF NOT EXISTS app_metrics_rate_limit_resource_samples (
+    sampled_at_ms Int64,
+    resource_type String DEFAULT 'rate_limit',
+    resource_id String,
+    namespace String,
+    labels String DEFAULT '{}',
+    mode String,
+    resource_created_at_ms Int64,
+    resource_updated_at_ms Int64,
+    resource_deleted_at_ms Nullable(Int64),
+    ingested_at_unix_nano Int64
+) ENGINE = ReplacingMergeTree(ingested_at_unix_nano)
+ORDER BY (sampled_at_ms, resource_id);

--- a/internal/app_metrics/migrations/postgres/000005_create_additional_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/postgres/000005_create_additional_resource_samples.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS app_metrics_rate_limit_resource_samples;
+DROP TABLE IF EXISTS app_metrics_namespace_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_version_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_resource_samples;

--- a/internal/app_metrics/migrations/postgres/000005_create_additional_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/postgres/000005_create_additional_resource_samples.up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connector_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connector',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    connector_version BIGINT NOT NULL DEFAULT 0,
+    total_versions BIGINT NOT NULL DEFAULT 0,
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_namespace ON app_metrics_connector_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_sampled_at ON app_metrics_connector_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_state ON app_metrics_connector_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_connector_version_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connector_version',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    connector_version BIGINT NOT NULL DEFAULT 0,
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id, connector_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_namespace ON app_metrics_connector_version_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_sampled_at ON app_metrics_connector_version_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_state ON app_metrics_connector_version_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_namespace_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'namespace',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_namespace ON app_metrics_namespace_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_sampled_at ON app_metrics_namespace_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_state ON app_metrics_namespace_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_rate_limit_resource_samples (
+    sampled_at_ms BIGINT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'rate_limit',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}',
+    mode TEXT NOT NULL,
+    resource_created_at_ms BIGINT NOT NULL,
+    resource_updated_at_ms BIGINT NOT NULL,
+    resource_deleted_at_ms BIGINT,
+    ingested_at_unix_nano BIGINT NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_namespace ON app_metrics_rate_limit_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_sampled_at ON app_metrics_rate_limit_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_mode ON app_metrics_rate_limit_resource_samples (mode);

--- a/internal/app_metrics/migrations/sqlite/000005_create_additional_resource_samples.down.sql
+++ b/internal/app_metrics/migrations/sqlite/000005_create_additional_resource_samples.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS app_metrics_rate_limit_resource_samples;
+DROP TABLE IF EXISTS app_metrics_namespace_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_version_resource_samples;
+DROP TABLE IF EXISTS app_metrics_connector_resource_samples;

--- a/internal/app_metrics/migrations/sqlite/000005_create_additional_resource_samples.up.sql
+++ b/internal/app_metrics/migrations/sqlite/000005_create_additional_resource_samples.up.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS app_metrics_connector_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connector',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    connector_version INTEGER NOT NULL DEFAULT 0,
+    total_versions INTEGER NOT NULL DEFAULT 0,
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_namespace ON app_metrics_connector_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_sampled_at ON app_metrics_connector_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connector_resource_samples_state ON app_metrics_connector_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_connector_version_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'connector_version',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    connector_version INTEGER NOT NULL DEFAULT 0,
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id, connector_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_namespace ON app_metrics_connector_version_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_sampled_at ON app_metrics_connector_version_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_connector_version_resource_samples_state ON app_metrics_connector_version_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_namespace_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'namespace',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    state TEXT NOT NULL,
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_namespace ON app_metrics_namespace_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_sampled_at ON app_metrics_namespace_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_namespace_resource_samples_state ON app_metrics_namespace_resource_samples (state);
+
+CREATE TABLE IF NOT EXISTS app_metrics_rate_limit_resource_samples (
+    sampled_at_ms INTEGER NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'rate_limit',
+    resource_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '{}',
+    mode TEXT NOT NULL,
+    resource_created_at_ms INTEGER NOT NULL,
+    resource_updated_at_ms INTEGER NOT NULL,
+    resource_deleted_at_ms INTEGER,
+    ingested_at_unix_nano INTEGER NOT NULL,
+    PRIMARY KEY (sampled_at_ms, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_namespace ON app_metrics_rate_limit_resource_samples (namespace);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_sampled_at ON app_metrics_rate_limit_resource_samples (sampled_at_ms);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_resource_samples_mode ON app_metrics_rate_limit_resource_samples (mode);

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -19,6 +19,10 @@ type RecordStore interface {
 type ResourceSampleStore interface {
 	StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error
 	StoreActorResourceSamples(ctx context.Context, samples []*ActorResourceSample) error
+	StoreConnectorResourceSamples(ctx context.Context, samples []*ConnectorResourceSample) error
+	StoreConnectorVersionResourceSamples(ctx context.Context, samples []*ConnectorVersionResourceSample) error
+	StoreNamespaceResourceSamples(ctx context.Context, samples []*NamespaceResourceSample) error
+	StoreRateLimitResourceSamples(ctx context.Context, samples []*RateLimitResourceSample) error
 }
 
 type migratable interface {
@@ -53,4 +57,8 @@ type RecordRetriever interface {
 type ResourceSampleRetriever interface {
 	ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error)
 	ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error)
+	ListConnectorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorResourceSample, error)
+	ListConnectorVersionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorVersionResourceSample, error)
+	ListNamespaceResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*NamespaceResourceSample, error)
+	ListRateLimitResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*RateLimitResourceSample, error)
 }

--- a/internal/app_metrics/provider_resource_metrics_test.go
+++ b/internal/app_metrics/provider_resource_metrics_test.go
@@ -175,6 +175,131 @@ func TestResourceMetrics_ActorCountsByNamespace(t *testing.T) {
 	}, series[1].Points)
 }
 
+func TestResourceMetrics_AdditionalResourceCounts(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+
+	ctx := context.Background()
+	start := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	rateLimitID := apid.New(apid.PrefixRateLimit)
+
+	require.NoError(t, resourceStore.StoreConnectorResourceSamples(ctx, []*ConnectorResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        connectorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod"},
+			State:             database.ConnectorVersionStatePrimary,
+			ConnectorVersion:  2,
+			TotalVersions:     2,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+	}))
+	require.NoError(t, resourceStore.StoreConnectorVersionResourceSamples(ctx, []*ConnectorVersionResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        connectorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod"},
+			State:             database.ConnectorVersionStatePrimary,
+			ConnectorVersion:  2,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+	}))
+	require.NoError(t, resourceStore.StoreNamespaceResourceSamples(ctx, []*NamespaceResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        "root.acme",
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod"},
+			State:             database.NamespaceStateActive,
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+	}))
+	require.NoError(t, resourceStore.StoreRateLimitResourceSamples(ctx, []*RateLimitResourceSample{
+		{
+			SampledAt:         start,
+			ResourceID:        rateLimitID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod"},
+			Mode:              "observe",
+			ResourceCreatedAt: start.Add(-time.Hour),
+			ResourceUpdatedAt: start,
+		},
+	}))
+
+	series, err := retriever.QueryResourceMetrics(ctx, []ResourceMetricsQuery{
+		{
+			RefID:             "connectors",
+			Metric:            ResourceMetricConnectorsCount,
+			Start:             start,
+			End:               start.Add(30 * time.Minute),
+			Step:              15 * time.Minute,
+			NamespaceMatchers: []string{"root.acme"},
+			LabelSelector:     "env=prod",
+			GroupBy:           []ResourceGroupBy{ResourceGroupByState, ResourceGroupByConnectorVersion},
+		},
+		{
+			RefID:             "namespaces",
+			Metric:            ResourceMetricNamespacesCount,
+			Start:             start,
+			End:               start.Add(30 * time.Minute),
+			Step:              15 * time.Minute,
+			NamespaceMatchers: []string{"root.acme"},
+			LabelSelector:     "env=prod",
+			GroupBy:           []ResourceGroupBy{ResourceGroupByState},
+		},
+		{
+			RefID:             "connector-versions",
+			Metric:            ResourceMetricConnectorVersionsCount,
+			Start:             start,
+			End:               start.Add(30 * time.Minute),
+			Step:              15 * time.Minute,
+			NamespaceMatchers: []string{"root.acme"},
+			LabelSelector:     "env=prod",
+			GroupBy:           []ResourceGroupBy{ResourceGroupByConnectorID, ResourceGroupByConnectorVersion},
+		},
+		{
+			RefID:             "rate-limits",
+			Metric:            ResourceMetricRateLimitsCount,
+			Start:             start,
+			End:               start.Add(30 * time.Minute),
+			Step:              15 * time.Minute,
+			NamespaceMatchers: []string{"root.acme"},
+			LabelSelector:     "env=prod",
+			GroupBy:           []ResourceGroupBy{ResourceGroupByMode},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, series, 4)
+
+	require.Equal(t, "connectors", series[0].RefID)
+	require.Equal(t, map[string]string{
+		"connector_version": "2",
+		"state":             string(database.ConnectorVersionStatePrimary),
+	}, series[0].Labels)
+	require.Equal(t, []ResourceMetricPoint{{Timestamp: start, Value: 1}, {Timestamp: start.Add(15 * time.Minute), Value: 0}}, series[0].Points)
+
+	require.Equal(t, "namespaces", series[1].RefID)
+	require.Equal(t, map[string]string{"state": string(database.NamespaceStateActive)}, series[1].Labels)
+	require.Equal(t, []ResourceMetricPoint{{Timestamp: start, Value: 1}, {Timestamp: start.Add(15 * time.Minute), Value: 0}}, series[1].Points)
+
+	require.Equal(t, "connector-versions", series[2].RefID)
+	require.Equal(t, map[string]string{
+		"connector_id":      connectorID.String(),
+		"connector_version": "2",
+	}, series[2].Labels)
+	require.Equal(t, []ResourceMetricPoint{{Timestamp: start, Value: 1}, {Timestamp: start.Add(15 * time.Minute), Value: 0}}, series[2].Points)
+
+	require.Equal(t, "rate-limits", series[3].RefID)
+	require.Equal(t, map[string]string{"mode": "observe"}, series[3].Labels)
+	require.Equal(t, []ResourceMetricPoint{{Timestamp: start, Value: 1}, {Timestamp: start.Add(15 * time.Minute), Value: 0}}, series[3].Points)
+}
+
 func TestResourceMetrics_InvalidGroupBy(t *testing.T) {
 	_, retriever, _ := MustNewBlankRequestEventsStore(t)
 	start := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)

--- a/internal/app_metrics/provider_resource_samples_test.go
+++ b/internal/app_metrics/provider_resource_samples_test.go
@@ -151,3 +151,116 @@ func TestResourceSamples_ActorSamples_IdempotentAndQueryable(t *testing.T) {
 	require.NotNil(t, got.ResourceDeletedAt)
 	require.True(t, deletedAt.Equal(*got.ResourceDeletedAt))
 }
+
+func TestResourceSamples_AdditionalSamples_IdempotentAndQueryable(t *testing.T) {
+	store, retriever, _ := MustNewBlankRequestEventsStore(t)
+	resourceStore := store.(ResourceSampleStore)
+	resourceRetriever := retriever.(ResourceSampleRetriever)
+
+	ctx := context.Background()
+	sampledAt := time.Date(2026, 5, 25, 12, 30, 0, 0, time.UTC)
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	rateLimitID := apid.New(apid.PrefixRateLimit)
+	createdAt := sampledAt.Add(-time.Hour)
+	updatedAt := sampledAt.Add(-time.Minute)
+
+	require.NoError(t, resourceStore.StoreConnectorResourceSamples(ctx, []*ConnectorResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        connectorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod", "kind": "connector"},
+			State:             database.ConnectorVersionStateDraft,
+			ConnectorVersion:  1,
+			TotalVersions:     1,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	}))
+	require.NoError(t, resourceStore.StoreConnectorResourceSamples(ctx, []*ConnectorResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        connectorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod", "kind": "connector"},
+			State:             database.ConnectorVersionStatePrimary,
+			ConnectorVersion:  2,
+			TotalVersions:     2,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: sampledAt,
+		},
+	}))
+
+	connectorSamples, err := resourceRetriever.ListConnectorResourceSamples(ctx, ResourceSampleQuery{
+		NamespaceMatchers: []string{"root.acme"},
+		LabelSelector:     "kind=connector",
+	})
+	require.NoError(t, err)
+	require.Len(t, connectorSamples, 1)
+	require.Equal(t, ResourceTypeConnector, connectorSamples[0].ResourceType)
+	require.Equal(t, database.ConnectorVersionStatePrimary, connectorSamples[0].State)
+	require.Equal(t, uint64(2), connectorSamples[0].ConnectorVersion)
+	require.Equal(t, int64(2), connectorSamples[0].TotalVersions)
+
+	require.NoError(t, resourceStore.StoreConnectorVersionResourceSamples(ctx, []*ConnectorVersionResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        connectorID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod", "kind": "connector-version"},
+			State:             database.ConnectorVersionStatePrimary,
+			ConnectorVersion:  2,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	}))
+	connectorVersionSamples, err := resourceRetriever.ListConnectorVersionResourceSamples(ctx, ResourceSampleQuery{
+		NamespaceMatchers: []string{"root.acme"},
+		LabelSelector:     "kind=connector-version",
+	})
+	require.NoError(t, err)
+	require.Len(t, connectorVersionSamples, 1)
+	require.Equal(t, ResourceTypeConnectorVersion, connectorVersionSamples[0].ResourceType)
+	require.Equal(t, database.ConnectorVersionStatePrimary, connectorVersionSamples[0].State)
+	require.Equal(t, uint64(2), connectorVersionSamples[0].ConnectorVersion)
+
+	require.NoError(t, resourceStore.StoreNamespaceResourceSamples(ctx, []*NamespaceResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        "root.acme",
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod", "kind": "namespace"},
+			State:             database.NamespaceStateDestroying,
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	}))
+	namespaceSamples, err := resourceRetriever.ListNamespaceResourceSamples(ctx, ResourceSampleQuery{
+		NamespaceMatchers: []string{"root.acme"},
+		LabelSelector:     "kind=namespace",
+	})
+	require.NoError(t, err)
+	require.Len(t, namespaceSamples, 1)
+	require.Equal(t, ResourceTypeNamespace, namespaceSamples[0].ResourceType)
+	require.Equal(t, database.NamespaceStateDestroying, namespaceSamples[0].State)
+
+	require.NoError(t, resourceStore.StoreRateLimitResourceSamples(ctx, []*RateLimitResourceSample{
+		{
+			SampledAt:         sampledAt,
+			ResourceID:        rateLimitID,
+			Namespace:         "root.acme",
+			Labels:            database.Labels{"env": "prod", "kind": "rate-limit"},
+			Mode:              "observe",
+			ResourceCreatedAt: createdAt,
+			ResourceUpdatedAt: updatedAt,
+		},
+	}))
+	rateLimitSamples, err := resourceRetriever.ListRateLimitResourceSamples(ctx, ResourceSampleQuery{
+		NamespaceMatchers: []string{"root.acme"},
+		LabelSelector:     "kind=rate-limit",
+	})
+	require.NoError(t, err)
+	require.Len(t, rateLimitSamples, 1)
+	require.Equal(t, ResourceTypeRateLimit, rateLimitSamples[0].ResourceType)
+	require.Equal(t, "observe", rateLimitSamples[0].Mode)
+}

--- a/internal/app_metrics/provider_resources.go
+++ b/internal/app_metrics/provider_resources.go
@@ -41,6 +41,57 @@ var actorResourceSampleColumns = []string{
 	"resource_deleted_at_ms",
 }
 
+var connectorResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"state",
+	"connector_version",
+	"total_versions",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
+var connectorVersionResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"state",
+	"connector_version",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
+var namespaceResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"state",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
+var rateLimitResourceSampleColumns = []string{
+	"sampled_at_ms",
+	"resource_type",
+	"resource_id",
+	"namespace",
+	"labels",
+	"mode",
+	"resource_created_at_ms",
+	"resource_updated_at_ms",
+	"resource_deleted_at_ms",
+}
+
 func (s *sqlRecordStore) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
 	if len(samples) == 0 {
 		return nil
@@ -145,6 +196,207 @@ func (s *sqlRecordStore) StoreActorResourceSamples(ctx context.Context, samples 
 	return nil
 }
 
+func (s *sqlRecordStore) StoreConnectorResourceSamples(ctx context.Context, samples []*ConnectorResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(connectorResourceSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, connectorResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnector),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ConnectorVersion,
+			sample.TotalVersions,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		state = excluded.state,
+		connector_version = excluded.connector_version,
+		total_versions = excluded.total_versions,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build connector resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert connector resource samples: %w", err)
+	}
+	return nil
+}
+
+func (s *sqlRecordStore) StoreConnectorVersionResourceSamples(ctx context.Context, samples []*ConnectorVersionResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(connectorVersionSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, connectorVersionResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnectorVersion),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ConnectorVersion,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id, connector_version) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		state = excluded.state,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build connector version resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert connector version resource samples: %w", err)
+	}
+	return nil
+}
+
+func (s *sqlRecordStore) StoreNamespaceResourceSamples(ctx context.Context, samples []*NamespaceResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(namespaceResourceSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, namespaceResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeNamespace),
+			sample.ResourceID,
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		state = excluded.state,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build namespace resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert namespace resource samples: %w", err)
+	}
+	return nil
+}
+
+func (s *sqlRecordStore) StoreRateLimitResourceSamples(ctx context.Context, samples []*RateLimitResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert(rateLimitResourceSamplesTable).
+		PlaceholderFormat(s.placeholderFormat).
+		Columns(append(append([]string{}, rateLimitResourceSampleColumns...), "ingested_at_unix_nano")...)
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		builder = builder.Values(
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeRateLimit),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			sample.Mode,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		)
+	}
+
+	builder = builder.Suffix(`ON CONFLICT (sampled_at_ms, resource_id) DO UPDATE SET
+		resource_type = excluded.resource_type,
+		namespace = excluded.namespace,
+		labels = excluded.labels,
+		mode = excluded.mode,
+		resource_created_at_ms = excluded.resource_created_at_ms,
+		resource_updated_at_ms = excluded.resource_updated_at_ms,
+		resource_deleted_at_ms = excluded.resource_deleted_at_ms,
+		ingested_at_unix_nano = excluded.ingested_at_unix_nano`)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build rate limit resource sample insert: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to insert rate limit resource samples: %w", err)
+	}
+	return nil
+}
+
 func (s *clickhouseRecordStore) StoreConnectionResourceSamples(ctx context.Context, samples []*ConnectionResourceSample) error {
 	if len(samples) == 0 {
 		return nil
@@ -240,12 +492,215 @@ func (s *clickhouseRecordStore) StoreActorResourceSamples(ctx context.Context, s
 	return tx.Commit()
 }
 
+func (s *clickhouseRecordStore) StoreConnectorResourceSamples(ctx context.Context, samples []*ConnectorResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		connectorResourceSamplesTable,
+		strings.Join(connectorResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnector),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ConnectorVersion,
+			sample.TotalVersions,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse connector resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *clickhouseRecordStore) StoreConnectorVersionResourceSamples(ctx context.Context, samples []*ConnectorVersionResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		connectorVersionSamplesTable,
+		strings.Join(connectorVersionResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeConnectorVersion),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ConnectorVersion,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse connector version resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *clickhouseRecordStore) StoreNamespaceResourceSamples(ctx context.Context, samples []*NamespaceResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		namespaceResourceSamplesTable,
+		strings.Join(namespaceResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeNamespace),
+			sample.ResourceID,
+			sample.Namespace,
+			labelsVal,
+			string(sample.State),
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse namespace resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *clickhouseRecordStore) StoreRateLimitResourceSamples(ctx context.Context, samples []*RateLimitResourceSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (%s, ingested_at_unix_nano) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		rateLimitResourceSamplesTable,
+		strings.Join(rateLimitResourceSampleColumns, ", "),
+	))
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	ingestedAt := time.Now().UnixNano()
+	for _, sample := range samples {
+		labelsVal, err := labelsValue(sample.Labels)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx,
+			sample.SampledAt.UnixMilli(),
+			defaultResourceType(sample.ResourceType, ResourceTypeRateLimit),
+			sample.ResourceID.String(),
+			sample.Namespace,
+			labelsVal,
+			sample.Mode,
+			sample.ResourceCreatedAt.UnixMilli(),
+			sample.ResourceUpdatedAt.UnixMilli(),
+			nullableUnixMillis(sample.ResourceDeletedAt),
+			ingestedAt,
+		); err != nil {
+			return fmt.Errorf("failed to insert clickhouse rate limit resource sample: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 func (r *sqlRecordRetriever) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
 	return fetchConnectionResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
 }
 
 func (r *sqlRecordRetriever) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
 	return fetchActorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *sqlRecordRetriever) ListConnectorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorResourceSample, error) {
+	return fetchConnectorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *sqlRecordRetriever) ListConnectorVersionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorVersionResourceSample, error) {
+	return fetchConnectorVersionResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *sqlRecordRetriever) ListNamespaceResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*NamespaceResourceSample, error) {
+	return fetchNamespaceResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
+}
+
+func (r *sqlRecordRetriever) ListRateLimitResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*RateLimitResourceSample, error) {
+	return fetchRateLimitResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, query)
 }
 
 func (r *sqlRecordRetriever) QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error) {
@@ -255,6 +710,18 @@ func (r *sqlRecordRetriever) QueryResourceMetrics(ctx context.Context, queries [
 		},
 		func(ctx context.Context, query ResourceMetricsQuery) ([]*ActorResourceSample, error) {
 			return fetchActorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectorResourceSample, error) {
+			return fetchConnectorResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectorVersionResourceSample, error) {
+			return fetchConnectorVersionResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*NamespaceResourceSample, error) {
+			return fetchNamespaceResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*RateLimitResourceSample, error) {
+			return fetchRateLimitResourceSamples(ctx, r.db, r.placeholderFormat, r.provider, resourceMetricsSampleQuery(query))
 		},
 	)
 }
@@ -267,6 +734,22 @@ func (r *clickhouseRecordRetriever) ListActorResourceSamples(ctx context.Context
 	return fetchActorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
 }
 
+func (r *clickhouseRecordRetriever) ListConnectorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorResourceSample, error) {
+	return fetchConnectorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func (r *clickhouseRecordRetriever) ListConnectorVersionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorVersionResourceSample, error) {
+	return fetchConnectorVersionResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func (r *clickhouseRecordRetriever) ListNamespaceResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*NamespaceResourceSample, error) {
+	return fetchNamespaceResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
+func (r *clickhouseRecordRetriever) ListRateLimitResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*RateLimitResourceSample, error) {
+	return fetchRateLimitResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, query)
+}
+
 func (r *clickhouseRecordRetriever) QueryResourceMetrics(ctx context.Context, queries []ResourceMetricsQuery) ([]ResourceMetricSeries, error) {
 	return executeResourceMetricsQueries(ctx, queries,
 		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectionResourceSample, error) {
@@ -274,6 +757,18 @@ func (r *clickhouseRecordRetriever) QueryResourceMetrics(ctx context.Context, qu
 		},
 		func(ctx context.Context, query ResourceMetricsQuery) ([]*ActorResourceSample, error) {
 			return fetchActorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectorResourceSample, error) {
+			return fetchConnectorResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*ConnectorVersionResourceSample, error) {
+			return fetchConnectorVersionResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*NamespaceResourceSample, error) {
+			return fetchNamespaceResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
+		},
+		func(ctx context.Context, query ResourceMetricsQuery) ([]*RateLimitResourceSample, error) {
+			return fetchRateLimitResourceSamples(ctx, r.db, sq.Question, config.DatabaseProviderClickhouse, resourceMetricsSampleQuery(query))
 		},
 	)
 }
@@ -338,6 +833,142 @@ func fetchActorResourceSamples(
 	var samples []*ActorResourceSample
 	for rows.Next() {
 		sample, err := scanActorResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func fetchConnectorResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*ConnectorResourceSample, error) {
+	builder := sq.Select(connectorResourceSampleColumns...).
+		From(resourceSampleTableName(connectorResourceSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*ConnectorResourceSample
+	for rows.Next() {
+		sample, err := scanConnectorResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func fetchConnectorVersionResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*ConnectorVersionResourceSample, error) {
+	builder := sq.Select(connectorVersionResourceSampleColumns...).
+		From(resourceSampleTableName(connectorVersionSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC", "connector_version ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*ConnectorVersionResourceSample
+	for rows.Next() {
+		sample, err := scanConnectorVersionResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func fetchNamespaceResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*NamespaceResourceSample, error) {
+	builder := sq.Select(namespaceResourceSampleColumns...).
+		From(resourceSampleTableName(namespaceResourceSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*NamespaceResourceSample
+	for rows.Next() {
+		sample, err := scanNamespaceResourceSample(rows)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, sample)
+	}
+	return samples, rows.Err()
+}
+
+func fetchRateLimitResourceSamples(
+	ctx context.Context,
+	db *sql.DB,
+	placeholderFormat sq.PlaceholderFormat,
+	provider config.DatabaseProvider,
+	query ResourceSampleQuery,
+) ([]*RateLimitResourceSample, error) {
+	builder := sq.Select(rateLimitResourceSampleColumns...).
+		From(resourceSampleTableName(rateLimitResourceSamplesTable, provider)).
+		PlaceholderFormat(placeholderFormat).
+		OrderBy("sampled_at_ms ASC", "resource_id ASC")
+
+	builder, err := applyResourceSampleQuery(builder, provider, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := queryResourceSamples(ctx, db, builder)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var samples []*RateLimitResourceSample
+	for rows.Next() {
+		sample, err := scanRateLimitResourceSample(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -444,6 +1075,115 @@ func scanActorResourceSample(row interface{ Scan(dest ...any) error }) (*ActorRe
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan actor resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceID = apid.ID(resourceID)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func scanConnectorResourceSample(row interface{ Scan(dest ...any) error }) (*ConnectorResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	var resourceID string
+	sample := &ConnectorResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&resourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.State,
+		&sample.ConnectorVersion,
+		&sample.TotalVersions,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan connector resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceID = apid.ID(resourceID)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func scanConnectorVersionResourceSample(row interface{ Scan(dest ...any) error }) (*ConnectorVersionResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	var resourceID string
+	sample := &ConnectorVersionResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&resourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.State,
+		&sample.ConnectorVersion,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan connector version resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceID = apid.ID(resourceID)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func scanNamespaceResourceSample(row interface{ Scan(dest ...any) error }) (*NamespaceResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	sample := &NamespaceResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&sample.ResourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.State,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan namespace resource sample: %w", err)
+	}
+	sample.SampledAt = unixMillis(sampledAtMs)
+	sample.ResourceCreatedAt = unixMillis(createdAtMs)
+	sample.ResourceUpdatedAt = unixMillis(updatedAtMs)
+	sample.ResourceDeletedAt = nullableTime(deletedAtMs)
+	return sample, nil
+}
+
+func scanRateLimitResourceSample(row interface{ Scan(dest ...any) error }) (*RateLimitResourceSample, error) {
+	var sampledAtMs, createdAtMs, updatedAtMs int64
+	var deletedAtMs sql.NullInt64
+	var resourceID string
+	sample := &RateLimitResourceSample{}
+	err := row.Scan(
+		&sampledAtMs,
+		&sample.ResourceType,
+		&resourceID,
+		&sample.Namespace,
+		&sample.Labels,
+		&sample.Mode,
+		&createdAtMs,
+		&updatedAtMs,
+		&deletedAtMs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan rate limit resource sample: %w", err)
 	}
 	sample.SampledAt = unixMillis(sampledAtMs)
 	sample.ResourceID = apid.ID(resourceID)

--- a/internal/app_metrics/resource_metrics.go
+++ b/internal/app_metrics/resource_metrics.go
@@ -9,15 +9,18 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 )
 
 type ResourceMetric string
 
 const (
-	ResourceMetricConnectionsCount ResourceMetric = "resources.connections.count"
-	ResourceMetricActorsCount      ResourceMetric = "resources.actors.count"
+	ResourceMetricConnectionsCount       ResourceMetric = "resources.connections.count"
+	ResourceMetricActorsCount            ResourceMetric = "resources.actors.count"
+	ResourceMetricConnectorsCount        ResourceMetric = "resources.connectors.count"
+	ResourceMetricConnectorVersionsCount ResourceMetric = "resources.connector_versions.count"
+	ResourceMetricNamespacesCount        ResourceMetric = "resources.namespaces.count"
+	ResourceMetricRateLimitsCount        ResourceMetric = "resources.rate_limits.count"
 )
 
 type ResourceGroupBy string
@@ -28,6 +31,7 @@ const (
 	ResourceGroupByConnectorID      ResourceGroupBy = "connector_id"
 	ResourceGroupByConnectorVersion ResourceGroupBy = "connector_version"
 	ResourceGroupByNamespace        ResourceGroupBy = "namespace"
+	ResourceGroupByMode             ResourceGroupBy = "mode"
 )
 
 type ResourceMetricsQuery struct {
@@ -89,7 +93,12 @@ func validateResourceMetricsQuery(q ResourceMetricsQuery) error {
 
 func isValidResourceMetric(metric ResourceMetric) bool {
 	switch metric {
-	case ResourceMetricConnectionsCount, ResourceMetricActorsCount:
+	case ResourceMetricConnectionsCount,
+		ResourceMetricActorsCount,
+		ResourceMetricConnectorsCount,
+		ResourceMetricConnectorVersionsCount,
+		ResourceMetricNamespacesCount,
+		ResourceMetricRateLimitsCount:
 		return true
 	default:
 		return false
@@ -112,6 +121,33 @@ func IsValidResourceGroupBy(metric ResourceMetric, groupBy ResourceGroupBy) bool
 		}
 	case ResourceMetricActorsCount:
 		return groupBy == ResourceGroupByNamespace
+	case ResourceMetricConnectorsCount:
+		switch groupBy {
+		case ResourceGroupByState,
+			ResourceGroupByConnectorVersion,
+			ResourceGroupByNamespace:
+			return true
+		}
+	case ResourceMetricConnectorVersionsCount:
+		switch groupBy {
+		case ResourceGroupByState,
+			ResourceGroupByConnectorID,
+			ResourceGroupByConnectorVersion,
+			ResourceGroupByNamespace:
+			return true
+		}
+	case ResourceMetricNamespacesCount:
+		switch groupBy {
+		case ResourceGroupByState,
+			ResourceGroupByNamespace:
+			return true
+		}
+	case ResourceMetricRateLimitsCount:
+		switch groupBy {
+		case ResourceGroupByMode,
+			ResourceGroupByNamespace:
+			return true
+		}
 	}
 	return false
 }
@@ -121,6 +157,10 @@ func executeResourceMetricsQueries(
 	queries []ResourceMetricsQuery,
 	fetchConnections func(context.Context, ResourceMetricsQuery) ([]*ConnectionResourceSample, error),
 	fetchActors func(context.Context, ResourceMetricsQuery) ([]*ActorResourceSample, error),
+	fetchConnectors func(context.Context, ResourceMetricsQuery) ([]*ConnectorResourceSample, error),
+	fetchConnectorVersions func(context.Context, ResourceMetricsQuery) ([]*ConnectorVersionResourceSample, error),
+	fetchNamespaces func(context.Context, ResourceMetricsQuery) ([]*NamespaceResourceSample, error),
+	fetchRateLimits func(context.Context, ResourceMetricsQuery) ([]*RateLimitResourceSample, error),
 ) ([]ResourceMetricSeries, error) {
 	out := make([]ResourceMetricSeries, 0)
 	for _, query := range queries {
@@ -140,6 +180,30 @@ func executeResourceMetricsQueries(
 				return nil, err
 			}
 			out = append(out, buildActorResourceMetricSeries(query, samples)...)
+		case ResourceMetricConnectorsCount:
+			samples, err := fetchConnectors(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildConnectorResourceMetricSeries(query, samples)...)
+		case ResourceMetricConnectorVersionsCount:
+			samples, err := fetchConnectorVersions(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildConnectorVersionResourceMetricSeries(query, samples)...)
+		case ResourceMetricNamespacesCount:
+			samples, err := fetchNamespaces(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildNamespaceResourceMetricSeries(query, samples)...)
+		case ResourceMetricRateLimitsCount:
+			samples, err := fetchRateLimits(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, buildRateLimitResourceMetricSeries(query, samples)...)
 		default:
 			return nil, fmt.Errorf("unsupported resource metric %q", query.Metric)
 		}
@@ -150,8 +214,8 @@ func executeResourceMetricsQueries(
 func buildConnectionResourceMetricSeries(query ResourceMetricsQuery, samples []*ConnectionResourceSample) []ResourceMetricSeries {
 	return buildResourceMetricSeries(query, samples, func(sample *ConnectionResourceSample) time.Time {
 		return sample.SampledAt
-	}, func(sample *ConnectionResourceSample) apid.ID {
-		return sample.ResourceID
+	}, func(sample *ConnectionResourceSample) string {
+		return sample.ResourceID.String()
 	}, func(sample *ConnectionResourceSample) map[string]string {
 		return connectionResourceMetricLabels(sample, query.GroupBy)
 	})
@@ -160,10 +224,50 @@ func buildConnectionResourceMetricSeries(query ResourceMetricsQuery, samples []*
 func buildActorResourceMetricSeries(query ResourceMetricsQuery, samples []*ActorResourceSample) []ResourceMetricSeries {
 	return buildResourceMetricSeries(query, samples, func(sample *ActorResourceSample) time.Time {
 		return sample.SampledAt
-	}, func(sample *ActorResourceSample) apid.ID {
-		return sample.ResourceID
+	}, func(sample *ActorResourceSample) string {
+		return sample.ResourceID.String()
 	}, func(sample *ActorResourceSample) map[string]string {
 		return actorResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildConnectorResourceMetricSeries(query ResourceMetricsQuery, samples []*ConnectorResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *ConnectorResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *ConnectorResourceSample) string {
+		return sample.ResourceID.String()
+	}, func(sample *ConnectorResourceSample) map[string]string {
+		return connectorResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildConnectorVersionResourceMetricSeries(query ResourceMetricsQuery, samples []*ConnectorVersionResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *ConnectorVersionResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *ConnectorVersionResourceSample) string {
+		return sample.ResourceID.String() + ":" + strconv.FormatUint(sample.ConnectorVersion, 10)
+	}, func(sample *ConnectorVersionResourceSample) map[string]string {
+		return connectorVersionResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildNamespaceResourceMetricSeries(query ResourceMetricsQuery, samples []*NamespaceResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *NamespaceResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *NamespaceResourceSample) string {
+		return sample.ResourceID
+	}, func(sample *NamespaceResourceSample) map[string]string {
+		return namespaceResourceMetricLabels(sample, query.GroupBy)
+	})
+}
+
+func buildRateLimitResourceMetricSeries(query ResourceMetricsQuery, samples []*RateLimitResourceSample) []ResourceMetricSeries {
+	return buildResourceMetricSeries(query, samples, func(sample *RateLimitResourceSample) time.Time {
+		return sample.SampledAt
+	}, func(sample *RateLimitResourceSample) string {
+		return sample.ResourceID.String()
+	}, func(sample *RateLimitResourceSample) map[string]string {
+		return rateLimitResourceMetricLabels(sample, query.GroupBy)
 	})
 }
 
@@ -171,7 +275,7 @@ func buildResourceMetricSeries[T any](
 	query ResourceMetricsQuery,
 	samples []*T,
 	sampledAt func(*T) time.Time,
-	resourceID func(*T) apid.ID,
+	resourceID func(*T) string,
 	labelsFor func(*T) map[string]string,
 ) []ResourceMetricSeries {
 	bucketCount := int(math.Ceil(float64(query.End.Sub(query.Start)) / float64(query.Step)))
@@ -179,7 +283,7 @@ func buildResourceMetricSeries[T any](
 		bucketCount = 1
 	}
 
-	seenByGroup := map[string][]map[apid.ID]struct{}{}
+	seenByGroup := map[string][]map[string]struct{}{}
 	labelsByKey := map[string]map[string]string{}
 
 	if len(query.GroupBy) == 0 {
@@ -231,10 +335,10 @@ func buildResourceMetricSeries[T any](
 	return series
 }
 
-func makeResourceMetricBuckets(bucketCount int) []map[apid.ID]struct{} {
-	buckets := make([]map[apid.ID]struct{}, bucketCount)
+func makeResourceMetricBuckets(bucketCount int) []map[string]struct{} {
+	buckets := make([]map[string]struct{}, bucketCount)
 	for i := range buckets {
-		buckets[i] = map[apid.ID]struct{}{}
+		buckets[i] = map[string]struct{}{}
 	}
 	return buckets
 }
@@ -260,6 +364,64 @@ func actorResourceMetricLabels(sample *ActorResourceSample, groupBy []ResourceGr
 	labels := make(map[string]string, len(groupBy))
 	for _, group := range groupBy {
 		if group == ResourceGroupByNamespace {
+			labels[string(group)] = sample.Namespace
+		}
+	}
+	return labels
+}
+
+func connectorResourceMetricLabels(sample *ConnectorResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case ResourceGroupByState:
+			labels[string(group)] = string(sample.State)
+		case ResourceGroupByConnectorVersion:
+			labels[string(group)] = strconv.FormatUint(sample.ConnectorVersion, 10)
+		case ResourceGroupByNamespace:
+			labels[string(group)] = sample.Namespace
+		}
+	}
+	return labels
+}
+
+func connectorVersionResourceMetricLabels(sample *ConnectorVersionResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case ResourceGroupByState:
+			labels[string(group)] = string(sample.State)
+		case ResourceGroupByConnectorID:
+			labels[string(group)] = sample.ResourceID.String()
+		case ResourceGroupByConnectorVersion:
+			labels[string(group)] = strconv.FormatUint(sample.ConnectorVersion, 10)
+		case ResourceGroupByNamespace:
+			labels[string(group)] = sample.Namespace
+		}
+	}
+	return labels
+}
+
+func namespaceResourceMetricLabels(sample *NamespaceResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case ResourceGroupByState:
+			labels[string(group)] = string(sample.State)
+		case ResourceGroupByNamespace:
+			labels[string(group)] = sample.Namespace
+		}
+	}
+	return labels
+}
+
+func rateLimitResourceMetricLabels(sample *RateLimitResourceSample, groupBy []ResourceGroupBy) map[string]string {
+	labels := make(map[string]string, len(groupBy))
+	for _, group := range groupBy {
+		switch group {
+		case ResourceGroupByMode:
+			labels[string(group)] = sample.Mode
+		case ResourceGroupByNamespace:
 			labels[string(group)] = sample.Namespace
 		}
 	}

--- a/internal/app_metrics/resource_samples.go
+++ b/internal/app_metrics/resource_samples.go
@@ -10,9 +10,17 @@ import (
 const (
 	connectionResourceSamplesTable = "app_metrics_connection_resource_samples"
 	actorResourceSamplesTable      = "app_metrics_actor_resource_samples"
+	connectorResourceSamplesTable  = "app_metrics_connector_resource_samples"
+	connectorVersionSamplesTable   = "app_metrics_connector_version_resource_samples"
+	namespaceResourceSamplesTable  = "app_metrics_namespace_resource_samples"
+	rateLimitResourceSamplesTable  = "app_metrics_rate_limit_resource_samples"
 
-	ResourceTypeConnection = "connection"
-	ResourceTypeActor      = "actor"
+	ResourceTypeConnection       = "connection"
+	ResourceTypeActor            = "actor"
+	ResourceTypeConnector        = "connector"
+	ResourceTypeConnectorVersion = "connector_version"
+	ResourceTypeNamespace        = "namespace"
+	ResourceTypeRateLimit        = "rate_limit"
 )
 
 // ResourceSampleQuery filters point-in-time resource samples.
@@ -52,6 +60,63 @@ type ActorResourceSample struct {
 	Namespace         string
 	Labels            database.Labels
 	ExternalID        string
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}
+
+// ConnectorResourceSample is a point-in-time snapshot of a connector collapsed
+// across versions.
+type ConnectorResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        apid.ID
+	Namespace         string
+	Labels            database.Labels
+	State             database.ConnectorVersionState
+	ConnectorVersion  uint64
+	TotalVersions     int64
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}
+
+// ConnectorVersionResourceSample is a point-in-time snapshot of a connector
+// version.
+type ConnectorVersionResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        apid.ID
+	Namespace         string
+	Labels            database.Labels
+	State             database.ConnectorVersionState
+	ConnectorVersion  uint64
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}
+
+// NamespaceResourceSample is a point-in-time snapshot of a namespace.
+type NamespaceResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        string
+	Namespace         string
+	Labels            database.Labels
+	State             database.NamespaceState
+	ResourceCreatedAt time.Time
+	ResourceUpdatedAt time.Time
+	ResourceDeletedAt *time.Time
+}
+
+// RateLimitResourceSample is a point-in-time snapshot of a rate limiter.
+type RateLimitResourceSample struct {
+	SampledAt         time.Time
+	ResourceType      string
+	ResourceID        apid.ID
+	Namespace         string
+	Labels            database.Labels
+	Mode              string
 	ResourceCreatedAt time.Time
 	ResourceUpdatedAt time.Time
 	ResourceDeletedAt *time.Time

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -67,12 +67,44 @@ func (ss *StorageService) StoreActorResourceSamples(ctx context.Context, samples
 	return ss.store.(ResourceSampleStore).StoreActorResourceSamples(ctx, samples)
 }
 
+func (ss *StorageService) StoreConnectorResourceSamples(ctx context.Context, samples []*ConnectorResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreConnectorResourceSamples(ctx, samples)
+}
+
+func (ss *StorageService) StoreConnectorVersionResourceSamples(ctx context.Context, samples []*ConnectorVersionResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreConnectorVersionResourceSamples(ctx, samples)
+}
+
+func (ss *StorageService) StoreNamespaceResourceSamples(ctx context.Context, samples []*NamespaceResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreNamespaceResourceSamples(ctx, samples)
+}
+
+func (ss *StorageService) StoreRateLimitResourceSamples(ctx context.Context, samples []*RateLimitResourceSample) error {
+	return ss.store.(ResourceSampleStore).StoreRateLimitResourceSamples(ctx, samples)
+}
+
 func (ss *StorageService) ListConnectionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectionResourceSample, error) {
 	return ss.retriever.(ResourceSampleRetriever).ListConnectionResourceSamples(ctx, query)
 }
 
 func (ss *StorageService) ListActorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ActorResourceSample, error) {
 	return ss.retriever.(ResourceSampleRetriever).ListActorResourceSamples(ctx, query)
+}
+
+func (ss *StorageService) ListConnectorResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListConnectorResourceSamples(ctx, query)
+}
+
+func (ss *StorageService) ListConnectorVersionResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*ConnectorVersionResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListConnectorVersionResourceSamples(ctx, query)
+}
+
+func (ss *StorageService) ListNamespaceResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*NamespaceResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListNamespaceResourceSamples(ctx, query)
+}
+
+func (ss *StorageService) ListRateLimitResourceSamples(ctx context.Context, query ResourceSampleQuery) ([]*RateLimitResourceSample, error) {
+	return ss.retriever.(ResourceSampleRetriever).ListRateLimitResourceSamples(ctx, query)
 }
 
 func (ss *StorageService) GetFullLog(ctx context.Context, id apid.ID) (*FullLog, error) {

--- a/internal/app_metrics/task_resource_snapshot.go
+++ b/internal/app_metrics/task_resource_snapshot.go
@@ -106,10 +106,38 @@ func (h *ResourceSnapshotTaskHandler) SnapshotResources(ctx context.Context, at 
 		return err
 	}
 
+	connectorCount, err := h.snapshotConnectors(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot connector resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
+	connectorVersionCount, err := h.snapshotConnectorVersions(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot connector version resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
+	namespaceCount, err := h.snapshotNamespaces(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot namespace resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
+	rateLimitCount, err := h.snapshotRateLimits(ctx, sampledAt)
+	if err != nil {
+		logger.Error("failed to snapshot rate limit resources", "error", err, "duration", time.Since(start))
+		return err
+	}
+
 	logger.Info(
 		"completed app metrics resource snapshot",
 		"connections", connectionCount,
 		"actors", actorCount,
+		"connectors", connectorCount,
+		"connector_versions", connectorVersionCount,
+		"namespaces", namespaceCount,
+		"rate_limits", rateLimitCount,
 		"duration", time.Since(start),
 	)
 	return nil
@@ -147,6 +175,137 @@ func (h *ResourceSnapshotTaskHandler) snapshotConnections(ctx context.Context, s
 		})
 	if err != nil {
 		return total, fmt.Errorf("failed to enumerate connection resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotConnectors(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListConnectorsBuilder().
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[database.Connector]) (pagination.KeepGoing, error) {
+			samples := make([]*ConnectorResourceSample, 0, len(page.Results))
+			for _, connector := range page.Results {
+				connector := connector
+				samples = append(samples, &ConnectorResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeConnector,
+					ResourceID:        connector.Id,
+					Namespace:         connector.Namespace,
+					Labels:            connector.Labels,
+					State:             connector.State,
+					ConnectorVersion:  connector.Version,
+					TotalVersions:     connector.TotalVersions,
+					ResourceCreatedAt: connector.CreatedAt,
+					ResourceUpdatedAt: connector.UpdatedAt,
+					ResourceDeletedAt: connector.DeletedAt,
+				})
+			}
+			if err := h.store.StoreConnectorResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate connector resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotConnectorVersions(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListConnectorVersionsBuilder().
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[database.ConnectorVersion]) (pagination.KeepGoing, error) {
+			samples := make([]*ConnectorVersionResourceSample, 0, len(page.Results))
+			for _, connectorVersion := range page.Results {
+				connectorVersion := connectorVersion
+				samples = append(samples, &ConnectorVersionResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeConnectorVersion,
+					ResourceID:        connectorVersion.Id,
+					Namespace:         connectorVersion.Namespace,
+					Labels:            connectorVersion.Labels,
+					State:             connectorVersion.State,
+					ConnectorVersion:  connectorVersion.Version,
+					ResourceCreatedAt: connectorVersion.CreatedAt,
+					ResourceUpdatedAt: connectorVersion.UpdatedAt,
+					ResourceDeletedAt: connectorVersion.DeletedAt,
+				})
+			}
+			if err := h.store.StoreConnectorVersionResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate connector version resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotNamespaces(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListNamespacesBuilder().
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[database.Namespace]) (pagination.KeepGoing, error) {
+			samples := make([]*NamespaceResourceSample, 0, len(page.Results))
+			for _, ns := range page.Results {
+				ns := ns
+				samples = append(samples, &NamespaceResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeNamespace,
+					ResourceID:        ns.Path,
+					Namespace:         ns.Path,
+					Labels:            ns.Labels,
+					State:             ns.State,
+					ResourceCreatedAt: ns.CreatedAt,
+					ResourceUpdatedAt: ns.UpdatedAt,
+					ResourceDeletedAt: ns.DeletedAt,
+				})
+			}
+			if err := h.store.StoreNamespaceResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate namespace resources for app metrics snapshot: %w", err)
+	}
+	return total, nil
+}
+
+func (h *ResourceSnapshotTaskHandler) snapshotRateLimits(ctx context.Context, sampledAt time.Time) (int, error) {
+	total := 0
+	err := h.db.ListRateLimitsBuilder().
+		Limit(resourceSnapshotBatchSize).
+		Enumerate(ctx, func(page pagination.PageResult[database.RateLimit]) (pagination.KeepGoing, error) {
+			samples := make([]*RateLimitResourceSample, 0, len(page.Results))
+			for _, rateLimit := range page.Results {
+				rateLimit := rateLimit
+				samples = append(samples, &RateLimitResourceSample{
+					SampledAt:         sampledAt,
+					ResourceType:      ResourceTypeRateLimit,
+					ResourceID:        rateLimit.Id,
+					Namespace:         rateLimit.Namespace,
+					Labels:            rateLimit.Labels,
+					Mode:              string(rateLimit.Definition.EffectiveMode()),
+					ResourceCreatedAt: rateLimit.CreatedAt,
+					ResourceUpdatedAt: rateLimit.UpdatedAt,
+					ResourceDeletedAt: rateLimit.DeletedAt,
+				})
+			}
+			if err := h.store.StoreRateLimitResourceSamples(ctx, samples); err != nil {
+				return pagination.Stop, err
+			}
+			total += len(samples)
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return total, fmt.Errorf("failed to enumerate rate limit resources for app metrics snapshot: %w", err)
 	}
 	return total, nil
 }

--- a/internal/app_metrics/task_resource_snapshot_test.go
+++ b/internal/app_metrics/task_resource_snapshot_test.go
@@ -2,6 +2,8 @@ package app_metrics
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,14 +11,16 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/test_utils"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
 
 func TestResourceSnapshotTask_CreatesSamplesAndIsIdempotent(t *testing.T) {
-	ctx, mainDB, store, retriever, handler := newResourceSnapshotTestHarness(t)
+	ctx, mainDB, rawDB, store, retriever, handler := newResourceSnapshotTestHarness(t)
 	now := time.Date(2026, time.May, 29, 12, 7, 0, 0, time.UTC)
 	sampledAt := time.Date(2026, time.May, 29, 12, 0, 0, 0, time.UTC)
 	ctx = apctx.NewBuilder(ctx).WithClock(clock.NewFakeClock(now)).Build()
@@ -41,6 +45,17 @@ func TestResourceSnapshotTask_CreatesSamplesAndIsIdempotent(t *testing.T) {
 		Labels:           database.Labels{"connector": "crm"},
 	}))
 
+	connectorResourceID := apid.New(apid.PrefixConnectorVersion)
+	insertConnectorVersion(t, rawDB, connectorResourceID, "root.metrics", 1, database.ConnectorVersionStatePrimary)
+
+	rateLimitID := apid.New(apid.PrefixRateLimit)
+	require.NoError(t, mainDB.CreateRateLimit(ctx, &database.RateLimit{
+		Id:         rateLimitID,
+		Namespace:  "root.metrics",
+		Definition: validSnapshotRateLimitDef(),
+		Labels:     database.Labels{"scope": "proxy"},
+	}))
+
 	require.NoError(t, handler.runResourceSnapshotTask(ctx, asynq.NewTask(taskTypeResourceSnapshot, nil)))
 	require.NoError(t, handler.SnapshotResources(ctx, now))
 
@@ -63,11 +78,36 @@ func TestResourceSnapshotTask_CreatesSamplesAndIsIdempotent(t *testing.T) {
 	require.Equal(t, "user-123", actorSamples[0].ExternalID)
 	require.Equal(t, "platform", actorSamples[0].Labels["team"])
 
+	connectorSamples := listConnectorSamples(t, retriever, ctx, sampledAt)
+	require.Len(t, connectorSamples, 1)
+	require.Equal(t, connectorResourceID, connectorSamples[0].ResourceID)
+	require.Equal(t, sampledAt, connectorSamples[0].SampledAt)
+	require.Equal(t, "root.metrics", connectorSamples[0].Namespace)
+	require.Equal(t, database.ConnectorVersionStatePrimary, connectorSamples[0].State)
+	require.Equal(t, uint64(1), connectorSamples[0].ConnectorVersion)
+	require.Equal(t, int64(1), connectorSamples[0].TotalVersions)
+
+	connectorVersionSamples := listConnectorVersionSamples(t, retriever, ctx, sampledAt)
+	require.Len(t, connectorVersionSamples, 1)
+	require.Equal(t, connectorResourceID, connectorVersionSamples[0].ResourceID)
+	require.Equal(t, uint64(1), connectorVersionSamples[0].ConnectorVersion)
+	require.Equal(t, database.ConnectorVersionStatePrimary, connectorVersionSamples[0].State)
+
+	namespaceSamples := listNamespaceSamples(t, retriever, ctx, sampledAt)
+	require.Contains(t, namespaceSampleIDs(namespaceSamples), "root.metrics")
+
+	rateLimitSamples := listRateLimitSamples(t, retriever, ctx, sampledAt)
+	require.Len(t, rateLimitSamples, 1)
+	require.Equal(t, rateLimitID, rateLimitSamples[0].ResourceID)
+	require.Equal(t, "root.metrics", rateLimitSamples[0].Namespace)
+	require.Equal(t, string(rlschema.ModeObserve), rateLimitSamples[0].Mode)
+	require.Equal(t, "proxy", rateLimitSamples[0].Labels["scope"])
+
 	require.NoError(t, store.StoreActorResourceSamples(ctx, nil), "empty stores remain no-ops")
 }
 
 func TestResourceSnapshotTask_DeletedResourcesDoNotAppearInLaterSlices(t *testing.T) {
-	ctx, mainDB, _, retriever, handler := newResourceSnapshotTestHarness(t)
+	ctx, mainDB, rawDB, _, retriever, handler := newResourceSnapshotTestHarness(t)
 	firstClock := clock.NewFakeClock(time.Date(2026, time.May, 29, 12, 7, 0, 0, time.UTC))
 	ctx = apctx.NewBuilder(ctx).WithClock(firstClock).Build()
 	firstSampledAt := time.Date(2026, time.May, 29, 12, 0, 0, 0, time.UTC)
@@ -89,11 +129,26 @@ func TestResourceSnapshotTask_DeletedResourcesDoNotAppearInLaterSlices(t *testin
 		State:            database.ConnectionStateConfigured,
 	}))
 
+	connectorResourceID := apid.New(apid.PrefixConnectorVersion)
+	insertConnectorVersion(t, rawDB, connectorResourceID, "root.metrics", 1, database.ConnectorVersionStatePrimary)
+
+	require.NoError(t, mainDB.EnsureNamespaceByPath(ctx, "root.metrics.deleted"))
+
+	rateLimitID := apid.New(apid.PrefixRateLimit)
+	require.NoError(t, mainDB.CreateRateLimit(ctx, &database.RateLimit{
+		Id:         rateLimitID,
+		Namespace:  "root.metrics",
+		Definition: validSnapshotRateLimitDef(),
+	}))
+
 	require.NoError(t, handler.SnapshotResources(ctx, firstClock.Now()))
 
 	firstClock.SetTime(time.Date(2026, time.May, 29, 12, 16, 0, 0, time.UTC))
 	require.NoError(t, mainDB.DeleteActor(ctx, actorID))
 	require.NoError(t, mainDB.DeleteConnection(ctx, connID))
+	require.NoError(t, mainDB.DeleteConnector(ctx, connectorResourceID))
+	require.NoError(t, mainDB.DeleteNamespace(ctx, "root.metrics.deleted"))
+	require.NoError(t, mainDB.DeleteRateLimit(ctx, rateLimitID))
 	require.NoError(t, handler.SnapshotResources(ctx, firstClock.Now()))
 
 	firstConnectionSamples := listConnectionSamples(t, retriever, ctx, firstSampledAt)
@@ -105,6 +160,26 @@ func TestResourceSnapshotTask_DeletedResourcesDoNotAppearInLaterSlices(t *testin
 	require.Len(t, firstActorSamples, 1)
 	secondActorSamples := listActorSamples(t, retriever, ctx, secondSampledAt)
 	require.Empty(t, secondActorSamples)
+
+	firstConnectorSamples := listConnectorSamples(t, retriever, ctx, firstSampledAt)
+	require.Len(t, firstConnectorSamples, 1)
+	secondConnectorSamples := listConnectorSamples(t, retriever, ctx, secondSampledAt)
+	require.Empty(t, secondConnectorSamples)
+
+	firstConnectorVersionSamples := listConnectorVersionSamples(t, retriever, ctx, firstSampledAt)
+	require.Len(t, firstConnectorVersionSamples, 1)
+	secondConnectorVersionSamples := listConnectorVersionSamples(t, retriever, ctx, secondSampledAt)
+	require.Empty(t, secondConnectorVersionSamples)
+
+	firstNamespaceSamples := listNamespaceSamples(t, retriever, ctx, firstSampledAt)
+	require.Contains(t, namespaceSampleIDs(firstNamespaceSamples), "root.metrics.deleted")
+	secondNamespaceSamples := listNamespaceSamples(t, retriever, ctx, secondSampledAt)
+	require.NotContains(t, namespaceSampleIDs(secondNamespaceSamples), "root.metrics.deleted")
+
+	firstRateLimitSamples := listRateLimitSamples(t, retriever, ctx, firstSampledAt)
+	require.Len(t, firstRateLimitSamples, 1)
+	secondRateLimitSamples := listRateLimitSamples(t, retriever, ctx, secondSampledAt)
+	require.Empty(t, secondRateLimitSamples)
 }
 
 func TestResourceSnapshotTask_CronUsesConfiguredInterval(t *testing.T) {
@@ -129,13 +204,14 @@ func TestResourceSnapshotTask_CronUsesConfiguredInterval(t *testing.T) {
 func newResourceSnapshotTestHarness(t testing.TB) (
 	context.Context,
 	database.DB,
+	*sql.DB,
 	ResourceSampleStore,
 	ResourceSampleRetriever,
 	*ResourceSnapshotTaskHandler,
 ) {
 	t.Helper()
 
-	_, mainDB := database.MustApplyBlankTestDbConfig(t, nil)
+	_, mainDB, rawDB := database.MustApplyBlankTestDbConfigRaw(t, nil)
 	require.NoError(t, mainDB.EnsureNamespaceByPath(context.Background(), "root.metrics"))
 	store, retriever, _ := MustNewBlankRequestEventsStore(t)
 	resourceStore := store.(ResourceSampleStore)
@@ -150,7 +226,39 @@ func newResourceSnapshotTestHarness(t testing.TB) (
 		test_utils.NewTestLogger(),
 	)
 
-	return context.Background(), mainDB, resourceStore, resourceRetriever, handler
+	return context.Background(), mainDB, rawDB, resourceStore, resourceRetriever, handler
+}
+
+func insertConnectorVersion(
+	t testing.TB,
+	rawDB *sql.DB,
+	id apid.ID,
+	namespace string,
+	version uint64,
+	state database.ConnectorVersionState,
+) {
+	t.Helper()
+	_, err := rawDB.Exec(fmt.Sprintf(`
+INSERT INTO connector_versions
+(id, namespace, version, state, type, encrypted_definition, hash, created_at, updated_at, deleted_at)
+VALUES
+('%s', '%s', %d, '%s', 'test', '{"id":"ekv_test","d":"encrypted-def"}', 'hash-%d', '2026-05-29 12:00:00', '2026-05-29 12:00:00', null)
+`, id, namespace, version, state, version))
+	require.NoError(t, err)
+}
+
+func validSnapshotRateLimitDef() rlschema.RateLimit {
+	return rlschema.RateLimit{
+		Mode: rlschema.ModeObserve,
+		Selector: rlschema.Selector{
+			Methods:      []string{"GET"},
+			RequestTypes: []common.RequestType{common.RequestTypeProxy},
+		},
+		Bucket: rlschema.Bucket{Dimensions: []string{rlschema.DimensionActor}},
+		Algorithm: rlschema.Algorithm{
+			TokenBucket: &rlschema.TokenBucket{Capacity: 60, RefillRate: 1},
+		},
+	}
 }
 
 func listConnectionSamples(
@@ -176,6 +284,74 @@ func listActorSamples(
 ) []*ActorResourceSample {
 	t.Helper()
 	samples, err := retriever.ListActorResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}
+
+func listConnectorSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*ConnectorResourceSample {
+	t.Helper()
+	samples, err := retriever.ListConnectorResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}
+
+func listConnectorVersionSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*ConnectorVersionResourceSample {
+	t.Helper()
+	samples, err := retriever.ListConnectorVersionResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}
+
+func listNamespaceSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*NamespaceResourceSample {
+	t.Helper()
+	samples, err := retriever.ListNamespaceResourceSamples(ctx, ResourceSampleQuery{
+		Start: &sampledAt,
+		End:   &sampledAt,
+	})
+	require.NoError(t, err)
+	return samples
+}
+
+func namespaceSampleIDs(samples []*NamespaceResourceSample) []string {
+	ids := make([]string, 0, len(samples))
+	for _, sample := range samples {
+		ids = append(ids, sample.ResourceID)
+	}
+	return ids
+}
+
+func listRateLimitSamples(
+	t testing.TB,
+	retriever ResourceSampleRetriever,
+	ctx context.Context,
+	sampledAt time.Time,
+) []*RateLimitResourceSample {
+	t.Helper()
+	samples, err := retriever.ListRateLimitResourceSamples(ctx, ResourceSampleQuery{
 		Start: &sampledAt,
 		End:   &sampledAt,
 	})

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -310,6 +310,22 @@ func resourceMetricFromAPI(metric, aggregation string) (app_metrics.ResourceMetr
 		if aggregation == "count" {
 			return app_metrics.ResourceMetricActorsCount, nil
 		}
+	case "resources.connectors":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricConnectorsCount, nil
+		}
+	case "resources.connector_versions":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricConnectorVersionsCount, nil
+		}
+	case "resources.namespaces":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricNamespacesCount, nil
+		}
+	case "resources.rate_limits":
+		if aggregation == "count" {
+			return app_metrics.ResourceMetricRateLimitsCount, nil
+		}
 	}
 	return "", httperr.BadRequestf("unsupported metric aggregation %q/%q", metric, aggregation)
 }


### PR DESCRIPTION
## Summary
- adds app_metrics sample tables for connectors, connector versions, namespaces, and rate limits across SQLite, Postgres, and ClickHouse
- extends the resource snapshot worker to store the new live resource samples while preserving existing deleted-resource slice behavior
- adds resource metrics query support for resources.connectors.count, resources.connector_versions.count, resources.namespaces.count, and resources.rate_limits.count

Closes #435

## Tests
- env GOCACHE=/private/tmp/authproxy-go-cache AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=sqlite go test ./internal/app_metrics ./internal/routes
- env GOCACHE=/private/tmp/authproxy-go-cache AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=postgres go test ./internal/app_metrics -run 'TestResourceSnapshotTask|TestResourceSamples|TestResourceMetrics' -count=1
- env GOCACHE=/private/tmp/authproxy-go-cache AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=postgres go test ./internal/app_metrics
- ./scripts/preflight.sh

Note: local ClickHouse test run could not authenticate to localhost:8123 (HTTP 401 REQUIRED_PASSWORD), so ClickHouse execution is left to CI.