### PR TITLE
[fix/A12] serve embedded demo UIs at root

### DIFF
--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -69,7 +69,7 @@ key, so these need real openssl). Create them in the release namespace
 | `<release>-jwt`            | `system` (RSA private), `system.pub`           |
 | `<release>-encryption`     | `global_aes.key` (32 raw bytes)                |
 | `<release>-demo-shell-key` | `private` (RSA private), `demo-shell.pub`      |
-| `<release>-actors`         | `demo-shell.pub` (matching the above)          |
+| `<release>-actors`         | `demo-shell.pub` plus one `<actor>.pub` entry for each demo actor, all matching the demo shell public key |
 | `authproxy-grafana-jwt`    | `jwt` (Grafana datasource bearer token, can be generated after `<release>-encryption`) |
 
 A reference one-shot generator:
@@ -94,7 +94,11 @@ kubectl -n "$NS" create secret generic "$RELEASE-demo-shell-key" \
   --from-file=private="$work/demo-shell" \
   --from-file=demo-shell.pub="$work/demo-shell.pub"
 kubectl -n "$NS" create secret generic "$RELEASE-actors" \
-  --from-file=demo-shell.pub="$work/demo-shell.pub"
+  --from-file=demo-shell.pub="$work/demo-shell.pub" \
+  --from-file=demo-admin.pub="$work/demo-shell.pub" \
+  --from-file=demo-user.pub="$work/demo-shell.pub" \
+  --from-file=fresh-user.pub="$work/demo-shell.pub" \
+  --from-file=grafana.pub="$work/demo-shell.pub"
 
 # Metrics plus request-event metadata tables. Database-backed actors
 # without their own self-signing key are verified with the global AES

--- a/deploy/charts/authproxy-demo/templates/demo-shell.yaml
+++ b/deploy/charts/authproxy-demo/templates/demo-shell.yaml
@@ -36,13 +36,14 @@ spec:
             # a sibling Secret (see actors-keys mount on the authproxy pod).
             - name: ADMIN_PRIVATE_KEY_PATH
               value: "/etc/authproxy/demo-shell/private"
-            # External URLs the BROWSER reaches — same hostname, sub-paths.
+            # External URLs the BROWSER reaches. Sub-domain layout —
+            # see templates/ingress.yaml for why this isn't sub-paths.
             - name: AUTHPROXY_AUTH_URL
-              value: "https://{{ .Values.global.hostname }}/public"
+              value: "https://marketplace.{{ .Values.global.hostname }}"
             - name: AUTHPROXY_MARKETPLACE_URL
-              value: "https://{{ .Values.global.hostname }}/marketplace"
+              value: "https://marketplace.{{ .Values.global.hostname }}"
             - name: AUTHPROXY_ADMIN_UI_URL
-              value: "https://{{ .Values.global.hostname }}/admin"
+              value: "https://admin.{{ .Values.global.hostname }}"
           volumeMounts:
             - name: admin-key
               mountPath: /etc/authproxy/demo-shell

--- a/deploy/charts/authproxy-demo/templates/ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/ingress.yaml
@@ -1,22 +1,25 @@
 {{- if and .Values.ingress.enabled .Values.global.hostname -}}
 {{/*
-  Single Ingress that fronts the entire demo stack. Sub-path routing:
+  Sub-domain routing under the demo hostname:
 
-    /                 → demo-shell (the SSO landing page)
-    /admin            → AuthProxy admin-api (which serves the admin UI)
-    /admin-api        → AuthProxy admin-api (the JSON API)
-    /marketplace      → AuthProxy public (which serves the marketplace UI)
-    /api              → AuthProxy api
-    /public           → AuthProxy public (OAuth callbacks etc.)
-    /oauth2           → go-oauth2-server (demo connector target)
-    /grafana          → Grafana demo dashboards
+    <hostname>             → demo-shell           (the SSO landing page)
+    <hostname>/grafana     → Grafana demo dashboards
+    marketplace.<hostname> → AuthProxy public      (marketplace UI + /api/v1 + OAuth callbacks)
+    admin.<hostname>       → AuthProxy admin-api   (admin UI + /api/v1 admin endpoints)
 
-  AuthProxy's single Service carries all four ports (named `api`,
-  `admin-api`, `public`, `worker-health`); per-path entries target the
-  named port matching the role.
+  Why subdomains and not subpaths: AuthProxy's embedded SPAs are built
+  with VITE_BASE_URL=/ and reference their assets relative to root
+  (e.g. /assets/index-xxx.js). Sub-path routing would 404 those
+  assets because the Ingress only forwards the prefix-matched path
+  and the SPA's <script src=> doesn't know about the prefix. Sub-
+  domain routing lets each SPA keep `base: /` while still landing
+  on the right backend service.
 
-  cert-manager.io/cluster-issuer annotation triggers cert issuance on
-  the host listed under tls.hosts.
+  external-dns reads `spec.rules[*].host` and creates A records for
+  each — no extra Route53 wiring needed. cert-manager mints a single
+  multi-SAN cert covering all three hostnames listed under tls.hosts.
+
+  go-oauth2-server (when enabled) lives on `oauth2.<hostname>`.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -35,56 +38,18 @@ spec:
   tls:
     - hosts:
         - {{ .Values.global.hostname | quote }}
+        - {{ printf "marketplace.%s" .Values.global.hostname | quote }}
+        - {{ printf "admin.%s" .Values.global.hostname | quote }}
+        {{- if .Values.goOauth2Server.enabled }}
+        - {{ printf "oauth2.%s" .Values.global.hostname | quote }}
+        {{- end }}
       secretName: {{ printf "%s-tls" (include "authproxy-demo.fullname" .) | quote }}
   {{- end }}
   rules:
+    {{- /* Apex hostname → demo-shell. */}}
     - host: {{ .Values.global.hostname | quote }}
       http:
         paths:
