### PR TITLE
Add app metrics schema API

### DIFF
--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -24,6 +24,7 @@ import (
 
 type OpenAPIRequestEventsEntry = schemaapiopenapi.RequestEventJson
 type OpenAPIListRequestEventsResponse = schemaapiopenapi.ListRequestEventsResponseJson
+type OpenAPIMetricsSchemaResponse = schemaapiopenapi.MetricsSchemaResponseJson
 
 type RequestEventsRoutes struct {
 	cfg  config.C
@@ -328,6 +329,97 @@ func resourceMetricFromAPI(metric, aggregation string) (app_metrics.ResourceMetr
 		}
 	}
 	return "", httperr.BadRequestf("unsupported metric aggregation %q/%q", metric, aggregation)
+}
+
+func metricsSchemaResponse() sapi.MetricsSchemaResponseJson {
+	requestEventGroupBy := []string{
+		string(app_metrics.RequestEventGroupByType),
+		string(app_metrics.RequestEventGroupByMethod),
+		string(app_metrics.RequestEventGroupByResponseStatusCode),
+		string(app_metrics.RequestEventGroupByResponseSource),
+		string(app_metrics.RequestEventGroupByConnectorID),
+	}
+
+	return sapi.MetricsSchemaResponseJson{
+		Metrics: []sapi.MetricsSchemaMetricJson{
+			{
+				Metric:       "request_events",
+				Kind:         "counter",
+				Aggregations: []string{"count"},
+				GroupBy:      requestEventGroupBy,
+			},
+			{
+				Metric:       "request_events.errors",
+				Kind:         "counter",
+				Aggregations: []string{"count"},
+				GroupBy:      requestEventGroupBy,
+			},
+			{
+				Metric:       "request_events.duration_ms",
+				Kind:         "gauge",
+				Aggregations: []string{"avg", "p95"},
+				GroupBy:      requestEventGroupBy,
+			},
+			{
+				Metric:       "resources.connections",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByState),
+					string(app_metrics.ResourceGroupByHealthState),
+					string(app_metrics.ResourceGroupByConnectorID),
+					string(app_metrics.ResourceGroupByConnectorVersion),
+				},
+			},
+			{
+				Metric:       "resources.actors",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByNamespace),
+				},
+			},
+			{
+				Metric:       "resources.connectors",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByState),
+					string(app_metrics.ResourceGroupByConnectorVersion),
+					string(app_metrics.ResourceGroupByNamespace),
+				},
+			},
+			{
+				Metric:       "resources.connector_versions",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByState),
+					string(app_metrics.ResourceGroupByConnectorID),
+					string(app_metrics.ResourceGroupByConnectorVersion),
+					string(app_metrics.ResourceGroupByNamespace),
+				},
+			},
+			{
+				Metric:       "resources.namespaces",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByState),
+					string(app_metrics.ResourceGroupByNamespace),
+				},
+			},
+			{
+				Metric:       "resources.rate_limits",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy: []string{
+					string(app_metrics.ResourceGroupByMode),
+					string(app_metrics.ResourceGroupByNamespace),
+				},
+			},
+		},
+	}
 }
 
 type metricsResponseSeries struct {
@@ -702,6 +794,19 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
 }
 
+// @Summary		Get application metrics schema
+// @Description	Get supported application metrics, aggregations, group-by dimensions, and metric kinds
+// @Tags			metrics
+// @Produce		json
+// @Success		200	{object}	OpenAPIMetricsSchemaResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		403	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/metrics/schema [get]
+func (r *RequestEventsRoutes) schema(gctx *gin.Context) {
+	gctx.PureJSON(http.StatusOK, metricsSchemaResponse())
+}
+
 func (r *RequestEventsRoutes) Register(g gin.IRouter) {
 	g.GET(
 		"/metrics/request-events/:id",
@@ -723,10 +828,18 @@ func (r *RequestEventsRoutes) Register(g gin.IRouter) {
 	g.POST(
 		"/metrics/query",
 		r.auth.NewRequiredBuilder().
-			ForResource("request-events").
-			ForVerb("list").
+			ForResource("app-metrics").
+			ForVerb("query").
 			Build(),
 		r.queryMetrics,
+	)
+	g.GET(
+		"/metrics/schema",
+		r.auth.NewRequiredBuilder().
+			ForResource("app-metrics").
+			ForVerb("schema").
+			Build(),
+		r.schema,
 	)
 }
 

--- a/internal/routes/request_events_test.go
+++ b/internal/routes/request_events_test.go
@@ -592,9 +592,17 @@ func TestRequestEventsRoutes(t *testing.T) {
 			require.Equal(t, http.StatusForbidden, w.Code)
 		})
 
-		t.Run("executes request event query", func(t *testing.T) {
+		t.Run("request event list permission cannot query metrics", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newMetricsRequest(t, validBody(nil), aschema.PermissionsSingle("root.**", "request-events", "list"))
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("executes request event query", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newMetricsRequest(t, validBody(nil), aschema.PermissionsSingle("root.**", "app-metrics", "query"))
 
 			tu.MockRetriever.EXPECT().
 				QueryRequestEventMetrics(gomock.Any(), gomock.Any()).
@@ -639,7 +647,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 					"aggregation": "count",
 					"group_by":    []string{"state", "health_state"},
 				},
-			}}), aschema.PermissionsSingle("root.**", "request-events", "list"))
+			}}), aschema.PermissionsSingle("root.**", "app-metrics", "query"))
 
 			tu.MockRetriever.EXPECT().
 				QueryResourceMetrics(gomock.Any(), gomock.Any()).
