### PR TITLE
Seed demo API key connector

### DIFF
--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -59,10 +59,11 @@ type ConnectorSeed struct {
 }
 
 type OAuth2TestProviderSeed struct {
-	BaseUrl          string                     `yaml:"base_url"`
-	Clients          []OAuth2TestProviderClient `yaml:"clients,omitempty"`
-	Users            []OAuth2TestProviderUser   `yaml:"users,omitempty"`
-	ResourcePolicies []OAuth2ResourcePolicy     `yaml:"resource_policies,omitempty"`
+	BaseUrl                string                     `yaml:"base_url"`
+	Clients                []OAuth2TestProviderClient `yaml:"clients,omitempty"`
+	Users                  []OAuth2TestProviderUser   `yaml:"users,omitempty"`
+	ResourcePolicies       []OAuth2ResourcePolicy     `yaml:"resource_policies,omitempty"`
+	APIKeyResourcePolicies []APIKeyResourcePolicy     `yaml:"api_key_resource_policies,omitempty"`
 }
 
 type OAuth2TestProviderClient struct {
@@ -86,6 +87,14 @@ type OAuth2TestProviderUser struct {
 type OAuth2ResourcePolicy struct {
 	Path          string `json:"path" yaml:"path"`
 	RequiredScope string `json:"required_scope" yaml:"required_scope"`
+}
+
+type APIKeyResourcePolicy struct {
+	Path       string `json:"path" yaml:"path"`
+	Key        string `json:"key" yaml:"key"`
+	Placement  string `json:"placement,omitempty" yaml:"placement,omitempty"`
+	HeaderName string `json:"header_name,omitempty" yaml:"header_name,omitempty"`
+	Prefix     string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 }
 
 type settings struct {
@@ -233,6 +242,18 @@ func seedOAuth2TestProvider(c *resty.Client, seed OAuth2TestProviderSeed) error 
 		}
 		if _, err := postOAuth2TestProvider(c, baseUrl, "/test/resource-policy", policy); err != nil {
 			return fmt.Errorf("seed oauth2 resource policy %q: %w", policy.Path, err)
+		}
+	}
+
+	for _, policy := range seed.APIKeyResourcePolicies {
+		if policy.Path == "" {
+			return fmt.Errorf("oauth2 test provider api-key resource policy path is required")
+		}
+		if policy.Key == "" {
+			return fmt.Errorf("oauth2 test provider api-key resource policy %q key is required", policy.Path)
+		}
+		if _, err := postOAuth2TestProvider(c, baseUrl, "/test/api-key-resource-policy", policy); err != nil {
+			return fmt.Errorf("seed oauth2 test provider api-key resource policy %q: %w", policy.Path, err)
 		}
 	}
 
@@ -541,6 +562,7 @@ func run(logger *slog.Logger) error {
 			"clients", len(cfg.OAuth2TestProvider.Clients),
 			"users", len(cfg.OAuth2TestProvider.Users),
 			"resource_policies", len(cfg.OAuth2TestProvider.ResourcePolicies),
+			"api_key_resource_policies", len(cfg.OAuth2TestProvider.APIKeyResourcePolicies),
 		)
 	}
 

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -146,6 +146,13 @@ func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "/test/resource/demo-resources", req.Path)
 			w.WriteHeader(http.StatusNoContent)
+		case "POST /test/api-key-resource-policy":
+			var req APIKeyResourcePolicy
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, "/test/api-key-resource/demo-api-key", req.Path)
+			require.Equal(t, "demo-api-key", req.Key)
+			require.Equal(t, "bearer", req.Placement)
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -168,11 +175,17 @@ func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
 			Path:          "/test/resource/demo-resources",
 			RequiredScope: "read",
 		}},
+		APIKeyResourcePolicies: []APIKeyResourcePolicy{{
+			Path:      "/test/api-key-resource/demo-api-key",
+			Key:       "demo-api-key",
+			Placement: "bearer",
+		}},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, seen["POST /test/clients"])
 	require.Equal(t, 1, seen["POST /test/users"])
 	require.Equal(t, 1, seen["POST /test/resource-policy"])
