### PR TITLE
Add Grafana scoped JWT CLI support

### DIFF
--- a/cmd/cli/config/resolver.go
+++ b/cmd/cli/config/resolver.go
@@ -5,12 +5,17 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
+
+const grafanaDefaultExpiresIn = 90 * 24 * time.Hour
 
 // Resolver is an interface that will pull config information from a combination of defaults, config file, and
 // command line arguments. These are the config settings for how the client interacts with AuthProxy.
@@ -27,6 +32,11 @@ type Resolver struct {
 	authUrl        string
 	marketplaceUrl string
 	adminUiUrl     string
+
+	expiresIn       string
+	noExpiry        bool
+	grafanaPreset   string
+	permissionsFile string
 }
 
 func WithConfigParams(cmd *cobra.Command) *Resolver {
@@ -49,6 +59,14 @@ func WithConfigParams(cmd *cobra.Command) *Resolver {
 	cmd.Flags().StringVar(&r.configFile, "config", "", ".authproxy.yaml config file to use.")
 
 	return &r
+}
+
+func (j *Resolver) AddTokenScopeParams(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&j.expiresIn, "expires-in", "", "Token lifetime, e.g. 24h, 90d, 2160h")
+	cmd.Flags().BoolVar(&j.noExpiry, "no-expiry", false, "Do not set an expiration on the signed token")
+	cmd.Flags().StringVar(&j.grafanaPreset, "grafana-preset", "", "Grafana datasource permission preset: aggregate or logs")
+	cmd.Flags().StringVar(&j.permissionsFile, "permissions-file", "", "YAML or JSON file containing token permission restrictions")
+	cmd.MarkFlagsMutuallyExclusive("expires-in", "no-expiry")
 }
 
 func (j *Resolver) resolveRoot() (*Root, error) {
@@ -169,6 +187,22 @@ func (j *Resolver) ResolveBuilder() (jwt.TokenBuilder, error) {
 		WithActorSigned().
 		WithServiceIds(serviceIds)
 
+	permissions, err := j.resolveTokenPermissions()
+	if err != nil {
+		return nil, err
+	}
+	if len(permissions) > 0 {
+		b = b.WithPermissions(permissions)
+	}
+
+	expiresIn, hasExpiration, err := j.resolveTokenExpiration()
+	if err != nil {
+		return nil, err
+	}
+	if hasExpiration {
+		b = b.WithExpiresIn(expiresIn)
+	}
+
 	if privateKeyPath != "" {
 		b = b.WithPrivateKeyPath(privateKeyPath)
 	} else {
@@ -176,6 +210,129 @@ func (j *Resolver) ResolveBuilder() (jwt.TokenBuilder, error) {
 	}
 
 	return b, nil
+}
+
+func (j *Resolver) resolveTokenExpiration() (time.Duration, bool, error) {
+	if j.noExpiry {
+		return 0, false, nil
+	}
+	if j.expiresIn != "" {
+		d, err := parseTokenDuration(j.expiresIn)
+		if err != nil {
+			return 0, false, err
+		}
+		return d, true, nil
+	}
+	if j.grafanaPreset != "" {
+		return grafanaDefaultExpiresIn, true, nil
+	}
+	return 0, false, nil
+}
+
+func parseTokenDuration(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("duration is required")
+	}
+	if strings.HasSuffix(raw, "d") {
+		days, err := time.ParseDuration(strings.TrimSuffix(raw, "d") + "h")
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", raw, err)
+		}
+		return days * 24, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", raw, err)
+	}
+	return d, nil
+}
+
+func (j *Resolver) resolveTokenPermissions() ([]aschema.Permission, error) {
+	var permissions []aschema.Permission
+
+	if j.grafanaPreset != "" {
+		presetPermissions, err := grafanaPresetPermissions(j.grafanaPreset)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, presetPermissions...)
+	}
+
+	if j.permissionsFile != "" {
+		filePermissions, err := readPermissionsFile(j.permissionsFile)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, filePermissions...)
+	}
+
+	for _, permission := range permissions {
+		if err := permission.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid token permissions: %w", err)
+		}
+	}
+
+	return permissions, nil
+}
+
+func grafanaPresetPermissions(preset string) ([]aschema.Permission, error) {
+	switch preset {
+	case "aggregate":
+		return grafanaAggregatePermissions(), nil
+	case "logs":
+		return append(grafanaAggregatePermissions(), aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"request-events"},
+			Verbs:     []string{"list"},
+		}), nil
+	case "":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("invalid grafana preset %q; expected aggregate or logs", preset)
+	}
+}
+
+func grafanaAggregatePermissions() []aschema.Permission {
+	return []aschema.Permission{
+		{
+			Namespace: "root.**",
+			Resources: []string{"app-metrics"},
+			Verbs:     []string{"schema", "query"},
+		},
+		{
+			Namespace: "root.**",
+			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate-limits"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: "root.**",
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list/versions"},
+		},
+	}
+}
+
+func readPermissionsFile(path string) ([]aschema.Permission, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read permissions file %q: %w", path, err)
+	}
+
+	var direct []aschema.Permission
+	if err := yaml.Unmarshal(data, &direct); err == nil && len(direct) > 0 {
+		return direct, nil
+	}
+
+	var wrapped struct {
+		Permissions []aschema.Permission `json:"permissions" yaml:"permissions"`
+	}
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse permissions file %q: %w", path, err)
+	}
+	if len(wrapped.Permissions) == 0 {
+		return nil, fmt.Errorf("permissions file %q must contain a permissions array", path)
+	}
+	return wrapped.Permissions, nil
 }
 
 func (j *Resolver) ResolveToken() (string, error) {

--- a/cmd/cli/config/resolver_test.go
+++ b/cmd/cli/config/resolver_test.go
@@ -1,0 +1,237 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apjwt "github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTokenDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supports days", func(t *testing.T) {
+		d, err := parseTokenDuration("90d")
+		require.NoError(t, err)
+		require.Equal(t, 90*24*time.Hour, d)
+	})
+
+	t.Run("keeps standard duration support", func(t *testing.T) {
+		d, err := parseTokenDuration("36h")
+		require.NoError(t, err)
+		require.Equal(t, 36*time.Hour, d)
+	})
+
+	t.Run("rejects invalid duration", func(t *testing.T) {
+		_, err := parseTokenDuration("forever")
+		require.Error(t, err)
+	})
+}
+
+func TestGrafanaPresetPermissions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("aggregate preset grants metric schema query and variable lists", func(t *testing.T) {
+		permissions, err := grafanaPresetPermissions("aggregate")
+		require.NoError(t, err)
+
+		require.Contains(t, permissions, aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"app-metrics"},
+			Verbs:     []string{"schema", "query"},
+		})
+		require.Contains(t, permissions, aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate-limits"},
+			Verbs:     []string{"list"},
+		})
+		require.Contains(t, permissions, aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list/versions"},
+		})
+		require.NotContains(t, permissions, aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"request-events"},
+			Verbs:     []string{"list"},
+		})
+	})
+
+	t.Run("logs preset includes request events", func(t *testing.T) {
+		permissions, err := grafanaPresetPermissions("logs")
+		require.NoError(t, err)
+
+		require.Contains(t, permissions, aschema.Permission{
+			Namespace: "root.**",
+			Resources: []string{"request-events"},
+			Verbs:     []string{"list"},
+		})
+	})
+
+	t.Run("unknown preset returns error", func(t *testing.T) {
+		_, err := grafanaPresetPermissions("wide-open")
+		require.Error(t, err)
+	})
+}
+
+func TestReadPermissionsFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct array", func(t *testing.T) {
+		path := writeTestFile(t, `
+- namespace: root.alpha
+  resources: [connections]
+  verbs: [list]
+`)
+
+		permissions, err := readPermissionsFile(path)
+		require.NoError(t, err)
+		require.Equal(t, []aschema.Permission{
+			{
+				Namespace: "root.alpha",
+				Resources: []string{"connections"},
+				Verbs:     []string{"list"},
+			},
+		}, permissions)
+	})
+
+	t.Run("wrapped permissions array", func(t *testing.T) {
+		path := writeTestFile(t, `
+permissions:
+  - namespace: root.beta
+    resources: [actors]
+    verbs: [get]
+`)
+
+		permissions, err := readPermissionsFile(path)
+		require.NoError(t, err)
+		require.Equal(t, []aschema.Permission{
+			{
+				Namespace: "root.beta",
+				Resources: []string{"actors"},
+				Verbs:     []string{"get"},
+			},
+		}, permissions)
+	})
+
+	t.Run("missing permissions returns error", func(t *testing.T) {
+		path := writeTestFile(t, `permissions: []`)
+
+		_, err := readPermissionsFile(path)
+		require.Error(t, err)
+	})
+}
+
+func TestResolveBuilderWithGrafanaPreset(t *testing.T) {
+	t.Parallel()
+
+	ctx := apctx.WithFixedClock(context.Background(), time.Date(2026, 5, 30, 15, 0, 0, 0, time.UTC))
+	secretPath := writeTestFile(t, "test-secret")
+
+	resolver := &Resolver{
+		actorId:       "grafana",
+		secretKeyPath: secretPath,
+		apis:          string(config.ServiceIdApi),
+		grafanaPreset: "logs",
+	}
+
+	builder, err := resolver.ResolveBuilder()
+	require.NoError(t, err)
+
+	token, err := builder.TokenCtx(ctx)
+	require.NoError(t, err)
+
+	claims := parseTestToken(t, ctx, token, []byte("test-secret"))
+	require.Equal(t, "grafana", claims.Subject)
+	require.Equal(t, []string{string(config.ServiceIdApi)}, []string(claims.Audience))
+	require.True(t, apctx.GetClock(ctx).Now().Add(grafanaDefaultExpiresIn).Equal(claims.ExpiresAt.Time))
+	require.Contains(t, claims.Permissions, aschema.Permission{
+		Namespace: "root.**",
+		Resources: []string{"request-events"},
+		Verbs:     []string{"list"},
+	})
+}
+
+func TestResolveBuilderNoExpiryOverridesGrafanaDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := apctx.WithFixedClock(context.Background(), time.Date(2026, 5, 30, 15, 0, 0, 0, time.UTC))
+	secretPath := writeTestFile(t, "test-secret")
+
+	resolver := &Resolver{
+		actorId:       "grafana",
+		secretKeyPath: secretPath,
+		apis:          string(config.ServiceIdApi),
+		grafanaPreset: "aggregate",
+		noExpiry:      true,
+	}
+
+	builder, err := resolver.ResolveBuilder()
+	require.NoError(t, err)
+
+	token, err := builder.TokenCtx(ctx)
+	require.NoError(t, err)
+
+	claims := parseTestToken(t, ctx, token, []byte("test-secret"))
+	require.Nil(t, claims.ExpiresAt)
+	require.NotEmpty(t, claims.Permissions)
+}
+
+func TestResolveBuilderMergesPermissionsFile(t *testing.T) {
+	t.Parallel()
+
+	secretPath := writeTestFile(t, "test-secret")
+	permissionsPath := writeTestFile(t, `
+permissions:
+  - namespace: root.team
+    resources: [connections]
+    verbs: [list]
+`)
+
+	resolver := &Resolver{
+		actorId:         "grafana",
+		secretKeyPath:   secretPath,
+		apis:            string(config.ServiceIdApi),
+		grafanaPreset:   "aggregate",
+		permissionsFile: permissionsPath,
+	}
+
+	permissions, err := resolver.resolveTokenPermissions()
+	require.NoError(t, err)
+
+	require.Contains(t, permissions, aschema.Permission{
+		Namespace: "root.**",
+		Resources: []string{"app-metrics"},
+		Verbs:     []string{"schema", "query"},
+	})
+	require.Contains(t, permissions, aschema.Permission{
+		Namespace: "root.team",
+		Resources: []string{"connections"},
+		Verbs:     []string{"list"},
+	})
+}
+
+func writeTestFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func parseTestToken(t *testing.T, ctx context.Context, token string, secret []byte) *apjwt.AuthProxyClaims {
+	t.Helper()
+
+	claims, err := apjwt.NewJwtTokenParserBuilder().
+		WithSharedKey(secret).
+		ParseCtx(ctx, token)
+	require.NoError(t, err)
+	return claims
+}

