### PR TITLE
Polish demo marketplace logos and titles

### DIFF
--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -195,6 +195,9 @@ seed:
         showcase: catalog
       definition:
         display_name: "Demo README Resource"
+        logo:
+          mime_type: image/svg+xml
+          base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJEZW1vIFJFQURNRSBSZXNvdXJjZSBsb2dvIj48cmVjdCB3aWR0aD0iMjgwIiBoZWlnaHQ9IjE0MCIgcng9IjEyIiBmaWxsPSIjMEIzRDJFIi8+PHBhdGggZD0iTTYyIDk2VjQ0aDM1YzE3IDAgMjggMTAgMjggMjZzLTExIDI2LTI4IDI2SDYyWm0yMC0xN2gxNGM2IDAgMTAtMyAxMC05cy00LTktMTAtOUg4MnYxOFptNjQgMTdWNDRoMjB2MzVoMzV2MTdoLTU1WiIgZmlsbD0iI0ZGRkZGRiIvPjwvc3ZnPg==
         highlight: "A no-auth catalog entry used to verify demo seeding."
         description: "This connector is intentionally simple: it demonstrates that the demo-seed job can publish connector definitions into the Marketplace catalog during install and upgrade. Follow-up demo connectors show OAuth, API key auth, pre-connect tenant selection, and post-connect configuration."
         labels:

--- a/ui/admin/index.html
+++ b/ui/admin/index.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
     />
-    <title>%VITE_APP_TITLE%</title>
+    <title>AuthProxy Admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/marketplace/index.html
+++ b/ui/marketplace/index.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
     />
