### PR TITLE
[A16] Add URL-targeted OAuth smoke harness

### DIFF
--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -12,8 +12,9 @@ Umbrella chart for the AuthProxy demo environment. Composes:
 | `demo-shell` (inline)   | SSO stand-in host (signs JWTs for demo actors)              |
 | `go-oauth2-server` (inline) | Connector target for the demo OAuth flow                |
 
-Single Ingress with sub-path routing fronts everything behind one
-hostname. TLS via cert-manager.
+Ingress fronts the demo shell and test OAuth provider on the apex host,
+with dedicated subdomains for the embedded marketplace and admin SPAs.
+TLS is issued by cert-manager.
 
 This is the **demo** chart — never install it for a customer. The
 production install path is `deploy/charts/authproxy` directly.
@@ -143,23 +144,21 @@ alongside the defaults.
 > connector-management admin API surface that isn't fully there yet;
 > tracked as a follow-up to A11.
 
-## Sub-path routing
+## Routing
 
-The umbrella Ingress maps host paths to backend services:
+The umbrella Ingress maps public hosts and paths to backend services:
 
-| Path           | Backend                                     |
-|----------------|---------------------------------------------|
-| `/`            | demo-shell                                  |
-| `/admin`       | AuthProxy admin-api (serves admin UI)       |
-| `/admin-api`   | AuthProxy admin-api (JSON API)              |
-| `/marketplace` | AuthProxy public (serves marketplace UI)    |
-| `/api`         | AuthProxy api                               |
-| `/public`      | AuthProxy public (OAuth callbacks, etc.)    |
-| `/oauth2`      | go-oauth2-server                            |
-| `/grafana`     | Grafana dashboards                          |
+| Host / path                | Backend                                  |
+|----------------------------|------------------------------------------|
+| `<hostname>/`              | demo-shell                               |
+| `<hostname>/oauth2`        | go-oauth2-server                         |
+| `<hostname>/grafana`       | Grafana dashboards                       |
+| `marketplace.<hostname>/`  | AuthProxy public (marketplace UI + API)  |
+| `admin.<hostname>/`        | AuthProxy admin-api (admin UI + API)     |
 
-(Paths are `pathType: Prefix`; order in the Ingress is significant only
-for `pathType: Exact` matches.)
+The OAuth test provider is path-routed because it is not a SPA. The
+marketplace and admin UIs use subdomains so their root-relative Vite
+assets resolve correctly.
 
 ## Smoke test
 

