### PR TITLE
Provision Grafana demo dashboards

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -68,6 +68,7 @@ jobs:
           helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           # authproxy-demo umbrella chart
           helm repo add bitnami        https://charts.bitnami.com/bitnami
+          helm repo add grafana        https://grafana.github.io/helm-charts
           helm repo update
 
       - name: ct lint
@@ -111,6 +112,7 @@ jobs:
           helm repo add external-dns   https://kubernetes-sigs.github.io/external-dns/
           helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           helm repo add bitnami        https://charts.bitnami.com/bitnami
+          helm repo add grafana        https://grafana.github.io/helm-charts
           helm repo update
 
       - name: Set up Docker Buildx

--- a/deploy/charts/authproxy-demo/Chart.yaml
+++ b/deploy/charts/authproxy-demo/Chart.yaml
@@ -58,3 +58,8 @@ dependencies:
     version: "14.7.16"
     repository: https://charts.bitnami.com/bitnami
     condition: minio.enabled
+
+  - name: grafana
+    version: "8.10.1"
+    repository: https://grafana.github.io/helm-charts
+    condition: grafana.enabled

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -8,6 +8,7 @@ Umbrella chart for the AuthProxy demo environment. Composes:
 | `postgresql` (bitnami)  | Backing DB                                                  |
 | `redis` (bitnami)       | Sessions + tasks + rate-limit                               |
 | `minio` (bitnami)       | Request-log blob storage                                    |
+| `grafana` (upstream)    | App-metrics datasource, variables, and sample dashboards    |
 | `demo-shell` (inline)   | SSO stand-in host (signs JWTs for demo actors)              |
 | `go-oauth2-server` (inline) | Connector target for the demo OAuth flow                |
 
@@ -69,6 +70,7 @@ key, so these need real openssl). Create them in the release namespace
 | `<release>-encryption`     | `global_aes.key` (32 raw bytes)                |
 | `<release>-demo-shell-key` | `private` (RSA private), `demo-shell.pub`      |
 | `<release>-actors`         | `demo-shell.pub` (matching the above)          |
+| `authproxy-grafana-jwt`    | `jwt` (Grafana datasource bearer token)        |
 
 A reference one-shot generator:
 
@@ -93,6 +95,13 @@ kubectl -n "$NS" create secret generic "$RELEASE-demo-shell-key" \
   --from-file=demo-shell.pub="$work/demo-shell.pub"
 kubectl -n "$NS" create secret generic "$RELEASE-actors" \
   --from-file=demo-shell.pub="$work/demo-shell.pub"
+
+# Metrics plus request-event metadata tables. The actor identified in
+# the token must have matching normal AuthProxy permissions; the
+# Grafana preset only restricts the token further.
+ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs > "$work/grafana.jwt"
+kubectl -n "$NS" create secret generic authproxy-grafana-jwt \
+  --from-file=jwt="$work/grafana.jwt"
 ```
 
 A Helm pre-install hook Job that generates the keypair Secrets is a
@@ -110,6 +119,7 @@ create the three demo identities the shell expects:
 | `demo-admin` | admin    | Lands in the admin UI                            |
 | `demo-user`  | user     | Lands in the marketplace                         |
 | `fresh-user` | user     | Lands in the marketplace with no connections     |
+| `grafana`    | datasource | Identity used by the provisioned Grafana datasource token |
 
 Idempotent: the seed binary GETs each actor by external_id and skips
 creation when AuthProxy returns 200. Re-running `helm upgrade` is a
@@ -135,6 +145,7 @@ The umbrella Ingress maps host paths to backend services:
 | `/api`         | AuthProxy api                               |
 | `/public`      | AuthProxy public (OAuth callbacks, etc.)    |
 | `/oauth2`      | go-oauth2-server                            |
+| `/grafana`     | Grafana dashboards                          |
 
 (Paths are `pathType: Prefix`; order in the Ingress is significant only
 for `pathType: Exact` matches.)
@@ -145,6 +156,26 @@ After install, open `https://<hostname>` — the demo-shell page loads.
 Pick **demo-admin** + **Admin UI** → submit → you should land in the
 admin UI as `demo-admin`. Pick **fresh-user** + **Marketplace UI** →
 empty marketplace, no connections.
