### PR TITLE
Improve marketplace first-connection discovery

### DIFF
--- a/ui/marketplace/src/components/ConnectionList.tsx
+++ b/ui/marketplace/src/components/ConnectionList.tsx
@@ -20,7 +20,9 @@ import {
   selectConnectionsError,
   fetchConnectionsAsync,
   fetchConnectorsAsync,
+  selectConnectors,
   selectConnectorsStatus,
+  selectConnectorsError,
   selectCurrentFormStep,
   selectSubmittingForm,
   selectFormSubmitError,
@@ -34,8 +36,11 @@ import {
   abortConnectionAsync,
   cancelSetupConnectionAsync,
   clearVerifyState,
+  selectInitiatingConnection,
+  initiateConnectionAsync,
 } from '../store';
 import ConnectionCard, { ConnectionCardSkeleton } from './ConnectionCard';
+import ConnectorCard, { ConnectorCardSkeleton } from './ConnectorCard';
 import ConnectionFormStep from './ConnectionFormStep';
 import { AppDispatch } from '../store';
 import { Link, useSearchParams } from 'react-router-dom';
@@ -50,7 +55,10 @@ const ConnectionList: React.FC = () => {
   const connections = useSelector(selectConnections);
   const status = useSelector(selectConnectionsStatus);
   const error = useSelector(selectConnectionsError);
+  const connectors = useSelector(selectConnectors);
   const connectorsStatus = useSelector(selectConnectorsStatus);
+  const connectorsError = useSelector(selectConnectorsError);
+  const isConnecting = useSelector(selectInitiatingConnection);
   const currentFormStep = useSelector(selectCurrentFormStep);
   const isSubmittingForm = useSelector(selectSubmittingForm);
   const formSubmitError = useSelector(selectFormSubmitError);
@@ -147,6 +155,62 @@ const ConnectionList: React.FC = () => {
     });
   }, [dispatch, verifyError]);
 
+  const handleConnect = useCallback((connectorId: string) => {
+    dispatch(initiateConnectionAsync({
+      connectorId,
+      returnToUrl: `${window.location.origin}/connections`,
+    })).then((action) => {
+      if (action.meta.requestStatus === 'fulfilled') {
+        const response = action.payload as any;
+        if (isRedirectResponse(response)) {
+          window.location.href = response.redirect_url;
+        }
+      }
+    });
+  }, [dispatch]);
+
+  const renderConnectorDiscovery = () => {
+    if (connectorsStatus === 'loading' || connectorsStatus === 'idle') {
+      return (
+        <Grid container spacing={4}>
+          {[1, 2, 3, 4].map((i) => (
+            <Grid key={`connector-skeleton-${i}`} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+              <ConnectorCardSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      );
+    }
+
+    if (connectorsStatus === 'failed') {
+      return <Alert severity="error">{connectorsError}</Alert>;
+    }
+
+    if (connectors.length === 0) {
+      return (
+        <Box sx={{ py: 3 }}>
+          <Typography color="text.secondary">
+            No connectors are available right now.
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <Grid container spacing={4}>
+        {connectors.map((connector) => (
+          <Grid key={connector.id} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <ConnectorCard
+              connector={connector}
+              onConnect={handleConnect}
+              isConnecting={isConnecting}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  };
+
   let content;
 
   if (status === 'loading') {
@@ -163,21 +227,40 @@ const ConnectionList: React.FC = () => {
     content = <Alert severity="error">{error}</Alert>;
   } else if (connections.length === 0) {
     content = (
-      <Box sx={{ textAlign: 'center', py: 4 }}>
-        <Typography variant="h6" color="text.secondary" gutterBottom>
-          No connections yet
-        </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          startIcon={<AddIcon />}
-          component={Link}
-          to="/connectors"
-          sx={{ mt: 2 }}
+      <>
+        <Box
+          sx={{
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 2,
+            bgcolor: 'background.paper',
+            mb: 4,
+            p: { xs: 3, sm: 4 },
+          }}
         >
-          Connect an Application
-        </Button>
-      </Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            Connect your first application
+          </Typography>
+          <Typography color="text.secondary" sx={{ maxWidth: 680 }}>
+            Choose a connector below to create a connection. Once connected, it will appear
+            here for ongoing setup, health, and management.
+          </Typography>
+          {isConnecting && (
+            <Box sx={{ display: 'flex', alignItems: 'center', mt: 3 }}>
+              <CircularProgress size={24} sx={{ mr: 1 }} />
+              <Typography variant="body2" color="text.secondary">
+                Starting connection...
+              </Typography>
+            </Box>
+          )}
+        </Box>
+        <Box>
+          <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+            Available connectors
+          </Typography>
+          {renderConnectorDiscovery()}
+        </Box>
+      </>
     );
   } else {
     content = (

--- a/ui/marketplace/src/stories/Marketplace.stories.tsx
+++ b/ui/marketplace/src/stories/Marketplace.stories.tsx
@@ -265,6 +265,26 @@ export const ConnectionsEmpty: Story = {
   },
 };
 
+export const ConnectionsEmptyMobile: Story = {
+  args: {
+    route: '/connections',
+    connectionsState: { ...baseConnectionsState, items: [] },
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};
+
+export const ConnectionsEmptyLoadingConnectors: Story = {
+  args: {
+    route: '/connections',
+    connectorsState: { items: [], status: 'loading', error: null },
+    connectionsState: { ...baseConnectionsState, items: [] },
+  },
+};
+
 export const AvailableConnectorsMobile: Story = {
   args: {
     route: '/connectors',

--- a/ui/marketplace/src/tests/ConnectionList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionList.test.tsx
@@ -112,9 +112,9 @@ describe('ConnectionList', () => {
         expect(screen.getByText('Failed to fetch connections')).toBeInTheDocument();
     });
 
-    test('shows empty state with call to action when there are no connections', () => {
+    test('shows first-connection guidance and connector discovery when there are no connections', () => {
         const store = createStore({
-            connectors: {items: [], status: 'succeeded', error: null},
+            connectors: {items: [connector], status: 'succeeded', error: null},
             connections: {
                 ...baseConnectionsState,
                 items: [],
@@ -132,8 +132,10 @@ describe('ConnectionList', () => {
             </MemoryRouter>
         );
 
-        expect(screen.getByText('No connections yet')).toBeInTheDocument();
-        expect(screen.getByRole('link', {name: /Connect an Application/i})).toBeInTheDocument();
+        expect(screen.getByText('Connect your first application')).toBeInTheDocument();
+        expect(screen.getByText('Available connectors')).toBeInTheDocument();
+        expect(screen.getByText('Google Calendar')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /Connect/i})).toBeInTheDocument();
     });
 
     test('renders list of connections when present', () => {


### PR DESCRIPTION
## Summary
- Replace the empty connections dead-end with first-connection guidance and in-context connector discovery
- Wire connector cards in the empty state to the existing initiate-connection flow
- Add Storybook coverage for mobile and loading connector empty-state variants
- Update tests to cover the first-connection discovery experience

Closes #475

## Screenshots
Screenshot capture was blocked in this Codex environment: local port binding was denied by the sandbox, the escalation reviewer timed out, and Chrome blocks the built Storybook bundle over file:// due module CORS. Storybook was still built successfully for reviewer verification.

## Validation
- yarn workspace @authproxy/marketplace typecheck
- yarn workspace @authproxy/marketplace lint
- yarn workspace @authproxy/marketplace test
- yarn workspace @authproxy/marketplace build-storybook
- ./scripts/preflight.sh