--- a/deploy/charts/authproxy-demo/templates/go-oauth2-server-ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/go-oauth2-server-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.ingress.enabled .Values.global.hostname .Values.goOauth2Server.enabled -}}
+{{/*
+  go-oauth2-server is reachable at https://<hostname>/oauth2 for
+  end-to-end smoke tests. Keep this on the apex host so cert-manager
+  only needs to solve the demo/admin/marketplace hostnames.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-go-oauth2-server" (include "authproxy-demo.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "authproxy-demo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: go-oauth2-server
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingressClassName | quote }}
+  rules:
+    - host: {{ .Values.global.hostname | quote }}
+      http:
+        paths:
+          - path: /oauth2(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "authproxy-demo.goOauth2Server.name" . }}
+                port:
+                  number: 80
+{{- end -}}

--- a/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
+++ b/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
@@ -28,15 +28,16 @@ spec:
         - name: go-oauth2-server
           image: "{{ .Values.goOauth2Server.image.repository }}:{{ .Values.goOauth2Server.image.tag }}"
           imagePullPolicy: {{ .Values.goOauth2Server.image.pullPolicy }}
-          # go-oauth2-server's entrypoint is a CLI; without a subcommand
-          # it prints --help and exits 0.
-          args: ["runserver"]
+          command: ["go-oauth2-server"]
+          # go-oauth2-server's entrypoint is a CLI; test mode uses an
+          # embedded store and exposes /test/* endpoints for smoke tests.
+          args: ["runserver", "--test-mode", "--test-port", {{ .Values.goOauth2Server.port | quote }}]
           ports:
             - name: http
               containerPort: {{ .Values.goOauth2Server.port }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /test/health
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5

--- a/deploy/charts/authproxy-demo/templates/ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/ingress.yaml
@@ -19,7 +19,9 @@
   each — no extra Route53 wiring needed. cert-manager mints a single
   multi-SAN cert covering all three hostnames listed under tls.hosts.
 
-  go-oauth2-server (when enabled) lives on `oauth2.<hostname>`.
+  go-oauth2-server (when enabled) lives on the apex `/oauth2` path via
+  a separate rewrite Ingress, because it is not a SPA and does not need
+  a dedicated hostname.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -40,9 +42,6 @@ spec:
         - {{ .Values.global.hostname | quote }}
         - {{ printf "marketplace.%s" .Values.global.hostname | quote }}
         - {{ printf "admin.%s" .Values.global.hostname | quote }}
-        {{- if .Values.goOauth2Server.enabled }}
-        - {{ printf "oauth2.%s" .Values.global.hostname | quote }}
-        {{- end }}
       secretName: {{ printf "%s-tls" (include "authproxy-demo.fullname" .) | quote }}
   {{- end }}
   rules:
@@ -88,16 +87,4 @@ spec:
                 name: {{ include "authproxy-demo.authproxy.serviceName" . }}
                 port:
                   name: admin-api
-    {{- if .Values.goOauth2Server.enabled }}
-    - host: {{ printf "oauth2.%s" .Values.global.hostname | quote }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "authproxy-demo.goOauth2Server.name" . }}
-                port:
-                  number: 80
-    {{- end }}
 {{- end -}}

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -4,7 +4,7 @@
 #   global           — shared inputs (hostname, ACME issuer, image tags)
 #   demoShell        — inline Deployment for the SSO stand-in host
 #   goOauth2Server   — inline Deployment for the demo connector target
-#   ingress          — single Ingress, sub-path routing
+#   ingress          — public Ingresses for demo shell, UIs, and test OAuth
 #   grafana          — optional Grafana subchart + app-metrics dashboards
 #   secrets          — auto-generation toggles for keys + passwords
 #   authproxy / postgresql / redis / minio — subchart passthroughs

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -45,12 +45,10 @@ demoShell:
   port: 8888
 
 goOauth2Server:
-  # -- Disabled by default. The upstream image expects etcd at
-  # localhost:2379 + a Postgres connection and won't come up without
-  # them — adding those subcharts is tracked as a follow-up to A11.
-  # Set to true once the chart is wired with an etcd + the right
-  # config to bring go-oauth2-server up cleanly.
-  enabled: false
+  # -- Enable the OAuth2 test provider used by demo smoke tests. It runs in
+  # upstream test mode, which uses an embedded store and exposes /test/* control
+  # endpoints for client/user setup and request inspection.
+  enabled: true
   image:
     # go-oauth2-server image — see https://github.com/rmorlok/go-oauth2-server.
     # Upstream's default branch is `master`, so that's the tag the Build
@@ -65,7 +63,7 @@ goOauth2Server:
       memory: 32Mi
     limits:
       memory: 128Mi
-  # -- Container port the upstream image listens on.
+  # -- Container port the upstream test-mode server listens on.
   port: 8080
 
 ingress:
@@ -213,6 +211,8 @@ authproxy:
     existingSecret: "{{ .Release.Name }}-actors"
   services:
     public:
+      baseUrl: "https://marketplace.{{ .Values.global.hostname }}"
+      enableProxy: true
       static:
         enabled: true
     adminApi:

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -9,6 +9,12 @@ Secrets, not in this ConfigMap.
 {{/* --- service ports --- */}}
 {{- if .Values.services.public.enabled -}}
 {{- $public := dict "port" .Values.ports.public -}}
+{{- if .Values.services.public.baseUrl -}}
+{{-   $_ := set $public "base_url" (tpl .Values.services.public.baseUrl $) -}}
+{{- end -}}
+{{- if .Values.services.public.enableProxy -}}
+{{-   $_ := set $public "enable_proxy" true -}}
+{{- end -}}
 {{- if .Values.services.public.static.enabled -}}
 {{-   $static := dict -}}
 {{-   if .Values.services.public.static.mountAt -}}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -257,6 +257,8 @@
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
+        "baseUrl": { "type": "string" },
+        "enableProxy": { "type": "boolean" },
         "static": { "$ref": "#/definitions/staticContent" }
       }
     },

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -84,6 +84,12 @@ services:
       serveFrom: ""
   public:
     enabled: true