+	require.Equal(t, 1, seen["POST /test/api-key-resource-policy"])
 }
 
 func TestPostOAuth2TestProviderTreatsDuplicateAsAlreadyPresent(t *testing.T) {
@@ -257,6 +270,40 @@ connectors:
 	require.Len(t, cfg.Connectors, 1)
 	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
 	require.True(t, cfg.Connectors[0].Definition.SetupFlow.HasPreconnect())
+}
+
+func TestSeedConfigParsesAPIKeyConnector(t *testing.T) {
+	data := []byte(`
+oauth2_test_provider:
+  base_url: http://go-oauth2-server
+  api_key_resource_policies:
+    - path: /test/api-key-resource/demo-api-key
+      key: demo-api-key
+      placement: bearer
+connectors:
+  - key: demo-api-key
+    namespace: root
+    definition:
+      display_name: Demo API Key
+      description: Demo API key connector
+      labels:
+        type: demo-api-key
+      auth:
+        type: api-key
+        placement:
+          type: bearer
+      probes:
+        - id: verify-api-key
+          proxy_http:
+            method: GET
+            url: http://go-oauth2-server/test/api-key-resource/demo-api-key
+`)
+	var cfg SeedConfig
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.NotNil(t, cfg.OAuth2TestProvider)
+	require.Len(t, cfg.OAuth2TestProvider.APIKeyResourcePolicies, 1)
+	require.Len(t, cfg.Connectors, 1)
+	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
 }
 
 func mustConnector(t *testing.T, displayName string) config.Connector {

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -139,10 +139,15 @@ no-op once the state matches. Toggle off with `--set seed.enabled=false`
 or extend via `seed.actors[*]` to seed customer-specific identities
 alongside the defaults.
 
-> **Currently NOT seeded:** per-actor pre-existing connections + the
-> demo connector itself. The connector pattern needs a dedicated
-> connector-management admin API surface that isn't fully there yet;
-> tracked as a follow-up to A11.
+The same seed job publishes the demo Marketplace catalog and configures
+the test-mode go-oauth2-server backing resources. The default catalog
+includes no-auth, OAuth, and API-key examples. The API-key connector uses
+the intentionally fake key `demo-api-key`; the provider accepts it only
+on `/test/api-key-resource/*`, and the connector probe makes bad-key
+setup failures visible during connection verification.
+
+> **Currently NOT seeded:** per-actor pre-existing connections. Demo
+> visitors create their own connections through the Marketplace UI.
 
 ## Routing
 

--- a/deploy/charts/authproxy-demo/values.schema.json
+++ b/deploy/charts/authproxy-demo/values.schema.json
@@ -124,6 +124,10 @@
             "resource_policies": {
               "type": "array",
               "items": { "type": "object", "additionalProperties": true }
+            },
+            "api_key_resource_policies": {
+              "type": "array",
+              "items": { "type": "object", "additionalProperties": true }
             }
           },
           "required": ["base_url"]

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -215,6 +215,10 @@ seed:
     resource_policies:
       - path: /test/resource/demo-resources
         required_scope: resources
+    api_key_resource_policies:
+      - path: /test/api-key-resource/demo-api-key
+        key: demo-api-key
+        placement: bearer
   # -- Connectors to seed into the Marketplace catalog. Each entry gets
   # created through the AuthProxy admin API, then forced to `primary` so
   # fresh demo environments show the catalog immediately. `key` is the
@@ -239,6 +243,32 @@ seed:
           demo: "true"
         auth:
           type: no-auth
+    - key: demo-api-key-bearer
+      namespace: root
+      labels:
+        demo: "true"
+        auth_method: api-key
+        showcase: api-key
+      definition:
+        display_name: "Demo API Key: Bearer Token"
+        logo:
+          mime_type: image/svg+xml
+          base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJBUEkgS2V5IERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iI0M4NDYzMCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTExNiA3MGg3NG0tMjAtMTYgMTYgMTYtMTYgMTYiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5BSzwvdGV4dD48L3N2Zz4=
+        highlight: "Creates a connection from a static demo API key."
+        description: "This connector demonstrates AuthProxy API-key setup and proxying. Enter `demo-api-key` when prompted; it is an intentionally fake key accepted only by the demo provider. AuthProxy stores the key as an encrypted credential, injects it as `Authorization: Bearer demo-api-key` on proxy requests, and verifies it with a probe so wrong keys are easy to spot."
+        labels:
+          type: demo-api-key-bearer
+          demo: "true"
+        auth:
+          type: api-key
+          placement:
+            type: bearer
+        probes:
+          - id: verify-api-key
+            proxy_http:
+              method: GET
+              url: "http://{{ include \"authproxy-demo.goOauth2Server.name\" . }}/test/api-key-resource/demo-api-key"
+            failure_threshold: 1
     - key: demo-oauth-simple
       namespace: root
       labels:


### PR DESCRIPTION
## Summary
- seed a demo API-key connector into the Marketplace catalog
- configure the demo provider with an API-key resource policy for the fake key `demo-api-key`
- add demo-seed parsing/POST support for API-key resource policies and document the seeded catalog

Depends on rmorlok/go-oauth2-server#65 so the `master` provider image exposes `/test/api-key-resource/*` before this deploys to demo.

Closes #502.

## Tests
- go test ./demos/seed/backend
- helm lint deploy/charts/authproxy-demo
- helm template dev deploy/charts/authproxy-demo --set global.hostname=example.dev.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test
- ./scripts/preflight.sh