### PR TITLE
[fix/A12] authproxy-demo: end-to-end-working chart on EKS

### DIFF
--- a/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
+++ b/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
@@ -28,6 +28,9 @@ spec:
         - name: go-oauth2-server
           image: "{{ .Values.goOauth2Server.image.repository }}:{{ .Values.goOauth2Server.image.tag }}"
           imagePullPolicy: {{ .Values.goOauth2Server.image.pullPolicy }}
+          # go-oauth2-server's entrypoint is a CLI; without a subcommand
+          # it prints --help and exits 0.
+          args: ["runserver"]
           ports:
             - name: http
               containerPort: {{ .Values.goOauth2Server.port }}

--- a/deploy/charts/authproxy-demo/templates/ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/ingress.yaml
@@ -11,7 +11,7 @@
     /oauth2           → go-oauth2-server (demo connector target)
 
   AuthProxy's single Service carries all four ports (named `api`,
-  `adminApi`, `public`, `workerHealth`); per-path entries target the
+  `admin-api`, `public`, `worker-health`); per-path entries target the
   named port matching the role.
 
   cert-manager.io/cluster-issuer annotation triggers cert issuance on
@@ -46,14 +46,14 @@ spec:
               service:
                 name: {{ include "authproxy-demo.authproxy.serviceName" . }}
                 port:
-                  name: adminApi
+                  name: admin-api
           - path: /admin
             pathType: Prefix
             backend:
               service:
                 name: {{ include "authproxy-demo.authproxy.serviceName" . }}
                 port:
-                  name: adminApi
+                  name: admin-api
           - path: /marketplace
             pathType: Prefix
             backend:
@@ -75,6 +75,7 @@ spec:
                 name: {{ include "authproxy-demo.authproxy.serviceName" . }}
                 port:
                   name: public
+          {{- if .Values.goOauth2Server.enabled }}
           - path: /oauth2
             pathType: Prefix
             backend:
@@ -82,6 +83,7 @@ spec:
                 name: {{ include "authproxy-demo.goOauth2Server.name" . }}
                 port:
                   number: 80
+          {{- end }}
           # Demo-shell catches everything else (it's the landing page).
           - path: /
             pathType: Prefix

--- a/deploy/charts/authproxy-demo/templates/secrets.yaml
+++ b/deploy/charts/authproxy-demo/templates/secrets.yaml
@@ -80,6 +80,9 @@ metadata:
     {{- include "authproxy-demo.labels" . | nindent 4 }}
 type: Opaque
 data:
-  # bitnami/minio reads root-user / root-password keys from the Secret.
+  # bitnami/minio reads both keys from the Secret when
+  # `auth.existingSecret` is set; rootUser is a constant by convention
+  # so the chart values stay clean.
+  root-user: {{ "authproxy" | b64enc }}
   root-password: {{ $minioRoot }}
 {{- end }}

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -10,7 +10,14 @@
       "properties": {
         "hostname":         { "type": "string" },
         "clusterIssuer":    { "type": "string", "minLength": 1 },
-        "ingressClassName": { "type": "string", "minLength": 1 }
+        "ingressClassName": { "type": "string", "minLength": 1 },
+        "security": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowInsecureImages": { "type": "boolean" }
+          }
+        }
       }
     },
     "demoShell": {

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -19,6 +19,14 @@ global:
   # -- IngressClass for the umbrella Ingress. Matches the bootstrap chart default.
   ingressClassName: "nginx"
 
+  # Bitnami removed their free Docker Hub images in Aug 2025; the
+  # archived versions live under `docker.io/bitnamilegacy/...`. The
+  # subchart-level image.repository overrides below redirect each
+  # subchart to that namespace; allowInsecureImages lets the bitnami
+  # charts use unsupported (i.e. non-tanzu) tags without erroring.
+  security:
+    allowInsecureImages: true
+
 demoShell:
   enabled: true
   image:
@@ -36,11 +44,18 @@ demoShell:
   port: 8888
 
 goOauth2Server:
-  enabled: true
+  # -- Disabled by default. The upstream image expects etcd at
+  # localhost:2379 + a Postgres connection and won't come up without
+  # them — adding those subcharts is tracked as a follow-up to A11.
+  # Set to true once the chart is wired with an etcd + the right
+  # config to bring go-oauth2-server up cleanly.
+  enabled: false
   image:
     # go-oauth2-server image — see https://github.com/rmorlok/go-oauth2-server.
+    # Upstream's default branch is `master`, so that's the tag the Build
+    # Image workflow over there publishes.
     repository: ghcr.io/rmorlok/go-oauth2-server
-    tag: "main"
+    tag: "master"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources:
@@ -92,14 +107,17 @@ seed:
   # actors alongside the defaults.
   actors:
     - external_id: demo-admin
+      namespace: root
       labels:
         demo: "true"
         role: admin
     - external_id: demo-user
+      namespace: root
       labels:
         demo: "true"
         role: user
     - external_id: fresh-user
+      namespace: root
       labels:
         demo: "true"
         role: user
@@ -143,6 +161,9 @@ authproxy:
 
 postgresql:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
   auth:
     username: authproxy
     database: authproxy
@@ -151,27 +172,34 @@ postgresql:
       adminPasswordKey: AUTHPROXY_DB_PASSWORD
       userPasswordKey: AUTHPROXY_DB_PASSWORD
   primary:
+    # -- Disabled by default: the demo is throwaway and the EKS cluster
+    # this chart targets doesn't ship with the aws-ebs-csi-driver addon
+    # (A8 + A12). Enable + set storageClass when a persistent volume is
+    # actually required.
     persistence:
-      enabled: true
-      size: 8Gi
+      enabled: false
 
 redis:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
   auth:
     existingSecret: "{{ .Release.Name }}-redis-creds"
     existingSecretPasswordKey: AUTHPROXY_REDIS_PASSWORD
   architecture: standalone
   master:
     persistence:
-      enabled: true
-      size: 4Gi
+      enabled: false
 
 minio:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/minio
   auth:
     rootUser: "authproxy"
     existingSecret: "{{ .Release.Name }}-minio-creds"
   defaultBuckets: "authproxy-request-logs"
   persistence:
-    enabled: true
-    size: 8Gi
+    enabled: false

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -78,13 +78,26 @@ template syntax.
   with the request-event capture moved under a `request_events`
   sub-block. See internal/schema/config/app_metrics.go.
 */}}