+    # -- External base URL for the public service. Used for OAuth redirect and
+    # callback URLs when AuthProxy is behind an Ingress or proxy.
+    baseUrl: ""
+    # -- Expose /api/v1/connections/:id/_proxy on the public service.
+    # Keep disabled unless browser/session clients need direct proxy calls.
+    enableProxy: false
     static:
       # -- Serve the embedded marketplace UI from this service.
       enabled: false

--- a/integration_tests/helpers/oauth2_provider.go
+++ b/integration_tests/helpers/oauth2_provider.go
@@ -47,6 +47,15 @@ func NewOAuth2TestProvider(t *testing.T) *OAuth2TestProvider {
 		base = defaultOAuth2TestProviderURL
 	}
 
+	return NewOAuth2TestProviderAt(t, base)
+}
+
+// NewOAuth2TestProviderAt connects to a specific test-mode OAuth2 server URL.
+// It is useful for smoke tests that target an already-running environment
+// instead of the docker-compose provider on localhost.
+func NewOAuth2TestProviderAt(t *testing.T, base string) *OAuth2TestProvider {
+	t.Helper()
+
 	p := &OAuth2TestProvider{
 		t:       t,
 		BaseURL: base,

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -1,0 +1,300 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/apid"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+type RemoteAuthProxyOptions struct {
+	BaseURL string
+
+	AdminURL    string
+	PublicURL   string
+	ProviderURL string
+
+	AdminActorExternalID string
+	UserActorExternalID  string
+	Namespace            string
+
+	AdminPrivateKey string
+}
+
+type RemoteAuthProxy struct {
+	AdminURL    string
+	PublicURL   string
+	ProviderURL string
+
+	AdminActorExternalID string
+	UserActorExternalID  string
+	Namespace            string
+
+	privateKey string
+	client     *http.Client
+}
+
+type remoteResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthProxy {
+	t.Helper()
+
+	require.NotEmpty(t, opts.BaseURL, "base URL is required")
+	require.NotEmpty(t, opts.AdminPrivateKey, "admin private key is required")
+
+	adminURL := opts.AdminURL
+	if adminURL == "" {
+		adminURL = mustDeriveSubdomainURL(t, opts.BaseURL, "admin")
+	}
+	publicURL := opts.PublicURL
+	if publicURL == "" {
+		publicURL = mustDeriveSubdomainURL(t, opts.BaseURL, "marketplace")
+	}
+	providerURL := opts.ProviderURL
+	if providerURL == "" {
+		providerURL = mustDeriveSubdomainURL(t, opts.BaseURL, "oauth2")
+	}
+
+	adminActor := opts.AdminActorExternalID
+	if adminActor == "" {
+		adminActor = "demo-shell"
+	}
+	userActor := opts.UserActorExternalID
+	if userActor == "" {
+		userActor = "fresh-user"
+	}
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = sconfig.RootNamespace
+	}
+
+	return &RemoteAuthProxy{
+		AdminURL:             strings.TrimRight(adminURL, "/"),
+		PublicURL:            strings.TrimRight(publicURL, "/"),
+		ProviderURL:          strings.TrimRight(providerURL, "/"),
+		AdminActorExternalID: adminActor,
+		UserActorExternalID:  userActor,
+		Namespace:            namespace,
+		privateKey:           opts.AdminPrivateKey,
+		client:               &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (h *RemoteAuthProxy) CreateActor(t *testing.T, externalID string, labels map[string]string) schemaapi.ActorJson {
+	t.Helper()
+
+	var actor schemaapi.ActorJson
+	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/actors", schemaapi.CreateActorRequestJson{
+		ExternalId: externalID,
+		Namespace:  h.Namespace,
+		Labels:     labels,
+	}, true, http.StatusCreated, &actor)
+	return actor
+}
+
+func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	var created schemaapi.ConnectorVersionJson
+	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/connectors", schemaapi.CreateConnectorRequestJson{
+		Namespace:  h.Namespace,
+		Definition: connector,
+		Labels: map[string]string{
+			"smoke": "true",
+		},
+	}, true, http.StatusCreated, &created)
+	return created
+}
+
+func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID apid.ID, version uint64, state string) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	var updated schemaapi.ConnectorVersionJson
+	h.doSigned(
+		t,
+		h.AdminActorExternalID,
+		http.MethodPut,
+		fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_force_state", h.AdminURL, connectorID, version),
+		schemaapi.ForceConnectorVersionStateRequestJson{State: state},
+		true,
+		http.StatusOK,
+		&updated,
+	)
+	return updated
+}
+
+func (h *RemoteAuthProxy) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToURL string) (connectionID, redirectURL string) {
+	t.Helper()
+
+	var redirect schemaapi.ConnectionSetupRedirect
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
+		ConnectorId:   connectorID,
+		IntoNamespace: h.Namespace,
+		ReturnToUrl:   returnToURL,
+	}, true, http.StatusOK, &redirect)
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, redirect.Type)
+	require.NotEmpty(t, redirect.RedirectUrl)
+	return redirect.Id.String(), redirect.RedirectUrl
+}
+
+func (h *RemoteAuthProxy) FollowOAuth2Redirect(t *testing.T, redirectURL string) string {
+	t.Helper()
+
+	resp := h.doSigned(t, h.UserActorExternalID, http.MethodGet, redirectURL, nil, false, http.StatusFound, nil)
+	loc := resp.Header.Get("Location")
+	require.NotEmpty(t, loc, "OAuth2 redirect response should include Location")
+	return loc
+}
+
+func (h *RemoteAuthProxy) DeliverOAuth2Callback(t *testing.T, callbackURL string) string {
+	t.Helper()
+
+	resp := h.doSigned(t, h.UserActorExternalID, http.MethodGet, callbackURL, nil, false, http.StatusFound, nil)
+	loc := resp.Header.Get("Location")
+	require.NotEmpty(t, loc, "OAuth2 callback response should include Location")
+	return loc
+}
+
+func (h *RemoteAuthProxy) DoProxyRequest(t *testing.T, connectionID, targetURL, method string) schemaapi.ProxyResponseJson {
+	t.Helper()
+
+	var proxyResp schemaapi.ProxyResponseJson
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_proxy", schemaapi.ProxyRequestJson{
+		URL:    targetURL,
+		Method: method,
+	}, true, http.StatusOK, &proxyResp)
+	return proxyResp
+}
+
+func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, method, rawURL string, body any, followRedirects bool, wantStatus int, out any) remoteResponse {
+	t.Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		require.NoError(t, err, "marshal request body")
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	signer, err := h.signer(actorExternalID)
+	require.NoError(t, err, "build JWT signer for %s", actorExternalID)
+	signer.SignAuthHeader(req)
+
+	client := h.client
+	if !followRedirects {
+		client = &http.Client{
+			Timeout: h.client.Timeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+
+	resp, err := client.Do(req)
+	require.NoError(t, err, "%s %s", method, rawURL)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "read response body")
+	require.Equalf(t, wantStatus, resp.StatusCode, "%s %s returned %d: %s", method, rawURL, resp.StatusCode, string(respBody))
+
+	if out != nil {
+		require.NoError(t, json.Unmarshal(respBody, out), "decode response from %s %s: %s", method, rawURL, string(respBody))
+	}
+
+	return remoteResponse{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header.Clone(),
+		Body:       respBody,
+	}
+}
+
+func (h *RemoteAuthProxy) signer(actorExternalID string) (jwt.Signer, error) {
+	builder := jwt.NewJwtTokenBuilder().
+		WithActorExternalId(actorExternalID).
+		WithNamespace(h.Namespace).
+		WithActorSigned().
+		WithServiceIds(sconfig.AllServiceIds()).
+		WithPermissions(aschema.AllPermissions()).
+		WithExpiresIn(15 * time.Minute)
+
+	if looksLikePath(h.privateKey) {
+		builder = builder.WithPrivateKeyPath(h.privateKey)
+	} else {
+		builder = builder.WithPrivateKeyString(h.privateKey)
+	}
+
+	return builder.Signer()
+}
+
+func mustDeriveSubdomainURL(t *testing.T, baseURL, subdomain string) string {
+	t.Helper()
+	derived, err := deriveSubdomainURL(baseURL, subdomain)
+	require.NoError(t, err)
+	return derived
+}
+
+func deriveSubdomainURL(baseURL, subdomain string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("base URL must include scheme and host: %q", baseURL)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("base URL must include host: %q", baseURL)
+	}
+	if !strings.HasPrefix(host, subdomain+".") {
+		host = subdomain + "." + host
+	}
+
+	if port := u.Port(); port != "" {
+		u.Host = net.JoinHostPort(host, port)
+	} else {
+		u.Host = host
+	}
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func looksLikePath(value string) bool {
+	if strings.Contains(value, "-----BEGIN ") {
+		return false
+	}
+	if strings.Contains(value, "\n") {
+		return false
+	}
+	_, err := os.Stat(value)
+	return err == nil
+}

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -70,7 +70,7 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 	}
 	providerURL := opts.ProviderURL
 	if providerURL == "" {
-		providerURL = mustDeriveSubdomainURL(t, opts.BaseURL, "oauth2")
+		providerURL = mustDerivePathURL(t, opts.BaseURL, "/oauth2")
 	}
 
 	adminActor := opts.AdminActorExternalID
