### PR TITLE
Seed demo connector catalog

### DIFF
--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -2,9 +2,11 @@
 // against a running AuthProxy admin API. Run as a Helm post-install /
 // post-upgrade hook from the authproxy-demo umbrella chart.
 //
-// Idempotency model: for each desired entity, first GET it by
-// external_id; if AuthProxy returns 404, POST it. Re-running the seed
-// job is a no-op once the state matches.
+// Idempotency model: for each desired actor, first GET it by
+// external_id; if AuthProxy returns 404, POST it. For each desired
+// connector, list by the stable demo seed label, create it when absent,
+// or publish a new version when the definition changes. Re-running the
+// seed job is a no-op once the state matches.
 //
 // Auth: signs requests as the demo-shell admin actor using the same
 // keypair the demo-shell itself uses. AuthProxy already trusts that
@@ -12,11 +14,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -30,12 +35,24 @@ import (
 
 // SeedConfig is the YAML shape the binary consumes.
 type SeedConfig struct {
-	Actors []ActorSeed `yaml:"actors"`
+	Actors     []ActorSeed     `yaml:"actors"`
+	Connectors []ConnectorSeed `yaml:"connectors"`
 }
 
 type ActorSeed struct {
 	ExternalId  string            `yaml:"external_id"`
 	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+type ConnectorSeed struct {
+	// Key is the stable seed identity. AuthProxy generates connector IDs
+	// for API-created connectors, so the seed job stores this key as an
+	// API label and uses it for future idempotent upgrades.
+	Key         string            `yaml:"key"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Definition  config.Connector  `yaml:"definition"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
@@ -48,8 +65,10 @@ type settings struct {
 }
 
 const (
-	actorRetryTimeout  = 5 * time.Minute
-	actorRetryInterval = 5 * time.Second
+	seedRetryTimeout  = 5 * time.Minute
+	seedRetryInterval = 5 * time.Second
+	seedLabelKey      = "demo.authproxy.net/seed-key"
+	defaultNamespace  = "root"
 )
 
 func mustGetenv(key string) string {
@@ -146,6 +165,220 @@ func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, er
 	return true, nil
 }
 
+type connectorAction string
+
+const (
+	connectorCreated        connectorAction = "created"
+	connectorAlreadyPresent connectorAction = "already-present"
+	connectorUpdated        connectorAction = "updated"
+)
+
+func connectorNamespace(seed ConnectorSeed) string {
+	if seed.Namespace != "" {
+		return seed.Namespace
+	}
+	if seed.Definition.Namespace != nil && *seed.Definition.Namespace != "" {
+		return *seed.Definition.Namespace
+	}
+	return defaultNamespace
+}
+
+func connectorLabels(seed ConnectorSeed) map[string]string {
+	labels := make(map[string]string, len(seed.Labels)+1)
+	for k, v := range seed.Labels {
+		labels[k] = v
+	}
+	labels[seedLabelKey] = seed.Key
+	return labels
+}
+
+func connectorDefinitionsEqual(want config.Connector, got api.ConnectorVersionJson) bool {
+	namespace := got.Namespace
+	normalizedWant := want
+	normalizedWant.Id = got.Id
+	normalizedWant.Version = got.Version
+	normalizedWant.Namespace = &namespace
+	normalizedWant.State = string(got.State)
+
+	normalizedGot := got.Definition
+	normalizedGot.Id = got.Id
+	normalizedGot.Version = got.Version
+	normalizedGot.Namespace = &namespace
+	normalizedGot.State = string(got.State)
+
+	return reflect.DeepEqual(normalizeForJSON(normalizedWant), normalizeForJSON(normalizedGot))
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeForJSON(v any) any {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return v
+	}
+	return out
+}
+
+func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*api.ConnectorJson, error) {
+	var list api.ListConnectorsResponseJson
+	resp, err := c.R().
+		SetHeader("Accept", "application/json").
+		SetQueryParam("namespace", connectorNamespace(seed)).
+		SetQueryParam("label_selector", fmt.Sprintf("%s=%s", seedLabelKey, seed.Key)).
+		SetQueryParam("limit", "1").
+		SetResult(&list).
+		Get(fmt.Sprintf("%s/api/v1/connectors", baseUrl))
+	if err != nil {
+		return nil, fmt.Errorf("GET connector seed %q: %w", seed.Key, err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, fmt.Errorf("GET connector seed %q returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+	}
+	if len(list.Items) == 0 {
+		return nil, nil
+	}
+	return &list.Items[0], nil
+}
+
+func getConnectorVersion(c *resty.Client, baseUrl string, connector api.ConnectorJson) (*api.ConnectorVersionJson, error) {
+	var version api.ConnectorVersionJson
+	resp, err := c.R().
+		SetHeader("Accept", "application/json").
+		SetResult(&version).
+		Get(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d", baseUrl, connector.Id, connector.Version))
+	if err != nil {
+		return nil, fmt.Errorf("GET connector version %s:%d: %w", connector.Id, connector.Version, err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, fmt.Errorf("GET connector version %s:%d returned %d: %s", connector.Id, connector.Version, resp.StatusCode(), resp.String())
+	}
+	return &version, nil
+}
+
+func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*api.ConnectorVersionJson, error) {
+	body := api.CreateConnectorRequestJson{
+		Namespace:   connectorNamespace(seed),
+		Definition:  seed.Definition,
+		Labels:      connectorLabels(seed),
+		Annotations: seed.Annotations,
+	}
+	var created api.ConnectorVersionJson
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		SetResult(&created).
+		Post(fmt.Sprintf("%s/api/v1/connectors", baseUrl))
+	if err != nil {
+		return nil, fmt.Errorf("POST connector seed %q: %w", seed.Key, err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, fmt.Errorf("POST connector seed %q returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+	}
+	return &created, nil
+}
+
+func createConnectorDraft(c *resty.Client, baseUrl string, connector api.ConnectorJson, seed ConnectorSeed) (*api.ConnectorVersionJson, error) {
+	labels := connectorLabels(seed)
+	body := api.CreateConnectorVersionRequestJson{
+		Definition:  &seed.Definition,
+		Labels:      &labels,
+		Annotations: &seed.Annotations,
+	}
+	var created api.ConnectorVersionJson
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		SetResult(&created).
+		Post(fmt.Sprintf("%s/api/v1/connectors/%s/versions", baseUrl, connector.Id))
+	if err != nil {
+		return nil, fmt.Errorf("POST connector seed %q version: %w", seed.Key, err)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, fmt.Errorf("POST connector seed %q version returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+	}
+	return &created, nil
+}
+
+func forceConnectorPrimary(c *resty.Client, baseUrl string, version api.ConnectorVersionJson) error {
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(api.ForceConnectorVersionStateRequestJson{State: string(api.ConnectorVersionStatePrimary)}).
+		Put(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_force_state", baseUrl, version.Id, version.Version))
+	if err != nil {
+		return fmt.Errorf("PUT connector seed %s:%d primary: %w", version.Id, version.Version, err)
+	}
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("PUT connector seed %s:%d primary returned %d: %s", version.Id, version.Version, resp.StatusCode(), resp.String())
+	}
+	return nil
+}
+
+func upsertConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (connectorAction, error) {
+	if seed.Key == "" {
+		return "", fmt.Errorf("connector seed key is required")
+	}
+
+	existing, err := listSeededConnector(c, baseUrl, seed)
+	if err != nil {
+		return "", err
+	}
+
+	if existing == nil {
+		created, err := createConnector(c, baseUrl, seed)
+		if err != nil {
+			return "", err
+		}
+		if created.State != api.ConnectorVersionStatePrimary {
+			if err := forceConnectorPrimary(c, baseUrl, *created); err != nil {
+				return "", err
+			}
+		}
+		return connectorCreated, nil
+	}
+
+	version, err := getConnectorVersion(c, baseUrl, *existing)
+	if err != nil {
+		return "", err
+	}
+
+	if connectorDefinitionsEqual(seed.Definition, *version) &&
+		stringMapsEqual(connectorLabels(seed), version.Labels) &&
+		stringMapsEqual(seed.Annotations, version.Annotations) {
+		if version.State != api.ConnectorVersionStatePrimary {
+			if err := forceConnectorPrimary(c, baseUrl, *version); err != nil {
+				return "", err
+			}
+			return connectorUpdated, nil
+		}
+		return connectorAlreadyPresent, nil
+	}
+
+	created, err := createConnectorDraft(c, baseUrl, *existing, seed)
+	if err != nil {
+		return "", err
+	}
+	if err := forceConnectorPrimary(c, baseUrl, *created); err != nil {
+		return "", err
+	}
+	return connectorUpdated, nil
+}
+
 func run(logger *slog.Logger) error {
 	s := loadSettings()
 	cfg, err := loadConfig(s.configPath)
@@ -158,7 +391,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	for _, a := range cfg.Actors {
-		deadline := time.Now().Add(actorRetryTimeout)
+		deadline := time.Now().Add(seedRetryTimeout)
 		var created bool
 		for attempt := 1; ; attempt++ {
 			created, err = upsertActor(client, s.adminApiUrl, a)
@@ -166,7 +399,7 @@ func run(logger *slog.Logger) error {
 				break
 			}
 			if time.Now().After(deadline) {
-				return fmt.Errorf("upsert actor %q after %s: %w", a.ExternalId, actorRetryTimeout, err)
+				return fmt.Errorf("upsert actor %q after %s: %w", a.ExternalId, seedRetryTimeout, err)
 			}
 			logger.Warn("actor seed attempt failed; retrying",
 				"external_id", a.ExternalId,
@@ -174,12 +407,42 @@ func run(logger *slog.Logger) error {
 				"attempt", attempt,
 				"err", err,
 			)
-			time.Sleep(actorRetryInterval)
+			time.Sleep(seedRetryInterval)
 		}
 		if created {
 			logger.Info("actor created", "external_id", a.ExternalId, "namespace", a.Namespace)
 		} else {
 			logger.Info("actor already present", "external_id", a.ExternalId, "namespace", a.Namespace)
+		}
+	}
+
+	for _, connector := range cfg.Connectors {
+		deadline := time.Now().Add(seedRetryTimeout)
+		var action connectorAction
+		for attempt := 1; ; attempt++ {
+			action, err = upsertConnector(client, s.adminApiUrl, connector)
+			if err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("upsert connector %q after %s: %w", connector.Key, seedRetryTimeout, err)
+			}
+			logger.Warn("connector seed attempt failed; retrying",
+				"key", connector.Key,
+				"namespace", connectorNamespace(connector),
+				"attempt", attempt,
+				"err", err,
+			)
+			time.Sleep(seedRetryInterval)
+		}
+
+		switch action {
+		case connectorCreated:
+			logger.Info("connector created", "key", connector.Key, "namespace", connectorNamespace(connector))
+		case connectorUpdated:
+			logger.Info("connector updated", "key", connector.Key, "namespace", connectorNamespace(connector))
+		case connectorAlreadyPresent:
+			logger.Info("connector already present", "key", connector.Key, "namespace", connectorNamespace(connector))
 		}
 	}
 	return nil

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+var testConnectorID = apid.MustParse("cxr_testgmail0000001")
+
+const testBaseURL = "http://seed.test"
+
+func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
+	seed := ConnectorSeed{
+		Key:        "demo-noauth",
+		Definition: mustConnector(t, "Demo NoAuth"),
+		Labels: map[string]string{
+			"demo": "true",
+		},
+	}
+
+	forcedPrimary := false
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/connectors":
+			require.Equal(t, defaultNamespace, r.URL.Query().Get("namespace"))
+			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("label_selector"))
+			writeJSON(t, w, api.ListConnectorsResponseJson{})
+		case "POST /api/v1/connectors":
+			var req api.CreateConnectorRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, defaultNamespace, req.Namespace)
+			require.Equal(t, "Demo NoAuth", req.Definition.DisplayName)
+			require.Equal(t, "demo-noauth", req.Labels[seedLabelKey])
+			require.Equal(t, "true", req.Labels["demo"])
+			writeJSON(t, w, connectorVersion(req.Definition, req.Labels, api.ConnectorVersionStateDraft, 1))
+		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/1/_force_state":
+			forcedPrimary = true
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertConnector(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, connectorCreated, action)
+	require.True(t, forcedPrimary)
+}
+
+func TestUpsertConnectorSkipsMatchingPrimarySeed(t *testing.T) {
+	seed := ConnectorSeed{
+		Key:        "demo-noauth",
+		Namespace:  "root",
+		Definition: mustConnector(t, "Demo NoAuth"),
+		Labels: map[string]string{
+			"demo": "true",
+		},
+	}
+
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/connectors":
+			writeJSON(t, w, api.ListConnectorsResponseJson{
+				Items: []api.ConnectorJson{connectorSummary(seed, api.ConnectorVersionStatePrimary, 1)},
+			})
+		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertConnector(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, connectorAlreadyPresent, action)
+}
+
+func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
+	seed := ConnectorSeed{
+		Key:        "demo-noauth",
+		Namespace:  "root",
+		Definition: mustConnector(t, "New Demo NoAuth"),
+	}
+	oldDefinition := mustConnector(t, "Old Demo NoAuth")
+	forcedPrimary := false
+
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/connectors":
+			writeJSON(t, w, api.ListConnectorsResponseJson{
+				Items: []api.ConnectorJson{connectorSummary(seed, api.ConnectorVersionStatePrimary, 1)},
+			})
+		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
+			writeJSON(t, w, connectorVersion(oldDefinition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+		case "POST /api/v1/connectors/cxr_testgmail0000001/versions":
+			var req api.CreateConnectorVersionRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.NotNil(t, req.Definition)
+			require.Equal(t, "New Demo NoAuth", req.Definition.DisplayName)
+			require.NotNil(t, req.Labels)
+			require.Equal(t, "demo-noauth", (*req.Labels)[seedLabelKey])
+			writeJSON(t, w, connectorVersion(*req.Definition, *req.Labels, api.ConnectorVersionStateDraft, 2))
+		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/2/_force_state":
+			forcedPrimary = true
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 2))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertConnector(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, connectorUpdated, action)
+	require.True(t, forcedPrimary)
+}
+
+func mustConnector(t *testing.T, displayName string) config.Connector {
+	t.Helper()
+
+	data := []byte(`
+display_name: "` + displayName + `"
+description: "Seeded test connector"
+labels:
+  type: demo-noauth
+auth:
+  type: no-auth
+`)
+	var connector config.Connector
+	require.NoError(t, yaml.Unmarshal(data, &connector))
+	return connector
+}
+
+func connectorSummary(seed ConnectorSeed, state api.ConnectorVersionState, version uint64) api.ConnectorJson {
+	return api.ConnectorJson{
+		Id:          testConnectorID,
+		Version:     version,
+		Namespace:   connectorNamespace(seed),
+		State:       state,
+		DisplayName: seed.Definition.DisplayName,
+		Description: seed.Definition.Description,
+		Labels:      connectorLabels(seed),
+	}
+}
+
+func connectorVersion(def config.Connector, labels map[string]string, state api.ConnectorVersionState, version uint64) api.ConnectorVersionJson {
+	namespace := defaultNamespace
+	def.Id = testConnectorID
+	def.Version = version
+	def.Namespace = &namespace
+	def.State = string(state)
+	return api.ConnectorVersionJson{
+		Id:         testConnectorID,
+		Version:    version,
+		Namespace:  namespace,
+		State:      state,
+		Definition: def,
+		Labels:     labels,
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestClient(handler http.Handler) *resty.Client {
+	return resty.New().SetTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		return recorder.Result(), nil
+	}))
+}

--- a/deploy/charts/authproxy-demo/templates/seed-job.yaml
+++ b/deploy/charts/authproxy-demo/templates/seed-job.yaml
@@ -1,9 +1,11 @@
 {{- if .Values.seed.enabled }}
-# Post-install / post-upgrade hook Job that seeds the demo actors.
+# Post-install / post-upgrade hook Job that seeds the demo actors and
+# Marketplace connector catalog.
 #
 # Idempotency: the demo-seed binary GETs each actor by external_id
-# and skips creation when AuthProxy returns 200, so re-running on
-# every helm upgrade is a no-op once the state matches.
+# and skips creation when AuthProxy returns 200. Connectors are tracked
+# by a stable seed label and promoted to primary after create/update.
+# Re-running on every helm upgrade is a no-op once the state matches.
 #
 # Hook ordering: seed-job runs AFTER the inner authproxy chart is up
 # (helm sequences post-install hooks after the main release applies).
@@ -65,8 +67,8 @@ spec:
           configMap:
             name: {{ printf "%s-seed-config" .Release.Name | quote }}
 ---
-# ConfigMap with the actor list the Job reads. Rendered from
-# `.Values.seed.actors` so customers can extend or override it.
+# ConfigMap with the actor and connector lists the Job reads. Rendered
+# from `.Values.seed` so customers can extend or override it.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -98,5 +100,11 @@ data:
           {{ $k }}: {{ $v | quote }}
 {{-     end }}
 {{-   end }}
+{{- end }}
+    connectors:
+{{- with .Values.seed.connectors }}
+{{- tpl (toYaml .) $ | nindent 6 }}
+{{- else }}
+      []
 {{- end }}
 {{- end }}

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -106,6 +106,21 @@
             },
             "required": ["external_id"]
           }
+        },
+        "connectors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key":         { "type": "string", "minLength": 1 },
+              "namespace":   { "type": "string" },
+              "definition":  { "type": "object", "additionalProperties": true },
+              "labels":      { "type": "object", "additionalProperties": { "type": "string" } },
+              "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "required": ["key", "definition"]
+          }
         }
       }
     }

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -181,6 +181,27 @@ seed:
       labels:
         demo: "true"
         role: datasource
