### PR TITLE
Protect OAuth callback return URLs

### DIFF
--- a/integration_tests/oauth2/callback_state_security_test.go
+++ b/integration_tests/oauth2/callback_state_security_test.go
@@ -99,7 +99,7 @@ func newCallbackStateSecurityRig(t *testing.T, name string) *callbackStateSecuri
 		connectorID:  connectorID,
 		connector:    connector,
 		scopes:       []string{"read"},
-		returnToURL:  "https://example.com/return",
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 		errorPageURL: env.Cfg.GetRoot().ErrorPages.InternalError,
 	}
 }

--- a/integration_tests/oauth2/callback_token_exchange_failure_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_failure_test.go
@@ -95,7 +95,7 @@ func newTokenExchangeFailureRig(t *testing.T, name string) *tokenExchangeFailure
 		userID:       user.ID,
 		connectorID:  connectorID,
 		scopes:       []string{"read"},
-		returnToURL:  "https://example.com/return",
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 		errorPageURL: env.Cfg.GetRoot().ErrorPages.InternalError,
 	}
 }

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.go
@@ -85,7 +85,7 @@ func newTokenExchangeRetryRig(t *testing.T, name string) *tokenExchangeRetryRig 
 		userID:       user.ID,
 		connectorID:  connectorID,
 		scopes:       []string{"read"},
-		returnToURL:  "https://example.com/return",
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 		errorPageURL: env.Cfg.GetRoot().ErrorPages.InternalError,
 	}
 }

--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -88,7 +88,7 @@ func newDisconnectRevocationRig(t *testing.T, name string) *disconnectRevocation
 		clientKey:   clientKey,
 		userID:      user.ID,
 		connectorID: connectorID,
-		returnToURL: "https://example.com/return",
+		returnToURL: env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 	}
 }
 

--- a/integration_tests/oauth2/open_redirect_test.go
+++ b/integration_tests/oauth2/open_redirect_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuth2OpenRedirectProtection_InvalidReturnURLFallsBackToMarketplace(t *testing.T) {
+	provider := helpers.NewOAuth2TestProvider(t)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := "open-redirect-client-" + suffix
+	clientSecret := "open-redirect-secret-" + suffix
+	userPassword := "p4ssw0rd-" + suffix
+	userEmail := "open-redirect-" + suffix + "@example.com"
+
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connector := helpers.NewOAuth2Connector(connectorID, "open-redirect-test", provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     clientKey,
+		ClientSecret: clientSecret,
+		Scopes:       []string{"read"},
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:            helpers.ServiceTypeAPI,
+		StartHTTPServer:    true,
+		IncludePublic:      true,
+		ServeMarketplaceUI: true,
+		Connectors:         []sconfig.Connector{connector},
+	})
+	defer env.Cleanup()
+
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: userEmail,
+		Password: userPassword,
+		Email:    userEmail,
+	})
+	require.NotEmpty(t, user.ID)
+
+	authToken, err := env.PublicAuthUtil.GenerateBearerToken(
+		context.Background(),
+		"test-actor",
+		sconfig.RootNamespace,
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	browserCtx, _ := helpers.NewBrowser(t)
+	connectorsURL := env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(authToken)
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Navigate(connectorsURL),
+		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
+	))
+
+	maliciousReturnURL := "https://evil.example/phish"
+	_, redirectURL := env.InitiateOAuth2Connection(t, connectorID, maliciousReturnURL)
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Navigate(redirectURL),
+		chromedp.WaitVisible(`input[name="email"]`, chromedp.ByQuery),
+	))
+	require.NotEmpty(t, redirectURL)
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.SendKeys(`input[name="email"]`, userEmail, chromedp.ByQuery),
+		chromedp.SendKeys(`input[name="password"]`, userPassword, chromedp.ByQuery),
+		chromedp.Submit(`input[name="email"]`, chromedp.ByQuery),
+		chromedp.WaitVisible(`input[name="allow"]`, chromedp.ByQuery),
+	))
+
+	require.NoError(t, chromedp.Run(browserCtx,
+		chromedp.Click(`input[name="allow"]`, chromedp.ByQuery),
+		chromedp.WaitVisible(`//h1[normalize-space()='Your Connections']`, chromedp.BySearch),
+	))
+
+	var finalURL string
+	require.NoError(t, chromedp.Run(browserCtx, chromedp.Location(&finalURL)))
+	assert.Truef(t, strings.HasPrefix(finalURL, env.PublicURL+"/connections"),
+		"invalid return_to_url should fall back to marketplace connections page; got %q", finalURL)
+	assert.NotContains(t, finalURL, "evil.example", "callback must not redirect to the attacker-controlled origin")
+
+	page := env.Db.ListConnectionsBuilder().
+		ForNamespaceMatcher(sconfig.RootNamespace).
+		Limit(10).
+		FetchPage(context.Background())
+	require.NoError(t, page.Error)
+	require.Len(t, page.Results, 1)
+	assert.Equal(t, database.ConnectionStateConfigured, page.Results[0].State)
+	require.NotNil(t, env.GetOAuth2Token(t, page.Results[0].Id.String()))
+}

