### PR TITLE
Drop setup form progress fields

### DIFF
--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -101,15 +101,12 @@ func (c *connection) renderStepResponse(
 ) (iface.ConnectionSetupResponse, error) {
 	switch step.Type() {
 	case iface.ManifestStepTypeForm:
-		currentIdx, total := stepIndex(flow, step.Id())
 		return &iface.ConnectionSetupForm{
 			Id:              c.GetId(),
 			Type:            iface.ConnectionSetupResponseTypeForm,
 			StepId:          step.Id(),
 			StepTitle:       step.Title(),
 			StepDescription: step.Description(),
-			CurrentStep:     currentIdx,
-			TotalSteps:      total,
 			JsonSchema:      json.RawMessage(step.JsonSchema()),
 			UiSchema:        json.RawMessage(step.UiSchema()),
 		}, nil
@@ -140,21 +137,6 @@ func (c *connection) renderStepResponse(
 
 	}
 	return nil, httperr.InternalServerError(httperr.WithInternalErrorf("unsupported manifest step type %q", step.Type()))
-}
-
-// stepIndex returns the 0-based position of stepId in the flow's linear
-// Steps() slice plus the total count. Used for the UI's "step N of M"
-// display. Pseudo-steps (verify / terminal failures) are not in Steps(),
-// so they return -1 for the index — callers shouldn't reach those for
-// form-step rendering.
-func stepIndex(flow iface.ManifestSetupFlow, stepId string) (int, int) {
-	steps := flow.Steps()
-	for i, s := range steps {
-		if s.Id() == stepId {
-			return i, len(steps)
-		}
-	}
-	return -1, len(steps)
 }
 
 // renderResumeResponse returns the response shape for the connection's

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -144,8 +144,6 @@ func TestSubmitForm(t *testing.T) {
 		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "region", form.StepId)
 		assert.Equal(t, "Region", form.StepTitle)
-		assert.Equal(t, 1, form.CurrentStep)
-		assert.Equal(t, 2, form.TotalSteps)
 	})
 
 	t.Run("last preconnect step transitions to OAuth2 redirect requires return_to_url", func(t *testing.T) {
@@ -311,8 +309,6 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		form := resp.(*iface.ConnectionSetupForm)
 		assert.Equal(t, "tenant", form.StepId)
 		assert.Equal(t, "Enter Tenant", form.StepTitle)
-		assert.Equal(t, 0, form.CurrentStep)
-		assert.Equal(t, 1, form.TotalSteps)
 	})
 
 	t.Run("returns redirect for OAuth2 authorize step", func(t *testing.T) {

--- a/internal/schema/api/connection_setup.go
+++ b/internal/schema/api/connection_setup.go
@@ -107,12 +107,6 @@ type ConnectionSetupForm struct {
 	// Step description.
 	StepDescription string `json:"step_description,omitempty" yaml:"step_description,omitempty"`
 
-	// Current step number in the setup phase.
-	CurrentStep int `json:"current_step" yaml:"current_step" example:"1"`
-
-	// Total number of steps in the setup phase.
-	TotalSteps int `json:"total_steps" yaml:"total_steps" example:"2"`
-
 	// JSON Schema defining the form fields.
 	JsonSchema json.RawMessage `json:"json_schema" yaml:"json_schema" swaggertype:"object"`
 

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -79,18 +79,10 @@
         "step_id": { "type": "string" },
         "step_title": { "type": "string" },
         "step_description": { "type": "string" },
-        "current_step": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "total_steps": {
-          "type": "integer",
-          "minimum": 0
-        },
         "json_schema": { "type": "object" },
         "ui_schema": { "type": "object" }
       },
-      "required": ["id", "type", "step_id", "current_step", "total_steps", "json_schema", "ui_schema"],
+      "required": ["id", "type", "step_id", "json_schema", "ui_schema"],
       "additionalProperties": false
     },
     "ConnectionSetupComplete": {

--- a/internal/schema/api/test_data/valid-connection-setup-form.json
+++ b/internal/schema/api/test_data/valid-connection-setup-form.json
@@ -3,8 +3,6 @@
   "type": "form",
   "step_id": "preconnect:0",
   "step_title": "Choose workspace",
-  "current_step": 1,
-  "total_steps": 1,
   "json_schema": {
     "type": "object",
     "properties": {

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -7825,11 +7825,6 @@ const docTemplateadmin_api = `{
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
-                "current_step": {
-                    "description": "Current step number in the setup phase.",
-                    "type": "integer",
-                    "example": 1
-                },
                 "id": {
                     "description": "Connection UUID.",
                     "type": "string",
@@ -7852,11 +7847,6 @@ const docTemplateadmin_api = `{
                     "description": "Step title.",
                     "type": "string",
                     "example": "Choose workspace"
-                },
-                "total_steps": {
-                    "description": "Total number of steps in the setup phase.",
-                    "type": "integer",
-                    "example": 2
                 },
                 "type": {
                     "description": "Response type.",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -7819,11 +7819,6 @@
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
-                "current_step": {
-                    "description": "Current step number in the setup phase.",
-                    "type": "integer",
-                    "example": 1
-                },
                 "id": {
                     "description": "Connection UUID.",
                     "type": "string",
@@ -7846,11 +7841,6 @@
                     "description": "Step title.",
                     "type": "string",
                     "example": "Choose workspace"
-                },
-                "total_steps": {
-                    "description": "Total number of steps in the setup phase.",
-                    "type": "integer",
-                    "example": 2
                 },
                 "type": {
                     "description": "Response type.",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -204,10 +204,6 @@ definitions:
   routes.ConnectionSetupForm:
     description: Form response for connection setup
     properties:
-      current_step:
-        description: Current step number in the setup phase.
-        example: 1
-        type: integer
       id:
         description: Connection UUID.
         example: cxn_test550e8400abcde
@@ -226,10 +222,6 @@ definitions:
         description: Step title.
         example: Choose workspace
         type: string
-      total_steps:
-        description: Total number of steps in the setup phase.
-        example: 2
-        type: integer
       type:
         description: Response type.
         example: form

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -7825,11 +7825,6 @@ const docTemplateApi = `{
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
-                "current_step": {
-                    "description": "Current step number in the setup phase.",
-                    "type": "integer",
-                    "example": 1
-                },
                 "id": {
                     "description": "Connection UUID.",
                     "type": "string",
@@ -7852,11 +7847,6 @@ const docTemplateApi = `{
                     "description": "Step title.",
                     "type": "string",
                     "example": "Choose workspace"
-                },
-                "total_steps": {
-                    "description": "Total number of steps in the setup phase.",
-                    "type": "integer",
-                    "example": 2
                 },
                 "type": {
                     "description": "Response type.",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -7819,11 +7819,6 @@
             "description": "Form response for connection setup",
             "type": "object",
             "properties": {
-                "current_step": {
-                    "description": "Current step number in the setup phase.",
-                    "type": "integer",
-                    "example": 1
-                },
                 "id": {
                     "description": "Connection UUID.",
                     "type": "string",
@@ -7846,11 +7841,6 @@
                     "description": "Step title.",
                     "type": "string",
                     "example": "Choose workspace"
-                },
-                "total_steps": {
-                    "description": "Total number of steps in the setup phase.",
-                    "type": "integer",
-                    "example": 2
                 },
                 "type": {
                     "description": "Response type.",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -204,10 +204,6 @@ definitions:
   routes.ConnectionSetupForm:
     description: Form response for connection setup
     properties:
-      current_step:
-        description: Current step number in the setup phase.
-        example: 1
-        type: integer
       id:
         description: Connection UUID.
         example: cxn_test550e8400abcde
@@ -226,10 +222,6 @@ definitions:
         description: Step title.
         example: Choose workspace
         type: string
-      total_steps:
-        description: Total number of steps in the setup phase.
-        example: 2
-        type: integer
       type:
         description: Response type.
         example: form

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -98,8 +98,6 @@ export interface ConnectionSetupFormResponse extends ConnectionSetupResponse {
     step_id: string;
     step_title?: string;
     step_description?: string;
-    current_step: number;
-    total_steps: number;
     json_schema: Record<string, unknown>;
     ui_schema: Record<string, unknown>;
 }

--- a/ui/marketplace/src/components/ConnectionFormStep.tsx
+++ b/ui/marketplace/src/components/ConnectionFormStep.tsx
@@ -3,15 +3,13 @@ import { JsonForms } from '@jsonforms/react';
 import { materialCells, materialRenderers } from '@jsonforms/material-renderers';
 import type { JsonFormsCore, UISchemaElement } from '@jsonforms/core';
 import type { JsonSchema } from '@jsonforms/core';
-import { Box, Button, CircularProgress, Typography, LinearProgress } from '@mui/material';
+import { Box, Button, CircularProgress, Typography } from '@mui/material';
 import { connections, DataSourceOption } from '@authproxy/api';
 
 export interface ConnectionFormStepProps {
     connectionId: string;
     stepTitle?: string;
     stepDescription?: string;
-    currentStep: number;
-    totalSteps: number;
     jsonSchema: Record<string, unknown>;
     uiSchema: Record<string, unknown>;
     onSubmit: (connectionId: string, data: unknown) => void;
@@ -76,8 +74,6 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
     connectionId,
     stepTitle,
     stepDescription,
-    currentStep,
-    totalSteps,
     jsonSchema,
     uiSchema,
     onSubmit,
@@ -127,20 +123,8 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
         onSubmit(connectionId, data);
     }, [connectionId, data, onSubmit]);
 
-    const progress = totalSteps > 0 ? ((currentStep + 1) / totalSteps) * 100 : 0;
-
     return (
         <Box sx={{ p: 2 }}>
-            {totalSteps > 1 && (
-                <Box sx={{ mb: 2 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                        <Typography variant="caption" color="text.secondary">
-                            Step {currentStep + 1} of {totalSteps}
-                        </Typography>
-                    </Box>
-                    <LinearProgress variant="determinate" value={progress} />
-                </Box>
-            )}
             {stepTitle && (
                 <Typography variant="h6" gutterBottom>
                     {stepTitle}

--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -227,8 +227,6 @@ const ConnectionList: React.FC = () => {
               connectionId={currentFormStep.connectionId}
               stepTitle={currentFormStep.stepTitle}
               stepDescription={currentFormStep.stepDescription}
-              currentStep={currentFormStep.currentStep}
-              totalSteps={currentFormStep.totalSteps}
               jsonSchema={currentFormStep.jsonSchema}
               uiSchema={currentFormStep.uiSchema}
               onSubmit={handleFormSubmit}

--- a/ui/marketplace/src/components/ConnectorList.tsx
+++ b/ui/marketplace/src/components/ConnectorList.tsx
@@ -160,8 +160,6 @@ const ConnectorList: React.FC = () => {
               connectionId={currentFormStep.connectionId}
               stepTitle={currentFormStep.stepTitle}
               stepDescription={currentFormStep.stepDescription}
-              currentStep={currentFormStep.currentStep}
-              totalSteps={currentFormStep.totalSteps}
               jsonSchema={currentFormStep.jsonSchema}
               uiSchema={currentFormStep.uiSchema}
               onSubmit={handleFormSubmit}

--- a/ui/marketplace/src/store/connectionsSlice.ts
+++ b/ui/marketplace/src/store/connectionsSlice.ts
@@ -18,8 +18,6 @@ interface FormStep {
     stepId: string;
     stepTitle?: string;
     stepDescription?: string;
-    currentStep: number;
-    totalSteps: number;
     jsonSchema: Record<string, unknown>;
     uiSchema: Record<string, unknown>;
 }
@@ -30,8 +28,6 @@ function formStepFromResponse(response: ConnectionSetupFormResponse): FormStep {
         stepId: response.step_id,
         stepTitle: response.step_title,
         stepDescription: response.step_description,
-        currentStep: response.current_step,
-        totalSteps: response.total_steps,
         jsonSchema: response.json_schema,
         uiSchema: response.ui_schema,
     };


### PR DESCRIPTION
## Summary
- remove current_step and total_steps from ConnectionSetupForm API/SDK/schema docs
- remove marketplace setup progress bar plumbing
- update tests, fixtures, and regenerated Swagger docs

Closes #433.

## Screenshots
Not included: this UI change removes the setup progress bar only. I attempted a Storybook capture for ConnectionFormStep, but Storybook failed to start in this clone with `Invariant failed: expected options to have a port` before a screenshot could be captured.

## Tests
- `go test ./internal/schema/api ./internal/core`
- `yarn workspace @authproxy/marketplace typecheck`
- `cd integration_tests && go list -mod=readonly ./...`
- `./scripts/check-schema-layout.sh`
- `./scripts/preflight.sh`