### PR TITLE
[A16 follow-up] Use DNS-01 wildcard TLS for demo deploys

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -215,12 +215,16 @@ jobs:
         id: upgrade
         env:
           GRAFANA_PLUGIN_INSTALL: ${{ vars.GRAFANA_AUTHPROXY_PLUGIN_INSTALL }}
+          DEMO_CLUSTER_ISSUER: ${{ vars.DEMO_CLUSTER_ISSUER || 'letsencrypt-prod' }}
+          DEMO_TLS_WILDCARD_SUBDOMAINS: ${{ vars.DEMO_TLS_WILDCARD_SUBDOMAINS || 'false' }}
         run: |
           set -euo pipefail
           helm_args=(
             --namespace "${RELEASE_NS}" --create-namespace
             --wait --timeout 10m
             --set "global.hostname=${{ vars.DEMO_HOSTNAME }}"
+            --set "global.clusterIssuer=${DEMO_CLUSTER_ISSUER}"
+            --set "ingress.wildcardSubdomains=${DEMO_TLS_WILDCARD_SUBDOMAINS}"
             --set "authproxy.image.tag=${{ steps.tag.outputs.tag }}"
             --set "demoShell.image.tag=${{ steps.tag.outputs.tag }}"
             --set "seed.image.tag=${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,6 +37,8 @@ jobs:
       RELEASE_NAME: dev
       CHART_PATH: deploy/charts/authproxy-demo
       DEV_DOMAIN: ${{ vars.DEV_DOMAIN || 'dev.authproxy.net' }}
+      DEV_CLUSTER_ISSUER: ${{ vars.DEV_CLUSTER_ISSUER || 'letsencrypt-prod' }}
+      DEV_TLS_WILDCARD_SUBDOMAINS: ${{ vars.DEV_TLS_WILDCARD_SUBDOMAINS || 'false' }}
       REGISTRY: ghcr.io
       PR_NUMBER: ${{ github.event.pull_request.number }}
       BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
@@ -300,6 +302,8 @@ jobs:
             --atomic \
             --wait --timeout 10m \
             --set "global.hostname=${{ steps.env.outputs.hostname }}" \
+            --set "global.clusterIssuer=${DEV_CLUSTER_ISSUER}" \
+            --set "ingress.wildcardSubdomains=${DEV_TLS_WILDCARD_SUBDOMAINS}" \
             --set "authproxy.image.tag=${{ steps.env.outputs.image_tag }}" \
             --set "demoShell.image.tag=${{ steps.env.outputs.image_tag }}" \
             --set "seed.image.tag=${{ steps.env.outputs.image_tag }}" \

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -160,6 +160,22 @@ The OAuth test provider is path-routed because it is not a SPA. The
 marketplace and admin UIs use subdomains so their root-relative Vite
 assets resolve correctly.
 
+## Wildcard TLS
+
+For per-branch dev environments, use a DNS-01 ClusterIssuer and set:
+
+```bash
+--set global.clusterIssuer=letsencrypt-prod-dns01 \
+--set ingress.wildcardSubdomains=true
+```
+
+The rendered Certificate will request `<hostname>` and `*.<hostname>`.
+For a branch hostname like `feature.dev.authproxy.net`, that covers
+`feature.dev.authproxy.net`, `admin.feature.dev.authproxy.net`, and
+`marketplace.feature.dev.authproxy.net` without creating HTTP-01 solver
+pods. The wildcard mode requires DNS-01; HTTP-01 issuers cannot issue
+wildcard certificates.
+
 ## Smoke test
 
 After install, open `https://<hostname>` — the demo-shell page loads.

--- a/deploy/charts/authproxy-demo/templates/ingress.yaml
+++ b/deploy/charts/authproxy-demo/templates/ingress.yaml
@@ -16,8 +16,10 @@
   on the right backend service.
 
   external-dns reads `spec.rules[*].host` and creates A records for
-  each — no extra Route53 wiring needed. cert-manager mints a single
-  multi-SAN cert covering all three hostnames listed under tls.hosts.
+  each — no extra Route53 wiring needed. By default cert-manager mints
+  a multi-SAN cert covering the hosts listed under tls.hosts. With a
+  DNS-01 issuer, ingress.tls.wildcardSubdomains can request the apex
+  hostname plus `*.<hostname>` instead.
 
   go-oauth2-server (when enabled) lives on the apex `/oauth2` path via
   a separate rewrite Ingress, because it is not a SPA and does not need
@@ -40,8 +42,12 @@ spec:
   tls:
     - hosts:
         - {{ .Values.global.hostname | quote }}
+        {{- if .Values.ingress.wildcardSubdomains }}
+        - {{ printf "*.%s" .Values.global.hostname | quote }}
+        {{- else }}
         - {{ printf "marketplace.%s" .Values.global.hostname | quote }}
         - {{ printf "admin.%s" .Values.global.hostname | quote }}
+        {{- end }}
       secretName: {{ printf "%s-tls" (include "authproxy-demo.fullname" .) | quote }}
   {{- end }}
   rules:

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -48,7 +48,8 @@
       "properties": {
         "enabled":     { "type": "boolean" },
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
-        "tls":         { "type": "boolean" }
+        "tls":         { "type": "boolean" },
+        "wildcardSubdomains": { "type": "boolean" }
       }
     },
     "grafanaAuthProxy": {

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -73,6 +73,10 @@ ingress:
   annotations: {}
   # -- TLS handled by cert-manager via the cluster-issuer annotation.
   tls: true
+  # -- Request `<hostname>` plus `*.<hostname>` in the TLS secret instead
+  # of listing each subdomain. Requires a DNS-01 issuer; HTTP-01 cannot
+  # issue wildcard certificates.
+  wildcardSubdomains: false
 
 grafanaAuthProxy:
   # -- Render the AuthProxy datasource and dashboard provisioning ConfigMaps

--- a/deploy/charts/bootstrap/README.md
+++ b/deploy/charts/bootstrap/README.md
@@ -6,7 +6,7 @@ in-cluster components every downstream workload depends on:
 | Component       | Role                                                        |
 |-----------------|-------------------------------------------------------------|
 | ingress-nginx   | HTTP/HTTPS entry point, fronted by an AWS NLB               |
-| cert-manager    | Automatic TLS issuance (Let's Encrypt prod, HTTP-01)        |
+| cert-manager    | Automatic TLS issuance (Let's Encrypt prod, HTTP-01 or DNS-01) |
 | external-dns    | Reconciles Ingress hosts → Route53 A records                |
 | metrics-server  | Resource metrics for HPA + `kubectl top`                    |
 | ClusterIssuer   | Let's Encrypt prod issuer named `letsencrypt-prod`          |
@@ -68,6 +68,32 @@ install until the main release's pods are Ready. Without it, the first
 install commonly trips a "no endpoints available for service
 …cert-manager-webhook" race.
 
+### Route53 DNS-01 issuer for wildcard TLS
+
+Wildcard certificates require DNS-01. To make `*.branch.dev.authproxy.net`
+work without HTTP-01 challenge pods, upgrade the bootstrap release with a
+Route53-backed issuer:
+
+```bash
+helm upgrade authproxy-bootstrap . \
+  --namespace kube-system \
+  --wait --timeout 5m \
+  --reuse-values \
+  --set "clusterIssuer.name=letsencrypt-prod-dns01" \
+  --set "clusterIssuer.solver=route53" \
+  --set "clusterIssuer.route53.region=us-east-1" \
+  --set "clusterIssuer.route53.hostedZoneId=$(cd ../../terraform/eks && terraform output -raw route53_zone_id)" \
+  --set "clusterIssuer.route53.dnsZones[0]=$(cd ../../terraform/eks && terraform output -raw domain_name)"
+```
+
+cert-manager also needs Route53 change permissions. The simplest path is
+to annotate the cert-manager controller ServiceAccount with an IRSA role
+that can call `route53:GetChange`, `route53:ChangeResourceRecordSets`,
+and `route53:ListResourceRecordSets` on the hosted zone, plus
+`route53:ListHostedZonesByName`. If you do not wire IRSA, cert-manager
+will create Certificate resources but DNS-01 challenges will stay
+pending.
+
 The post-install NOTES print a verification checklist; follow them in
 order.
 
@@ -86,6 +112,12 @@ kubectl get clusterissuer letsencrypt-prod -o wide
 
 `READY=True` once cert-manager has registered with Let's Encrypt (~10-30s
 after the post-install hook fires).
+
+For the DNS-01 issuer, use:
+
+```bash
+kubectl get clusterissuer letsencrypt-prod-dns01 -o wide
+```
 
 ## Smoke test — DNS + TLS round-trip
 

--- a/deploy/charts/bootstrap/README.md
+++ b/deploy/charts/bootstrap/README.md
@@ -79,6 +79,7 @@ helm upgrade authproxy-bootstrap . \
   --namespace kube-system \
   --wait --timeout 5m \
   --reuse-values \
+  --set "cert-manager.serviceAccount.annotations.eks\.amazonaws\.com/role-arn=$(cd ../../terraform/eks && terraform output -raw cert_manager_route53_role_arn)" \
   --set "clusterIssuer.name=letsencrypt-prod-dns01" \
   --set "clusterIssuer.solver=route53" \
   --set "clusterIssuer.route53.region=us-east-1" \

--- a/deploy/charts/bootstrap/templates/cluster_issuer.yaml
+++ b/deploy/charts/bootstrap/templates/cluster_issuer.yaml
@@ -22,6 +22,8 @@
   the hook itself fails (preserve a working issuer across upgrades).
 */ -}}
 {{- if .Values.clusterIssuer.enabled -}}
