### PR TITLE
Add top-level JWT permission restrictions

### DIFF
--- a/internal/apauth/jwt/auth_proxy_claims.go
+++ b/internal/apauth/jwt/auth_proxy_claims.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 )
 
 var ErrInvalidClaims = errors.New("invalid jwt claims")
@@ -31,6 +32,11 @@ type AuthProxyClaims struct {
 	// actor configured in the system. If Actor is specified, the value of ExternalId must be the same as sub in the
 	// base claims.
 	Actor *core.Actor `json:"actor,omitempty"`
+
+	// Permissions optionally restrict what this specific token can do. These
+	// permissions are intersected with the authenticated actor's permissions and
+	// cannot grant access the actor does not already have.
+	Permissions []aschema.Permission `json:"permissions,omitempty"`
 
 	// SystemSigned indicates this token was signed by an AuthProxy service using the GlobalAESKey (HMAC).
 	// This is used for internal auth transfer between services, OAuth redirects, etc.
@@ -80,6 +86,12 @@ func (tc *AuthProxyClaims) Validate(v *jwt.Validator) error {
 
 		if tc.GetNamespace() != tc.Actor.GetNamespace() {
 			result = multierror.Append(result, errors.New("token namespace and actor namespace do not match"))
+		}
+	}
+
+	for _, permission := range tc.Permissions {
+		if err := permission.Validate(); err != nil {
+			result = multierror.Append(result, err)
 		}
 	}
 

--- a/internal/apauth/jwt/auth_proxy_claims_test.go
+++ b/internal/apauth/jwt/auth_proxy_claims_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/rmorlok/authproxy/internal/apauth/core"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,5 +54,25 @@ func TestJwtTokenClaims(t *testing.T) {
 			}
 			assert.True(t, tc.IsExpired(context.Background()), "expired token should be expired")
 		})
+	})
+	t.Run("Validate top-level permissions", func(t *testing.T) {
+		tc := AuthProxyClaims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "bobdole",
+			},
+			Permissions: []aschema.Permission{
+				{
+					Namespace: "root.**",
+					Resources: []string{"connections"},
+					Verbs:     []string{"list"},
+				},
+			},
+		}
+		assert.NoError(t, tc.Validate(jwt.NewValidator()))
+
+		tc.Permissions = []aschema.Permission{{Namespace: "root.**"}}
+		err := tc.Validate(jwt.NewValidator())
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidClaims)
 	})
 }

--- a/internal/apauth/jwt/claims_builder.go
+++ b/internal/apauth/jwt/claims_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -29,6 +30,7 @@ type ClaimsBuilder interface {
 	WithActorExternalId(id string) ClaimsBuilder
 	WithNamespace(namespace string) ClaimsBuilder
 	WithActor(actor core.IActorData) ClaimsBuilder
+	WithPermissions(permissions []aschema.Permission) ClaimsBuilder
 	WithLabels(labels map[string]string) ClaimsBuilder
 	WithLabel(key, value string) ClaimsBuilder
 	WithNonce() ClaimsBuilder
@@ -46,6 +48,7 @@ type claimsBuilder struct {
 	externalId   *string
 	namespace    *string
 	actor        *core.Actor
+	permissions  []aschema.Permission
 	labels       map[string]string
 	systemSigned bool
 	actorSigned  bool
@@ -113,6 +116,11 @@ func (b *claimsBuilder) WithNamespace(namespace string) ClaimsBuilder {
 
 func (b *claimsBuilder) WithActor(actor core.IActorData) ClaimsBuilder {
 	b.actor = core.CreateActor(actor)
+	return b
+}
+
+func (b *claimsBuilder) WithPermissions(permissions []aschema.Permission) ClaimsBuilder {
+	b.permissions = permissions
 	return b
 }
 
@@ -184,6 +192,7 @@ func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) 
 			ID:       apctx.GetIdGenerator(ctx).NewString(apid.PrefixJwtId),
 		},
 		Actor:        b.actor,
+		Permissions:  b.permissions,
 		SystemSigned: b.systemSigned,
 		ActorSigned:  b.actorSigned,
 	}

--- a/internal/apauth/jwt/claims_builder_test.go
+++ b/internal/apauth/jwt/claims_builder_test.go
@@ -117,6 +117,31 @@ func TestClaimsBuilder(t *testing.T) {
 		require.Equal(t, "root.child", claims.Namespace)
 		require.Equal(t, apctx.GetClock(ctx).Now().Add(10*time.Minute), claims.ExpiresAt.Time)
 	})
+	t.Run("valid with top-level permissions", func(t *testing.T) {
+		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+		permissions := []aschema.Permission{
+			{
+				Namespace: "root.child.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"list"},
+			},
+		}
+
+		claims, err := NewClaimsBuilder().
+			WithServiceId(config.ServiceIdPublic).
+			WithActorExternalId("bob-dole").
+			WithNamespace("root.child").
+			WithPermissions(permissions).
+			BuildCtx(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, permissions, claims.Permissions)
+		require.Nil(t, claims.Actor)
+		require.Equal(t, "bob-dole", claims.Subject)
+		require.Equal(t, "root.child", claims.Namespace)
+	})
 	t.Run("nonce", func(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
 			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)

--- a/internal/apauth/jwt/schema.json
+++ b/internal/apauth/jwt/schema.json
@@ -38,7 +38,11 @@
       "type": "string",
       "description": "JWT ID. Optional. Not used by Auth Proxy."
     },