@@ -259,6 +259,13 @@ func mustDeriveSubdomainURL(t *testing.T, baseURL, subdomain string) string {
 	return derived
 }
 
+func mustDerivePathURL(t *testing.T, baseURL, path string) string {
+	t.Helper()
+	derived, err := derivePathURL(baseURL, path)
+	require.NoError(t, err)
+	return derived
+}
+
 func deriveSubdomainURL(baseURL, subdomain string) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -282,6 +289,22 @@ func deriveSubdomainURL(baseURL, subdomain string) (string, error) {
 		u.Host = host
 	}
 	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func derivePathURL(baseURL, path string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("base URL must include scheme and host: %q", baseURL)
+	}
+
+	u.Path = "/" + strings.Trim(path, "/")
 	u.RawPath = ""
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -1,0 +1,136 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	smokeBaseURL  = flag.String("base-url", os.Getenv("SMOKE_BASE_URL"), "base AuthProxy demo URL, e.g. https://demo.authproxy.net")
+	smokeAdminKey = flag.String("admin-key", os.Getenv("SMOKE_ADMIN_KEY"), "admin actor private key PEM, or a path to it")
+)
+
+func TestRemoteOAuth2ProxySmoke(t *testing.T) {
+	if *smokeBaseURL == "" {
+		t.Skip("set SMOKE_BASE_URL or pass -base-url")
+	}
+	if *smokeAdminKey == "" {
+		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
+	}
+
+	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
+		BaseURL:         *smokeBaseURL,
+		AdminPrivateKey: *smokeAdminKey,
+	})
+	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
+
+	startedAt := time.Now().Add(-1 * time.Second)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := "smoke-client-" + suffix
+	clientSecret := "smoke-secret-" + suffix
+	userEmail := "smoke-user-" + suffix + "@example.com"
+
+	client := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             rig.PublicURL + "/oauth2/callback",
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, client.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: "p4ssw0rd-" + suffix,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "smoke-oauth2-"+suffix, provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+	created := rig.CreateConnector(t, connector)
+	require.Equal(t, uint64(1), created.Version)
+	rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStatePrimary))
+	t.Cleanup(func() {
+		rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStateArchived))
+	})
+
+	connectionID, redirectURL := rig.InitiateOAuth2Connection(t, created.Id, rig.PublicURL+"/connections")
+	require.NotEmpty(t, connectionID)
+
+	authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
+	authorizeParams := parseQuery(t, authorizeURL)
+	require.Equal(t, clientKey, authorizeParams.Get("client_id"))
+	require.Equal(t, rig.PublicURL+"/oauth2/callback", authorizeParams.Get("redirect_uri"))
+	require.NotEmpty(t, authorizeParams.Get("state"))
+
+	callback := provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    clientKey,
+		UserID:      user.ID,
+		RedirectURI: authorizeParams.Get("redirect_uri"),
+		Scope:       authorizeParams.Get("scope"),
+		State:       authorizeParams.Get("state"),
+		Decision:    helpers.AuthorizeApprove,
+	})
+	require.NotEmpty(t, callback.RedirectURL)
+
+	finalLocation := rig.DeliverOAuth2Callback(t, callback.RedirectURL)
+	assert.Truef(t, strings.HasPrefix(finalLocation, rig.PublicURL+"/connections"),
+		"expected callback to land on marketplace connections page, got %q", finalLocation)
+
+	proxyResp := rig.DoProxyRequest(t, connectionID, provider.ResourceURL("/echo"), http.MethodGet)
+	require.Equal(t, http.StatusOK, proxyResp.StatusCode)
+
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientKey,
+		Since:    startedAt,
+	})
+	require.NotEmpty(t, tokenReqs, "provider should record the token exchange")
+	assert.Equal(t, "authorization_code", lastFormValue(tokenReqs[len(tokenReqs)-1].Form, "grant_type"))
+
+	resourceReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointResource,
+		Since:    startedAt,
+	})
+	require.NotEmpty(t, resourceReqs, "provider should record the proxied resource call")
+	authHeader := resourceReqs[len(resourceReqs)-1].Headers["Authorization"]
+	if authHeader == "" {
+		authHeader = resourceReqs[len(resourceReqs)-1].Headers["authorization"]
+	}
+	require.Truef(t, strings.HasPrefix(strings.ToLower(authHeader), "bearer "),
+		"proxied resource call should use bearer auth, got %q", authHeader)
+}
+
+func parseQuery(t *testing.T, rawURL string) url.Values {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed.Query()
+}
+
+func lastFormValue(form map[string][]string, key string) string {
+	values := form[key]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[len(values)-1]
+}

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -599,6 +599,9 @@
         "port": {
           "$ref": "../common/schema.json#/$defs/IntegerValue"
         },