+{{- $solver := default "http01" .Values.clusterIssuer.solver -}}
+{{- $dnsZones := .Values.clusterIssuer.route53.dnsZones -}}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -37,7 +39,26 @@ spec:
     privateKeySecretRef:
       name: {{ printf "%s-account-key" .Values.clusterIssuer.name | quote }}
     solvers:
+      {{- if eq $solver "route53" }}
+      -
+        {{- if or $dnsZones .Values.global.domain }}
+        selector:
+          dnsZones:
+            {{- if $dnsZones }}
+            {{- toYaml $dnsZones | nindent 12 }}
+            {{- else }}
+            - {{ .Values.global.domain | quote }}
+            {{- end }}
+        {{- end }}
+        dns01:
+          route53:
+            region: {{ required "clusterIssuer.route53.region is required when clusterIssuer.solver=route53" .Values.clusterIssuer.route53.region | quote }}
+            hostedZoneID: {{ required "global.hostedZoneId or clusterIssuer.route53.hostedZoneId is required when clusterIssuer.solver=route53" (default .Values.global.hostedZoneId .Values.clusterIssuer.route53.hostedZoneId) | quote }}
+      {{- else if eq $solver "http01" }}
       - http01:
           ingress:
             ingressClassName: {{ .Values.clusterIssuer.solverIngressClass | quote }}
