### PR TITLE
Add OAuth access token expiry buffer

### DIFF
--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -142,15 +142,18 @@ func (r *proxyRefreshRig) completeAuthFlow(t *testing.T) string {
 // underlying provider-issued refresh_token is still valid.
 func (r *proxyRefreshRig) forceTokenExpired(t *testing.T, connectionID string, clearRefreshToken bool) {
 	t.Helper()
-	ctx := context.Background()
+	r.forceTokenExpiresAt(t, connectionID, time.Now().Add(-1*time.Hour), clearRefreshToken)
+}
 
+func (r *proxyRefreshRig) forceTokenExpiresAt(t *testing.T, connectionID string, expiresAt time.Time, clearRefreshToken bool) {
+	t.Helper()
+	ctx := context.Background()
 	existing := r.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, existing, "auth flow must have persisted a token")
 	require.False(t, existing.EncryptedRefreshToken.IsZero(),
 		"fixture invariant: provider must have issued a refresh_token in the initial grant")
 	require.False(t, existing.EncryptedAccessToken.IsZero(), "fixture invariant: access_token present")
 
-	pastExpiry := time.Now().Add(-1 * time.Hour)
 	refreshToken := existing.EncryptedRefreshToken
 	if clearRefreshToken {
 		refreshToken = encfield.EncryptedField{}
@@ -164,19 +167,18 @@ func (r *proxyRefreshRig) forceTokenExpired(t *testing.T, connectionID string, c
 		nil,
 		refreshToken,
 		existing.EncryptedAccessToken,
-		&pastExpiry,
+		&expiresAt,
 		existing.Scopes,
 		existing.RequestedScopes,
 		existing.CreatedByActorId,
 	)
-	require.NoError(t, err, "force-expire: insert replacement token row")
+	require.NoError(t, err, "force-expiry: insert replacement token row")
 
-	// Sanity: GetOAuth2Token now returns the expired row.
+	// Sanity: GetOAuth2Token now returns the forged row.
 	current := r.env.GetOAuth2Token(t, connectionID)
 	require.NotNil(t, current)
 	require.NotNil(t, current.AccessTokenExpiresAt)
-	require.True(t, current.AccessTokenExpiresAt.Before(time.Now()),
-		"forge-expire: replacement token should be expired (expires_at=%s)", current.AccessTokenExpiresAt)
+	require.WithinDuration(t, expiresAt, *current.AccessTokenExpiresAt, time.Second)
 }
 
 // TestProxyRefresh_ExpiredAccessTokenRefreshes covers scenario 6 from #169:
@@ -242,6 +244,42 @@ func TestProxyRefresh_ExpiredAccessTokenRefreshes(t *testing.T) {
 	assert.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState)
 	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, connectionHealthStateChangedMessage),
 		"idempotent healthy→healthy must not emit a transition event")
+}
+
+func TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-refresh-near-expiry")
+	connID := rig.completeAuthFlow(t)
+
+	rig.forceTokenExpiresAt(t, connID, time.Now().Add(database.OAuth2AccessTokenExpiryBuffer-time.Second), false)
+	forged := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, forged)
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code,
+		"proxy must refresh a token inside the expiry buffer; got %d body=%s", w.Code, w.Body.String())
+
+	refreshed := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, refreshed)
+	assert.NotEqual(t, forged.Id, refreshed.Id, "near-expiry token should be replaced by refresh")
+	require.Len(t, refreshGrantRequests(rig), 1, "token inside expiry buffer should refresh exactly once")
+}
+
+func TestProxyRefresh_TokenOutsideExpiryBufferDoesNotRefreshAggressively(t *testing.T) {
+	rig := newProxyRefreshRig(t, "proxy-refresh-outside-buffer")
+	connID := rig.completeAuthFlow(t)
+
+	rig.forceTokenExpiresAt(t, connID, time.Now().Add(database.OAuth2AccessTokenExpiryBuffer+10*time.Second), false)
+	forged := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, forged)
+
+	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), "GET")
+	require.Equalf(t, 200, w.Code,
+		"proxy should use token outside the expiry buffer; got %d body=%s", w.Code, w.Body.String())
+
+	current := rig.env.GetOAuth2Token(t, connID)
+	require.NotNil(t, current)
+	assert.Equal(t, forged.Id, current.Id, "token outside expiry buffer should not be refreshed")
+	require.Empty(t, refreshGrantRequests(rig), "token outside expiry buffer should not trigger refresh")
 }
 
 // TestProxyRefresh_NoRefreshTokenFlipsUnhealthy covers scenario 13:

