### PR TITLE
Document app metrics query foundation

### DIFF
--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -92,7 +92,7 @@ app_metrics:
   #  database:
   #    provider: sqlite
   #    auto_migrate: true
-  #    path: ./dev_config/http_log.db
+  #    path: ./dev_config/app_metrics.db
   database:
     provider: clickhouse
     auto_migrate: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 - **[CLI (`ap`)](cli.md)** — config file shape (`~/.authproxy.yaml`), RS256 vs HS256 signing keys, every command (list, sign-jwt / verify-jwt, signing-proxy, the connection-scoped streaming `proxy` with `curl`/`wget` modes, marketplace helpers).
 - **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
 - **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
+- **[Application metrics](app_metrics.md)** — configure the app metrics store, query request-event and resource metrics, and understand supported aggregations and dimensions.
 
 ## Operational guides
 

--- a/docs/app_metrics.md
+++ b/docs/app_metrics.md
@@ -1,0 +1,104 @@
+# Application Metrics
+
+AuthProxy stores Admin UI-facing application metrics in the `app_metrics` store. This store includes request-event records, optional full request/response payloads, and periodic resource snapshots used for time-series dashboards.
+
+## Configuration
+
+`app_metrics` is required because request-event listing and metrics queries are routed through it. In development the store can use SQLite, Postgres, or ClickHouse. Deployed environments should prefer ClickHouse or a dedicated Postgres database when request volume is high.
+
+```yaml
+app_metrics:
+  resource_snapshot_interval: 15m
+  database:
+    provider: clickhouse
+    auto_migrate: true
+    addresses:
+      - localhost:8123
+    database: authproxy
+    user: authproxy
+    password: authproxy
+  request_events:
+    full_request_recording: errors
+  blob_storage:
+    provider: s3
+    bucket: authproxy-request-logs
+```
+
+Key settings:
+
+| Setting | Purpose |
+|---|---|
+| `app_metrics.database` | Dedicated database for request events and resource sample tables. |
+| `app_metrics.resource_snapshot_interval` | Cadence for the worker snapshot job. Defaults to `15m`. |
+| `app_metrics.request_events.full_request_recording` | Controls when full request/response bodies are captured. |
+| `app_metrics.blob_storage` | Stores full request/response payloads when capture is enabled. |
+
+The resource snapshot worker stores live resources at each interval. Deleted resources remain visible in historical time slices where they were sampled, but they are excluded from later snapshots.
+
+## Query API
+
+Use `POST /api/v1/metrics/query` with a time range, optional namespace matcher, optional label selector, and one or more query refs.
+
+```json
+{
+  "range": {
+    "start": "2026-05-25T12:00:00Z",
+    "end": "2026-05-25T13:00:00Z",
+    "step": "15m"
+  },
+  "namespace": "root.**",
+  "label_selector": "env=prod",
+  "queries": [
+    {
+      "ref_id": "connections",
+      "metric": "resources.connections",
+      "aggregation": "count",
+      "group_by": ["state", "health_state"]
+    }
+  ]
+}
+```
+
+Responses are returned as labeled time series:
+
+```json
+{
+  "series": [
+    {
+      "ref_id": "connections",
+      "metric": "resources.connections",
+      "aggregation": "count",
+      "labels": {
+        "state": "configured",
+        "health_state": "healthy"
+      },
+      "points": [
+        {"timestamp": "2026-05-25T12:00:00Z", "value": 4}
+      ]
+    }
+  ]
+}
+```
+
+## Metrics
+
+Request-event metrics are computed from stored request events.
+
+| Metric | Aggregations | `group_by` |
+|---|---|---|
+| `request_events` | `count` | `type`, `method`, `response_status_code`, `response_source`, `connector_id` |
+| `request_events.errors` | `count` | `type`, `method`, `response_status_code`, `response_source`, `connector_id` |
+| `request_events.duration_ms` | `avg`, `p95` | `type`, `method`, `response_status_code`, `response_source`, `connector_id` |
+
+Resource metrics are computed from periodic app-metrics resource samples.
+
+| Metric | Aggregations | `group_by` |
+|---|---|---|
+| `resources.connections` | `count` | `state`, `health_state`, `connector_id`, `connector_version` |
+| `resources.actors` | `count` | `namespace` |
+| `resources.connectors` | `count` | `state`, `connector_version`, `namespace` |
+| `resources.connector_versions` | `count` | `state`, `connector_id`, `connector_version`, `namespace` |
+| `resources.namespaces` | `count` | `state`, `namespace` |
+| `resources.rate_limits` | `count` | `mode`, `namespace` |
+
+All metric queries accept the same namespace matcher and label selector fields. Label selectors evaluate against the frozen labels stored with the request event or resource sample, not the current live resource.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,14 @@ AuthProxy acts as an HTTP proxy between your application and external APIs. When
 - **Actors** represent users or service accounts with namespace-scoped permissions. JWTs can carry a subset of an actor's permissions for least-privilege access.
 - **Labels** are Kubernetes-style key-value metadata on all resources, enabling lightweight integration with your host application's data model.
 - **Application-level encryption** ensures all sensitive data (OAuth tokens, API keys, connector definitions) is encrypted before reaching any data store, with support for per-namespace keys, external key providers, and automatic key rotation with re-encryption.
-- **Request logging** captures comprehensive metadata and optionally full request/response bodies for auditability and debugging.
+- **Application metrics** capture request-event metadata, optional full request/response bodies, and periodic resource snapshots for auditability, debugging, and Admin UI dashboards.
 
 ## Resources
 
 * [GitHub Repository](https://github.com/rmorlok/authproxy)
 * [Marketplace UI Storybook](./storybook/marketplace/)
 * [Admin UI Storybook](./storybook/admin/)
+* [Application Metrics](./app_metrics.md)
 
 ## Architecture Diagrams
 

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -358,7 +358,17 @@
         "ref_id": { "type": "string" },
         "metric": {
           "type": "string",
-          "enum": ["request_events", "request_events.errors", "request_events.duration_ms"]
+          "enum": [
+            "request_events",
+            "request_events.errors",
+            "request_events.duration_ms",
+            "resources.connections",
+            "resources.actors",
+            "resources.connectors",
+            "resources.connector_versions",
+            "resources.namespaces",
+            "resources.rate_limits"
+          ]
         },
         "aggregation": {
           "type": "string",
@@ -368,7 +378,18 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["type", "method", "response_status_code", "response_source", "connector_id"]
+            "enum": [
+              "type",
+              "method",
+              "response_status_code",
+              "response_source",
+              "connector_id",
+              "state",
+              "health_state",
+              "connector_version",
+              "namespace",
+              "mode"
+            ]
           }
         }
       },

--- a/internal/schema/api/test_data/valid-metrics-query.json
+++ b/internal/schema/api/test_data/valid-metrics-query.json
@@ -12,6 +12,12 @@
       "metric": "request_events",
       "aggregation": "count",
       "group_by": ["method", "response_status_code"]
+    },
+    {
+      "ref_id": "connections",
+      "metric": "resources.connections",
+      "aggregation": "count",
+      "group_by": ["state", "health_state"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- adds app metrics docs for configuration, resource snapshots, query API, metric names, aggregations, and group_by dimensions
- links the new guide from the docs index/README and updates the stale dev config SQLite example path
- expands the API JSON schema/test fixture to include resource metrics alongside request-event metrics

Closes #406

## Tests
- go test ./internal/schema/api ./internal/schema/config
- ./scripts/preflight.sh

## Screenshots
No screenshots: documentation/schema-only PR; no rendered Admin UI changes.