+      {{- else }}
+      {{- fail (printf "unsupported clusterIssuer.solver %q; expected http01 or route53" $solver) }}
+      {{- end }}
 {{- end }}

--- a/deploy/charts/bootstrap/values.schema.json
+++ b/deploy/charts/bootstrap/values.schema.json
@@ -20,7 +20,20 @@
         "enabled":             { "type": "boolean" },
         "name":                { "type": "string", "minLength": 1 },
         "server":              { "type": "string", "format": "uri" },
-        "solverIngressClass":  { "type": "string", "minLength": 1 }
+        "solver":              { "type": "string", "enum": ["http01", "route53"] },
+        "solverIngressClass":  { "type": "string", "minLength": 1 },
+        "route53": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "region":       { "type": "string", "minLength": 1 },
+            "hostedZoneId": { "type": "string" },
+            "dnsZones": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
       }
     }
   }

--- a/deploy/charts/bootstrap/values.yaml
+++ b/deploy/charts/bootstrap/values.yaml
@@ -125,6 +125,16 @@ clusterIssuer:
   enabled: true
   name: letsencrypt-prod
   server: https://acme-v02.api.letsencrypt.org/directory
-  # solverIngressClass matches the ingress-nginx IngressClass above so
-  # cert-manager can complete HTTP-01 challenges via the same controller.
+  # -- ACME solver to render. `http01` preserves the original nginx
+  # challenge-pod flow. `route53` enables DNS-01, which is required for
+  # wildcard certificates like `*.branch.dev.authproxy.net`.
+  solver: http01
+  # -- HTTP-01 ingress class. Matches the ingress-nginx IngressClass above.
   solverIngressClass: nginx
