### PR TITLE
Make OAuth integration docs self-contained

### DIFF
--- a/integration_tests/oauth2/callback_actor_mismatch_test.md
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.md
@@ -1,7 +1,7 @@
 # OAuth2 Callback State Security — Cross-Actor Case
 
 Companion specification for `callback_actor_mismatch_test.go`. Covers
-case 5 of #167: an attacker initiates a connection, drives the
+the cross-actor callback attack: an attacker initiates a connection, drives the
 provider's authorize step to mint a code, and sends the resulting
 `/oauth2/callback?state=…&code=…` URL to a different actor (the
 victim). When the victim's browser follows the link, the public
@@ -10,9 +10,10 @@ state record carries the attacker's actor id. State validation must
 reject with `actor_mismatch` and redirect to the configured error
 page; no token must be exchanged or persisted.
 
-The four direct-HTTP cases (1–4) live in
-`callback_state_security_test.go`. The cross-tenant + cross-connection
-cases (6–7) are PR 5.
+The direct-HTTP callback-shape and state-envelope rejection cases live in
+`callback_state_security_test.go`. The cross-tenant and cross-connection
+namespace defenses live in `callback_cross_namespace_test.go` and
+`callback_namespace_mismatch_test.go`.
 
 ## Threat model
 

--- a/integration_tests/oauth2/callback_cross_namespace_test.md
+++ b/integration_tests/oauth2/callback_cross_namespace_test.md
@@ -1,13 +1,14 @@
 # OAuth2 Callback State Security — Cross-Namespace Cases
 
 Companion specification for `callback_cross_namespace_test.go` and
-`callback_namespace_mismatch_test.go`. Together they cover cases 6–7 of
-issue #167 — state validation when the calling actor and the state
-envelope disagree on namespace, and when the state envelope and the
-referenced connection disagree on namespace.
+`callback_namespace_mismatch_test.go`. Together they cover namespace-bound
+state validation: rejecting callbacks when the calling actor and the state
+envelope disagree on namespace, and rejecting callbacks when the state
+envelope and the referenced connection disagree on namespace.
 
-The four direct-HTTP cases (1–4) live in `callback_state_security_test.go`.
-The cross-actor case (5) lives in `callback_actor_mismatch_test.go`.
+The direct-HTTP callback-shape and state-envelope rejection cases live
+in `callback_state_security_test.go`. The cross-actor defense lives in
+`callback_actor_mismatch_test.go`.
 
 ## Threat model
 

--- a/integration_tests/oauth2/callback_malformed_test.md
+++ b/integration_tests/oauth2/callback_malformed_test.md
@@ -1,9 +1,9 @@
-# OAuth2 Malformed Callbacks (scenarios 15, 16)
+# OAuth2 Malformed Callbacks
 
-Companion specification for `callback_malformed_test.go`. Covers
-issue #175 — the callback handler must reject callback URLs whose
-query-param shape violates RFC 6749 §4.1.2 (the `code` xor `error`
-contract).
+Companion specification for `callback_malformed_test.go`. The callback
+handler must reject callback URLs whose query-param shape violates RFC
+6749 §4.1.2: an authorization response should contain either `code`
+or `error`, not both, and a successful response must include `code`.
 
 ## Scope
 
@@ -106,11 +106,11 @@ primary alerting axis stable.
 
 ## Property: "code is not exchanged"
 
-Issue #175 names "Authorization code is not exchanged unless
-explicitly allowed" as a verify item. Operationally that property is
+Malformed callbacks must not exchange an authorization code unless the
+callback shape is explicitly allowed. Operationally that property is
 visible as a single observable: **zero POSTs to the provider's
-`/token` endpoint** when the callback is malformed. Both tests pin
-this directly with `provider.Requests(RequestsFilter{Endpoint:
+`/token` endpoint** when the callback is malformed. Both tests pin this
+directly with `provider.Requests(RequestsFilter{Endpoint:
 EndpointToken, ClientID: rig.clientKey})`.
 
 The filter uses `ClientID = rig.clientKey` rather than `Since =
@@ -131,12 +131,12 @@ the same provider container do not appear in the filter result.
 - **Replayed / cross-tenant / unknown state.** Those callback-state
   shapes are covered by `callback_state_security_test.go`,
   `callback_actor_mismatch_test.go`, and