+  # -- Connectors to seed into the Marketplace catalog. Each entry gets
+  # created through the AuthProxy admin API, then forced to `primary` so
+  # fresh demo environments show the catalog immediately. `key` is the
+  # stable seed identity used for idempotent upgrades; the AuthProxy API
+  # still owns the generated connector id.
+  connectors:
+    - key: demo-readme-noauth
+      namespace: root
+      labels:
+        demo: "true"
+        auth_method: no_auth
+        showcase: catalog
+      definition:
+        display_name: "Demo README Resource"
+        highlight: "A no-auth catalog entry used to verify demo seeding."
+        description: "This connector is intentionally simple: it demonstrates that the demo-seed job can publish connector definitions into the Marketplace catalog during install and upgrade. Follow-up demo connectors show OAuth, API key auth, pre-connect tenant selection, and post-connect configuration."
+        labels:
+          type: demo-readme-noauth
+          demo: "true"
+        auth:
+          type: no-auth
 
 # ---------------------------------------------------------------------------
 # Subchart passthroughs — see each upstream's values.yaml for the full


### PR DESCRIPTION
Closes #503.

## Summary
- extend demo-seed to seed connectors through the AuthProxy admin API
- make connector seeding idempotent via a stable seed label and primary promotion
- add a minimal no-auth catalog connector to the demo chart values

## Verification
- env GOCACHE=/private/tmp/authproxy-go-cache go test ./demos/seed/backend
- helm lint deploy/charts/authproxy-demo
- helm template authproxy-demo deploy/charts/authproxy-demo -f deploy/charts/authproxy-demo/ci/all-disabled-values.yaml --set seed.enabled=true --set authproxy.enabled=false --set secrets.autoGenerate=false
- ./scripts/preflight.sh