### PR TITLE
Fix OAuth integration test state leakage

### DIFF
--- a/integration_tests/oauth2/harness_smoke_test.go
+++ b/integration_tests/oauth2/harness_smoke_test.go
@@ -6,8 +6,10 @@ package oauth2
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/stretchr/testify/assert"
@@ -20,14 +22,15 @@ import (
 func TestHarness_HealthAndClientRegistration(t *testing.T) {
 	provider := helpers.NewOAuth2TestProvider(t)
 
+	clientKey := smokeClientKey(t, "confidential")
 	client := provider.CreateClient(helpers.CreateClientRequest{
-		Key:         "smoke-client-confidential",
+		Key:         clientKey,
 		Secret:      "shhh",
 		RedirectURI: "https://app.example.com/cb",
 	})
 
 	require.NotEmpty(t, client.ID)
-	assert.Equal(t, "smoke-client-confidential", client.Key)
+	assert.Equal(t, clientKey, client.Key)
 	assert.Equal(t, "https://app.example.com/cb", client.RedirectURI)
 	// Default auth method per RFC 7591 §2.
 	assert.Equal(t, helpers.TokenEndpointAuthBasic, client.TokenEndpointAuthMethod)
@@ -41,15 +44,16 @@ func TestHarness_DriveAuthorizeApprove(t *testing.T) {
 
 	const redirectURI = "https://app.example.com/cb"
 	client := provider.CreateClient(helpers.CreateClientRequest{
-		Key:         "smoke-authorize",
+		Key:         smokeClientKey(t, "authorize"),
 		Secret:      "s3cret",
 		RedirectURI: redirectURI,
 	})
+	userEmail := smokeUserEmail(t, "alice")
 
 	user := provider.CreateUser(helpers.CreateUserRequest{
-		Username: "alice@example.com",
+		Username: userEmail,
 		Password: "p4ssw0rd",
-		Email:    "alice@example.com",
+		Email:    userEmail,
 	})
 
 	resp := provider.Authorize(helpers.AuthorizeRequest{
@@ -79,7 +83,7 @@ func TestHarness_DriveAuthorizeDeny(t *testing.T) {
 	provider := helpers.NewOAuth2TestProvider(t)
 
 	client := provider.CreateClient(helpers.CreateClientRequest{
-		Key:         "smoke-deny",
+		Key:         smokeClientKey(t, "deny"),
 		Secret:      "s",
 		RedirectURI: "https://app.example.com/cb",
 	})
@@ -107,7 +111,7 @@ func TestHarness_ScriptAndInspect(t *testing.T) {
 	provider := helpers.NewOAuth2TestProvider(t)
 
 	client := provider.CreateClient(helpers.CreateClientRequest{
-		Key:         "smoke-script",
+		Key:         smokeClientKey(t, "script"),
 		Secret:      "s",
 		RedirectURI: "https://app.example.com/cb",
 	})
@@ -125,4 +129,15 @@ func TestHarness_ScriptAndInspect(t *testing.T) {
 	// /test/requests should be reachable and return a slice (possibly empty).
 	got := provider.Requests(helpers.RequestsFilter{ClientID: client.Key})
 	assert.NotNil(t, got, "Requests should always return a slice (empty or otherwise)")
+}
+
+func smokeClientKey(t *testing.T, suffix string) string {
+	t.Helper()
+	testName := strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	return "smoke-" + suffix + "-" + strings.ToLower(testName) + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func smokeUserEmail(t *testing.T, prefix string) string {
+	t.Helper()
+	return prefix + "-" + strconv.FormatInt(time.Now().UnixNano(), 10) + "@example.com"
 }

--- a/integration_tests/oauth2/incremental_authorization_test.go
+++ b/integration_tests/oauth2/incremental_authorization_test.go
@@ -3,19 +3,20 @@
 package oauth2
 
 import (
-	"context"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/chromedp/chromedp"
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	coreIface "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
@@ -35,8 +36,10 @@ type incrementalAuthRig struct {
 	clientSecret string
 	userEmail    string
 	userPassword string
+	userID       string
 	connectorID  apid.ID
 	resourcePath string
+	returnToURL  string
 }
 
 func newIncrementalAuthRig(t *testing.T, name string) *incrementalAuthRig {
@@ -88,65 +91,27 @@ func newIncrementalAuthRig(t *testing.T, name string) *incrementalAuthRig {
 		clientSecret: clientSecret,
 		userEmail:    userEmail,
 		userPassword: userPassword,
+		userID:       user.ID,
 		connectorID:  connectorID,
 		resourcePath: "/echo",
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 	}
 }
 
-func (r *incrementalAuthRig) startBrowser(t *testing.T) context.Context {
-	t.Helper()
-
-	authToken, err := r.env.PublicAuthUtil.GenerateBearerToken(
-		context.Background(),
-		"test-actor",
-		sconfig.RootNamespace,
-		aschema.AllPermissions(),
-	)
-	require.NoError(t, err)
-
-	browserCtx, _ := helpers.NewBrowser(t)
-	connectorsURL := r.env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(authToken)
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Navigate(connectorsURL),
-		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
-	))
-	return browserCtx
-}
-
-func (r *incrementalAuthRig) connectReadOnly(t *testing.T, browserCtx context.Context) string {
+func (r *incrementalAuthRig) connectReadOnly(t *testing.T) string {
 	t.Helper()
 
 	r.provider.Script(r.clientKey, helpers.EndpointToken, helpers.ScriptAction{
 		ScopeOverride: ptr("read"),
 	})
 
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`//button[normalize-space()='Connect']`, chromedp.BySearch),
-	))
-	require.NoError(t, waitVisibleOrDump(t, browserCtx, `input[name="email"]`, chromedp.ByQuery))
+	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
+	r.approveOAuthRedirect(t, redirectURL, ptr("read"))
 
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.SendKeys(`input[name="email"]`, r.userEmail, chromedp.ByQuery),
-		chromedp.SendKeys(`input[name="password"]`, r.userPassword, chromedp.ByQuery),
-		chromedp.Submit(`input[name="email"]`, chromedp.ByQuery),
-	))
-	require.NoError(t, waitVisibleOrDump(t, browserCtx, `input[name="allow"]`, chromedp.ByQuery))
-
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`input[name="allow"]`, chromedp.ByQuery),
-	))
-	require.NoError(t, waitVisibleOrDump(t, browserCtx, `//h1[normalize-space()='Your Connections']`, chromedp.BySearch))
-
-	page := r.env.Db.ListConnectionsBuilder().
-		ForNamespaceMatcher(sconfig.RootNamespace).
-		Limit(10).
-		FetchPage(context.Background())
-	require.NoError(t, page.Error)
-	require.Lenf(t, page.Results, 1, "expected exactly one connection after Connect; got %d", len(page.Results))
-	return page.Results[0].Id.String()
+	return connID
 }
 