+
+Grafana is available at `https://<hostname>/grafana` when
+`grafana.enabled=true` (the default). The chart provisions:
+
+- `AuthProxy` datasource (`uid: authproxy-app-metrics`) pointed at the
+  in-cluster AuthProxy API service.
+- `AuthProxy App Metrics` dashboard with resource counts, connection
+  states, request volume/errors/duration, rate-limit attribution, and
+  request-event metadata.
+- Dashboard variables for namespaces, connectors, and connections.
+
+The datasource JWT comes from the `authproxy-grafana-jwt` Secret and is
+injected into Grafana as `AUTHPROXY_GRAFANA_JWT`; override
+`grafana.envValueFrom` if you use a differently named Secret.
+
+By default the chart asks Grafana to install the
+`rmorlok-authproxy-datasource` plugin by id. If you are testing a plugin
+release artifact before it is available in the Grafana catalog, override
+`grafana.plugins[0]` with Grafana's URL install format:
+`https://.../rmorlok-authproxy-datasource.zip;rmorlok-authproxy-datasource`.
 
 ## Uninstall
 

--- a/deploy/charts/authproxy-demo/ci/all-disabled-values.yaml
+++ b/deploy/charts/authproxy-demo/ci/all-disabled-values.yaml
@@ -28,6 +28,12 @@ secrets:
 seed:
   enabled: false
 
+grafanaAuthProxy:
+  enabled: false
+
+grafana:
+  enabled: false
+
 authproxy:
   enabled: false
 

