### PR TITLE
Add live catalog API support for Grafana

### DIFF
--- a/cmd/cli/config/resolver.go
+++ b/cmd/cli/config/resolver.go
@@ -301,7 +301,7 @@ func grafanaAggregatePermissions() []aschema.Permission {
 		},
 		{
 			Namespace: "root.**",
-			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate-limits"},
+			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate_limits"},
 			Verbs:     []string{"list"},
 		},
 		{

--- a/cmd/cli/config/resolver_test.go
+++ b/cmd/cli/config/resolver_test.go
@@ -49,7 +49,7 @@ func TestGrafanaPresetPermissions(t *testing.T) {
 		})
 		require.Contains(t, permissions, aschema.Permission{
 			Namespace: "root.**",
-			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate-limits"},
+			Resources: []string{"namespaces", "connectors", "connections", "actors", "rate_limits"},
 			Verbs:     []string{"list"},
 		})
 		require.Contains(t, permissions, aschema.Permission{

--- a/internal/core/iface/list_connections.go
+++ b/internal/core/iface/list_connections.go
@@ -3,6 +3,7 @@ package iface
 import (
 	"context"
 
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -17,6 +18,7 @@ type ListConnectionsBuilder interface {
 	Limit(int32) ListConnectionsBuilder
 	ForState(database.ConnectionState) ListConnectionsBuilder
 	ForStates([]database.ConnectionState) ListConnectionsBuilder
+	ForConnectorId(id apid.ID) ListConnectionsBuilder
 	ForNamespaceMatcher(matcher string) ListConnectionsBuilder
 	ForNamespaceMatchers(matchers []string) ListConnectionsBuilder
 	OrderBy(database.ConnectionOrderByField, pagination.OrderBy) ListConnectionsBuilder

--- a/internal/core/service_connection_list.go
+++ b/internal/core/service_connection_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -99,6 +100,10 @@ func (l *listConnectionsWrapper) ForState(s database.ConnectionState) iface.List
 
 func (l *listConnectionsWrapper) ForStates(states []database.ConnectionState) iface.ListConnectionsBuilder {
 	return l.cloneWithBuilder(l.l.ForStates(states))
+}
+
+func (l *listConnectionsWrapper) ForConnectorId(id apid.ID) iface.ListConnectionsBuilder {
+	return l.cloneWithBuilder(l.l.ForConnectorId(id))
 }
 
 func (l *listConnectionsWrapper) ForNamespaceMatcher(m string) iface.ListConnectionsBuilder {

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -212,6 +212,30 @@ func TestActorsRoutes(t *testing.T) {
 			require.Equal(t, "user/l1", resp.Items[0].ExternalId)
 			require.Equal(t, "test-app", resp.Items[0].Labels["app"])
 		})
+
+		t.Run("permission constrained namespace dropdown", func(t *testing.T) {
+			createActor(t, tu.Db, "user/child", "root.child")
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/actors",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.child.**", "actors", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListActorsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 1)
+			require.Equal(t, "user/child", resp.Items[0].ExternalId)
+			require.Equal(t, "root.child", resp.Items[0].Namespace)
+		})
 	})
 
 	t.Run("get by id", func(t *testing.T) {

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -292,6 +292,7 @@ type ListConnectionRequestQuery struct {
 	Cursor        *string                   `form:"cursor"`
 	LimitVal      *int32                    `form:"limit"`
 	StateVal      *database.ConnectionState `form:"state"`
+	ConnectorId   *string                   `form:"connector_id"`
 	NamespaceVal  *string                   `form:"namespace"`
 	LabelSelector *string                   `form:"label_selector"`
 	OrderByVal    *string                   `form:"order_by"`
@@ -305,6 +306,7 @@ type ListConnectionRequestQuery struct {
 // @Param			cursor			query		string	false	"Pagination cursor"
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			state			query		string	false	"Filter by connection state"
+// @Param			connector_id	query		string	false	"Filter by connector ID"
 // @Param			namespace		query		string	false	"Filter by namespace"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:asc')"
@@ -345,6 +347,21 @@ func (r *ConnectionsRoutes) list(gctx *gin.Context) {
 
 		if req.StateVal != nil {
 			b = b.ForState(*req.StateVal)
+		}
+
+		if req.ConnectorId != nil {
+			connectorId, err := apid.Parse(*req.ConnectorId)
+			if err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequest("invalid connector_id format", httperr.WithInternalErr(err)))
+				val.MarkErrorReturn()
+				return
+			}
+			if err := connectorId.ValidatePrefix(apid.PrefixConnectorVersion); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequest("invalid connector_id prefix", httperr.WithInternalErr(err)))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForConnectorId(connectorId)
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -343,6 +343,65 @@ func TestConnections(t *testing.T) {
 			require.Len(t, resp.Items, 3)
 		})
 
+		t.Run("permission constrained namespace dropdown", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/connections?limit=50&order=created_at%20asc",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.child.**", "connections", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListConnectionResponseJson
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			require.Len(t, resp.Items, 3)
+			for _, item := range resp.Items {
+				require.Contains(t, item.Namespace, "root.child")
+			}
+		})
+
+		t.Run("filter to connector id", func(t *testing.T) {
+			oauthConnectionId := apid.New(apid.PrefixConnection)
+			err := tu.Db.CreateConnection(ctx, &database.Connection{
+				Id:               oauthConnectionId,
+				Namespace:        "root",
+				ConnectorId:      oauthConnectorId,
+				ConnectorVersion: oauthConnectorVersion,
+				State:            database.ConnectionStateSetup,
+			})
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/connections?connector_id="+oauthConnectorId.String(), nil, "root", "some-actor", aschema.PermissionsSingle("root.**", "connections", "list"))
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListConnectionResponseJson
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			require.Len(t, resp.Items, 1)
+			require.Equal(t, oauthConnectionId, resp.Items[0].Id)
+			require.Equal(t, oauthConnectorId, resp.Items[0].Connector.Id)
+		})
+
+		t.Run("invalid connector id filter", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/connections?connector_id=not-an-id", nil, "root", "some-actor", aschema.PermissionsSingle("root.**", "connections", "list"))
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
 		t.Run("filter with label_selector", func(t *testing.T) {
 			connId := apid.New(apid.PrefixConnection)
 			err := tu.Db.CreateConnection(ctx, &database.Connection{

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -294,6 +294,28 @@ func TestConnectors(t *testing.T) {
 				require.Equal(t, "Test ConnectorJson 2", resp.Items[0].DisplayName)
 			})
 
+			t.Run("permission constrained namespace dropdown", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodGet,
+					"/connectors?order=id%20asc",
+					nil,
+					"root",
+					"some-actor",
+					aschema.PermissionsSingle("root.child.**", "connectors", "list"),
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.Equal(t, http.StatusOK, w.Code)
+
+				var resp ListConnectorsResponseJson
+				err = json.Unmarshal(w.Body.Bytes(), &resp)
+				require.NoError(t, err)
+				require.Len(t, resp.Items, 1)
+				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[0].Id)
+			})
+
 			t.Run("label filter", func(t *testing.T) {
 				connectorId := apid.MustParse("cxr_test0000000000001")
 				cfg := config.FromRoot(&sconfig.Root{

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -467,6 +467,29 @@ func TestNamespaces(t *testing.T) {
 			require.Len(t, resp.Items, 4)
 		})
 
+		t.Run("permission constrained namespace dropdown", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/namespaces?limit=50&order=created_at%20asc",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.dev.**", "namespaces", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ListNamespacesResponseJson
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			require.Len(t, resp.Items, 2)
+			require.Equal(t, "root.dev", resp.Items[0].Path)
+			require.Equal(t, "root.dev.old", resp.Items[1].Path)
+		})
+
 		t.Run("filter to namespace", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/namespaces?limit=50&order=created_at%20asc&namespace=root.dev", nil, "root", "some-actor", aschema.AllPermissions())

--- a/internal/routes/rate_limits_test.go
+++ b/internal/routes/rate_limits_test.go
@@ -524,6 +524,24 @@ func TestRateLimits(t *testing.T) {
 			require.Equal(t, "alpha", resp.Items[0].Labels["team"])
 		})
 
+		t.Run("permission constrained namespace dropdown", func(t *testing.T) {
+			_ = createRateLimit(t, tu, "root.child", map[string]string{"team": "child"})
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/rate-limits", nil,
+				"root", "some-actor", aschema.PermissionsSingle("root.child.**", "rate_limits", "list"))
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp ListRateLimitsResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 1)
+			require.Equal(t, "root.child", resp.Items[0].Namespace)
+			require.Equal(t, "child", resp.Items[0].Labels["team"])
+		})
+
 		t.Run("invalid order_by", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1133,6 +1133,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by connector ID",
+                        "name": "connector_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1127,6 +1127,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by connector ID",
+                        "name": "connector_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -1702,6 +1702,10 @@ paths:
         in: query
         name: state
         type: string
+      - description: Filter by connector ID
+        in: query
+        name: connector_id
+        type: string
       - description: Filter by namespace
         in: query
         name: namespace

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1133,6 +1133,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by connector ID",
+                        "name": "connector_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1127,6 +1127,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by connector ID",
+                        "name": "connector_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -1702,6 +1702,10 @@ paths:
         in: query
         name: state
         type: string
+      - description: Filter by connector ID
+        in: query
+        name: connector_id
+        type: string
       - description: Filter by namespace
         in: query
         name: namespace


### PR DESCRIPTION
## Summary
- add `connector_id` filtering to `GET /connections` and expose it through the core list builder
- verify namespace-scoped dropdown behavior for namespaces, connectors, connections, actors, and rate limits
- fix the Grafana JWT aggregate preset to use the existing `rate_limits` permission resource and regenerate Swagger for the new connection filter

## Tests
- `go test ./internal/routes -count=1`
- `go test ./cmd/cli/config -count=1`
- `go test ./internal/core/iface ./internal/core -run TestNonExistent -count=1`
- `./scripts/preflight.sh`

Closes #448