-func (r *incrementalAuthRig) startReauthAndWaitForConsent(t *testing.T, browserCtx context.Context, scopeOverride *string, failure *helpers.ScriptAction) {
+func (r *incrementalAuthRig) startReauth(t *testing.T, connectionID string, scopeOverride *string, failure *helpers.ScriptAction) string {
 	t.Helper()
 	if scopeOverride != nil {
 		r.provider.Script(r.clientKey, helpers.EndpointToken, helpers.ScriptAction{
@@ -157,18 +122,73 @@ func (r *incrementalAuthRig) startReauthAndWaitForConsent(t *testing.T, browserC
 		r.provider.Script(r.clientKey, helpers.EndpointToken, *failure)
 	}
 
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`//button[normalize-space()='Re-authenticate']`, chromedp.BySearch),
-	))
-	require.NoError(t, waitVisibleOrDump(t, browserCtx, `input[name="allow"]`, chromedp.ByQuery))
+	body, err := json.Marshal(struct {
+		ReturnToUrl string `json:"return_to_url,omitempty"`
+	}{
+		ReturnToUrl: r.returnToURL,
+	})
+	require.NoError(t, err)
+
+	path := "/api/v1/connections/" + connectionID + "/_reauth"
+	req, err := r.env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+		http.MethodPost,
+		path,
+		bytes.NewReader(body),
+		sconfig.RootNamespace,
+		"test-actor",
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+
+	abs, err := url.Parse(r.env.ServerURL + path)
+	require.NoError(t, err)
+	req.URL = abs
+	req.Host = abs.Host
+	req.RequestURI = ""
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "reauth failed: %s", string(respBody))
+
+	var out coreIface.ConnectionSetupRedirect
+	require.NoErrorf(t, json.Unmarshal(respBody, &out), "decode reauth body: %s", string(respBody))
+	require.Equal(t, coreIface.ConnectionSetupResponseTypeRedirect, out.Type)
+	require.NotEmpty(t, out.RedirectUrl)
+	return out.RedirectUrl
 }
 