--- a/deploy/charts/authproxy-demo/dashboards/authproxy-app-metrics.json
+++ b/deploy/charts/authproxy-demo/dashboards/authproxy-app-metrics.json
@@ -1,0 +1,558 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.0",
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.namespaces",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Namespaces"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.connectors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Connectors"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.connections",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Connections"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.actors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Actors"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.rate_limits",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "RateLimits"
+        }
+      ],
+      "title": "Resource Counts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["state", "health_state"],
+          "metric": "resources.connections",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection States",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["mode", "namespace"],
+          "metric": "resources.rate_limits",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Rate Limit Attribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "req"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["method"],
+          "metric": "request_events",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "errors"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["response_status_code", "connector_id"],
+          "metric": "request_events.errors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "p95",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["connector_id"],
+          "metric": "request_events.duration_ms",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "queryType": "request_events",
+          "refId": "A",
+          "requestFilters": {
+            "connectorId": "$connector",
+            "connectionId": "$connection",
+            "labelSelector": "$label_selector",
+            "namespace": "$namespace",
+            "statusCodeRange": "$status"
+          }
+        }
+      ],
+      "title": "Request Event Metadata",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": ["authproxy", "app-metrics", "demo"],
+  "templating": {
+    "list": [
+      {
+        "allValue": "root.**",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "namespaces",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "type": "namespaces"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": "All connectors",
+          "value": ""
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "connectors",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Connector",
+        "multi": false,
+        "name": "connector",
+        "options": [],
+        "query": {
+          "namespace": "$namespace",
+          "type": "connectors"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": "All connections",
+          "value": ""
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "connections",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Connection",
+        "multi": false,
+        "name": "connection",
+        "options": [],
+        "query": {
+          "connectorId": "$connector",
+          "namespace": "$namespace",
+          "type": "connections"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "Any status",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Status",
+        "multi": false,
+        "name": "status",
+        "options": [
+          {
+            "selected": true,
+            "text": "Any status",
+            "value": ""
+          },
+          {
+            "selected": false,
+            "text": "2xx",
+            "value": "2xx"
+          },
+          {
+            "selected": false,
+            "text": "3xx",
+            "value": "3xx"
+          },
+          {
+            "selected": false,
+            "text": "4xx",
+            "value": "4xx"
+          },
+          {
+            "selected": false,
+            "text": "5xx",
+            "value": "5xx"
+          }
+        ],
+        "query": ",2xx,3xx,4xx,5xx",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Label selector",
+        "name": "label_selector",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AuthProxy App Metrics",
+  "uid": "authproxy-app-metrics-demo",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/charts/authproxy-demo/templates/_helpers.tpl
+++ b/deploy/charts/authproxy-demo/templates/_helpers.tpl
@@ -26,6 +26,27 @@ have their own helpers and aren't affected by these.
 {{- printf "%s-authproxy" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "authproxy-demo.grafana.serviceName" -}}
+{{/* Matches the grafana subchart's fullname helper default. */}}
+{{- printf "%s-grafana" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "authproxy-demo.grafanaAuthProxy.datasourceName" -}}
+{{- default "AuthProxy" .Values.grafanaAuthProxy.datasource.name -}}
+{{- end -}}
+
+{{- define "authproxy-demo.grafanaAuthProxy.datasourceUid" -}}
+{{- default "authproxy-app-metrics" .Values.grafanaAuthProxy.datasource.uid -}}
+{{- end -}}
+
+{{- define "authproxy-demo.grafanaAuthProxy.baseUrl" -}}
+{{- if .Values.grafanaAuthProxy.datasource.authproxyBaseUrl -}}
+{{- .Values.grafanaAuthProxy.datasource.authproxyBaseUrl -}}
+{{- else -}}
+{{- printf "http://%s:%v" (include "authproxy-demo.authproxy.serviceName" .) .Values.grafanaAuthProxy.datasource.authproxyApiPort -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "authproxy-demo.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/authproxy-demo/templates/grafana-dashboards.yaml
+++ b/deploy/charts/authproxy-demo/templates/grafana-dashboards.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.grafana.enabled .Values.grafanaAuthProxy.enabled .Values.grafanaAuthProxy.dashboards.enabled -}}
+{{- $dashboards := .Files.Glob "dashboards/*.json" -}}
+{{- if $dashboards }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-grafana-dashboards" (include "authproxy-demo.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "authproxy-demo.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+{{- range $path, $_ := $dashboards }}
+  {{ base $path }}: |-
+{{ $.Files.Get $path | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/deploy/charts/authproxy-demo/templates/grafana-datasource.yaml
+++ b/deploy/charts/authproxy-demo/templates/grafana-datasource.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.grafana.enabled .Values.grafanaAuthProxy.enabled .Values.grafanaAuthProxy.datasource.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-grafana-datasource" (include "authproxy-demo.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "authproxy-demo.labels" . | nindent 4 }}
+    grafana_datasource: "1"
+data:
+  authproxy-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: {{ include "authproxy-demo.grafanaAuthProxy.datasourceName" . | quote }}
+        uid: {{ include "authproxy-demo.grafanaAuthProxy.datasourceUid" . | quote }}
+        type: rmorlok-authproxy-datasource
+        access: proxy
+        editable: true
+        jsonData:
+          baseUrl: {{ include "authproxy-demo.grafanaAuthProxy.baseUrl" . | quote }}
+        secureJsonData:
+          jwt: {{ printf "${%s}" .Values.grafanaAuthProxy.datasource.jwtEnvVar | quote }}
+{{- end -}}

--- a/deploy/charts/authproxy-demo/templates/ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/ingress.yaml
@@ -9,6 +9,7 @@
     /api              → AuthProxy api
     /public           → AuthProxy public (OAuth callbacks etc.)
     /oauth2           → go-oauth2-server (demo connector target)
+    /grafana          → Grafana demo dashboards
 
   AuthProxy's single Service carries all four ports (named `api`,
   `admin-api`, `public`, `worker-health`); per-path entries target the
@@ -81,6 +82,15 @@ spec:
             backend:
               service:
                 name: {{ include "authproxy-demo.goOauth2Server.name" . }}
+                port:
+                  number: 80
+          {{- end }}
+          {{- if .Values.grafana.enabled }}
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "authproxy-demo.grafana.serviceName" . }}
                 port:
                   number: 80
           {{- end }}

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -51,6 +51,32 @@
         "tls":         { "type": "boolean" }
       }
     },
+    "grafanaAuthProxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "datasource": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled":          { "type": "boolean" },
+            "name":             { "type": "string", "minLength": 1 },
+            "uid":              { "type": "string", "minLength": 1 },
+            "authproxyApiPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "authproxyBaseUrl": { "type": "string" },
+            "jwtEnvVar":        { "type": "string", "minLength": 1 }
+          }
+        },
+        "dashboards": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
     "secrets": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -5,6 +5,7 @@
 #   demoShell        — inline Deployment for the SSO stand-in host
 #   goOauth2Server   — inline Deployment for the demo connector target
 #   ingress          — single Ingress, sub-path routing
+#   grafana          — optional Grafana subchart + app-metrics dashboards
 #   secrets          — auto-generation toggles for keys + passwords
 #   authproxy / postgresql / redis / minio — subchart passthroughs
 
@@ -75,6 +76,58 @@ ingress:
   # -- TLS handled by cert-manager via the cluster-issuer annotation.
   tls: true
 