-          - path: /admin-api
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
-                port:
-                  name: admin-api
-          - path: /admin
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
-                port:
-                  name: admin-api
-          - path: /marketplace
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
-                port:
-                  name: public
-          - path: /api
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
-                port:
-                  name: api
-          - path: /public
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
-                port:
-                  name: public
-          {{- if .Values.goOauth2Server.enabled }}
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.goOauth2Server.name" . }}
-                port:
-                  number: 80
-          {{- end }}
           {{- if .Values.grafana.enabled }}
           - path: /grafana
             pathType: Prefix
@@ -94,7 +59,6 @@ spec:
                 port:
                   number: 80
           {{- end }}
-          # Demo-shell catches everything else (it's the landing page).
           - path: /
             pathType: Prefix
             backend:
@@ -102,4 +66,38 @@ spec:
                 name: {{ include "authproxy-demo.demoShell.name" . }}
                 port:
                   number: 80
+    {{- /* Marketplace subdomain → AuthProxy public service (port `public`). */}}
+    - host: {{ printf "marketplace.%s" .Values.global.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
+                port:
+                  name: public
+    {{- /* Admin subdomain → AuthProxy admin-api service (port `admin-api`). */}}
+    - host: {{ printf "admin.%s" .Values.global.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "authproxy-demo.authproxy.serviceName" . }}
+                port:
+                  name: admin-api
+    {{- if .Values.goOauth2Server.enabled }}
+    - host: {{ printf "oauth2.%s" .Values.global.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "authproxy-demo.goOauth2Server.name" . }}
+                port:
+                  number: 80
+    {{- end }}
 {{- end -}}

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -211,6 +211,17 @@ authproxy:
     existingSecret: "{{ .Release.Name }}-encryption"
   actors:
     existingSecret: "{{ .Release.Name }}-actors"
+  services:
+    public:
+      static:
+        enabled: true
+    adminApi:
+      ui:
+        enabled: true
+        baseUrl: "https://admin.{{ .Values.global.hostname }}"
+        initiateSessionUrl: "https://{{ .Values.global.hostname }}/"
+      static:
+        enabled: true
   hostApplication:
     initiateSessionUrl: "https://{{ .Values.global.hostname }}/"
   connectors:

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -8,13 +8,45 @@ Secrets, not in this ConfigMap.
 
 {{/* --- service ports --- */}}
 {{- if .Values.services.public.enabled -}}
-{{- $_ := set $cfg "public" (dict "port" .Values.ports.public) -}}
+{{- $public := dict "port" .Values.ports.public -}}
+{{- if .Values.services.public.static.enabled -}}
+{{-   $static := dict -}}
+{{-   if .Values.services.public.static.mountAt -}}
+{{-     $_ := set $static "mount_at" .Values.services.public.static.mountAt -}}
+{{-   end -}}
+{{-   if .Values.services.public.static.serveFrom -}}
+{{-     $_ := set $static "serve_from" (tpl .Values.services.public.static.serveFrom $) -}}
+{{-   end -}}
+{{-   $_ := set $public "static" $static -}}
+{{- end -}}
+{{- $_ := set $cfg "public" $public -}}
 {{- end -}}
 {{- if .Values.services.api.enabled -}}
 {{- $_ := set $cfg "api" (dict "port" .Values.ports.api) -}}
 {{- end -}}
 {{- if .Values.services.adminApi.enabled -}}
-{{- $_ := set $cfg "admin_api" (dict "port" .Values.ports.adminApi) -}}
+{{- $adminApi := dict "port" .Values.ports.adminApi -}}
+{{- if .Values.services.adminApi.ui.enabled -}}
+{{-   $ui := dict "enabled" true -}}
+{{-   if .Values.services.adminApi.ui.baseUrl -}}
+{{-     $_ := set $ui "base_url" (tpl .Values.services.adminApi.ui.baseUrl $) -}}
+{{-   end -}}
+{{-   if .Values.services.adminApi.ui.initiateSessionUrl -}}
+{{-     $_ := set $ui "initiate_session_url" (tpl .Values.services.adminApi.ui.initiateSessionUrl $) -}}
+{{-   end -}}
+{{-   $_ := set $adminApi "ui" $ui -}}
+{{- end -}}
+{{- if .Values.services.adminApi.static.enabled -}}
+{{-   $static := dict -}}
+{{-   if .Values.services.adminApi.static.mountAt -}}
+{{-     $_ := set $static "mount_at" .Values.services.adminApi.static.mountAt -}}
+{{-   end -}}
+{{-   if .Values.services.adminApi.static.serveFrom -}}
+{{-     $_ := set $static "serve_from" (tpl .Values.services.adminApi.static.serveFrom $) -}}
+{{-   end -}}
+{{-   $_ := set $adminApi "static" $static -}}
+{{- end -}}
+{{- $_ := set $cfg "admin_api" $adminApi -}}
 {{- end -}}
 {{- if .Values.services.worker.enabled -}}
 {{- $_ := set $cfg "worker" (dict "health_check_port" .Values.ports.workerHealth) -}}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -50,8 +50,8 @@
       "additionalProperties": false,
       "properties": {
         "api":      { "$ref": "#/definitions/serviceToggle" },
-        "adminApi": { "$ref": "#/definitions/serviceToggle" },
-        "public":   { "$ref": "#/definitions/serviceToggle" },
+        "adminApi": { "$ref": "#/definitions/adminApiService" },
+        "public":   { "$ref": "#/definitions/publicService" },
         "worker":   { "$ref": "#/definitions/serviceToggle" }
       }
     },
@@ -250,6 +250,40 @@
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" }
+      }
+    },
+    "publicService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "static": { "$ref": "#/definitions/staticContent" }
+      }
+    },
+    "adminApiService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ui": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled":            { "type": "boolean" },
+            "baseUrl":            { "type": "string" },
+            "initiateSessionUrl": { "type": "string" }
+          }
+        },
+        "static": { "$ref": "#/definitions/staticContent" }
+      }
+    },
+    "staticContent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":   { "type": "boolean" },
+        "mountAt":   { "type": "string" },
+        "serveFrom": { "type": "string" }
       }
     },
     "portNumber": {

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -68,8 +68,29 @@ services:
     enabled: true
   adminApi:
     enabled: true
+    ui:
+      # -- Enable AuthProxy's browser admin UI/session endpoints.
+      enabled: false
+      # -- Public base URL for the admin UI.
+      baseUrl: ""
+      # -- Host-app login URL used when the admin UI needs a session.
+      initiateSessionUrl: ""
+    static:
+      # -- Serve the embedded admin UI from this service.
+      enabled: false
+      # -- URL path where the UI is mounted. Empty mounts at the service root.
+      mountAt: ""
+      # -- Optional on-disk UI build path. Empty uses embedded assets.
+      serveFrom: ""
   public:
     enabled: true
+    static:
+      # -- Serve the embedded marketplace UI from this service.
+      enabled: false
+      # -- URL path where the UI is mounted. Empty mounts at the service root.
+      mountAt: ""
+      # -- Optional on-disk UI build path. Empty uses embedded assets.
+      serveFrom: ""
   worker:
     enabled: true
 

--- a/internal/apgin/static_embed.go
+++ b/internal/apgin/static_embed.go
@@ -3,9 +3,11 @@ package apgin
 import (
 	"io/fs"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/gin-gonic/contrib/static"
+	"github.com/gin-gonic/gin"
 )
 
 // embedServeFileSystem adapts an fs.FS (typically an embed.FS sub-FS) for use
@@ -43,4 +45,44 @@ func (e *embedServeFileSystem) Exists(prefix string, urlPath string) bool {
 	}
 	_ = f.Close()
 	return true
+}
+
+// ServeEmbeddedStatic serves concrete files from an embedded UI filesystem
+// without letting http.FileServer redirect the mount root. SPA roots and deep
+// links intentionally fall through to the caller's NoRoute index fallback.
+func ServeEmbeddedStatic(mountAt string, efs fs.FS) gin.HandlerFunc {
+	mountPrefix := strings.TrimSuffix(mountAt, "/")
+	httpFS := http.FS(efs)
+
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead {
+			return
+		}
+
+		urlPath := c.Request.URL.Path
+		if mountPrefix != "" {
+			if !strings.HasPrefix(urlPath, mountPrefix) {
+				return
+			}
+			urlPath = strings.TrimPrefix(urlPath, mountPrefix)
+		}
+
+		name := strings.TrimPrefix(path.Clean("/"+urlPath), "/")
+		if name == "" || name == "." {
+			return
+		}
+
+		f, err := efs.Open(name)
+		if err != nil {
+			return
+		}
+		stat, err := f.Stat()
+		_ = f.Close()
+		if err != nil || stat.IsDir() {
+			return
+		}
+
+		c.FileFromFS(name, httpFS)
+		c.Abort()
+	}
 }

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -2,6 +2,7 @@ package admin_api
 
 import (
 	"context"
+	"io/fs"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -216,9 +217,13 @@ func GetGinServer(
 		mountPrefix := strings.TrimSuffix(service.StaticVal.MountAtPath, "/")
 		var serveIndex func(c *gin.Context)
 		if service.StaticVal.IsEmbedded() {
-			embedHTTPFS := http.FS(adminembed.FS())
+			indexHTML, readErr := fs.ReadFile(adminembed.FS(), "index.html")
 			serveIndex = func(c *gin.Context) {
-				c.FileFromFS("index.html", embedHTTPFS)
+				if readErr != nil {
+					c.Status(http.StatusNotFound)
+					return
+				}
+				c.Data(http.StatusOK, "text/html; charset=utf-8", indexHTML)
 			}
 		} else {
 			indexPath := filepath.Join(service.StaticVal.ServeFromPath, "index.html")

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -71,13 +71,12 @@ func GetGinServer(
 		// Static content: prefer the compiled-in admin UI; fall back to an
 		// on-disk directory when ServeFromPath is set (local iteration,
 		// custom builds).
-		var sfs static.ServeFileSystem
 		if service.StaticVal.IsEmbedded() {
-			sfs = apgin.NewEmbedServeFileSystem(adminembed.FS())
+			server.Use(apgin.ServeEmbeddedStatic(service.StaticVal.MountAtPath, adminembed.FS()))
 		} else {
-			sfs = static.LocalFile(service.StaticVal.ServeFromPath, true)
+			sfs := static.LocalFile(service.StaticVal.ServeFromPath, true)
+			server.Use(static.Serve(service.StaticVal.MountAtPath, sfs))
 		}
-		server.Use(static.Serve(service.StaticVal.MountAtPath, sfs))
 	}
 
 	// Swagger documentation endpoint

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -2,6 +2,7 @@ package admin_api
 
 import (
 	"context"
+	"io/fs"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -221,9 +222,13 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		mountPrefix := strings.TrimSuffix(service.StaticVal.MountAtPath, "/")
 		var serveIndex func(c *gin.Context)
 		if service.StaticVal.IsEmbedded() {
-			embedHTTPFS := http.FS(marketplaceembed.FS())
+			indexHTML, readErr := fs.ReadFile(marketplaceembed.FS(), "index.html")
 			serveIndex = func(c *gin.Context) {
-				c.FileFromFS("index.html", embedHTTPFS)
+				if readErr != nil {
+					c.Status(http.StatusNotFound)
+					return
+				}
+				c.Data(http.StatusOK, "text/html; charset=utf-8", indexHTML)
 			}
 		} else {
 			indexPath := filepath.Join(service.StaticVal.ServeFromPath, "index.html")

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -79,13 +79,12 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		// Static content: prefer the compiled-in marketplace UI; fall back to
 		// an on-disk directory when ServeFromPath is set (local iteration,
 		// custom builds).
-		var sfs static.ServeFileSystem
 		if service.StaticVal.IsEmbedded() {
-			sfs = apgin.NewEmbedServeFileSystem(marketplaceembed.FS())
+			server.Use(apgin.ServeEmbeddedStatic(service.StaticVal.MountAtPath, marketplaceembed.FS()))
 		} else {
-			sfs = static.LocalFile(service.StaticVal.ServeFromPath, true)
+			sfs := static.LocalFile(service.StaticVal.ServeFromPath, true)
+			server.Use(static.Serve(service.StaticVal.MountAtPath, sfs))
 		}
-		server.Use(static.Serve(service.StaticVal.MountAtPath, sfs))
 	}
 
 	healthChecker.GET("/ping", func(c *gin.Context) {


### PR DESCRIPTION
## Summary
- route demo marketplace/admin UIs on subdomains
- render embedded static UI config from chart values
- serve embedded SPA files without root redirect loops

## Verification
- ./scripts/preflight.sh
- go test ./internal/apgin ./internal/service/public ./internal/service/admin_api

Follow-up to #454 while validating https://demo.authproxy.net/.