-    "actor": { "$ref": "schema-actor.json" }
+    "actor": { "$ref": "schema-actor.json" },
+    "permissions": {
+      "type": "array",
+      "description": "Optional request-level permission restrictions. These are intersected with the authenticated actor's permissions and cannot grant additional access."
+    }
   },
   "additionalProperties": true
 }

--- a/internal/apauth/jwt/test_data/example.json
+++ b/internal/apauth/jwt/test_data/example.json
@@ -15,5 +15,12 @@
       "root.prod.actor-1234#/connections/_initiate",
       "root.prod.**#/connections/_list"
     ]
-  }
+  },
+  "permissions": [
+    {
+      "namespace": "root.prod.**",
+      "resources": ["connections"],
+      "verbs": ["list"]
+    }
+  ]
 }

--- a/internal/apauth/jwt/token_builder.go
+++ b/internal/apauth/jwt/token_builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rmorlok/authproxy/internal/apauth/core"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
 	"golang.org/x/crypto/ssh"
@@ -41,6 +42,7 @@ type TokenBuilder interface {
 	WithActorExternalId(id string) TokenBuilder
 	WithNamespace(namespace string) TokenBuilder
 	WithActor(actor core.IActorData) TokenBuilder
+	WithPermissions(permissions []aschema.Permission) TokenBuilder
 	WithLabels(labels map[string]string) TokenBuilder
 	WithLabel(key, value string) TokenBuilder
 	WithNonce() TokenBuilder
@@ -137,6 +139,11 @@ func (tb *tokenBuilder) WithNamespace(namespace string) TokenBuilder {
 
 func (tb *tokenBuilder) WithActor(actor core.IActorData) TokenBuilder {
 	tb.jwtBuilder.WithActor(actor)
+	return tb
+}
+
+func (tb *tokenBuilder) WithPermissions(permissions []aschema.Permission) TokenBuilder {
+	tb.jwtBuilder.WithPermissions(permissions)
 	return tb
 }
 

--- a/internal/apauth/service/auth_methods.go
+++ b/internal/apauth/service/auth_methods.go
@@ -373,7 +373,11 @@ func (s *service) establishAuthFromRequest(ctx context.Context, requireSessionXs
 			cache.Put(actor)
 		}
 
-		ra = core.NewAuthenticatedRequestAuth(actor)
+		if len(claims.Permissions) > 0 {
+			ra = core.NewAuthenticatedRequestAuthWithPermissions(actor, claims.Permissions)
+		} else {
+			ra = core.NewAuthenticatedRequestAuth(actor)
+		}
 	}
 
 	// Extend auth with session, or establish the user authed from session if not authenticated yet

--- a/internal/apauth/service/auth_methods_test.go
+++ b/internal/apauth/service/auth_methods_test.go
@@ -885,6 +885,58 @@ func TestAuth_ActorCacheReducesDbCalls(t *testing.T) {
 	require.Equal(t, actorId, ra.MustGetActor().Id)
 }
 
+func TestAuth_TopLevelPermissionsRestrictRequest(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.FromRoot(&testConfigPublicPrivateKey)
+	_, authService, _ := TestAuthService(t, sconfig.ServiceIdAdminApi, cfg)
+	raw := authService.(*service)
+
+	actorPermissions := []aschema.Permission{
+		{
+			Namespace: "root.**",
+			Resources: []string{"connections"},
+			Verbs:     []string{"list", "get"},
+		},
+	}
+	tokenPermissions := []aschema.Permission{
+		{
+			Namespace: "root.**",
+			Resources: []string{"connections"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: "root.**",
+			Resources: []string{"actors"},
+			Verbs:     []string{"list"},
+		},
+	}
+
+	claims := *testClaims()
+	claims.Actor = &core.Actor{
+		ExternalId:  "grafana-token",
+		Namespace:   "root",
+		Permissions: actorPermissions,
+	}
+	claims.Subject = "grafana-token"
+	claims.Permissions = tokenPermissions
+
+	tok, err := authService.Token(testContext, &claims)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Add(JwtHeaderKey, fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+	ra, err := raw.establishAuthFromRequest(testContext, true, req, w)
+	require.NoError(t, err)
+	require.True(t, ra.IsAuthenticated())
+	require.Equal(t, tokenPermissions, ra.GetPermissions())
+
+	require.True(t, ra.Allows("root.prod", "connections", "list", ""))
+	require.False(t, ra.Allows("root.prod", "connections", "get", ""))
+	require.False(t, ra.Allows("root.prod", "actors", "list", ""))
+}
+
 func TestAuth_Nonce(t *testing.T) {
 	now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
 	ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()


### PR DESCRIPTION
## Summary
- Adds top-level JWT `permissions` claims for request-level permission restrictions.
- Applies those permissions during auth establishment through the existing `RequestAuth` restriction path.
- Extends JWT builders, schema docs, example payload, and auth/JWT tests.

Closes #446

## Validation
- `go test ./internal/apauth/jwt -run 'TestClaimsBuilder|TestJwtTokenClaims' -count=1`
- `go test ./internal/apauth/service -run 'TestAuth_TopLevelPermissionsRestrictRequest|TestAuth_Token|TestClaims_String' -count=1`
- `go test ./internal/apauth/... -count=1`
- `./scripts/preflight.sh`
