### PR TITLE
Drop dead SetupStepAuth singleton (#368)

### DIFF
--- a/internal/core/connection_data_source_test.go
+++ b/internal/core/connection_data_source_test.go
@@ -71,7 +71,8 @@ func TestGetDataSource(t *testing.T) {
 				},
 			},
 		})
-		step := cschema.SetupStepAuth
+		// A pseudo-step (or any non-configure step) gates data-source access.
+		step := cschema.SetupStepVerify
 		conn.SetupStep = &step
 
 		_, err := conn.GetDataSource(context.Background(), "some_source")

--- a/internal/core/service_connection_abort_test.go
+++ b/internal/core/service_connection_abort_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/database"
 	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
 	"github.com/rmorlok/authproxy/internal/encrypt"
@@ -70,7 +71,7 @@ func TestAbortConnection(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		step := cschema.SetupStepAuth
+		step := cschema.MustNewSetupStep(oauth2.OAuth2AuthorizeStepId)
 		conn, db := setupAbortTest(t, ctrl, &cschema.SetupFlow{
 			Preconnect: &cschema.SetupFlowPhase{
 				Steps: []cschema.SetupFlowStep{

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -84,11 +84,10 @@ func (sf *SetupFlow) TotalSteps() int {
 }
 
 // ApxyStepPrefix is the reserved prefix for system-emitted step ids. User-
-// authored step ids must not start with this prefix. The auth-method-emitted
-// steps that #366 introduces use "apxy:auth:<val>"; terminal pseudo-steps use
-// "apxy:verify_failed" / "apxy:auth_failed"; the verify pseudo-step is
-// "apxy:verify". The placeholder "apxy:auth" is the OAuth2-only wait state
-// until #366 replaces it with the auth-method-emitted redirect step.
+// authored step ids must not start with this prefix. Auth-method-emitted
+// steps use "apxy:auth:<val>" (e.g. "apxy:auth:oauth2_authorize");
+// terminal pseudo-steps use "apxy:verify_failed" / "apxy:auth_failed";
+// the verify pseudo-step is "apxy:verify".
 const ApxyStepPrefix = "apxy:"
 
 // SetupStep is the typed identifier for a step within a connection's setup
@@ -118,16 +117,17 @@ func MustNewSetupStep(id string) SetupStep {
 	return step
 }
 
-// Predefined SetupSteps for the system-emitted pseudo-steps.
+// Predefined SetupSteps for the system-emitted pseudo-steps the schema
+// itself owns.
 //
-//   - SetupStepAuth is the OAuth2-only "waiting for callback" placeholder.
-//     #366 replaces direct use of this with auth-method-emitted redirect
-//     steps whose ids are method-specific (e.g. apxy:auth:oauth2_authorize).
 //   - SetupStepVerify is the post-auth "probes running" pseudo-step.
 //   - SetupStepVerifyFailed and SetupStepAuthFailed are terminal failure
 //     pseudo-steps; connections in these are retryable via the retry endpoint.
+//
+// Auth-method-emitted steps (e.g. apxy:auth:oauth2_authorize) are not
+// predefined here — they're constructed in the respective auth_methods/*
+// packages and exposed as package-level constants there.
 var (
-	SetupStepAuth         = MustNewSetupStep(ApxyStepPrefix + "auth")
 	SetupStepVerify       = MustNewSetupStep(ApxyStepPrefix + "verify")
 	SetupStepVerifyFailed = MustNewSetupStep(ApxyStepPrefix + "verify_failed")
 	SetupStepAuthFailed   = MustNewSetupStep(ApxyStepPrefix + "auth_failed")

--- a/internal/schema/resources/connectors/setup_flow_test.go
+++ b/internal/schema/resources/connectors/setup_flow_test.go
@@ -355,9 +355,9 @@ func TestParseSetupStep(t *testing.T) {
 	})
 
 	t.Run("apxy-emitted pseudo-step", func(t *testing.T) {
-		s, err := ParseSetupStep("apxy:auth")
+		s, err := ParseSetupStep("apxy:verify")
 		require.NoError(t, err)
-		assert.True(t, s.Equals(SetupStepAuth))
+		assert.True(t, s.Equals(SetupStepVerify))
 		assert.True(t, s.IsApxyEmitted())
 	})
 
@@ -434,9 +434,9 @@ func TestSetupStepJSONMarshal(t *testing.T) {
 	})
 
 	t.Run("apxy-emitted id marshals as JSON string", func(t *testing.T) {
-		b, err := json.Marshal(SetupStepAuth)
+		b, err := json.Marshal(SetupStepVerify)
 		require.NoError(t, err)
-		assert.Equal(t, `"apxy:auth"`, string(b))
+		assert.Equal(t, `"apxy:verify"`, string(b))
 	})
 
 	t.Run("zero value marshals as null", func(t *testing.T) {
@@ -501,7 +501,7 @@ func TestSetupStepJSONUnmarshal(t *testing.T) {
 }
 
 func TestSetupStepYAMLRoundTrip(t *testing.T) {
-	cases := []string{"tenant", "apxy:auth", "apxy:verify_failed"}
+	cases := []string{"tenant", "apxy:verify", "apxy:verify_failed"}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {
 			parsed, err := ParseSetupStep(c)
@@ -530,18 +530,20 @@ func TestSetupStepYAMLRoundTrip(t *testing.T) {
 }
 
 func TestSetupStepIsApxyEmitted(t *testing.T) {
-	assert.True(t, SetupStepAuth.IsApxyEmitted())
 	assert.True(t, SetupStepVerify.IsApxyEmitted())
 	assert.True(t, SetupStepVerifyFailed.IsApxyEmitted())
 	assert.True(t, SetupStepAuthFailed.IsApxyEmitted())
+	// Auth-method-emitted steps (constructed in their own packages) also
+	// carry the prefix; the schema only knows the convention.
+	assert.True(t, MustNewSetupStep("apxy:auth:oauth2_authorize").IsApxyEmitted())
 	assert.False(t, MustNewSetupStep("tenant").IsApxyEmitted())
 }
 
 func TestSetupStepIsTerminalFailure(t *testing.T) {
 	assert.True(t, SetupStepVerifyFailed.IsTerminalFailure())
 	assert.True(t, SetupStepAuthFailed.IsTerminalFailure())
-	assert.False(t, SetupStepAuth.IsTerminalFailure())
 	assert.False(t, SetupStepVerify.IsTerminalFailure())
+	assert.False(t, MustNewSetupStep("apxy:auth:oauth2_authorize").IsTerminalFailure())
 	assert.False(t, MustNewSetupStep("tenant").IsTerminalFailure())
 }
 
@@ -616,7 +618,7 @@ func TestSetupFlow_IsConfigureStep(t *testing.T) {
 
 	assert.False(t, sf.IsConfigureStep(MustNewSetupStep("tenant")))
 	assert.True(t, sf.IsConfigureStep(MustNewSetupStep("workspace")))
-	assert.False(t, sf.IsConfigureStep(SetupStepAuth))
+	assert.False(t, sf.IsConfigureStep(SetupStepVerify))
 	assert.False(t, sf.IsConfigureStep(SetupStep{}))
 }
 


### PR DESCRIPTION
Closes #368. Closes the last open ticket on #360.

## Summary

The bulk of #368 (OAuth2 factory emitting its redirect step via the new manifest mechanism) already landed inside #366 once it became clear the placeholder-then-replace dance the ticket originally described was unnecessary — #362's iface contract already supported runtime redirect rendering. What was left was the dead ``apxy:auth`` ``SetupStepAuth`` singleton plus its test references.

This PR removes that singleton. No production code referenced it after #366; only a handful of test fixtures and doc comments used it as an example apxy id.

## Scope

- ``internal/schema/resources/connectors/setup_flow.go``: delete the ``SetupStepAuth`` var; update the ``ApxyStepPrefix`` doc comment.
- ``internal/schema/resources/connectors/setup_flow_test.go``: retarget examples at ``apxy:verify`` (the surviving schema-owned pseudo-step) and at ``apxy:auth:oauth2_authorize`` (auth-method-emitted) where the example needs that shape.
- ``internal/core/connection_data_source_test.go``: the "not a configure step" test fixture uses ``SetupStepVerify`` instead.
- ``internal/core/service_connection_abort_test.go``: the "aborts auth step connection" fixture uses the real OAuth2 authorize step id (``oauth2.OAuth2AuthorizeStepId``).

## Test plan

- [x] ``go test ./...`` clean.
- [x] ``./scripts/preflight.sh`` clean.
- [x] Integration: ``./api_key/`` and ``./probes/`` pass.

## Wrap-up

With this merged, the entire #360 project (8 sub-tickets) is complete:

| # | Title | PR |
|---|---|---|
| #361 | Standardize ``auth_methods.Factory`` | #373 |
| #362 | ``ManifestSetupStep`` / flow types in ``core/iface`` | #400 |
| #363 | Rename ``ConnectionState``: Created→Setup, Ready→Configured | #397 |
| #364 | Move api-key credential persistence into ``auth_methods/api_key`` | #419 |
| #365 | ``setup_step_id`` rename; ID-based step encoding; drop ``SetupStepPhase`` | #418 |
| #366 | Auth-method factories emit setup steps; core dispatches via manifest | #424 |
| #367 | ``SetupFlowStep.Type`` (form/redirect) + setup_token + ``/setup/{advance,abort}`` | #437 |
| #368 | (this PR) | — |

#352 (OAuth2 client-credentials grant) is now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)