### PR TITLE
Fix Grafana demo deploy wiring

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -20,12 +20,17 @@ name: Deploy Demo
 #   - `demo` namespace exists, with the four keypair Secrets created
 #     manually (jwt, encryption, demo-shell-key, actors) — A10 README's
 #     openssl one-shot covers this
+#   - The workflow derives/refreshes authproxy-grafana-jwt from the
+#     existing encryption Secret before every deploy.
 #   - Repo secrets:
 #       AWS_ROLE_ARN  : the role from `terraform output gh_actions_role_arn`
 #   - Repo variables (Settings → Variables):
 #       AWS_REGION    : e.g. us-east-1
 #       EKS_CLUSTER   : e.g. authproxy-eks
 #       DEMO_HOSTNAME : e.g. demo.authproxy.net
+#       GRAFANA_AUTHPROXY_PLUGIN_INSTALL : GF_INSTALL_PLUGINS override
+#         required to enable Grafana until the plugin is catalog-published,
+#         e.g. https://.../plugin.zip;rmorlok-authproxy-datasource
 
 on:
   push:
@@ -71,6 +76,11 @@ jobs:
         with:
           version: v3.16.4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Resolve image tag
         id: tag
         run: |
@@ -101,10 +111,38 @@ jobs:
         run: |
           # Same set the helm-chart-ci lint/install jobs use.
           helm repo add bitnami        https://charts.bitnami.com/bitnami
+          helm repo add grafana        https://grafana.github.io/helm-charts
           helm repo update
 
       - name: helm dependency update
         run: helm dependency update "${CHART_PATH}"
+
+      - name: Provision Grafana datasource JWT
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
+
+          # Database-backed actors without a self-signing key fall back to
+          # verifying actor-signed JWTs with the global AES key. The seeded
+          # `grafana` actor uses that path, and the token itself further
+          # restricts permissions via the Grafana logs preset.
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-encryption" \
+            -o jsonpath='{.data.global_aes\.key}' \
+            | base64 -d > "${workdir}/global_aes.key"
+          chmod 600 "${workdir}/global_aes.key"
+
+          go run ./cmd/cli sign-jwt \
+            --actorId grafana \
+            --apis api,admin-api \
+            --grafana-preset logs \
+            --secretKeyPath "${workdir}/global_aes.key" \
+            > "${workdir}/grafana.jwt"
+
+          kubectl -n "${RELEASE_NS}" create secret generic authproxy-grafana-jwt \
+            --from-file=jwt="${workdir}/grafana.jwt" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
 
       - name: Capture pre-deploy revision (for rollback)
         id: pre
@@ -125,29 +163,47 @@ jobs:
 
       - name: helm upgrade --install
         id: upgrade
+        env:
+          GRAFANA_PLUGIN_INSTALL: ${{ vars.GRAFANA_AUTHPROXY_PLUGIN_INSTALL }}
         run: |
           set -euo pipefail
-          helm upgrade --install "${RELEASE_NAME}" "${CHART_PATH}" \
-            --namespace "${RELEASE_NS}" --create-namespace \
-            --wait --timeout 10m \
-            --set "global.hostname=${{ vars.DEMO_HOSTNAME }}" \
-            --set "authproxy.image.tag=${{ steps.tag.outputs.tag }}" \
-            --set "demoShell.image.tag=${{ steps.tag.outputs.tag }}" \
+          helm_args=(
+            --namespace "${RELEASE_NS}" --create-namespace
+            --wait --timeout 10m
+            --set "global.hostname=${{ vars.DEMO_HOSTNAME }}"
+            --set "authproxy.image.tag=${{ steps.tag.outputs.tag }}"
+            --set "demoShell.image.tag=${{ steps.tag.outputs.tag }}"
             --set "seed.image.tag=${{ steps.tag.outputs.tag }}"
+          )
+
+          if [ -n "${GRAFANA_PLUGIN_INSTALL}" ]; then
+            helm_args+=(--set-string "grafana.plugins[0]=${GRAFANA_PLUGIN_INSTALL}")
+          else
+            echo "::warning::GRAFANA_AUTHPROXY_PLUGIN_INSTALL is unset; disabling Grafana for this demo deploy."
+            helm_args+=(--set "grafana.enabled=false" --set "grafanaAuthProxy.enabled=false")
+          fi
+
+          helm upgrade --install "${RELEASE_NAME}" "${CHART_PATH}" \
+            "${helm_args[@]}"
 
       - name: Wait for workload rollouts
         # `helm --wait` already blocks on the main release, but the
-        # umbrella's inline Deployments (demo-shell, go-oauth2-server)
-        # may need additional time. Cap at 5 min — past that, fall
-        # through to rollback.
+        # subchart + inline Deployments may need additional time. Skip
+        # disabled optional deployments so default-off workloads don't
+        # fail the deploy.
         timeout-minutes: 5
         run: |
           set -euo pipefail
           for d in \
             "${RELEASE_NAME}-authproxy" \
             "${RELEASE_NAME}-demo-shell" \
+            "${RELEASE_NAME}-grafana" \
             "${RELEASE_NAME}-go-oauth2-server" \
           ; do
+            if ! kubectl -n "${RELEASE_NS}" get "deployment/$d" >/dev/null 2>&1; then
+              echo "Skipping $d; deployment is not rendered."
+              continue
+            fi
             echo "Waiting for $d..."
             kubectl -n "${RELEASE_NS}" rollout status "deployment/$d" --timeout=5m
           done
