### PR TITLE
Prepare Admin UI metrics client integration

### DIFF
--- a/sdks/js/src/metrics.ts
+++ b/sdks/js/src/metrics.ts
@@ -1,8 +1,31 @@
+import {AxiosRequestConfig} from 'axios';
 import {client} from './client';
 
 export type MetricsAggregation = 'count' | 'avg' | 'p95';
-export type MetricsMetric = 'request_events' | 'request_events.errors' | 'request_events.duration_ms';
-export type MetricsGroupBy = 'type' | 'method' | 'response_status_code' | 'response_source' | 'connector_id';
+export type RequestEventMetricsMetric = 'request_events' | 'request_events.errors' | 'request_events.duration_ms';
+export type ResourceMetricsMetric =
+    | 'resources.connections'
+    | 'resources.actors'
+    | 'resources.connectors'
+    | 'resources.connector_versions'
+    | 'resources.namespaces'
+    | 'resources.rate_limits';
+export type MetricsMetric = RequestEventMetricsMetric | ResourceMetricsMetric;
+
+export type RequestEventMetricsGroupBy =
+    | 'type'
+    | 'method'
+    | 'response_status_code'
+    | 'response_source'
+    | 'connector_id';
+export type ResourceMetricsGroupBy =
+    | 'state'
+    | 'health_state'
+    | 'connector_id'
+    | 'connector_version'
+    | 'namespace'
+    | 'mode';
+export type MetricsGroupBy = RequestEventMetricsGroupBy | ResourceMetricsGroupBy;
 
 export interface MetricsRange {
     start: string;
@@ -41,8 +64,8 @@ export interface MetricsQueryResponse {
     series: MetricsSeries[];
 }
 
-export const queryMetrics = (request: MetricsQueryRequest) => {
-    return client.post<MetricsQueryResponse>('/api/v1/metrics/query', request);
+export const queryMetrics = (request: MetricsQueryRequest, config?: AxiosRequestConfig) => {
+    return client.post<MetricsQueryResponse>('/api/v1/metrics/query', request, config);
 };
 
 export const metrics = {

--- a/ui/admin/src/metrics/index.ts
+++ b/ui/admin/src/metrics/index.ts
@@ -1,0 +1,2 @@
+export * from './timeSeries';
+export * from './useMetricsQuery';

--- a/ui/admin/src/metrics/timeSeries.test.ts
+++ b/ui/admin/src/metrics/timeSeries.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from 'vitest';
+import {
+    metricSeriesLabel,
+    metricsResponseIsEmpty,
+    metricsSeriesByRef,
+    metricsSeriesToChartRows,
+    summarizeMetricSeries,
+} from './timeSeries';
+import type {MetricsQueryResponse, MetricsSeries} from '@authproxy/api';
+
+const series = (overrides: Partial<MetricsSeries>): MetricsSeries => ({
+    ref_id: 'connections',
+    metric: 'resources.connections',
+    aggregation: 'count',
+    labels: {},
+    points: [],
+    ...overrides,
+});
+
+describe('metrics time-series helpers', () => {
+    it('formats labels in a stable order', () => {
+        expect(metricSeriesLabel(series({
+            labels: {state: 'configured', health_state: 'healthy'},
+        }))).toEqual('health_state: healthy, state: configured');
+        expect(metricSeriesLabel(series({labels: {}}))).toEqual('connections');
+    });
+
+    it('summarizes latest point and total value', () => {
+        const summary = summarizeMetricSeries(series({
+            points: [
+                {timestamp: '2026-05-29T12:00:00Z', value: 2},
+                {timestamp: '2026-05-29T12:15:00Z', value: 3},
+            ],
+        }));
+        expect(summary.latest?.value).toEqual(3);
+        expect(summary.total).toEqual(5);
+        expect(summary.isEmpty).toEqual(false);
+    });
+
+    it('detects empty responses', () => {
+        expect(metricsResponseIsEmpty(null)).toEqual(true);
+        expect(metricsResponseIsEmpty({series: []})).toEqual(true);
+        expect(metricsResponseIsEmpty({series: [series({
+            points: [{timestamp: '2026-05-29T12:00:00Z', value: 0}],
+        })]})).toEqual(true);
+    });
+
+    it('groups series by ref and converts chart rows', () => {
+        const response: MetricsQueryResponse = {
+            series: [
+                series({
+                    labels: {state: 'configured'},
+                    points: [{timestamp: '2026-05-29T12:00:00Z', value: 2}],
+                }),
+                series({
+                    labels: {state: 'setup'},
+                    points: [{timestamp: '2026-05-29T12:00:00Z', value: 1}],
+                }),
+            ],
+        };
+
+        expect(metricsSeriesByRef(response).connections).toHaveLength(2);
+        expect(metricsSeriesToChartRows(response.series)).toEqual([
+            {
+                timestamp: '2026-05-29T12:00:00Z',
+                'state: configured': 2,
+                'state: setup': 1,
+            },
+        ]);
+    });
+});

--- a/ui/admin/src/metrics/timeSeries.ts
+++ b/ui/admin/src/metrics/timeSeries.ts
@@ -1,0 +1,79 @@
+import type {MetricsPoint, MetricsQueryResponse, MetricsSeries} from '@authproxy/api';
+
+export interface MetricsSeriesSummary {
+    refId: string;
+    metric: string;
+    aggregation: string;
+    labels: Record<string, string>;
+    latest: MetricsPoint | null;
+    total: number;
+    isEmpty: boolean;
+}
+
+export interface ChartMetricPoint {
+    timestamp: string;
+    [seriesKey: string]: string | number | null;
+}
+
+export const metricSeriesLabel = (series: Pick<MetricsSeries, 'ref_id' | 'labels'>): string => {
+    const labels = series.labels || {};
+    const entries = Object.entries(labels).sort(([a], [b]) => a.localeCompare(b));
+    if (entries.length === 0) {
+        return series.ref_id;
+    }
+    return entries.map(([key, value]) => `${key}: ${value}`).join(', ');
+};
+
+export const summarizeMetricSeries = (series: MetricsSeries): MetricsSeriesSummary => {
+    const latest = findLatestMetricPoint(series.points || []);
+    const total = (series.points || []).reduce((sum, point) => sum + point.value, 0);
+    return {
+        refId: series.ref_id,
+        metric: series.metric,
+        aggregation: series.aggregation,
+        labels: series.labels || {},
+        latest,
+        total,
+        isEmpty: !latest || total === 0,
+    };
+};
+
+export const summarizeMetricsResponse = (response: MetricsQueryResponse | null | undefined): MetricsSeriesSummary[] => {
+    return (response?.series || []).map(summarizeMetricSeries);
+};
+
+export const metricsResponseIsEmpty = (response: MetricsQueryResponse | null | undefined): boolean => {
+    const series = response?.series || [];
+    return series.length === 0 || series.every((item) => summarizeMetricSeries(item).isEmpty);
+};
+
+export const metricsSeriesByRef = (response: MetricsQueryResponse | null | undefined): Record<string, MetricsSeries[]> => {
+    const grouped: Record<string, MetricsSeries[]> = {};
+    for (const series of response?.series || []) {
+        grouped[series.ref_id] = grouped[series.ref_id] || [];
+        grouped[series.ref_id].push(series);
+    }
+    return grouped;
+};
+
+export const metricsSeriesToChartRows = (series: MetricsSeries[]): ChartMetricPoint[] => {
+    const rowsByTimestamp = new Map<string, ChartMetricPoint>();
+    for (const item of series) {
+        const key = metricSeriesLabel(item);
+        for (const point of item.points || []) {
+            const row = rowsByTimestamp.get(point.timestamp) || {timestamp: point.timestamp};
+            row[key] = point.value;
+            rowsByTimestamp.set(point.timestamp, row);
+        }
+    }
+    return Array.from(rowsByTimestamp.values()).sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+};
+
+const findLatestMetricPoint = (points: MetricsPoint[]): MetricsPoint | null => {
+    if (points.length === 0) {
+        return null;
+    }
+    return points.reduce((latest, point) => {
+        return point.timestamp > latest.timestamp ? point : latest;
+    }, points[0]);
+};

--- a/ui/admin/src/metrics/useMetricsQuery.ts
+++ b/ui/admin/src/metrics/useMetricsQuery.ts
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import {
+    MetricsQueryRef,
+    MetricsQueryResponse,
+    MetricsRange,
+    namespaceAndChildren,
+    queryMetrics,
+} from '@authproxy/api';
+import {useSelector} from 'react-redux';
+import {selectCurrentNamespacePath} from '../store/namespacesSlice';
+import {metricsResponseIsEmpty, metricsSeriesByRef, summarizeMetricsResponse} from './timeSeries';
+
+export interface UseMetricsQueryOptions {
+    range: MetricsRange;
+    queries: MetricsQueryRef[];
+    namespace?: string | null;
+    labelSelector?: string;
+    enabled?: boolean;
+}
+
+export interface UseMetricsQueryResult {
+    data: MetricsQueryResponse | null;
+    loading: boolean;
+    error: string | null;
+    empty: boolean;
+    summaries: ReturnType<typeof summarizeMetricsResponse>;
+    seriesByRef: ReturnType<typeof metricsSeriesByRef>;
+    reload: () => void;
+}
+
+export const useMetricsQuery = ({
+    range,
+    queries,
+    namespace,
+    labelSelector,
+    enabled = true,
+}: UseMetricsQueryOptions): UseMetricsQueryResult => {
+    const currentNamespace = useSelector(selectCurrentNamespacePath);
+    const [data, setData] = React.useState<MetricsQueryResponse | null>(null);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [reloadNonce, setReloadNonce] = React.useState(0);
+
+    const effectiveNamespace = React.useMemo(
+        () => namespace ?? namespaceAndChildren(currentNamespace),
+        [currentNamespace, namespace],
+    );
+    React.useEffect(() => {
+        if (!enabled || queries.length === 0) {
+            setLoading(false);
+            setError(null);
+            setData(null);
+            return;
+        }
+
+        const controller = new AbortController();
+        setLoading(true);
+        setError(null);
+
+        void queryMetrics(
+            {
+                range,
+                namespace: effectiveNamespace,
+                label_selector: labelSelector || undefined,
+                queries,
+            },
+            {signal: controller.signal},
+        )
+            .then((response) => {
+                if (!controller.signal.aborted) {
+                    setData(response.data);
+                }
+            })
+            .catch((err: unknown) => {
+                if (!controller.signal.aborted) {
+                    setData(null);
+                    setError(metricsErrorMessage(err));
+                }
+            })
+            .finally(() => {
+                if (!controller.signal.aborted) {
+                    setLoading(false);
+                }
+            });
+
+        return () => controller.abort();
+    }, [effectiveNamespace, enabled, labelSelector, queries, range, reloadNonce]);
+
+    const summaries = React.useMemo(() => summarizeMetricsResponse(data), [data]);
+    const seriesByRef = React.useMemo(() => metricsSeriesByRef(data), [data]);
+
+    return {
+        data,
+        loading,
+        error,
+        empty: metricsResponseIsEmpty(data),
+        summaries,
+        seriesByRef,
+        reload: () => setReloadNonce((value) => value + 1),
+    };
+};
+
+const metricsErrorMessage = (err: unknown): string => {
+    if (typeof err === 'object' && err !== null) {
+        const maybeAxios = err as {
+            message?: string;
+            response?: {data?: {error?: string; message?: string}};
+        };
+        return maybeAxios.response?.data?.error ||
+            maybeAxios.response?.data?.message ||
+            maybeAxios.message ||
+            'Failed to load metrics';
+    }
+    return 'Failed to load metrics';
+};


### PR DESCRIPTION
## Summary
- expands the JS SDK metrics types to include resource metrics and allows request cancellation config on queryMetrics
- adds an Admin UI useMetricsQuery hook that uses the current namespace by default, accepts label selectors, and returns loading/error/empty state
- adds reusable UI formatting helpers for metric summaries, grouping, and chart rows, with unit coverage

Closes #408

## Tests
- yarn workspace @authproxy/api typecheck
- yarn workspace @authproxy/admin typecheck
- yarn workspace @authproxy/admin test --run src/metrics/timeSeries.test.ts
- yarn workspace @authproxy/api lint
- yarn workspace @authproxy/admin lint
- ./scripts/preflight.sh

## Screenshots
No screenshots attached because this PR adds client/hooks/helpers only and does not change rendered Admin UI screens.