### PR TITLE
Add OAuth provider auth method compatibility tests

### DIFF
--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -66,6 +66,10 @@ func WithActor(externalID, namespace string) OAuth2Option {
 type OAuth2ConnectorOptions struct {
 	ClientID     string
 	ClientSecret string
+	// TokenEndpointAuthMethod selects how the proxy authenticates to the
+	// provider's token endpoint. Empty means "omit the field" so the
+	// production default applies.
+	TokenEndpointAuthMethod connectors.TokenEndpointAuthMethod
 	// Scopes lists scope IDs that are required (Scope.Required defaults to
 	// true via IsRequired when unspecified).
 	Scopes []string
@@ -117,10 +121,9 @@ func NewOAuth2Connector(connectorID apid.ID, displayName string, provider *OAuth
 	}
 
 	auth := &connectors.AuthOAuth2{
-		Type:         connectors.AuthTypeOAuth2,
-		ClientId:     &common.StringValue{InnerVal: &common.StringValueDirect{Value: opts.ClientID}},
-		ClientSecret: &common.StringValue{InnerVal: &common.StringValueDirect{Value: opts.ClientSecret}},
-		Scopes:       scopes,
+		Type:     connectors.AuthTypeOAuth2,
+		ClientId: &common.StringValue{InnerVal: &common.StringValueDirect{Value: opts.ClientID}},
+		Scopes:   scopes,
 		Authorization: connectors.AuthOauth2Authorization{
 			Endpoint: authEndpoint,
 			PKCE:     opts.PKCE,
@@ -128,6 +131,12 @@ func NewOAuth2Connector(connectorID apid.ID, displayName string, provider *OAuth
 		Token: connectors.AuthOauth2Token{
 			Endpoint: tokenEndpoint,
 		},
+	}
+	if opts.TokenEndpointAuthMethod != "" {
+		auth.TokenEndpointAuthMethod = connectors.NewTokenEndpointAuthMethod(opts.TokenEndpointAuthMethod)
+	}
+	if opts.TokenEndpointAuthMethod != connectors.TokenEndpointAuthNone || opts.ClientSecret != "" {
+		auth.ClientSecret = &common.StringValue{InnerVal: &common.StringValueDirect{Value: opts.ClientSecret}}
 	}
 
 	if opts.IncludeRevocation {

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.go
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.go
@@ -1,0 +1,276 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 19 from issue #178: providers differ on how they require OAuth2
+// clients to authenticate to /token. These tests drive the production callback
+// handler against go-oauth2-server clients registered for each supported method
+// and assert the provider accepts the configured shape.
+
+type authMethodCompatibilityRig struct {
+	provider     *helpers.OAuth2TestProvider
+	env          *helpers.IntegrationTestEnv
+	logCapture   *helpers.LogCapture
+	clientKey    string
+	clientSecret string
+	userID       string
+	connectorID  apid.ID
+	returnToURL  string
+}
+
+func newAuthMethodCompatibilityRig(
+	t *testing.T,
+	name string,
+	connectorMethod cschema.TokenEndpointAuthMethod,
+	providerMethod helpers.TokenEndpointAuthMethod,
+	pkce bool,
+) *authMethodCompatibilityRig {
+	t.Helper()
+
+	provider := helpers.NewOAuth2TestProvider(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := name + "-client-" + suffix
+	clientSecret := name + "-secret-" + suffix
+	userEmail := name + "-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	opts := helpers.OAuth2ConnectorOptions{
+		ClientID:                clientKey,
+		ClientSecret:            clientSecret,
+		TokenEndpointAuthMethod: connectorMethod,
+		Scopes:                  []string{"read"},
+	}
+	if pkce {
+		opts.ClientSecret = ""
+		opts.PKCE = &cschema.AuthOauth2PKCE{Method: cschema.PKCEMethodS256}
+	}
+	connector := helpers.NewOAuth2Connector(connectorID, name, provider, opts)
+
+	logCapture := helpers.NewLogCapture()
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+		LogCapture:    logCapture,
+	})
+	t.Cleanup(env.Cleanup)
+
+	createClient := helpers.CreateClientRequest{
+		Key:                     clientKey,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: providerMethod,
+		Scope:                   "read",
+		RequirePKCE:             pkce,
+	}
+	if !pkce {
+		createClient.Secret = clientSecret
+	}
+	registered := provider.CreateClient(createClient)
+	require.Equal(t, clientKey, registered.Key)
+	require.Equal(t, providerMethod, registered.TokenEndpointAuthMethod)
+	require.Equal(t, pkce, registered.RequirePKCE)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: "irrelevant-test-password",
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	return &authMethodCompatibilityRig{
+		provider:     provider,
+		env:          env,
+		logCapture:   logCapture,
+		clientKey:    clientKey,
+		clientSecret: clientSecret,
+		userID:       user.ID,
+		connectorID:  connectorID,
+		returnToURL:  "https://example.com/oauth-auth-method-return",
+	}
+}
+
+func (r *authMethodCompatibilityRig) completeAuthFlow(t *testing.T, pkce bool) (connectionID string, tokenReq helpers.RecordedRequest) {
+	t.Helper()
+
+	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
+	parsedRedirect, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsedRedirect.Query().Get("state_id")
+	require.NotEmpty(t, stateID)
+
+	authReq := helpers.AuthorizeRequest{
+		ClientID:    r.clientKey,
+		UserID:      r.userID,
+		RedirectURI: r.env.PublicOAuthCallbackURL(),
+		Scope:       "read",
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	}
+	if pkce {
+		upstreamAuthorizeURL := r.env.FollowOAuth2Redirect(t, redirectURL)
+		upstreamParsed, err := url.Parse(upstreamAuthorizeURL)
+		require.NoError(t, err)
+		authReq.CodeChallenge = upstreamParsed.Query().Get("code_challenge")
+		authReq.CodeChallengeMethod = upstreamParsed.Query().Get("code_challenge_method")
+		require.NotEmptyf(t, authReq.CodeChallenge,
+			"public-client flow must emit a PKCE code_challenge; authorize URL=%s", upstreamAuthorizeURL)
+		require.NotEmpty(t, authReq.CodeChallengeMethod)
+	}
+
+	beforeCallback := time.Now().Add(-1 * time.Second)
+	authResp := r.provider.Authorize(authReq)
+	require.NotEmpty(t, authResp.RedirectURL)
+
+	loc := r.env.DeliverOAuth2Callback(t, authResp.RedirectURL)
+	require.Truef(t, strings.HasPrefix(loc, r.returnToURL),
+		"successful auth method flow should redirect to return_to_url; got %q", loc)
+
+	token := r.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, token, "successful auth method flow must persist a token")
+	conn := r.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State)
+
+	tokenReqs := r.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: r.clientKey,
+		Since:    beforeCallback,
+	})
+	require.Lenf(t, tokenReqs, 1, "expected exactly one /token request for %s; got %d", r.clientKey, len(tokenReqs))
+	return connID, tokenReqs[0]
+}
+
+func recordedHeader(headers map[string]string, name string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestProviderAuthMethodCompatibility_ClientSecretBasic(t *testing.T) {
+	rig := newAuthMethodCompatibilityRig(t,
+		"auth-method-basic",
+		cschema.TokenEndpointAuthClientSecretBasic,
+		helpers.TokenEndpointAuthBasic,
+		false,
+	)
+
+	_, tokenReq := rig.completeAuthFlow(t, false)
+	authHeader := recordedHeader(tokenReq.Headers, "Authorization")
+	assert.Truef(t, strings.HasPrefix(authHeader, "Basic "),
+		"client_secret_basic must authenticate with Basic auth; got %q", authHeader)
+	assert.Empty(t, lastForm(tokenReq.Form, "client_id"),
+		"client_secret_basic must not duplicate client_id in the form body")
+	assert.Empty(t, lastForm(tokenReq.Form, "client_secret"),
+		"client_secret_basic must not duplicate client_secret in the form body")
+	assert.NotContains(t, authHeader, rig.clientSecret,
+		"client secret must not be exposed in plaintext in the recorded Authorization header")
+}
+
+func TestProviderAuthMethodCompatibility_ClientSecretPost(t *testing.T) {
+	rig := newAuthMethodCompatibilityRig(t,
+		"auth-method-post",
+		cschema.TokenEndpointAuthClientSecretPost,
+		helpers.TokenEndpointAuthPost,
+		false,
+	)
+
+	_, tokenReq := rig.completeAuthFlow(t, false)
+	assert.Empty(t, recordedHeader(tokenReq.Headers, "Authorization"),
+		"client_secret_post must not use Authorization header")
+	assert.Equal(t, rig.clientKey, lastForm(tokenReq.Form, "client_id"))
+	assert.NotEmpty(t, lastForm(tokenReq.Form, "client_secret"),
+		"client_secret_post must send client_secret in the form body")
+	assert.NotEqual(t, rig.clientSecret, lastForm(tokenReq.Form, "client_secret"),
+		"provider recorder should redact client_secret even though it was accepted")
+}
+
+func TestProviderAuthMethodCompatibility_PublicClientPKCE(t *testing.T) {
+	rig := newAuthMethodCompatibilityRig(t,
+		"auth-method-none",
+		cschema.TokenEndpointAuthNone,
+		helpers.TokenEndpointAuthNone,
+		true,
+	)
+
+	_, tokenReq := rig.completeAuthFlow(t, true)
+	assert.Empty(t, recordedHeader(tokenReq.Headers, "Authorization"),
+		"public client must not use Authorization header")
+	assert.Equal(t, rig.clientKey, lastForm(tokenReq.Form, "client_id"))
+	assert.Empty(t, lastForm(tokenReq.Form, "client_secret"),
+		"public client must not send client_secret")
+	assert.True(t, hasCodeVerifierForm(tokenReq.Form),
+		"public-client flow must send PKCE code_verifier at /token")
+}
+
+func TestProviderAuthMethodCompatibility_InvalidMethodFailsClearly(t *testing.T) {
+	rig := newAuthMethodCompatibilityRig(t,
+		"auth-method-invalid",
+		cschema.TokenEndpointAuthClientSecretPost,
+		helpers.TokenEndpointAuthBasic,
+		false,
+	)
+
+	connID, redirectURL := rig.env.InitiateOAuth2Connection(t, rig.connectorID, rig.returnToURL)
+	parsedRedirect, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsedRedirect.Query().Get("state_id")
+	require.NotEmpty(t, stateID)
+
+	authResp := rig.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    rig.clientKey,
+		UserID:      rig.userID,
+		RedirectURI: rig.env.PublicOAuthCallbackURL(),
+		Scope:       "read",
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	require.NotEmpty(t, authResp.RedirectURL)
+
+	loc := rig.env.DeliverOAuth2Callback(t, authResp.RedirectURL)
+	require.Truef(t, strings.HasPrefix(loc, rig.returnToURL),
+		"invalid auth method should redirect to return_to_url with setup=pending; got %q", loc)
+	parsedLoc, err := url.Parse(loc)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", parsedLoc.Query().Get("setup"))
+	assert.Equal(t, connID, parsedLoc.Query().Get("connection_id"))
+
+	require.Nil(t, rig.env.GetOAuth2Token(t, connID),
+		"token row must not persist when provider rejects the configured client auth method")
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateSetup, conn.State)
+	require.NotNil(t, conn.SetupStep)
+	assert.True(t, conn.SetupStep.Equals(cschema.SetupStepAuthFailed),
+		"connection should land in auth_failed after invalid token-endpoint auth method")
+	require.NotNil(t, conn.SetupError)
+	assert.NotContains(t, *conn.SetupError, rig.clientSecret,
+		"setup_error must not leak client_secret")
+
+	events := rig.logCapture.RecordsWithMessage(t, tokenExchangeFailureMessage)
+	require.Lenf(t, events, 1, "expected exactly one token-exchange failure event; got %d (%v)", len(events), events)
+	category, _ := events[0]["category"].(string)
+	assert.Containsf(t, []string{"invalid_client", "provider_4xx_other"}, category,
+		"invalid client-auth method should be classified as invalid_client or provider_4xx_other; got %q", category)
+
+	assertConnectionIDPresent(t, rig.logCapture, connID)
+	assertNoSecretsInLogs(t, rig.logCapture, flowSecrets{
+		ClientSecret: rig.clientSecret,
+	})
+}

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.md
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.md
@@ -1,0 +1,46 @@
+# Provider Auth Method Compatibility
+
+Companion notes for `provider_auth_method_compatibility_test.go`.
+Covers issue #178 / scenario 19 from #159.
+
+## Scope
+
+The tests prove the proxy can exchange authorization codes with OAuth2
+providers that require different token-endpoint client authentication methods:
+
+- `client_secret_basic`
+- `client_secret_post`
+- `none` for public clients with PKCE
+- a mismatched proxy/provider method that fails during token exchange
+
+## Approach
+
+These are non-interactive token-endpoint scenarios, so the tests use the
+go-oauth2-server `/test/*` control plane rather than Chrome:
+
+1. Register a provider client with the desired `token_endpoint_auth_method`.
+2. Initiate a real AuthProxy OAuth2 connection.
+3. Mint a real authorization code through `/test/authorize`.
+4. Deliver the callback through the production public handler.
+5. Inspect the provider's recorded `/token` request.
+
+The public-client case follows `/oauth2/redirect` once before calling
+`/test/authorize` so the provider binds the authorization code to the same PKCE
+challenge the proxy generated.
+
+## Assertions
+
+Successful cases must persist an OAuth2 token, leave the connection configured,
+and send the expected wire shape:
+
+- Basic auth uses `Authorization: Basic ...` and does not duplicate credentials
+  in the form body.
+- Post-body auth sends `client_id` and `client_secret` in the form body and no
+  Authorization header.
+- Public-client auth sends `client_id`, omits `client_secret`, and includes a
+  PKCE `code_verifier`.
+
+The mismatched-method case registers the provider for `client_secret_basic` but
+configures the proxy for `client_secret_post`. It must fail clearly with no
+token row, an `auth_failed` setup step, a token-exchange failure log event, and
+no plaintext client secret in logs or setup error.


### PR DESCRIPTION
Closes #178.

## Summary
- add token_endpoint_auth_method support to the OAuth2 integration connector helper
- add provider-backed integration coverage for client_secret_basic, client_secret_post, public client none+PKCE, and mismatched auth-method failure
- document the scenario in a companion markdown note

## Tests
- go test ./internal/auth_methods/oauth2
- go test -tags integration ./oauth2 -run 'TestProviderAuthMethodCompatibility' -count=1
- ./scripts/preflight.sh