--- a/integration_tests/oauth2/proxy_refresh_test.md
+++ b/integration_tests/oauth2/proxy_refresh_test.md
@@ -1,12 +1,13 @@
 # OAuth2 Proxy-Time Refresh Cases
 
 Companion specification for `proxy_refresh_test.go`. Covers the
-proxy-time refresh leg of issue #169 — at request time the proxy
-detects that the persisted access token has expired, and either
-exchanges the persisted `refresh_token` for a new access token
-(scenario 6) or, if no `refresh_token` was issued, flips the
-connection's `health_state` to unhealthy without making any HTTP
-call (scenario 13).
+proxy-time refresh leg of issue #169 and the clock-skew buffer case
+from issue #185. At request time the proxy detects that the persisted
+access token is expired or inside the configured expiry buffer, and
+either exchanges the persisted `refresh_token` for a new access token
+(scenario 6 / #185) or, if no `refresh_token` was issued, flips the
+connection's `health_state` to unhealthy without making any HTTP call
+(scenario 13).
 
 The initial code → token exchange leg lives in
 `callback_token_exchange_failure_test.go` / `callback_token_exchange_retry_test.go`
@@ -20,7 +21,8 @@ retry-once-after-401 path are deliberately not included here — see
 Source: `internal/auth_methods/oauth2/proxy.go:31-132, 166-189`.
 
 - `getValidToken` is called for every proxied request. If the
-  persisted `AccessTokenExpiresAt` is in the past, it calls
+  persisted `AccessTokenExpiresAt` is in the past or within the
+  `database.OAuth2AccessTokenExpiryBuffer`, it calls
   `refreshAccessToken(ctx, token, refreshModeOnlyExpired)` before
   letting the request proceed.
 - `refreshAccessToken` acquires a per-connection mutex, re-reads the
@@ -71,6 +73,19 @@ over-eager flip on a transient blip would spam reconnect prompts.
   healthy → healthy would render the dashboard's "unhealthy →
   healthy recovery" alert useless.
 
+### Scenario 30 — clock skew / expiry buffer
+
+- **Inside the buffer refreshes.** `TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer`
+  forges an active token whose expiry is one second inside
+  `OAuth2AccessTokenExpiryBuffer`. The next proxy request must refresh
+  before forwarding, persist a replacement token row, and make exactly
+  one refresh-token grant.
+- **Outside the buffer does not refresh aggressively.**
+  `TestProxyRefresh_TokenOutsideExpiryBufferDoesNotRefreshAggressively`
+  forges an active token whose expiry is safely beyond the buffer. The
+  proxy request should succeed using the existing token row and should
+  not call the refresh endpoint.
+
 ### Scenario 13 — no refresh token flips unhealthy
 
 - **Non-200 from the proxy.** The proxy cannot obtain a new access
@@ -101,9 +116,11 @@ over-eager flip on a transient blip would spam reconnect prompts.
 
 ## Test plan
 
-| Test | Pre-expiry refresh_token? | Expected proxy response | Expected health state | Issue #169 case(s) covered |
+| Test | Pre-expiry refresh_token? | Expected proxy response | Expected health state | Issue case(s) covered |
 | ---- | ------------------------- | ----------------------- | --------------------- | -------------------------- |
 | `TestProxyRefresh_ExpiredAccessTokenRefreshes` | yes | 200 (request succeeds) | healthy (no transition) | 6 — expired access token, valid refresh_token |
+| `TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer` | yes | 200 (request succeeds after refresh) | healthy | #185 — token inside expiry buffer |
+| `TestProxyRefresh_TokenOutsideExpiryBufferDoesNotRefreshAggressively` | yes | 200 (request succeeds without refresh) | healthy | #185 — token outside expiry buffer |
 | `TestProxyRefresh_NoRefreshTokenFlipsUnhealthy` | no (cleared) | non-200 (refresh impossible) | unhealthy (transition emitted) | 13 — expired access token, no refresh_token |
 
 ## Why direct HTTP + DB-level expiry forge, not chromedp
@@ -120,9 +137,10 @@ Each test:
    `DeliverOAuth2Callback`) once via the `completeAuthFlow` helper to
    mint a real provider-issued token (with refresh_token). This is
    the same shortcut pattern the token-exchange tests use.