--- a/integration_tests/oauth2/open_redirect_test.md
+++ b/integration_tests/oauth2/open_redirect_test.md
@@ -1,0 +1,25 @@
+# OAuth open redirect protection
+
+Companion specification for `open_redirect_test.go`. Covers issue #184 /
+#159 scenario 29: OAuth callback and post-auth redirect behavior must not send
+users to arbitrary external URLs.
+
+## Coverage
+
+`TestOAuth2OpenRedirectProtection_InvalidReturnURLFallsBackToMarketplace`
+boots a real marketplace session in Chrome, initiates an OAuth connection from
+that browser session with a malicious external `return_to_url`, and then drives
+the provider login and consent forms through chromedp. After the provider
+redirects back to AuthProxy's OAuth callback, the browser must land on the
+marketplace `/connections` page, not the hostile origin.
+
+The test also asserts the connection completed successfully and a token row was
+persisted. That proves the safe fallback affects only the browser destination;
+it does not abort an otherwise valid OAuth authorization.
+
+## Product rule
+
+OAuth return URLs are accepted only when they are absolute `http` or `https`
+URLs on the configured public service origin. Malformed URLs, relative URLs,
+URLs with embedded userinfo, unsafe schemes, and different origins are replaced
+with the safe default: the public service's `/connections` page.

