### PR TITLE
Add OAuth proxy response handling tests

### DIFF
--- a/integration_tests/oauth2/proxy_response_handling_test.go
+++ b/integration_tests/oauth2/proxy_response_handling_test.go
@@ -1,0 +1,237 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 20-24 from issue #179: once OAuth credentials are established,
+// proxy-side response handling must preserve upstream responses, refresh and
+// replay only for 401, avoid retry loops, and leave connection state intact for
+// non-auth upstream failures.
+
+const (
+	proxyUpstreamAuthFailureMessage    = "proxy upstream auth failure"
+	proxyUpstreamRateLimitedMessage    = "proxy upstream rate limited"
+	proxyUpstreamRetryAttemptedMessage = "proxy upstream retry attempted"
+)
+
+func resourceRequestsSince(r *proxyRefreshRig, since time.Time) []helpers.RecordedRequest {
+	return r.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointResource,
+		Since:    since,
+	})
+}
+
+func assertNoRefreshActivity(t *testing.T, rig *proxyRefreshRig) {
+	t.Helper()
+	assert.Equalf(t, 0, rig.refreshCallCount(),
+		"upstream status must not trigger OAuth refresh; got %d refresh-token POSTs", rig.refreshCallCount())
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage),
+		"upstream status must not emit refresh-succeeded event")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
+		"upstream status must not emit refresh-failed event")
+}
+
+func assertConnectionStillReady(t *testing.T, rig *proxyRefreshRig, connID string) {
+	t.Helper()
+	conn := rig.env.GetConnection(t, connID)
+	assert.Equal(t, database.ConnectionStateConfigured, conn.State,
+		"upstream response classification must not change connection state")
+	assert.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState,
+		"upstream response classification must not flip connection unhealthy")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
+		"upstream response classification must not emit health-state transition")
+}
+
+func TestProxyResponseHandling_ValidTokenPreservesResponse(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-200")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status: 200,
+		Headers: map[string]string{
+			"Content-Type":      "application/json",
+			"X-Upstream-Trace":  "trace-200",
+			"X-Upstream-Status": "ok",
+		},
+		Body: `{"ok":true,"source":"provider"}`,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, true, resp.BodyJson["ok"])
+	assert.Equal(t, "provider", resp.BodyJson["source"])
+	assert.Equal(t, "trace-200", resp.Headers["X-Upstream-Trace"])
+	assert.Equal(t, "ok", resp.Headers["X-Upstream-Status"])
+
+	resourceReqs := resourceRequestsSince(rig, since)
+	require.Lenf(t, resourceReqs, 1, "valid-token request should hit upstream exactly once; got %d", len(resourceReqs))
+	authHeader := recordedHeader(resourceReqs[0].Headers, "Authorization")
+	require.Truef(t, strings.HasPrefix(authHeader, "Bearer "), "upstream should receive Bearer auth; got %q", authHeader)
+	assert.NotEqual(t, "Bearer ", authHeader,
+		"upstream must receive a non-empty Bearer token")
+
+	assertNoRefreshActivity(t, rig)
+	assertConnectionStillReady(t, rig, connID)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRateLimitedMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage))
+}
+
+func TestProxyResponseHandling_401RefreshesAndRetriesOnce(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-401-heal")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status:    401,
+		Body:      `{"error":"invalid_token"}`,
+		FailCount: 1,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"single upstream 401 should refresh and replay to success; body=%s", w.Body.String())
+
+	resourceReqs := resourceRequestsSince(rig, since)
+	assert.Lenf(t, resourceReqs, 2,
+		"401 self-heal should call upstream once, refresh, then retry once; got %d resource calls", len(resourceReqs))
+	assert.Equalf(t, 1, rig.refreshCallCount(),
+		"401 self-heal should perform exactly one refresh-token grant; got %d", rig.refreshCallCount())
+
+	retryEvents := rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage)
+	require.Lenf(t, retryEvents, 1, "401 self-heal should emit exactly one retry-attempt event; got %d", len(retryEvents))
+	assert.Equal(t, connID, retryEvents[0]["connection_id"])
+	assert.Equal(t, float64(401), retryEvents[0]["provider_status_code"])
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
+		"401 self-heal should emit one refresh-succeeded event")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage),
+		"self-healed 401 should not emit final auth-failure event")
+	assertConnectionStillReady(t, rig, connID)
+}
+
+func TestProxyResponseHandling_Persistent401RefreshesOnceThenSurfaces(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-401-persistent")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status:    401,
+		Body:      `{"error":"not_really_token_related"}`,
+		FailCount: 10,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"persistent upstream 401 should surface after one refresh+retry")
+
+	resourceReqs := resourceRequestsSince(rig, since)
+	assert.Lenf(t, resourceReqs, 2,
+		"persistent 401 must avoid retry loops; expected original + one replay, got %d", len(resourceReqs))
+	assert.Equalf(t, 1, rig.refreshCallCount(),
+		"persistent 401 should perform exactly one refresh-token grant; got %d", rig.refreshCallCount())
+
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage), 1,
+		"persistent 401 should emit exactly one retry-attempt event")
+	authFailures := rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage)
+	require.Lenf(t, authFailures, 1, "persistent final 401 should emit one auth-failure event; got %d", len(authFailures))
+	assert.Equal(t, connID, authFailures[0]["connection_id"])
+	assert.Equal(t, float64(401), authFailures[0]["provider_status_code"])
+	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
+		"persistent 401 still refreshes successfully once")
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage))
+	assertConnectionStillReady(t, rig, connID)
+}
+
+func TestProxyResponseHandling_403DoesNotRefresh(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-403")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status: 403,
+		Body:   `{"error":"insufficient_scope"}`,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Lenf(t, resourceRequestsSince(rig, since), 1,
+		"403 should be returned without upstream retry")
+	assertNoRefreshActivity(t, rig)
+
+	authFailures := rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage)
+	require.Lenf(t, authFailures, 1, "403 should emit one auth-failure event; got %d", len(authFailures))
+	assert.Equal(t, float64(403), authFailures[0]["provider_status_code"])
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage))
+	assertConnectionStillReady(t, rig, connID)
+}
+
+func TestProxyResponseHandling_429DoesNotRefresh(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-429")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status: 429,
+		Headers: map[string]string{
+			"Retry-After": "7",
+		},
+		Body: `{"error":"rate_limited"}`,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, "7", resp.Headers["Retry-After"])
+	assert.Lenf(t, resourceRequestsSince(rig, since), 1,
+		"429 should be returned without upstream retry")
+	assertNoRefreshActivity(t, rig)
+
+	rateLimitEvents := rig.logCapture.RecordsWithMessage(t, proxyUpstreamRateLimitedMessage)
+	require.Lenf(t, rateLimitEvents, 1, "429 should emit one rate-limit event; got %d", len(rateLimitEvents))
+	assert.Equal(t, connID, rateLimitEvents[0]["connection_id"])
+	assert.Equal(t, float64(429), rateLimitEvents[0]["provider_status_code"])
+	assert.Equal(t, "7", rateLimitEvents[0]["retry_after"])
+	assert.Equal(t, float64(7), rateLimitEvents[0]["retry_after_seconds"])
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage))
+	assertConnectionStillReady(t, rig, connID)
+}
+
+func TestProxyResponseHandling_5xxDoesNotRefreshOrRetry(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-response-5xx")
+	connID := rig.completeAuthFlow(t)
+
+	since := time.Now()
+	rig.provider.Script("", helpers.EndpointResource, helpers.ScriptAction{
+		Status: 503,
+		Body:   `{"error":"temporarily_unavailable"}`,
+	})
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	resp := parseRevocationProxyResponse(t, w)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Lenf(t, resourceRequestsSince(rig, since), 1,
+		"5xx should be surfaced without upstream retry")
+	assertNoRefreshActivity(t, rig)
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRateLimitedMessage))
+	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage))
+	assertConnectionStillReady(t, rig, connID)
+}