+        "base_url": {
+          "$ref": "../common/schema.json#/$defs/StringValue"
+        },
         "domain": {
           "type": "string"
         },
@@ -653,6 +656,9 @@
         "port": {
           "$ref": "../common/schema.json#/$defs/IntegerValue"
         },
+        "base_url": {
+          "$ref": "../common/schema.json#/$defs/StringValue"
+        },
         "domain": {
           "type": "string"
         },
@@ -676,6 +682,9 @@
         },
         "port": {
           "$ref": "../common/schema.json#/$defs/IntegerValue"
+        },
+        "base_url": {
+          "$ref": "../common/schema.json#/$defs/StringValue"
         },
         "domain": {
           "type": "string"

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -1053,6 +1053,11 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"port": 8080, "health_check_port": 8081}}`,
 				},
 				{
+					Name:  "base_url as string",
+					Valid: true,
+					Data:  `{"test": {"port": 8080, "base_url": "https://api.example.com"}}`,
+				},
+				{
 					Name:  "port as string is invalid for IntegerValue",
 					Valid: false,
 					Data:  `{"test": {"port": "bad"}}`,

--- a/internal/schema/config/service_common.go
+++ b/internal/schema/config/service_common.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -29,6 +30,7 @@ func (s *ServiceCommon) healthCheckPort() *uint64 {
 type ServiceHttp struct {
 	ServiceCommon `json:",inline" yaml:",inline"`
 	PortVal       *IntegerValue `json:"port" yaml:"port"`
+	BaseUrl       *StringValue  `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	DomainVal     string        `json:"domain" yaml:"domain"`
 	IsHttpsVal    bool          `json:"https" yaml:"https"`
 	CorsVal       *CorsConfig   `json:"cors,omitempty" yaml:"cors,omitempty"`
