### PR TITLE
Add OAuth disconnect revocation tests

### DIFF
--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 26 from issue #181: proxy-initiated disconnect revokes provider
+// credentials, removes local usability, and blocks future proxy calls.
+
+type disconnectRevocationRig struct {
+	provider    *helpers.OAuth2TestProvider
+	env         *helpers.IntegrationTestEnv
+	clientKey   string
+	userID      string
+	connectorID apid.ID
+	returnToURL string
+}
+
+func newDisconnectRevocationRig(t *testing.T, name string) *disconnectRevocationRig {
+	t.Helper()
+
+	provider := helpers.NewOAuth2TestProvider(t)
+	suffix := time.Now().Format("20060102150405.000000000")
+	clientKey := name + "-client-" + suffix
+	clientSecret := name + "-secret-" + suffix
+	userEmail := name + "-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
+		ClientID:          clientKey,
+		ClientSecret:      clientSecret,
+		Scopes:            []string{"read"},
+		IncludeRevocation: true,
+	})
+	oauthAuth := connector.Auth.InnerVal.(*cschema.AuthOAuth2)
+	supportedTokens := cschema.AuthOAuth2RevocationSupportedTypeRefreshToken
+	oauthAuth.Revocation.SupportedTokens = &supportedTokens
+	oauthAuth.Revocation.FormOverrides = map[string]string{
+		"client_id":     clientKey,
+		"client_secret": clientSecret,
+	}
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+		Connectors:    []sconfig.Connector{connector},
+	})
+	t.Cleanup(env.Cleanup)
+
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: "p4ssw0rd-" + suffix,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	return &disconnectRevocationRig{
+		provider:    provider,
+		env:         env,
+		clientKey:   clientKey,
+		userID:      user.ID,
+		connectorID: connectorID,
+		returnToURL: "https://example.com/return",
+	}
+}
+
+func (r *disconnectRevocationRig) completeAuthFlow(t *testing.T) string {
+	t.Helper()
+
+	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID)
+
+	authResp := r.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    r.clientKey,
+		UserID:      r.userID,
+		RedirectURI: r.env.PublicOAuthCallbackURL(),
+		Scope:       "read",
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	callback, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code := callback.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	loc := r.env.DeliverOAuth2Callback(t, r.env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Contains(t, loc, r.returnToURL)
+	return connID
+}
+
+func (r *disconnectRevocationRig) disconnect(t *testing.T, connectionID string) {
+	t.Helper()
+
+	path := "/api/v1/connections/" + connectionID + "/_disconnect"
+	req, err := r.env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+		http.MethodPost,
+		path,
+		nil,
+		sconfig.RootNamespace,
+		"test-actor",
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r.env.ApiGin.ServeHTTP(w, req)
+	require.Equalf(t, http.StatusOK, w.Code, "disconnect failed: %s", w.Body.String())
+
+	var body struct {
+		Connection struct {
+			State string `json:"state"`
+		} `json:"connection"`
+		TaskID string `json:"task_id"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, string(database.ConnectionStateDisconnecting), body.Connection.State)
+	assert.NotEmpty(t, body.TaskID)
+}
+
+func startCoreTaskWorker(t *testing.T, rig *disconnectRevocationRig) {
+	t.Helper()
+
+	srv := asynq.NewServerFromRedisClient(
+		rig.env.DM.GetRedisClient(),
+		asynq.Config{
+			Concurrency: 1,
+			Queues: map[string]int{
+				"default": 1,
+			},
+		},
+	)
+	mux := asynq.NewServeMux()
+	rig.env.Core.RegisterTasks(mux)
+
+	go func() {
+		_ = srv.Run(mux)
+	}()
+
+	t.Cleanup(func() {
+		srv.Shutdown()
+	})
+}
+
+func requireConnectionDeleted(t *testing.T, rig *disconnectRevocationRig, connectionID string) {
+	t.Helper()
+
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, err := rig.env.Db.GetConnection(context.Background(), id)
+		return errors.Is(err, database.ErrNotFound)
+	}, 10*time.Second, 100*time.Millisecond, "connection should be soft-deleted after disconnect task")
+}
+
+func requireProxyBlockedAfterDisconnect(t *testing.T, rig *disconnectRevocationRig, connectionID string) {
+	t.Helper()
+
+	w := rig.env.DoProxyRequest(t, connectionID, rig.provider.ResourceURL("/echo"), http.MethodGet)
+	assert.Equalf(t, http.StatusNotFound, w.Code,
+		"future proxied calls should require reconnect after disconnect; body=%s", w.Body.String())
+}
+
+func TestDisconnectRevocation_RevokesProviderTokensAndBlocksFutureProxy(t *testing.T) {
+	rig := newDisconnectRevocationRig(t, "disconnect-revoke")
+	connID := rig.completeAuthFlow(t)
+
+	token := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, token)
+	accessToken := rig.env.DecryptOAuth2AccessToken(t, token)
+	refreshToken := rig.env.DecryptOAuth2RefreshToken(t, token)
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), http.MethodGet)
+	require.Equal(t, http.StatusOK, parseRevocationProxyResponse(t, w).StatusCode)
+
+	rig.disconnect(t, connID)
+	startCoreTaskWorker(t, rig)
+	requireConnectionDeleted(t, rig, connID)
+
+	assert.Nil(t, rig.env.GetOAuth2Token(t, connID), "successful disconnect should tombstone the local OAuth token row")
+	requireProxyBlockedAfterDisconnect(t, rig, connID)
+
+	revokeReqs := rig.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointRevoke,
+		ClientID: rig.clientKey,
+	})
+	require.Lenf(t, revokeReqs, 1, "expected one refresh-token revocation request; got %d", len(revokeReqs))
+	assert.Equal(t, "refresh_token", lastForm(revokeReqs[0].Form, "token_type_hint"))
+	assert.Equal(t, refreshToken, lastForm(revokeReqs[0].Form, "token"))
+	assert.NotEqual(t, accessToken, lastForm(revokeReqs[0].Form, "token"))
+	assert.Equal(t, rig.clientKey, lastForm(revokeReqs[0].Form, "client_id"))
+}
+
+func TestDisconnectRevocation_RevocationFailureStillCompletesDisconnect(t *testing.T) {
+	rig := newDisconnectRevocationRig(t, "disconnect-revoke-fail")
+	connID := rig.completeAuthFlow(t)
+
+	require.NotNil(t, rig.env.GetOAuth2Token(t, connID))
+	rig.provider.Script("", helpers.EndpointRevoke, helpers.ScriptAction{
+		Status:    http.StatusServiceUnavailable,
+		Body:      `{"error":"temporarily_unavailable"}`,
+		FailCount: 10,
+	})
+
+	rig.disconnect(t, connID)
+	startCoreTaskWorker(t, rig)
+	requireConnectionDeleted(t, rig, connID)
+	requireProxyBlockedAfterDisconnect(t, rig, connID)
+
+	revokeReqs := rig.provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointRevoke,
+		ClientID: rig.clientKey,
+	})
+	assert.Lenf(t, revokeReqs, 3,
+		"disconnect should exhaust the revocation retry budget, then proceed with local disconnect")
+}

--- a/integration_tests/oauth2/disconnect_revocation_test.md
+++ b/integration_tests/oauth2/disconnect_revocation_test.md
@@ -1,0 +1,13 @@
+# OAuth disconnect revocation
+
+Scenario for issue #181. The test uses the provider `/test/*` control plane to complete authorization without a browser, then calls the AuthProxy disconnect API and drains the queued `core:disconnect_connection` task with an in-test Asynq worker.
+
+The fixture connector enables OAuth revocation and configures the provider's expected revoke form credentials. It revokes the refresh token, which is sufficient to invalidate provider-side credentials while exercising AuthProxy's local token cleanup path.
+
+The assertions cover:
+
+- `POST /connections/{id}/_disconnect` returns a disconnecting connection and task id;
+- the disconnect task calls the provider revocation endpoint with the stored refresh token;
+- successful provider revocation tombstones the local OAuth token row and soft-deletes the connection;
+- future proxied calls fail with `connection not found`, forcing a reconnect instead of using stale credentials;
+- provider revocation failures are retried and then the product policy proceeds with local disconnect so the connection cannot remain stuck in `disconnecting`.


### PR DESCRIPTION
Closes #181.

## Summary
- add non-interactive OAuth disconnect integration coverage using the provider /test control plane
- verify disconnect queues and drains provider revocation, tombstones the local OAuth token, and blocks future proxy calls
- verify revocation failures exhaust the retry budget but still complete local disconnect per product policy

## Tests
- go test -tags integration ./oauth2 -run 'TestDisconnectRevocation' -count=1
- ./scripts/preflight.sh