-2. Calls `forceTokenExpired(t, connID, clearRefreshToken)` to insert a
-   replacement `oauth2_tokens` row with `AccessTokenExpiresAt` in the
-   past, optionally clearing the refresh_token.
+2. Calls `forceTokenExpired(t, connID, clearRefreshToken)` or
+   `forceTokenExpiresAt(t, connID, expiresAt, clearRefreshToken)` to
+   insert a replacement `oauth2_tokens` row with a deterministic
+   `AccessTokenExpiresAt`, optionally clearing the refresh_token.
 3. Calls `env.DoProxyRequest(t, connID, …)` to exercise the proxy
    path with the now-expired token.
 

--- a/internal/database/oauth2_token.go
+++ b/internal/database/oauth2_token.go
@@ -32,6 +32,8 @@ func init() {
 
 const OAuth2TokensTable = "oauth2_tokens"
 
+const OAuth2AccessTokenExpiryBuffer = 30 * time.Second
+
 type OAuth2Token struct {
 	Id                    apid.ID
 	ConnectionId          apid.ID // Foreign key to Connection; not enforced by database
@@ -103,7 +105,7 @@ func (t *OAuth2Token) IsAccessTokenExpired(ctx context.Context) bool {
 		return false
 	}
 
-	return t.AccessTokenExpiresAt.Before(apctx.GetClock(ctx).Now())
+	return !t.AccessTokenExpiresAt.After(apctx.GetClock(ctx).Now().Add(OAuth2AccessTokenExpiryBuffer))
 }
 
 func (t *OAuth2Token) Validate() error {

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -41,6 +41,21 @@ func TestOAuth2Token_IsAccessTokenExpired(t *testing.T) {
 				accessTokenExpires: util.ToPtr(now.Add(1 * time.Hour)),
 				expected:           false,
 			},
+			{
+				name:               "expires inside buffer",
+				accessTokenExpires: util.ToPtr(now.Add(OAuth2AccessTokenExpiryBuffer - time.Second)),
+				expected:           true,
+			},
+			{
+				name:               "expires exactly at buffer",
+				accessTokenExpires: util.ToPtr(now.Add(OAuth2AccessTokenExpiryBuffer)),
+				expected:           true,
+			},
+			{
+				name:               "expires outside buffer",
+				accessTokenExpires: util.ToPtr(now.Add(OAuth2AccessTokenExpiryBuffer + time.Second)),
+				expected:           false,
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- treat OAuth access tokens as expired 30 seconds before provider expiry
- add model-level tests for the expiry-buffer boundary
- add proxy-refresh integration coverage proving near-expiry tokens refresh while tokens outside the buffer are reused

## Testing
- go test ./internal/database -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags=integration ./oauth2 -run 'TestProxyRefresh_(ExpiredAccessTokenRefreshes|NearlyExpiredAccessTokenRefreshesWithinBuffer|TokenOutsideExpiryBufferDoesNotRefreshAggressively)' -count=1 (from integration_tests)
- ./scripts/preflight.sh

Closes #185