-    <title>%VITE_APP_TITLE%</title>
+    <title>AuthProxy Marketplace</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/marketplace/src/components/ConnectorCard.tsx
+++ b/ui/marketplace/src/components/ConnectorCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { 
-  Card, 
-  CardContent, 
-  CardMedia, 
-  Typography, 
-  Button, 
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
   CardActions,
   Box,
   Skeleton
@@ -28,11 +28,67 @@ const truncateText = (text: string, maxLength: number = 120): string => {
   return text.substring(0, maxLength).trim() + '...';
 };
 
+const connectorInitials = (displayName: string): string => {
+  const words = displayName
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean);
+
+  if (words.length === 0) {
+    return 'AP';
+  }
+
+  return words.slice(0, 2).map((word) => word[0].toUpperCase()).join('');
+};
+
+const ConnectorLogoMedia: React.FC<{connector: Connector}> = ({connector}) => {
+  const [logoFailed, setLogoFailed] = React.useState(false);
+
+  React.useEffect(() => {
+    setLogoFailed(false);
+  }, [connector.logo]);
+
+  if (connector.logo && !logoFailed) {
+    return (
+      <CardMedia
+        component="img"
+        image={connector.logo}
+        alt={`${connector.display_name} logo`}
+        onError={() => setLogoFailed(true)}
+        sx={{
+          height: marketplaceTokens.card.mediaHeight,
+          objectFit: 'contain',
+          bgcolor: 'background.default',
+          p: 2,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box
+      role="img"
+      aria-label={`${connector.display_name} logo`}
+      sx={{
+        height: marketplaceTokens.card.mediaHeight,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bgcolor: 'primary.dark',
+        color: 'primary.contrastText',
+      }}
+    >
+      <Typography variant="h3" component="span" sx={{ fontWeight: 700 }}>
+        {connectorInitials(connector.display_name)}
+      </Typography>
+    </Box>
+  );
+};
+
 /**
  * Component to display a single connector with its details
  */
-const ConnectorCard: React.FC<ConnectorCardProps> = ({ 
-  connector, 
+const ConnectorCard: React.FC<ConnectorCardProps> = ({
+  connector,
   onConnect,
   isConnecting
 }) => {
@@ -50,28 +106,23 @@ const ConnectorCard: React.FC<ConnectorCardProps> = ({
         boxShadow: marketplaceTokens.card.shadow,
       }}
     >
-      <CardMedia
-        component="img"
-        height={marketplaceTokens.card.mediaHeight}
-        image={connector.logo}
-        alt={`${connector.display_name} logo`}
-      />
+      <ConnectorLogoMedia connector={connector} />
       <CardContent sx={{ flexGrow: 1 }}>
         <Typography gutterBottom variant="h5" component="div">
           {connector.display_name}
         </Typography>
-        <Box sx={{ 
+        <Box sx={{
           '& p': { margin: 0, fontSize: marketplaceTokens.markdown.bodyFontSize, color: 'text.secondary' },
           '& strong': { color: 'text.primary' },
           '& em': { color: 'text.secondary' },
-          '& code': { 
-            backgroundColor: 'action.hover', 
+          '& code': {
+            backgroundColor: 'action.hover',
             padding: marketplaceTokens.markdown.codePadding,
             borderRadius: marketplaceTokens.radius.control,
             fontSize: marketplaceTokens.markdown.codeFontSize
           }
         }}>
-          <ReactMarkdown 
+          <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
               // Override paragraph to remove default margins
@@ -81,8 +132,8 @@ const ConnectorCard: React.FC<ConnectorCardProps> = ({
               // Override em to use secondary color
               em: ({ children }) => <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>{children}</Typography>,
               // Override code to use custom styling
-              code: ({ children }) => <Typography component="code" sx={{ 
-                backgroundColor: 'action.hover', 
+              code: ({ children }) => <Typography component="code" sx={{
+                backgroundColor: 'action.hover',
                 padding: marketplaceTokens.markdown.codePadding,
                 borderRadius: marketplaceTokens.radius.control,
                 fontSize: marketplaceTokens.markdown.codeFontSize,

--- a/ui/marketplace/src/tests/ConnectorCard.test.tsx
+++ b/ui/marketplace/src/tests/ConnectorCard.test.tsx
@@ -89,6 +89,33 @@ describe('ConnectorCard', () => {
         expect(mockOnConnect).not.toHaveBeenCalled();
     });
 
+    test('renders initials when the connector has no logo', () => {
+        render(
+            <ConnectorCard
+                connector={{...mockConnector, display_name: 'No Logo Connector', logo: ''}}
+                onConnect={mockOnConnect}
+                isConnecting={false}
+            />
+        );
+
+        expect(screen.getByLabelText('No Logo Connector logo')).toHaveTextContent('NL');
+    });
+
+    test('falls back to initials when the connector logo fails to load', () => {
+        render(
+            <ConnectorCard
+                connector={mockConnector}
+                onConnect={mockOnConnect}
+                isConnecting={false}
+            />
+        );
+
+        const logoImg = screen.getByAltText('Google Calendar logo');
+        fireEvent.error(logoImg);
+
+        expect(screen.getByLabelText('Google Calendar logo')).toHaveTextContent('GC');
+    });
+
     test('renders skeleton correctly', () => {
         render(<ConnectorCardSkeleton/>);
 


### PR DESCRIPTION
## Summary
- render connector logo placeholders when a connector has no logo or an image fails to load
- add an inline SVG logo to the seeded Demo README connector so the next seed upgrade publishes a real logo
- replace Vite title placeholders with concrete Marketplace/Admin page titles

## Verification
- yarn workspace @authproxy/marketplace test
- yarn workspace @authproxy/marketplace build
- yarn workspace @authproxy/admin build
- helm lint deploy/charts/authproxy-demo
- helm template authproxy-demo deploy/charts/authproxy-demo -f deploy/charts/authproxy-demo/ci/all-disabled-values.yaml --set seed.enabled=true --set authproxy.enabled=false --set secrets.autoGenerate=false
- ./scripts/preflight.sh

## Screenshot note
I attempted to capture the ConnectorCard story, but local Storybook would not serve in this checkout: the package script hardcodes the occupied 6006 port, and direct workspace exec exits with Storybook's "expected options to have a port" invariant before serving. The logo fallback is covered by tests and production build verification.