@@ -677,7 +685,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 
 		t.Run("namespace is constrained by actor permissions", func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := newMetricsRequest(t, validBody(map[string]any{"namespace": "root.**"}), aschema.PermissionsSingle("root.tenant.**", "request-events", "list"))
+			req := newMetricsRequest(t, validBody(map[string]any{"namespace": "root.**"}), aschema.PermissionsSingle("root.tenant.**", "app-metrics", "query"))
 
 			tu.MockRetriever.EXPECT().
 				QueryRequestEventMetrics(gomock.Any(), gomock.Any()).
@@ -722,11 +730,87 @@ func TestRequestEventsRoutes(t *testing.T) {
 		for _, tc := range invalidCases {
 			t.Run(tc.name, func(t *testing.T) {
 				w := httptest.NewRecorder()
-				req := newMetricsRequest(t, tc.body, aschema.PermissionsSingle("root.**", "request-events", "list"))
+				req := newMetricsRequest(t, tc.body, aschema.PermissionsSingle("root.**", "app-metrics", "query"))
 
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusBadRequest, w.Code)
 			})
 		}
+	})
+
+	t.Run("metrics schema", func(t *testing.T) {
+		tu := setup(t, nil)
+
+		newSchemaRequest := func(t *testing.T, permissions []aschema.Permission) *http.Request {
+			t.Helper()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/metrics/schema",
+				nil,
+				"root",
+				"some-actor",
+				permissions,
+			)
+			require.NoError(t, err)
+			return req
+		}
+
+		t.Run("unauthorized", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/metrics/schema", nil)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+
+		t.Run("forbidden without schema permission", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newSchemaRequest(t, aschema.PermissionsSingle("root.**", "app-metrics", "query"))
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("returns supported metrics", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newSchemaRequest(t, aschema.PermissionsSingle("root.**", "app-metrics", "schema"))
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp sapi.MetricsSchemaResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Contains(t, resp.Metrics, sapi.MetricsSchemaMetricJson{
+				Metric:       "request_events.duration_ms",
+				Kind:         "gauge",
+				Aggregations: []string{"avg", "p95"},
+				GroupBy:      []string{"type", "method", "response_status_code", "response_source", "connector_id"},
+			})
+			require.Contains(t, resp.Metrics, sapi.MetricsSchemaMetricJson{
+				Metric:       "resources.connections",
+				Kind:         "gauge",
+				Aggregations: []string{"count"},
+				GroupBy:      []string{"state", "health_state", "connector_id", "connector_version"},
+			})
+		})
+
+		t.Run("aggregate-only permissions cannot list request events", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/metrics/request-events",
+				nil,
+				"root",
+				"some-actor",
+				[]aschema.Permission{
+					{Namespace: "root.**", Resources: []string{"app-metrics"}, Verbs: []string{"schema", "query"}},
+				},
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
 	})
 }

--- a/internal/schema/api/metrics.go
+++ b/internal/schema/api/metrics.go
@@ -56,3 +56,20 @@ type MetricsSeriesJson struct {
 type MetricsQueryResponseJson struct {
 	Series []MetricsSeriesJson `json:"series" yaml:"series"`
 }
+
+// MetricsSchemaMetricJson describes one metric supported by the metrics query API.
+//
+//	@Description	Supported metric definition
+type MetricsSchemaMetricJson struct {
+	Metric       string   `json:"metric" yaml:"metric" example:"request_events"`
+	Kind         string   `json:"kind" yaml:"kind" example:"counter"`
+	Aggregations []string `json:"aggregations" yaml:"aggregations" example:"count"`
+	GroupBy      []string `json:"group_by" yaml:"group_by" example:"method,response_status_code"`
+}
+
+// MetricsSchemaResponseJson is the response for the metrics schema endpoint.
+//
+//	@Description	Application metrics schema response
+type MetricsSchemaResponseJson struct {
+	Metrics []MetricsSchemaMetricJson `json:"metrics" yaml:"metrics"`
+}

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -141,6 +141,13 @@ type ListRequestEventsResponseJson struct {
 	Total  *int64        `json:"total,omitempty"`
 }
 
+// MetricsSchemaResponseJson documents the metrics schema response.
+//
+//	@Description	Application metrics schema response
+type MetricsSchemaResponseJson struct {
+	Metrics []schemaapi.MetricsSchemaMetricJson `json:"metrics"`
+}
+
 // RequestEventJson documents the public request-event record projection.
 //
 //	@Description	HTTP request events entry

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -449,6 +449,68 @@
       "required": ["series"],
       "additionalProperties": false
     },