+{{/*
+  When shareMainDatabase is true we pick a per-provider strategy that
+  avoids the golang-migrate `schema_migrations` collision:
+    - SQLite: sibling file path (`<main>.app-metrics`).
+    - Postgres: app_metrics gets pinned to an ephemeral SQLite file
+      under /tmp instead of sharing the main Postgres database.
+      Postgres-share would have to either (a) create a second
+      database on the same server, or (b) pass an
+      `x-migrations-table` URI param the Go migrator picks up.
+      Both are bigger lifts than warranted for a demo; flip
+      `shareMainDatabase: false` + supply your own
+      `appMetrics.database` block for production-grade setups.
+*/}}
 {{- $metricsDb := dict -}}
 {{- if .Values.appMetrics.shareMainDatabase -}}
 {{-   if eq .Values.database.provider "sqlite" -}}
 {{-     $sharedPath := printf "%s.app-metrics" .Values.database.path -}}
 {{-     $metricsDb = dict "provider" "sqlite" "path" $sharedPath -}}
 {{-   else -}}
-{{-     $metricsDb = $db -}}
+{{-     $metricsDb = dict "provider" "sqlite" "path" "/tmp/authproxy-app-metrics.db" -}}
 {{-   end -}}
 {{- else -}}
 {{-   $metricsDb = .Values.appMetrics.database -}}


### PR DESCRIPTION
## Summary
After working through the remaining install errors against the live demo cluster, six fixes go together as a single batch. **Verified end-to-end:** helm install completes cleanly, `curl -fsSI https://demo.authproxy.net/` returns `HTTP/2 200`, all 5 pods Ready, seed Job creates the three actors.

### Six fixes in this PR

| # | Symptom | Cause | Fix |
|---|---|---|---|
| 1 | `bitnami/postgresql:17.2.0-debian-12-r0: not found` | Bitnami removed their free Docker Hub images Aug 2025 | Point subcharts at `bitnamilegacy/...` + `global.security.allowInsecureImages: true` |
| 2 | Postgres/Redis/MinIO Pending forever ("unbound PVC") | No working CSI driver (we removed aws-ebs-csi-driver in A8); only legacy `gp2` SC remains | `persistence.enabled: false` on all three bitnami subcharts |
| 3 | `Ingress invalid: port.name "adminApi"` | Strict k8s port-name validation (lowercase + hyphens) | Use `admin-api` (matches inner chart's Service port name); **supersedes #445** |
| 4 | MinIO `CreateContainerConfigError: couldn't find key root-user` | bitnami/minio reads both `root-user` + `root-password` from existingSecret | Add `root-user: authproxy` to the auto-generated Secret |
| 5 | `panic: failed to migrate app metrics database: no migration found for version 10` | golang-migrate's default `schema_migrations` table collision between main and app_metrics (Postgres flavor of the same A5 SQLite bug) | When shareMainDatabase=true on Postgres, pin app_metrics to a /tmp SQLite file. Proper "second DB or `x-migrations-table`" path is too big for a demo |
| 6 | Seed Job `400: invalid namespace '': path is required` | AuthProxy validates POST /actors; empty namespace rejected | Default `namespace: root` on the three seed actors |

### Plus
- **`goOauth2Server.enabled: false` by default.** Upstream image expects etcd + Postgres; wiring those is a bigger lift than warranted now. Tracked as A11 follow-up. The Ingress `/oauth2` rule is now conditional on the toggle.
- `goOauth2Server.image.tag`: `main` → `master` (upstream's actual default branch).
- `args: ["runserver"]` retained on the go-oauth2-server Deployment so re-enabling it later doesn't immediately re-break.

## Test plan
- [x] `helm dependency update && helm template …` renders cleanly.
- [x] **Live install on the demo cluster**: `helm upgrade --install demo … --wait --timeout 8m` exits 0, all 5 pods Ready.
- [x] `curl -fsSI https://demo.authproxy.net/` → `HTTP/2 200`.
- [ ] CI: helm chart lint + install pass.
- [ ] **Post-merge**: Deploy Demo workflow re-runs and succeeds.

## Closes
- Supersedes #445 (port-name fix is included here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)