-  `callback_cross_namespace_test.go`. Scenarios 15 and 16 are
-  specifically about the `code`/`error` query-param shape with an
-  otherwise-valid state row.
-- **PKCE on the callback.** PKCE isn't implemented in the proxy yet
-  (issue #174 / scenario 14). When it lands, a separate file should
-  cover missing/wrong `code_verifier` shapes.
+  `callback_cross_namespace_test.go`. This file is specifically about
+  the `code`/`error` query-param shape with an otherwise-valid state
+  row.
+- **PKCE on the callback.** PKCE callback behavior is covered by
+  `pkce_test.go`, which verifies missing and mismatched
+  `code_verifier` shapes through the provider's real PKCE validator.
 - **HTML / non-redirect responses from the authorize endpoint.** Not
   reachable through the proxy — the user's browser interacts with the
   authorize endpoint directly. A hung authorize page is also out of
@@ -148,7 +148,7 @@ the same provider container do not appear in the filter result.
 | --- | --- |
 | User denial via `error=access_denied` (callback carries error, no code) | `user_denial_test.go` — end-to-end through the browser UI. Same category (`provider_denied`), but the trigger is a real user click rather than a forged callback. |
 | Token-endpoint rejection of an exchanged code | `callback_token_exchange_failure_test.go` — covers `invalid_grant`, `invalid_client`, and the rest of RFC 6749 §5.2. Those tests exercise the path *after* the callback shape is accepted; this file exercises rejection *before* the token endpoint is reached. |
-| Malformed *response* from the token endpoint | `callback_token_exchange_malformed_test.go` (scenario 17). Distinct from this file: that one tests broken bodies in the provider's response to a successful POST. This file tests malformed callbacks *to* the proxy, before any POST happens. |
+| Malformed *response* from the token endpoint | `callback_token_exchange_malformed_test.go`. Distinct from this file: that one tests broken bodies in the provider's response to a successful POST. This file tests malformed callbacks *to* the proxy, before any POST happens. |
 | Callback state security (CSRF, replay, cross-tenant) | `callback_state_security_test.go` and friends. Orthogonal — those tests vary the `state` row; this file varies the `code`/`error` query params with a valid state. |
 
 ## Components
@@ -159,5 +159,5 @@ the same provider container do not appear in the filter result.
 | `env.ForgeOAuth2CallbackURL(state, "")` | Builds the missing-code callback URL. Existing helper; passing `code=""` already produces `?state=<id>` with no code parameter. |
 | `forgeCallbackURLWithErrorAndCode(env, state, code, errCode, errDescription)` | New helper local to this file — covers the code-plus-error shape that `ForgeOAuth2CallbackURL` can't emit. |
 | `env.DeliverOAuth2Callback(t, url)` | Drives the in-process callback delivery; reused unchanged. |
-| `provider.Requests(RequestsFilter{Endpoint: EndpointToken, ClientID: rig.clientKey})` | Counts `/token` POSTs scoped to this rig's client key. The zero-length assertion is the property `#175` is fundamentally about. |
+| `provider.Requests(RequestsFilter{Endpoint: EndpointToken, ClientID: rig.clientKey})` | Counts `/token` POSTs scoped to this rig's client key. The zero-length assertion proves malformed callbacks are rejected before token exchange. |
 | `tokenExchangeProviderDenied = "provider_denied"`, `tokenExchangeMissingCode = "missing_code"` | Category strings pinned by the tests. Defined in `internal/auth_methods/oauth2/token_exchange_failure.go:22, 25`. |

--- a/integration_tests/oauth2/callback_state_security_test.md
+++ b/integration_tests/oauth2/callback_state_security_test.md
@@ -1,15 +1,16 @@
 # OAuth2 Callback State Security — Direct-HTTP Cases
 
 Companion specification for `callback_state_security_test.go`. Covers
-the four direct-HTTP rejection scenarios from #167:
+the direct-HTTP callback rejection cases:
 
 1. Missing `state`.
 2. Unknown `state`.
 3. Tampered `state` (Redis value mutated outside the proxy).
 4. Replayed `state` (state already consumed by a prior successful callback).
 
-The cross-actor case (5) lives in a separate chromedp-driven test
-(#PR 4); the cross-tenant + cross-connection cases (6–7) are PR 5.
+The cross-actor case lives in `callback_actor_mismatch_test.go`. The
+cross-tenant and cross-connection cases live in
+`callback_cross_namespace_test.go`.
 
 ## Why direct HTTP, not chromedp
 
@@ -42,8 +43,9 @@ For every case:
 - **Suspicious callback is logged.** A single `oauth callback rejected`
   slog event is emitted with the expected `category` and no sensitive
   values (no raw `state` parameter for the malformed cases, no
-  ciphertext for the tampered case). The category comes from PR 1
-  (#214).
+  ciphertext for the tampered case). The category is emitted by the
+  callback rejection classifier and is the stable operator-facing
+  signal.
 - **No /token call.** The OAuth provider's `/token` endpoint observes
   zero requests during the rejection — proves the token exchange path
   was short-circuited.
@@ -120,4 +122,4 @@ reason — go-oauth2-server persists clients/users across runs.
 
 PKCE and provider-side `error=...` codes belong to the auth-failure
 path (`HandleAuthFailed`), not to state validation. Those are covered
-by `user_denial_test.go` and the future PKCE test, not here.
+by `user_denial_test.go` and `pkce_test.go`, not here.

--- a/integration_tests/oauth2/callback_token_exchange_failure_test.md
+++ b/integration_tests/oauth2/callback_token_exchange_failure_test.md
@@ -1,15 +1,16 @@
 # OAuth2 Callback Token-Exchange Rejection Cases
 
 Companion specification for `callback_token_exchange_failure_test.go`.
-Covers the non-retryable token-exchange failure cases of issue #168 — the
-proxy POSTs to the provider's `/token` endpoint, the provider responds
-with a 4xx error or a malformed body, and the proxy must classify the
-failure into a stable category, record `auth_failed` on the connection,
-and emit a single `oauth token exchange failed` event.
+Covers non-retryable token-exchange failures: the proxy POSTs to the
+provider's `/token` endpoint, the provider responds with a 4xx error or
+a malformed body, and the proxy must classify the failure into a stable
+category, record `auth_failed` on the connection, and emit a single
+`oauth token exchange failed` event.
 
-The transient retry/5xx cases are PR C (issue #168 part 3). The state /
-actor / namespace validation cases (which short-circuit *before* the
-token exchange ever runs) live in `callback_state_security_test.go`,
+The transient retry/5xx cases live in
+`callback_token_exchange_retry_test.go`. The state / actor / namespace
+validation cases (which short-circuit *before* the token exchange ever
+runs) live in `callback_state_security_test.go`,
 `callback_actor_mismatch_test.go`, and `callback_namespace_mismatch_test.go`.
 
 ## Threat model
@@ -64,11 +65,11 @@ resp.StatusCode != 200 → classifyTokenEndpointStatus(status, body)
 The classifier (`internal/auth_methods/oauth2/token_exchange_failure.go:136-162`)
 runs the body through a small JSON parse looking for the RFC 6749 §5.2
 `error` field. 5xx is always `provider_5xx` regardless of body (covered
-in PR C). 4xx with a recognized error code dispatches to one of the
+in the transient retry tests). 4xx with a recognized error code dispatches to one of the
 named categories; 4xx with no recognized code becomes
 `provider_4xx_other`.
 
-| Test | Scripted token endpoint response | Expected category | Issue #168 case(s) covered |
+| Test | Scripted token endpoint response | Expected category | Provider condition covered |
 | ---- | -------------------------------- | ----------------- | -------------------------- |
 | `TestTokenExchangeRejection_InvalidGrant` | `400 {"error":"invalid_grant"}` | `invalid_grant` | 1 (code expired), 2 (code reused), 3 (invalid code), 6 (redirect_uri mismatch), 7 (provider invalid_grant) |
 | `TestTokenExchangeRejection_InvalidClient` | `401 {"error":"invalid_client"}` | `invalid_client` | 4 (invalid client_id), 5 (invalid client_secret), 8 (provider invalid_client) |
@@ -90,9 +91,9 @@ failure modes into the single `invalid_grant` error code:
 > or was issued to another client.
 
 Because the proxy classifies on `error=invalid_grant` from the body —
-not on which underlying condition produced it — issue #168's separate
-"code expired", "code reused", "invalid code", and "redirect_uri
-mismatch" cases are observably indistinguishable on the proxy side.
+not on which underlying condition produced it — the separate "code
+expired", "code reused", "invalid code", and "redirect_uri mismatch"
+provider conditions are observably indistinguishable on the proxy side.
 A single scripted test exercises the classification path; reproducing
 each underlying condition against the real test provider would not
 strengthen the assertion (the proxy would see the same body either way)
@@ -106,9 +107,9 @@ into the single `invalid_client` test.
 
 The user-flow leg (Connect → login → consent) is irrelevant to these
 cases — the failure mode is purely server-side at the token endpoint.
-Per the saved guidance on issue #168 ("use the go-oauth2-server
-`/test/*` control plane and short-circuit the authorize step"), each
-test:
+Each test uses the go-oauth2-server `/test/*` control plane to
+materialize a real state, authorization code, and scripted token
+response without booting a browser:
 
 1. Calls `env.InitiateOAuth2Connection(t, …)` to materialize a real
    state envelope in Redis and a real connection row.
@@ -171,7 +172,7 @@ sequenceDiagram
 ## What is *not* covered here
 
 - **5xx / transient failures.** `provider_5xx` is bounded-retry territory
-  and is exercised in PR C (the retry policy + a 5xx-then-success script).
+  and is exercised by the retry policy tests with a 5xx-then-success script.
 - **State validation failures.** Missing/unknown/tampered/replayed state
   is `callback_state_security_test.go`. Cross-actor / cross-namespace
   is `callback_actor_mismatch_test.go` and

--- a/integration_tests/oauth2/callback_token_exchange_malformed_test.md
+++ b/integration_tests/oauth2/callback_token_exchange_malformed_test.md
@@ -1,8 +1,8 @@
-# OAuth2 Malformed Token Responses (scenario 17)
+# OAuth2 Malformed Token Responses
 
 Companion specification for `callback_token_exchange_malformed_test.go`.
-Covers issue #176 scenario 17 — the provider returns 200 with a
-malformed or incomplete token-response body and the proxy must:
+Covers the case where the provider returns 200 with a malformed or
+semantically incomplete token-response body and the proxy must:
 
 1. Fail safely (no partial credentials persisted).
 2. Not overwrite existing valid credentials.
@@ -14,12 +14,13 @@ The same shape of bug applies to the refresh leg (which reuses
 `createDbTokenFromResponse`); refresh-side coverage lives in
 `proxy_refresh_failure_test.go` and is cross-referenced below.
 
-## The twelve sub-cases
+## Malformed-response matrix
 
-Issue #176 lists twelve malformed shapes. Three are currently rejected
-by the proxy; nine are currently accepted. Both groups are tested in
-this file — the accepted group as a regression guard so that a future
-shift in validation (in either direction) is observable.
+The matrix includes twelve malformed or edge-case token-response
+shapes. Three are currently rejected by the proxy; nine are currently
+accepted. Both groups are tested in this file — the accepted group as a
+regression guard so that a future shift in validation (in either
+direction) is observable.
 
 ### Rejected as `malformed_response` (3)
 
@@ -65,18 +66,17 @@ For the spec-violating rows (every row except `MissingScope`), the
 assertion `GetOAuth2Token != nil` is the **regression guard**: when
 validation is added later, that assertion fails and the case moves into
 `TestTokenExchangeMalformed_FailsSafely`. Each row carries a `note`
-explaining why the proxy accepts it today so a reviewer of a future
-validation PR knows what the gap was.
+explaining why the proxy accepts it today so a reviewer of future
+validation work knows what the gap was.
 
-## Why a separate "currently accepted" test instead of follow-up bugs
+## Why a separate "currently accepted" test
 
-Splitting the gap cases off into separate follow-up issues without a
-test would leave the failure mode silent — the proxy's behaviour would
-remain undocumented until someone exercises one of the shapes in a
-production incident. Documenting the gaps as passing tests captures the
-observed behaviour at the time of writing, makes the gap visible in the
-test suite, and turns "we now validate `token_type`" into a single
-diff-able assertion update.
+Leaving the gap cases outside this file would make the failure mode
+silent — the proxy's behaviour would remain undocumented until someone
+exercises one of the shapes in a production incident. Documenting the
+gaps as passing tests captures the observed behaviour at the time of
+writing, makes the gap visible in the test suite, and turns "we now
+validate `token_type`" into a single diff-able assertion update.
 
 When the proxy's validation surface is expanded, the workflow is:
 
@@ -88,17 +88,18 @@ When the proxy's validation surface is expanded, the workflow is:
    `malformed_response`.
 
 This is the same pattern `proxy_refresh_failure_test.go` uses for
-`NoAccessTokenInResponse` (folded into `malformed_response` despite the
-RFC arguably wanting a distinct category) — see issue #189 for the
-related discussion.
+`NoAccessTokenInResponse`: a success response without a usable access
+token is folded into `malformed_response` because the proxy has no
+credential it can safely use, and the refresh path must mark the
+connection unhealthy instead of entering a reconnect loop.
 
 ## Property 2: "existing valid credentials are not overwritten"
 
-Issue #176 lists this as a separate verify item. The exchange path
-runs at initial connect — there is no prior token row to overwrite, so
-the property is vacuously satisfied here. The load-bearing version of
-this property lives on the **refresh** path, where a prior token row
-exists when the failing refresh occurs.
+Malformed responses must not overwrite existing valid credentials. The
+exchange path runs at initial connect — there is no prior token row to
+overwrite, so the property is vacuously satisfied here. The
+load-bearing version of this property lives on the **refresh** path,
+where a prior token row exists when the failing refresh occurs.
 
 That refresh-side property is already covered by
 `proxy_refresh_failure_test.go`'s `MalformedResponse` and
@@ -125,13 +126,13 @@ coverage; the cross-reference here is the documentation.
   surface in either suite.
 - **Bytes-on-the-wire integrity.** This test scripts the response
   body; it does not exercise the connection-drop / partial-write
-  surface. Transport-level failure modes are scenario 18's territory
-  (`#177`).
+  surface. Transport-level failure modes are covered in the provider
+  timeout tests.
 - **Provider returning 4xx with malformed JSON body.** Already covered
   by `TestTokenExchangeRejection_Provider4xxOther` — when the status
   is 4xx the body shape is irrelevant to classification, the category
   is the status-bucket.
-- **Time-overflow expires_in.** Issue #176 calls out "extremely long
+- **Time-overflow expires_in.** The matrix calls out "extremely long
   expiry" but does not specify a numeric extreme. `LongExpiry` uses 50
   years (well within `time.Duration` range); the int64-overflow case
   would produce non-deterministic wraparound and is left for a

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.md
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.md
@@ -1,11 +1,11 @@
 # OAuth2 Callback Token-Exchange Retry / 5xx Cases
 
 Companion specification for `callback_token_exchange_retry_test.go`.
-Covers the transient retry leg of issue #168 — the proxy POSTs to the
+Covers transient token-exchange retry behavior: the proxy POSTs to the
 provider's `/token` endpoint, the provider responds with a 5xx, and the
 proxy retries up to a small bounded budget before either succeeding or
 giving up. The non-retryable rejection cases (4xx + malformed 200) live
-in `callback_token_exchange_failure_test.go` (PR B).
+in `callback_token_exchange_failure_test.go`.
 
 ## What the retry policy is, and why
 
@@ -61,17 +61,17 @@ For every retry case:
 - **`attempts` field on the failure event records exhaustion.** Set to
   `tokenExchangeMaxAttempts` on the exhausted-retry path so dashboards
   can distinguish "we tried 3 times and gave up" from a single
-  non-retryable failure. The PR B 4xx tests don't pin the field — it's
-  populated there too, but the assertion belongs in PR C where the
-  value is the point of the test.
+  non-retryable failure. The non-retryable 4xx tests do not pin the
+  field — it is populated there too, but the assertion belongs here
+  where the exhausted retry budget is the point of the test.
 - **302 to `return_to_url?setup=pending&connection_id=<id>` even on
-  exhaustion.** Same as the PR B failure path — the user must land
+  exhaustion.** Same as the permanent failure path — the user must land
   somewhere recoverable, the marketplace UI re-renders the connection
   in `auth_failed`, and the user can retry/cancel.
 
 ## Test plan
 
-| Test | Scripted token endpoint response | Expected outcome | Issue #168 case(s) covered |
+| Test | Scripted token endpoint response | Expected outcome | Retry behavior covered |
 | ---- | -------------------------------- | ---------------- | -------------------------- |
 | `TestTokenExchange_TransientRetrySucceeds` | `503 {"error":"temporarily_unavailable"}` × 2, then default success | `state=ready`, token persisted, **3** `/token` calls, **no** failure event | Transient outage that resolves within budget |
 | `TestTokenExchange_TransientRetryExhausted` | `503 {"error":"temporarily_unavailable"}` × 10 (only first 3 consumed) | `state=created`, `setup_step=auth_failed`, **3** `/token` calls, single failure event with `category=provider_5xx`, `attempts=3`, `provider_status_code=503` | Sustained 5xx outage exceeding budget |
@@ -95,9 +95,10 @@ confusing error.
 
 ## Why direct HTTP, not chromedp
 
-Same rationale as PR B: the user-flow leg (Connect → login → consent)
-is irrelevant to these cases — the failure mode is purely server-side
-at the token endpoint. Each test:
+Same rationale as the non-retryable token-exchange tests: the
+user-flow leg (Connect → login → consent) is irrelevant to these cases
+— the failure mode is purely server-side at the token endpoint. Each
+test:
 
 1. Calls `env.InitiateOAuth2Connection(t, …)` to materialize a real
    state envelope in Redis and a real connection row.
@@ -124,8 +125,8 @@ at the token endpoint. Each test:
   reproducing a cancellation between two specific attempts from the
   integration boundary requires a pre-orchestrated race; the helper's
   behavior is asserted by unit tests instead.
-- **Non-retryable 4xx and malformed 200 responses.** PR B
-  (`callback_token_exchange_failure_test.go`).
+- **Non-retryable 4xx and malformed 200 responses.**
+  `callback_token_exchange_failure_test.go`.
 
 ## Components
 

--- a/integration_tests/oauth2/disconnect_revocation_test.md
+++ b/integration_tests/oauth2/disconnect_revocation_test.md
@@ -1,6 +1,6 @@
 # OAuth disconnect revocation
 
-Scenario for issue #181. The test uses the provider `/test/*` control plane to complete authorization without a browser, then calls the AuthProxy disconnect API and drains the queued `core:disconnect_connection` task with an in-test Asynq worker.
+This test verifies proxy-initiated OAuth disconnect and revocation. It uses the provider `/test/*` control plane to complete authorization without a browser, then calls the AuthProxy disconnect API and drains the queued `core:disconnect_connection` task with an in-test Asynq worker.
 
 The fixture connector enables OAuth revocation and configures the provider's expected revoke form credentials. It revokes the refresh token, which is sufficient to invalidate provider-side credentials while exercising AuthProxy's local token cleanup path.
 

--- a/integration_tests/oauth2/incremental_authorization_test.md
+++ b/integration_tests/oauth2/incremental_authorization_test.md
@@ -1,6 +1,6 @@
 # OAuth incremental authorization
 
-Scenario for issue #180. The test drives re-authentication through the marketplace UI and the provider's login/consent pages with chromedp, rather than short-circuiting through the provider test API.
+This test verifies incremental authorization during OAuth re-authentication. It drives re-authentication through the marketplace UI and the provider's login/consent pages with chromedp, rather than short-circuiting through the provider test API.
 
 The provider fixture currently accepts single scope identifiers in the browser flow, so this scenario uses `read_write` as the optional upgraded scope. The first token response is scripted to grant only `read`, which leaves the connection configured with a missing optional scope. Re-authentication then either returns `read_write` or fails at token exchange.
 

--- a/integration_tests/oauth2/multiple_connections_test.md
+++ b/integration_tests/oauth2/multiple_connections_test.md
@@ -1,8 +1,7 @@
 # OAuth multiple connections
 
-Companion specification for `multiple_connections_test.go`. Covers issue
-#183 / #159 scenario 28: multiple independent OAuth connections to the same
-provider.
+Companion specification for `multiple_connections_test.go`. It covers
+multiple independent OAuth connections to the same provider.
 
 ## Coverage
 

--- a/integration_tests/oauth2/open_redirect_test.md
+++ b/integration_tests/oauth2/open_redirect_test.md
@@ -1,8 +1,7 @@
 # OAuth open redirect protection
 
-Companion specification for `open_redirect_test.go`. Covers issue #184 /
-#159 scenario 29: OAuth callback and post-auth redirect behavior must not send
-users to arbitrary external URLs.
+Companion specification for `open_redirect_test.go`. OAuth callback and
+post-auth redirect behavior must not send users to arbitrary external URLs.
 
 ## Coverage
 

--- a/integration_tests/oauth2/pkce_test.md
+++ b/integration_tests/oauth2/pkce_test.md
@@ -1,8 +1,8 @@
-# PKCE validation (issue #174, scenario 14)
+# PKCE Validation
 
 ## What this verifies
 
-The OAuth2 PKCE machinery added in #335 wires three pieces together:
+The OAuth2 PKCE machinery wires three pieces together:
 
 1. The authorize URL builder (`internal/auth_methods/oauth2/auth_url.go:96-113`)
    emits `code_challenge` and `code_challenge_method` when the connector
@@ -25,19 +25,19 @@ proxy persists hashes to, that the persisted verifier actually rides on
 the token exchange POST, and that the proxy fails the connection cleanly
 when the provider rejects PKCE.
 
-## Issue spec mapping
+## Coverage matrix
 
-Issue #174 lists four cases and three verifies. The mapping to this file's
-tests:
+The PKCE integration coverage maps the important success and failure
+cases to concrete tests:
 
-| #174 case                          | Covered by                                              |
+| PKCE case                           | Covered by                                              |
 |------------------------------------|---------------------------------------------------------|
 | Valid `code_verifier`              | `TestPKCE_HappyPath_S256`                               |
 | Missing `code_verifier`            | `TestPKCE_TokenExchangeRejected/MissingVerifier`        |
 | Invalid `code_verifier`            | `TestPKCE_TokenExchangeRejected/MismatchedVerifier`     |
 | Unsupported `code_challenge_method` | Unit tests in `internal/auth_methods/oauth2/pkce_test.go` (`TestAuthOAuth2_Validate_RejectsUnknownPKCEMethod`) — schema validator rejects at config load, so the bad value never reaches an integration test. Calling it out here so the audit trail is complete. |
 
-| #174 verify                          | Covered by                                              |
+| Verification point                   | Covered by                                              |
 |--------------------------------------|---------------------------------------------------------|
 | Valid PKCE succeeds                  | `TestPKCE_HappyPath_S256`                               |
 | Invalid PKCE fails token exchange    | Both `TestPKCE_TokenExchangeRejected` subtests          |
@@ -54,8 +54,8 @@ would experience it.
   refuses any authorize that arrives without `code_challenge`, so a green
   flow is a positive signal that the proxy is emitting the challenge.
 - Connector with `pkce: {method: S256}`.
-- chromedp + marketplace + provider UI (per the issue's "test approach"
-  comment and the `feedback_oauth_flow_tests_use_real_ui` memory).
+- chromedp + marketplace + provider UI for the user-facing
+  authorization leg.
 
 **Assertions:**
 1. Connection landed in `ready`. Token row persisted with non-empty
@@ -75,9 +75,10 @@ would experience it.
    is pinned end to end in Test 2 (see "Pre-callback PKCE assertion"
    below).
 
-**Why chromedp over the in-process driver:** the issue explicitly calls
-for it, and #174's #scenario-comment notes that the `/test/authorize`
-shortcut would skip the user-driven leg under test. The happy-path
+**Why chromedp over the in-process driver:** the happy path is the
+user-driven authorization leg under test. The `/test/authorize`
+shortcut would mint a code without exercising the marketplace redirect,
+provider login, consent, and browser callback chain. The happy-path
 verification depends on the same code that runs in production redirect
 chains, not a hand-rolled callback delivery.
 
@@ -128,7 +129,7 @@ and state persistence would surface here.
 
 **Per-subtest assertions:**
 1. Callback redirects to `return_to_url?connection_id=<id>&setup=pending`.
-   This matches the scenario 7 (`callback_token_exchange_failure_test.go`)
+   This matches the token-exchange failure path in `callback_token_exchange_failure_test.go`
    shape: a token-exchange failure during setup is a setup failure, and
    the marketplace UI's reconnect prompt fires on the `setup=pending`
    annotation. It does *not* redirect to `error_pages.internal_error`
@@ -156,8 +157,8 @@ and state persistence would surface here.
    provider would have accepted it, and all the failure-path
    assertions above would have failed differently.
 
-**Why not just script `invalid_grant`:** scenario 7
-(`callback_token_exchange_failure_test.go`) already covers "provider
+**Why not just script `invalid_grant`:**
+`callback_token_exchange_failure_test.go` already covers "provider
 returns invalid_grant → connection lands in auth_failed". Pointing the
 PKCE test at a scripted response would duplicate that coverage without
 exercising any PKCE-specific code. The state-mutation approach forces

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.md
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.md
@@ -1,7 +1,7 @@
 # Provider Auth Method Compatibility
 
 Companion notes for `provider_auth_method_compatibility_test.go`.
-Covers issue #178 / scenario 19 from #159.
+Covers OAuth provider token-endpoint client authentication compatibility.
 
 ## Scope
 

--- a/integration_tests/oauth2/provider_timeouts_test.md
+++ b/integration_tests/oauth2/provider_timeouts_test.md
@@ -1,10 +1,10 @@
-# OAuth2 Provider Timeouts (scenario 18)
+# OAuth2 Provider Timeouts
 
-Companion specification for `provider_timeouts_test.go`. Covers issue
-#177 scenario 18 — when a provider endpoint hangs (or, more broadly,
-when the connection terminates mid-flight), the proxy must classify the
-failure as a transient transport error, retry on the legs where retry
-is policy, and never silently overwrite credentials.
+Companion specification for `provider_timeouts_test.go`. Covers the
+provider transport-failure surface: when a provider endpoint hangs (or,
+more broadly, when the connection terminates mid-flight), the proxy
+must classify the failure as a transient transport error, retry on the
+legs where retry is policy, and never silently overwrite credentials.
 
 ## Scope
 
@@ -45,7 +45,7 @@ calls `Close()` on the underlying conn, producing an `EOF` /
 From the proxy's perspective, a server-side timeout, a TCP reset, and
 a process crash are all the same failure: a transport error on the
 pending request, with no HTTP status to classify. That is the
-observable surface scenario 18 is about.
+observable surface this file is about.
 
 If and when the proxy adds an HTTP client timeout, the same tests
 should still cover the property — the failure surfaces the same way
@@ -116,11 +116,11 @@ should still cover the property — the failure surfaces the same way
 
 | Property | Where else covered |
 | --- | --- |
-| Token-exchange retry budget on 5xx | `callback_token_exchange_retry_test.go` (PR for #168). Same retry helper as the timeout case; 5xx exhaustion and timeout exhaustion both produce `attempts=tokenExchangeMaxAttempts`. |
-| Refresh retry budget on 5xx | `proxy_refresh_retry_test.go` (PR for scenario 8). Asserts the parallel observable shape against 5xx; the 5xx test is the canonical case and this scenario is the transport-layer companion. |
+| Token-exchange retry budget on 5xx | `callback_token_exchange_retry_test.go`. Same retry helper as the timeout case; 5xx exhaustion and timeout exhaustion both produce `attempts=tokenExchangeMaxAttempts`. |
+| Refresh retry budget on 5xx | `proxy_refresh_retry_test.go`. Asserts the parallel observable shape against 5xx; the 5xx test is the canonical case and this timeout spec is the transport-layer companion. |
 | Transport-error retry at the helper level | `internal/auth_methods/oauth2/proxy_test.go::TestPostRefreshWithRetry_TransportErrorRetried` and `internal/auth_methods/oauth2/callback_test.go::TestPostTokenExchangeWithRetry_TransportErrorRetried`. Unit-level coverage of the same retry branch this scenario drives end-to-end. |
-| Permanent vs transient health flip | `proxy_refresh_failure_test.go` (scenario 7) for the permanent categories; this file for the transient `network_error` category. |
-| Wire-format response parsing on the refresh leg | `proxy_refresh_failure_test.go::MalformedResponse` row and `callback_token_exchange_malformed_test.go` (scenario 17). |
+| Permanent vs transient health flip | `proxy_refresh_failure_test.go` covers the permanent categories; this file covers the transient `network_error` category. |
+| Wire-format response parsing on the refresh leg | `proxy_refresh_failure_test.go::MalformedResponse` row and `callback_token_exchange_malformed_test.go`. |
 
 ## What is *not* covered here
 
@@ -128,13 +128,13 @@ should still cover the property — the failure surfaces the same way
   authorize endpoint — the user's browser hits it directly. A hung
   authorize page manifests as a UI failure (the user sees a spinner
   forever, then closes the tab) and never reaches any proxy code path
-  that scenario 18 could cover. The state row would expire on TTL.
+  this timeout suite could cover. The state row would expire on TTL.
 - **Revocation endpoint timeouts.** Revocation is fired from the
   background `disconnect_connection` Asynq task in
   `internal/auth_methods/oauth2/revocation.go`; the integration-test
   harness doesn't run the worker by default, so reproducing a
   revoke-timeout end-to-end requires standing one up. The P2
-  disconnect tests (issue #181) cover the disconnect path including
+  disconnect tests cover the disconnect path including
   revocation failure modes. The unit test
   `revocation_test.go::TestRevokeRefreshToken_*` pins the per-call
   classifier behavior.
@@ -146,7 +146,7 @@ should still cover the property — the failure surfaces the same way
   the response body is written, so the body-parser path is not
   exercised here. A drop mid-body would surface as an `io.ErrUnexpectedEOF`
   on the read; that is a different code path that the malformed-
-  response scenario (#176) is the natural home for if needed.
+  malformed-response tests are the natural home for if needed.
 
 ## Components
 

--- a/integration_tests/oauth2/proxy_refresh_concurrent_test.md
+++ b/integration_tests/oauth2/proxy_refresh_concurrent_test.md
@@ -1,14 +1,12 @@
-# OAuth2 Concurrent Refresh Safety (scenario 10)
+# OAuth2 Concurrent Refresh Safety
 
 Companion specification for `proxy_refresh_concurrent_test.go`. Covers
-issue #171 scenario 10 — the serialization property that protects the
-refresh path when N proxy requests detect an expired access token at
-the same time.
+the serialization property that protects the refresh path when N proxy
+requests detect an expired access token at the same time.
 
-Scenario 9 (rotation) is PR A and lives in `proxy_refresh_rotation_test.go`
-/ `proxy_refresh_rotation_test.md`. The two scenarios are paired in
-issue #171 because rotation correctness is the property the
-concurrency test exercises end-to-end: the test provider's default
+Refresh-token rotation lives in `proxy_refresh_rotation_test.go` /
+`proxy_refresh_rotation_test.md`. Rotation correctness is the property
+the concurrency test exercises end-to-end: the test provider's default
 revocation-on-rotation behavior turns "loser POSTed a stale RT" into
 an observable 400 invalid_grant failure event.
 
@@ -74,8 +72,8 @@ the *real* refresh handler. This gives us two properties at once:
   access_token is a valid bearer credential at `/echo`. A scripted
   body would mint a synthetic access_token that `/echo` would 401,
   triggering the proxy's `retry-once-after-refresh` path in
-  `ProxyRequest` and double-counting refresh POSTs. PR A documented
-  that trap for the rotation tests; the same reasoning applies here.
+  `ProxyRequest` and double-counting refresh POSTs. The rotation tests
+  avoid synthetic access tokens for the same reason.
 
 The script action is consumed only by the *first* request that reaches
 the script middleware (the queue is FIFO and `Pop` is mutex-protected).
@@ -173,7 +171,7 @@ sequenceDiagram
 
 | Lever                                                              | What it controls |
 | ------------------------------------------------------------------ | ---------------- |
-| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired`       | Same fixture used by scenarios 6, 7, 8, 9, 13. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge. |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired`       | Shared refresh fixture. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge. |
 | `provider.Script(clientKey, EndpointRefresh, ScriptAction{DelayMs: 500})` | Delay-only action. The script middleware sleeps the configured duration and then falls through to the real refresh handler, preserving real-grant semantics (so the new access_token is a valid bearer at `/echo`). |
 | `close(start)` barrier + `sync.WaitGroup`                          | Releases all N goroutines simultaneously so they hit the expired-token check inside `getValidToken` in a single tight window. |
 | `env.DoProxyRequest(...)` × N                                      | Concurrent proxy calls that all observe the same expired token and contend for the same redis mutex. |

--- a/integration_tests/oauth2/proxy_refresh_failure_test.md
+++ b/integration_tests/oauth2/proxy_refresh_failure_test.md
@@ -1,21 +1,21 @@
-# OAuth2 Refresh Failure Modes (scenario 7)
+# OAuth2 Refresh Failure Modes
 
 Companion specification for `proxy_refresh_failure_test.go`. Covers
-issue #170 scenario 7 — the *deterministic* refresh failure cases that
-must flip the connection unhealthy on the first failed POST.
+the *deterministic* refresh failure cases that must flip the connection
+unhealthy on the first failed POST.
 
-The scenario 8 transient/retry cases (5xx-then-success, exhausted retry
-budget) are PR C and live in a separate file. The auth-flow leg uses the
+The transient/retry cases (5xx-then-success, exhausted retry budget) live
+in `proxy_refresh_retry_test.md`. The auth-flow leg uses the
 `/test/authorize` shortcut rather than chromedp because the failure
 point under test is the refresh endpoint, not the consent screen — same
 reasoning as `callback_token_exchange_failure_test.md`.
 
 ## Cases covered
 
-Scenario 7 in issue #170 lists six observable failure modes for the
+The deterministic refresh-failure matrix covers six observable failure modes for the
 refresh leg:
 
-| Case (issue #170)                        | Test                       | Scripted refresh response                              | Category            |
+| Refresh failure case                     | Test                       | Scripted refresh response                              | Category            |
 | ---------------------------------------- | -------------------------- | ------------------------------------------------------ | ------------------- |
 | Refresh token expired / revoked / invalid; provider returns `invalid_grant` | `InvalidGrant`             | `400 {"error":"invalid_grant"}`                       | `invalid_grant`     |
 | Provider returns `invalid_client`         | `InvalidClient`            | `401 {"error":"invalid_client"}`                      | `invalid_client`    |
@@ -23,7 +23,7 @@ refresh leg:
 | Provider returns malformed refresh response | `MalformedResponse`        | `200` with unparseable JSON body                       | `malformed_response`|
 | Provider returns success without an access token | `NoAccessTokenInResponse`  | `200 {"token_type":"Bearer","expires_in":3600}`        | `malformed_response`|
 
-### Why `invalid_grant` collapses three issue-#170 cases
+### Why `invalid_grant` Collapses Three Provider Cases
 
 RFC 6749 §5.2 deliberately folds *refresh-token expired*, *refresh-token
 revoked*, and *refresh-token invalid* into the single `error=invalid_grant`
@@ -45,9 +45,9 @@ A 200 with a well-formed JSON envelope that omits `access_token` is
 indistinguishable from a 200 with unparseable JSON from the proxy's
 recovery perspective — both leave it with no usable credential and no
 useful information about *why*. `createDbTokenFromResponse` rejects both
-into `tokenRefreshMalformedResponse`. Issue #189 (an endless-refresh-loop
-symptom report) folded into this case once #170's MarkHealthState wiring
-landed in PR #265.
+into `tokenRefreshMalformedResponse`. This case also guards against an
+endless reconnect loop: malformed refresh success responses must mark the
+connection unhealthy instead of repeatedly trying to use a bad token row.
 
 ## What is asserted
 
@@ -75,15 +75,15 @@ For every case:
   — a malformed refresh response must not overwrite the row with
   garbage, because the next refresh attempt would then run against
   corrupted state.
-- **Exactly one refresh POST.** Scenario 7 cases are non-retryable, so
-  the retry loop must short-circuit on the first response. Filtered on
+- **Exactly one refresh POST.** These cases are non-retryable, so the
+  retry loop must short-circuit on the first response. Filtered on
   `grant_type=refresh_token` so the authorization-code POST from the
   initial auth flow doesn't count.
 
 ## What is *not* covered here
 
 - **5xx / transport-error retry behavior.** Bounded retry policy + the
-  "exhausted-budget" failure shape are scenario 8 (PR C) — see
+  "exhausted-budget" failure shape live in
   `proxy_refresh_retry_test.md`.
 - **No-refresh-token short-circuit.** That case never hits the refresh
   endpoint; it's covered by `TestProxyRefresh_NoRefreshTokenFlipsUnhealthy`

--- a/integration_tests/oauth2/proxy_refresh_retry_test.md
+++ b/integration_tests/oauth2/proxy_refresh_retry_test.md
@@ -1,18 +1,17 @@
-# OAuth2 Refresh Transient Retry (scenario 8)
+# OAuth2 Refresh Transient Retry
 
 Companion specification for `proxy_refresh_retry_test.go`. Covers
-issue #170 scenario 8 — the *transient* refresh failure cases that
-exercise the bounded retry policy in `postRefreshWithRetry` (#276).
+the *transient* refresh failure cases that exercise the bounded retry
+policy in `postRefreshWithRetry`.
 
-The permanent failure cases (scenario 7) are PR B and live in
-`proxy_refresh_failure_test.go`. The retry policy itself (constants and
+The permanent failure cases live in `proxy_refresh_failure_test.go`. The retry policy itself (constants and
 loop shape) lives in `internal/auth_methods/oauth2/proxy.go` and is
 unit-tested in `proxy_test.go`; this file pins the end-to-end observable
 shape via real provider scripts.
 
 ## Retry policy under test
 
-Mirrors the token-exchange retry policy in PR A (#276):
+Mirrors the token-exchange retry policy:
 
 | Setting                       | Value (production)                |
 | ----------------------------- | --------------------------------- |
@@ -59,13 +58,13 @@ For every case:
   single non-retryable failures and is the central reason this file
   exists.
 
-### Health-flip asymmetry with scenario 7
+### Health-Flip Asymmetry With Permanent Failures
 
 `provider_5xx` is *transient* — `IsPermanent()` returns false for it —
 so retry-budget exhaustion must NOT flip the connection unhealthy. The
 next proxy call gets another chance.
 
-This is the load-bearing asymmetry with scenario 7, where every
+This is the load-bearing asymmetry with permanent refresh failures, where every
 permanent category (`invalid_grant`, `invalid_client`,
 `provider_4xx_other`, `malformed_response`, `no_refresh_token`) flips
 health on the first failure. A regression that reclassified 5xx as
@@ -88,7 +87,7 @@ the next refresh attempt's input state — this catches it.
 
 ## Why direct DB forge + scripts, not real TTLs
 
-Same reasoning as scenario 7 (`proxy_refresh_failure_test.md`): the
+Same reasoning as the permanent refresh-failure tests (`proxy_refresh_failure_test.md`): the
 failure point under test is purely at the refresh endpoint. The
 go-oauth2-server test provider's `/test/scripts` queue mints arbitrary
 refresh-endpoint responses without booting a browser, and
@@ -153,7 +152,7 @@ sequenceDiagram
 
 - **Permanent failure categories** (`invalid_grant`, `invalid_client`,
   `provider_4xx_other`, `malformed_response`, `no_refresh_token`).
-  Scenario 7 — see `proxy_refresh_failure_test.md`.
+  See `proxy_refresh_failure_test.md`.
 - **Per-attempt log line schema.** The retry-warn line carries
   `attempt`, `max_attempts`, and `provider_status_code` / `error` fields;
   the field-level shape is pinned by the unit tests in
@@ -174,7 +173,7 @@ sequenceDiagram
 
 | Lever                                                       | What it controls |
 | ----------------------------------------------------------- | ---------------- |
-| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Same fixture used by scenarios 6, 7, and 13. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge so the proxy's expiry check fires immediately. |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Shared refresh fixture. Drives the standard auth flow to Ready, then advances the access-token expiry into the past via a DB-level forge so the proxy's expiry check fires immediately. |
 | `provider.Script(clientKey, EndpointRefresh, ScriptAction{Status:5xx, FailCount:N})` | Enqueue N scripted 5xx responses; subsequent calls fall through to the provider's default refresh-token grant. `FailCount=10` outlasts the retry budget for the exhaustion case. |
 | `env.DoProxyRequest(...)`                                   | Triggers the expired-token → refresh path in-process. The retry loop is driven entirely server-side; the test never has to wait for real TTLs. |
 | `rig.refreshCallCount()`                                    | Counts `grant_type=refresh_token` POSTs the provider has observed for this client. Filtered to exclude the authorization-code POSTs from the auth-flow leg. |

--- a/integration_tests/oauth2/proxy_refresh_rotation_test.md
+++ b/integration_tests/oauth2/proxy_refresh_rotation_test.md
@@ -1,17 +1,17 @@
-# OAuth2 Refresh Token Rotation (scenario 9)
+# OAuth2 Refresh Token Rotation
 
 Companion specification for `proxy_refresh_rotation_test.go`. Covers
-issue #171 scenario 9 — refresh-token rotation. RFC 6749 §6 allows but
-does not require the provider to issue a new `refresh_token` on every
+refresh-token rotation. RFC 6749 §6 allows but does not require the
+provider to issue a new `refresh_token` on every
 refresh response. The proxy must persist any rotated value, carry the
 prior value forward when the provider chooses not to rotate, and send
 the *current* `refresh_token` on every subsequent refresh.
 
-The "old refresh token is not restored by stale writes" property listed
-in scenario 9 is a concurrency property — the redis mutex around
-`refreshAccessToken` prevents a slow concurrent refresh from writing
-back a stale value after a faster one has rotated. That is exercised in
-scenario 10 (PR B for #171).
+The "old refresh token is not restored by stale writes" property is a
+concurrency property — the redis mutex around `refreshAccessToken`
+prevents a slow concurrent refresh from writing back a stale value after
+a faster one has rotated. That is exercised in
+`proxy_refresh_concurrent_test.go`.
 
 ## Cases covered
 
@@ -40,7 +40,7 @@ For every case:
   invalidate the rotation chain assertions and is itself a regression.
 - **Structured events.** One `oauth token refresh succeeded` event per
   successful refresh, zero `oauth token refresh failed` events. A
-  failure event in the rotation chain test would mean refresh #2 sent
+  failure event in the rotation chain test would mean the second refresh sent
   the rotated-away RT and the provider rejected it.
 
 ### Why the forward-chain test relies on the provider's revocation behaviour
@@ -50,15 +50,15 @@ refresh_token revoked
 (`UPDATE oauth_refresh_tokens SET revoked_at = now() WHERE id = ? AND revoked_at IS NULL`),
 and `GetValidRefreshToken` returns `invalid_grant` on a revoked replay.
 So if a regression caused the proxy to keep sending the original RT
-after refresh #1, refresh #2 would 400, the proxy would emit a
+after the first refresh, the second refresh would 400, the proxy would emit a
 refresh-failed event, and the connection would flip unhealthy. The
 chain succeeding twice is therefore proof-by-survival that the proxy is
 reading the rotated value and sending it.
 
 ## Why direct DB-level expiry forge + real rotation, not scripts
 
-Scripting refresh responses (the technique used by scenarios 7 and 8)
-fails for rotation tests because:
+Scripting refresh responses (the technique used by refresh failure and
+retry tests) fails for rotation tests because:
 
 - the test provider redacts `refresh_token` values in the recorded
   request log (`recorder.go:redactedFormFields`), so pinning wire-level
@@ -127,15 +127,16 @@ sequenceDiagram
     API->>DB: InsertOAuth2Token (encrypted RT-C)
     API-->>T: 200
 
-    note over T: chain survives because the proxy sent RT-B on refresh #2,<br/>not the rotated-away RT-A
+    note over T: chain survives because the proxy sent RT-B on the second refresh,<br/>not the rotated-away RT-A
 ```
 
 ## What is *not* covered here
 
 - **Concurrent refresh safety.** The mutex around `refreshAccessToken`
   serializes concurrent refreshes; a slow goroutine must not write back
-  a stale RT after a faster one rotated. Scenario 10 — PR B for #171,
-  driven by a `DelayMs`-padded scripted refresh.
+  a stale RT after a faster one rotated. Covered by
+  `proxy_refresh_concurrent_test.go`, driven by a `DelayMs`-padded
+  scripted refresh.
 - **`response omits refresh_token` carry-forward branch.** The proxy's
   `createDbTokenFromResponse` has a branch that copies
   `refreshFrom.EncryptedRefreshToken` byte-for-byte when the response
@@ -150,14 +151,14 @@ sequenceDiagram
 - **Wire-level refresh_token value.** Redacted by the test provider's
   request recorder; we read the persisted (decrypted) column instead.
 - **Rotation under provider 5xx / transient retry.** Covered by
-  scenario 8 (`proxy_refresh_retry_test.go`); the rotation tests assume
+  `proxy_refresh_retry_test.go`; the rotation tests assume
   the happy path on the refresh response itself.
 
 ## Components
 
 | Lever                                                       | What it controls |
 | ----------------------------------------------------------- | ---------------- |
-| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Same fixture used by scenarios 6, 7, 8, 13. Drives the standard auth flow to Ready, then advances `access_token_expires_at` into the past via a DB-level forge so the proxy's expiry check fires immediately. |
+| `proxyRefreshRig` + `completeAuthFlow` / `forceTokenExpired` | Shared refresh fixture. Drives the standard auth flow to Ready, then advances `access_token_expires_at` into the past via a DB-level forge so the proxy's expiry check fires immediately. |
 | `provider.SetRefreshRotation(bool)` (+ `t.Cleanup` restore)  | Toggle the provider's rotation policy at runtime. Test mode defaults to **on**; the no-rotation test disables and restores. |
 | `env.DoProxyRequest(t, connID, …)`                          | Triggers the expired-token → refresh path in-process. The retry loop is driven entirely server-side; the test never has to wait for real TTLs. |
 | `env.GetOAuth2Token(t, connID)`                             | Read the current token row out of the database. |

--- a/integration_tests/oauth2/proxy_refresh_test.md
+++ b/integration_tests/oauth2/proxy_refresh_test.md
@@ -1,17 +1,17 @@
 # OAuth2 Proxy-Time Refresh Cases
 
 Companion specification for `proxy_refresh_test.go`. Covers the
-proxy-time refresh leg of issue #169 and the clock-skew buffer case
-from issue #185. At request time the proxy detects that the persisted
+proxy-time refresh behavior and the clock-skew expiry-buffer case. At
+request time the proxy detects that the persisted
 access token is expired or inside the configured expiry buffer, and
 either exchanges the persisted `refresh_token` for a new access token
-(scenario 6 / #185) or, if no `refresh_token` was issued, flips the
+or, if no `refresh_token` was issued, flips the
 connection's `health_state` to unhealthy without making any HTTP call
-(scenario 13).
+when refresh is impossible.
 
 The initial code → token exchange leg lives in
 `callback_token_exchange_failure_test.go` / `callback_token_exchange_retry_test.go`
-(issue #168). Refresh-call 4xx/5xx rejection cases (invalid_grant,
+Refresh-call 4xx/5xx rejection cases (invalid_grant,
 invalid_client, provider 4xx-other, 5xx) and the
 retry-once-after-401 path are deliberately not included here — see
 "What is *not* covered" below.
@@ -37,7 +37,8 @@ Source: `internal/auth_methods/oauth2/proxy.go:31-132, 166-189`.
 - On a successful refresh, `MarkHealthState(healthy, "refresh_succeeded")`
   is called unconditionally. `MarkHealthState` is idempotent — if the
   connection was already healthy, no `connection health state changed`
-  event is emitted. This is what the scenario-6 assertion pins.
+  event is emitted. The expired-token refresh test pins this no-op
+  transition behavior.
 
 The health-state flip is the load-bearing signal the marketplace UI
 keys off to render its reconnect prompt. A refresh failure that
@@ -46,7 +47,7 @@ over-eager flip on a transient blip would spam reconnect prompts.
 
 ## What is asserted
 
-### Scenario 6 — expired access token refreshes
+### Expired access token refreshes
 
 - **200 from the proxy.** The customer's app sees the request succeed
   modulo the fresh token. End-to-end proof that the refresh round-trip
@@ -73,7 +74,7 @@ over-eager flip on a transient blip would spam reconnect prompts.
   healthy → healthy would render the dashboard's "unhealthy →
   healthy recovery" alert useless.
 
-### Scenario 30 — clock skew / expiry buffer
+### Clock skew / expiry buffer
 
 - **Inside the buffer refreshes.** `TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer`
   forges an active token whose expiry is one second inside
@@ -86,7 +87,7 @@ over-eager flip on a transient blip would spam reconnect prompts.
   proxy request should succeed using the existing token row and should
   not call the refresh endpoint.
 
-### Scenario 13 — no refresh token flips unhealthy
+### No refresh token flips unhealthy
 
 - **Non-200 from the proxy.** The proxy cannot obtain a new access
   token without user interaction, so the customer's request fails.
@@ -116,16 +117,16 @@ over-eager flip on a transient blip would spam reconnect prompts.
 
 ## Test plan
 
-| Test | Pre-expiry refresh_token? | Expected proxy response | Expected health state | Issue case(s) covered |
+| Test | Pre-expiry refresh_token? | Expected proxy response | Expected health state | Behavior covered |
 | ---- | ------------------------- | ----------------------- | --------------------- | -------------------------- |
-| `TestProxyRefresh_ExpiredAccessTokenRefreshes` | yes | 200 (request succeeds) | healthy (no transition) | 6 — expired access token, valid refresh_token |
-| `TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer` | yes | 200 (request succeeds after refresh) | healthy | #185 — token inside expiry buffer |
-| `TestProxyRefresh_TokenOutsideExpiryBufferDoesNotRefreshAggressively` | yes | 200 (request succeeds without refresh) | healthy | #185 — token outside expiry buffer |
-| `TestProxyRefresh_NoRefreshTokenFlipsUnhealthy` | no (cleared) | non-200 (refresh impossible) | unhealthy (transition emitted) | 13 — expired access token, no refresh_token |
+| `TestProxyRefresh_ExpiredAccessTokenRefreshes` | yes | 200 (request succeeds) | healthy (no transition) | Expired access token with a valid refresh token |
+| `TestProxyRefresh_NearlyExpiredAccessTokenRefreshesWithinBuffer` | yes | 200 (request succeeds after refresh) | healthy | Token inside expiry buffer |
+| `TestProxyRefresh_TokenOutsideExpiryBufferDoesNotRefreshAggressively` | yes | 200 (request succeeds without refresh) | healthy | Token outside expiry buffer |
+| `TestProxyRefresh_NoRefreshTokenFlipsUnhealthy` | no (cleared) | non-200 (refresh impossible) | unhealthy (transition emitted) | Expired access token with no refresh token |
 
 ## Why direct HTTP + DB-level expiry forge, not chromedp
 
-Same rationale as the issue #168 tests: the user-flow leg (Connect →
+Same rationale as the token-endpoint behavior tests: the user-flow leg (Connect →
 login → consent) is irrelevant to these cases. The failure mode is
 purely at the persisted-token level — once the auth flow has minted a
 real token, the test forces the expiry condition and exercises the
@@ -159,7 +160,7 @@ Two reasons:
   decrypts and POSTs it, the provider accepts it and returns a fresh
   grant.
 
-For scenario 13, `encfield.EncryptedField{}` (zero value) is passed
+For the no-refresh-token case, `encfield.EncryptedField{}` (zero value) is passed
 instead. `EncryptedRefreshToken.IsZero()` returns true → the
 `errNoRefreshToken` short-circuit fires.
 
@@ -177,9 +178,9 @@ EndpointAuthorize  = "authorize"
 
 Both `EndpointToken` and `EndpointRefresh` map to the same HTTP path
 on the provider, but the inspector classifies by `grant_type` so
-tests can filter cleanly without scanning form bodies. The scenario-6
-refresh assertion filters by `EndpointRefresh`; scenario 13 asserts
-zero `EndpointRefresh` calls.
+tests can filter cleanly without scanning form bodies. The
+expired-token refresh assertion filters by `EndpointRefresh`; the
+no-refresh-token test asserts zero `EndpointRefresh` calls.
 
 ## What is *not* covered here
 
@@ -220,10 +221,10 @@ zero `EndpointRefresh` calls.
 | `completeAuthFlow(t)` (test-local helper)                   | One-call auth flow: `InitiateOAuth2Connection` → `provider.Authorize` → `DeliverOAuth2Callback`. Returns a `connection_id` with a real provider-issued token persisted. |
 | `forceTokenExpired(t, connectionID, clearRefreshToken)`     | Insert a replacement `oauth2_tokens` row with `AccessTokenExpiresAt` 1 hour in the past, optionally with a zero-value `EncryptedRefreshToken`. Reuses the existing encrypted access-token field — the expiry check fires before any decrypt. |
 | `env.DoProxyRequest(t, connectionID, url, method)`          | In-process POST to `/api/v1/connections/<id>/_proxy`. Exercises `oAuth2Connection.ProxyRequest` end to end, including the refresh path triggered by `getValidToken`. |
-| `provider.Requests(RequestsFilter{Endpoint: EndpointRefresh, ClientID})` | Count refresh-token grants observed at the provider. The load-bearing assertion that proves the refresh round-trip ran (scenario 6) or did not (scenario 13). |
+| `provider.Requests(RequestsFilter{Endpoint: EndpointRefresh, ClientID})` | Count refresh-token grants observed at the provider. The load-bearing assertion that proves the refresh round-trip ran or did not when refresh is impossible. |
 | `logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage / FailureMessage / connectionHealthStateChangedMessage)` | Surface the three structured events the tests pin: refresh success/failure (`oauth token refresh succeeded` / `failed`) and the health transition (`connection health state changed`). Message strings are duplicated as constants at the top of `proxy_refresh_test.go` and fail-fast if either drifts from the production source. |
 
-## Sequence (scenario 6 — successful refresh)
+## Sequence — Successful Refresh
 
 ```mermaid
 sequenceDiagram
@@ -257,7 +258,7 @@ sequenceDiagram
     API-->>T: 200
 ```
 
-## Sequence (scenario 13 — no refresh token, flip unhealthy)
+## Sequence — No Refresh Token, Flip Unhealthy
 
 ```mermaid
 sequenceDiagram

--- a/integration_tests/oauth2/proxy_response_handling_test.md
+++ b/integration_tests/oauth2/proxy_response_handling_test.md
@@ -1,7 +1,7 @@
 # Proxy API Response Handling
 
 Companion notes for `proxy_response_handling_test.go`.
-Covers issue #179 / scenarios 20-24 from #159.
+Covers proxied upstream response handling for successful responses, auth failures, permission failures, rate limits, and server errors.
 
 ## Scope
 
@@ -32,8 +32,8 @@ resource requests authenticate with Bearer tokens, not client credentials.
 
 ## Observability
 
-The proxy orchestrator emits stable structured events for the classifications
-called out in #179:
+The proxy orchestrator emits stable structured events for the upstream response
+classifications:
 
 - `proxy upstream retry attempted`
 - `proxy upstream auth failure`

--- a/integration_tests/oauth2/proxy_third_party_revocation_test.md
+++ b/integration_tests/oauth2/proxy_third_party_revocation_test.md
@@ -1,8 +1,8 @@
-# OAuth2 Third-Party Revocation Detection (scenario 11)
+# OAuth2 Third-Party Revocation Detection
 
 Companion specification for `proxy_third_party_revocation_test.go`.
-Covers issue #172 scenario 11 — when a user revokes access at the
-provider, the proxy must detect the dead credential on its next
+Covers third-party revocation detection: when a user revokes access at
+the provider, the proxy must detect the dead credential on its next
 request, surface it as a reconnect-required failure (unhealthy), and
 stop using the dead refresh token.
 
@@ -16,12 +16,12 @@ Three tests cover the full surface:
 3. `TestProxyRevocation_AccessTokenRevokeDoesNotCascadeToRefresh` —
    sanity guard against a future test-provider change.
 
-Scenario 7 (`proxy_refresh_test.go`'s InvalidGrant case) is the
-related spec: it scripts an RFC-compliant `invalid_grant` response on
-the refresh endpoint and pins the proxy's reaction in isolation.
-Scenario 11 is the causal-chain version — the provider's natural
-revocation state machine produces the failure end-to-end, exercising
-the same proxy code path through a real-world cause.
+`proxy_refresh_failure_test.go` covers the related isolated behavior:
+it scripts an RFC-compliant `invalid_grant` response on the refresh
+endpoint and pins the proxy's reaction in isolation. This file is the
+causal-chain version — the provider's natural revocation state machine
+produces the failure end-to-end, exercising the same proxy code path
+through a real-world cause.
 
 ## What is asserted
 
@@ -63,7 +63,7 @@ the same proxy code path through a real-world cause.
   and the replay succeeds — no further refresh.
 - **Token row rotated forward.** New row id, new refresh_token
   plaintext (test provider default rotation policy is on). This
-  re-exercises scenario 9's rotation guarantee under the 401-retry
+  re-exercises the rotation guarantee under the 401-retry
   path.
 - **Second proxy request also 200, no additional refresh.** Pins that
   the self-heal stuck — the new access token works at `/echo` on its
@@ -110,8 +110,8 @@ repo). The proxy's classifier sees a string it does not recognize and
 labels the failure `provider_4xx_other` with reason
 `refresh_provider_4xx_other`.
 
-Scenario 7's InvalidGrant test covers the RFC-compliant mapping
-(scripted response). Scenario 11 covers the causal chain end-to-end;
+The scripted InvalidGrant refresh-failure test covers the
+RFC-compliant mapping. This file covers the causal chain end-to-end;
 its assertions reflect what the fixture actually emits. If the test
 provider is ever updated to return RFC-compliant `invalid_grant` for
 revoked tokens, this test should be updated to assert
@@ -182,30 +182,29 @@ sequenceDiagram
 
 ## What is *not* covered here
 
-- **Scripted invalid_grant.** Scenario 7's existing test covers the
-  RFC-compliant response (`{"error":"invalid_grant"}`) and the
+- **Scripted invalid_grant.** `proxy_refresh_failure_test.go` covers
+  the RFC-compliant response (`{"error":"invalid_grant"}`) and the
   `category=invalid_grant` / `reason=refresh_invalid_grant` mapping.
 - **Revocation discovered by the introspection endpoint.** The proxy
   detects revocation via 401-at-resource and 400-at-token, not via
   RFC 7662 introspection. If introspection-based detection is added,
   it would warrant its own scenario.
 - **Concurrent proxy requests against a revoked credential.**
-  Scenario 10 (`proxy_refresh_concurrent_test.go`) covers concurrent
-  refresh safety. Concurrent requests against a revoked credential
-  would all fail individually but the redis mutex behavior is
-  unchanged — adding that combinatorial case would add little
-  signal.
+  `proxy_refresh_concurrent_test.go` covers concurrent refresh safety.
+  Concurrent requests against a revoked credential would all fail
+  individually but the redis mutex behavior is unchanged — adding that
+  combinatorial case would add little signal.
 - **Recovery via a fresh OAuth flow after revocation.** Re-running
   `completeAuthFlow` against an unhealthy connection is the
-  reconnect path; the auth-flow tests cover the recovery side.
-  Scenario 11 only asserts that revocation is *detected* and the
-  unhealthy state sticks.
+  reconnect path; the auth-flow tests cover the recovery side. This
+  file only asserts that revocation is *detected* and the unhealthy
+  state sticks.
 
 ## Components
 
 | Lever | What it controls |
 | --- | --- |
-| `proxyRefreshRig` + `completeAuthFlow` | Standard fixture used by scenarios 6, 7, 8, 9, 10, 13. Drives the auth flow to Ready and exposes `rig.userID` and `rig.provider`. |
+| `proxyRefreshRig` + `completeAuthFlow` | Shared refresh fixture. Drives the auth flow to Ready and exposes `rig.userID` and `rig.provider`. |
 | `provider.RevokeUser(userID)` | Test-mode control plane: revokes all access + refresh tokens for the user. Models a user revoking access at the provider's UI. |
 | `provider.RevokeToken(plaintext)` | Test-mode control plane: revokes just that token. Access plaintext → access-only revoke (no cascade). Refresh plaintext → cascade to all access tokens for the same client+user. |
 | `env.DecryptOAuth2AccessToken(t, token)` | Plaintext of the encrypted access_token column — required to call `RevokeToken` on the access leg. |

--- a/integration_tests/oauth2/redaction_test.md
+++ b/integration_tests/oauth2/redaction_test.md
@@ -1,7 +1,7 @@
-# OAuth2 Sensitive-Value Redaction (scenario 12)
+# OAuth2 Sensitive-Value Redaction
 
-Companion specification for `redaction_test.go`. Covers issue #173
-scenario 12 — logs, errors, and metrics emitted by any OAuth flow must
+Companion specification for `redaction_test.go`. Logs, errors, and
+metrics emitted by any OAuth flow must
 not contain access tokens, refresh tokens, authorization codes, client
 secrets, PKCE code verifiers, or raw provider credentials.
 
@@ -65,12 +65,12 @@ slog emitted.
 
 ## What is *not* covered here
 
-- **PKCE code verifiers.** The proxy does not implement PKCE
-  (`internal/auth_methods/oauth2` has no `code_verifier` reference; issue
-  #174 / scenario 14 is P1). When PKCE lands, the test should add a
-  `CodeVerifier` field to `flowSecrets` and a per-flow capture point.
-  Adding PKCE without adding it to this test is the silent-leak
-  failure mode this scenario exists to catch.
+- **PKCE code verifiers.** `pkce_test.go` exercises verifier handling,
+  but this redaction suite does not currently capture the verifier
+  plaintext. Add a `CodeVerifier` field to `flowSecrets` and a
+  per-flow capture point if the verifier becomes observable from the
+  integration boundary. Adding new secret material without adding it to
+  this test is the silent-leak failure mode this suite exists to catch.
 - **Gin HTTP access log.** Gin writes its `[api] ... | 200 | ... |
   POST /...` line directly to stdout, not through the configured slog
   handler, so `LogCapture` does not see it. The access log already
@@ -102,13 +102,13 @@ slog emitted.
 ## Why substring scan against decrypted plaintext
 
 The wire-format redaction tests in `request_log` are about checking
-specific known keys (`Authorization`, `client_secret`, etc.).
-Scenario 12 is about catching *any* leak path, including ones that
-emit the value under an unexpected key. The strongest test against
-that class of bug is: the bytes that the provider actually emitted
-must not appear anywhere in the captured log stream. Decrypting the
-persisted row gives us the exact plaintext the proxy held in memory
-and is the only source for the post-rotation refresh_token value.
+specific known keys (`Authorization`, `client_secret`, etc.). This
+suite is about catching *any* leak path, including ones that emit the
+value under an unexpected key. The strongest test against that class of
+bug is: the bytes that the provider actually emitted must not appear
+anywhere in the captured log stream. Decrypting the persisted row gives
+us the exact plaintext the proxy held in memory and is the only source
+for the post-rotation refresh_token value.
 
 A weaker version of this test would scan for keys like `access_token`
 or `refresh_token` in record maps. That misses leaks via different

--- a/integration_tests/oauth2/scope_mismatch_test.md
+++ b/integration_tests/oauth2/scope_mismatch_test.md
@@ -21,7 +21,7 @@ The proxy must:
 3. Treat **missing optional** scopes as a soft failure: the connection
    goes ready and the divergence is exposed via the `/scopes` endpoint
    so callers can decide which features to expose. (A future
-   capabilities system, #209, will surface this to downstream systems
+   capabilities system will surface this to downstream systems
    directly.)
 4. Treat **extra granted** scopes as informational: log them, store the
    granted set verbatim, no blocking.
@@ -48,9 +48,9 @@ The file contains five flow tests (one per scope-shape case):
 The connector declarations use scope names like `write` and `admin`
 that are not in the provider's default seeded scopes table. The
 `provider.CreateClient(Scope: …)` call in the test setup registers
-each requested scope with the provider's `oauth_scopes` table (added
-in go-oauth2-server #44), so the provider's login handler accepts the
-authorize request and renders the consent page.
+each requested scope with the provider's `oauth_scopes` table, so the
+provider's login handler accepts the authorize request and renders the
+consent page.
 
 For the success cases, each test additionally hits
 `GET /api/v1/connections/{id}/scopes` over the real HTTP server and
@@ -123,10 +123,8 @@ sequenceDiagram
 
 ## Why chromedp + provider scripts
 
-This is an OAuth flow scenario, so per the
-[chromedp vs `/test/*` convention](https://github.com/rmorlok/authproxy/issues/159#issuecomment-4361428298)
-adopted across the test suite, we drive the consent leg through the real
-marketplace + provider UI. The user-facing interaction (click Allow) is
+This is an OAuth flow scenario, so we drive the consent leg through the
+real marketplace + provider UI. The user-facing interaction (click Allow) is
 identical to the happy path in `standard_flow_test.go`; what varies is
 purely server-side — what the token endpoint returns. We control that
 via `provider.Script(EndpointToken, ScriptAction{ScopeOverride: …})`,

--- a/integration_tests/oauth2/user_denial_test.md
+++ b/integration_tests/oauth2/user_denial_test.md
@@ -107,6 +107,4 @@ flow would produce, but it bypasses the very leg under test: the user
 clicking the "Deny" button on a real consent form. The primary goal of
 this scenario is to verify that the marketplace + provider UI + proxy
 callback behave correctly when a real user denies, so we drive the full
-browser flow (matching the
-[chromedp vs `/test/*` convention](https://github.com/rmorlok/authproxy/issues/159#issuecomment-4361428298)
-adopted across the test suite).
+browser flow.


### PR DESCRIPTION
## Summary
- remove issue, PR, and scenario-number references from OAuth integration markdown specs
- inline the behavioral context that those ticket references previously implied
- update cross-references to point at concrete test files and observable behaviors

## Verification
- rg ticket-reference scan over integration_tests/oauth2/*.md and integration_tests/README.md
- ./scripts/preflight.sh