@@ -112,6 +114,14 @@ func (s *ServiceHttp) Domain() string {
 }
 
 func (s *ServiceHttp) GetBaseUrl() string {
+	ctx := context.Background()
+	if s.BaseUrl != nil && s.BaseUrl.HasValue(ctx) {
+		baseUrl, err := s.BaseUrl.GetValue(ctx)
+		if err == nil && baseUrl != "" {
+			return strings.TrimRight(baseUrl, "/")
+		}
+	}
+
 	proto := "http"
 	if s.IsHttps() {
 		proto = "https"


### PR DESCRIPTION
## Summary
- add a build-tagged smoke package that can target a deployed demo URL with SMOKE_BASE_URL/SMOKE_ADMIN_KEY or -base-url/-admin-key
- add a reusable remote AuthProxy test helper for signed admin/public requests
- wire the demo chart to run go-oauth2-server in test mode and expose public proxying/base_url for ingress-backed OAuth callbacks

Closes #302.

## Verification
- go test ./internal/schema/config -count=1
- go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 (from integration_tests, skips without env)
- helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.authproxy.net --show-only charts/authproxy/templates/configmap.yaml
- ./scripts/preflight.sh

## Live demo note
I enabled the in-cluster go-oauth2-server and public proxying on the live demo while testing. The full live smoke still needs this branch's new image because the current deployed image rejects the new public.base_url config field in its embedded schema; I restored the live release without base_url after confirming that.