--- a/integration_tests/oauth2/proxy_response_handling_test.md
+++ b/integration_tests/oauth2/proxy_response_handling_test.md
@@ -1,0 +1,44 @@
+# Proxy API Response Handling
+
+Companion notes for `proxy_response_handling_test.go`.
+Covers issue #179 / scenarios 20-24 from #159.
+
+## Scope
+
+The suite verifies OAuth-backed proxy behavior once a connection already has
+valid provider credentials:
+
+- 200 responses are returned without mutation and include the expected Bearer
+  token upstream.
+- 401 responses trigger one forced refresh and one replay.
+- Persistent 401 responses surface after that single retry, avoiding loops.
+- 403 responses are treated as authorization/permission failures, not refresh
+  prompts.
+- 429 responses are treated as upstream rate limits, preserving `Retry-After`
+  and avoiding OAuth reconnect/refresh behavior.
+- 5xx responses are surfaced as upstream failures without OAuth refresh.
+
+## Approach
+
+The tests reuse `proxyRefreshRig`:
+
+1. Complete a real authorization-code flow through `/test/authorize`.
+2. Script the go-oauth2-server resource endpoint with the response under test.
+3. Call AuthProxy's wrapped `/api/v1/connections/{id}/_proxy` path.
+4. Inspect both the wrapped proxy response and the provider's request recorder.
+
+The resource endpoint is scripted through the wildcard client key because
+resource requests authenticate with Bearer tokens, not client credentials.
+
+## Observability
+
+The proxy orchestrator emits stable structured events for the classifications
+called out in #179:
+
+- `proxy upstream retry attempted`
+- `proxy upstream auth failure`
+- `proxy upstream rate limited`
+
+The tests assert these events fire only for the final response category that
+reaches the caller. A 401 that self-heals therefore records a retry attempt and
+refresh success, but no final auth-failure event.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,7 +12,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
+	"strconv"
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -36,6 +38,7 @@ type proxy struct {
 	conn        iface.Connection
 	auth        auth_methods.Authenticator
 	accelerator ProbeAccelerator
+	logger      *slog.Logger
 }
 
 // New constructs an iface.Proxy that orchestrates calls for a single