+    "MetricsSchemaMetric": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "type": "string",
+          "enum": [
+            "request_events",
+            "request_events.errors",
+            "request_events.duration_ms",
+            "resources.connections",
+            "resources.actors",
+            "resources.connectors",
+            "resources.connector_versions",
+            "resources.namespaces",
+            "resources.rate_limits"
+          ]
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["counter", "gauge"]
+        },
+        "aggregations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["count", "avg", "p95"]
+          },
+          "minItems": 1
+        },
+        "group_by": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "type",
+              "method",
+              "response_status_code",
+              "response_source",
+              "connector_id",
+              "state",
+              "health_state",
+              "connector_version",
+              "namespace",
+              "mode"
+            ]
+          }
+        }
+      },
+      "required": ["metric", "kind", "aggregations", "group_by"],
+      "additionalProperties": false
+    },
+    "MetricsSchemaResponse": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MetricsSchemaMetric" }
+        }
+      },
+      "required": ["metrics"],
+      "additionalProperties": false
+    },
     "Connector": {
       "description": "API summary projection of a connector version. This intentionally differs from the resource connector definition schema: fields such as logo are flattened for responses, while runtime fields such as state, has_configure, timestamps, version counts, and state summaries are added by the API. Request bodies and version detail responses reference the canonical resource schema under their definition fields.",
       "type": "object",

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -85,6 +85,7 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "update actor", ref: "./schema.json#/$defs/UpdateActorRequest", file: "valid-update-actor.json"},
 		{name: "list actors", ref: "./schema.json#/$defs/ListActorsResponse", file: "valid-list-actors.json"},
 		{name: "metrics query", ref: "./schema.json#/$defs/MetricsQueryRequest", file: "valid-metrics-query.json"},
+		{name: "metrics schema", ref: "./schema.json#/$defs/MetricsSchemaResponse", file: "valid-metrics-schema.json"},
 		{name: "connector", ref: "./schema.json#/$defs/Connector", file: "valid-connector.json"},
 		{name: "list connectors", ref: "./schema.json#/$defs/ListConnectorsResponse", file: "valid-list-connectors.json"},
 		{name: "connector version", ref: "./schema.json#/$defs/ConnectorVersion", file: "valid-connector-version.json"},

