### PR TITLE
Add actor-templated permission namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Permissions are defined as a combination of **namespace**, **resources**, and **
 
 Wildcards (`*`) are supported for resources and verbs. The `**` suffix on namespaces matches all descendants.
 
+Permission namespaces may also template fields from the authenticated actor: `{{external_id}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. For example, `root.{{external_id}}.**` grants each actor access under a namespace named for its external ID. If a referenced label or annotation is missing, that permission does not match.
+
 ### JWT Authentication and Scoped Tokens
 
 AuthProxy uses JWTs for authentication with a flexible model designed for **least-privilege access**. Actors (users or service accounts) have a set of permissions stored in the database, but each JWT issued can carry a **subset** of those permissions.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,6 +118,8 @@ ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs --no-ex
 
 Grafana presets use top-level JWT permissions. Those permissions only restrict the token; the backing actor still needs matching normal permissions.
 
+Permission namespaces in a permissions file support the same actor templates as normal actor permissions: `{{external_id}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. These render against the backing actor, and missing label or annotation values make the permission fail to match.
+
 ### `ap verify-jwt`
 
 Reads a JWT on stdin and verifies it against the supplied public/secret key.

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -13,6 +13,10 @@ type IActorData interface {
 	GetLabels() map[string]string
 }
 
+type actorAnnotationsData interface {
+	GetAnnotations() map[string]string
+}
+
 // Actor is the information that identifies who is making a request. This can be an actor in the calling
 // system, an admin from the calling system, a devops admin from the cli, etc.
 type Actor struct {
@@ -23,6 +27,7 @@ type Actor struct {
 	ExternalId  string               `json:"external_id"`
 	Namespace   string               `json:"namespace,omitempty"`
 	Labels      map[string]string    `json:"labels,omitempty"`
+	Annotations map[string]string    `json:"-"`
 	Permissions []aschema.Permission `json:"permissions"`
 }
 
@@ -44,14 +49,19 @@ func (a *Actor) GetNamespace() string {
 
 func (a *Actor) GetLabels() map[string]string { return a.Labels }
 
-// GetAnnotations always returns nil for JWT-derived actors. Annotations are
-// server-side metadata and do not propagate via JWT, so an upsert from a JWT
-// claim must not overwrite annotations on the stored actor.
-func (a *Actor) GetAnnotations() map[string]string { return nil }
+// GetAnnotations returns server-side actor annotations when this actor was
+// built from database state. The field is not deserialized from JWT actor
+// claims, so upserts from claims preserve existing annotations.
+func (a *Actor) GetAnnotations() map[string]string { return a.Annotations }
 
 func CreateActor(data IActorData) *Actor {
 	if a, ok := data.(*Actor); ok {
 		return a
+	}
+
+	var annotations map[string]string
+	if a, ok := data.(actorAnnotationsData); ok {
+		annotations = a.GetAnnotations()
 	}
 
 	return &Actor{
@@ -59,6 +69,7 @@ func CreateActor(data IActorData) *Actor {
 		ExternalId:  data.GetExternalId(),
 		Namespace:   data.GetNamespace(),
 		Labels:      data.GetLabels(),
+		Annotations: annotations,
 		Permissions: data.GetPermissions(),
 	}
 }

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -3,6 +3,7 @@ package core
 import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 type IActorData interface {
@@ -49,15 +50,36 @@ func (a *Actor) GetLabels() map[string]string { return a.Labels }
 // GetAnnotations returns actor annotations from database state or JWT claims.
 func (a *Actor) GetAnnotations() map[string]string { return a.Annotations }
 
+func isValidValueForNamespaceTemplating(val string) bool {
+	return val != "" && val != namespace.NamespaceWildcard
+}
+
+func filterLabelOrAnnotationForPermission(vals map[string]string) map[string]string {
+	result := make(map[string]string, len(vals))
+
+	for k, v := range vals {
+		if isValidValueForNamespaceTemplating(v) {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
 // GetPermissionTemplateData returns actor data for permission template context. These are
 // the values that can be used in templated namespaces for permissions baed on actor data.
 // E.g. root.{{labels.team_id}}
 func (a *Actor) GetPermissionTemplateData() map[string]any {
-	return map[string]any{
-		"external_id": a.ExternalId,
-		"labels":      a.Labels,
-		"annotations": a.Annotations,
+	result := map[string]any{
+		"labels":      filterLabelOrAnnotationForPermission(a.Labels),
+		"annotations": filterLabelOrAnnotationForPermission(a.Annotations),
 	}
+
+	if isValidValueForNamespaceTemplating(a.ExternalId) {
+		result["external_id"] = a.ExternalId
+	}
+
+	return result
 }
 
 func CreateActor(data IActorData) *Actor {

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -27,7 +27,7 @@ type Actor struct {
 	ExternalId  string               `json:"external_id"`
 	Namespace   string               `json:"namespace,omitempty"`
 	Labels      map[string]string    `json:"labels,omitempty"`
-	Annotations map[string]string    `json:"-"`
+	Annotations map[string]string    `json:"annotations,omitempty"`
 	Permissions []aschema.Permission `json:"permissions"`
 }
 
@@ -49,9 +49,7 @@ func (a *Actor) GetNamespace() string {
 
 func (a *Actor) GetLabels() map[string]string { return a.Labels }
 
-// GetAnnotations returns server-side actor annotations when this actor was
-// built from database state. The field is not deserialized from JWT actor
-// claims, so upserts from claims preserve existing annotations.
+// GetAnnotations returns actor annotations from database state or JWT claims.
 func (a *Actor) GetAnnotations() map[string]string { return a.Annotations }
 
 func CreateActor(data IActorData) *Actor {

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -11,9 +11,6 @@ type IActorData interface {
 	GetPermissions() []aschema.Permission
 	GetNamespace() string
 	GetLabels() map[string]string
-}
-
-type actorAnnotationsData interface {
 	GetAnnotations() map[string]string
 }
 
@@ -57,17 +54,12 @@ func CreateActor(data IActorData) *Actor {
 		return a
 	}
 
-	var annotations map[string]string
-	if a, ok := data.(actorAnnotationsData); ok {
-		annotations = a.GetAnnotations()
-	}
-
 	return &Actor{
 		Id:          data.GetId(),
 		ExternalId:  data.GetExternalId(),
 		Namespace:   data.GetNamespace(),
 		Labels:      data.GetLabels(),
-		Annotations: annotations,
+		Annotations: data.GetAnnotations(),
 		Permissions: data.GetPermissions(),
 	}
 }

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -49,6 +49,17 @@ func (a *Actor) GetLabels() map[string]string { return a.Labels }
 // GetAnnotations returns actor annotations from database state or JWT claims.
 func (a *Actor) GetAnnotations() map[string]string { return a.Annotations }
 
+// GetPermissionTemplateData returns actor data for permission template context. These are
+// the values that can be used in templated namespaces for permissions baed on actor data.
+// E.g. root.{{labels.team_id}}
+func (a *Actor) GetPermissionTemplateData() map[string]any {
+	return map[string]any{
+		"external_id": a.ExternalId,
+		"labels":      a.Labels,
+		"annotations": a.Annotations,
+	}
+}
+
 func CreateActor(data IActorData) *Actor {
 	if a, ok := data.(*Actor); ok {
 		return a

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -164,7 +164,7 @@ func permissionsAllowForActor(actor *Actor, permissions []aschema.Permission, na
 	return false
 }
 
-// permissionsAllowWithRestrictions checks if an action is allowed by both the actor's permissions
+// permissionsAllowWithRestrictionsForActor checks if an action is allowed by both the actor's permissions
 // and any additional request-level restrictions.
 //
 // This implements the intersection of two permission sets:
@@ -178,14 +178,6 @@ func permissionsAllowForActor(actor *Actor, permissions []aschema.Permission, na
 //   - actorPermissions: The permissions granted to the actor (user/service).
 //   - restrictions: Optional additional restrictions. If nil or empty, only actor permissions are checked.
 //   - namespace, resource, verb, resourceId: The action being checked.
-func permissionsAllowWithRestrictions(
-	actorPermissions []aschema.Permission,
-	restrictions []aschema.Permission,
-	namespace, resource, verb, resourceId string,
-) bool {
-	return permissionsAllowWithRestrictionsForActor(nil, actorPermissions, restrictions, namespace, resource, verb, resourceId)
-}
-
 func permissionsAllowWithRestrictionsForActor(
 	actor *Actor,
 	actorPermissions []aschema.Permission,

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -1,14 +1,12 @@
 package core
 
 import (
-	"regexp"
 	"slices"
 	"strings"
 
+	"github.com/rmorlok/authproxy/internal/aptmpl"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 )
-
-var permissionNamespaceTemplateRegex = regexp.MustCompile(`{{\s*([^{}]+?)\s*}}`)
 
 // Allows checks if this permission allows the specified action.
 //
@@ -71,7 +69,7 @@ func matchesNamespace(actor *Actor, p aschema.Permission, targetNamespace string
 }
 
 func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
-	if !strings.Contains(namespace, "{{") {
+	if !aptmpl.ContainsMustache(namespace) {
 		return namespace, true
 	}
 
@@ -79,33 +77,25 @@ func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
 		return "", false
 	}
 
-	matches := permissionNamespaceTemplateRegex.FindAllStringSubmatchIndex(namespace, -1)
-	if len(matches) == 0 {
+	vars, err := aptmpl.ExtractVariables(namespace)
+	if err != nil {
 		return "", false
 	}
 
-	var rendered strings.Builder
-	last := 0
-	for _, match := range matches {
-		rendered.WriteString(namespace[last:match[0]])
-
-		name := strings.TrimSpace(namespace[match[2]:match[3]])
-		value, ok := actorPermissionTemplateValue(actor, name)
+	data := actorPermissionTemplateContext(actor)
+	for _, name := range vars {
+		_, ok := actorPermissionTemplateValue(data, name)
 		if !ok {
 			return "", false
 		}
-
-		rendered.WriteString(value)
-		last = match[1]
 	}
-	rendered.WriteString(namespace[last:])
 
-	result := rendered.String()
-	if strings.Contains(result, "{{") || strings.Contains(result, "}}") {
+	rendered, err := aptmpl.RenderMustache(namespace, data)
+	if err != nil {
 		return "", false
 	}
 
-	return result, true
+	return rendered, true
 }
 
 func renderValidPermissionNamespace(actor *Actor, namespace string) (string, bool) {
@@ -121,23 +111,34 @@ func renderValidPermissionNamespace(actor *Actor, namespace string) (string, boo
 	return rendered, true
 }
 
-func actorPermissionTemplateValue(actor *Actor, name string) (string, bool) {
+func actorPermissionTemplateContext(actor *Actor) map[string]any {
+	return map[string]any{
+		"external_id": actor.ExternalId,
+		"labels":      actor.Labels,
+		"annotations": actor.Annotations,
+	}
+}
+
+func actorPermissionTemplateValue(data map[string]any, name string) (string, bool) {
 	switch {
 	case name == "external_id":
-		return actor.ExternalId, true
+		value, ok := data["external_id"].(string)
+		return value, ok
 	case strings.HasPrefix(name, "labels."):
 		key := strings.TrimPrefix(name, "labels.")
-		if key == "" || actor.Labels == nil {
+		labels, _ := data["labels"].(map[string]string)
+		if key == "" || labels == nil {
 			return "", false
 		}
-		value, ok := actor.Labels[key]
+		value, ok := labels[key]
 		return value, ok
 	case strings.HasPrefix(name, "annotations."):
 		key := strings.TrimPrefix(name, "annotations.")
-		if key == "" || actor.Annotations == nil {
+		annotations, _ := data["annotations"].(map[string]string)
+		if key == "" || annotations == nil {
 			return "", false
 		}
-		value, ok := actor.Annotations[key]
+		value, ok := annotations[key]
 		return value, ok
 	default:
 		return "", false

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"slices"
-	"strings"
 
 	"github.com/rmorlok/authproxy/internal/aptmpl"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
@@ -64,6 +63,9 @@ func matchesNamespace(actor *Actor, p aschema.Permission, targetNamespace string
 	return aschema.NamespaceMatches(matcher, targetNamespace)
 }
 
+// renderPermissionNamespace applies templating to a given namespace string and returns
+// the resulting string and whether the rendering was successful. If rendering was not
+// successful, the namespace should be considered invalid.
 func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
 	if !aptmpl.ContainsMustache(namespace) {
 		return namespace, true
@@ -73,20 +75,7 @@ func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
 		return "", false
 	}
 
-	vars, err := aptmpl.ExtractVariables(namespace)
-	if err != nil {
-		return "", false
-	}
-
-	data := actorPermissionTemplateContext(actor)
-	for _, name := range vars {
-		_, ok := actorPermissionTemplateValue(data, name)
-		if !ok {
-			return "", false
-		}
-	}
-
-	rendered, err := aptmpl.RenderMustache(namespace, data)
+	rendered, err := aptmpl.RenderMustache(namespace, actor.GetPermissionTemplateData())
 	if err != nil {
 		return "", false
 	}
@@ -105,40 +94,6 @@ func renderValidPermissionNamespace(actor *Actor, namespace string) (string, boo
 	}
 
 	return rendered, true
-}
-
-func actorPermissionTemplateContext(actor *Actor) map[string]any {
-	return map[string]any{
-		"external_id": actor.ExternalId,
-		"labels":      actor.Labels,
-		"annotations": actor.Annotations,
-	}
-}
-
-func actorPermissionTemplateValue(data map[string]any, name string) (string, bool) {
-	switch {
-	case name == "external_id":
-		value, ok := data["external_id"].(string)
-		return value, ok
-	case strings.HasPrefix(name, "labels."):
-		key := strings.TrimPrefix(name, "labels.")
-		labels, _ := data["labels"].(map[string]string)
-		if key == "" || labels == nil {
-			return "", false
-		}
-		value, ok := labels[key]
-		return value, ok
-	case strings.HasPrefix(name, "annotations."):
-		key := strings.TrimPrefix(name, "annotations.")
-		annotations, _ := data["annotations"].(map[string]string)
-		if key == "" || annotations == nil {
-			return "", false
-		}
-		value, ok := annotations[key]
-		return value, ok
-	default:
-		return "", false
-	}
 }
 
 // matchesResource checks if this permission allows access to the target resource.

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -83,6 +83,9 @@ func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
 	return rendered, true
 }
 
+// renderValidPermissionNamespace optionally renders a namespace with templating based on actor data
+// and validates that the resulting namespace is valid. If the templating cannot be fufulled, or the
+// resulting namespace is not valid, it returns false.
 func renderValidPermissionNamespace(actor *Actor, namespace string) (string, bool) {
 	rendered, ok := renderPermissionNamespace(actor, namespace)
 	if !ok {

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -8,7 +8,7 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 )
 
-// Allows checks if this permission allows the specified action.
+// allowsForActor checks if this permission allows the specified action for the given actor.
 //
 // Parameters:
 //   - namespace: The namespace where the action is being performed (e.g., "root.foo.bar").
@@ -25,10 +25,6 @@ import (
 //   - Verbs: Exact match with any verb in the permission, or permission contains "*".
 //   - ResourceIds: If permission has no ResourceIds, all IDs are allowed. If permission has
 //     ResourceIds, the requested ID must be in the list.
-func allows(p aschema.Permission, namespace, resource, verb, resourceId string) bool {
-	return allowsForActor(nil, p, namespace, resource, verb, resourceId)
-}
-
 func allowsForActor(actor *Actor, p aschema.Permission, namespace, resource, verb, resourceId string) bool {
 	if !matchesNamespace(actor, p, namespace) {
 		return false
@@ -196,14 +192,10 @@ func matchesResourceId(p aschema.Permission, targetResourceId string) bool {
 	return slices.Contains(p.ResourceIds, targetResourceId)
 }
 
-// permissionsAllow checks if any permission in the slice allows the specified action.
+// permissionsAllowForActor checks if any permission in the slice allows the specified action for the given actor.
 // Permissions are additive - if any single permission allows the action, it is permitted.
 //
 // This is the primary function for checking if an actor has permission to perform an action.
-func permissionsAllow(permissions []aschema.Permission, namespace, resource, verb, resourceId string) bool {
-	return permissionsAllowForActor(nil, permissions, namespace, resource, verb, resourceId)
-}
-
 func permissionsAllowForActor(actor *Actor, permissions []aschema.Permission, namespace, resource, verb, resourceId string) bool {
 	for _, p := range permissions {
 		if allowsForActor(actor, p, namespace, resource, verb, resourceId) {

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -1,10 +1,14 @@
 package core
 
 import (
+	"regexp"
 	"slices"
+	"strings"
 
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 )
+
+var permissionNamespaceTemplateRegex = regexp.MustCompile(`{{\s*([^{}]+?)\s*}}`)
 
 // Allows checks if this permission allows the specified action.
 //
@@ -24,7 +28,11 @@ import (
 //   - ResourceIds: If permission has no ResourceIds, all IDs are allowed. If permission has
 //     ResourceIds, the requested ID must be in the list.
 func allows(p aschema.Permission, namespace, resource, verb, resourceId string) bool {
-	if !matchesNamespace(p, namespace) {
+	return allowsForActor(nil, p, namespace, resource, verb, resourceId)
+}
+
+func allowsForActor(actor *Actor, p aschema.Permission, namespace, resource, verb, resourceId string) bool {
+	if !matchesNamespace(actor, p, namespace) {
 		return false
 	}
 
@@ -45,7 +53,7 @@ func allows(p aschema.Permission, namespace, resource, verb, resourceId string) 
 
 // matchesNamespace checks if this permission's namespace matches the target namespace.
 // Supports wildcard matching with ".**" suffix.
-func matchesNamespace(p aschema.Permission, targetNamespace string) bool {
+func matchesNamespace(actor *Actor, p aschema.Permission, targetNamespace string) bool {
 	if p.Namespace == "" || targetNamespace == "" {
 		return false
 	}
@@ -54,7 +62,86 @@ func matchesNamespace(p aschema.Permission, targetNamespace string) bool {
 		return true
 	}
 
-	return aschema.NamespaceMatches(p.Namespace, targetNamespace)
+	matcher, ok := renderValidPermissionNamespace(actor, p.Namespace)
+	if !ok {
+		return false
+	}
+
+	return aschema.NamespaceMatches(matcher, targetNamespace)
+}
+
+func renderPermissionNamespace(actor *Actor, namespace string) (string, bool) {
+	if !strings.Contains(namespace, "{{") {
+		return namespace, true
+	}
+
+	if actor == nil {
+		return "", false
+	}
+
+	matches := permissionNamespaceTemplateRegex.FindAllStringSubmatchIndex(namespace, -1)
+	if len(matches) == 0 {
+		return "", false
+	}
+
+	var rendered strings.Builder
+	last := 0
+	for _, match := range matches {
+		rendered.WriteString(namespace[last:match[0]])
+
+		name := strings.TrimSpace(namespace[match[2]:match[3]])
+		value, ok := actorPermissionTemplateValue(actor, name)
+		if !ok {
+			return "", false
+		}
+
+		rendered.WriteString(value)
+		last = match[1]
+	}
+	rendered.WriteString(namespace[last:])
+
+	result := rendered.String()
+	if strings.Contains(result, "{{") || strings.Contains(result, "}}") {
+		return "", false
+	}
+
+	return result, true
+}
+
+func renderValidPermissionNamespace(actor *Actor, namespace string) (string, bool) {
+	rendered, ok := renderPermissionNamespace(actor, namespace)
+	if !ok {
+		return "", false
+	}
+
+	if err := aschema.ValidateNamespaceMatcher(rendered); err != nil {
+		return "", false
+	}
+
+	return rendered, true
+}
+
+func actorPermissionTemplateValue(actor *Actor, name string) (string, bool) {
+	switch {
+	case name == "external_id":
+		return actor.ExternalId, true
+	case strings.HasPrefix(name, "labels."):
+		key := strings.TrimPrefix(name, "labels.")
+		if key == "" || actor.Labels == nil {
+			return "", false
+		}
+		value, ok := actor.Labels[key]
+		return value, ok
+	case strings.HasPrefix(name, "annotations."):
+		key := strings.TrimPrefix(name, "annotations.")
+		if key == "" || actor.Annotations == nil {
+			return "", false
+		}
+		value, ok := actor.Annotations[key]
+		return value, ok
+	default:
+		return "", false
+	}
 }
 
 // matchesResource checks if this permission allows access to the target resource.
@@ -113,8 +200,12 @@ func matchesResourceId(p aschema.Permission, targetResourceId string) bool {
 //
 // This is the primary function for checking if an actor has permission to perform an action.
 func permissionsAllow(permissions []aschema.Permission, namespace, resource, verb, resourceId string) bool {
+	return permissionsAllowForActor(nil, permissions, namespace, resource, verb, resourceId)
+}
+
+func permissionsAllowForActor(actor *Actor, permissions []aschema.Permission, namespace, resource, verb, resourceId string) bool {
 	for _, p := range permissions {
-		if allows(p, namespace, resource, verb, resourceId) {
+		if allowsForActor(actor, p, namespace, resource, verb, resourceId) {
 			return true
 		}
 	}
@@ -141,8 +232,17 @@ func permissionsAllowWithRestrictions(
 	restrictions []aschema.Permission,
 	namespace, resource, verb, resourceId string,
 ) bool {
+	return permissionsAllowWithRestrictionsForActor(nil, actorPermissions, restrictions, namespace, resource, verb, resourceId)
+}
+
+func permissionsAllowWithRestrictionsForActor(
+	actor *Actor,
+	actorPermissions []aschema.Permission,
+	restrictions []aschema.Permission,
+	namespace, resource, verb, resourceId string,
+) bool {
 	// First check if the actor's permissions allow the action
-	if !permissionsAllow(actorPermissions, namespace, resource, verb, resourceId) {
+	if !permissionsAllowForActor(actor, actorPermissions, namespace, resource, verb, resourceId) {
 		return false
 	}
 
@@ -152,5 +252,5 @@ func permissionsAllowWithRestrictions(
 	}
 
 	// Check if the restrictions also allow the action
-	return permissionsAllow(restrictions, namespace, resource, verb, resourceId)
+	return permissionsAllowForActor(actor, restrictions, namespace, resource, verb, resourceId)
 }

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPermission_Allows(t *testing.T) {
+func TestPermission_AllowsForActor(t *testing.T) {
 	tests := []struct {
 		name       string
 		p          aschema.Permission
@@ -15,8 +15,139 @@ func TestPermission_Allows(t *testing.T) {
 		resource   string
 		verb       string
 		resourceId string
+		actor      *Actor
 		allowed    bool
 	}{
+		// Templated namespace matching
+		{
+			name: "templated namespace match by external id",
+			p: aschema.Permission{
+				Namespace: "root.{{external_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.actor-123",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{ExternalId: "actor-123"},
+			allowed:   true,
+		},
+		{
+			name: "templated namespace mismatch by external id",
+			p: aschema.Permission{
+				Namespace: "root.{{external_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.actor-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{ExternalId: "actor-123"},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace match by label",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-123",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Labels: map[string]string{"team_id": "team-123"}},
+			allowed:   true,
+		},
+		{
+			name: "templated namespace mismatch by label",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Labels: map[string]string{"team_id": "team-123"}},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace mismatch by missing label",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Labels: map[string]string{"foo": "bar"}},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace mismatch by missing label actor",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   false,
+		},
+		{
+			name: "templated namespace match by annotation",
+			p: aschema.Permission{
+				Namespace: "root.{{annotations.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-123",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Annotations: map[string]string{"team_id": "team-123"}},
+			allowed:   true,
+		},
+		{
+			name: "templated namespace mismatch by annotation",
+			p: aschema.Permission{
+				Namespace: "root.{{annotations.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Annotations: map[string]string{"team_id": "team-123"}},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace mismatch by missing annotation",
+			p: aschema.Permission{
+				Namespace: "root.{{annotations.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Annotations: map[string]string{"foo": "bar"}},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace mismatch by missing annotation actor",
+			p: aschema.Permission{
+				Namespace: "root.{{annotations.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   false,
+		},
+
 		// Exact namespace matching
 		{
 			name: "exact namespace match",
@@ -370,13 +501,13 @@ func TestPermission_Allows(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := allows(tt.p, tt.namespace, tt.resource, tt.verb, tt.resourceId)
+			result := allowsForActor(tt.actor, tt.p, tt.namespace, tt.resource, tt.verb, tt.resourceId)
 			require.Equal(t, tt.allowed, result)
 		})
 	}
 }
 
-func TestPermissionsAllow(t *testing.T) {
+func TestPermissionsAllowForActor(t *testing.T) {
 	tests := []struct {
 		name        string
 		permissions []aschema.Permission
@@ -384,6 +515,7 @@ func TestPermissionsAllow(t *testing.T) {
 		resource    string
 		verb        string
 		resourceId  string
+		actor       *Actor
 		allowed     bool
 	}{
 		{
@@ -492,11 +624,26 @@ func TestPermissionsAllow(t *testing.T) {
 			verb:      "get",
 			allowed:   true,
 		},
+		{
+			name: "templated namespace match",
+			permissions: []aschema.Permission{
+				{
+					Namespace: "root.{{external_id}}",
+					Resources: []string{"connections"},
+					Verbs:     []string{"get"},
+				},
+			},
+			namespace: "root.actor-123",
+			resource:  "connectors",
+			verb:      "get",
+			actor:     &Actor{ExternalId: "actor-123"},
+			allowed:   true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := permissionsAllow(tt.permissions, tt.namespace, tt.resource, tt.verb, tt.resourceId)
+			result := permissionsAllowForActor(tt.actor, tt.permissions, tt.namespace, tt.resource, tt.verb, tt.resourceId)
 			require.Equal(t, tt.allowed, result)
 		})
 	}

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,19 @@ func TestPermission_AllowsForActor(t *testing.T) {
 			allowed:   false,
 		},
 		{
+			name: "templated namespace does not allow wildcards by external id",
+			p: aschema.Permission{
+				Namespace: "root.{{external_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.actor-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{ExternalId: namespace.NamespaceWildcard},
+			allowed:   false,
+		},
+		{
 			name: "templated namespace match by label",
 			p: aschema.Permission{
 				Namespace: "root.{{labels.team_id}}",
@@ -69,6 +83,19 @@ func TestPermission_AllowsForActor(t *testing.T) {
 			resource:  "connections",
 			verb:      "get",
 			actor:     &Actor{Labels: map[string]string{"team_id": "team-123"}},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace does not allow wildcard by label",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Labels: map[string]string{"team_id": namespace.NamespaceWildcard}},
 			allowed:   false,
 		},
 		{
@@ -123,6 +150,19 @@ func TestPermission_AllowsForActor(t *testing.T) {
 			allowed:   false,
 		},
 		{
+			name: "templated namespace does not allow wildcard by annotation",
+			p: aschema.Permission{
+				Namespace: "root.{{annotations.team_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.team-999",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Annotations: map[string]string{"team_id": namespace.NamespaceWildcard}},
+			allowed:   false,
+		},
+		{
 			name: "templated namespace mismatch by missing annotation",
 			p: aschema.Permission{
 				Namespace: "root.{{annotations.team_id}}",
@@ -157,7 +197,33 @@ func TestPermission_AllowsForActor(t *testing.T) {
 			namespace: "root.foo.bar",
 			resource:  "connections",
 			verb:      "get",
-			actor:     &Actor{Annotations: map[string]string{"foo": "**"}}, // Will render root.**.**
+			actor:     &Actor{Annotations: map[string]string{"foo": "."}}, // Will render root...**
+			allowed:   false,
+		},
+		{
+			name: "templated namespace rejects invalid templates",
+			p: aschema.Permission{
+				Namespace: "root.{{invalid}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{},
+			allowed:   false,
+		},
+		{
+			name: "templated namespace rejects nested invalid templates",
+			p: aschema.Permission{
+				Namespace: "root.{{nested.invalid}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{},
 			allowed:   false,
 		},
 

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -713,7 +713,7 @@ func TestPermissionsAllowForActor(t *testing.T) {
 				},
 			},
 			namespace: "root.actor-123",
-			resource:  "connectors",
+			resource:  "connections",
 			verb:      "get",
 			actor:     &Actor{ExternalId: "actor-123"},
 			allowed:   true,

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -671,6 +671,7 @@ func TestPermissionsAllowWithRestrictions(t *testing.T) {
 		resource         string
 		verb             string
 		resourceId       string
+		actor            *Actor
 		allowed          bool
 	}{
 		{
@@ -868,11 +869,34 @@ func TestPermissionsAllowWithRestrictions(t *testing.T) {
 			resourceId: "xyz-789",
 			allowed:    false,
 		},
+		{
+			name: "actor allowed, restrictions deny different resource, both templated",
+			actorPermissions: []aschema.Permission{
+				{
+					Namespace: "root.{{external_id}}",
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
+			},
+			restrictions: []aschema.Permission{
+				{
+					Namespace: "root.{{external_id}}",
+					Resources: []string{"connections"},
+					Verbs:     []string{"get"},
+				},
+			},
+			namespace: "root.actor-123",
+			resource:  "connectors",
+			verb:      "get",
+			actor:     &Actor{ExternalId: "actor-123"},
+			allowed:   false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := permissionsAllowWithRestrictions(
+			result := permissionsAllowWithRestrictionsForActor(
+				tt.actor,
 				tt.actorPermissions,
 				tt.restrictions,
 				tt.namespace,

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -147,6 +147,19 @@ func TestPermission_AllowsForActor(t *testing.T) {
 			verb:      "get",
 			allowed:   false,
 		},
+		{
+			name: "rejects templates that render to invalid namespaces",
+			p: aschema.Permission{
+				Namespace: "root.{{labels.foo}}.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			},
+			namespace: "root.foo.bar",
+			resource:  "connections",
+			verb:      "get",
+			actor:     &Actor{Annotations: map[string]string{"foo": "**"}}, // Will render root.**.**
+			allowed:   false,
+		},
 
 		// Exact namespace matching
 		{

--- a/internal/apauth/core/request_auth.go
+++ b/internal/apauth/core/request_auth.go
@@ -107,7 +107,9 @@ func (ra *RequestAuth) GetNamespacesAllowed(resource, verb string) []string {
 			slices.Contains(permission.Verbs, aschema.PermissionWildcard)
 
 		if appliesToResource && appliesToVerb {
-			candidateNamespaces = append(candidateNamespaces, permission.Namespace)
+			if ns, ok := renderValidPermissionNamespace(ra.actor, permission.Namespace); ok {
+				candidateNamespaces = append(candidateNamespaces, ns)
+			}
 		}
 	}
 
@@ -123,8 +125,13 @@ func (ra *RequestAuth) GetNamespacesAllowed(resource, verb string) []string {
 				slices.Contains(permission.Verbs, aschema.PermissionWildcard)
 
 			if appliesToResource && appliesToVerb {
+				restrictionNamespace, ok := renderValidPermissionNamespace(ra.actor, permission.Namespace)
+				if !ok {
+					continue
+				}
+
 				for _, candidateNamespace := range candidateNamespaces {
-					if restricted, ok := aschema.NamespaceMatcherConstrained(permission.Namespace, candidateNamespace); ok {
+					if restricted, ok := aschema.NamespaceMatcherConstrained(restrictionNamespace, candidateNamespace); ok {
 						finalNamespaces = append(finalNamespaces, restricted)
 					}
 				}
@@ -159,7 +166,8 @@ func (ra *RequestAuth) Allows(namespace, resource, verb, resourceId string) bool
 	actor := ra.GetActor()
 
 	// Check actor permissions with optional request-level restrictions
-	return permissionsAllowWithRestrictions(
+	return permissionsAllowWithRestrictionsForActor(
+		actor,
 		actor.GetPermissions(),
 		ra.permissions,
 		namespace, resource, verb, resourceId,
@@ -180,13 +188,13 @@ func (ra *RequestAuth) AllowsReason(namespace, resource, verb, resourceId string
 	actor := ra.GetActor()
 
 	// Check actor permissions
-	if !permissionsAllow(actor.GetPermissions(), namespace, resource, verb, resourceId) {
+	if !permissionsAllowForActor(actor, actor.GetPermissions(), namespace, resource, verb, resourceId) {
 		return false, "actor permissions do not allow this action"
 	}
 
 	// Check request-level restrictions if present
 	if len(ra.permissions) > 0 {
-		if !permissionsAllow(ra.permissions, namespace, resource, verb, resourceId) {
+		if !permissionsAllowForActor(actor, ra.permissions, namespace, resource, verb, resourceId) {
 			return false, "request permissions do not allow this action"
 		}
 	}

--- a/internal/apauth/core/request_auth.go
+++ b/internal/apauth/core/request_auth.go
@@ -94,6 +94,10 @@ func (ra *RequestAuth) SetPermissions(permissions []aschema.Permission) {
 	ra.permissions = permissions
 }
 
+// GetNamespacesAllowed returns the set of namespaces allowed for the given resource and verb. This
+// function applies both actor permissions and request-level restrictions to determine the allowed namespaces.
+// For any namespaces that leverage templating, if the template cannot be applied from the actor's
+// data, that namespace is omitted.
 func (ra *RequestAuth) GetNamespacesAllowed(resource, verb string) []string {
 	if ra == nil || !ra.IsAuthenticated() {
 		return nil

--- a/internal/apauth/core/request_auth_test.go
+++ b/internal/apauth/core/request_auth_test.go
@@ -191,6 +191,98 @@ func TestRequestAuth_Allows(t *testing.T) {
 			resourceId: "xyz-789",
 			allowed:    false,
 		},
+		{
+			name: "actor with external id namespace template",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:         apid.New(apid.PrefixActor),
+				ExternalId: "tenant-a",
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{external_id}}.**",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			namespace: "root.tenant-a.project",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   true,
+		},
+		{
+			name: "actor with label namespace template",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:         apid.New(apid.PrefixActor),
+				ExternalId: "user",
+				Labels:     map[string]string{"tenant": "tenant-b"},
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{labels.tenant}}",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			namespace: "root.tenant-b",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   true,
+		},
+		{
+			name: "actor with annotation namespace template",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:          apid.New(apid.PrefixActor),
+				ExternalId:  "user",
+				Annotations: map[string]string{"tenant": "tenant-c"},
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{annotations.tenant}}",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			namespace: "root.tenant-c",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   true,
+		},
+		{
+			name: "actor missing label namespace template denies",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:         apid.New(apid.PrefixActor),
+				ExternalId: "user",
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{labels.tenant}}.**",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			namespace: "root.tenant-a",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   false,
+		},
+		{
+			name: "actor missing annotation namespace template denies",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:         apid.New(apid.PrefixActor),
+				ExternalId: "user",
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{annotations.tenant}}.**",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			namespace: "root.tenant-a",
+			resource:  "connections",
+			verb:      "get",
+			allowed:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -556,6 +648,42 @@ func TestRequestAuth_GetNamespacesAllowedForResource(t *testing.T) {
 			resource:   "connections",
 			verb:       "get",
 			namespaces: []string{"root.other"},
+		},
+		{
+			name: "templated permission",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:          apid.New(apid.PrefixActor),
+				ExternalId:  "tenant-a",
+				Labels:      map[string]string{"team": "platform"},
+				Annotations: map[string]string{"region": "us-east"},
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{external_id}}.{{labels.team}}.{{annotations.region}}.**",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			resource:   "connections",
+			verb:       "get",
+			namespaces: []string{"root.tenant-a.platform.us-east.**"},
+		},
+		{
+			name: "templated permission missing label has no namespace",
+			ra: NewAuthenticatedRequestAuth(&Actor{
+				Id:         apid.New(apid.PrefixActor),
+				ExternalId: "tenant-a",
+				Permissions: []aschema.Permission{
+					{
+						Namespace: "root.{{labels.team}}.**",
+						Resources: []string{"connections"},
+						Verbs:     []string{"get"},
+					},
+				},
+			}),
+			resource:   "connections",
+			verb:       "get",
+			namespaces: []string{},
 		},
 		{
 			name: "multiple permissions",

--- a/internal/apauth/jwt/claims_builder.go
+++ b/internal/apauth/jwt/claims_builder.go
@@ -31,10 +31,10 @@ type ClaimsBuilder interface {
 	WithNamespace(namespace string) ClaimsBuilder
 	WithActor(actor core.IActorData) ClaimsBuilder
 	WithPermissions(permissions []aschema.Permission) ClaimsBuilder
-	WithLabels(labels map[string]string) ClaimsBuilder
-	WithLabel(key, value string) ClaimsBuilder
-	WithAnnotations(annotations map[string]string) ClaimsBuilder
-	WithAnnotation(key, value string) ClaimsBuilder
+	WithActorLabels(labels map[string]string) ClaimsBuilder
+	WithActorLabel(key, value string) ClaimsBuilder
+	WithActorAnnotations(annotations map[string]string) ClaimsBuilder
+	WithActorAnnotation(key, value string) ClaimsBuilder
 	WithNonce() ClaimsBuilder
 	BuildCtx(context.Context) (*AuthProxyClaims, error)
 	Build() (*AuthProxyClaims, error)
@@ -127,12 +127,12 @@ func (b *claimsBuilder) WithPermissions(permissions []aschema.Permission) Claims
 	return b
 }
 
-func (b *claimsBuilder) WithLabels(labels map[string]string) ClaimsBuilder {
+func (b *claimsBuilder) WithActorLabels(labels map[string]string) ClaimsBuilder {
 	b.labels = labels
 	return b
 }
 
-func (b *claimsBuilder) WithLabel(key, value string) ClaimsBuilder {
+func (b *claimsBuilder) WithActorLabel(key, value string) ClaimsBuilder {
 	if b.labels == nil {
 		b.labels = make(map[string]string)
 	}
@@ -140,12 +140,12 @@ func (b *claimsBuilder) WithLabel(key, value string) ClaimsBuilder {
 	return b
 }
 
-func (b *claimsBuilder) WithAnnotations(annotations map[string]string) ClaimsBuilder {
+func (b *claimsBuilder) WithActorAnnotations(annotations map[string]string) ClaimsBuilder {
 	b.annotations = annotations
 	return b
 }
 
-func (b *claimsBuilder) WithAnnotation(key, value string) ClaimsBuilder {
+func (b *claimsBuilder) WithActorAnnotation(key, value string) ClaimsBuilder {
 	if b.annotations == nil {
 		b.annotations = make(map[string]string)
 	}

--- a/internal/apauth/jwt/claims_builder.go
+++ b/internal/apauth/jwt/claims_builder.go
@@ -33,6 +33,8 @@ type ClaimsBuilder interface {
 	WithPermissions(permissions []aschema.Permission) ClaimsBuilder
 	WithLabels(labels map[string]string) ClaimsBuilder
 	WithLabel(key, value string) ClaimsBuilder
+	WithAnnotations(annotations map[string]string) ClaimsBuilder
+	WithAnnotation(key, value string) ClaimsBuilder
 	WithNonce() ClaimsBuilder
 	BuildCtx(context.Context) (*AuthProxyClaims, error)
 	Build() (*AuthProxyClaims, error)
@@ -50,6 +52,7 @@ type claimsBuilder struct {
 	actor        *core.Actor
 	permissions  []aschema.Permission
 	labels       map[string]string
+	annotations  map[string]string
 	systemSigned bool
 	actorSigned  bool
 	nonce        *apid.ID
@@ -137,6 +140,19 @@ func (b *claimsBuilder) WithLabel(key, value string) ClaimsBuilder {
 	return b
 }
 
+func (b *claimsBuilder) WithAnnotations(annotations map[string]string) ClaimsBuilder {
+	b.annotations = annotations
+	return b
+}
+
+func (b *claimsBuilder) WithAnnotation(key, value string) ClaimsBuilder {
+	if b.annotations == nil {
+		b.annotations = make(map[string]string)
+	}
+	b.annotations[key] = value
+	return b
+}
+
 func (b *claimsBuilder) WithNonce() ClaimsBuilder {
 	id := apid.New(apid.PrefixNonce)
 	b.nonce = &id
@@ -173,11 +189,21 @@ func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) 
 				b.actor.Labels[k] = v
 			}
 		}
+
+		if len(b.annotations) > 0 {
+			if b.actor.Annotations == nil {
+				b.actor.Annotations = make(map[string]string)
+			}
+			for k, v := range b.annotations {
+				b.actor.Annotations[k] = v
+			}
+		}
 	}
 
-	if b.actor == nil && len(b.labels) > 0 {
+	if b.actor == nil && (len(b.labels) > 0 || len(b.annotations) > 0) {
 		b.actor = &core.Actor{
-			Labels: b.labels,
+			Labels:      b.labels,
+			Annotations: b.annotations,
 		}
 	}
 

--- a/internal/apauth/jwt/claims_builder_test.go
+++ b/internal/apauth/jwt/claims_builder_test.go
@@ -235,8 +235,8 @@ func TestClaimsBuilder(t *testing.T) {
 			cb.WithServiceId(config.ServiceIdPublic).
 				WithActorExternalId("bob-dole").
 				WithNamespace("root.child").
-				WithLabel("foo", "bar").
-				WithLabel("baz", "qux").
+				WithActorLabel("foo", "bar").
+				WithActorLabel("baz", "qux").
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)
@@ -254,7 +254,7 @@ func TestClaimsBuilder(t *testing.T) {
 			cb.WithServiceId(config.ServiceIdPublic).
 				WithActorExternalId("bob-dole").
 				WithNamespace("root.child").
-				WithLabels(map[string]string{"foo": "bar", "baz": "qux"}).
+				WithActorLabels(map[string]string{"foo": "bar", "baz": "qux"}).
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)
@@ -275,7 +275,7 @@ func TestClaimsBuilder(t *testing.T) {
 					Namespace:  "root.child",
 					Labels:     map[string]string{"foo": "bar"},
 				}).
-				WithLabel("baz", "qux").
+				WithActorLabel("baz", "qux").
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)
@@ -295,8 +295,8 @@ func TestClaimsBuilder(t *testing.T) {
 			cb.WithServiceId(config.ServiceIdPublic).
 				WithActorExternalId("bob-dole").
 				WithNamespace("root.child").
-				WithAnnotation("foo", "bar").
-				WithAnnotation("baz", "qux").
+				WithActorAnnotation("foo", "bar").
+				WithActorAnnotation("baz", "qux").
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)
@@ -314,7 +314,7 @@ func TestClaimsBuilder(t *testing.T) {
 			cb.WithServiceId(config.ServiceIdPublic).
 				WithActorExternalId("bob-dole").
 				WithNamespace("root.child").
-				WithAnnotations(map[string]string{"foo": "bar", "baz": "qux"}).
+				WithActorAnnotations(map[string]string{"foo": "bar", "baz": "qux"}).
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)
@@ -335,7 +335,7 @@ func TestClaimsBuilder(t *testing.T) {
 					Namespace:   "root.child",
 					Annotations: map[string]string{"foo": "bar"},
 				}).
-				WithAnnotation("baz", "qux").
+				WithActorAnnotation("baz", "qux").
 				WithExpiresIn(10 * time.Minute)
 
 			claims, err := cb.BuildCtx(ctx)

--- a/internal/apauth/jwt/claims_builder_test.go
+++ b/internal/apauth/jwt/claims_builder_test.go
@@ -285,4 +285,64 @@ func TestClaimsBuilder(t *testing.T) {
 			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
 		})
 	})
+	t.Run("annotations", func(t *testing.T) {
+		t.Run("with individual annotations", func(t *testing.T) {
+			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
+			ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+			cb := NewClaimsBuilder()
+
+			cb.WithServiceId(config.ServiceIdPublic).
+				WithActorExternalId("bob-dole").
+				WithNamespace("root.child").
+				WithAnnotation("foo", "bar").
+				WithAnnotation("baz", "qux").
+				WithExpiresIn(10 * time.Minute)
+
+			claims, err := cb.BuildCtx(ctx)
+			require.NoError(t, err)
+
+			require.NotNil(t, claims.Actor)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+		})
+		t.Run("with map of annotations", func(t *testing.T) {
+			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
+			ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+			cb := NewClaimsBuilder()
+
+			cb.WithServiceId(config.ServiceIdPublic).
+				WithActorExternalId("bob-dole").
+				WithNamespace("root.child").
+				WithAnnotations(map[string]string{"foo": "bar", "baz": "qux"}).
+				WithExpiresIn(10 * time.Minute)
+
+			claims, err := cb.BuildCtx(ctx)
+			require.NoError(t, err)
+
+			require.NotNil(t, claims.Actor)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+		})
+		t.Run("merge annotations with actor", func(t *testing.T) {
+			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
+			ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+			cb := NewClaimsBuilder()
+
+			cb.WithServiceId(config.ServiceIdPublic).
+				WithActor(&core.Actor{
+					ExternalId:  "bob-dole",
+					Namespace:   "root.child",
+					Annotations: map[string]string{"foo": "bar"},
+				}).
+				WithAnnotation("baz", "qux").
+				WithExpiresIn(10 * time.Minute)
+
+			claims, err := cb.BuildCtx(ctx)
+			require.NoError(t, err)
+
+			require.NotNil(t, claims.Actor)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+		})
+	})
 }

--- a/internal/apauth/jwt/schema-actor.json
+++ b/internal/apauth/jwt/schema-actor.json
@@ -21,6 +21,16 @@
     "permissions": {
       "type": "array",
       "description": "A list of permissions that the actor has. Required."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Labels to carry on the actor."
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Annotations to carry on the actor."
     }
   },
   "additionalProperties": false,

--- a/internal/apauth/jwt/token_builder.go
+++ b/internal/apauth/jwt/token_builder.go
@@ -45,6 +45,8 @@ type TokenBuilder interface {
 	WithPermissions(permissions []aschema.Permission) TokenBuilder
 	WithLabels(labels map[string]string) TokenBuilder
 	WithLabel(key, value string) TokenBuilder
+	WithAnnotations(annotations map[string]string) TokenBuilder
+	WithAnnotation(key, value string) TokenBuilder
 	WithNonce() TokenBuilder
 
 	WithConfigKey(ctx context.Context, cfgKey *config.Key) (TokenBuilder, error)
@@ -154,6 +156,16 @@ func (tb *tokenBuilder) WithLabels(labels map[string]string) TokenBuilder {
 
 func (tb *tokenBuilder) WithLabel(key, value string) TokenBuilder {
 	tb.jwtBuilder.WithLabel(key, value)
+	return tb
+}
+
+func (tb *tokenBuilder) WithAnnotations(annotations map[string]string) TokenBuilder {
+	tb.jwtBuilder.WithAnnotations(annotations)
+	return tb
+}
+
+func (tb *tokenBuilder) WithAnnotation(key, value string) TokenBuilder {
+	tb.jwtBuilder.WithAnnotation(key, value)
 	return tb
 }
 

--- a/internal/apauth/jwt/token_builder.go
+++ b/internal/apauth/jwt/token_builder.go
@@ -43,10 +43,10 @@ type TokenBuilder interface {
 	WithNamespace(namespace string) TokenBuilder
 	WithActor(actor core.IActorData) TokenBuilder
 	WithPermissions(permissions []aschema.Permission) TokenBuilder
-	WithLabels(labels map[string]string) TokenBuilder
-	WithLabel(key, value string) TokenBuilder
-	WithAnnotations(annotations map[string]string) TokenBuilder
-	WithAnnotation(key, value string) TokenBuilder
+	WithActorLabels(labels map[string]string) TokenBuilder
+	WithActorLabel(key, value string) TokenBuilder
+	WithActorAnnotations(annotations map[string]string) TokenBuilder
+	WithActorAnnotation(key, value string) TokenBuilder
 	WithNonce() TokenBuilder
 
 	WithConfigKey(ctx context.Context, cfgKey *config.Key) (TokenBuilder, error)
@@ -149,22 +149,22 @@ func (tb *tokenBuilder) WithPermissions(permissions []aschema.Permission) TokenB
 	return tb
 }
 
-func (tb *tokenBuilder) WithLabels(labels map[string]string) TokenBuilder {
+func (tb *tokenBuilder) WithActorLabels(labels map[string]string) TokenBuilder {
 	tb.jwtBuilder.WithActorLabels(labels)
 	return tb
 }
 
-func (tb *tokenBuilder) WithLabel(key, value string) TokenBuilder {
+func (tb *tokenBuilder) WithActorLabel(key, value string) TokenBuilder {
 	tb.jwtBuilder.WithActorLabel(key, value)
 	return tb
 }
 
-func (tb *tokenBuilder) WithAnnotations(annotations map[string]string) TokenBuilder {
+func (tb *tokenBuilder) WithActorAnnotations(annotations map[string]string) TokenBuilder {
 	tb.jwtBuilder.WithActorAnnotations(annotations)
 	return tb
 }
 
-func (tb *tokenBuilder) WithAnnotation(key, value string) TokenBuilder {
+func (tb *tokenBuilder) WithActorAnnotation(key, value string) TokenBuilder {
 	tb.jwtBuilder.WithActorAnnotation(key, value)
 	return tb
 }

--- a/internal/apauth/jwt/token_builder.go
+++ b/internal/apauth/jwt/token_builder.go
@@ -150,22 +150,22 @@ func (tb *tokenBuilder) WithPermissions(permissions []aschema.Permission) TokenB
 }
 
 func (tb *tokenBuilder) WithLabels(labels map[string]string) TokenBuilder {
-	tb.jwtBuilder.WithLabels(labels)
+	tb.jwtBuilder.WithActorLabels(labels)
 	return tb
 }
 
 func (tb *tokenBuilder) WithLabel(key, value string) TokenBuilder {
-	tb.jwtBuilder.WithLabel(key, value)
+	tb.jwtBuilder.WithActorLabel(key, value)
 	return tb
 }
 
 func (tb *tokenBuilder) WithAnnotations(annotations map[string]string) TokenBuilder {
-	tb.jwtBuilder.WithAnnotations(annotations)
+	tb.jwtBuilder.WithActorAnnotations(annotations)
 	return tb
 }
 
 func (tb *tokenBuilder) WithAnnotation(key, value string) TokenBuilder {
-	tb.jwtBuilder.WithAnnotation(key, value)
+	tb.jwtBuilder.WithActorAnnotation(key, value)
 	return tb
 }
 

--- a/internal/apauth/jwt/token_builder_test.go
+++ b/internal/apauth/jwt/token_builder_test.go
@@ -77,8 +77,8 @@ func TestJwtTokenBuilder(t *testing.T) {
 		tb := NewJwtTokenBuilder().
 			WithActorExternalId("bob-dole").
 			WithNamespace("root.child").
-			WithLabels(map[string]string{"foo": "bar"}).
-			WithLabel("baz", "qux")
+			WithActorLabels(map[string]string{"foo": "bar"}).
+			WithActorLabel("baz", "qux")
 
 		x := tb.(*tokenBuilder)
 		claims, err := x.jwtBuilder.Build()
@@ -90,8 +90,8 @@ func TestJwtTokenBuilder(t *testing.T) {
 		tb := NewJwtTokenBuilder().
 			WithActorExternalId("bob-dole").
 			WithNamespace("root.child").
-			WithAnnotations(map[string]string{"foo": "bar"}).
-			WithAnnotation("baz", "qux")
+			WithActorAnnotations(map[string]string{"foo": "bar"}).
+			WithActorAnnotation("baz", "qux")
 
 		x := tb.(*tokenBuilder)
 		claims, err := x.jwtBuilder.Build()

--- a/internal/apauth/jwt/token_builder_test.go
+++ b/internal/apauth/jwt/token_builder_test.go
@@ -86,4 +86,17 @@ func TestJwtTokenBuilder(t *testing.T) {
 		require.NotNil(t, claims.Actor)
 		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
 	})
+	t.Run("annotations", func(t *testing.T) {
+		tb := NewJwtTokenBuilder().
+			WithActorExternalId("bob-dole").
+			WithNamespace("root.child").
+			WithAnnotations(map[string]string{"foo": "bar"}).
+			WithAnnotation("baz", "qux")
+
+		x := tb.(*tokenBuilder)
+		claims, err := x.jwtBuilder.Build()
+		require.NoError(t, err)
+		require.NotNil(t, claims.Actor)
+		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+	})
 }

--- a/internal/apauth/service/auth_methods_test.go
+++ b/internal/apauth/service/auth_methods_test.go
@@ -602,6 +602,53 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 				require.Equal(t, dbActorId, retrieved.Id, "should preserve original database ID")
 				require.Equal(t, database.Permissions(newPerms), retrieved.Permissions, "permissions should be updated in database")
 			})
+
+			t.Run("actor annotations updated in database", func(t *testing.T) {
+				setup(t)
+
+				dbActorId := apid.New(apid.PrefixActor)
+				externalId := "annotation-test-actor"
+				dbActor := &database.Actor{
+					Id:          dbActorId,
+					Namespace:   "root",
+					ExternalId:  externalId,
+					Annotations: database.Annotations{"old": "value"},
+				}
+				require.NoError(t, db.CreateActor(testContext, dbActor))
+
+				claims := &jwt2.AuthProxyClaims{
+					RegisteredClaims: jwt.RegisteredClaims{
+						ID:        "random id",
+						Subject:   externalId,
+						Issuer:    "remark42",
+						Audience:  []string{string(sconfig.ServiceIdAdminApi)},
+						ExpiresAt: &jwt.NumericDate{time.Date(2058, 5, 21, 7, 30, 22, 0, time.UTC)},
+						NotBefore: &jwt.NumericDate{time.Date(2018, 5, 21, 6, 30, 22, 0, time.UTC)},
+						IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
+					},
+					Actor: &core.Actor{
+						ExternalId:  externalId,
+						Namespace:   "root",
+						Annotations: map[string]string{"tenant": "acme"},
+					},
+				}
+
+				tok, err := a.Token(testContext, claims)
+				require.NoError(t, err)
+
+				req := httptest.NewRequest("GET", "/", nil)
+				req.Header.Add(JwtHeaderKey, fmt.Sprintf("Bearer %s", tok))
+				w := httptest.NewRecorder()
+				ra, err := raw.establishAuthFromRequest(testContext, true, req, w)
+				require.NoError(t, err)
+				require.True(t, ra.IsAuthenticated())
+				require.Equal(t, map[string]string{"tenant": "acme"}, ra.MustGetActor().Annotations)
+
+				retrieved, err := db.GetActorByExternalId(testContext, "root", externalId)
+				require.NoError(t, err)
+				require.Equal(t, dbActorId, retrieved.Id, "should preserve original database ID")
+				require.Equal(t, database.Annotations{"tenant": "acme"}, retrieved.Annotations, "annotations should be updated in database")
+			})
 		})
 
 		t.Run("expired", func(t *testing.T) {

--- a/internal/auth_methods/oauth2/interface.go
+++ b/internal/auth_methods/oauth2/interface.go
@@ -15,6 +15,7 @@ type IActorData interface {
 	GetId() apid.ID
 	GetExternalId() string
 	GetLabels() map[string]string
+	GetAnnotations() map[string]string
 	GetPermissions() []aschema.Permission
 	GetNamespace() string
 }

--- a/internal/auth_methods/oauth2/mock/oauth2.go
+++ b/internal/auth_methods/oauth2/mock/oauth2.go
@@ -83,6 +83,20 @@ func (mr *MockIActorDataMockRecorder) GetLabels() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabels", reflect.TypeOf((*MockIActorData)(nil).GetLabels))
 }
 
+// GetAnnotations mocks base method.
+func (m *MockIActorData) GetAnnotations() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnnotations")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetAnnotations indicates an expected call of GetAnnotations.
+func (mr *MockIActorDataMockRecorder) GetAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockIActorData)(nil).GetAnnotations))
+}
+
 // GetNamespace mocks base method.
 func (m *MockIActorData) GetNamespace() string {
 	m.ctrl.T.Helper()

--- a/internal/auth_methods/oauth2/mustache_test.go
+++ b/internal/auth_methods/oauth2/mustache_test.go
@@ -585,5 +585,6 @@ type mockActorData struct {
 func (m *mockActorData) GetId() apid.ID                       { return m.id }
 func (m *mockActorData) GetExternalId() string                { return "ext-123" }
 func (m *mockActorData) GetLabels() map[string]string         { return nil }
+func (m *mockActorData) GetAnnotations() map[string]string    { return nil }
 func (m *mockActorData) GetPermissions() []aschema.Permission { return nil }
 func (m *mockActorData) GetNamespace() string                 { return "/" }

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -27,11 +27,12 @@ type stateTestActor struct {
 	namespace string
 }
 
-func (a stateTestActor) GetId() apid.ID                      { return a.id }
-func (a stateTestActor) GetExternalId() string               { return "" }
-func (a stateTestActor) GetLabels() map[string]string        { return nil }
+func (a stateTestActor) GetId() apid.ID                       { return a.id }
+func (a stateTestActor) GetExternalId() string                { return "" }
+func (a stateTestActor) GetLabels() map[string]string         { return nil }
+func (a stateTestActor) GetAnnotations() map[string]string    { return nil }
 func (a stateTestActor) GetPermissions() []aschema.Permission { return nil }
-func (a stateTestActor) GetNamespace() string                { return a.namespace }
+func (a stateTestActor) GetNamespace() string                 { return a.namespace }
 
 // stateTestCore is a minimal coreIface.C that only implements GetConnection.
 // Other method calls will nil-panic, making accidental coupling obvious.

--- a/internal/schema/auth/README.md
+++ b/internal/schema/auth/README.md
@@ -3,3 +3,5 @@
 This package contains authentication and authorization contract types, including permissions used in JWTs and configuration.
 
 Namespace path and matcher semantics are owned by `internal/schema/resources/namespace`. This package re-exports namespace helpers for compatibility while callers migrate to the resource package.
+
+Permission namespaces may be literal namespace matchers such as `root.team.**`, or actor-templated matchers using `{{external_id}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. Missing label or annotation values render the permission unmatched rather than broadening access.

--- a/internal/schema/auth/schema.json
+++ b/internal/schema/auth/schema.json
@@ -6,8 +6,9 @@
       "type": "object",
       "properties": {
         "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespaceMatcher",
-          "description": "The namespace pattern this permission applies to."
+          "type": "string",
+          "pattern": "^root(?:\\.(?:(?:[A-Za-z0-9_][A-Za-z0-9_-]*)|(?:\\{\\{\\s*(?:external_id|labels\\.[^{}]+|annotations\\.[^{}]+)\\s*\\}\\})))*(?:\\.\\*\\*)?$",
+          "description": "The namespace pattern this permission applies to. Supports normal namespace matchers and actor templates: {{external_id}}, {{labels.<label>}}, and {{annotations.<annotation>}}."
         },
         "resources": {
           "type": "array",

--- a/internal/schema/auth/schema_test.go
+++ b/internal/schema/auth/schema_test.go
@@ -74,6 +74,21 @@ func TestSchema(t *testing.T) {
 			data:  `{"test": {"namespace": "root.prod", "resources": ["connector"], "resource_ids": ["conn-1"], "verbs": ["read"]}}`,
 		},
 		{
+			name:  "valid permission with external_id namespace template",
+			valid: true,
+			data:  `{"test": {"namespace": "root.{{external_id}}.**", "resources": ["connector"], "verbs": ["read"]}}`,
+		},
+		{
+			name:  "valid permission with label and annotation namespace templates",
+			valid: true,
+			data:  `{"test": {"namespace": "root.{{labels.tenant}}.{{annotations.region}}", "resources": ["connector"], "verbs": ["read"]}}`,
+		},
+		{
+			name:  "invalid permission with unsupported namespace template",
+			valid: false,
+			data:  `{"test": {"namespace": "root.{{email}}", "resources": ["connector"], "verbs": ["read"]}}`,
+		},
+		{
 			name:  "missing namespace",
 			valid: false,
 			data:  `{"test": {"resources": ["connector"], "verbs": ["read"]}}`,

--- a/internal/schema/resources/namespace/namespace.go
+++ b/internal/schema/resources/namespace/namespace.go
@@ -27,7 +27,7 @@ const NamespaceWildcardSuffix = NamespacePathSeparator + NamespaceWildcard
 
 // NamespaceSkipNamespacePermissionChecks is a sentinel value used to indicate that the namespace is not currently
 // known at the time of permission checking. During permission checking, at the API layer namespace won't generally be
-// known, so permission checking starts with resource and  verb. This essential value is used to indicate that
+// known, so permission checking starts with resource and verb. This value is used to indicate that
 // namespace checking for permissions should be ignored.
 const NamespaceSkipNamespacePermissionChecks = "<SKIP_NAMESPACE_PERMISSION_CHECK>"
 


### PR DESCRIPTION
## Summary

- Adds actor-based rendering for permission namespace matchers using `{{external_id}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`.
- Denies permission matches when referenced labels or annotations are missing, or when rendered values do not form a valid namespace matcher.
- Updates auth permission schema/docs and adds tests for matching, query namespace derivation, and schema validation.

Closes #516.

## Tests

- `go test ./internal/apauth/core`
- `go test ./internal/schema/auth`
- `go test ./internal/apauth/service`
- `go test ./internal/schema/config`
- `go test ./internal/apauth/...`
- `go test ./internal/schema/...`
- `./scripts/preflight.sh`