### PR TITLE
Rename app metrics list builder filters

### DIFF
--- a/integration_tests/proxy/raw_body_capture_test.go
+++ b/integration_tests/proxy/raw_body_capture_test.go
@@ -57,7 +57,7 @@ func waitForLog(t *testing.T, env *helpers.IntegrationTestEnv, connectionID stri
 	end := time.Now().Add(deadline)
 	for time.Now().Before(end) {
 		page := store.NewListRequestsBuilder().
-			WithConnectionId(connID).
+			ForConnectionId(connID).
 			Limit(5).
 			FetchPage(context.Background())
 		if page.Error == nil && len(page.Results) > 0 {

--- a/internal/app_metrics/list.go
+++ b/internal/app_metrics/list.go
@@ -64,25 +64,25 @@ type ListRequestBuilder interface {
 	 * Filters
 	 */
 
-	WithNamespaceMatcher(matcher string) ListRequestBuilder
-	WithNamespaceMatchers(matchers []string) ListRequestBuilder
-	WithRequestType(requestType httpf.RequestType) ListRequestBuilder
-	WithCorrelationId(correlationId string) ListRequestBuilder
-	WithConnectionId(u apid.ID) ListRequestBuilder
-	WithConnectorType(t string) ListRequestBuilder
-	WithConnectorId(u apid.ID) ListRequestBuilder
-	WithConnectorVersion(v uint64) ListRequestBuilder
-	WithMethod(method string) ListRequestBuilder
-	WithStatusCode(s int) ListRequestBuilder
-	WithStatusCodeRangeInclusive(start, end int) ListRequestBuilder
-	WithParsedStatusCodeRange(r string) (ListRequestBuilder, error)
-	WithPath(path string) ListRequestBuilder
-	WithPathRegex(r string) (ListRequestBuilder, error)
-	WithTimestampRange(start, end time.Time) ListRequestBuilder
-	WithParsedTimestampRange(r string) (ListRequestBuilder, error)
-	WithLabelSelector(selector string) (ListRequestBuilder, error)
-	WithResponseSource(s ResponseSource) ListRequestBuilder
-	WithRateLimitId(id apid.ID) ListRequestBuilder
+	ForNamespaceMatcher(matcher string) ListRequestBuilder
+	ForNamespaceMatchers(matchers []string) ListRequestBuilder
+	ForRequestType(requestType httpf.RequestType) ListRequestBuilder
+	ForCorrelationId(correlationId string) ListRequestBuilder
+	ForConnectionId(u apid.ID) ListRequestBuilder
+	ForConnectorType(t string) ListRequestBuilder
+	ForConnectorId(u apid.ID) ListRequestBuilder
+	ForConnectorVersion(v uint64) ListRequestBuilder
+	ForMethod(method string) ListRequestBuilder
+	ForStatusCode(s int) ListRequestBuilder
+	ForStatusCodeRangeInclusive(start, end int) ListRequestBuilder
+	ForParsedStatusCodeRange(r string) (ListRequestBuilder, error)
+	ForPath(path string) ListRequestBuilder
+	ForPathRegex(r string) (ListRequestBuilder, error)
+	ForTimestampRange(start, end time.Time) ListRequestBuilder
+	ForParsedTimestampRange(r string) (ListRequestBuilder, error)
+	ForLabelSelector(selector string) (ListRequestBuilder, error)
+	ForResponseSource(s ResponseSource) ListRequestBuilder
+	ForRateLimitId(id apid.ID) ListRequestBuilder
 }
 
 // ListFilters holds the filter, pagination, and ordering data for list requests.

--- a/internal/app_metrics/mock/list.go
+++ b/internal/app_metrics/mock/list.go
@@ -38,99 +38,99 @@ type MockListRequestBuilderExecutor struct {
 	RateLimitId              *apid.ID    `json:"rate_limit_id,omitempty"`
 }
 
-func (l *MockListRequestBuilderExecutor) WithNamespaceMatcher(matcher string) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForNamespaceMatcher(matcher string) app_metrics.ListRequestBuilder {
 	l.Namespace = util.ToPtr(matcher)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithNamespaceMatchers(matchers []string) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForNamespaceMatchers(matchers []string) app_metrics.ListRequestBuilder {
 	l.Namespaces = matchers
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithRequestType(requestType httpf.RequestType) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForRequestType(requestType httpf.RequestType) app_metrics.ListRequestBuilder {
 	l.RequestType = util.ToPtr(string(requestType))
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithCorrelationId(correlationId string) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForCorrelationId(correlationId string) app_metrics.ListRequestBuilder {
 	l.CorrelationId = util.ToPtr(correlationId)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithConnectionId(u apid.ID) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForConnectionId(u apid.ID) app_metrics.ListRequestBuilder {
 	l.ConnectionId = util.ToPtr(u)
 	return l
 }
 
-// WithConnectorType sets the filter to match a specific connector type. The connector type
+// ForConnectorType sets the filter to match a specific connector type. The connector type
 // may include wildcards * and %.
-func (l *MockListRequestBuilderExecutor) WithConnectorType(t string) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForConnectorType(t string) app_metrics.ListRequestBuilder {
 	l.ConnectorType = util.ToPtr(t)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithConnectorId(u apid.ID) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForConnectorId(u apid.ID) app_metrics.ListRequestBuilder {
 	l.ConnectorId = util.ToPtr(u)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithConnectorVersion(v uint64) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForConnectorVersion(v uint64) app_metrics.ListRequestBuilder {
 	l.ConnectorVersion = util.ToPtr(v)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithMethod(method string) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForMethod(method string) app_metrics.ListRequestBuilder {
 	l.Method = util.ToPtr(method)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithStatusCode(s int) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForStatusCode(s int) app_metrics.ListRequestBuilder {
 	l.StatusCodeRangeInclusive = []int{s, s}
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithStatusCodeRangeInclusive(start, end int) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForStatusCodeRangeInclusive(start, end int) app_metrics.ListRequestBuilder {
 	l.StatusCodeRangeInclusive = []int{start, end}
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithParsedStatusCodeRange(r string) (app_metrics.ListRequestBuilder, error) {
+func (l *MockListRequestBuilderExecutor) ForParsedStatusCodeRange(r string) (app_metrics.ListRequestBuilder, error) {
 	// No op
 	return l, nil
 }
 
-// WithPath sets the filter to match a specific path. The path can include wildcards * and %.
-func (l *MockListRequestBuilderExecutor) WithPath(path string) app_metrics.ListRequestBuilder {
+// ForPath sets the filter to match a specific path. The path can include wildcards * and %.
+func (l *MockListRequestBuilderExecutor) ForPath(path string) app_metrics.ListRequestBuilder {
 	l.Path = util.ToPtr(path)
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithPathRegex(r string) (app_metrics.ListRequestBuilder, error) {
+func (l *MockListRequestBuilderExecutor) ForPathRegex(r string) (app_metrics.ListRequestBuilder, error) {
 	l.PathRegex = util.ToPtr(r)
 	return l, nil
 }
 
-func (l *MockListRequestBuilderExecutor) WithTimestampRange(start, end time.Time) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForTimestampRange(start, end time.Time) app_metrics.ListRequestBuilder {
 	l.TimestampRange = []time.Time{start, end}
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithParsedTimestampRange(r string) (app_metrics.ListRequestBuilder, error) {
+func (l *MockListRequestBuilderExecutor) ForParsedTimestampRange(r string) (app_metrics.ListRequestBuilder, error) {
 	return l, nil
 }
 
-func (l *MockListRequestBuilderExecutor) WithLabelSelector(selector string) (app_metrics.ListRequestBuilder, error) {
+func (l *MockListRequestBuilderExecutor) ForLabelSelector(selector string) (app_metrics.ListRequestBuilder, error) {
 	l.LabelSelector = util.ToPtr(selector)
 	return l, nil
 }
 
-func (l *MockListRequestBuilderExecutor) WithResponseSource(s app_metrics.ResponseSource) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForResponseSource(s app_metrics.ResponseSource) app_metrics.ListRequestBuilder {
 	l.ResponseSource = util.ToPtr(string(s))
 	return l
 }
 
-func (l *MockListRequestBuilderExecutor) WithRateLimitId(id apid.ID) app_metrics.ListRequestBuilder {
+func (l *MockListRequestBuilderExecutor) ForRateLimitId(id apid.ID) app_metrics.ListRequestBuilder {
 	l.RateLimitId = util.ToPtr(id)
 	return l
 }

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -327,110 +327,110 @@ func (l *clickhouseListRequestsBuilder) OrderBy(field RequestOrderByField, by pa
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithNamespaceMatcher(matcher string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithNamespaceMatcher(matcher)
+func (l *clickhouseListRequestsBuilder) ForNamespaceMatcher(matcher string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForNamespaceMatcher(matcher)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithNamespaceMatchers(matchers []string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithNamespaceMatchers(matchers)
+func (l *clickhouseListRequestsBuilder) ForNamespaceMatchers(matchers []string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForNamespaceMatchers(matchers)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithRequestType(requestType httpf.RequestType) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithRequestType(requestType)
+func (l *clickhouseListRequestsBuilder) ForRequestType(requestType httpf.RequestType) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForRequestType(requestType)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithCorrelationId(correlationId string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithCorrelationId(correlationId)
+func (l *clickhouseListRequestsBuilder) ForCorrelationId(correlationId string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForCorrelationId(correlationId)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithConnectionId(u apid.ID) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithConnectionId(u)
+func (l *clickhouseListRequestsBuilder) ForConnectionId(u apid.ID) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForConnectionId(u)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithConnectorType(t string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithConnectorType(t)
+func (l *clickhouseListRequestsBuilder) ForConnectorType(t string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForConnectorType(t)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithConnectorId(u apid.ID) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithConnectorId(u)
+func (l *clickhouseListRequestsBuilder) ForConnectorId(u apid.ID) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForConnectorId(u)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithConnectorVersion(v uint64) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithConnectorVersion(v)
+func (l *clickhouseListRequestsBuilder) ForConnectorVersion(v uint64) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForConnectorVersion(v)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithMethod(method string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithMethod(method)
+func (l *clickhouseListRequestsBuilder) ForMethod(method string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForMethod(method)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithStatusCode(s int) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithStatusCode(s)
+func (l *clickhouseListRequestsBuilder) ForStatusCode(s int) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForStatusCode(s)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithStatusCodeRangeInclusive(start, end int) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithStatusCodeRangeInclusive(start, end)
+func (l *clickhouseListRequestsBuilder) ForStatusCodeRangeInclusive(start, end int) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForStatusCodeRangeInclusive(start, end)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithParsedStatusCodeRange(r string) (ListRequestBuilder, error) {
-	_, err := l.sqlListRequestsBuilder.WithParsedStatusCodeRange(r)
+func (l *clickhouseListRequestsBuilder) ForParsedStatusCodeRange(r string) (ListRequestBuilder, error) {
+	_, err := l.sqlListRequestsBuilder.ForParsedStatusCodeRange(r)
 	if err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func (l *clickhouseListRequestsBuilder) WithPath(path string) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithPath(path)
+func (l *clickhouseListRequestsBuilder) ForPath(path string) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForPath(path)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithPathRegex(r string) (ListRequestBuilder, error) {
-	_, err := l.sqlListRequestsBuilder.WithPathRegex(r)
+func (l *clickhouseListRequestsBuilder) ForPathRegex(r string) (ListRequestBuilder, error) {
+	_, err := l.sqlListRequestsBuilder.ForPathRegex(r)
 	if err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func (l *clickhouseListRequestsBuilder) WithTimestampRange(start, end time.Time) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithTimestampRange(start, end)
+func (l *clickhouseListRequestsBuilder) ForTimestampRange(start, end time.Time) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForTimestampRange(start, end)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithParsedTimestampRange(r string) (ListRequestBuilder, error) {
-	_, err := l.sqlListRequestsBuilder.WithParsedTimestampRange(r)
+func (l *clickhouseListRequestsBuilder) ForParsedTimestampRange(r string) (ListRequestBuilder, error) {
+	_, err := l.sqlListRequestsBuilder.ForParsedTimestampRange(r)
 	if err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func (l *clickhouseListRequestsBuilder) WithLabelSelector(selector string) (ListRequestBuilder, error) {
-	_, err := l.sqlListRequestsBuilder.WithLabelSelector(selector)
+func (l *clickhouseListRequestsBuilder) ForLabelSelector(selector string) (ListRequestBuilder, error) {
+	_, err := l.sqlListRequestsBuilder.ForLabelSelector(selector)
 	if err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func (l *clickhouseListRequestsBuilder) WithResponseSource(s ResponseSource) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithResponseSource(s)
+func (l *clickhouseListRequestsBuilder) ForResponseSource(s ResponseSource) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForResponseSource(s)
 	return l
 }
 
-func (l *clickhouseListRequestsBuilder) WithRateLimitId(id apid.ID) ListRequestBuilder {
-	l.sqlListRequestsBuilder.WithRateLimitId(id)
+func (l *clickhouseListRequestsBuilder) ForRateLimitId(id apid.ID) ListRequestBuilder {
+	l.sqlListRequestsBuilder.ForRateLimitId(id)
 	return l
 }
 

--- a/internal/app_metrics/provider_record_test.go
+++ b/internal/app_metrics/provider_record_test.go
@@ -186,14 +186,14 @@ func TestRequestEvents_List_FilterByNamespace(t *testing.T) {
 	require.NoError(t, store.StoreRecords(ctx, []*LogRecord{rRoot, rRootA, rRootAB, rRootC}))
 
 	t.Run("exact namespace match", func(t *testing.T) {
-		result := retriever.NewListRequestsBuilder().WithNamespaceMatcher("root.a").FetchPage(ctx)
+		result := retriever.NewListRequestsBuilder().ForNamespaceMatcher("root.a").FetchPage(ctx)
 		require.NoError(t, result.Error)
 		ids := collectIDs(result.Results)
 		require.Equal(t, map[apid.ID]bool{rRootA.RequestId: true}, ids)
 	})
 
 	t.Run("recursive namespace match with .**", func(t *testing.T) {
-		result := retriever.NewListRequestsBuilder().WithNamespaceMatcher("root.**").FetchPage(ctx)
+		result := retriever.NewListRequestsBuilder().ForNamespaceMatcher("root.**").FetchPage(ctx)
 		require.NoError(t, result.Error)
 		ids := collectIDs(result.Results)
 		require.True(t, ids[rRoot.RequestId])
@@ -240,19 +240,19 @@ func TestRequestEvents_List_FilterByScalarFields(t *testing.T) {
 		name  string
 		apply func(b ListRequestBuilder) ListRequestBuilder
 	}{
-		{"correlation_id", func(b ListRequestBuilder) ListRequestBuilder { return b.WithCorrelationId("match") }},
-		{"connection_id", func(b ListRequestBuilder) ListRequestBuilder { return b.WithConnectionId(connId) }},
-		{"connector_id", func(b ListRequestBuilder) ListRequestBuilder { return b.WithConnectorId(connectorId) }},
-		{"connector_version", func(b ListRequestBuilder) ListRequestBuilder { return b.WithConnectorVersion(42) }},
-		{"method", func(b ListRequestBuilder) ListRequestBuilder { return b.WithMethod("POST") }},
-		{"status_code single", func(b ListRequestBuilder) ListRequestBuilder { return b.WithStatusCode(404) }},
-		{"status_code range", func(b ListRequestBuilder) ListRequestBuilder { return b.WithStatusCodeRangeInclusive(400, 499) }},
-		{"path exact", func(b ListRequestBuilder) ListRequestBuilder { return b.WithPath("/wanted") }},
-		{"request_type", func(b ListRequestBuilder) ListRequestBuilder { return b.WithRequestType(httpf.RequestTypeOAuth) }},
+		{"correlation_id", func(b ListRequestBuilder) ListRequestBuilder { return b.ForCorrelationId("match") }},
+		{"connection_id", func(b ListRequestBuilder) ListRequestBuilder { return b.ForConnectionId(connId) }},
+		{"connector_id", func(b ListRequestBuilder) ListRequestBuilder { return b.ForConnectorId(connectorId) }},
+		{"connector_version", func(b ListRequestBuilder) ListRequestBuilder { return b.ForConnectorVersion(42) }},
+		{"method", func(b ListRequestBuilder) ListRequestBuilder { return b.ForMethod("POST") }},
+		{"status_code single", func(b ListRequestBuilder) ListRequestBuilder { return b.ForStatusCode(404) }},
+		{"status_code range", func(b ListRequestBuilder) ListRequestBuilder { return b.ForStatusCodeRangeInclusive(400, 499) }},
+		{"path exact", func(b ListRequestBuilder) ListRequestBuilder { return b.ForPath("/wanted") }},
+		{"request_type", func(b ListRequestBuilder) ListRequestBuilder { return b.ForRequestType(httpf.RequestTypeOAuth) }},
 		{"response_source", func(b ListRequestBuilder) ListRequestBuilder {
-			return b.WithResponseSource(ResponseSourceConnectorRateLimiter)
+			return b.ForResponseSource(ResponseSourceConnectorRateLimiter)
 		}},
-		{"rate_limit_id", func(b ListRequestBuilder) ListRequestBuilder { return b.WithRateLimitId(rateLimitId) }},
+		{"rate_limit_id", func(b ListRequestBuilder) ListRequestBuilder { return b.ForRateLimitId(rateLimitId) }},
 	}
 
 	for _, tc := range cases {
@@ -278,7 +278,7 @@ func TestRequestEvents_List_FilterByTimestampRange(t *testing.T) {
 
 	rangeStart := base.Add(-90 * time.Minute)
 	rangeEnd := base.Add(-30 * time.Minute)
-	result := retriever.NewListRequestsBuilder().WithTimestampRange(rangeStart, rangeEnd).FetchPage(ctx)
+	result := retriever.NewListRequestsBuilder().ForTimestampRange(rangeStart, rangeEnd).FetchPage(ctx)
 	require.NoError(t, result.Error)
 	require.Equal(t, map[apid.ID]bool{mid.RequestId: true}, collectIDs(result.Results))
 }
@@ -295,42 +295,42 @@ func TestRequestEvents_List_LabelSelector(t *testing.T) {
 	require.NoError(t, store.StoreRecords(ctx, []*LogRecord{r1, r2, r3, r4, r5}))
 
 	t.Run("equality", func(t *testing.T) {
-		b, err := retriever.NewListRequestsBuilder().WithLabelSelector("env=prod")
+		b, err := retriever.NewListRequestsBuilder().ForLabelSelector("env=prod")
 		require.NoError(t, err)
 		ids := collectIDs(b.FetchPage(ctx).Results)
 		require.Equal(t, map[apid.ID]bool{r1.RequestId: true, r3.RequestId: true}, ids)
 	})
 
 	t.Run("multiple equalities", func(t *testing.T) {
-		b, err := retriever.NewListRequestsBuilder().WithLabelSelector("env=prod,team=api")
+		b, err := retriever.NewListRequestsBuilder().ForLabelSelector("env=prod,team=api")
 		require.NoError(t, err)
 		ids := collectIDs(b.FetchPage(ctx).Results)
 		require.Equal(t, map[apid.ID]bool{r1.RequestId: true}, ids)
 	})
 
 	t.Run("exists", func(t *testing.T) {
-		b, err := retriever.NewListRequestsBuilder().WithLabelSelector("env")
+		b, err := retriever.NewListRequestsBuilder().ForLabelSelector("env")
 		require.NoError(t, err)
 		ids := collectIDs(b.FetchPage(ctx).Results)
 		require.Equal(t, map[apid.ID]bool{r1.RequestId: true, r2.RequestId: true, r3.RequestId: true}, ids)
 	})
 
 	t.Run("not exists", func(t *testing.T) {
-		b, err := retriever.NewListRequestsBuilder().WithLabelSelector("!env")
+		b, err := retriever.NewListRequestsBuilder().ForLabelSelector("!env")
 		require.NoError(t, err)
 		ids := collectIDs(b.FetchPage(ctx).Results)
 		require.Equal(t, map[apid.ID]bool{r4.RequestId: true, r5.RequestId: true}, ids)
 	})
 
 	t.Run("not equal", func(t *testing.T) {
-		b, err := retriever.NewListRequestsBuilder().WithLabelSelector("env!=prod")
+		b, err := retriever.NewListRequestsBuilder().ForLabelSelector("env!=prod")
 		require.NoError(t, err)
 		ids := collectIDs(b.FetchPage(ctx).Results)
 		require.Equal(t, map[apid.ID]bool{r2.RequestId: true, r4.RequestId: true, r5.RequestId: true}, ids)
 	})
 
 	t.Run("invalid selector", func(t *testing.T) {
-		_, err := retriever.NewListRequestsBuilder().WithLabelSelector("invalid key with spaces=value")
+		_, err := retriever.NewListRequestsBuilder().ForLabelSelector("invalid key with spaces=value")
 		require.Error(t, err)
 	})
 }
@@ -389,7 +389,7 @@ func TestRequestEvents_List_Pagination_CursorRoundTrip(t *testing.T) {
 		}
 	}
 
-	page1 := retriever.NewListRequestsBuilder().Limit(2).WithPath("/page").FetchPage(ctx)
+	page1 := retriever.NewListRequestsBuilder().Limit(2).ForPath("/page").FetchPage(ctx)
 	require.NoError(t, page1.Error)
 	require.True(t, page1.HasMore)
 	require.NotEmpty(t, page1.Cursor)

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -386,66 +386,66 @@ func (l *sqlListRequestsBuilder) OrderBy(field RequestOrderByField, by paginatio
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithNamespaceMatcher(matcher string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForNamespaceMatcher(matcher string) ListRequestBuilder {
 	if err := l.ListFilters.SetNamespaceMatcher(matcher); err != nil {
 		return l.addError(err)
 	}
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithNamespaceMatchers(matchers []string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForNamespaceMatchers(matchers []string) ListRequestBuilder {
 	if err := l.ListFilters.SetNamespaceMatchers(matchers); err != nil {
 		return l.addError(err)
 	}
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithRequestType(requestType httpf.RequestType) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForRequestType(requestType httpf.RequestType) ListRequestBuilder {
 	l.ListFilters.SetRequestType(requestType)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithCorrelationId(correlationId string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForCorrelationId(correlationId string) ListRequestBuilder {
 	l.ListFilters.SetCorrelationId(correlationId)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithConnectionId(u apid.ID) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForConnectionId(u apid.ID) ListRequestBuilder {
 	l.ListFilters.SetConnectionId(u)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithConnectorType(t string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForConnectorType(t string) ListRequestBuilder {
 	l.ListFilters.SetConnectorType(t)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithConnectorId(u apid.ID) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForConnectorId(u apid.ID) ListRequestBuilder {
 	l.ListFilters.SetConnectorId(u)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithConnectorVersion(v uint64) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForConnectorVersion(v uint64) ListRequestBuilder {
 	l.ListFilters.SetConnectorVersion(v)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithMethod(method string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForMethod(method string) ListRequestBuilder {
 	l.ListFilters.SetMethod(method)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithStatusCode(s int) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForStatusCode(s int) ListRequestBuilder {
 	l.ListFilters.SetStatusCode(s)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithStatusCodeRangeInclusive(start, end int) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForStatusCodeRangeInclusive(start, end int) ListRequestBuilder {
 	l.ListFilters.SetStatusCodeRangeInclusive(start, end)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithParsedStatusCodeRange(r string) (ListRequestBuilder, error) {
+func (l *sqlListRequestsBuilder) ForParsedStatusCodeRange(r string) (ListRequestBuilder, error) {
 	start, end, err := util.ParseIntegerRange(r, 100, 999)
 	if err != nil {
 		return nil, err
@@ -454,24 +454,24 @@ func (l *sqlListRequestsBuilder) WithParsedStatusCodeRange(r string) (ListReques
 	return l, nil
 }
 
-func (l *sqlListRequestsBuilder) WithPath(path string) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForPath(path string) ListRequestBuilder {
 	l.ListFilters.SetPath(path)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithPathRegex(r string) (ListRequestBuilder, error) {
+func (l *sqlListRequestsBuilder) ForPathRegex(r string) (ListRequestBuilder, error) {
 	if err := l.ListFilters.SetPathRegex(r); err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func (l *sqlListRequestsBuilder) WithTimestampRange(start, end time.Time) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForTimestampRange(start, end time.Time) ListRequestBuilder {
 	l.ListFilters.SetTimestampRange(start, end)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithParsedTimestampRange(r string) (ListRequestBuilder, error) {
+func (l *sqlListRequestsBuilder) ForParsedTimestampRange(r string) (ListRequestBuilder, error) {
 	start, end, err := util.ParseTimestampRange(r)
 	if err != nil {
 		return nil, err
@@ -480,7 +480,7 @@ func (l *sqlListRequestsBuilder) WithParsedTimestampRange(r string) (ListRequest
 	return l, nil
 }
 
-func (l *sqlListRequestsBuilder) WithLabelSelector(selector string) (ListRequestBuilder, error) {
+func (l *sqlListRequestsBuilder) ForLabelSelector(selector string) (ListRequestBuilder, error) {
 	_, err := database.ParseLabelSelector(selector)
 	if err != nil {
 		return nil, err
@@ -489,12 +489,12 @@ func (l *sqlListRequestsBuilder) WithLabelSelector(selector string) (ListRequest
 	return l, nil
 }
 
-func (l *sqlListRequestsBuilder) WithResponseSource(s ResponseSource) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForResponseSource(s ResponseSource) ListRequestBuilder {
 	l.ListFilters.SetResponseSource(s)
 	return l
 }
 
-func (l *sqlListRequestsBuilder) WithRateLimitId(id apid.ID) ListRequestBuilder {
+func (l *sqlListRequestsBuilder) ForRateLimitId(id apid.ID) ListRequestBuilder {
 	l.ListFilters.SetRateLimitId(id)
 	return l
 }

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -62,35 +62,35 @@ func (q *ListRequestEventsQuery) ApplyToBuilder(
 	b app_metrics.ListRequestBuilder,
 ) (_ app_metrics.ListRequestBuilder, err error) {
 	if q.Namespace != nil {
-		b = b.WithNamespaceMatcher(*q.Namespace)
+		b = b.ForNamespaceMatcher(*q.Namespace)
 	}
 
 	if q.RequestType != nil {
-		b = b.WithRequestType(httpf.RequestType(*q.RequestType))
+		b = b.ForRequestType(httpf.RequestType(*q.RequestType))
 	}
 
 	if q.CorrelationId != nil {
-		b = b.WithCorrelationId(*q.CorrelationId)
+		b = b.ForCorrelationId(*q.CorrelationId)
 	}
 
 	if q.ConnectionId != nil {
-		b = b.WithConnectionId(*q.ConnectionId)
+		b = b.ForConnectionId(*q.ConnectionId)
 	}
 
 	if q.ConnectorType != nil {
-		b = b.WithConnectorType(*q.ConnectorType)
+		b = b.ForConnectorType(*q.ConnectorType)
 	}
 
 	if q.ConnectorId != nil {
-		b = b.WithConnectorId(*q.ConnectorId)
+		b = b.ForConnectorId(*q.ConnectorId)
 	}
 
 	if q.ConnectorVersion != nil {
-		b = b.WithConnectorVersion(*q.ConnectorVersion)
+		b = b.ForConnectorVersion(*q.ConnectorVersion)
 	}
 
 	if q.Method != nil {
-		b = b.WithMethod(*q.Method)
+		b = b.ForMethod(*q.Method)
 	}
 
 	if q.StatusCode != nil && q.StatusCodeRangeInclusive != nil {
@@ -98,18 +98,18 @@ func (q *ListRequestEventsQuery) ApplyToBuilder(
 	}
 
 	if q.StatusCode != nil {
-		b = b.WithStatusCode(*q.StatusCode)
+		b = b.ForStatusCode(*q.StatusCode)
 	}
 
 	if q.StatusCodeRangeInclusive != nil {
-		b, err = b.WithParsedStatusCodeRange(*q.StatusCodeRangeInclusive)
+		b, err = b.ForParsedStatusCodeRange(*q.StatusCodeRangeInclusive)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if q.TimestampRange != nil {
-		b, err = b.WithParsedTimestampRange(*q.TimestampRange)
+		b, err = b.ForParsedTimestampRange(*q.TimestampRange)
 		if err != nil {
 			return nil, err
 		}
@@ -120,18 +120,18 @@ func (q *ListRequestEventsQuery) ApplyToBuilder(
 	}
 
 	if q.Path != nil {
-		b = b.WithPath(*q.Path)
+		b = b.ForPath(*q.Path)
 	}
 
 	if q.PathRegex != nil {
-		b, err = b.WithPathRegex(*q.PathRegex)
+		b, err = b.ForPathRegex(*q.PathRegex)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if q.LabelSelector != nil {
-		b, err = b.WithLabelSelector(*q.LabelSelector)
+		b, err = b.ForLabelSelector(*q.LabelSelector)
 		if err != nil {
 			return nil, err
 		}
@@ -142,11 +142,11 @@ func (q *ListRequestEventsQuery) ApplyToBuilder(
 		if !app_metrics.IsValidResponseSource(src) {
 			return nil, httperr.BadRequestf("invalid response_source %q", *q.ResponseSource)
 		}
-		b = b.WithResponseSource(src)
+		b = b.ForResponseSource(src)
 	}
 
 	if q.RateLimitId != nil {
-		b = b.WithRateLimitId(*q.RateLimitId)
+		b = b.ForRateLimitId(*q.RateLimitId)
 	}
 
 	return b, nil
@@ -628,7 +628,7 @@ func (r *RequestEventsRoutes) list(gctx *gin.Context) {
 	} else {
 		b := r.rl.NewListRequestsBuilder()
 
-		b = b.WithNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.Namespace))
+		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.Namespace))
 
 		b, err = req.ApplyToBuilder(b)
 		if err != nil {


### PR DESCRIPTION
## Summary
- rename app metrics list builder filter methods from With* to For* to match the database query-builder convention
- update SQL, ClickHouse, route, mock, and test call sites

Closes #62

## Tests
- go test ./internal/app_metrics
- go test ./internal/routes
- go test -tags integration ./proxy -run TestProxyRawBodyCapture_TeeDecision -count=1 (from integration_tests)
- ./scripts/preflight.sh