### PR TITLE
Gate dev demo deployments on PR label

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,9 +1,10 @@
 # schema: https://json.schemastore.org/github-workflow.json
 name: Deploy Dev
 
-# Deploys one isolated authproxy-demo environment per pull request.
-# The namespace is derived from the PR branch name and the image tag is
-# the Build Image workflow's PR tag: `pr-<number>`.
+# Deploys one isolated authproxy-demo environment for pull requests
+# labeled `deploy:demo`. The namespace is derived from the PR branch
+# name and the image tag is the Build Image workflow's PR tag:
+# `pr-<number>`.
 #
 # Fork PRs are skipped deliberately: the image workflow does not push
 # GHCR tags for forks, and deploying untrusted fork code with AWS OIDC
@@ -12,7 +13,7 @@ name: Deploy Dev
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   actions: read
@@ -28,7 +29,9 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'deploy:demo')
     runs-on: ubuntu-latest
     environment: gha-eks
     timeout-minutes: 45

--- a/deploy/docs/runbook.md
+++ b/deploy/docs/runbook.md
@@ -206,6 +206,19 @@ image tag pinned to that commit's `sha-<short>`. One-time setup:
    Once green, every subsequent merge to `main` deploys automatically
    within ~5 min.
 
+### 1.11 PR dev demo environments
+
+The `Deploy Dev` workflow (`.github/workflows/deploy-dev.yml`) creates
+an isolated `authproxy-demo` environment for same-repository pull
+requests that carry the `deploy:demo` label. Add the label when opening
+the PR, or add it to an existing PR later; either path triggers the dev
+deployment. Subsequent pushes to a labeled PR redeploy the same
+environment with the `pr-<number>` image tag.
+
+The `Teardown Dev` workflow still runs on PR close regardless of labels,
+so merged or closed PRs tear down any previously-created dev demo
+environment even if the opt-in label has since been removed.
+
 ## 2. Granting kubectl access
 
 The cluster uses the **modern EKS access-entry model**


### PR DESCRIPTION
## Summary
- require the `deploy:demo` label before the per-PR Deploy Dev workflow runs
- trigger Deploy Dev when that label is added after PR creation
- document the opt-in label and confirm Teardown Dev still runs on PR close regardless of labels

## Verification
- `./scripts/preflight.sh`
- parsed `.github/workflows/deploy-dev.yml` with Ruby YAML loader