### PR TITLE
Support OAuth2 client credentials grant

### DIFF
--- a/internal/auth_methods/api_key/interface.go
+++ b/internal/auth_methods/api_key/interface.go
@@ -22,7 +22,7 @@ type Factory interface {
 	// PersistCredentials extracts the api-key credential field values from
 	// credData (the validated form payload from a credentials-phase submit),
 	// encrypts them as a single JSON blob, and inserts the row into
-	// api_key_credentials. The actor on the request context is recorded as
+	// connection_credentials. The actor on the request context is recorded as
 	// the credential's creator. Validation of which fields are present is
 	// placement-specific (e.g. basic placement requires the username field).
 	//

--- a/internal/auth_methods/api_key/manifest_steps.go
+++ b/internal/auth_methods/api_key/manifest_steps.go
@@ -43,7 +43,7 @@ func (f *factory) ManifestSetupSteps(connection coreIface.Connection, connector 
 				// ValidateAndMergeData with nil config returns a fresh map of
 				// the validated fields; we hand it to PersistCredentials and
 				// discard the map (the plaintext is then encrypted into the
-				// api_key_credentials row).
+				// connection_credentials row).
 				credData, err := spec.ValidateAndMergeData(spec.Id, data, nil)
 				if err != nil {
 					return httperr.BadRequest(err.Error())

--- a/internal/auth_methods/api_key/persist.go
+++ b/internal/auth_methods/api_key/persist.go
@@ -14,7 +14,7 @@ import (
 // PersistCredentials extracts the api-key credential field values from
 // credData (validated by the schema-step's JSON Schema upstream), encrypts
 // the resulting plaintext as a single JSON blob, and inserts a fresh row
-// into api_key_credentials. InsertApiKeyCredential soft-deletes any active
+// into connection_credentials. InsertApiKeyCredential soft-deletes any active
 // row in the same transaction, so this is the rotation path as well as the
 // initial-set path.
 //

--- a/internal/auth_methods/api_key/synthesized_step.go
+++ b/internal/auth_methods/api_key/synthesized_step.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/common/json_schema"
+	"github.com/rmorlok/authproxy/internal/schema/common/ui_schema"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -30,55 +32,34 @@ func synthesizeCredentialsStep(placement *cschema.ApiKeyPlacement) *cschema.Setu
 		return nil
 	}
 
-	type schemaProp struct {
-		Type      string `json:"type"`
-		Title     string `json:"title,omitempty"`
-		MinLength int    `json:"minLength,omitempty"`
-	}
-	type schema struct {
-		Type                 string                `json:"type"`
-		Required             []string              `json:"required"`
-		Properties           map[string]schemaProp `json:"properties"`
-		AdditionalProperties bool                  `json:"additionalProperties"`
-	}
-	type uiControl struct {
-		Type    string            `json:"type"`
-		Scope   string            `json:"scope"`
-		Options map[string]string `json:"options,omitempty"`
-	}
-	type uiSchema struct {
-		Type     string      `json:"type"`
-		Elements []uiControl `json:"elements"`
-	}
-
-	js := schema{
+	js := json_schema.Schema{
 		Type:                 "object",
 		Required:             []string{},
-		Properties:           map[string]schemaProp{},
+		Properties:           map[string]json_schema.Property{},
 		AdditionalProperties: false,
 	}
-	ui := uiSchema{Type: "VerticalLayout", Elements: []uiControl{}}
+	ui := ui_schema.Schema{Type: "VerticalLayout", Elements: []ui_schema.Control{}}
 
 	if placement.Type == cschema.ApiKeyPlacementBasic && placement.UsernameField != "" {
 		js.Required = append(js.Required, placement.UsernameField)
-		js.Properties[placement.UsernameField] = schemaProp{
+		js.Properties[placement.UsernameField] = json_schema.Property{
 			Type:      "string",
 			Title:     "Username",
 			MinLength: 1,
 		}
-		ui.Elements = append(ui.Elements, uiControl{
+		ui.Elements = append(ui.Elements, ui_schema.Control{
 			Type:  "Control",
 			Scope: "#/properties/" + placement.UsernameField,
 		})
 	}
 
 	js.Required = append(js.Required, "api_key")
-	js.Properties["api_key"] = schemaProp{
+	js.Properties["api_key"] = json_schema.Property{
 		Type:      "string",
 		Title:     "API Key",
 		MinLength: 1,
 	}
-	ui.Elements = append(ui.Elements, uiControl{
+	ui.Elements = append(ui.Elements, ui_schema.Control{
 		Type:    "Control",
 		Scope:   "#/properties/api_key",
 		Options: map[string]string{"format": "password"},

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -85,11 +85,15 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 // dashboards and alerts can key off `category` rather than parsing error strings.
 func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url.Values) (string, error) {
 	var returnURL string
-	err := o.tel.withSpan(ctx, "token_exchange", o.connectorIDForTelemetry(), func(ctx context.Context) error {
-		var err error
-		returnURL, err = o.exchangeCodeAndAdvanceInner(ctx, query)
-		return err
-	})
+	err := o.tel.withSpan(
+		ctx,
+		"token_exchange",
+		o.connectorIDForTelemetry(),
+		func(ctx context.Context) error {
+			var err error
+			returnURL, err = o.exchangeCodeAndAdvanceInner(ctx, query)
+			return err
+		})
 	return returnURL, err
 }
 
@@ -97,7 +101,11 @@ func (o *oAuth2Connection) exchangeCodeAndAdvance(ctx context.Context, query url
 // failure-counter bump for token-exchange failures. Mirrors the refresh-side
 // classifyAndRecordRefreshFailure: every callsite uses the same shape so the
 // "category" string lands consistently on logs, metrics, and span errors.
-func (o *oAuth2Connection) emitAndRecordExchangeFailure(ctx context.Context, category tokenExchangeCategory, attrs tokenExchangeAttrs) {
+func (o *oAuth2Connection) emitAndRecordExchangeFailure(
+	ctx context.Context,
+	category tokenExchangeCategory,
+	attrs tokenExchangeAttrs,
+) {
 	emitTokenExchangeFailure(ctx, o.logger, category, attrs)
 	o.tel.recordTokenExchangeFailure(ctx, string(category), o.connectionLabelsForTelemetry())
 }
@@ -231,9 +239,13 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 // endpoint exchange for service-to-service connectors. There is no authorize
 // redirect or callback; the client credentials are the grant.
 func (o *oAuth2Connection) ExchangeClientCredentials(ctx context.Context) error {
-	return o.tel.withSpan(ctx, "token_exchange", o.connectorIDForTelemetry(), func(ctx context.Context) error {
-		return o.exchangeClientCredentialsInner(ctx)
-	})
+	return o.tel.withSpan(
+		ctx,
+		"token_exchange",
+		o.connectorIDForTelemetry(),
+		func(ctx context.Context) error {
+			return o.exchangeClientCredentialsInner(ctx)
+		})
 }
 
 func (o *oAuth2Connection) exchangeClientCredentialsInner(ctx context.Context) error {
@@ -299,12 +311,6 @@ func (o *oAuth2Connection) exchangeClientCredentialsInner(ctx context.Context) e
 	if err != nil {
 		err = fmt.Errorf("failed to create db token from response: %w", err)
 		o.emitAndRecordExchangeFailure(ctx, tokenExchangeMalformedResponse, o.tokenExchangeAttrsFromConn(err))
-		return err
-	}
-
-	if _, err := o.connection.HandleCredentialsEstablished(ctx); err != nil {
-		err = fmt.Errorf("failed to handle post-auth state transition: %w", err)
-		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
 		return err
 	}
 

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -227,6 +227,91 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 	return o.state.ReturnToUrl, nil
 }
 
+// ExchangeClientCredentials performs RFC 6749 §4.4's synchronous token
+// endpoint exchange for service-to-service connectors. There is no authorize
+// redirect or callback; the client credentials are the grant.
+func (o *oAuth2Connection) ExchangeClientCredentials(ctx context.Context) error {
+	return o.tel.withSpan(ctx, "token_exchange", o.connectorIDForTelemetry(), func(ctx context.Context) error {
+		return o.exchangeClientCredentialsInner(ctx)
+	})
+}
+
+func (o *oAuth2Connection) exchangeClientCredentialsInner(ctx context.Context) error {
+	c := o.httpf.
+		ForRequestType(httpf.RequestTypeOAuth).
+		ForConnection(o.connection).
+		New().
+		UseContext(ctx)
+
+	clientId, clientSecret, err := o.resolveClientCredentials(ctx)
+	if err != nil {
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+
+	tokenEndpoint, err := o.renderMustache(ctx, o.auth.Token.Endpoint)
+	if err != nil {
+		err = fmt.Errorf("failed to render token endpoint template: %w", err)
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+
+	values := url.Values{
+		"grant_type": {"client_credentials"},
+	}
+	if scopes := JoinScopes(o.auth.Scopes); scopes != "" {
+		values.Set("scope", scopes)
+	}
+
+	values, authHeader, err := applyTokenEndpointClientAuth(
+		o.auth.GetTokenEndpointAuthMethodOrDefault(), clientId, clientSecret, values,
+	)
+	if err != nil {
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+
+	for k, v := range o.auth.Token.FormOverrides {
+		values.Set(k, v)
+	}
+
+	resp, attempts, err := o.postTokenExchangeWithRetry(ctx, c, tokenEndpoint, values, authHeader)
+	if err != nil {
+		err = fmt.Errorf("failed to post client credentials token exchange: %w", err)
+		attrs := o.tokenExchangeAttrsFromConn(err)
+		attrs.Attempts = attempts
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeNetworkError, attrs)
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		category, providerErr := classifyTokenEndpointStatus(resp.StatusCode, resp.Bytes())
+		err := fmt.Errorf("received status code %d from client credentials token exchange", resp.StatusCode)
+		attrs := o.tokenExchangeAttrsFromConn(err)
+		attrs.ProviderStatusCode = resp.StatusCode
+		attrs.ProviderError = providerErr
+		attrs.Attempts = attempts
+		o.emitAndRecordExchangeFailure(ctx, category, attrs)
+		return err
+	}
+
+	_, err = o.createDbTokenFromResponseWithOptions(ctx, resp, nil, tokenPersistOptions{PersistRefreshToken: false})
+	if err != nil {
+		err = fmt.Errorf("failed to create db token from response: %w", err)
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeMalformedResponse, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+
+	if _, err := o.connection.HandleCredentialsEstablished(ctx); err != nil {
+		err = fmt.Errorf("failed to handle post-auth state transition: %w", err)
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+
+	o.tel.recordTokenExchangeSuccess(ctx, o.connectionLabelsForTelemetry())
+	return nil
+}
+
 // postTokenExchangeWithRetry POSTs the token-exchange form to the provider's
 // token endpoint, retrying transient failures (transport errors and 5xx
 // responses) up to tokenExchangeMaxAttempts times. Returns the final

--- a/internal/auth_methods/oauth2/client_auth.go
+++ b/internal/auth_methods/oauth2/client_auth.go
@@ -3,9 +3,11 @@ package oauth2
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
+	"github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
@@ -14,6 +16,10 @@ import (
 // optional — public clients have no secret to send — so its absence is not
 // an error.
 func (o *oAuth2Connection) resolveClientCredentials(ctx context.Context) (string, string, error) {
+	if o.auth.GetGrantTypeOrDefault() == sconfig.OAuth2GrantClientCredentials {
+		return o.resolveStoredClientCredentials(ctx)
+	}
+
 	clientId, err := o.auth.ClientId.GetValue(ctx)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get client id for connector: %w", err)
@@ -28,6 +34,32 @@ func (o *oAuth2Connection) resolveClientCredentials(ctx context.Context) (string
 		return "", "", fmt.Errorf("failed to get client secret for connector: %w", err)
 	}
 	return clientId, clientSecret, nil
+}
+
+func (o *oAuth2Connection) resolveStoredClientCredentials(ctx context.Context) (string, string, error) {
+	cred, err := o.db.GetActiveApiKeyCredential(ctx, o.connection.GetId())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load OAuth2 client credentials: %w", err)
+	}
+
+	plaintextJSON, err := o.encrypt.DecryptString(ctx, cred.EncryptedCredentials)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decrypt OAuth2 client credentials: %w", err)
+	}
+
+	var plaintext database.OAuth2ClientCredentialsPlaintext
+	if err := json.Unmarshal([]byte(plaintextJSON), &plaintext); err != nil {
+		return "", "", fmt.Errorf("failed to parse OAuth2 client credentials: %w", err)
+	}
+	if plaintext.ClientId == "" {
+		return "", "", fmt.Errorf("OAuth2 client credentials missing client_id")
+	}
+	if o.auth.GetTokenEndpointAuthMethodOrDefault() != sconfig.TokenEndpointAuthNone &&
+		plaintext.ClientSecret == "" {
+		return "", "", fmt.Errorf("OAuth2 client credentials missing client_secret")
+	}
+
+	return plaintext.ClientId, plaintext.ClientSecret, nil
 }
 
 // applyTokenEndpointClientAuth attaches client credentials to the

--- a/internal/auth_methods/oauth2/client_auth_test.go
+++ b/internal/auth_methods/oauth2/client_auth_test.go
@@ -386,6 +386,47 @@ func TestAuthOAuth2_Validate_NilMethodAcceptedAsDefault(t *testing.T) {
 	assert.Equal(t, cschema.TokenEndpointAuthClientSecretPost, a.GetTokenEndpointAuthMethodOrDefault())
 }
 
+func TestAuthOAuth2_Validate_ClientCredentialsRejectsAuthorizationBlock(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:         cschema.AuthTypeOAuth2,
+		GrantType:    cschema.NewOAuth2GrantType(cschema.OAuth2GrantClientCredentials),
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
+		Authorization: cschema.AuthOauth2Authorization{
+			Endpoint: "https://example.com/oauth/authorize",
+		},
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authorization")
+}
+
+func TestAuthOAuth2_Validate_ClientCredentialsRequiresSecretUnlessNone(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:      cschema.AuthTypeOAuth2,
+		GrantType: cschema.NewOAuth2GrantType(cschema.OAuth2GrantClientCredentials),
+		ClientId:  common.NewStringValueDirect("client-id"),
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_secret")
+
+	a.TokenEndpointAuthMethod = cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthNone)
+	require.NoError(t, a.Validate(&common.ValidationContext{}))
+}
+
+func TestAuthOAuth2_Validate_RejectsUnknownGrantType(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:         cschema.AuthTypeOAuth2,
+		GrantType:    cschema.NewOAuth2GrantType(cschema.OAuth2GrantType("implicit")),
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
+	}
+	err := a.Validate(&common.ValidationContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "grant_type")
+}
+
 // TestAuthOAuth2_Validate_RejectsUnknownTokenEndpointAuthMethod guards
 // the validator against typos / unsupported RFC 7591 methods (client_secret_jwt
 // etc., out of scope).

--- a/internal/auth_methods/oauth2/client_auth_test.go
+++ b/internal/auth_methods/oauth2/client_auth_test.go
@@ -120,6 +120,46 @@ func TestApplyTokenEndpointClientAuth_UnknownMethod(t *testing.T) {
 	assert.Contains(t, err.Error(), "bogus")
 }
 
+func TestResolveClientCredentials_ClientCredentialsUsesStoredSetupCredential(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	connectionId := apid.New(apid.PrefixConnection)
+	grantType := sconfig.OAuth2GrantClientCredentials
+	auth := &cschema.AuthOAuth2{
+		Type:      cschema.AuthTypeOAuth2,
+		GrantType: &grantType,
+	}
+
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	encrypted := encfield.EncryptedField{ID: "ekv_test", Data: "encrypted"}
+	db.EXPECT().
+		GetActiveApiKeyCredential(gomock.Any(), connectionId).
+		Return(&database.ApiKeyCredential{
+			Id:                   apid.New(apid.PrefixApiKeyCredential),
+			ConnectionId:         connectionId,
+			EncryptedCredentials: encrypted,
+		}, nil)
+	encrypt.EXPECT().
+		DecryptString(gomock.Any(), encrypted).
+		Return(`{"client_id":"stored-client","client_secret":"stored-secret"}`, nil)
+
+	o := &oAuth2Connection{
+		db:      db,
+		encrypt: encrypt,
+		auth:    auth,
+		connection: &mockCore.Connection{
+			Id: connectionId,
+		},
+	}
+
+	clientId, clientSecret, err := o.resolveClientCredentials(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "stored-client", clientId)
+	assert.Equal(t, "stored-secret", clientSecret)
+}
+
 // captureHeader is a gock matcher that records the value of a specific
 // header from the incoming request. Pairs with captureBody (defined in
 // pkce_test.go) when a test needs both.
@@ -401,17 +441,24 @@ func TestAuthOAuth2_Validate_ClientCredentialsRejectsAuthorizationBlock(t *testi
 	assert.Contains(t, err.Error(), "authorization")
 }
 
-func TestAuthOAuth2_Validate_ClientCredentialsRequiresSecretUnlessNone(t *testing.T) {
+func TestAuthOAuth2_Validate_ClientCredentialsRejectsConnectorCredentials(t *testing.T) {
 	a := &cschema.AuthOAuth2{
-		Type:      cschema.AuthTypeOAuth2,
-		GrantType: cschema.NewOAuth2GrantType(cschema.OAuth2GrantClientCredentials),
-		ClientId:  common.NewStringValueDirect("client-id"),
+		Type:         cschema.AuthTypeOAuth2,
+		GrantType:    cschema.NewOAuth2GrantType(cschema.OAuth2GrantClientCredentials),
+		ClientId:     common.NewStringValueDirect("client-id"),
+		ClientSecret: common.NewStringValueDirect("client-secret"),
 	}
 	err := a.Validate(&common.ValidationContext{})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_id")
 	assert.Contains(t, err.Error(), "client_secret")
+}
 
-	a.TokenEndpointAuthMethod = cschema.NewTokenEndpointAuthMethod(cschema.TokenEndpointAuthNone)
+func TestAuthOAuth2_Validate_ClientCredentialsCollectsCredentialsDuringSetup(t *testing.T) {
+	a := &cschema.AuthOAuth2{
+		Type:      cschema.AuthTypeOAuth2,
+		GrantType: cschema.NewOAuth2GrantType(cschema.OAuth2GrantClientCredentials),
+	}
 	require.NoError(t, a.Validate(&common.ValidationContext{}))
 }
 

--- a/internal/auth_methods/oauth2/client_credentials.go
+++ b/internal/auth_methods/oauth2/client_credentials.go
@@ -9,57 +9,38 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/common/json_schema"
+	"github.com/rmorlok/authproxy/internal/schema/common/ui_schema"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 func synthesizeClientCredentialsStep(method cschema.TokenEndpointAuthMethod) *cschema.SetupFlowStep {
-	type schemaProp struct {
-		Type      string `json:"type"`
-		Title     string `json:"title,omitempty"`
-		MinLength int    `json:"minLength,omitempty"`
-	}
-	type schema struct {
-		Type                 string                `json:"type"`
-		Required             []string              `json:"required"`
-		Properties           map[string]schemaProp `json:"properties"`
-		AdditionalProperties bool                  `json:"additionalProperties"`
-	}
-	type uiControl struct {
-		Type    string            `json:"type"`
-		Scope   string            `json:"scope"`
-		Options map[string]string `json:"options,omitempty"`
-	}
-	type uiSchema struct {
-		Type     string      `json:"type"`
-		Elements []uiControl `json:"elements"`
-	}
-
-	js := schema{
+	js := json_schema.Schema{
 		Type:                 "object",
 		Required:             []string{"client_id"},
-		Properties:           map[string]schemaProp{},
+		Properties:           map[string]json_schema.Property{},
 		AdditionalProperties: false,
 	}
-	ui := uiSchema{Type: "VerticalLayout", Elements: []uiControl{}}
+	ui := ui_schema.Schema{Type: "VerticalLayout", Elements: []ui_schema.Control{}}
 
-	js.Properties["client_id"] = schemaProp{
+	js.Properties["client_id"] = json_schema.Property{
 		Type:      "string",
 		Title:     "Client ID",
 		MinLength: 1,
 	}
-	ui.Elements = append(ui.Elements, uiControl{
+	ui.Elements = append(ui.Elements, ui_schema.Control{
 		Type:  "Control",
 		Scope: "#/properties/client_id",
 	})
 
 	if method != cschema.TokenEndpointAuthNone {
 		js.Required = append(js.Required, "client_secret")
-		js.Properties["client_secret"] = schemaProp{
+		js.Properties["client_secret"] = json_schema.Property{
 			Type:      "string",
 			Title:     "Client Secret",
 			MinLength: 1,
 		}
-		ui.Elements = append(ui.Elements, uiControl{
+		ui.Elements = append(ui.Elements, ui_schema.Control{
 			Type:    "Control",
 			Scope:   "#/properties/client_secret",
 			Options: map[string]string{"format": "password"},

--- a/internal/auth_methods/oauth2/client_credentials.go
+++ b/internal/auth_methods/oauth2/client_credentials.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
@@ -14,35 +15,39 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
+const attrClientId = "client_id"
+const attrClientSecret = "client_secret"
+
 func synthesizeClientCredentialsStep(method cschema.TokenEndpointAuthMethod) *cschema.SetupFlowStep {
+
 	js := json_schema.Schema{
 		Type:                 "object",
-		Required:             []string{"client_id"},
+		Required:             []string{attrClientId},
 		Properties:           map[string]json_schema.Property{},
 		AdditionalProperties: false,
 	}
 	ui := ui_schema.Schema{Type: "VerticalLayout", Elements: []ui_schema.Control{}}
 
-	js.Properties["client_id"] = json_schema.Property{
+	js.Properties[attrClientId] = json_schema.Property{
 		Type:      "string",
 		Title:     "Client ID",
 		MinLength: 1,
 	}
 	ui.Elements = append(ui.Elements, ui_schema.Control{
 		Type:  "Control",
-		Scope: "#/properties/client_id",
+		Scope: fmt.Sprintf("#/properties/%s", attrClientId),
 	})
 
 	if method != cschema.TokenEndpointAuthNone {
-		js.Required = append(js.Required, "client_secret")
-		js.Properties["client_secret"] = json_schema.Property{
+		js.Required = append(js.Required, attrClientSecret)
+		js.Properties[attrClientSecret] = json_schema.Property{
 			Type:      "string",
 			Title:     "Client Secret",
 			MinLength: 1,
 		}
 		ui.Elements = append(ui.Elements, ui_schema.Control{
 			Type:    "Control",
-			Scope:   "#/properties/client_secret",
+			Scope:   fmt.Sprintf("#/properties/%s", attrClientSecret),
 			Options: map[string]string{"format": "password"},
 		})
 	}
@@ -72,18 +77,18 @@ func (f *factory) PersistClientCredentials(
 	credData map[string]any,
 ) error {
 	plaintext := database.OAuth2ClientCredentialsPlaintext{}
-	if v, ok := credData["client_id"].(string); ok {
+	if v, ok := credData[attrClientId].(string); ok {
 		plaintext.ClientId = v
 	}
 	if plaintext.ClientId == "" {
-		return httperr.BadRequest("client_id is required")
+		return httperr.BadRequest(fmt.Sprintf("%s is required", attrClientId))
 	}
 
-	if v, ok := credData["client_secret"].(string); ok {
+	if v, ok := credData[attrClientSecret].(string); ok {
 		plaintext.ClientSecret = v
 	}
 	if auth.GetTokenEndpointAuthMethodOrDefault() != cschema.TokenEndpointAuthNone && plaintext.ClientSecret == "" {
-		return httperr.BadRequest("client_secret is required")
+		return httperr.BadRequest(fmt.Sprintf("%s is required", attrClientSecret))
 	}
 
 	blobJSON, err := json.Marshal(plaintext)

--- a/internal/auth_methods/oauth2/client_credentials.go
+++ b/internal/auth_methods/oauth2/client_credentials.go
@@ -1,0 +1,122 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+
+	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+)
+
+func synthesizeClientCredentialsStep(method cschema.TokenEndpointAuthMethod) *cschema.SetupFlowStep {
+	type schemaProp struct {
+		Type      string `json:"type"`
+		Title     string `json:"title,omitempty"`
+		MinLength int    `json:"minLength,omitempty"`
+	}
+	type schema struct {
+		Type                 string                `json:"type"`
+		Required             []string              `json:"required"`
+		Properties           map[string]schemaProp `json:"properties"`
+		AdditionalProperties bool                  `json:"additionalProperties"`
+	}
+	type uiControl struct {
+		Type    string            `json:"type"`
+		Scope   string            `json:"scope"`
+		Options map[string]string `json:"options,omitempty"`
+	}
+	type uiSchema struct {
+		Type     string      `json:"type"`
+		Elements []uiControl `json:"elements"`
+	}
+
+	js := schema{
+		Type:                 "object",
+		Required:             []string{"client_id"},
+		Properties:           map[string]schemaProp{},
+		AdditionalProperties: false,
+	}
+	ui := uiSchema{Type: "VerticalLayout", Elements: []uiControl{}}
+
+	js.Properties["client_id"] = schemaProp{
+		Type:      "string",
+		Title:     "Client ID",
+		MinLength: 1,
+	}
+	ui.Elements = append(ui.Elements, uiControl{
+		Type:  "Control",
+		Scope: "#/properties/client_id",
+	})
+
+	if method != cschema.TokenEndpointAuthNone {
+		js.Required = append(js.Required, "client_secret")
+		js.Properties["client_secret"] = schemaProp{
+			Type:      "string",
+			Title:     "Client Secret",
+			MinLength: 1,
+		}
+		ui.Elements = append(ui.Elements, uiControl{
+			Type:    "Control",
+			Scope:   "#/properties/client_secret",
+			Options: map[string]string{"format": "password"},
+		})
+	}
+
+	jsBytes, err := json.Marshal(js)
+	if err != nil {
+		panic("oauth2: failed to marshal synthesized client credentials json_schema: " + err.Error())
+	}
+	uiBytes, err := json.Marshal(ui)
+	if err != nil {
+		panic("oauth2: failed to marshal synthesized client credentials ui_schema: " + err.Error())
+	}
+
+	return &cschema.SetupFlowStep{
+		Id:          OAuth2ClientCredentialsStepId,
+		Title:       "Enter OAuth client credentials",
+		Description: "Provide the client credentials used to authenticate with this service.",
+		JsonSchema:  common.RawJSON(jsBytes),
+		UiSchema:    common.RawJSON(uiBytes),
+	}
+}
+
+func (f *factory) PersistClientCredentials(
+	ctx context.Context,
+	connection coreIface.Connection,
+	auth *cschema.AuthOAuth2,
+	credData map[string]any,
+) error {
+	plaintext := database.OAuth2ClientCredentialsPlaintext{}
+	if v, ok := credData["client_id"].(string); ok {
+		plaintext.ClientId = v
+	}
+	if plaintext.ClientId == "" {
+		return httperr.BadRequest("client_id is required")
+	}
+
+	if v, ok := credData["client_secret"].(string); ok {
+		plaintext.ClientSecret = v
+	}
+	if auth.GetTokenEndpointAuthMethodOrDefault() != cschema.TokenEndpointAuthNone && plaintext.ClientSecret == "" {
+		return httperr.BadRequest("client_secret is required")
+	}
+
+	blobJSON, err := json.Marshal(plaintext)
+	if err != nil {
+		return httperr.InternalServerError(httperr.WithInternalErrorf("failed to marshal OAuth2 client credentials: %w", err))
+	}
+	encrypted, err := f.encrypt.EncryptStringForNamespace(ctx, connection.GetNamespace(), string(blobJSON))
+	if err != nil {
+		return httperr.InternalServerError(httperr.WithInternalErrorf("failed to encrypt OAuth2 client credentials: %w", err))
+	}
+
+	actorId := apauthcore.GetAuthFromContext(ctx).MustGetActor().GetId()
+	if _, err := f.db.InsertApiKeyCredential(ctx, connection.GetId(), encrypted, nil, &actorId); err != nil {
+		return httperr.InternalServerError(httperr.WithInternalErrorf("failed to persist OAuth2 client credentials: %w", err))
+	}
+	return nil
+}

--- a/internal/auth_methods/oauth2/interface.go
+++ b/internal/auth_methods/oauth2/interface.go
@@ -37,4 +37,5 @@ type OAuth2Connection interface {
 		returnToUrl string,
 	) (string, error)
 	CallbackFrom3rdParty(ctx context.Context, query url.Values) (string, error)
+	ExchangeClientCredentials(ctx context.Context) error
 }

--- a/internal/auth_methods/oauth2/manifest_steps.go
+++ b/internal/auth_methods/oauth2/manifest_steps.go
@@ -11,20 +11,33 @@ import (
 
 // OAuth2AuthorizeStepId is the manifest id for OAuth2's authorize-redirect
 // step. Constant so core's dispatcher can compare against it when handling
-// the callback transition. #352 (client_credentials grant) will introduce a
-// second id for the synchronous token-exchange path.
+// the callback transition.
 const OAuth2AuthorizeStepId = "apxy:auth:oauth2_authorize"
 
+// OAuth2ClientCredentialsStepId is the manifest id for OAuth2's synchronous
+// client-credentials exchange step. Core recognizes this id as an immediate
+// auth step.
+const OAuth2ClientCredentialsStepId = "apxy:auth:oauth2_client_credentials"
+
 // ManifestSetupSteps returns the OAuth2-emitted setup steps for this
-// connection. The authorization_code grant (today's only supported grant)
-// emits a single redirect step whose RenderRedirect resolves to the
-// freshly-minted authorize URL (state + PKCE already persisted to redis).
+// connection. authorization_code emits a redirect step; client_credentials
+// emits an immediate step that core executes synchronously.
 func (f *factory) ManifestSetupSteps(connection coreIface.Connection, connector *cschema.Connector) []coreIface.ManifestSetupStep {
 	if connector == nil || connector.Auth == nil {
 		return nil
 	}
-	if _, ok := connector.Auth.Inner().(*cschema.AuthOAuth2); !ok {
+	auth, ok := connector.Auth.Inner().(*cschema.AuthOAuth2)
+	if !ok {
 		return nil
+	}
+	if auth.GetGrantTypeOrDefault() == cschema.OAuth2GrantClientCredentials {
+		return []coreIface.ManifestSetupStep{
+			coreIface.NewFormStep(coreIface.FormStepConfig{
+				Id:          OAuth2ClientCredentialsStepId,
+				Title:       "Authorize",
+				Description: "Authorizing this connection.",
+			}),
+		}
 	}
 	return []coreIface.ManifestSetupStep{
 		coreIface.NewRedirectStep(coreIface.RedirectStepConfig{

--- a/internal/auth_methods/oauth2/manifest_steps.go
+++ b/internal/auth_methods/oauth2/manifest_steps.go
@@ -2,10 +2,12 @@ package oauth2
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -14,14 +16,14 @@ import (
 // the callback transition.
 const OAuth2AuthorizeStepId = "apxy:auth:oauth2_authorize"
 
-// OAuth2ClientCredentialsStepId is the manifest id for OAuth2's synchronous
-// client-credentials exchange step. Core recognizes this id as an immediate
-// auth step.
+// OAuth2ClientCredentialsStepId is the manifest id for OAuth2's synthesized
+// client-credentials collection form.
 const OAuth2ClientCredentialsStepId = "apxy:auth:oauth2_client_credentials"
 
 // ManifestSetupSteps returns the OAuth2-emitted setup steps for this
 // connection. authorization_code emits a redirect step; client_credentials
-// emits an immediate step that core executes synchronously.
+// emits a credential form that stores the submitted client id / secret and
+// performs the token endpoint exchange on submit.
 func (f *factory) ManifestSetupSteps(connection coreIface.Connection, connector *cschema.Connector) []coreIface.ManifestSetupStep {
 	if connector == nil || connector.Auth == nil {
 		return nil
@@ -31,19 +33,24 @@ func (f *factory) ManifestSetupSteps(connection coreIface.Connection, connector 
 		return nil
 	}
 	if auth.GetGrantTypeOrDefault() == cschema.OAuth2GrantClientCredentials {
+		spec := synthesizeClientCredentialsStep(auth.GetTokenEndpointAuthMethodOrDefault())
 		return []coreIface.ManifestSetupStep{
-			coreIface.NewImmediateStep(coreIface.ImmediateStepConfig{
-				Id:          OAuth2ClientCredentialsStepId,
-				Title:       "Authorize",
-				Description: "Authorizing this connection.",
-				OnEnter: func(ctx context.Context) error {
-					o2 := f.NewOAuth2(connection)
-					if err := o2.ExchangeClientCredentials(ctx); err != nil {
-						if recordErr := connection.HandleAuthFailed(ctx, err); recordErr != nil {
-							return fmt.Errorf("failed to record auth failure (%v) after: %w", recordErr, err)
-						}
+			coreIface.NewFormStep(coreIface.FormStepConfig{
+				Id:          spec.Id,
+				Title:       spec.Title,
+				Description: spec.Description,
+				JsonSchema:  json.RawMessage(spec.JsonSchema),
+				UiSchema:    json.RawMessage(spec.UiSchema),
+				OnSubmit: func(ctx context.Context, data json.RawMessage) error {
+					credData, err := spec.ValidateAndMergeData(spec.Id, data, nil)
+					if err != nil {
+						return httperr.BadRequest(err.Error())
 					}
-					return nil
+					if err := f.PersistClientCredentials(ctx, connection, auth, credData); err != nil {
+						return err
+					}
+					o2 := f.NewOAuth2(connection)
+					return o2.ExchangeClientCredentials(ctx)
 				},
 			}),
 		}

--- a/internal/auth_methods/oauth2/manifest_steps.go
+++ b/internal/auth_methods/oauth2/manifest_steps.go
@@ -32,10 +32,19 @@ func (f *factory) ManifestSetupSteps(connection coreIface.Connection, connector 
 	}
 	if auth.GetGrantTypeOrDefault() == cschema.OAuth2GrantClientCredentials {
 		return []coreIface.ManifestSetupStep{
-			coreIface.NewFormStep(coreIface.FormStepConfig{
+			coreIface.NewImmediateStep(coreIface.ImmediateStepConfig{
 				Id:          OAuth2ClientCredentialsStepId,
 				Title:       "Authorize",
 				Description: "Authorizing this connection.",
+				OnEnter: func(ctx context.Context) error {
+					o2 := f.NewOAuth2(connection)
+					if err := o2.ExchangeClientCredentials(ctx); err != nil {
+						if recordErr := connection.HandleAuthFailed(ctx, err); recordErr != nil {
+							return fmt.Errorf("failed to record auth failure (%v) after: %w", recordErr, err)
+						}
+					}
+					return nil
+				},
 			}),
 		}
 	}

--- a/internal/auth_methods/oauth2/mock/oauth2.go
+++ b/internal/auth_methods/oauth2/mock/oauth2.go
@@ -243,6 +243,20 @@ func (mr *MockOAuth2ConnectionMockRecorder) CancelSessionAfterAuth() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSessionAfterAuth", reflect.TypeOf((*MockOAuth2Connection)(nil).CancelSessionAfterAuth))
 }
 
+// ExchangeClientCredentials mocks base method.
+func (m *MockOAuth2Connection) ExchangeClientCredentials(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExchangeClientCredentials", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExchangeClientCredentials indicates an expected call of ExchangeClientCredentials.
+func (mr *MockOAuth2ConnectionMockRecorder) ExchangeClientCredentials(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeClientCredentials", reflect.TypeOf((*MockOAuth2Connection)(nil).ExchangeClientCredentials), ctx)
+}
+
 // GenerateAuthUrl mocks base method.
 func (m *MockOAuth2Connection) GenerateAuthUrl(ctx context.Context, actor oauth2.IActorData) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -98,7 +98,7 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 		return token, nil
 	}
 
-	if token.EncryptedRefreshToken.IsZero() {
+	if token.EncryptedRefreshToken.IsZero() && o.auth.SupportsRefreshToken() {
 		// Permanent — there is no way to obtain a new access token without
 		// user interaction. Flip the connection unhealthy so the unified
 		// reauth UX surfaces the prompt.
@@ -106,11 +106,6 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 	}
 
 	clientId, clientSecret, err := o.resolveClientCredentials(ctx)
-	if err != nil {
-		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
-	}
-
-	refreshToken, err := o.encrypt.DecryptString(ctx, token.EncryptedRefreshToken)
 	if err != nil {
 		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
 	}
@@ -125,9 +120,21 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 			fmt.Errorf("failed to render token endpoint template: %w", err))
 	}
 
-	values := url.Values{
-		"grant_type":    {"refresh_token"},
-		"refresh_token": {refreshToken},
+	values := url.Values{}
+	persistOptions := tokenPersistOptions{PersistRefreshToken: true}
+	if o.auth.SupportsRefreshToken() {
+		refreshToken, err := o.encrypt.DecryptString(ctx, token.EncryptedRefreshToken)
+		if err != nil {
+			return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0, err)
+		}
+		values.Set("grant_type", "refresh_token")
+		values.Set("refresh_token", refreshToken)
+	} else {
+		values.Set("grant_type", "client_credentials")
+		if scopes := JoinScopes(o.auth.Scopes); scopes != "" {
+			values.Set("scope", scopes)
+		}
+		persistOptions.PersistRefreshToken = false
 	}
 
 	values, authHeader, err := applyTokenEndpointClientAuth(
@@ -150,7 +157,7 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 		return nil, o.classifyAndRecordRefreshFailure(ctx, category, refreshResp.StatusCode, providerErr, attempts, err)
 	}
 
-	newToken, err := o.createDbTokenFromResponse(ctx, refreshResp, token)
+	newToken, err := o.createDbTokenFromResponseWithOptions(ctx, refreshResp, token, persistOptions)
 	if err != nil {
 		return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshMalformedResponse, refreshResp.StatusCode, "", attempts,
 			fmt.Errorf("failed to refresh token: %w", err))

--- a/internal/auth_methods/oauth2/token_response.go
+++ b/internal/auth_methods/oauth2/token_response.go
@@ -23,12 +23,25 @@ type tokenResponse struct {
 	Scope        string `json:"scope"`
 }
 
+type tokenPersistOptions struct {
+	PersistRefreshToken bool
+}
+
 // createDbTokenFromResponse deserializes an oauth token from a refresh or authorization code response. It deserializes
 // the response and then inserts a token into the database. It returns the newly created token.
 func (o *oAuth2Connection) createDbTokenFromResponse(
 	ctx context.Context,
 	resp *gentleman.Response,
 	refreshFrom *database.OAuth2Token,
+) (*database.OAuth2Token, error) {
+	return o.createDbTokenFromResponseWithOptions(ctx, resp, refreshFrom, tokenPersistOptions{PersistRefreshToken: true})
+}
+
+func (o *oAuth2Connection) createDbTokenFromResponseWithOptions(
+	ctx context.Context,
+	resp *gentleman.Response,
+	refreshFrom *database.OAuth2Token,
+	opts tokenPersistOptions,
 ) (*database.OAuth2Token, error) {
 	jsonResp := tokenResponse{}
 	err := resp.JSON(&jsonResp)
@@ -48,13 +61,15 @@ func (o *oAuth2Connection) createDbTokenFromResponse(
 	var encryptedRefreshToken encfield.EncryptedField
 
 	// Not all OAuth has refresh tokens
-	if jsonResp.RefreshToken != "" {
+	if jsonResp.RefreshToken != "" && opts.PersistRefreshToken {
 		encryptedRefreshToken, err = o.encrypt.EncryptStringForEntity(ctx, o.connection, jsonResp.RefreshToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encrypt refresh token: %w", err)
 		}
-	} else if refreshFrom != nil {
+	} else if opts.PersistRefreshToken && refreshFrom != nil {
 		encryptedRefreshToken = refreshFrom.EncryptedRefreshToken
+	} else if jsonResp.RefreshToken != "" && o.logger != nil {
+		o.logger.WarnContext(ctx, "oauth token response included refresh_token for client_credentials grant; discarding")
 	}
 
 	requestedScopes := JoinScopes(o.auth.Scopes)

--- a/internal/auth_methods/oauth2/token_response_test.go
+++ b/internal/auth_methods/oauth2/token_response_test.go
@@ -15,6 +15,8 @@ import (
 	encrypt_mock "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -126,4 +128,63 @@ func TestCreateDbTokenFromResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateDbTokenFromResponse_ClientCredentialsDiscardsRefreshToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database_mock.NewMockDB(ctrl)
+	mockEncrypt := encrypt_mock.NewMockE(ctrl)
+
+	mockEncrypt.EXPECT().
+		EncryptStringForEntity(gomock.Any(), gomock.Any(), "valid_access_token").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"}, nil)
+	mockDB.EXPECT().
+		InsertOAuth2Token(
+			gomock.Any(),
+			gomock.Any(),
+			nil,
+			encfield.EncryptedField{},
+			encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"},
+			gomock.Any(),
+			"read",
+			"read",
+			gomock.Any(),
+		).
+		Return(&database.OAuth2Token{}, nil)
+
+	logger, read := bufLogger(t)
+	grantType := sconfig.OAuth2GrantClientCredentials
+	oauth := &oAuth2Connection{
+		db:      mockDB,
+		encrypt: mockEncrypt,
+		logger:  logger,
+		auth: &sconfig.AuthOAuth2{
+			GrantType: &grantType,
+			Scopes:    []sconfig.Scope{{Id: "read"}},
+		},
+		connection: &mockCore.Connection{
+			Id: apid.MustParse("cxn_test1234567890ab"),
+		},
+	}
+
+	resp := test_utils.MockGentlemenGetResponse("https://example.com", "example", func(m *gock.Request) {
+		m.
+			Reply(200).
+			AddHeader("Content-Type", "application/json").
+			BodyString(`{"access_token":"valid_access_token","refresh_token":"must_not_persist","scope":"read","expires_in":3600}`)
+	})
+
+	_, err := oauth.createDbTokenFromResponseWithOptions(
+		context.Background(),
+		resp,
+		nil,
+		tokenPersistOptions{PersistRefreshToken: false},
+	)
+	require.NoError(t, err)
+
+	records := read()
+	require.Len(t, records, 1)
+	assert.Contains(t, records[0]["msg"], "discarding")
 }

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
@@ -35,24 +34,6 @@ func (c *connection) advanceToStep(
 		return c.completeFlow(ctx)
 	}
 
-	if next.Id() == oauth2.OAuth2ClientCredentialsStepId {
-		nextStep := cschema.MustNewSetupStep(next.Id())
-		if err := c.SetSetupStep(ctx, &nextStep); err != nil {
-			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
-		}
-		factory, ok := c.s.getAuthMethodFactory(c.GetConnectorVersionEntity().GetDefinition()).(oauth2.Factory)
-		if !ok || factory == nil {
-			return nil, httperr.InternalServerErrorMsg("oauth2 factory unavailable for client-credentials exchange")
-		}
-		if err := factory.NewOAuth2(c).ExchangeClientCredentials(ctx); err != nil {
-			if recordErr := c.HandleAuthFailed(ctx, err); recordErr != nil {
-				return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to record auth failure (%v) after: %w", recordErr, err))
-			}
-			return c.GetCurrentSetupStepResponse(ctx)
-		}
-		return c.GetCurrentSetupStepResponse(ctx)
-	}
-
 	// For redirect steps, render the URL FIRST. The closure may reject
 	// invalid inputs (missing return_to_url) — surfacing those before any
 	// DB write keeps the connection's setup_step consistent on rejection.
@@ -68,6 +49,13 @@ func (c *connection) advanceToStep(
 	nextStep := cschema.MustNewSetupStep(next.Id())
 	if err := c.SetSetupStep(ctx, &nextStep); err != nil {
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
+	}
+
+	if next.Type() == iface.ManifestStepTypeImmediate {
+		if err := next.OnEnter(ctx); err != nil {
+			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to enter setup step %q: %w", next.Id(), err))
+		}
+		return c.GetCurrentSetupStepResponse(ctx)
 	}
 
 	if next.Type() == iface.ManifestStepTypeVerify {
@@ -156,6 +144,9 @@ func (c *connection) renderStepResponse(
 			Id:   c.GetId(),
 			Type: iface.ConnectionSetupResponseTypeVerifying,
 		}, nil
+
+	case iface.ManifestStepTypeImmediate:
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("immediate setup step %q cannot be rendered", step.Id()))
 	}
 	return nil, httperr.InternalServerError(httperr.WithInternalErrorf("unsupported manifest step type %q", step.Type()))
 }

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -51,13 +51,6 @@ func (c *connection) advanceToStep(
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
 	}
 
-	if next.Type() == iface.ManifestStepTypeImmediate {
-		if err := next.OnEnter(ctx); err != nil {
-			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to enter setup step %q: %w", next.Id(), err))
-		}
-		return c.GetCurrentSetupStepResponse(ctx)
-	}
-
 	if next.Type() == iface.ManifestStepTypeVerify {
 		if err := c.s.EnqueueVerifyConnection(ctx, c.GetId()); err != nil {
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to enqueue verify connection task: %w", err))
@@ -145,8 +138,6 @@ func (c *connection) renderStepResponse(
 			Type: iface.ConnectionSetupResponseTypeVerifying,
 		}, nil
 
-	case iface.ManifestStepTypeImmediate:
-		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("immediate setup step %q cannot be rendered", step.Id()))
 	}
 	return nil, httperr.InternalServerError(httperr.WithInternalErrorf("unsupported manifest step type %q", step.Type()))
 }

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
@@ -32,6 +33,24 @@ func (c *connection) advanceToStep(
 ) (iface.ConnectionSetupResponse, error) {
 	if next == nil {
 		return c.completeFlow(ctx)
+	}
+
+	if next.Id() == oauth2.OAuth2ClientCredentialsStepId {
+		nextStep := cschema.MustNewSetupStep(next.Id())
+		if err := c.SetSetupStep(ctx, &nextStep); err != nil {
+			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to update setup step: %w", err))
+		}
+		factory, ok := c.s.getAuthMethodFactory(c.GetConnectorVersionEntity().GetDefinition()).(oauth2.Factory)
+		if !ok || factory == nil {
+			return nil, httperr.InternalServerErrorMsg("oauth2 factory unavailable for client-credentials exchange")
+		}
+		if err := factory.NewOAuth2(c).ExchangeClientCredentials(ctx); err != nil {
+			if recordErr := c.HandleAuthFailed(ctx, err); recordErr != nil {
+				return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to record auth failure (%v) after: %w", recordErr, err))
+			}
+			return c.GetCurrentSetupStepResponse(ctx)
+		}
+		return c.GetCurrentSetupStepResponse(ctx)
 	}
 
 	// For redirect steps, render the URL FIRST. The closure may reject

--- a/internal/core/iface/manifest_setup_step.go
+++ b/internal/core/iface/manifest_setup_step.go
@@ -15,9 +15,27 @@ import (
 type ManifestStepType string
 
 const (
-	ManifestStepTypeForm      ManifestStepType = "form"
-	ManifestStepTypeRedirect  ManifestStepType = "redirect"
+	// ManifestStepTypeForm is a UI-rendered data-entry step. The setup API
+	// returns JSON Schema / UI Schema for the client to render, and the user
+	// submits values back through SubmitForm. Schema-defined preconnect /
+	// configure steps use this, and auth methods can use it for credential
+	// collection (for example API-key connectors).
+	ManifestStepTypeForm ManifestStepType = "form"
+
+	// ManifestStepTypeRedirect is a UI-visible off-platform handoff. The
+	// setup API returns a URL and the client sends the user there; completion
+	// happens later through a callback or signed return URL. OAuth2
+	// authorization-code setup uses this for the provider authorize URL, and
+	// connector-authored redirect steps can use it for external setup tasks.
+	ManifestStepTypeRedirect ManifestStepType = "redirect"
+
+	// ManifestStepTypeImmediate is a server-side step that runs as soon as
+	// the setup flow enters it. There is no form or redirect for the UI to
+	// render; the handler performs work and advances the connection to the
+	// next visible state. OAuth2 client_credentials uses this to exchange at
+	// the token endpoint without involving an end user.
 	ManifestStepTypeImmediate ManifestStepType = "immediate"
+
 	// ManifestStepTypeVerify is the type tag for the synthetic apxy:verify
 	// pseudo-step: the connection is waiting for the verify task to finish.
 	// The user sees a "verifying" response and polls; OnSubmit /

--- a/internal/core/iface/manifest_setup_step.go
+++ b/internal/core/iface/manifest_setup_step.go
@@ -10,8 +10,8 @@ import (
 // distinguishes user-authored kinds (form vs. redirect) — those carry through
 // to the manifest unchanged, plus the auth-method-emitted steps that get one
 // or the other depending on what the method needs at that point in the flow
-// (api-key emits form steps for credential collection; OAuth2 emits redirect
-// or immediate steps depending on grant type).
+// (api-key and OAuth2 client_credentials emit form steps for credential
+// collection; OAuth2 authorization_code emits a redirect step).
 type ManifestStepType string
 
 const (
@@ -19,7 +19,7 @@ const (
 	// returns JSON Schema / UI Schema for the client to render, and the user
 	// submits values back through SubmitForm. Schema-defined preconnect /
 	// configure steps use this, and auth methods can use it for credential
-	// collection (for example API-key connectors).
+	// collection (for example API-key connectors or OAuth2 client_credentials).
 	ManifestStepTypeForm ManifestStepType = "form"
 
 	// ManifestStepTypeRedirect is a UI-visible off-platform handoff. The
@@ -28,13 +28,6 @@ const (
 	// authorization-code setup uses this for the provider authorize URL, and
 	// connector-authored redirect steps can use it for external setup tasks.
 	ManifestStepTypeRedirect ManifestStepType = "redirect"
-
-	// ManifestStepTypeImmediate is a server-side step that runs as soon as
-	// the setup flow enters it. There is no form or redirect for the UI to
-	// render; the handler performs work and advances the connection to the
-	// next visible state. OAuth2 client_credentials uses this to exchange at
-	// the token endpoint without involving an end user.
-	ManifestStepTypeImmediate ManifestStepType = "immediate"
 
 	// ManifestStepTypeVerify is the type tag for the synthetic apxy:verify
 	// pseudo-step: the connection is waiting for the verify task to finish.
@@ -50,7 +43,6 @@ const (
 var (
 	ErrSubmitNotSupported   = errors.New("step does not accept form submissions")
 	ErrRedirectNotSupported = errors.New("step is not a redirect step")
-	ErrEnterNotSupported    = errors.New("step does not support immediate entry")
 )
 
 // RedirectInfo is the resolved redirect for a redirect-type step. The setup
@@ -85,8 +77,8 @@ type RenderRedirectOptions struct {
 // they came from.
 //
 // All steps expose presentation metadata (Id, Title, Description, Type). Type
-// determines which of OnSubmit / RenderRedirect / OnEnter is meaningful —
-// calling another returns the matching sentinel error.
+// determines which of OnSubmit / RenderRedirect is meaningful — calling the
+// other returns the matching sentinel error.
 type ManifestSetupStep interface {
 	// Id is the step identifier. User-authored steps carry the id from the
 	// connector YAML; system-emitted steps use the apxy: prefix (e.g.
@@ -99,7 +91,7 @@ type ManifestSetupStep interface {
 	Description() string
 
 	// Type selects the dispatch branch — form steps receive OnSubmit, redirect
-	// steps receive RenderRedirect, and immediate steps receive OnEnter.
+	// steps receive RenderRedirect.
 	Type() ManifestStepType
 
 	// JsonSchema and UiSchema are the JSONForms-shaped payloads for form
@@ -121,12 +113,6 @@ type ManifestSetupStep interface {
 	// carries request-scoped values (ReturnToUrl) the step may need to mint
 	// the URL.
 	RenderRedirect(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
-
-	// OnEnter runs when core advances into an immediate step. Implementations
-	// are expected to perform their side effect and transition the connection
-	// onward (for example by calling HandleCredentialsEstablished or
-	// HandleAuthFailed). Non-immediate steps return ErrEnterNotSupported.
-	OnEnter(ctx context.Context) error
 }
 
 // ManifestSetupFlow is the ordered, fully-materialized setup flow for a
@@ -194,17 +180,6 @@ func NewRedirectStep(cfg RedirectStepConfig) ManifestSetupStep {
 	return &redirectStep{cfg: cfg}
 }
 
-type ImmediateStepConfig struct {
-	Id          string
-	Title       string
-	Description string
-	OnEnter     func(ctx context.Context) error
-}
-
-func NewImmediateStep(cfg ImmediateStepConfig) ManifestSetupStep {
-	return &immediateStep{cfg: cfg}
-}
-
 // NewVerifyStep returns the synthetic apxy:verify pseudo-step that
 // ManifestSetupFlow uses to mark "credentials established, probes running."
 // The id and title are fixed; OnSubmit / RenderRedirect both return the
@@ -235,10 +210,6 @@ func (s *formStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (R
 	return RedirectInfo{}, ErrRedirectNotSupported
 }
 
-func (s *formStep) OnEnter(_ context.Context) error {
-	return ErrEnterNotSupported
-}
-
 type redirectStep struct {
 	cfg RedirectStepConfig
 }
@@ -261,36 +232,6 @@ func (s *redirectStep) RenderRedirect(ctx context.Context, opts RenderRedirectOp
 	return s.cfg.Render(ctx, opts)
 }
 
-func (s *redirectStep) OnEnter(_ context.Context) error {
-	return ErrEnterNotSupported
-}
-
-type immediateStep struct {
-	cfg ImmediateStepConfig
-}
-
-func (s *immediateStep) Id() string                  { return s.cfg.Id }
-func (s *immediateStep) Title() string               { return s.cfg.Title }
-func (s *immediateStep) Description() string         { return s.cfg.Description }
-func (s *immediateStep) Type() ManifestStepType      { return ManifestStepTypeImmediate }
-func (s *immediateStep) JsonSchema() json.RawMessage { return nil }
-func (s *immediateStep) UiSchema() json.RawMessage   { return nil }
-
-func (s *immediateStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
-	return ErrSubmitNotSupported
-}
-
-func (s *immediateStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
-	return RedirectInfo{}, ErrRedirectNotSupported
-}
-
-func (s *immediateStep) OnEnter(ctx context.Context) error {
-	if s.cfg.OnEnter == nil {
-		return ErrEnterNotSupported
-	}
-	return s.cfg.OnEnter(ctx)
-}
-
 // verifyStep is the synthetic apxy:verify pseudo-step. Stateless — no
 // configuration is needed since its sole purpose is to mark "probes are
 // running; the UI should display Verifying."
@@ -309,8 +250,4 @@ func (s *verifyStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
 
 func (s *verifyStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
 	return RedirectInfo{}, ErrRedirectNotSupported
-}
-
-func (s *verifyStep) OnEnter(_ context.Context) error {
-	return ErrEnterNotSupported
 }

--- a/internal/core/iface/manifest_setup_step.go
+++ b/internal/core/iface/manifest_setup_step.go
@@ -10,13 +10,14 @@ import (
 // distinguishes user-authored kinds (form vs. redirect) — those carry through
 // to the manifest unchanged, plus the auth-method-emitted steps that get one
 // or the other depending on what the method needs at that point in the flow
-// (api-key emits form steps for credential collection; OAuth2 emits a redirect
-// step for the authorize URL).
+// (api-key emits form steps for credential collection; OAuth2 emits redirect
+// or immediate steps depending on grant type).
 type ManifestStepType string
 
 const (
-	ManifestStepTypeForm     ManifestStepType = "form"
-	ManifestStepTypeRedirect ManifestStepType = "redirect"
+	ManifestStepTypeForm      ManifestStepType = "form"
+	ManifestStepTypeRedirect  ManifestStepType = "redirect"
+	ManifestStepTypeImmediate ManifestStepType = "immediate"
 	// ManifestStepTypeVerify is the type tag for the synthetic apxy:verify
 	// pseudo-step: the connection is waiting for the verify task to finish.
 	// The user sees a "verifying" response and polls; OnSubmit /
@@ -31,6 +32,7 @@ const (
 var (
 	ErrSubmitNotSupported   = errors.New("step does not accept form submissions")
 	ErrRedirectNotSupported = errors.New("step is not a redirect step")
+	ErrEnterNotSupported    = errors.New("step does not support immediate entry")
 )
 
 // RedirectInfo is the resolved redirect for a redirect-type step. The setup
@@ -65,8 +67,8 @@ type RenderRedirectOptions struct {
 // they came from.
 //
 // All steps expose presentation metadata (Id, Title, Description, Type). Type
-// determines which of OnSubmit / RenderRedirect is meaningful — calling the
-// other returns the matching sentinel error.
+// determines which of OnSubmit / RenderRedirect / OnEnter is meaningful —
+// calling another returns the matching sentinel error.
 type ManifestSetupStep interface {
 	// Id is the step identifier. User-authored steps carry the id from the
 	// connector YAML; system-emitted steps use the apxy: prefix (e.g.
@@ -79,7 +81,7 @@ type ManifestSetupStep interface {
 	Description() string
 
 	// Type selects the dispatch branch — form steps receive OnSubmit, redirect
-	// steps receive RenderRedirect.
+	// steps receive RenderRedirect, and immediate steps receive OnEnter.
 	Type() ManifestStepType
 
 	// JsonSchema and UiSchema are the JSONForms-shaped payloads for form
@@ -101,6 +103,12 @@ type ManifestSetupStep interface {
 	// carries request-scoped values (ReturnToUrl) the step may need to mint
 	// the URL.
 	RenderRedirect(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
+
+	// OnEnter runs when core advances into an immediate step. Implementations
+	// are expected to perform their side effect and transition the connection
+	// onward (for example by calling HandleCredentialsEstablished or
+	// HandleAuthFailed). Non-immediate steps return ErrEnterNotSupported.
+	OnEnter(ctx context.Context) error
 }
 
 // ManifestSetupFlow is the ordered, fully-materialized setup flow for a
@@ -168,6 +176,17 @@ func NewRedirectStep(cfg RedirectStepConfig) ManifestSetupStep {
 	return &redirectStep{cfg: cfg}
 }
 
+type ImmediateStepConfig struct {
+	Id          string
+	Title       string
+	Description string
+	OnEnter     func(ctx context.Context) error
+}
+
+func NewImmediateStep(cfg ImmediateStepConfig) ManifestSetupStep {
+	return &immediateStep{cfg: cfg}
+}
+
 // NewVerifyStep returns the synthetic apxy:verify pseudo-step that
 // ManifestSetupFlow uses to mark "credentials established, probes running."
 // The id and title are fixed; OnSubmit / RenderRedirect both return the
@@ -180,12 +199,12 @@ type formStep struct {
 	cfg FormStepConfig
 }
 
-func (s *formStep) Id() string                       { return s.cfg.Id }
-func (s *formStep) Title() string                    { return s.cfg.Title }
-func (s *formStep) Description() string              { return s.cfg.Description }
-func (s *formStep) Type() ManifestStepType           { return ManifestStepTypeForm }
-func (s *formStep) JsonSchema() json.RawMessage      { return s.cfg.JsonSchema }
-func (s *formStep) UiSchema() json.RawMessage        { return s.cfg.UiSchema }
+func (s *formStep) Id() string                  { return s.cfg.Id }
+func (s *formStep) Title() string               { return s.cfg.Title }
+func (s *formStep) Description() string         { return s.cfg.Description }
+func (s *formStep) Type() ManifestStepType      { return ManifestStepTypeForm }
+func (s *formStep) JsonSchema() json.RawMessage { return s.cfg.JsonSchema }
+func (s *formStep) UiSchema() json.RawMessage   { return s.cfg.UiSchema }
 
 func (s *formStep) OnSubmit(ctx context.Context, data json.RawMessage) error {
 	if s.cfg.OnSubmit == nil {
@@ -196,6 +215,10 @@ func (s *formStep) OnSubmit(ctx context.Context, data json.RawMessage) error {
 
 func (s *formStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
 	return RedirectInfo{}, ErrRedirectNotSupported
+}
+
+func (s *formStep) OnEnter(_ context.Context) error {
+	return ErrEnterNotSupported
 }
 
 type redirectStep struct {
@@ -220,6 +243,36 @@ func (s *redirectStep) RenderRedirect(ctx context.Context, opts RenderRedirectOp
 	return s.cfg.Render(ctx, opts)
 }
 
+func (s *redirectStep) OnEnter(_ context.Context) error {
+	return ErrEnterNotSupported
+}
+
+type immediateStep struct {
+	cfg ImmediateStepConfig
+}
+
+func (s *immediateStep) Id() string                  { return s.cfg.Id }
+func (s *immediateStep) Title() string               { return s.cfg.Title }
+func (s *immediateStep) Description() string         { return s.cfg.Description }
+func (s *immediateStep) Type() ManifestStepType      { return ManifestStepTypeImmediate }
+func (s *immediateStep) JsonSchema() json.RawMessage { return nil }
+func (s *immediateStep) UiSchema() json.RawMessage   { return nil }
+
+func (s *immediateStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
+	return ErrSubmitNotSupported
+}
+
+func (s *immediateStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
+	return RedirectInfo{}, ErrRedirectNotSupported
+}
+
+func (s *immediateStep) OnEnter(ctx context.Context) error {
+	if s.cfg.OnEnter == nil {
+		return ErrEnterNotSupported
+	}
+	return s.cfg.OnEnter(ctx)
+}
+
 // verifyStep is the synthetic apxy:verify pseudo-step. Stateless — no
 // configuration is needed since its sole purpose is to mark "probes are
 // running; the UI should display Verifying."
@@ -238,4 +291,8 @@ func (s *verifyStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
 
 func (s *verifyStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
 	return RedirectInfo{}, ErrRedirectNotSupported
+}
+
+func (s *verifyStep) OnEnter(_ context.Context) error {
+	return ErrEnterNotSupported
 }

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -276,6 +276,30 @@ func TestSubmitForm(t *testing.T) {
 	})
 }
 
+func TestAdvanceToStepImmediateRunsGenericStep(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+	immediateStep := iface.NewImmediateStep(iface.ImmediateStepConfig{
+		Id: "apxy:auth:test_immediate",
+		OnEnter: func(ctx context.Context) error {
+			_, err := conn.completeFlow(ctx)
+			return err
+		},
+	})
+	active := cschema.MustNewSetupStep("apxy:auth:test_immediate")
+
+	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &active).Return(nil)
+	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
+	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+
+	resp, err := conn.advanceToStep(context.Background(), immediateStep, &manifestFlow{}, "")
+	require.NoError(t, err)
+	require.IsType(t, &iface.ConnectionSetupComplete{}, resp)
+	assert.Equal(t, iface.ConnectionSetupResponseTypeComplete, resp.GetType())
+}
+
 func TestGetCurrentSetupStepResponse(t *testing.T) {
 	t.Run("returns complete when no setup step", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -276,30 +276,6 @@ func TestSubmitForm(t *testing.T) {
 	})
 }
 
-func TestAdvanceToStepImmediateRunsGenericStep(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
-	immediateStep := iface.NewImmediateStep(iface.ImmediateStepConfig{
-		Id: "apxy:auth:test_immediate",
-		OnEnter: func(ctx context.Context) error {
-			_, err := conn.completeFlow(ctx)
-			return err
-		},
-	})
-	active := cschema.MustNewSetupStep("apxy:auth:test_immediate")
-
-	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &active).Return(nil)
-	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
-	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
-
-	resp, err := conn.advanceToStep(context.Background(), immediateStep, &manifestFlow{}, "")
-	require.NoError(t, err)
-	require.IsType(t, &iface.ConnectionSetupComplete{}, resp)
-	assert.Equal(t, iface.ConnectionSetupResponseTypeComplete, resp.GetType())
-}
-
 func TestGetCurrentSetupStepResponse(t *testing.T) {
 	t.Run("returns complete when no setup step", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/internal/database/api_key_credential.go
+++ b/internal/database/api_key_credential.go
@@ -20,7 +20,7 @@ import (
 
 func init() {
 	RegisterEncryptedField(EncryptedFieldRegistration{
-		Table:            ApiKeyCredentialsTable,
+		Table:            ConnectionCredentialsTable,
 		PrimaryKeyCols:   []string{"id"},
 		EncryptedCols:    []string{"encrypted_credentials"},
 		JoinTable:        ConnectionsTable,
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-const ApiKeyCredentialsTable = "api_key_credentials"
+const ConnectionCredentialsTable = "connection_credentials"
 
 // ApiKeyCredentialPlaintext is the canonical plaintext shape stored, encrypted,
 // inside ApiKeyCredential.EncryptedCredentials. Defined here so callers that
@@ -47,12 +47,13 @@ type OAuth2ClientCredentialsPlaintext struct {
 	ClientSecret string `json:"client_secret,omitempty"`
 }
 
-// ApiKeyCredential is one row in the api_key_credentials table — the encrypted
-// credential blob (api key and, for basic placement, username) submitted by a
-// user for a connection. The encrypted_credentials column stores a single
-// opaque encrypted blob; the substructure inside (e.g. {"api_key": "...",
-// "username": "..."}) is decided by the encrypt/decrypt layer that owns the
-// plaintext shape — the database is agnostic to it.
+// ApiKeyCredential is one row in the connection_credentials table — an
+// encrypted credential blob submitted by a user for a connection. API-key
+// connections store api key material here; OAuth2 client_credentials
+// connections store client id / secret material here. The encrypted_credentials
+// column stores a single opaque encrypted blob; the substructure inside is
+// decided by the encrypt/decrypt layer that owns the plaintext shape — the
+// database is agnostic to it.
 //
 // Rotation produces a new row and soft-deletes the prior, so the history of
 // credentials is preserved. At most one row per connection has
@@ -60,8 +61,8 @@ type OAuth2ClientCredentialsPlaintext struct {
 type ApiKeyCredential struct {
 	Id                   apid.ID
 	ConnectionId         apid.ID                  // FK to Connection; not enforced by DB
-	EncryptedCredentials encfield.EncryptedField  // Opaque encrypted blob (api key + optional username)
-	PlacementSnapshot    *cschema.ApiKeyPlacement // Placement config at submission time
+	EncryptedCredentials encfield.EncryptedField  // Opaque encrypted credential blob
+	PlacementSnapshot    *cschema.ApiKeyPlacement // API-key placement config at submission time
 	CreatedByActorId     *apid.ID                 // Actor who submitted (or rotated to) this credential
 	LastValidatedAt      *time.Time               // Most recent successful probe against this credential
 	CreatedAt            time.Time
@@ -188,7 +189,7 @@ func (s *service) GetActiveApiKeyCredential(
 	var result ApiKeyCredential
 	err := s.sq.
 		Select(result.cols()...).
-		From(ApiKeyCredentialsTable).
+		From(ConnectionCredentialsTable).
 		Where(sq.Eq{
 			"connection_id": connectionId,
 			"deleted_at":    nil,
@@ -233,7 +234,7 @@ func (s *service) InsertApiKeyCredential(
 	var newCred *ApiKeyCredential
 
 	err := s.transaction(func(tx *sql.Tx) error {
-		dbResult, err := s.sq.Update(ApiKeyCredentialsTable).
+		dbResult, err := s.sq.Update(ConnectionCredentialsTable).
 			Set("deleted_at", now).
 			Where(sq.Eq{
 				"connection_id": connectionId,
@@ -269,7 +270,7 @@ func (s *service) InsertApiKeyCredential(
 		}
 
 		insertResult, err := s.sq.
-			Insert(ApiKeyCredentialsTable).
+			Insert(ConnectionCredentialsTable).
 			Columns(newCred.cols()...).
 			Values(newCred.values()...).
 			RunWith(tx).
@@ -303,7 +304,7 @@ func (s *service) UpdateApiKeyCredentialLastValidated(
 	at time.Time,
 ) error {
 	dbResult, err := s.sq.
-		Update(ApiKeyCredentialsTable).
+		Update(ConnectionCredentialsTable).
 		Set("last_validated_at", at).
 		Where(sq.Eq{"id": credentialId}).
 		RunWith(s.db).
@@ -338,7 +339,7 @@ func (s *service) DeleteAllApiKeyCredentialsForConnection(
 
 	now := apctx.GetClock(ctx).Now()
 	dbResult, err := s.sq.
-		Update(ApiKeyCredentialsTable).
+		Update(ConnectionCredentialsTable).
 		Set("deleted_at", now).
 		Where(sq.Eq{
 			"connection_id": connectionId,

--- a/internal/database/api_key_credential.go
+++ b/internal/database/api_key_credential.go
@@ -42,6 +42,11 @@ type ApiKeyCredentialPlaintext struct {
 	Username string `json:"username,omitempty"`
 }
 
+type OAuth2ClientCredentialsPlaintext struct {
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret,omitempty"`
+}
+
 // ApiKeyCredential is one row in the api_key_credentials table — the encrypted
 // credential blob (api key and, for basic placement, username) submitted by a
 // user for a connection. The encrypted_credentials column stores a single

--- a/internal/database/api_key_credential_test.go
+++ b/internal/database/api_key_credential_test.go
@@ -89,8 +89,8 @@ func TestApiKeyCredentials_RoundTrip(t *testing.T) {
 	require.Equal(t, blob, got.EncryptedCredentials)
 	require.Equal(t, placement, got.PlacementSnapshot)
 
-	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials"))
-	require.Equal(t, 0, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials WHERE deleted_at IS NOT NULL"))
+	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials"))
+	require.Equal(t, 0, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials WHERE deleted_at IS NOT NULL"))
 }
 
 func TestApiKeyCredentials_GetActive_NoneFound(t *testing.T) {
@@ -131,8 +131,8 @@ func TestApiKeyCredentials_InsertSoftDeletesPrior(t *testing.T) {
 	require.NotEqual(t, first.Id, second.Id)
 
 	// Exactly one active row remains.
-	require.Equal(t, 2, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials"))
-	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials WHERE deleted_at IS NULL"))
+	require.Equal(t, 2, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials"))
+	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials WHERE deleted_at IS NULL"))
 
 	got, err := db.GetActiveApiKeyCredential(ctx, connectionId)
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestApiKeyCredentials_UpdateLastValidated(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// Ensure we didn't mutate row count.
-	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials"))
+	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials"))
 }
 
 func TestApiKeyCredentials_DeleteAllForConnection(t *testing.T) {
@@ -236,20 +236,20 @@ func TestApiKeyCredentials_DeleteAllForConnection(t *testing.T) {
 	require.Equal(t, siblingCred.Id, siblingGot.Id)
 
 	// Total rows: 2 for connectionId (both soft-deleted) + 1 for sibling (active).
-	require.Equal(t, 3, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials"))
-	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM api_key_credentials WHERE deleted_at IS NULL"))
+	require.Equal(t, 3, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials"))
+	require.Equal(t, 1, sqlh.MustCount(rawDb, "SELECT COUNT(*) FROM connection_credentials WHERE deleted_at IS NULL"))
 }
 
 func TestApiKeyCredentials_EncryptedFieldRegistration(t *testing.T) {
 	regs := GetEncryptedFieldRegistrations()
 	var found *EncryptedFieldRegistration
 	for i := range regs {
-		if regs[i].Table == ApiKeyCredentialsTable {
+		if regs[i].Table == ConnectionCredentialsTable {
 			found = &regs[i]
 			break
 		}
 	}
-	require.NotNil(t, found, "api_key_credentials must register its encrypted column with the re-encryption registry")
+	require.NotNil(t, found, "connection_credentials must register its encrypted column with the re-encryption registry")
 	require.ElementsMatch(t, []string{"encrypted_credentials"}, found.EncryptedCols,
 		"a single encrypted_credentials column simplifies re-encryption jobs")
 	require.Equal(t, ConnectionsTable, found.JoinTable, "namespace should resolve via JOIN to connections")

--- a/internal/database/migrations/postgres/000006_create_api_key_credentials.down.sql
+++ b/internal/database/migrations/postgres/000006_create_api_key_credentials.down.sql
@@ -1,3 +1,0 @@
-drop index if exists idx_api_key_credentials_connection_active;
-drop index if exists idx_api_key_credentials_deleted_at;
-drop table if exists api_key_credentials;

--- a/internal/database/migrations/postgres/000006_create_connection_credentials.down.sql
+++ b/internal/database/migrations/postgres/000006_create_connection_credentials.down.sql
@@ -1,0 +1,3 @@
+drop index if exists idx_connection_credentials_connection_active;
+drop index if exists idx_connection_credentials_deleted_at;
+drop table if exists connection_credentials;

--- a/internal/database/migrations/postgres/000006_create_connection_credentials.up.sql
+++ b/internal/database/migrations/postgres/000006_create_connection_credentials.up.sql
@@ -1,4 +1,4 @@
-create table api_key_credentials
+create table connection_credentials
 (
     id                    text primary key,
     connection_id         text not null,
@@ -11,8 +11,8 @@ create table api_key_credentials
     deleted_at            timestamptz
 );
 
-create index idx_api_key_credentials_deleted_at
-    on api_key_credentials (deleted_at);
+create index idx_connection_credentials_deleted_at
+    on connection_credentials (deleted_at);
 
-create index idx_api_key_credentials_connection_active
-    on api_key_credentials (connection_id, deleted_at);
+create index idx_connection_credentials_connection_active
+    on connection_credentials (connection_id, deleted_at);

--- a/internal/database/migrations/sqlite/000006_create_api_key_credentials.down.sql
+++ b/internal/database/migrations/sqlite/000006_create_api_key_credentials.down.sql
@@ -1,3 +1,0 @@
-drop index if exists idx_api_key_credentials_connection_active;
-drop index if exists idx_api_key_credentials_deleted_at;
-drop table if exists api_key_credentials;

--- a/internal/database/migrations/sqlite/000006_create_connection_credentials.down.sql
+++ b/internal/database/migrations/sqlite/000006_create_connection_credentials.down.sql
@@ -1,0 +1,3 @@
+drop index if exists idx_connection_credentials_connection_active;
+drop index if exists idx_connection_credentials_deleted_at;
+drop table if exists connection_credentials;

--- a/internal/database/migrations/sqlite/000006_create_connection_credentials.up.sql
+++ b/internal/database/migrations/sqlite/000006_create_connection_credentials.up.sql
@@ -1,4 +1,4 @@
-create table api_key_credentials
+create table connection_credentials
 (
     id                    text primary key,
     connection_id         text not null,
@@ -11,8 +11,8 @@ create table api_key_credentials
     deleted_at            datetime
 );
 
-create index idx_api_key_credentials_deleted_at
-    on api_key_credentials (deleted_at);
+create index idx_connection_credentials_deleted_at
+    on connection_credentials (deleted_at);
 
-create index idx_api_key_credentials_connection_active
-    on api_key_credentials (connection_id, deleted_at);
+create index idx_connection_credentials_connection_active
+    on connection_credentials (connection_id, deleted_at);

--- a/internal/schema/common/README.md
+++ b/internal/schema/common/README.md
@@ -1,5 +1,5 @@
 # Common Schema Types
 
-This package contains reusable primitives used by other schema packages, including string and integer value sources, images, human-readable durations and byte sizes, request types, and raw JSON helpers.
+This package contains reusable primitives used by other schema packages, including string and integer value sources, images, human-readable durations and byte sizes, request types, raw JSON helpers, and setup-form JSON Schema / UI Schema helper subpackages.
 
 Types here should be generic and independent of AuthProxy resources, APIs, or configuration sections.

--- a/internal/schema/common/json_schema/README.md
+++ b/internal/schema/common/json_schema/README.md
@@ -1,0 +1,5 @@
+# JSON Schema Helpers
+
+This package contains small Go structs for JSON Schema fragments that AuthProxy emits in setup-flow form steps.
+
+The contract is sourced from JSON Schema. Setup forms currently use the object and string-property portions of the vocabulary to describe credential fields that clients render and submit back to AuthProxy.

--- a/internal/schema/common/json_schema/schema.go
+++ b/internal/schema/common/json_schema/schema.go
@@ -1,0 +1,18 @@
+package json_schema
+
+const SchemaIdJSONSchema = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/json_schema/schema.json"
+
+// Property describes a single JSON Schema property emitted in a setup form.
+type Property struct {
+	Type      string `json:"type" yaml:"type"`
+	Title     string `json:"title,omitempty" yaml:"title,omitempty"`
+	MinLength int    `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+}
+
+// Schema describes the JSON Schema object emitted for a setup form.
+type Schema struct {
+	Type                 string              `json:"type" yaml:"type"`
+	Required             []string            `json:"required" yaml:"required"`
+	Properties           map[string]Property `json:"properties" yaml:"properties"`
+	AdditionalProperties bool                `json:"additionalProperties" yaml:"additionalProperties"`
+}

--- a/internal/schema/common/json_schema/schema.json
+++ b/internal/schema/common/json_schema/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/json_schema/schema.json",
+  "$defs": {
+    "Property": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string" },
+        "title": { "type": "string" },
+        "minLength": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "required", "properties", "additionalProperties"],
+      "properties": {
+        "type": { "type": "string" },
+        "required": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/Property" }
+        },
+        "additionalProperties": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/internal/schema/common/json_schema/schema_test.go
+++ b/internal/schema/common/json_schema/schema_test.go
@@ -1,0 +1,55 @@
+package json_schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema(t *testing.T) {
+	schemaBytes, err := os.ReadFile("./schema.json")
+	require.NoError(t, err)
+
+	var schemaId struct {
+		Id string `json:"$id"`
+	}
+	require.NoError(t, json.Unmarshal(schemaBytes, &schemaId))
+	require.Equal(t, SchemaIdJSONSchema, schemaId.Id)
+
+	c := jsonschemav5.NewCompiler()
+	require.NoError(t, c.AddResource(schemaId.Id, bytes.NewReader(schemaBytes)))
+	_, err = c.Compile(schemaId.Id)
+	require.NoError(t, err)
+}
+
+func TestMarshaledSchemaMatchesContract(t *testing.T) {
+	c := jsonschemav5.NewCompiler()
+	schemaBytes, err := os.ReadFile("./schema.json")
+	require.NoError(t, err)
+	require.NoError(t, c.AddResource(SchemaIdJSONSchema, bytes.NewReader(schemaBytes)))
+
+	schema, err := c.Compile(SchemaIdJSONSchema + "#/$defs/Schema")
+	require.NoError(t, err)
+
+	data, err := json.Marshal(Schema{
+		Type:                 "object",
+		Required:             []string{"client_id"},
+		AdditionalProperties: false,
+		Properties: map[string]Property{
+			"client_id": {
+				Type:      "string",
+				Title:     "Client ID",
+				MinLength: 1,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var decoded any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NoError(t, schema.Validate(decoded))
+}

--- a/internal/schema/common/ui_schema/README.md
+++ b/internal/schema/common/ui_schema/README.md
@@ -1,0 +1,5 @@
+# UI Schema Helpers
+
+This package contains small Go structs for UI Schema fragments that AuthProxy emits in setup-flow form steps.
+
+The contract is sourced from JSON Forms UI Schema. Setup forms currently use a vertical layout containing control elements scoped to JSON Schema properties, with optional control options such as password formatting.

--- a/internal/schema/common/ui_schema/schema.go
+++ b/internal/schema/common/ui_schema/schema.go
@@ -1,0 +1,16 @@
+package ui_schema
+
+const SchemaIdUISchema = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/ui_schema/schema.json"
+
+// Control describes a JSON Forms control element rendered by the setup UI.
+type Control struct {
+	Type    string            `json:"type" yaml:"type"`
+	Scope   string            `json:"scope" yaml:"scope"`
+	Options map[string]string `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// Schema describes the JSON Forms UI schema emitted for a setup form.
+type Schema struct {
+	Type     string    `json:"type" yaml:"type"`
+	Elements []Control `json:"elements" yaml:"elements"`
+}

--- a/internal/schema/common/ui_schema/schema.json
+++ b/internal/schema/common/ui_schema/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/ui_schema/schema.json",
+  "$defs": {
+    "Control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "scope"],
+      "properties": {
+        "type": { "type": "string" },
+        "scope": { "type": "string" },
+        "options": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "elements"],
+      "properties": {
+        "type": { "type": "string" },
+        "elements": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Control" }
+        }
+      }
+    }
+  }
+}

--- a/internal/schema/common/ui_schema/schema_test.go
+++ b/internal/schema/common/ui_schema/schema_test.go
@@ -1,0 +1,57 @@
+package ui_schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema(t *testing.T) {
+	schemaBytes, err := os.ReadFile("./schema.json")
+	require.NoError(t, err)
+
+	var schemaId struct {
+		Id string `json:"$id"`
+	}
+	require.NoError(t, json.Unmarshal(schemaBytes, &schemaId))
+	require.Equal(t, SchemaIdUISchema, schemaId.Id)
+
+	c := jsonschemav5.NewCompiler()
+	require.NoError(t, c.AddResource(schemaId.Id, bytes.NewReader(schemaBytes)))
+	_, err = c.Compile(schemaId.Id)
+	require.NoError(t, err)
+}
+
+func TestMarshaledSchemaMatchesContract(t *testing.T) {
+	c := jsonschemav5.NewCompiler()
+	schemaBytes, err := os.ReadFile("./schema.json")
+	require.NoError(t, err)
+	require.NoError(t, c.AddResource(SchemaIdUISchema, bytes.NewReader(schemaBytes)))
+
+	schema, err := c.Compile(SchemaIdUISchema + "#/$defs/Schema")
+	require.NoError(t, err)
+
+	data, err := json.Marshal(Schema{
+		Type: "VerticalLayout",
+		Elements: []Control{
+			{
+				Type:  "Control",
+				Scope: "#/properties/client_id",
+			},
+			{
+				Type:    "Control",
+				Scope:   "#/properties/client_secret",
+				Options: map[string]string{"format": "password"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var decoded any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NoError(t, schema.Validate(decoded))
+}

--- a/internal/schema/config/reexport.go
+++ b/internal/schema/config/reexport.go
@@ -55,6 +55,7 @@ type (
 	Connector               = connectors.Connector
 	Connectors              = connectors.Connectors
 	PKCEMethod              = connectors.PKCEMethod
+	OAuth2GrantType         = connectors.OAuth2GrantType
 	Scope                   = connectors.Scope
 	TokenEndpointAuthMethod = connectors.TokenEndpointAuthMethod
 )
@@ -71,6 +72,9 @@ const (
 
 	PKCEMethodS256  = connectors.PKCEMethodS256
 	PKCEMethodPlain = connectors.PKCEMethodPlain
+
+	OAuth2GrantAuthorizationCode = connectors.OAuth2GrantAuthorizationCode
+	OAuth2GrantClientCredentials = connectors.OAuth2GrantClientCredentials
 
 	TokenEndpointAuthClientSecretPost  = connectors.TokenEndpointAuthClientSecretPost
 	TokenEndpointAuthClientSecretBasic = connectors.TokenEndpointAuthClientSecretBasic

--- a/internal/schema/resources/connectors/auth_api_key.go
+++ b/internal/schema/resources/connectors/auth_api_key.go
@@ -50,7 +50,7 @@ func (p *ApiKeyPlacement) Clone() *ApiKeyPlacement {
 
 // CredentialFieldNames returns the field names that carry secret values in the
 // connection-initiate form for this placement. These fields are extracted from
-// submitted form data, encrypted, and stored in api_key_credentials — they do
+// submitted form data, encrypted, and stored in connection_credentials — they do
 // NOT merge into the connection's EncryptedConfiguration.
 //
 // For bearer / header / query placements this is just "api_key". For basic, it

--- a/internal/schema/resources/connectors/auth_oauth2.go
+++ b/internal/schema/resources/connectors/auth_oauth2.go
@@ -30,8 +30,18 @@ const (
 	TokenEndpointAuthNone = TokenEndpointAuthMethod("none")
 )
 
+type OAuth2GrantType string
+
+const (
+	OAuth2GrantAuthorizationCode = OAuth2GrantType("authorization_code")
+	OAuth2GrantClientCredentials = OAuth2GrantType("client_credentials")
+)
+
 type AuthOAuth2 struct {
 	Type AuthType `json:"type" yaml:"type"`
+	// GrantType selects the OAuth2 grant flow. nil preserves the historical
+	// authorization-code behavior.
+	GrantType *OAuth2GrantType `json:"grant_type,omitempty" yaml:"grant_type,omitempty"`
 	// TokenEndpointAuthMethod selects how client credentials are presented
 	// to the token endpoint. nil signals "use the default" and resolves to
 	// client_secret_post via GetTokenEndpointAuthMethodOrDefault, matching
@@ -55,6 +65,10 @@ func NewTokenEndpointAuthMethod(m TokenEndpointAuthMethod) *TokenEndpointAuthMet
 	return &m
 }
 
+func NewOAuth2GrantType(g OAuth2GrantType) *OAuth2GrantType {
+	return &g
+}
+
 // GetTokenEndpointAuthMethodOrDefault returns the configured method, defaulting
 // to client_secret_post only when the field was omitted (nil). This is the
 // single place where the nil → post collapse happens; callers that already
@@ -66,6 +80,17 @@ func (a *AuthOAuth2) GetTokenEndpointAuthMethodOrDefault() TokenEndpointAuthMeth
 		return TokenEndpointAuthClientSecretPost
 	}
 	return *a.TokenEndpointAuthMethod
+}
+
+func (a *AuthOAuth2) GetGrantTypeOrDefault() OAuth2GrantType {
+	if a == nil || a.GrantType == nil {
+		return OAuth2GrantAuthorizationCode
+	}
+	return *a.GrantType
+}
+
+func (a *AuthOAuth2) SupportsRefreshToken() bool {
+	return a.GetGrantTypeOrDefault() == OAuth2GrantAuthorizationCode
 }
 
 func (a *AuthOAuth2) GetType() AuthType {
@@ -85,9 +110,11 @@ func (a *AuthOAuth2) ValidateMustacheReferences(vc *common.ValidationContext, mc
 	preconnectFields := mctx.PreconnectFields
 	allConfigFields := mctx.AllConfigFields
 
-	checkMustacheTemplate(vc.PushField("authorization").PushField("endpoint"), a.Authorization.Endpoint, preconnectFields, "preconnect", result)
-	for k, v := range a.Authorization.QueryOverrides {
-		checkMustacheTemplate(vc.PushField("authorization").PushField("query_overrides").PushField(k), v, preconnectFields, "preconnect", result)
+	if a.GetGrantTypeOrDefault() == OAuth2GrantAuthorizationCode {
+		checkMustacheTemplate(vc.PushField("authorization").PushField("endpoint"), a.Authorization.Endpoint, preconnectFields, "preconnect", result)
+		for k, v := range a.Authorization.QueryOverrides {
+			checkMustacheTemplate(vc.PushField("authorization").PushField("query_overrides").PushField(k), v, preconnectFields, "preconnect", result)
+		}
 	}
 
 	checkMustacheTemplate(vc.PushField("token").PushField("endpoint"), a.Token.Endpoint, preconnectFields, "preconnect", result)
@@ -148,8 +175,37 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 	}
 
 	result := &multierror.Error{}
+	grantType := a.GetGrantTypeOrDefault()
+	switch grantType {
+	case OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials:
+	case "":
+		result = multierror.Append(result, vc.NewErrorfForField("grant_type",
+			"must not be empty; omit the field to use the default (%q), or set one of %q, %q",
+			OAuth2GrantAuthorizationCode,
+			OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials,
+		))
+		return result.ErrorOrNil()
+	default:
+		result = multierror.Append(result, vc.NewErrorfForField("grant_type",
+			"%q is not a valid grant type; must be %q or %q",
+			grantType,
+			OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials,
+		))
+	}
 
-	if a.Authorization.PKCE != nil {
+	if grantType == OAuth2GrantClientCredentials {
+		if a.Authorization.Endpoint != "" || len(a.Authorization.QueryOverrides) > 0 || a.Authorization.PKCE != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("authorization",
+				"must be omitted when grant_type is %q", OAuth2GrantClientCredentials,
+			))
+		}
+	} else if a.Authorization.Endpoint == "" {
+		result = multierror.Append(result, vc.PushField("authorization").NewErrorfForField("endpoint",
+			"is required when grant_type is %q", OAuth2GrantAuthorizationCode,
+		))
+	}
+
+	if grantType == OAuth2GrantAuthorizationCode && a.Authorization.PKCE != nil {
 		pkceVC := vc.PushField("authorization").PushField("pkce")
 		switch a.Authorization.PKCE.Method {
 		case "", PKCEMethodS256, PKCEMethodPlain:
@@ -175,7 +231,12 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 		return result.ErrorOrNil()
 	}
 
+	hasClientId := a.ClientId != nil && a.ClientId.InnerVal != nil
 	hasSecret := a.ClientSecret != nil && a.ClientSecret.InnerVal != nil
+	if !hasClientId {
+		result = multierror.Append(result, vc.NewErrorfForField("client_id", "is required"))
+	}
+
 	method := a.GetTokenEndpointAuthMethodOrDefault()
 	switch method {
 	case TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic:
@@ -191,7 +252,7 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 				TokenEndpointAuthNone,
 			))
 		}
-		if a.Authorization.PKCE == nil {
+		if grantType == OAuth2GrantAuthorizationCode && a.Authorization.PKCE == nil {
 			result = multierror.Append(result, vc.PushField("authorization").NewErrorfForField("pkce",
 				"is required when token_endpoint_auth_method is %q (public clients have no proof-of-possession without PKCE)",
 				TokenEndpointAuthNone,

--- a/internal/schema/resources/connectors/auth_oauth2.go
+++ b/internal/schema/resources/connectors/auth_oauth2.go
@@ -199,6 +199,18 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 				"must be omitted when grant_type is %q", OAuth2GrantClientCredentials,
 			))
 		}
+		if a.ClientId != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("client_id",
+				"must be omitted when grant_type is %q; client credentials are collected during connection setup",
+				OAuth2GrantClientCredentials,
+			))
+		}
+		if a.ClientSecret != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("client_secret",
+				"must be omitted when grant_type is %q; client credentials are collected during connection setup",
+				OAuth2GrantClientCredentials,
+			))
+		}
 	} else if a.Authorization.Endpoint == "" {
 		result = multierror.Append(result, vc.PushField("authorization").NewErrorfForField("endpoint",
 			"is required when grant_type is %q", OAuth2GrantAuthorizationCode,
@@ -233,14 +245,14 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 
 	hasClientId := a.ClientId != nil && a.ClientId.InnerVal != nil
 	hasSecret := a.ClientSecret != nil && a.ClientSecret.InnerVal != nil
-	if !hasClientId {
+	if grantType == OAuth2GrantAuthorizationCode && !hasClientId {
 		result = multierror.Append(result, vc.NewErrorfForField("client_id", "is required"))
 	}
 
 	method := a.GetTokenEndpointAuthMethodOrDefault()
 	switch method {
 	case TokenEndpointAuthClientSecretPost, TokenEndpointAuthClientSecretBasic:
-		if !hasSecret {
+		if grantType == OAuth2GrantAuthorizationCode && !hasSecret {
 			result = multierror.Append(result, vc.NewErrorfForField("client_secret",
 				"is required when token_endpoint_auth_method is %q", method,
 			))

--- a/internal/schema/resources/connectors/schema-oauth.json
+++ b/internal/schema/resources/connectors/schema-oauth.json
@@ -103,6 +103,9 @@
     "client_secret": {
       "$ref": "../../common/schema.json#/$defs/StringValue"
     },
+    "grant_type": {
+      "enum": ["authorization_code", "client_credentials"]
+    },
     "token_endpoint_auth_method": {
       "enum": ["client_secret_post", "client_secret_basic", "none"]
     },


### PR DESCRIPTION
## Summary
- Add OAuth2 grant_type selection with client_credentials validation and schema support
- Add synchronous client-credentials setup exchange and re-grant refresh path
- Discard refresh_token values returned for client_credentials responses

## Tests
- go test ./internal/schema/resources/connectors ./internal/auth_methods/oauth2 ./internal/core
- ./scripts/preflight.sh

Closes #352