### PR TITLE
Defer setup form validation errors

### DIFF
--- a/ui/marketplace/src/components/ConnectionFormStep.tsx
+++ b/ui/marketplace/src/components/ConnectionFormStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { JsonForms } from '@jsonforms/react';
 import { materialCells, materialRenderers } from '@jsonforms/material-renderers';
 import type { JsonFormsCore, UISchemaElement } from '@jsonforms/core';
@@ -71,6 +71,14 @@ function applyDataSourcesToSchema(
     return { ...schema, properties: newProperties };
 }
 
+function hasMeaningfulValue(value: unknown): boolean {
+    if (value == null) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (Array.isArray(value)) return value.some(hasMeaningfulValue);
+    if (typeof value === 'object') return Object.values(value).some(hasMeaningfulValue);
+    return true;
+}
+
 const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
     connectionId,
     stepTitle,
@@ -82,9 +90,12 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
     isSubmitting,
 }) => {
     const [data, setData] = useState<unknown>({});
-    const [hasErrors, setHasErrors] = useState(false);
+    const [hasErrors, setHasErrors] = useState(true);
+    const [shouldShowValidation, setShouldShowValidation] = useState(false);
     const [dataSourceOptions, setDataSourceOptions] = useState<Record<string, DataSourceOption[]>>({});
     const [loadingDataSources, setLoadingDataSources] = useState(false);
+    const hasUserInteracted = useRef(false);
+    const hasEnteredValue = useRef(false);
 
     const dataSources = useMemo(() => findDataSources(jsonSchema), [jsonSchema]);
     const hasDataSources = Object.keys(dataSources).length > 0;
@@ -116,8 +127,25 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
     );
 
     const handleChange = useCallback((state: Pick<JsonFormsCore, 'data' | 'errors'>) => {
+        const hasCurrentErrors = (state.errors?.length ?? 0) > 0;
         setData(state.data);
-        setHasErrors((state.errors?.length ?? 0) > 0);
+        setHasErrors(hasCurrentErrors);
+        if (hasUserInteracted.current && hasMeaningfulValue(state.data)) {
+            hasEnteredValue.current = true;
+        }
+        if (hasUserInteracted.current && hasEnteredValue.current && hasCurrentErrors) {
+            setShouldShowValidation(true);
+        }
+    }, []);
+
+    const handleUserInteraction = useCallback(() => {
+        hasUserInteracted.current = true;
+    }, []);
+
+    const handleBlur = useCallback(() => {
+        if (hasUserInteracted.current) {
+            setShouldShowValidation(true);
+        }
     }, []);
 
     const handleSubmit = useCallback(() => {
@@ -152,14 +180,21 @@ const ConnectionFormStep: React.FC<ConnectionFormStepProps> = ({
                     </Typography>
                 </Box>
             ) : (
-                <JsonForms
-                    schema={resolvedSchema as JsonSchema}
-                    uischema={uiSchema as unknown as UISchemaElement}
-                    data={data}
-                    renderers={materialRenderers}
-                    cells={materialCells}
-                    onChange={handleChange}
-                />
+                <Box
+                    onInputCapture={handleUserInteraction}
+                    onChangeCapture={handleUserInteraction}
+                    onBlurCapture={handleBlur}
+                >
+                    <JsonForms
+                        schema={resolvedSchema as JsonSchema}
+                        uischema={uiSchema as unknown as UISchemaElement}
+                        data={data}
+                        renderers={materialRenderers}
+                        cells={materialCells}
+                        validationMode={shouldShowValidation ? 'ValidateAndShow' : 'ValidateAndHide'}
+                        onChange={handleChange}
+                    />
+                </Box>
             )}
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: marketplaceTokens.spacing.headerGap + 1 }}>
                 <Button

--- a/ui/marketplace/src/tests/ConnectionFormStep.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionFormStep.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, test, vi} from 'vitest';
+import ConnectionFormStep from '../components/ConnectionFormStep';
+
+const requiredTextStep = {
+    connectionId: 'cxn_preconnect',
+    stepTitle: 'Choose a pretend tenant',
+    stepDescription: 'This pre-connect step runs before OAuth.',
+    jsonSchema: {
+        type: 'object',
+        required: ['tenant'],
+        properties: {
+            tenant: {
+                type: 'string',
+                title: 'Demo tenant',
+            },
+        },
+    },
+    uiSchema: {
+        type: 'VerticalLayout',
+        elements: [{type: 'Control', scope: '#/properties/tenant'}],
+    },
+};
+
+describe('ConnectionFormStep', () => {
+    test('hides required validation until the user changes the field', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <ConnectionFormStep
+                {...requiredTextStep}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+                isSubmitting={false}
+            />,
+        );
+
+        expect(screen.getByLabelText(/Demo tenant/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /Save and verify/i})).toBeDisabled();
+        expect(screen.queryByText(/is a required property/i)).not.toBeInTheDocument();
+
+        await user.type(screen.getByLabelText(/Demo tenant/i), 'acme');
+        expect(screen.queryByText(/is a required property/i)).not.toBeInTheDocument();
+
+        await user.clear(screen.getByLabelText(/Demo tenant/i));
+        expect(screen.queryByText(/is a required property/i)).not.toBeInTheDocument();
+
+        await user.tab();
+        expect(screen.getByText(/is a required property/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /Save and verify/i})).toBeDisabled();
+    });
+});


### PR DESCRIPTION
## Summary
- Keep setup/pre-connect form validation hidden on initial render while preserving required markers and disabled submit behavior.
- Reveal JSONForms validation only after user interaction produces an invalid edited form or after the user leaves an interacted field.
- Add a focused RTL test covering the required-field UX: neutral initial state, disabled submit, and error display after entering, clearing, and leaving the field.

## Scope
ConnectionFormStep is shared by connector pre-connect/connect/configure setup dialogs, so this applies across those flows.

## Screenshots
Screenshot capture was attempted against the rebuilt Storybook setup-dialog story, but the environment approval review timed out for both the local static server and the file:// fallback. The Storybook build completed successfully.

## Verification
- yarn workspace @authproxy/marketplace typecheck
- yarn workspace @authproxy/marketplace test --run
- yarn workspace @authproxy/marketplace lint
- yarn workspace @authproxy/marketplace build-storybook
- ./scripts/preflight.sh