--- a/integration_tests/oauth2/pkce_test.go
+++ b/integration_tests/oauth2/pkce_test.go
@@ -295,7 +295,6 @@ func TestPKCE_TokenExchangeRejected(t *testing.T) {
 			clientKey := "pkce-rej-" + strings.ToLower(sub.name) + "-" + suffix
 			clientSecret := "pkce-rej-secret-" + suffix
 			userEmail := "alice-pkce-rej-" + suffix + "@example.com"
-			returnToURL := "https://example.com/return"
 
 			connectorID := apid.New(apid.PrefixConnectorVersion)
 			connector := helpers.NewOAuth2Connector(connectorID, "pkce-rejected", provider, helpers.OAuth2ConnectorOptions{
@@ -313,6 +312,7 @@ func TestPKCE_TokenExchangeRejected(t *testing.T) {
 				LogCapture:    logCapture,
 			})
 			defer env.Cleanup()
+			returnToURL := env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections"
 
 			provider.CreateClient(helpers.CreateClientRequest{
 				Key:                     clientKey,

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.go
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.go
@@ -101,7 +101,7 @@ func newAuthMethodCompatibilityRig(
 		clientSecret: clientSecret,
 		userID:       user.ID,
 		connectorID:  connectorID,
-		returnToURL:  "https://example.com/oauth-auth-method-return",
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 	}
 }
 

--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -98,7 +98,7 @@ func newProxyRefreshRig(t *testing.T, name string) *proxyRefreshRig {
 		userID:      user.ID,
 		connectorID: connectorID,
 		scopes:      []string{"read"},
-		returnToURL: "https://example.com/return",
+		returnToURL: env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 	}
 }
 

--- a/integration_tests/probes/oauth2_probe_health_test.go
+++ b/integration_tests/probes/oauth2_probe_health_test.go
@@ -90,7 +90,7 @@ func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
 	// proxyRefreshRig uses — /test/authorize for the consent step
 	// (#169) — since we're testing health transitions, not the user-
 	// facing consent leg.
-	returnToURL := "https://example.com/return"
+	returnToURL := env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections"
 	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)

--- a/internal/auth_methods/oauth2/auth_url.go
+++ b/internal/auth_methods/oauth2/auth_url.go
@@ -135,7 +135,7 @@ func (o *oAuth2Connection) SetStateAndGeneratePublicUrl(
 ) (string, error) {
 	stateId := apid.New(apid.PrefixOauth2State)
 
-	if err := o.saveStateToRedis(ctx, actor, stateId, returnToUrl); err != nil {
+	if err := o.saveStateToRedis(ctx, actor, stateId, o.safeReturnToUrl(returnToUrl)); err != nil {
 		return "", err
 	}
 

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -75,7 +75,7 @@ func (o *oAuth2Connection) CallbackFrom3rdParty(ctx context.Context, query url.V
 	if recordErr := o.connection.HandleAuthFailed(ctx, err); recordErr != nil {
 		return errorRedirectPage, fmt.Errorf("failed to record auth failure (%v) after: %w", recordErr, err)
 	}
-	return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
+	return o.appendSetupPendingToReturnUrl(o.safeReturnToUrl(o.state.ReturnToUrl)), nil
 }
 
 // exchangeCodeAndAdvance performs the OAuth token exchange and post-auth state transition.
@@ -229,10 +229,11 @@ func (o *oAuth2Connection) exchangeCodeAndAdvanceInner(ctx context.Context, quer
 
 	o.tel.recordTokenExchangeSuccess(ctx, o.connectionLabelsForTelemetry())
 
+	returnToUrl := o.safeReturnToUrl(o.state.ReturnToUrl)
 	if outcome.SetupPending {
-		return o.appendSetupPendingToReturnUrl(o.state.ReturnToUrl), nil
+		return o.appendSetupPendingToReturnUrl(returnToUrl), nil
 	}
-	return o.state.ReturnToUrl, nil
+	return returnToUrl, nil
 }
 
 // ExchangeClientCredentials performs RFC 6749 §4.4's synchronous token

--- a/internal/auth_methods/oauth2/mustache_test.go
+++ b/internal/auth_methods/oauth2/mustache_test.go
@@ -359,7 +359,7 @@ func TestCallbackFrom3rdParty_TemplatedEndpoint(t *testing.T) {
 			},
 			state: &state{
 				Id:          apid.New(apid.PrefixOauth2State),
-				ReturnToUrl: "https://app.example.com/callback",
+				ReturnToUrl: "http://localhost:8080/callback",
 			},
 		}, db, encrypt, ctrl
 	}
@@ -387,7 +387,7 @@ func TestCallbackFrom3rdParty_TemplatedEndpoint(t *testing.T) {
 		query := url.Values{"code": {"auth-code-123"}}
 		returnUrl, err := o2.CallbackFrom3rdParty(context.Background(), query)
 		require.NoError(t, err)
-		assert.Equal(t, "https://app.example.com/callback", returnUrl)
+		assert.Equal(t, "http://localhost:8080/callback", returnUrl)
 	})
 
 	t.Run("static token endpoint works without configuration", func(t *testing.T) {
@@ -412,7 +412,7 @@ func TestCallbackFrom3rdParty_TemplatedEndpoint(t *testing.T) {
 		query := url.Values{"code": {"auth-code-456"}}
 		returnUrl, err := o2.CallbackFrom3rdParty(context.Background(), query)
 		require.NoError(t, err)
-		assert.Equal(t, "https://app.example.com/callback", returnUrl)
+		assert.Equal(t, "http://localhost:8080/callback", returnUrl)
 	})
 }
 