@@ -45,7 +48,20 @@ type proxy struct {
 // without waiting for the next scheduled probe tick. One instance per
 // connection — held inside the connection's lazy proxy-impl cache.
 func New(h httpf.F, conn iface.Connection, auth auth_methods.Authenticator, accelerator ProbeAccelerator) iface.Proxy {
-	return &proxy{httpf: h, conn: conn, auth: auth, accelerator: accelerator}
+	return &proxy{httpf: h, conn: conn, auth: auth, accelerator: accelerator, logger: proxyLogger(conn)}
+}
+
+type loggedConnection interface {
+	Logger() *slog.Logger
+}
+
+func proxyLogger(conn iface.Connection) *slog.Logger {
+	if connWithLogger, ok := conn.(loggedConnection); ok {
+		if logger := connWithLogger.Logger(); logger != nil {
+			return logger
+		}
+	}
+	return slog.Default()
 }
 
 // maybeAccelerateProbes fires a best-effort probe-now enqueue when the
@@ -90,6 +106,7 @@ func (p *proxy) ProxyRequest(ctx context.Context, reqType httpf.RequestType, req
 	if resp.StatusCode == http.StatusUnauthorized {
 		recoverErr := p.auth.RecoverFrom401(ctx)
 		if recoverErr == nil {
+			p.logUpstreamRetryAttempted(ctx, reqType, resp.StatusCode)
 			retried, retryErr := p.send(ctx, reqType, req)
 			if retryErr == nil {
 				resp = retried
@@ -107,6 +124,7 @@ func (p *proxy) ProxyRequest(ctx context.Context, reqType httpf.RequestType, req
 	// so the probe-driven health signal flips without waiting for the
 	// next scheduled probe interval.
 	p.maybeAccelerateProbes(ctx, reqType, resp.StatusCode)
+	p.logFinalUpstreamStatus(ctx, reqType, resp)
 
 	return iface.ProxyResponseFromGentlemen(resp)
 }
@@ -150,6 +168,7 @@ func (p *proxy) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, 
 	if resp.StatusCode == http.StatusUnauthorized && canRetryRawAfter401(originalBody) {
 		recoverErr := p.auth.RecoverFrom401(ctx)
 		if recoverErr == nil {
+			p.logUpstreamRetryAttempted(ctx, reqType, resp.StatusCode)
 			drainAndClose(resp.Body)
 			retried, retryErr := p.sendRaw(ctx, client, req.Outbound.WithContext(ctx))
 			if retryErr == nil {
@@ -163,8 +182,56 @@ func (p *proxy) ProxyRequestRaw(ctx context.Context, reqType httpf.RequestType, 
 	// Same 401/403 acceleration as the wrapped path. See ProxyRequest's
 	// comment for the rationale.
 	p.maybeAccelerateProbes(ctx, reqType, resp.StatusCode)
+	p.logFinalRawUpstreamStatus(ctx, reqType, resp)
 
 	return streamResponse(w, resp)
+}
+
+func (p *proxy) logUpstreamRetryAttempted(ctx context.Context, reqType httpf.RequestType, statusCode int) {
+	p.logger.InfoContext(ctx, "proxy upstream retry attempted",
+		"connection_id", p.conn.GetId().String(),
+		"request_type", reqType.String(),
+		"provider_status_code", statusCode,
+		"reason", "upstream_401",
+	)
+}
+
+func (p *proxy) logFinalUpstreamStatus(ctx context.Context, reqType httpf.RequestType, resp *gentleman.Response) {
+	if resp == nil {
+		return
+	}
+	p.logFinalStatus(ctx, reqType, resp.StatusCode, resp.Header.Get("Retry-After"))
+}
+
+func (p *proxy) logFinalRawUpstreamStatus(ctx context.Context, reqType httpf.RequestType, resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	p.logFinalStatus(ctx, reqType, resp.StatusCode, resp.Header.Get("Retry-After"))
+}
+
+func (p *proxy) logFinalStatus(ctx context.Context, reqType httpf.RequestType, statusCode int, retryAfter string) {
+	switch {
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
+		p.logger.WarnContext(ctx, "proxy upstream auth failure",
+			"connection_id", p.conn.GetId().String(),
+			"request_type", reqType.String(),
+			"provider_status_code", statusCode,
+		)
+	case statusCode == http.StatusTooManyRequests:
+		args := []any{
+			"connection_id", p.conn.GetId().String(),
+			"request_type", reqType.String(),
+			"provider_status_code", statusCode,
+		}
+		if retryAfter != "" {
+			args = append(args, "retry_after", retryAfter)
+			if seconds, err := strconv.Atoi(retryAfter); err == nil {
+				args = append(args, "retry_after_seconds", seconds)
+			}
+		}
+		p.logger.WarnContext(ctx, "proxy upstream rate limited", args...)
+	}
 }
 
 // canRetryRawAfter401 reports whether the inbound body is in a state


### PR DESCRIPTION
Closes #179.

## Summary
- add proxy-level structured events for upstream retry attempts, auth failures, and rate limits
- add provider-backed OAuth integration coverage for 200, 401 self-heal, persistent 401, 403, 429, and 5xx proxy responses
- document the scenario in a companion markdown note

## Tests
- go test ./internal/proxy ./internal/auth_methods/oauth2
- go test -tags integration ./oauth2 -run 'TestProxyResponseHandling' -count=1
- ./scripts/preflight.sh