+grafanaAuthProxy:
+  # -- Render the AuthProxy datasource and dashboard provisioning ConfigMaps
+  # consumed by the Grafana chart sidecars.
+  enabled: true
+  datasource:
+    enabled: true
+    # -- Datasource name shown in Grafana.
+    name: AuthProxy
+    # -- Stable UID used by the sample dashboards.
+    uid: authproxy-app-metrics
+    # -- Internal AuthProxy API port. Matches deploy/charts/authproxy
+    # `ports.api` default; override if the inner chart port is customized.
+    authproxyApiPort: 8081
+    # -- Override the full AuthProxy base URL used by the datasource.
+    # Defaults to http://<release>-authproxy:<authproxyApiPort>.
+    authproxyBaseUrl: ""
+    # -- Grafana reads this environment variable when provisioning the
+    # datasource. The grafana.envValueFrom block below wires it from a Secret.
+    jwtEnvVar: AUTHPROXY_GRAFANA_JWT
+  dashboards:
+    enabled: true
+
+grafana:
+  enabled: true
+  # -- Install the AuthProxy datasource plugin. If installing from a
+  # release artifact URL instead of the Grafana catalog, override this with
+  # the GF_INSTALL_PLUGINS entry format: https://.../plugin.zip;plugin-folder.
+  plugins:
+    - rmorlok-authproxy-datasource
+  # -- The demo Ingress serves Grafana under /grafana.
+  grafana.ini:
+    plugins:
+      allow_loading_unsigned_plugins: rmorlok-authproxy-datasource
+    server:
+      root_url: "%(protocol)s://%(domain)s/grafana/"
+      serve_from_sub_path: true
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      provider:
+        allowUiUpdates: true
+    datasources:
+      enabled: true
+      label: grafana_datasource
+  envValueFrom:
+    AUTHPROXY_GRAFANA_JWT:
+      secretKeyRef:
+        # Create this Secret before install/upgrade; see README.
+        name: authproxy-grafana-jwt
+        key: jwt
+
 secrets:
   # -- When true, the chart auto-generates DB / Redis / MinIO passwords
   # on first install via sprig random helpers. Subsequent upgrades
@@ -121,6 +174,11 @@ seed:
       labels:
         demo: "true"
         role: user
+    - external_id: grafana
+      namespace: root
+      labels:
+        demo: "true"
+        role: datasource
 
 # ---------------------------------------------------------------------------
 # Subchart passthroughs — see each upstream's values.yaml for the full

--- a/plugins/grafana/authproxy-datasource/src/DataSource.ts
+++ b/plugins/grafana/authproxy-datasource/src/DataSource.ts
@@ -36,6 +36,13 @@ export class DataSource extends DataSourceWithBackend<AuthProxyQuery, AuthProxyD
 
   async metricFindQuery(query: AuthProxyVariableQuery): Promise<MetricFindValue[]> {
     const now = dateTime();
+    const replace = (value?: string) => getTemplateSrv().replace(value ?? '');
+    const variableQuery: AuthProxyVariableQuery = {
+      ...query,
+      namespace: replace(query.namespace),
+      labelSelector: replace(query.labelSelector),
+      connectorId: replace(query.connectorId),
+    };
     const request = {
       app: 'dashboard',
       requestId: 'authproxy-variable-query',
@@ -52,7 +59,7 @@ export class DataSource extends DataSourceWithBackend<AuthProxyQuery, AuthProxyD
         {
           refId: 'VariableQuery',
           queryType: 'variable',
-          variable: query,
+          variable: variableQuery,
         },
       ],
       timezone: 'browser',


### PR DESCRIPTION
## Summary
- Add Grafana to the authproxy-demo umbrella chart with AuthProxy datasource provisioning
- Add an app-metrics dashboard covering resource counts, connection states, request volume/errors/duration, rate-limit attribution, and request-event metadata
- Document the Grafana datasource token secret and plugin install options
- Template Grafana under /grafana and allow datasource variable queries to use Grafana template variables

Closes #451

## Tests
- npm run validate (plugins/grafana/authproxy-datasource)
- helm lint . --values ci/all-disabled-values.yaml (deploy/charts/authproxy-demo)
- helm lint . --set global.hostname=demo.example.com (deploy/charts/authproxy-demo)
- helm template demo . --namespace demo --values ci/all-disabled-values.yaml (deploy/charts/authproxy-demo)
- helm template demo . --namespace demo --set global.hostname=demo.example.com --show-only templates/grafana-datasource.yaml (deploy/charts/authproxy-demo)
- jq empty deploy/charts/authproxy-demo/dashboards/authproxy-app-metrics.json
- ./scripts/preflight.sh