@@ -191,5 +247,10 @@ jobs:
             echo "- Result:      ${{ job.status }}"
             echo "- Image tag:   \`${{ steps.tag.outputs.tag }}\`"
             echo "- Hostname:    \`https://${{ vars.DEMO_HOSTNAME }}/\`"
+            if kubectl -n "${RELEASE_NS}" get deployment "${RELEASE_NAME}-grafana" >/dev/null 2>&1; then
+              echo "- Grafana:     \`https://${{ vars.DEMO_HOSTNAME }}/grafana\`"
+            else
+              echo "- Grafana:     disabled for this deploy"
+            fi
             echo "- Helm rev:    \`$(helm history "${RELEASE_NAME}" -n "${RELEASE_NS}" -o json 2>/dev/null | jq -r '[.[] | select(.status=="deployed")] | last | .revision // "?"')\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -32,7 +32,7 @@ production install path is `deploy/charts/authproxy` directly.
 
 ```bash
 cd deploy/charts/authproxy-demo
-helm dependency update      # pulls authproxy/* and the bitnami charts
+helm dependency update      # pulls authproxy/*, Grafana, and the bitnami charts
 
 helm upgrade --install demo . \
   --namespace demo --create-namespace \
@@ -70,7 +70,7 @@ key, so these need real openssl). Create them in the release namespace
 | `<release>-encryption`     | `global_aes.key` (32 raw bytes)                |
 | `<release>-demo-shell-key` | `private` (RSA private), `demo-shell.pub`      |
 | `<release>-actors`         | `demo-shell.pub` (matching the above)          |
-| `authproxy-grafana-jwt`    | `jwt` (Grafana datasource bearer token)        |
+| `authproxy-grafana-jwt`    | `jwt` (Grafana datasource bearer token, can be generated after `<release>-encryption`) |
 
 A reference one-shot generator:
 
@@ -96,10 +96,17 @@ kubectl -n "$NS" create secret generic "$RELEASE-demo-shell-key" \
 kubectl -n "$NS" create secret generic "$RELEASE-actors" \
   --from-file=demo-shell.pub="$work/demo-shell.pub"
 
-# Metrics plus request-event metadata tables. The actor identified in
-# the token must have matching normal AuthProxy permissions; the
-# Grafana preset only restricts the token further.
-ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs > "$work/grafana.jwt"
+# Metrics plus request-event metadata tables. Database-backed actors
+# without their own self-signing key are verified with the global AES
+# key, and the Grafana preset only restricts the token further. The
+# actor identified in the token must still have matching normal
+# AuthProxy permissions.
+ap sign-jwt \
+  --actorId grafana \
+  --apis api,admin-api \
+  --grafana-preset logs \
+  --secretKeyPath "$work/global_aes.key" \
+  > "$work/grafana.jwt"
 kubectl -n "$NS" create secret generic authproxy-grafana-jwt \
   --from-file=jwt="$work/grafana.jwt"
 ```
@@ -176,6 +183,11 @@ By default the chart asks Grafana to install the
 release artifact before it is available in the Grafana catalog, override
 `grafana.plugins[0]` with Grafana's URL install format:
 `https://.../rmorlok-authproxy-datasource.zip;rmorlok-authproxy-datasource`.
+The `deploy-demo.yml` workflow reads the same override from the optional
+`GRAFANA_AUTHPROXY_PLUGIN_INSTALL` repository variable. Until the plugin
+is available from the Grafana catalog, the workflow disables Grafana when
+that variable is unset so the main demo rollout is not blocked by plugin
+installation.
 
 ## Uninstall
 

--- a/deploy/charts/authproxy-demo/templates/NOTES.txt
+++ b/deploy/charts/authproxy-demo/templates/NOTES.txt
@@ -12,6 +12,13 @@ Next steps
      kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
 
 3. Open https://{{ .Values.global.hostname }} — pick a demo actor + destination, click sign-in.
+{{- if .Values.grafana.enabled }}
+
+4. Open https://{{ .Values.global.hostname }}/grafana for the provisioned
+   app-metrics dashboards. Grafana needs Secret `authproxy-grafana-jwt`
+   in namespace `{{ .Release.Namespace }}` so the AuthProxy datasource
+   can authenticate.
+{{- end }}
 
 The shell signs a JWT using the auto-generated demo-shell admin keypair
 (stored in Secret `{{ .Release.Name }}-demo-shell-key`) and redirects you


### PR DESCRIPTION
## Summary
- Register the Grafana Helm repo in deploy-demo before dependency update
- Generate/refresh authproxy-grafana-jwt from the demo encryption Secret using the Grafana logs preset
- Allow deploy-demo to use a GF_INSTALL_PLUGINS URL override and disable Grafana when that override is absent, so main demo deploys do not fail before the plugin is catalog-published
- Wait for rendered deployments only, including Grafana when enabled
- Correct demo docs for Grafana token signing with the global AES key

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-demo.yml"); puts "ok"'
- helm lint . --set global.hostname=demo.example.com (deploy/charts/authproxy-demo)
- helm lint . --set global.hostname=demo.example.com --set grafana.enabled=false --set grafanaAuthProxy.enabled=false (deploy/charts/authproxy-demo)
- helm template demo . --namespace demo --set global.hostname=demo.example.com (deploy/charts/authproxy-demo)
- helm template demo . --namespace demo --set global.hostname=demo.example.com --set grafana.enabled=false --set grafanaAuthProxy.enabled=false (deploy/charts/authproxy-demo)
- go run ./cmd/cli sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs --secretKeyPath <raw-aes-key>
- ./scripts/preflight.sh