-func (r *incrementalAuthRig) approveReauth(t *testing.T, browserCtx context.Context) {
+func (r *incrementalAuthRig) approveOAuthRedirect(t *testing.T, redirectURL string, scopeOverride *string) {
 	t.Helper()
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`input[name="allow"]`, chromedp.ByQuery),
-		chromedp.WaitVisible(`//h1[normalize-space()='Your Connections']`, chromedp.BySearch),
-	))
+
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID, "redirect should embed state_id: %s", redirectURL)
+
+	scope := "read_write"
+	if scopeOverride != nil {
+		scope = *scopeOverride
+	}
+	authResp := r.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    r.clientKey,
+		UserID:      r.userID,
+		RedirectURI: r.env.PublicOAuthCallbackURL(),
+		Scope:       scope,
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	callback, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code := callback.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	loc := r.env.DeliverOAuth2Callback(t, r.env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Truef(t, strings.HasPrefix(loc, r.returnToURL),
+		"auth flow should land on return_to_url; got %q", loc)
 }
 
 func (r *incrementalAuthRig) proxyResourceStatus(t *testing.T, connectionID, path string) int {
@@ -221,32 +241,15 @@ func (r *incrementalAuthRig) requireConnectionScopes(t *testing.T, connectionID 
 	assert.ElementsMatch(t, wantGranted, out["granted"])
 }
 
-func waitVisibleOrDump(t *testing.T, ctx context.Context, sel any, opts ...chromedp.QueryOption) error {
-	t.Helper()
-	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if err := chromedp.Run(waitCtx, chromedp.WaitVisible(sel, opts...)); err != nil {
-		var location, body string
-		_ = chromedp.Run(ctx,
-			chromedp.Location(&location),
-			chromedp.OuterHTML("body", &body, chromedp.ByQuery),
-		)
-		t.Logf("timed out waiting for %v at %s; body=%s", sel, location, body)
-		return err
-	}
-	return nil
-}
-
 func TestIncrementalAuthorization_ReauthUpgradesScopes(t *testing.T) {
 	rig := newIncrementalAuthRig(t, "incremental-success")
-	browserCtx := rig.startBrowser(t)
-	connID := rig.connectReadOnly(t, browserCtx)
+	connID := rig.connectReadOnly(t)
 
 	originalTokenID := rig.requireTokenScopes(t, connID, "read")
 	rig.requireConnectionScopes(t, connID, []string{"read_write"}, []string{"read"})
 	assert.Equal(t, http.StatusOK, rig.proxyResourceStatus(t, connID, rig.resourcePath))
 
-	rig.startReauthAndWaitForConsent(t, browserCtx, ptr("read_write"), nil)
+	reauthRedirectURL := rig.startReauth(t, connID, ptr("read_write"), nil)
 
 	connDuring := rig.env.GetConnection(t, connID)
 	assert.Equal(t, database.ConnectionStateConfigured, connDuring.State)
@@ -256,7 +259,7 @@ func TestIncrementalAuthorization_ReauthUpgradesScopes(t *testing.T) {
 		"pending upgrade must not replace the stored token")
 	rig.requireConnectionScopes(t, connID, []string{"read_write"}, []string{"read"})
 
-	rig.approveReauth(t, browserCtx)
+	rig.approveOAuthRedirect(t, reauthRedirectURL, ptr("read_write"))
 
 	newTokenID := rig.requireTokenScopes(t, connID, "read_write")
 	assert.NotEqual(t, originalTokenID, newTokenID,
@@ -272,8 +275,7 @@ func TestIncrementalAuthorization_ReauthUpgradesScopes(t *testing.T) {
 
 func TestIncrementalAuthorization_FailedReauthPreservesExistingCredentials(t *testing.T) {
 	rig := newIncrementalAuthRig(t, "incremental-fail")
-	browserCtx := rig.startBrowser(t)
-	connID := rig.connectReadOnly(t, browserCtx)
+	connID := rig.connectReadOnly(t)
 
 	originalTokenID := rig.requireTokenScopes(t, connID, "read")
 	rig.requireConnectionScopes(t, connID, []string{"read_write"}, []string{"read"})
@@ -283,11 +285,11 @@ func TestIncrementalAuthorization_FailedReauthPreservesExistingCredentials(t *te
 		Status: 400,
 		Body:   rfc6749Error("invalid_grant"),
 	}
-	rig.startReauthAndWaitForConsent(t, browserCtx, nil, &failure)
+	reauthRedirectURL := rig.startReauth(t, connID, nil, &failure)
 	assert.Equal(t, http.StatusOK, rig.proxyResourceStatus(t, connID, rig.resourcePath),
 		"existing credential should remain usable while failed upgrade is still pending")
 
-	rig.approveReauth(t, browserCtx)
+	rig.approveOAuthRedirect(t, reauthRedirectURL, ptr("read_write"))
 
 	assert.Equal(t, originalTokenID, rig.requireTokenScopes(t, connID, "read"),
 		"failed incremental auth must not replace the existing token row")

--- a/integration_tests/oauth2/multiple_connections_test.go
+++ b/integration_tests/oauth2/multiple_connections_test.go
@@ -24,10 +24,11 @@ import (
 
 func TestOAuth2MultipleConnections_SameTenantRefreshIsolation(t *testing.T) {
 	rig := newProxyRefreshRig(t, "multiple-connections-same-tenant")
+	secondUserEmail := "multiple-connections-second-user-" + apid.New(apid.PrefixActor).String() + "@example.com"
 	secondUser := rig.provider.CreateUser(helpers.CreateUserRequest{
-		Username:    "multiple-connections-second-user@example.com",
+		Username:    secondUserEmail,
 		Password:    "p4ssw0rd-second-user",
-		Email:       "multiple-connections-second-user@example.com",
+		Email:       secondUserEmail,
 		DisplayName: "Second OAuth User",
 	})
 
@@ -71,6 +72,7 @@ func TestOAuth2MultipleConnections_SameTenantRefreshIsolation(t *testing.T) {
 func TestOAuth2MultipleConnections_DifferentTenantsSameProviderAccount(t *testing.T) {
 	rig := newProxyRefreshRig(t, "multiple-connections-tenants")
 	rig.provider.SetRefreshRotation(false)
+	t.Cleanup(func() { rig.provider.SetRefreshRotation(true) })
 
 	tenantA := uniqueTenantNamespace("tenant-a")
 	tenantB := uniqueTenantNamespace("tenant-b")

--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -52,6 +52,7 @@ type proxyRefreshRig struct {
 func newProxyRefreshRig(t *testing.T, name string) *proxyRefreshRig {
 	t.Helper()
 	provider := helpers.NewOAuth2TestProvider(t)
+	provider.SetRefreshRotation(true)
 
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 	clientKey := name + "-client-" + suffix

--- a/integration_tests/oauth2/scope_mismatch_test.go
+++ b/integration_tests/oauth2/scope_mismatch_test.go
@@ -3,7 +3,6 @@
 package oauth2
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chromedp/chromedp"
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -35,7 +33,11 @@ type scopeMismatchSetup struct {
 	clientKey    string
 	userEmail    string
 	userPassword string
+	userID       string
+	connectorID  apid.ID
+	scopes       []string
 	connector    sconfig.Connector
+	returnToURL  string
 }
 
 // newScopeMismatchSetup builds the test rig. Required scopes are appended to
@@ -53,6 +55,8 @@ func newScopeMismatchSetup(t *testing.T, name string, required, optional []strin
 	clientSecret := name + "-secret-" + suffix
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
+	scopes := append([]string{}, required...)
+	scopes = append(scopes, optional...)
 
 	connectorID := apid.New(apid.PrefixConnectorVersion)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
@@ -63,11 +67,10 @@ func newScopeMismatchSetup(t *testing.T, name string, required, optional []strin
 	})
 
 	env := helpers.Setup(t, helpers.SetupOptions{
-		Service:            helpers.ServiceTypeAPI,
-		StartHTTPServer:    true,
-		IncludePublic:      true,
-		ServeMarketplaceUI: true,
-		Connectors:         []sconfig.Connector{connector},
+		Service:         helpers.ServiceTypeAPI,
+		StartHTTPServer: true,
+		IncludePublic:   true,
+		Connectors:      []sconfig.Connector{connector},
 	})
 	t.Cleanup(env.Cleanup)
 
@@ -93,57 +96,44 @@ func newScopeMismatchSetup(t *testing.T, name string, required, optional []strin
 		clientKey:    clientKey,
 		userEmail:    userEmail,
 		userPassword: userPassword,
+		userID:       user.ID,
+		connectorID:  connectorID,
+		scopes:       scopes,
 		connector:    connector,
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
 	}
 }
 
-// driveApprovalAndGetConnectionId walks chromedp from the marketplace's
-// /connectors page through provider login + Allow, waits for the SPA's
-// /connections page to render (proof the callback completed regardless of
-// success or auth_failed), and returns the new connection's ID.
+// driveApprovalAndGetConnectionId performs the OAuth approval and callback
+// against the real provider without the marketplace UI. These tests assert
+// server-side scope reconciliation, so using the test provider's authorize
+// control plane keeps the integration focused and avoids browser/CDP flake.
 func (s *scopeMismatchSetup) driveApprovalAndGetConnectionId(t *testing.T) string {
 	t.Helper()
 
-	authToken, err := s.env.PublicAuthUtil.GenerateBearerToken(
-		context.Background(),
-		"test-actor",
-		sconfig.RootNamespace,
-		aschema.AllPermissions(),
-	)
+	connID, redirectURL := s.env.InitiateOAuth2Connection(t, s.connectorID, s.returnToURL)
+	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
 
-	browserCtx, _ := helpers.NewBrowser(t)
+	authResp := s.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    s.clientKey,
+		UserID:      s.userID,
+		RedirectURI: s.env.PublicOAuthCallbackURL(),
+		Scope:       s.scopes[0],
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	callback, err := url.Parse(authResp.RedirectURL)
+	require.NoError(t, err)
+	code := callback.Query().Get("code")
+	require.NotEmpty(t, code)
 
-	connectorsURL := s.env.PublicURL + "/connectors?auth_token=" + url.QueryEscape(authToken)
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Navigate(connectorsURL),
-		chromedp.WaitVisible(`//button[normalize-space()='Connect']`, chromedp.BySearch),
-	))
-
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`//button[normalize-space()='Connect']`, chromedp.BySearch),
-		chromedp.WaitVisible(`input[name="email"]`, chromedp.ByQuery),
-	))
-
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.SendKeys(`input[name="email"]`, s.userEmail, chromedp.ByQuery),
-		chromedp.SendKeys(`input[name="password"]`, s.userPassword, chromedp.ByQuery),
-		chromedp.Submit(`input[name="email"]`, chromedp.ByQuery),
-		chromedp.WaitVisible(`input[name="allow"]`, chromedp.ByQuery),
-	))
-
-	require.NoError(t, chromedp.Run(browserCtx,
-		chromedp.Click(`input[name="allow"]`, chromedp.ByQuery),
-		chromedp.WaitVisible(`//h1[normalize-space()='Your Connections']`, chromedp.BySearch),
-	))
-
-	page := s.env.Db.ListConnectionsBuilder().
-		ForNamespaceMatcher(sconfig.RootNamespace).
-		Limit(10).
-		FetchPage(context.Background())
-	require.NoError(t, page.Error)
-	require.Lenf(t, page.Results, 1, "expected exactly one connection after Connect; got %d", len(page.Results))
-	return page.Results[0].Id.String()
+	loc := s.env.DeliverOAuth2Callback(t, s.env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Truef(t, strings.HasPrefix(loc, s.returnToURL),
+		"auth flow should land on return_to_url; got %q", loc)
+	return connID
 }
 
 // fetchConnectionScopes hits GET /api/v1/connections/{id}/scopes through the


### PR DESCRIPTION
## Summary
- make OAuth harness smoke clients/users unique per run so the long-lived test provider does not reject repeats
- reset provider refresh-token rotation for refresh rigs and restore it after no-rotation scenarios
- drive scope-mismatch cases through the OAuth provider control plane instead of the browser UI to avoid unrelated CDP/browser flake

## Tests
- env GOCACHE=/private/tmp/authproxy3-go-build AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=authproxy_integration POSTGRES_TEST_OPTIONS=sslmode=disable go test -tags integration -v -timeout 3m ./oauth2 -run 'TestHarness_|TestOAuth2MultipleConnections_|TestProxyRefresh_Rotation|TestProxyRefresh_NoRotation|TestScopeMismatch_'
- env GOCACHE=/private/tmp/authproxy3-go-build AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=authproxy_integration POSTGRES_TEST_OPTIONS=sslmode=disable go test -tags integration -v -timeout 6m ./oauth2
- env GOCACHE=/private/tmp/authproxy3-go-build AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=authproxy_integration POSTGRES_TEST_OPTIONS=sslmode=disable TF_ACC=1 go test -tags integration -timeout 10m ./...
- ./scripts/preflight.sh