--- a/cmd/cli/sign_jwt.go
+++ b/cmd/cli/sign_jwt.go
@@ -28,6 +28,7 @@ func cmdSignJwt() *cobra.Command {
 	}
 
 	resolver = config.WithConfigParams(cmd)
+	resolver.AddTokenScopeParams(cmd)
 
 	return cmd
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,6 +93,31 @@ ap sign-jwt --admin                   # sign as the current OS user, all service
 ap sign-jwt --actorId alice --apis api
 ```
 
+Useful scoping flags:
+
+| Flag | Purpose |
+|---|---|
+| `--expires-in 24h` | Adds an expiration relative to now. Durations accept Go units plus `d` for days. |
+| `--no-expiry` | Leaves the token without an expiration. Mutually exclusive with `--expires-in`. |
+| `--permissions-file perms.yaml` | Adds top-level JWT permission restrictions from a YAML/JSON array or `{permissions: [...]}` object. |
+| `--grafana-preset aggregate` | Adds least-privilege permissions for Grafana app-metrics time-series dashboards and live dropdown variables. Defaults expiration to 90 days. |
+| `--grafana-preset logs` | Includes the aggregate preset plus `request-events:list` for request-log metadata tables. Defaults expiration to 90 days. |
+
+Grafana datasource token examples:
+
+```bash
+# Metrics dashboards only.
+ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset aggregate
+
+# Metrics plus request-event metadata tables.
+ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs
+
+# Provisioned datasource token with no expiry.
+ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs --no-expiry
+```
+
+Grafana presets use top-level JWT permissions. Those permissions only restrict the token; the backing actor still needs matching normal permissions.
+
 ### `ap verify-jwt`
 
 Reads a JWT on stdin and verifies it against the supplied public/secret key.


### PR DESCRIPTION
## Summary
- add scoped-token flags to `ap sign-jwt` for expirations, no-expiry tokens, Grafana presets, and permissions files
- define aggregate/logs Grafana presets using top-level JWT permissions for app metrics, live dropdown resources, and request-event metadata
- document Grafana token recipes and add resolver coverage for presets, permissions files, and signed claims

## Tests
- `go test ./cmd/cli/config -count=1`
- `go test ./cmd/cli/... -count=1`
- `./scripts/preflight.sh`

Closes #449