--- a/internal/auth_methods/oauth2/return_url.go
+++ b/internal/auth_methods/oauth2/return_url.go
@@ -1,0 +1,58 @@
+package oauth2
+
+import (
+	"net/url"
+	"strings"
+)
+
+const defaultOAuthReturnPath = "/connections"
+
+func (o *oAuth2Connection) safeReturnToUrl(raw string) string {
+	fallback := o.defaultReturnToUrl()
+
+	returnURL, err := url.Parse(raw)
+	if err != nil || returnURL.Scheme == "" || returnURL.Host == "" {
+		return fallback
+	}
+
+	if returnURL.User != nil || !isAllowedReturnScheme(returnURL.Scheme) {
+		return fallback
+	}
+
+	publicURL, err := url.Parse(o.cfg.GetRoot().Public.GetBaseUrl())
+	if err != nil {
+		return fallback
+	}
+
+	if !sameOrigin(publicURL, returnURL) {
+		return fallback
+	}
+
+	return returnURL.String()
+}
+
+func (o *oAuth2Connection) defaultReturnToUrl() string {
+	raw := o.cfg.GetRoot().Public.GetBaseUrl()
+	publicURL, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	publicURL.Path = defaultOAuthReturnPath
+	publicURL.RawQuery = ""
+	publicURL.Fragment = ""
+	return publicURL.String()
+}
+
+func isAllowedReturnScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}

--- a/internal/auth_methods/oauth2/return_url_test.go
+++ b/internal/auth_methods/oauth2/return_url_test.go
@@ -1,0 +1,36 @@
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeReturnToUrl_AllowsPublicOrigin(t *testing.T) {
+	o := &oAuth2Connection{cfg: configWithPublicBaseUrl(t, "proxy.example.com")}
+
+	got := o.safeReturnToUrl("http://proxy.example.com/connections?tab=integrations")
+
+	assert.Equal(t, "http://proxy.example.com/connections?tab=integrations", got)
+}
+
+func TestSafeReturnToUrl_RejectsExternalOrigin(t *testing.T) {
+	o := &oAuth2Connection{cfg: configWithPublicBaseUrl(t, "proxy.example.com")}
+
+	got := o.safeReturnToUrl("https://evil.example/phish")
+
+	assert.Equal(t, "http://proxy.example.com/connections", got)
+}
+
+func TestSafeReturnToUrl_RejectsAmbiguousOrUnsafeUrls(t *testing.T) {
+	o := &oAuth2Connection{cfg: configWithPublicBaseUrl(t, "proxy.example.com")}
+
+	for _, raw := range []string{
+		"/connections",
+		"javascript:alert(1)",
+		"http://proxy.example.com@evil.example/connections",
+		"http://proxy.example.com/\x7f",
+	} {
+		assert.Equalf(t, "http://proxy.example.com/connections", o.safeReturnToUrl(raw), "raw=%q", raw)
+	}
+}


### PR DESCRIPTION
## Summary
- sanitize OAuth return URLs to the configured public origin and fall back to /connections for invalid or external destinations
- apply the guard when minting OAuth state and again at callback time before success/auth-failed redirects
- add unit coverage and a chromedp OAuth flow proving a malicious return_to_url lands on the marketplace instead of an external origin

## Testing
- go test ./internal/auth_methods/oauth2 -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags=integration ./oauth2 -run 'TestOAuth2OpenRedirectProtection|TestProxyRefresh_ExpiredAccessTokenRefreshes|TestProviderAuthMethodCompatibility|TestPKCETokenExchangeRejectsMissingOrMismatchedVerifier|TestCallbackStateSecurity' -count=1 (from integration_tests)
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags=integration ./probes -run TestOAuth2ProbeHealth -count=1 (from integration_tests)
- ./scripts/preflight.sh

Closes #184