### PR TITLE
Support repeated proxy request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ At its core, AuthProxy is an HTTP proxy that sits between your application and e
 
 If an OAuth2 access token has expired, AuthProxy automatically refreshes it using the stored refresh token before forwarding the request. Your application never needs to handle token lifecycle management.
 
-The JSON proxy endpoint (`POST /connections/{id}/_proxy`) accepts request
-headers as either a single string value or an array of string values:
-`{"Accept": "application/json", "X-Trace": ["one", "two"]}`. Arrays are
-forwarded as repeated HTTP header values in order. The streaming raw proxy
-endpoint (`/_proxy_raw`) uses normal HTTP headers directly and preserves
-repeated values after stripping hop-by-hop and AuthProxy envelope headers.
-
 ```mermaid
 sequenceDiagram
     participant App as Your Application

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ At its core, AuthProxy is an HTTP proxy that sits between your application and e
 
 If an OAuth2 access token has expired, AuthProxy automatically refreshes it using the stored refresh token before forwarding the request. Your application never needs to handle token lifecycle management.
 
+The JSON proxy endpoint (`POST /connections/{id}/_proxy`) accepts request
+headers as either a single string value or an array of string values:
+`{"Accept": "application/json", "X-Trace": ["one", "two"]}`. Arrays are
+forwarded as repeated HTTP header values in order. The streaming raw proxy
+endpoint (`/_proxy_raw`) uses normal HTTP headers directly and preserves
+repeated values after stripping hop-by-hop and AuthProxy envelope headers.
+
 ```mermaid
 sequenceDiagram
     participant App as Your Application

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
 // GetDataSource fetches data from an external API through the connection's authenticated proxy,
@@ -68,7 +69,7 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 	proxyReq := &iface.ProxyRequest{
 		URL:     renderedUrl,
 		Method:  ds.ProxyRequest.Method,
-		Headers: renderedHeaders,
+		Headers: common.HeadersValMapFromStrings(renderedHeaders),
 	}
 
 	proxyResp, err := c.ProxyRequest(ctx, httpf.RequestTypeProxy, proxyReq)

--- a/internal/core/iface/proxy.go
+++ b/internal/core/iface/proxy.go
@@ -9,16 +9,19 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"gopkg.in/h2non/gentleman.v2"
 )
 