+  route53:
+    # -- AWS region for Route53 DNS-01. Defaults to the cluster region.
+    region: us-east-1
+    # -- Hosted zone id to update. Defaults to global.hostedZoneId.
+    hostedZoneId: ""
+    # -- Optional solver selector. Defaults to global.domain when set.
+    dnsZones: []

--- a/deploy/terraform/eks/irsa_cert_manager_route53.tf
+++ b/deploy/terraform/eks/irsa_cert_manager_route53.tf
@@ -1,0 +1,72 @@
+# IRSA role for cert-manager DNS-01 challenges.
+#
+# cert-manager uses this role when a ClusterIssuer with the Route53 DNS-01
+# solver issues wildcard certificates. It runs as the cert-manager controller
+# ServiceAccount in kube-system and exchanges its EKS-issued JWT for STS
+# credentials via IRSA.
+#
+# Scoped narrowly: change and list records only in the authproxy.net hosted
+# zone, with Route53's required global read calls left at "*".
+
+locals {
+  cert_manager_namespace            = "kube-system"
+  cert_manager_service_account_name = "authproxy-bootstrap-cert-manager"
+}
+
+data "aws_iam_policy_document" "cert_manager_route53_trust" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:sub"
+      values   = ["system:serviceaccount:${local.cert_manager_namespace}:${local.cert_manager_service_account_name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cert_manager_route53_inline" {
+  # DNS-01 needs to create and remove the _acme-challenge TXT records.
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${aws_route53_zone.primary.zone_id}"]
+  }
+
+  # These APIs do not support resource-level constraints.
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:GetChange",
+      "route53:ListHostedZonesByName",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cert_manager_route53" {
+  name               = "${var.cluster_name}-cert-manager-route53"
+  description        = "IRSA role assumed by cert-manager to solve Route53 DNS-01 challenges for ${var.domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.cert_manager_route53_trust.json
+}
+
+resource "aws_iam_role_policy" "cert_manager_route53" {
+  name   = "${var.cluster_name}-cert-manager-route53"
+  role   = aws_iam_role.cert_manager_route53.id
+  policy = data.aws_iam_policy_document.cert_manager_route53_inline.json
+}

--- a/deploy/terraform/eks/outputs.tf
+++ b/deploy/terraform/eks/outputs.tf
@@ -53,6 +53,11 @@ output "external_dns_role_arn" {
   value       = aws_iam_role.external_dns.arn
 }
 
+output "cert_manager_route53_role_arn" {
+  description = "ARN of the IRSA role cert-manager assumes for Route53 DNS-01 challenges."
+  value       = aws_iam_role.cert_manager_route53.arn
+}
+
 output "oidc_provider_arn" {
   description = "ARN of the cluster's OIDC provider. Future IRSA roles bind their trust policy to this."
   value       = module.eks.oidc_provider_arn


### PR DESCRIPTION
## Summary
- add Route53 DNS-01 support to the bootstrap ClusterIssuer template
- add wildcard TLS mode for demo/dev ingress hostnames
- add cert-manager Route53 IRSA role and output for bootstrap wiring
- add deploy workflow variables for DNS-01 issuer/wildcard TLS

## Verification
- terraform fmt -check deploy/terraform/eks
- helm lint deploy/charts/bootstrap
- helm lint deploy/charts/authproxy-demo
- helm template checks for DNS-01 issuer and wildcard demo TLS
- ./scripts/preflight.sh

## Manual setup already performed
- bootstrap upgraded with cert-manager Route53 IRSA annotation
- letsencrypt-prod-dns01 ClusterIssuer verified Ready
- gha-eks variables should be set with DEV/DEMO_CLUSTER_ISSUER=letsencrypt-prod-dns01 and DEV/DEMO_TLS_WILDCARD_SUBDOMAINS=true