--- a/internal/schema/api/test_data/valid-metrics-schema.json
+++ b/internal/schema/api/test_data/valid-metrics-schema.json
@@ -1,0 +1,16 @@
+{
+  "metrics": [
+    {
+      "metric": "request_events",
+      "kind": "counter",
+      "aggregations": ["count"],
+      "group_by": ["type", "method", "response_status_code", "response_source", "connector_id"]
+    },
+    {
+      "metric": "resources.connections",
+      "kind": "gauge",
+      "aggregations": ["count"],
+      "group_by": ["state", "health_state", "connector_id", "connector_version"]
+    }
+  ]
+}

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -5623,6 +5623,43 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/metrics/schema": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get supported application metrics, aggregations, group-by dimensions, and metric kinds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "Get application metrics schema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIMetricsSchemaResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/namespaces": {
             "get": {
                 "security": [
@@ -7637,6 +7674,39 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+            "description": "Supported metric definition",
+            "type": "object",
+            "properties": {
+                "aggregations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "count"
+                    ]
+                },
+                "group_by": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "method",
+                        "response_status_code"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "counter"
+                },
+                "metric": {
+                    "type": "string",
+                    "example": "request_events"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -8442,6 +8512,18 @@ const docTemplateadmin_api = `{
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "routes.OpenAPIMetricsSchemaResponse": {
+            "description": "Application metrics schema response",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                    }
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -5617,6 +5617,43 @@
                 }
             }
         },
+        "/metrics/schema": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get supported application metrics, aggregations, group-by dimensions, and metric kinds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "Get application metrics schema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIMetricsSchemaResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/namespaces": {
             "get": {
                 "security": [
@@ -7631,6 +7668,39 @@
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+            "description": "Supported metric definition",
+            "type": "object",
+            "properties": {
+                "aggregations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "count"
+                    ]
+                },
+                "group_by": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "method",
+                        "response_status_code"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "counter"
+                },
+                "metric": {
+                    "type": "string",
+                    "example": "request_events"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -8436,6 +8506,18 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "routes.OpenAPIMetricsSchemaResponse": {
+            "description": "Application metrics schema response",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                    }
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -103,6 +103,29 @@ definitions:
       updated_at:
         type: string
     type: object
+  github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson:
+    description: Supported metric definition
+    properties:
+      aggregations:
+        example:
+        - count
+        items:
+          type: string
+        type: array
+      group_by:
+        example:
+        - method
+        - response_status_code
+        items:
+          type: string
+        type: array
+      kind:
+        example: counter
+        type: string
+      metric:
+        example: request_events
+        type: string
+    type: object
   github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -679,6 +702,14 @@ definitions:
         type: array
       total:
         type: integer
+    type: object
+  routes.OpenAPIMetricsSchemaResponse:
+    description: Application metrics schema response
+    properties:
+      metrics:
+        items:
+          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson'
+        type: array
     type: object
   routes.OpenAPIProxyResponseJson:
     description: Response from a proxied HTTP request
@@ -4610,6 +4641,30 @@ paths:
       summary: Get request events entry
       tags:
       - request-events
+  /metrics/schema:
+    get:
+      description: Get supported application metrics, aggregations, group-by dimensions,
+        and metric kinds
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIMetricsSchemaResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get application metrics schema
+      tags:
+      - metrics
   /namespaces:
     get:
       consumes:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -5623,6 +5623,43 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/metrics/schema": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get supported application metrics, aggregations, group-by dimensions, and metric kinds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "Get application metrics schema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIMetricsSchemaResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/namespaces": {
             "get": {
                 "security": [
@@ -7637,6 +7674,39 @@ const docTemplateApi = `{
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+            "description": "Supported metric definition",
+            "type": "object",
+            "properties": {
+                "aggregations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "count"
+                    ]
+                },
+                "group_by": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "method",
+                        "response_status_code"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "counter"
+                },
+                "metric": {
+                    "type": "string",
+                    "example": "request_events"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -8442,6 +8512,18 @@ const docTemplateApi = `{
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "routes.OpenAPIMetricsSchemaResponse": {
+            "description": "Application metrics schema response",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                    }
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -5617,6 +5617,43 @@
                 }
             }
         },
+        "/metrics/schema": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get supported application metrics, aggregations, group-by dimensions, and metric kinds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "Get application metrics schema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIMetricsSchemaResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/namespaces": {
             "get": {
                 "security": [
@@ -7631,6 +7668,39 @@
                 }
             }
         },
+        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+            "description": "Supported metric definition",
+            "type": "object",
+            "properties": {
+                "aggregations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "count"
+                    ]
+                },
+                "group_by": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "method",
+                        "response_status_code"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "counter"
+                },
+                "metric": {
+                    "type": "string",
+                    "example": "request_events"
+                }
+            }
+        },
         "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
@@ -8436,6 +8506,18 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "routes.OpenAPIMetricsSchemaResponse": {
+            "description": "Application metrics schema response",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                    }
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -103,6 +103,29 @@ definitions:
       updated_at:
         type: string
     type: object
+  github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson:
+    description: Supported metric definition
+    properties:
+      aggregations:
+        example:
+        - count
+        items:
+          type: string
+        type: array
+      group_by:
+        example:
+        - method
+        - response_status_code
+        items:
+          type: string
+        type: array
+      kind:
+        example: counter
+        type: string
+      metric:
+        example: request_events
+        type: string
+    type: object
   github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -679,6 +702,14 @@ definitions:
         type: array
       total:
         type: integer
+    type: object
+  routes.OpenAPIMetricsSchemaResponse:
+    description: Application metrics schema response
+    properties:
+      metrics:
+        items:
+          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson'
+        type: array
     type: object
   routes.OpenAPIProxyResponseJson:
     description: Response from a proxied HTTP request
@@ -4610,6 +4641,30 @@ paths:
       summary: Get request events entry
       tags:
       - request-events
+  /metrics/schema:
+    get:
+      description: Get supported application metrics, aggregations, group-by dimensions,
+        and metric kinds
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIMetricsSchemaResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get application metrics schema
+      tags:
+      - metrics
   /namespaces:
     get:
       consumes:


### PR DESCRIPTION
## Summary
- move `/metrics/query` authorization to `app-metrics:query` while keeping request-event metadata behind `request-events:list`
- add `GET /metrics/schema` protected by `app-metrics:schema` with supported metrics, aggregations, group-by dimensions, and metric kinds
- add API schema/sample coverage, route authorization tests, and regenerated Swagger docs

## Tests
- `go test ./internal/routes -count=1`
- `go test ./internal/schema/api -count=1`
- `go test ./cmd/cli/config -count=1`
- `./scripts/preflight.sh`

Closes #447