+type HeadersVal = common.HeadersVal
+
 type ProxyRequest struct {
-	URL      string            `json:"url"`
-	Method   string            `json:"method"`
-	Headers  map[string]string `json:"headers"`
-	Labels   map[string]string `json:"labels,omitempty"`
-	BodyRaw  []byte            `json:"body_raw,omitempty"`
-	BodyJson interface{}       `json:"body_json,omitempty"`
+	URL      string                `json:"url"`
+	Method   string                `json:"method"`
+	Headers  map[string]HeadersVal `json:"headers"`
+	Labels   map[string]string     `json:"labels,omitempty"`
+	BodyRaw  []byte                `json:"body_raw,omitempty"`
+	BodyJson interface{}           `json:"body_json,omitempty"`
 }
 
 func (r *ProxyRequest) Apply(req *gentleman.Request) {
@@ -26,7 +29,9 @@ func (r *ProxyRequest) Apply(req *gentleman.Request) {
 	req.Method(r.Method)
 
 	for h, v := range r.Headers {
-		req.AddHeader(h, v)
+		for _, hv := range v.Values() {
+			req.AddHeader(h, hv)
+		}
 	}
 
 	if r.BodyJson != nil {

--- a/internal/core/iface/proxy_test.go
+++ b/internal/core/iface/proxy_test.go
@@ -3,13 +3,16 @@ package iface
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	mock "gopkg.in/h2non/gentleman-mock.v2"
 	"gopkg.in/h2non/gentleman.v2"
 	"gopkg.in/h2non/gock.v1"
 
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProxyRequest_Validate(t *testing.T) {
@@ -23,9 +26,9 @@ func TestProxyRequest_Validate(t *testing.T) {
 			proxyRequest: ProxyRequest{
 				URL:    "http://example.com",
 				Method: http.MethodGet,
-				Headers: map[string]string{
+				Headers: common.HeadersValMapFromStrings(map[string]string{
 					"Content-Type": "application/json",
-				},
+				}),
 			},
 			expectedError: "",
 		},
@@ -33,9 +36,9 @@ func TestProxyRequest_Validate(t *testing.T) {
 			name: "missing URL",
 			proxyRequest: ProxyRequest{
 				Method: http.MethodGet,
-				Headers: map[string]string{
+				Headers: common.HeadersValMapFromStrings(map[string]string{
 					"Content-Type": "application/json",
-				},
+				}),
 			},
 			expectedError: "url is required",
 		},
@@ -43,9 +46,9 @@ func TestProxyRequest_Validate(t *testing.T) {
 			name: "missing Method",
 			proxyRequest: ProxyRequest{
 				URL: "http://example.com",
-				Headers: map[string]string{
+				Headers: common.HeadersValMapFromStrings(map[string]string{
 					"Content-Type": "application/json",
-				},
+				}),
 			},
 			expectedError: "method is required",
 		},
@@ -54,9 +57,9 @@ func TestProxyRequest_Validate(t *testing.T) {
 			proxyRequest: ProxyRequest{
 				URL:    "http://example.com",
 				Method: "INVALID",
-				Headers: map[string]string{
+				Headers: common.HeadersValMapFromStrings(map[string]string{
 					"Content-Type": "application/json",
-				},
+				}),
 			},
 			expectedError: "invalid HTTP method",
 		},
@@ -65,9 +68,9 @@ func TestProxyRequest_Validate(t *testing.T) {
 			proxyRequest: ProxyRequest{
 				URL:    "http://example.com",
 				Method: http.MethodPost,
-				Headers: map[string]string{
+				Headers: common.HeadersValMapFromStrings(map[string]string{
 					"Content-Type": "application/json",
-				},
+				}),
 			},
 			expectedError: "either body_raw or body_json is must be specified",
 		},
@@ -102,6 +105,30 @@ func TestProxyRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProxyRequestApply_AddsRepeatedHeaderValues(t *testing.T) {
+	seen := make(chan []string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Values("X-Trace")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	req := ProxyRequest{
+		URL:    srv.URL,
+		Method: http.MethodGet,
+		Headers: map[string]HeadersVal{
+			"X-Trace": common.NewHeadersValSlice([]string{"one", "two"}),
+		},
+	}
+
+	greq := gentleman.New().Request()
+	req.Apply(greq)
+	resp, err := greq.Send()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, []string{"one", "two"}, <-seen)
 }
 
 func TestProxyResponseFromGentlemen(t *testing.T) {

--- a/internal/core/probe_http.go
+++ b/internal/core/probe_http.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
 type probeHttp struct {
@@ -32,7 +33,7 @@ func (p *probeHttp) Invoke(ctx context.Context) (string, error) {
 			req := iface.ProxyRequest{
 				Method:   h.Method,
 				URL:      h.URL,
-				Headers:  h.Headers,
+				Headers:  common.HeadersValMapFromStrings(h.Headers),
 				BodyRaw:  h.BodyRaw,
 				BodyJson: h.BodyJson,
 			}

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -53,12 +53,12 @@ type ListConnectionResponseJson = schemaapi.ListConnectionResponseJson
 type DisconnectResponseJson = schemaapi.DisconnectResponseJson
 type ForceStateRequestJson = schemaapi.ForceConnectionStateRequestJson
 type UpdateConnectionRequestJson = schemaapi.UpdateConnectionRequestJson
-type ProxyRequest = schemaapi.ProxyRequestJson
 type ProxyResponse = schemaapi.ProxyResponseJson
 
 type OpenAPIConnectionJson = schemaapiopenapi.ConnectionJson
 type OpenAPIListConnectionResponseJson = schemaapiopenapi.ListConnectionResponseJson
 type OpenAPIDisconnectResponseJson = schemaapiopenapi.DisconnectResponseJson
+type ProxyRequest = schemaapiopenapi.ProxyRequestJson
 type OpenAPIProxyResponseJson = schemaapiopenapi.ProxyResponseJson
 
 // @Summary		Initiate connection

--- a/internal/routes/connections_proxy_raw_test.go
+++ b/internal/routes/connections_proxy_raw_test.go
@@ -152,3 +152,14 @@ func TestCopyInboundHeadersForRawProxy(t *testing.T) {
 	assert.Empty(t, dst.Get("Host"), "Host set by http.NewRequest from outbound URL")
 	assert.Empty(t, dst.Get("Content-Length"), "Content-Length set separately from inbound ContentLength")
 }
+
+func TestCopyInboundHeadersForRawProxy_PreservesRepeatedValues(t *testing.T) {
+	src := http.Header{}
+	src.Add("X-Multi", "one")
+	src.Add("X-Multi", "two")
+
+	dst := http.Header{}
+	copyInboundHeadersForRawProxy(dst, src)
+
+	assert.Equal(t, []string{"one", "two"}, dst.Values("X-Multi"))
+}

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -236,7 +236,7 @@ type UpdateRateLimitRequestJson struct {
 
 // ProxyRequestJson documents the proxy-shaped request used by dry-run.
 //
-//	@Description	Request to simulate an HTTP request
+//	@Description	Request to proxy or simulate an HTTP request
 type ProxyRequestJson struct {
 	URL      string            `json:"url" example:"https://api.example.com/v1/users"`
 	Method   string            `json:"method" example:"POST"`

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -240,7 +240,7 @@ type UpdateRateLimitRequestJson struct {
 type ProxyRequestJson struct {
 	URL      string            `json:"url" example:"https://api.example.com/v1/users"`
 	Method   string            `json:"method" example:"POST"`
-	Headers  map[string]string `json:"headers,omitempty"`
+	Headers  map[string]any    `json:"headers,omitempty" swaggertype:"object"`
 	Labels   map[string]string `json:"labels,omitempty"`
 	BodyRaw  []byte            `json:"body_raw,omitempty"`
 	BodyJson interface{}       `json:"body_json,omitempty"`

--- a/internal/schema/api/rate_limits.go
+++ b/internal/schema/api/rate_limits.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 )
 
@@ -49,12 +50,12 @@ type UpdateRateLimitRequestJson struct {
 //
 //	@Description	Request to proxy or simulate an HTTP request
 type ProxyRequestJson struct {
-	URL      string            `json:"url" yaml:"url" example:"https://api.example.com/v1/users"`
-	Method   string            `json:"method" yaml:"method" example:"GET"`
-	Headers  map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Labels   map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	BodyRaw  []byte            `json:"body_raw,omitempty" yaml:"body_raw,omitempty"`
-	BodyJson interface{}       `json:"body_json,omitempty" yaml:"body_json,omitempty"`
+	URL      string                       `json:"url" yaml:"url" example:"https://api.example.com/v1/users"`
+	Method   string                       `json:"method" yaml:"method" example:"GET"`
+	Headers  map[string]common.HeadersVal `json:"headers,omitempty" yaml:"headers,omitempty" swaggertype:"object"`
+	Labels   map[string]string            `json:"labels,omitempty" yaml:"labels,omitempty"`
+	BodyRaw  []byte                       `json:"body_raw,omitempty" yaml:"body_raw,omitempty"`
+	BodyJson interface{}                  `json:"body_json,omitempty" yaml:"body_json,omitempty"`
 }
 
 // DryRunRequestJson is the request body for POST /rate-limits/_dry_run.

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -32,6 +32,19 @@
         "type": "string"
       }
     },
+    "HeadersVal": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "HeadersMap": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/HeadersVal" }
+    },
     "ErrorResponse": {
       "type": "object",
       "properties": {
@@ -699,7 +712,7 @@
           "format": "uri"
         },
         "method": { "$ref": "../resources/rate_limit/schema.json#/$defs/HttpMethod" },
-        "headers": { "$ref": "#/$defs/StringMap" },
+        "headers": { "$ref": "#/$defs/HeadersMap" },
         "labels": { "$ref": "#/$defs/StringMap" },
         "body_raw": {
           "type": "string",

--- a/internal/schema/api/test_data/valid-dry-run-request.json
+++ b/internal/schema/api/test_data/valid-dry-run-request.json
@@ -3,7 +3,8 @@
     "url": "https://api.example.com/v1/users",
     "method": "POST",
     "headers": {
-      "content-type": "application/json"
+      "content-type": "application/json",
+      "x-trace": ["one", "two"]
     },
     "labels": {
       "team": "payments"

--- a/internal/schema/common/headers_val.go
+++ b/internal/schema/common/headers_val.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// HeadersVal is a proxy request header value as it appears in JSON.
+// It accepts either a single string or an array of strings so callers can
+// represent repeated HTTP field values without losing order.
+type HeadersVal struct {
+	values []string
+	array  bool
+}
+
+func NewHeadersVal(value string) HeadersVal {
+	return HeadersVal{values: []string{value}}
+}
+
+func NewHeadersValSlice(values []string) HeadersVal {
+	return HeadersVal{values: append([]string(nil), values...), array: true}
+}
+
+func HeadersValMapFromStrings(headers map[string]string) map[string]HeadersVal {
+	if headers == nil {
+		return nil
+	}
+	out := make(map[string]HeadersVal, len(headers))
+	for k, v := range headers {
+		out[k] = NewHeadersVal(v)
+	}
+	return out
+}
+
+func (v HeadersVal) Values() []string {
+	return append([]string(nil), v.values...)
+}
+
+func (v HeadersVal) MarshalJSON() ([]byte, error) {
+	if v.array {
+		return json.Marshal(v.values)
+	}
+	if len(v.values) == 0 {
+		return json.Marshal("")
+	}
+	return json.Marshal(v.values[0])
+}
+
+func (v *HeadersVal) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		v.values = []string{single}
+		v.array = false
+		return nil
+	}
+
+	var multiple []string
+	if err := json.Unmarshal(data, &multiple); err == nil {
+		v.values = append([]string(nil), multiple...)
+		v.array = true
+		return nil
+	}
+
+	return fmt.Errorf("header value must be a string or array of strings")
+}

--- a/internal/schema/common/headers_val_test.go
+++ b/internal/schema/common/headers_val_test.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadersValJSON(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var got HeadersVal
+		require.NoError(t, json.Unmarshal([]byte(`"application/json"`), &got))
+		require.Equal(t, []string{"application/json"}, got.Values())
+
+		encoded, err := json.Marshal(got)
+		require.NoError(t, err)
+		require.JSONEq(t, `"application/json"`, string(encoded))
+	})
+
+	t.Run("array", func(t *testing.T) {
+		var got HeadersVal
+		require.NoError(t, json.Unmarshal([]byte(`["a=1", "b=2"]`), &got))
+		require.Equal(t, []string{"a=1", "b=2"}, got.Values())
+
+		encoded, err := json.Marshal(got)
+		require.NoError(t, err)
+		require.JSONEq(t, `["a=1", "b=2"]`, string(encoded))
+	})
+
+	t.Run("rejects non-string values", func(t *testing.T) {
+		var got HeadersVal
+		require.Error(t, json.Unmarshal([]byte(`["ok", 7]`), &got))
+		require.Error(t, json.Unmarshal([]byte(`{"value":"ok"}`), &got))
+	})
+}

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -8758,7 +8758,7 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to simulate an HTTP request",
+            "description": "Request to proxy or simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -8758,7 +8758,7 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to proxy or simulate an HTTP request",
+            "description": "Request to simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},
@@ -8769,10 +8769,7 @@ const docTemplateadmin_api = `{
                     }
                 },
                 "headers": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "labels": {
                     "type": "object",
@@ -8782,7 +8779,7 @@ const docTemplateadmin_api = `{
                 },
                 "method": {
                     "type": "string",
-                    "example": "GET"
+                    "example": "POST"
                 },
                 "url": {
                     "type": "string",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -8752,7 +8752,7 @@
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to proxy or simulate an HTTP request",
+            "description": "Request to simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},
@@ -8763,10 +8763,7 @@
                     }
                 },
                 "headers": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "labels": {
                     "type": "object",
@@ -8776,7 +8773,7 @@
                 },
                 "method": {
                     "type": "string",
-                    "example": "GET"
+                    "example": "POST"
                 },
                 "url": {
                     "type": "string",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -8752,7 +8752,7 @@
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to simulate an HTTP request",
+            "description": "Request to proxy or simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -868,7 +868,7 @@ definitions:
         type: object
     type: object
   routes.ProxyRequest:
-    description: Request to proxy or simulate an HTTP request
+    description: Request to simulate an HTTP request
     properties:
       body_json: {}
       body_raw:
@@ -876,15 +876,13 @@ definitions:
           type: integer
         type: array
       headers:
-        additionalProperties:
-          type: string
         type: object
       labels:
         additionalProperties:
           type: string
         type: object
       method:
-        example: GET
+        example: POST
         type: string
       url:
         example: https://api.example.com/v1/users

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -868,7 +868,7 @@ definitions:
         type: object
     type: object
   routes.ProxyRequest:
-    description: Request to simulate an HTTP request
+    description: Request to proxy or simulate an HTTP request
     properties:
       body_json: {}
       body_raw:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -8758,7 +8758,7 @@ const docTemplateApi = `{
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to simulate an HTTP request",
+            "description": "Request to proxy or simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -8758,7 +8758,7 @@ const docTemplateApi = `{
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to proxy or simulate an HTTP request",
+            "description": "Request to simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},
@@ -8769,10 +8769,7 @@ const docTemplateApi = `{
                     }
                 },
                 "headers": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "labels": {
                     "type": "object",
@@ -8782,7 +8779,7 @@ const docTemplateApi = `{
                 },
                 "method": {
                     "type": "string",
-                    "example": "GET"
+                    "example": "POST"
                 },
                 "url": {
                     "type": "string",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -8752,7 +8752,7 @@
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to proxy or simulate an HTTP request",
+            "description": "Request to simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},
@@ -8763,10 +8763,7 @@
                     }
                 },
                 "headers": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "labels": {
                     "type": "object",
@@ -8776,7 +8773,7 @@
                 },
                 "method": {
                     "type": "string",
-                    "example": "GET"
+                    "example": "POST"
                 },
                 "url": {
                     "type": "string",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -8752,7 +8752,7 @@
             }
         },
         "routes.ProxyRequest": {
-            "description": "Request to simulate an HTTP request",
+            "description": "Request to proxy or simulate an HTTP request",
             "type": "object",
             "properties": {
                 "body_json": {},

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -868,7 +868,7 @@ definitions:
         type: object
     type: object
   routes.ProxyRequest:
-    description: Request to proxy or simulate an HTTP request
+    description: Request to simulate an HTTP request
     properties:
       body_json: {}
       body_raw:
@@ -876,15 +876,13 @@ definitions:
           type: integer
         type: array
       headers:
-        additionalProperties:
-          type: string
         type: object
       labels:
         additionalProperties:
           type: string
         type: object
       method:
-        example: GET
+        example: POST
         type: string
       url:
         example: https://api.example.com/v1/users

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -868,7 +868,7 @@ definitions:
         type: object
     type: object
   routes.ProxyRequest:
-    description: Request to simulate an HTTP request
+    description: Request to proxy or simulate an HTTP request
     properties:
       body_json: {}
       body_raw:


### PR DESCRIPTION
## Summary
- add a proxy header value type that accepts either a JSON string or an array of strings
- forward array values as repeated outbound headers while preserving existing string payloads
- document the JSON proxy behavior and update API schema/Swagger artifacts

Closes #9

## Testing
- go test ./...
- go list -mod=readonly ./... from integration_tests
- ./scripts/check-schema-layout.sh

Note: ./scripts/preflight.sh was attempted, but swag generation did not complete in this environment; the non-Swagger preflight checks passed and Swagger artifacts were updated consistently.