### PR TITLE
Migrate connection disconnect to workflow

### DIFF
--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -55,7 +55,23 @@ Secrets, not in this ConfigMap.
 {{- $_ := set $cfg "admin_api" $adminApi -}}
 {{- end -}}
 {{- if .Values.services.worker.enabled -}}
-{{- $_ := set $cfg "worker" (dict "health_check_port" .Values.ports.workerHealth) -}}
+{{- $worker := dict "health_check_port" .Values.ports.workerHealth -}}
+{{- if .Values.worker.workflowPollers -}}
+{{-   $_ := set $worker "workflow_pollers" .Values.worker.workflowPollers -}}
+{{- end -}}
+{{- if .Values.worker.activityPollers -}}
+{{-   $_ := set $worker "activity_pollers" .Values.worker.activityPollers -}}
+{{- end -}}
+{{- if .Values.worker.maxParallelWorkflowTasks -}}
+{{-   $_ := set $worker "max_parallel_workflow_tasks" .Values.worker.maxParallelWorkflowTasks -}}
+{{- end -}}
+{{- if .Values.worker.maxParallelActivityTasks -}}
+{{-   $_ := set $worker "max_parallel_activity_tasks" .Values.worker.maxParallelActivityTasks -}}
+{{- end -}}
+{{- if .Values.worker.workflowHeartbeatInterval -}}
+{{-   $_ := set $worker "workflow_heartbeat_interval" .Values.worker.workflowHeartbeatInterval -}}
+{{- end -}}
+{{- $_ := set $cfg "worker" $worker -}}
 {{- end -}}
 
 {{/*

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -67,6 +67,18 @@
       }
     },
 
+    "worker": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "workflowPollers":          { "$ref": "#/definitions/workflowIntegerValue" },
+        "activityPollers":          { "$ref": "#/definitions/workflowIntegerValue" },
+        "maxParallelWorkflowTasks": { "$ref": "#/definitions/workflowIntegerValue" },
+        "maxParallelActivityTasks": { "$ref": "#/definitions/workflowIntegerValue" },
+        "workflowHeartbeatInterval": { "type": "string" }
+      }
+    },
+
     "service": {
       "type": "object",
       "additionalProperties": false,
@@ -292,6 +304,12 @@
       "type": "integer",
       "minimum": 1,
       "maximum": 65535
+    },
+    "workflowIntegerValue": {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "integer" }
+      ]
     }
   }
 }

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -107,6 +107,15 @@ ports:
   adminApi: 8082
   workerHealth: 8083
 
+# -- Workflow worker tuning. Empty values keep the go-workflows library
+# defaults. Numeric values may be supplied as YAML numbers or strings.
+worker:
+  workflowPollers: ""
+  activityPollers: ""
+  maxParallelWorkflowTasks: ""
+  maxParallelActivityTasks: ""
+  workflowHeartbeatInterval: ""
+
 service:
   # -- Service type.
   type: ClusterIP

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/service/admin_api"
 	api_service "github.com/rmorlok/authproxy/internal/service/api"
 	public_service "github.com/rmorlok/authproxy/internal/service/public"
+	"github.com/rmorlok/authproxy/internal/workflows"
 	"github.com/stretchr/testify/require"
 )
 
@@ -213,6 +214,7 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 	// MustApplyBlankTestDbConfig reads connection info from POSTGRES_TEST_* env vars
 	// and updates cfg.GetRoot().Database to point at the new isolated database.
 	cfg, _ = database.MustApplyBlankTestDbConfig(t, cfg)
+	require.NoError(t, workflows.Migrate(cfg.GetRoot(), cfg.GetRoot().GetRootLogger()))
 
 	// Merge test-specific connectors into config
 	if len(opts.Connectors) > 0 {

--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -12,13 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
+	workflowworker "github.com/cschleiden/go-workflows/worker"
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -148,27 +149,42 @@ func (r *disconnectRevocationRig) disconnect(t *testing.T, connectionID string) 
 	assert.NotEmpty(t, body.TaskID)
 }
 
-func startCoreTaskWorker(t *testing.T, rig *disconnectRevocationRig) {
+func startCoreWorkflowWorker(t *testing.T, rig *disconnectRevocationRig) {
 	t.Helper()
 
-	srv := asynq.NewServerFromRedisClient(
-		rig.env.DM.GetRedisClient(),
-		asynq.Config{
-			Concurrency: 1,
-			Queues: map[string]int{
-				"default": 1,
-			},
+	workflowRuntime := rig.env.DM.GetWorkflowRuntime()
+	workflowWorker, err := apworkflows.NewWorker(workflowRuntime, &workflowworker.Options{
+		WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
+			WorkflowPollers:          2,
+			MaxParallelWorkflowTasks: 1,
 		},
-	)
-	mux := asynq.NewServeMux()
-	rig.env.Core.RegisterTasks(mux)
+		ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
+			ActivityPollers:          2,
+			MaxParallelActivityTasks: 1,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, rig.env.Core.RegisterWorkflows(workflowWorker))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
 
 	go func() {
-		_ = srv.Run(mux)
+		if err := workflowWorker.Start(ctx); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- workflowWorker.WaitForCompletion()
 	}()
 
 	t.Cleanup(func() {
-		srv.Shutdown()
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("workflow worker did not stop")
+		}
 	})
 }
 
@@ -181,7 +197,7 @@ func requireConnectionDeleted(t *testing.T, rig *disconnectRevocationRig, connec
 	require.Eventually(t, func() bool {
 		_, err := rig.env.Db.GetConnection(context.Background(), id)
 		return errors.Is(err, database.ErrNotFound)
-	}, 10*time.Second, 100*time.Millisecond, "connection should be soft-deleted after disconnect task")
+	}, 10*time.Second, 100*time.Millisecond, "connection should be soft-deleted after disconnect workflow")
 }
 
 func requireProxyBlockedAfterDisconnect(t *testing.T, rig *disconnectRevocationRig, connectionID string) {
@@ -204,8 +220,8 @@ func TestDisconnectRevocation_RevokesProviderTokensAndBlocksFutureProxy(t *testi
 	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), http.MethodGet)
 	require.Equal(t, http.StatusOK, parseRevocationProxyResponse(t, w).StatusCode)
 
+	startCoreWorkflowWorker(t, rig)
 	rig.disconnect(t, connID)
-	startCoreTaskWorker(t, rig)
 	requireConnectionDeleted(t, rig, connID)
 
 	assert.Nil(t, rig.env.GetOAuth2Token(t, connID), "successful disconnect should tombstone the local OAuth token row")
@@ -233,8 +249,8 @@ func TestDisconnectRevocation_RevocationFailureStillCompletesDisconnect(t *testi
 		FailCount: 10,
 	})
 
+	startCoreWorkflowWorker(t, rig)
 	rig.disconnect(t, connID)
-	startCoreTaskWorker(t, rig)
 	requireConnectionDeleted(t, rig, connID)
 	requireProxyBlockedAfterDisconnect(t, rig, connID)
 

--- a/integration_tests/oauth2/disconnect_revocation_test.md
+++ b/integration_tests/oauth2/disconnect_revocation_test.md
@@ -1,13 +1,13 @@
 # OAuth disconnect revocation
 
-This test verifies proxy-initiated OAuth disconnect and revocation. It uses the provider `/test/*` control plane to complete authorization without a browser, then calls the AuthProxy disconnect API and drains the queued `core:disconnect_connection` task with an in-test Asynq worker.
+This test verifies proxy-initiated OAuth disconnect and revocation. It uses the provider `/test/*` control plane to complete authorization without a browser, then calls the AuthProxy disconnect API and drains the `core.connection.disconnect.v1` workflow with an in-test workflow worker.
 
 The fixture connector enables OAuth revocation and configures the provider's expected revoke form credentials. It revokes the refresh token, which is sufficient to invalidate provider-side credentials while exercising AuthProxy's local token cleanup path.
 
 The assertions cover:
 
 - `POST /connections/{id}/_disconnect` returns a disconnecting connection and task id;
-- the disconnect task calls the provider revocation endpoint with the stored refresh token;
+- the disconnect workflow calls the provider revocation endpoint with the stored refresh token;
 - successful provider revocation tombstones the local OAuth token row and soft-deletes the connection;
 - future proxied calls fail with `connection not found`, forcing a reconnect instead of using stale credentials;
 - provider revocation failures are retried and then the product policy proceeds with local disconnect so the connection cannot remain stuck in `disconnecting`.

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -10,6 +10,7 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/tasks"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
 
 type ConnectorVersionId = database.ConnectorVersionId
@@ -285,5 +286,6 @@ type C interface {
 	 */
 
 	RegisterTasks(mux *asynq.ServeMux)
+	RegisterWorkflows(worker *apworkflows.Worker) error
 	GetCronTasks() []*asynq.PeriodicTaskConfig
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -1,8 +1,11 @@
 package core
 
 import (
+	"context"
 	"log/slog"
 
+	"github.com/cschleiden/go-workflows/client"
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/rmorlok/authproxy/internal/apasynq"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
@@ -27,6 +30,7 @@ type service struct {
 	r       apredis.Client
 	httpf   httpf.F
 	ac      apasynq.Client
+	wc      workflowClient
 	logger  *slog.Logger
 
 	// rlCache is the enforcer-shared rate-limit cache. Optional —
@@ -53,6 +57,10 @@ type service struct {
 // need the new dependency change.
 type Option func(*service)
 
+type workflowClient interface {
+	CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error)
+}
+
 // WithRateLimitCache wires the in-memory rate-limit rule cache the
 // enforcer reads. Required by C.DryRunRateLimit; harmless to omit when
 // the dry-run path isn't exercised.
@@ -69,6 +77,10 @@ func WithTelemetry(providers *aptelemetry.Providers, cfg *sconfig.Telemetry) Opt
 		s.telProviders = providers
 		s.telCfg = cfg
 	}
+}
+
+func WithWorkflowClient(c workflowClient) Option {
+	return func(s *service) { s.wc = c }
 }
 
 // NewCoreService creates a new core service

--- a/internal/core/service_connection_disconnect.go
+++ b/internal/core/service_connection_disconnect.go
@@ -32,6 +32,11 @@ func (s *service) DisconnectConnection(
 		return nil, err
 	}
 
-	s.logger.Info("disconnect connection workflow started", "id", id, "workflow_instance_id", instance.InstanceID, "workflow_execution_id", instance.ExecutionID)
+	s.logger.Info(
+		"disconnect connection workflow started",
+		"id", id,
+		"workflow_instance_id", instance.InstanceID,
+		"workflow_execution_id", instance.ExecutionID,
+		)
 	return tasks.FromWorkflowInstance(instance, WorkflowNameDisconnectConnectionV1, string(apworkflows.DefaultQueue)), nil
 }

--- a/internal/core/service_connection_disconnect.go
+++ b/internal/core/service_connection_disconnect.go
@@ -3,13 +3,12 @@ package core
 import (
 	"context"
 	"errors"
-	"time"
 
-	"github.com/hibiken/asynq"
-	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/tasks"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
 
 func (s *service) DisconnectConnection(
@@ -27,17 +26,12 @@ func (s *service) DisconnectConnection(
 		return nil, err
 	}
 
-	s.logger.Info("queueing disconnect connection task", "id", id)
-	t, err := newDisconnectConnectionTask(id)
+	s.logger.Info("starting disconnect connection workflow", "id", id)
+	instance, err := s.startDisconnectConnectionWorkflow(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	ti, err := s.ac.EnqueueContext(ctx, t, asynq.Retention(10*time.Minute))
-	if err != nil {
-		return nil, err
-	}
-
-	s.logger.Info("disconnect connection task queued", "id", id, "task_id", ti.ID)
-	return tasks.FromAsynqTask(ti), nil
+	s.logger.Info("disconnect connection workflow started", "id", id, "workflow_instance_id", instance.InstanceID, "workflow_execution_id", instance.ExecutionID)
+	return tasks.FromWorkflowInstance(instance, WorkflowNameDisconnectConnectionV1, string(apworkflows.DefaultQueue)), nil
 }

--- a/internal/core/service_connection_disconnect_test.go
+++ b/internal/core/service_connection_disconnect_test.go
@@ -2,14 +2,14 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
+	"github.com/cschleiden/go-workflows/client"
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/golang/mock/gomock"
-	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/tasks"
 	"github.com/stretchr/testify/require"
 
 	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
@@ -20,28 +20,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type fakeDisconnectWorkflowClient struct {
+	instance *wflib.Instance
+	err      error
+
+	options  client.WorkflowInstanceOptions
+	workflow wflib.Workflow
+	args     []any
+}
+
+func (f *fakeDisconnectWorkflowClient) CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error) {
+	f.options = options
+	f.workflow = workflow
+	f.args = args
+	return f.instance, f.err
+}
+
 func TestDisconnectConnection(t *testing.T) {
 	ctx := context.Background()
-	connectionId := apid.New(apid.PrefixActor)
+	connectionId := apid.New(apid.PrefixConnection)
 
-	setup := func(t *testing.T) (*service, *mockDb.MockDB, *mockAsynq.MockClient, *gomock.Controller) {
+	setup := func(t *testing.T) (*service, *mockDb.MockDB, *fakeDisconnectWorkflowClient, *gomock.Controller) {
 		ctrl := gomock.NewController(t)
 		db := mockDb.NewMockDB(ctrl)
 		ac := mockAsynq.NewMockClient(ctrl)
 		encrypt := mockEncrypt.NewMockE(ctrl)
 		logger, _ := mockLog.NewTestLogger(t)
+		wc := &fakeDisconnectWorkflowClient{
+			instance: &wflib.Instance{
+				InstanceID:  "workflow-instance-id",
+				ExecutionID: "workflow-execution-id",
+			},
+		}
 
 		return &service{
 			cfg:     nil,
 			db:      db,
 			encrypt: encrypt,
 			ac:      ac,
+			wc:      wc,
 			logger:  logger,
-		}, db, ac, ctrl
+		}, db, wc, ctrl
 	}
 
 	t.Run("successfully disconnect connection", func(t *testing.T) {
-		svc, dbMock, asynqMock, ctrl := setup(t)
+		svc, dbMock, workflowClient, ctrl := setup(t)
 		defer ctrl.Finish()
 
 		dbMock.
@@ -49,33 +72,17 @@ func TestDisconnectConnection(t *testing.T) {
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnecting).
 			Return(nil)
 
-		taskMatcher := gomock.AssignableToTypeOf(&asynq.Task{})
-		asynqMock.
-			EXPECT().
-			EnqueueContext(gomock.Any(), taskMatcher, asynq.Retention(10*time.Minute)).
-			DoAndReturn(func(_ context.Context, task *asynq.Task, _ ...asynq.Option) (*asynq.TaskInfo, error) {
-				// Verify the task type
-				assert.Equal(t, "core:disconnect_connection", task.Type())
-
-				// Parse the payload to verify the connection ID
-				var payload struct {
-					ConnectionId apid.ID `json:"connection_id"`
-				}
-				err := json.Unmarshal(task.Payload(), &payload)
-				require.NoError(t, err)
-
-				// Verify the connection ID matches what we expect
-				assert.Equal(t, connectionId, payload.ConnectionId)
-
-				// Return a mock TaskInfo
-				return &asynq.TaskInfo{ID: "mock-task-id"}, nil
-
-			})
-
 		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "mock-task-id", taskInfo.AsynqId)
+		require.NotNil(t, taskInfo)
+		assert.Equal(t, tasks.TrackedViaWorkflow, taskInfo.TrackedVia)
+		assert.Equal(t, "workflow-instance-id", taskInfo.WorkflowInstanceId)
+		assert.Equal(t, "workflow-execution-id", taskInfo.WorkflowExecutionId)
+		assert.Equal(t, WorkflowNameDisconnectConnectionV1, taskInfo.WorkflowName)
+		assert.Equal(t, WorkflowNameDisconnectConnectionV1, workflowClient.workflow)
+		assert.Equal(t, []any{connectionId.String()}, workflowClient.args)
+		assert.Contains(t, workflowClient.options.InstanceID, connectionId.String())
 	})
 
 	t.Run("database not found error", func(t *testing.T) {
@@ -106,18 +113,15 @@ func TestDisconnectConnection(t *testing.T) {
 		assert.Nil(t, taskInfo)
 	})
 
-	t.Run("task creation error", func(t *testing.T) {
-		svc, dbMock, asynqMock, ctrl := setup(t)
+	t.Run("workflow start error", func(t *testing.T) {
+		svc, dbMock, workflowClient, ctrl := setup(t)
 		defer ctrl.Finish()
 
 		dbMock.EXPECT().
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnecting).
 			Return(nil)
 
-		asynqMock.
-			EXPECT().
-			EnqueueContext(gomock.Any(), gomock.Any(), asynq.Retention(10*time.Minute)).
-			Return((*asynq.TaskInfo)(nil), errors.New("enqueue error"))
+		workflowClient.err = errors.New("workflow error")
 
 		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
 

--- a/internal/core/service_tasks.go
+++ b/internal/core/service_tasks.go
@@ -12,7 +12,6 @@ import (
 
 func (s *service) RegisterTasks(mux *asynq.ServeMux) {
 	mux.HandleFunc(taskTypeMigrateConnectionsBetweenConnectorVersions, s.migrateConnectionsBetweenConnectorVersions)
-	mux.HandleFunc(taskTypeDisconnectConnection, s.disconnectConnection)
 	mux.HandleFunc(taskTypeProbe, s.runProbeForConnection)
 	mux.HandleFunc(taskTypeVerifyConnection, s.verifyConnection)
 	mux.HandleFunc(taskTypeProbeOutcomeCleanup, s.runProbeOutcomeCleanup)

--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -56,7 +56,7 @@ func disconnectConnectionRevokeActivityOptions() wflib.ActivityOptions {
 	return opts
 }
 
-func (s *service) RegisterWorkflows(worker *apworkflows.Worker) error {
+func (s *service) registerDisconnectConnectionWorkflow(worker *apworkflows.Worker) error {
 	if err := worker.RegisterWorkflow(
 		disconnectConnectionWorkflowV1,
 		registry.WithName(WorkflowNameDisconnectConnectionV1),
@@ -75,8 +75,12 @@ func (s *service) RegisterWorkflows(worker *apworkflows.Worker) error {
 	)
 }
 
+func (s *service) RegisterWorkflows(worker *apworkflows.Worker) error {
+	return s.registerDisconnectConnectionWorkflow(worker)
+}
+
 func disconnectConnectionWorkflowInstanceID(connectionId apid.ID) string {
-	return fmt.Sprintf("%s:%s:%s", WorkflowNameDisconnectConnectionV1, connectionId, apid.New(apid.PrefixNonce))
+	return fmt.Sprintf("%s:%s", WorkflowNameDisconnectConnectionV1, connectionId)
 }
 
 func (s *service) startDisconnectConnectionWorkflow(ctx context.Context, connectionId apid.ID) (*wflib.Instance, error) {
@@ -109,7 +113,11 @@ func (s *service) revokeDisconnectConnectionCredentialsV1(ctx context.Context, c
 		return err
 	}
 
-	logger := s.logger.With("workflow", WorkflowNameDisconnectConnectionV1, "activity", ActivityNameDisconnectConnectionRevokeCredentialsV1, "connection_id", id)
+	logger := s.logger.With(
+		"workflow", WorkflowNameDisconnectConnectionV1,
+		"activity", ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		"connection_id", id,
+	)
 	logger.Info("disconnect connection revoke activity started")
 	defer logger.Info("disconnect connection revoke activity completed")
 

--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -2,18 +2,24 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/hibiken/asynq"
+	"github.com/cschleiden/go-workflows/client"
+	"github.com/cschleiden/go-workflows/registry"
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/util/retry"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
 
-const taskTypeDisconnectConnection = "core:disconnect_connection"
+const (
+	WorkflowNameDisconnectConnectionV1 = "core.connection.disconnect.v1"
+
+	ActivityNameDisconnectConnectionRevokeCredentialsV1 = "core.connection.disconnect.revoke_credentials.v1"
+	ActivityNameDisconnectConnectionFinalizeV1          = "core.connection.disconnect.finalize.v1"
+)
 
 // maxRevokeAttempts caps the number of times a revoke operation is retried
 // inside a single disconnect task invocation. After exhausting attempts, the
@@ -21,36 +27,93 @@ const taskTypeDisconnectConnection = "core:disconnect_connection"
 // because a 3rd-party revoke endpoint is misbehaving.
 const maxRevokeAttempts = 3
 
-func newDisconnectConnectionTask(connectionId apid.ID) (*asynq.Task, error) {
-	payload, err := json.Marshal(disconnectConnectionTaskPayload{connectionId})
+func disconnectConnectionWorkflowV1(ctx wflib.Context, connectionId string) error {
+	if _, err := wflib.ExecuteActivity[any](
+		ctx,
+		disconnectConnectionRevokeActivityOptions(),
+		ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		connectionId,
+	).Get(ctx); err != nil {
+		return err
+	}
+
+	_, err := wflib.ExecuteActivity[any](
+		ctx,
+		wflib.DefaultActivityOptions,
+		ActivityNameDisconnectConnectionFinalizeV1,
+		connectionId,
+	).Get(ctx)
+	return err
+}
+
+func disconnectConnectionRevokeActivityOptions() wflib.ActivityOptions {
+	opts := wflib.DefaultActivityOptions
+	opts.RetryOptions = wflib.RetryOptions{
+		MaxAttempts:        maxRevokeAttempts,
+		FirstRetryInterval: 1 * time.Second,
+		BackoffCoefficient: 1,
+	}
+	return opts
+}
+
+func (s *service) RegisterWorkflows(worker *apworkflows.Worker) error {
+	if err := worker.RegisterWorkflow(
+		disconnectConnectionWorkflowV1,
+		registry.WithName(WorkflowNameDisconnectConnectionV1),
+	); err != nil {
+		return err
+	}
+	if err := worker.RegisterActivity(
+		s.revokeDisconnectConnectionCredentialsV1,
+		registry.WithName(ActivityNameDisconnectConnectionRevokeCredentialsV1),
+	); err != nil {
+		return err
+	}
+	return worker.RegisterActivity(
+		s.finalizeDisconnectConnectionV1,
+		registry.WithName(ActivityNameDisconnectConnectionFinalizeV1),
+	)
+}
+
+func disconnectConnectionWorkflowInstanceID(connectionId apid.ID) string {
+	return fmt.Sprintf("%s:%s:%s", WorkflowNameDisconnectConnectionV1, connectionId, apid.New(apid.PrefixNonce))
+}
+
+func (s *service) startDisconnectConnectionWorkflow(ctx context.Context, connectionId apid.ID) (*wflib.Instance, error) {
+	if s.wc == nil {
+		return nil, fmt.Errorf("workflow client is not configured")
+	}
+	return s.wc.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
+		InstanceID: disconnectConnectionWorkflowInstanceID(connectionId),
+		Queue:      apworkflows.DefaultQueue,
+	}, WorkflowNameDisconnectConnectionV1, connectionId.String())
+}
+
+func parseDisconnectConnectionWorkflowConnectionID(connectionId string) (apid.ID, error) {
+	id, err := apid.Parse(connectionId)
 	if err != nil {
-		return nil, err
+		return apid.Nil, fmt.Errorf("invalid connection id: %w", err)
 	}
-	return asynq.NewTask(taskTypeDisconnectConnection, payload), nil
+	if id == apid.Nil {
+		return apid.Nil, fmt.Errorf("connection id not specified")
+	}
+	if err := id.ValidatePrefix(apid.PrefixConnection); err != nil {
+		return apid.Nil, err
+	}
+	return id, nil
 }
 
-type disconnectConnectionTaskPayload struct {
-	ConnectionId apid.ID `json:"connection_id"`
-}
-
-func (s *service) disconnectConnection(ctx context.Context, t *asynq.Task) error {
-	logger := aplog.NewBuilder(s.logger).
-		WithTask(t).
-		WithCtx(ctx).
-		Build()
-	logger.Info("disconnect connection task started")
-	defer logger.Info("disconnect connection task completed")
-
-	var p disconnectConnectionTaskPayload
-	if err := json.Unmarshal(t.Payload(), &p); err != nil {
-		return fmt.Errorf("%s json.Unmarshal failed: %v: %w", taskTypeDisconnectConnection, err, asynq.SkipRetry)
+func (s *service) revokeDisconnectConnectionCredentialsV1(ctx context.Context, connectionId string) error {
+	id, err := parseDisconnectConnectionWorkflowConnectionID(connectionId)
+	if err != nil {
+		return err
 	}
 
-	if p.ConnectionId == apid.Nil {
-		return fmt.Errorf("%s connection id not specified: %w", taskTypeDisconnectConnection, asynq.SkipRetry)
-	}
+	logger := s.logger.With("workflow", WorkflowNameDisconnectConnectionV1, "activity", ActivityNameDisconnectConnectionRevokeCredentialsV1, "connection_id", id)
+	logger.Info("disconnect connection revoke activity started")
+	defer logger.Info("disconnect connection revoke activity completed")
 
-	conn, err := s.getConnection(ctx, p.ConnectionId)
+	conn, err := s.getConnection(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to get connection to disconnect connection: %w", err)
 	}
@@ -98,6 +161,24 @@ func (s *service) disconnectConnection(ctx context.Context, t *asynq.Task) error
 		}
 	}
 
+	return nil
+}
+
+func (s *service) finalizeDisconnectConnectionV1(ctx context.Context, connectionId string) error {
+	id, err := parseDisconnectConnectionWorkflowConnectionID(connectionId)
+	if err != nil {
+		return err
+	}
+
+	logger := s.logger.With("workflow", WorkflowNameDisconnectConnectionV1, "activity", ActivityNameDisconnectConnectionFinalizeV1, "connection_id", id)
+	logger.Info("disconnect connection finalize activity started")
+	defer logger.Info("disconnect connection finalize activity completed")
+
+	conn, err := s.getConnection(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get connection to disconnect connection: %w", err)
+	}
+
 	logger.Debug("marking connection as disconnected")
 	err = conn.SetState(ctx, database.ConnectionStateDisconnected)
 	if err != nil {
@@ -106,7 +187,7 @@ func (s *service) disconnectConnection(ctx context.Context, t *asynq.Task) error
 	}
 
 	logger.Debug("deleting connection")
-	err = s.db.DeleteConnection(ctx, p.ConnectionId)
+	err = s.db.DeleteConnection(ctx, id)
 	if err != nil {
 		logger.Error("failed to delete connection", "error", err)
 		return err

--- a/internal/core/task_disconnect_connection_test.go
+++ b/internal/core/task_disconnect_connection_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/rmorlok/authproxy/internal/apasynq"
-	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
@@ -21,7 +20,6 @@ import (
 	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	tclock "k8s.io/utils/clock/testing"
 )
 
@@ -37,10 +35,9 @@ func TestTaskDisconnectConnection(t *testing.T) {
 		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
 	}
 
-	setupWithMocks := func(t *testing.T) (*service, *mockDb.MockDB, *mockAsynq.MockClient, *mockEncrypt.MockE, *gomock.Controller) {
+	setupWithMocks := func(t *testing.T) (*service, *mockDb.MockDB, *mockEncrypt.MockE, *gomock.Controller) {
 		ctrl := gomock.NewController(t)
 		db := mockDb.NewMockDB(ctrl)
-		ac := mockAsynq.NewMockClient(ctrl)
 		encrypt := mockEncrypt.NewMockE(ctrl)
 		logger, _ := mockLog.NewTestLogger(t)
 
@@ -48,14 +45,13 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			cfg:                 nil,
 			db:                  db,
 			encrypt:             encrypt,
-			ac:                  ac,
 			logger:              logger,
 			authMethodFactories: map[cschema.AuthType]auth_methods.Factory{},
-		}, db, ac, encrypt, ctrl
+		}, db, encrypt, ctrl
 	}
 
 	t.Run("successfully disconnect connection", func(t *testing.T) {
-		svc, dbMock, _, e, ctrl := setupWithMocks(t)
+		svc, dbMock, e, ctrl := setupWithMocks(t)
 		defer ctrl.Finish()
 
 		mock.MockConnectionRetrieval(context.Background(), dbMock, e, connectionId, apiKeyConnector)
@@ -70,16 +66,13 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			DeleteConnection(gomock.Any(), connectionId).
 			Return(nil)
 
-		task, err := newDisconnectConnectionTask(connectionId)
-		require.NoError(t, err)
-
-		err = svc.disconnectConnection(ctx, task)
+		err := svc.finalizeDisconnectConnectionV1(ctx, connectionId.String())
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("is retriable on database state update error", func(t *testing.T) {
-		svc, dbMock, _, e, ctrl := setupWithMocks(t)
+		svc, dbMock, e, ctrl := setupWithMocks(t)
 		defer ctrl.Finish()
 
 		mock.MockConnectionRetrieval(context.Background(), dbMock, e, connectionId, apiKeyConnector)
@@ -89,10 +82,7 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnected).
 			Return(errors.New("some error"))
 
-		task, err := newDisconnectConnectionTask(connectionId)
-		require.NoError(t, err)
-
-		err = svc.disconnectConnection(ctx, task)
+		err := svc.finalizeDisconnectConnectionV1(ctx, connectionId.String())
 		assert.Error(t, err)
 		assert.True(t, apasynq.IsRetriable(err))
 	})
@@ -110,7 +100,7 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			}},
 		}
 
-		svc, dbMock, _, e, ctrl := setupWithMocks(t)
+		svc, dbMock, e, ctrl := setupWithMocks(t)
 		defer ctrl.Finish()
 
 		// Swap the OAuth2 factory in the auth-method registry with a mock that
@@ -126,19 +116,6 @@ func TestTaskDisconnectConnection(t *testing.T) {
 		authMock.EXPECT().Revoke(gomock.Any()).Return(errors.New("3rd party 400")).Times(maxRevokeAttempts)
 
 		mock.MockConnectionRetrieval(context.Background(), dbMock, e, connectionId, oauthConnector)
-
-		dbMock.
-			EXPECT().
-			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnected).
-			Return(nil)
-
-		dbMock.
-			EXPECT().
-			DeleteConnection(gomock.Any(), connectionId).
-			Return(nil)
-
-		task, err := newDisconnectConnectionTask(connectionId)
-		require.NoError(t, err)
 
 		// Use a fake clock so the inter-attempt backoff doesn't burn real
 		// time. The retry helper sleeps via clk.After + select, which is not
@@ -162,12 +139,12 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			}
 		}()
 
-		err = svc.disconnectConnection(retryCtx, task)
+		err := svc.revokeDisconnectConnectionCredentialsV1(retryCtx, connectionId.String())
 		assert.NoError(t, err, "disconnect should succeed even when revocation fails")
 	})
 
 	t.Run("is retriable on database delete error", func(t *testing.T) {
-		svc, dbMock, _, e, ctrl := setupWithMocks(t)
+		svc, dbMock, e, ctrl := setupWithMocks(t)
 		defer ctrl.Finish()
 
 		mock.MockConnectionRetrieval(context.Background(), dbMock, e, connectionId, apiKeyConnector)
@@ -182,10 +159,7 @@ func TestTaskDisconnectConnection(t *testing.T) {
 			DeleteConnection(gomock.Any(), connectionId).
 			Return(errors.New("some error"))
 
-		task, err := newDisconnectConnectionTask(connectionId)
-		require.NoError(t, err)
-
-		err = svc.disconnectConnection(ctx, task)
+		err := svc.finalizeDisconnectConnectionV1(ctx, connectionId.String())
 		assert.Error(t, err)
 		assert.True(t, apasynq.IsRetriable(err))
 	})

--- a/internal/core/task_probe.go
+++ b/internal/core/task_probe.go
@@ -51,11 +51,11 @@ func (s *service) runProbeForConnection(ctx context.Context, t *asynq.Task) erro
 
 	var p probeTaskPayload
 	if err := json.Unmarshal(t.Payload(), &p); err != nil {
-		return fmt.Errorf("%s json.Unmarshal failed: %v: %w", taskTypeDisconnectConnection, err, asynq.SkipRetry)
+		return fmt.Errorf("%s json.Unmarshal failed: %v: %w", taskTypeProbe, err, asynq.SkipRetry)
 	}
 
 	if p.ConnectionId == apid.Nil {
-		return fmt.Errorf("%s connection id not specified: %w", taskTypeDisconnectConnection, asynq.SkipRetry)
+		return fmt.Errorf("%s connection id not specified: %w", taskTypeProbe, asynq.SkipRetry)
 	}
 
 	logger = aplog.NewBuilder(logger).

--- a/internal/routes/tasks.go
+++ b/internal/routes/tasks.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	wfbackend "github.com/cschleiden/go-workflows/backend"
+	wfcore "github.com/cschleiden/go-workflows/core"
 	"github.com/gin-gonic/gin"
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/apasynq"
@@ -17,6 +19,7 @@ import (
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	"github.com/rmorlok/authproxy/internal/tasks"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
 
 type TaskRoutes struct {
@@ -24,6 +27,7 @@ type TaskRoutes struct {
 	auth           auth.A
 	encrypt        encrypt.E
 	asynqInspector apasynq.Inspector
+	workflowClient apworkflows.Client
 }
 
 type TaskState = schemaapi.TaskState
@@ -83,6 +87,22 @@ func TaskInfoToJson(encryptedId string, ti *asynq.TaskInfo) *TaskInfoJson {
 	}
 }
 
+func WorkflowTaskInfoToJson(encryptedId string, ti *tasks.TaskInfo, state wfcore.WorkflowInstanceState) *TaskInfoJson {
+	ts := TaskStateUnknown
+	switch state {
+	case wfcore.WorkflowInstanceStateActive:
+		ts = TaskStateActive
+	case wfcore.WorkflowInstanceStateContinuedAsNew, wfcore.WorkflowInstanceStateFinished:
+		ts = TaskStateCompleted
+	}
+
+	return &TaskInfoJson{
+		Id:    encryptedId,
+		Type:  ti.WorkflowName,
+		State: ts,
+	}
+}
+
 // @Summary		Get task status
 // @Description	Get the status of a background task by its encrypted task info
 // @Tags			tasks
@@ -123,6 +143,37 @@ func (r *TaskRoutes) get(gctx *gin.Context) {
 		return
 	}
 
+	if ti.ActorId != apid.Nil && ti.ActorId != ra.MustGetActor().Id {
+		apgin.WriteError(gctx, nil, httperr.Forbidden("not authorized to view task"))
+		return
+	}
+
+	if ti.TrackedVia == tasks.TrackedViaWorkflow {
+		if r.workflowClient == nil {
+			apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("workflow task tracking is not configured"))
+			return
+		}
+		if ti.WorkflowInstanceId == "" || ti.WorkflowExecutionId == "" || ti.WorkflowName == "" {
+			apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("invalid task info: data missing"))
+			return
+		}
+
+		instance := wfcore.NewWorkflowInstance(ti.WorkflowInstanceId, ti.WorkflowExecutionId)
+		state, err := r.workflowClient.GetWorkflowInstanceState(ctx, instance)
+		if err != nil {
+			if errors.Is(err, wfbackend.ErrInstanceNotFound) {
+				apgin.WriteError(gctx, nil, httperr.NotFound("task not found"))
+				return
+			}
+
+			apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("failed to load task", httperr.WithInternalErr(err)))
+			return
+		}
+
+		gctx.PureJSON(http.StatusOK, WorkflowTaskInfoToJson(encryptedTaskInfo, ti, state))
+		return
+	}
+
 	if ti.TrackedVia != tasks.TrackedViaAsynq {
 		apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("invalid task info: bad type"))
 		return
@@ -130,11 +181,6 @@ func (r *TaskRoutes) get(gctx *gin.Context) {
 
 	if ti.AsynqQueue == "" || ti.AsynqId == "" {
 		apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("invalid task info: data missing"))
-		return
-	}
-
-	if ti.ActorId != apid.Nil && ti.ActorId != ra.MustGetActor().Id {
-		apgin.WriteError(gctx, nil, httperr.Forbidden("not authorized to view task"))
 		return
 	}
 
@@ -165,11 +211,13 @@ func NewTaskRoutes(
 	authService auth.A,
 	encrypt encrypt.E,
 	asynqInspector apasynq.Inspector,
+	workflowClient apworkflows.Client,
 ) *TaskRoutes {
 	return &TaskRoutes{
 		cfg:            cfg,
 		auth:           authService,
 		encrypt:        encrypt,
 		asynqInspector: asynqInspector,
+		workflowClient: workflowClient,
 	}
 }

--- a/internal/routes/tasks_test.go
+++ b/internal/routes/tasks_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/client"
+	wfcore "github.com/cschleiden/go-workflows/core"
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/rmorlok/authproxy/internal/apgin"
 
 	"github.com/gin-gonic/gin"
@@ -26,12 +30,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeTaskWorkflowClient struct {
+	state wfcore.WorkflowInstanceState
+	err   error
+
+	requestedInstance *wflib.Instance
+}
+
+func (f *fakeTaskWorkflowClient) CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeTaskWorkflowClient) GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error) {
+	f.requestedInstance = instance
+	return f.state, f.err
+}
+
 func TestTasks(t *testing.T) {
 	type TestSetup struct {
 		Gin            *gin.Engine
 		Cfg            config.C
 		AuthUtil       *auth2.AuthTestUtil
 		MockInspector  *mock.MockInspector
+		WorkflowClient *fakeTaskWorkflowClient
 		EncryptService encrypt.E
 	}
 
@@ -46,8 +67,9 @@ func TestTasks(t *testing.T) {
 		// Use fake encryption service with doBase64Encode set to false
 		e := encrypt.NewFakeEncryptService(false)
 		cfg, auth, authUtil := auth2.TestAuthServiceWithDb(sconfig.ServiceIdApi, cfg, db)
+		workflowClient := &fakeTaskWorkflowClient{state: wfcore.WorkflowInstanceStateActive}
 
-		tr := NewTaskRoutes(cfg, auth, e, mockInspector)
+		tr := NewTaskRoutes(cfg, auth, e, mockInspector, workflowClient)
 
 		r := apgin.ForTest(nil)
 		tr.Register(r)
@@ -57,6 +79,7 @@ func TestTasks(t *testing.T) {
 			Cfg:            cfg,
 			AuthUtil:       authUtil,
 			MockInspector:  mockInspector,
+			WorkflowClient: workflowClient,
 			EncryptService: e,
 		}
 	}
@@ -291,6 +314,62 @@ func TestTasks(t *testing.T) {
 			require.Equal(t, "test-type", resp.Type)
 			require.Equal(t, string(TaskStateRetry), string(resp.State))
 			require.Equal(t, now.UTC().Format(time.RFC3339), resp.UpdatedAt.UTC().Format(time.RFC3339))
+		})
+
+		t.Run("workflow success", func(t *testing.T) {
+			tu := setup(t, nil)
+			taskInfo := &tasks.TaskInfo{
+				TrackedVia:          tasks.TrackedViaWorkflow,
+				WorkflowInstanceId:  "workflow-instance-id",
+				WorkflowExecutionId: "workflow-execution-id",
+				WorkflowName:        "core.connection.disconnect.v1",
+				WorkflowQueue:       "default",
+			}
+
+			ctx := context.Background()
+			encryptedTaskInfo, err := taskInfo.ToSecureEncryptedString(ctx, tu.EncryptService)
+			require.NoError(t, err)
+
+			tu.WorkflowClient.state = wfcore.WorkflowInstanceStateFinished
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp TaskInfoJson
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			require.Equal(t, encryptedTaskInfo, resp.Id)
+			require.Equal(t, "core.connection.disconnect.v1", resp.Type)
+			require.Equal(t, string(TaskStateCompleted), string(resp.State))
+			require.Equal(t, "workflow-instance-id", tu.WorkflowClient.requestedInstance.InstanceID)
+			require.Equal(t, "workflow-execution-id", tu.WorkflowClient.requestedInstance.ExecutionID)
+		})
+
+		t.Run("workflow not found", func(t *testing.T) {
+			tu := setup(t, nil)
+			taskInfo := &tasks.TaskInfo{
+				TrackedVia:          tasks.TrackedViaWorkflow,
+				WorkflowInstanceId:  "workflow-instance-id",
+				WorkflowExecutionId: "workflow-execution-id",
+				WorkflowName:        "core.connection.disconnect.v1",
+			}
+
+			ctx := context.Background()
+			encryptedTaskInfo, err := taskInfo.ToSecureEncryptedString(ctx, tu.EncryptService)
+			require.NoError(t, err)
+
+			tu.WorkflowClient.err = backend.ErrInstanceNotFound
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusNotFound, w.Code)
 		})
 	})
 }

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -745,6 +745,26 @@
         "cron_sync_interval": {
           "$ref": "../common/schema.json#/$defs/HumanDuration",
           "description": "The interval at which the the system will sync the list of cron tasks. Cron tasks are both global and connection specific. If not set, the default is every 5 minutes."
+        },
+        "workflow_pollers": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "The number of workflow task pollers to start for go-workflows. If not set, the go-workflows library default is used."
+        },
+        "activity_pollers": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "The number of activity task pollers to start for go-workflows. If not set, the go-workflows library default is used."
+        },
+        "max_parallel_workflow_tasks": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "The maximum number of concurrent workflow tasks processed by the worker. If not set, the go-workflows library default is used."
+        },
+        "max_parallel_activity_tasks": {
+          "$ref": "../common/schema.json#/$defs/StringValue",
+          "description": "The maximum number of concurrent activity tasks processed by the worker. If not set, the go-workflows library default is used."
+        },
+        "workflow_heartbeat_interval": {
+          "$ref": "../common/schema.json#/$defs/HumanDuration",
+          "description": "The interval between heartbeat attempts on workflow tasks. If not set, the go-workflows library default is used."
         }
       },
       "additionalProperties": false,

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -1070,6 +1070,39 @@ func TestSchemaDefinitions(t *testing.T) {
 			},
 		},
 		{
+			Name: "ServiceWorker workflow options",
+			Schema: `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/config/test.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["test"],
+  "properties": {
+	"test": {
+		"$ref": "./schema.json#/$defs/ServiceWorker"
+    }
+  }
+}`,
+			Tests: []test{
+				{
+					Name:  "workflow options as strings",
+					Valid: true,
+					Data:  `{"test": {"workflow_pollers": "3", "activity_pollers": "4", "max_parallel_workflow_tasks": "5", "max_parallel_activity_tasks": "6", "workflow_heartbeat_interval": "7s"}}`,
+				},
+				{
+					Name:  "workflow options as integer equivalents",
+					Valid: true,
+					Data:  `{"test": {"workflow_pollers": 3, "activity_pollers": 4, "max_parallel_workflow_tasks": 5, "max_parallel_activity_tasks": 6}}`,
+				},
+				{
+					Name:  "extra property",
+					Valid: false,
+					Data:  `{"test": {"workflow_pollers": "3", "extra": "field"}}`,
+				},
+			},
+		},
+		{
 			Name: "HostApplication",
 			Schema: `
 {

--- a/internal/schema/config/service_worker.go
+++ b/internal/schema/config/service_worker.go
@@ -7,9 +7,14 @@ import (
 )
 
 type ServiceWorker struct {
-	ServiceCommon    `json:",inline" yaml:",inline"`
-	ConcurrencyVal   *StringValue   `json:"concurrency" yaml:"concurrency"`
-	CronSyncInterval *HumanDuration `json:"cron_sync_interval,omitempty" yaml:"cron_sync_interval,omitempty"`
+	ServiceCommon             `json:",inline" yaml:",inline"`
+	ConcurrencyVal            *StringValue   `json:"concurrency" yaml:"concurrency"`
+	CronSyncInterval          *HumanDuration `json:"cron_sync_interval,omitempty" yaml:"cron_sync_interval,omitempty"`
+	WorkflowPollers           *StringValue   `json:"workflow_pollers,omitempty" yaml:"workflow_pollers,omitempty"`
+	ActivityPollers           *StringValue   `json:"activity_pollers,omitempty" yaml:"activity_pollers,omitempty"`
+	MaxParallelWorkflowTasks  *StringValue   `json:"max_parallel_workflow_tasks,omitempty" yaml:"max_parallel_workflow_tasks,omitempty"`
+	MaxParallelActivityTasks  *StringValue   `json:"max_parallel_activity_tasks,omitempty" yaml:"max_parallel_activity_tasks,omitempty"`
+	WorkflowHeartbeatInterval *HumanDuration `json:"workflow_heartbeat_interval,omitempty" yaml:"workflow_heartbeat_interval,omitempty"`
 }
 
 func (s *ServiceWorker) HealthCheckPort() uint64 {
@@ -26,21 +31,36 @@ func (s *ServiceWorker) GetId() ServiceId {
 }
 
 func (s *ServiceWorker) GetConcurrency(ctx context.Context) int {
-	if s.ConcurrencyVal == nil {
+	val := s.getOptionalInt(ctx, s.ConcurrencyVal)
+	if val == nil {
 		return 0
 	}
 
-	val, err := s.ConcurrencyVal.GetValue(ctx)
-	if err != nil {
-		return 0
+	return *val
+}
+
+func (s *ServiceWorker) GetWorkflowPollers(ctx context.Context) *int {
+	return s.getOptionalInt(ctx, s.WorkflowPollers)
+}
+
+func (s *ServiceWorker) GetActivityPollers(ctx context.Context) *int {
+	return s.getOptionalInt(ctx, s.ActivityPollers)
+}
+
+func (s *ServiceWorker) GetMaxParallelWorkflowTasks(ctx context.Context) *int {
+	return s.getOptionalInt(ctx, s.MaxParallelWorkflowTasks)
+}
+
+func (s *ServiceWorker) GetMaxParallelActivityTasks(ctx context.Context) *int {
+	return s.getOptionalInt(ctx, s.MaxParallelActivityTasks)
+}
+
+func (s *ServiceWorker) GetWorkflowHeartbeatInterval() *time.Duration {
+	if s == nil || s.WorkflowHeartbeatInterval == nil {
+		return nil
 	}
 
-	parsedVal, err := strconv.Atoi(val)
-	if err != nil {
-		return 0
-	}
-
-	return parsedVal
+	return &s.WorkflowHeartbeatInterval.Duration
 }
 
 func (s *ServiceWorker) GetCronSyncInterval() time.Duration {
@@ -51,4 +71,22 @@ func (s *ServiceWorker) GetCronSyncInterval() time.Duration {
 	return s.CronSyncInterval.Duration
 }
 
-var _ Service = (*ServicePublic)(nil)
+func (s *ServiceWorker) getOptionalInt(ctx context.Context, value *StringValue) *int {
+	if s == nil || value == nil {
+		return nil
+	}
+
+	rawValue, err := value.GetValue(ctx)
+	if err != nil {
+		return nil
+	}
+
+	parsedVal, err := strconv.Atoi(rawValue)
+	if err != nil {
+		return nil
+	}
+
+	return &parsedVal
+}
+
+var _ Service = (*ServiceWorker)(nil)

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -126,6 +126,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		authService,
 		dm.GetEncryptService(),
 		dm.GetAsyncInspector(),
+		dm.GetWorkflowRuntime().Client(),
 	)
 	routesRequestEvents := common_routes.NewRequestEventsRoutes(
 		dm.GetConfig(),

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -484,6 +484,7 @@ func (dm *DependencyManager) GetCoreService() coreIface.C {
 			dm.GetLogger(),
 			core.WithRateLimitCache(dm.GetRateLimitCache()),
 			core.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
+			core.WithWorkflowClient(dm.GetWorkflowRuntime().Client()),
 		)
 	}
 

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -192,6 +192,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 			authService,
 			dm.GetEncryptService(),
 			dm.GetAsyncInspector(),
+			dm.GetWorkflowRuntime().Client(),
 		)
 		routesTasks.Register(api)
 	}

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -39,8 +39,12 @@ func Serve(cfg config.C) {
 	defer dm.ShutdownTelemetry()
 
 	workerConfig := cfg.GetRoot().Worker
-	router := apgin.ForService(&workerConfig, logger, cfg.IsDebugMode(),
-		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()))
+	router := apgin.ForService(
+		&workerConfig,
+		logger,
+		cfg.IsDebugMode(),
+		apgin.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry, dm.GetServiceId()),
+	)
 
 	router.GET("/ping", func(c *gin.Context) {
 		c.PureJSON(http.StatusOK, gin.H{
@@ -139,16 +143,19 @@ func Serve(cfg config.C) {
 	mux.Use(asynqTel.Middleware())
 
 	workflowRuntime := dm.GetWorkflowRuntime()
-	workflowWorker, err := apworkflows.NewWorker(workflowRuntime, &workflowworker.Options{
-		WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
-			WorkflowPollers:          2,
-			MaxParallelWorkflowTasks: workerConfig.GetConcurrency(context.Background()),
+	workflowWorker, err := apworkflows.NewWorker(
+		workflowRuntime,
+		&workflowworker.Options{
+			WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
+				WorkflowPollers:          2,
+				MaxParallelWorkflowTasks: workerConfig.GetConcurrency(context.Background()),
+			},
+			ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
+				ActivityPollers:          2,
+				MaxParallelActivityTasks: workerConfig.GetConcurrency(context.Background()),
+			},
 		},
-		ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
-			ActivityPollers:          2,
-			MaxParallelActivityTasks: workerConfig.GetConcurrency(context.Background()),
-		},
-	})
+	)
 	if err != nil {
 		log.Fatalf("failed to construct workflow worker: %v", err)
 	}

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -141,14 +141,19 @@ func Serve(cfg config.C) {
 	workflowRuntime := dm.GetWorkflowRuntime()
 	workflowWorker, err := apworkflows.NewWorker(workflowRuntime, &workflowworker.Options{
 		WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
+			WorkflowPollers:          2,
 			MaxParallelWorkflowTasks: workerConfig.GetConcurrency(context.Background()),
 		},
 		ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
+			ActivityPollers:          2,
 			MaxParallelActivityTasks: workerConfig.GetConcurrency(context.Background()),
 		},
 	})
 	if err != nil {
 		log.Fatalf("failed to construct workflow worker: %v", err)
+	}
+	if err := dm.GetCoreService().RegisterWorkflows(workflowWorker); err != nil {
+		log.Fatalf("failed to register core workflows: %v", err)
 	}
 
 	oauth2TaskHandler := oauth2.NewTaskHandler(

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/config"
 	dbTasks "github.com/rmorlok/authproxy/internal/database/tasks"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	schemaConfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/service"
 	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
@@ -145,16 +146,7 @@ func Serve(cfg config.C) {
 	workflowRuntime := dm.GetWorkflowRuntime()
 	workflowWorker, err := apworkflows.NewWorker(
 		workflowRuntime,
-		&workflowworker.Options{
-			WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
-				WorkflowPollers:          2,
-				MaxParallelWorkflowTasks: workerConfig.GetConcurrency(context.Background()),
-			},
-			ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
-				ActivityPollers:          2,
-				MaxParallelActivityTasks: workerConfig.GetConcurrency(context.Background()),
-			},
-		},
+		workflowOptionsFromConfig(context.Background(), &workerConfig),
 	)
 	if err != nil {
 		log.Fatalf("failed to construct workflow worker: %v", err)
@@ -280,4 +272,30 @@ func Serve(cfg config.C) {
 	wg.Wait()
 	logger.Info("Worker shutting down")
 	defer logger.Info("Worker shutdown complete")
+}
+
+func workflowOptionsFromConfig(ctx context.Context, workerConfig *schemaConfig.ServiceWorker) *workflowworker.Options {
+	options := workflowworker.DefaultOptions
+
+	if workerConfig == nil {
+		return &options
+	}
+
+	if workflowPollers := workerConfig.GetWorkflowPollers(ctx); workflowPollers != nil {
+		options.WorkflowPollers = *workflowPollers
+	}
+	if activityPollers := workerConfig.GetActivityPollers(ctx); activityPollers != nil {
+		options.ActivityPollers = *activityPollers
+	}
+	if maxParallelWorkflowTasks := workerConfig.GetMaxParallelWorkflowTasks(ctx); maxParallelWorkflowTasks != nil {
+		options.MaxParallelWorkflowTasks = *maxParallelWorkflowTasks
+	}
+	if maxParallelActivityTasks := workerConfig.GetMaxParallelActivityTasks(ctx); maxParallelActivityTasks != nil {
+		options.MaxParallelActivityTasks = *maxParallelActivityTasks
+	}
+	if workflowHeartbeatInterval := workerConfig.GetWorkflowHeartbeatInterval(); workflowHeartbeatInterval != nil {
+		options.WorkflowHeartbeatInterval = *workflowHeartbeatInterval
+	}
+
+	return &options
 }

--- a/internal/service/worker/workflow_options_test.go
+++ b/internal/service/worker/workflow_options_test.go
@@ -1,0 +1,37 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	workflowworker "github.com/cschleiden/go-workflows/worker"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowOptionsFromConfigDefaultsToLibraryValues(t *testing.T) {
+	options := workflowOptionsFromConfig(context.Background(), &config.ServiceWorker{})
+
+	require.Equal(t, workflowworker.DefaultOptions.WorkflowPollers, options.WorkflowPollers)
+	require.Equal(t, workflowworker.DefaultOptions.ActivityPollers, options.ActivityPollers)
+	require.Equal(t, workflowworker.DefaultOptions.MaxParallelWorkflowTasks, options.MaxParallelWorkflowTasks)
+	require.Equal(t, workflowworker.DefaultOptions.MaxParallelActivityTasks, options.MaxParallelActivityTasks)
+	require.Equal(t, workflowworker.DefaultOptions.WorkflowHeartbeatInterval, options.WorkflowHeartbeatInterval)
+}
+
+func TestWorkflowOptionsFromConfigOverridesConfiguredValues(t *testing.T) {
+	options := workflowOptionsFromConfig(context.Background(), &config.ServiceWorker{
+		WorkflowPollers:           config.NewStringValueDirectInline("3"),
+		ActivityPollers:           config.NewStringValueDirectInline("4"),
+		MaxParallelWorkflowTasks:  config.NewStringValueDirectInline("5"),
+		MaxParallelActivityTasks:  config.NewStringValueDirectInline("6"),
+		WorkflowHeartbeatInterval: &config.HumanDuration{Duration: 7 * time.Second},
+	})
+
+	require.Equal(t, 3, options.WorkflowPollers)
+	require.Equal(t, 4, options.ActivityPollers)
+	require.Equal(t, 5, options.MaxParallelWorkflowTasks)
+	require.Equal(t, 6, options.MaxParallelActivityTasks)
+	require.Equal(t, 7*time.Second, options.WorkflowHeartbeatInterval)
+}

--- a/internal/tasks/task_info.go
+++ b/internal/tasks/task_info.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
@@ -14,15 +15,20 @@ import (
 type TrackedVia string
 
 const (
-	TrackedViaAsynq = "asynq"
+	TrackedViaAsynq    TrackedVia = "asynq"
+	TrackedViaWorkflow TrackedVia = "workflow"
 )
 
 type TaskInfo struct {
-	TrackedVia TrackedVia `json:"tracked_via"`
-	ActorId    apid.ID    `json:"actor_id,omitempty"`
-	AsynqId    string     `json:"asynq_id,omitempty"`
-	AsynqQueue string     `json:"asynq_queue,omitempty"`
-	AsynqType  string     `json:"asynq_type,omitempty"`
+	TrackedVia          TrackedVia `json:"tracked_via"`
+	ActorId             apid.ID    `json:"actor_id,omitempty"`
+	AsynqId             string     `json:"asynq_id,omitempty"`
+	AsynqQueue          string     `json:"asynq_queue,omitempty"`
+	AsynqType           string     `json:"asynq_type,omitempty"`
+	WorkflowInstanceId  string     `json:"workflow_instance_id,omitempty"`
+	WorkflowExecutionId string     `json:"workflow_execution_id,omitempty"`
+	WorkflowName        string     `json:"workflow_name,omitempty"`
+	WorkflowQueue       string     `json:"workflow_queue,omitempty"`
 }
 
 type Actor interface {
@@ -68,6 +74,20 @@ func FromAsynqTask(task *asynq.TaskInfo) *TaskInfo {
 		AsynqId:    task.ID,
 		AsynqQueue: task.Queue,
 		AsynqType:  task.Type,
+	}
+}
+
+func FromWorkflowInstance(instance *wflib.Instance, name string, queue string) *TaskInfo {
+	if instance == nil {
+		return nil
+	}
+
+	return &TaskInfo{
+		TrackedVia:          TrackedViaWorkflow,
+		WorkflowInstanceId:  instance.InstanceID,
+		WorkflowExecutionId: instance.ExecutionID,
+		WorkflowName:        name,
+		WorkflowQueue:       queue,
 	}
 }
 

--- a/internal/workflows/migrations/postgres/000001_initial.down.sql
+++ b/internal/workflows/migrations/postgres/000001_initial.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS attributes;
+DROP TABLE IF EXISTS instances;
+DROP TABLE IF EXISTS pending_events;
+DROP TABLE IF EXISTS history;
+DROP TABLE IF EXISTS activities;

--- a/internal/workflows/migrations/postgres/000001_initial.up.sql
+++ b/internal/workflows/migrations/postgres/000001_initial.up.sql
@@ -1,0 +1,84 @@
+DROP TABLE IF EXISTS instances;
+
+CREATE TABLE instances (
+  id bigserial NOT NULL PRIMARY KEY,
+  instance_id varchar(128) NOT NULL,
+  execution_id varchar(128) NOT NULL,
+  parent_instance_id varchar(128) NULL,
+  parent_execution_id varchar(128) NULL,
+  parent_schedule_event_id numeric NULL,
+  metadata bytea NULL,
+  state int NOT NULL,
+  queue varchar(128) DEFAULT '' NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  completed_at timestamptz NULL,
+  locked_until timestamptz NULL,
+  sticky_until timestamptz NULL,
+  worker varchar(64) NULL
+);
+
+CREATE UNIQUE INDEX idx_instances_instance_id_execution_id on instances (instance_id, execution_id);
+CREATE INDEX idx_instances_locked_until_completed_at_queue ON instances (completed_at, locked_until, sticky_until, worker, queue);
+CREATE INDEX idx_instances_parent_instance_id_parent_execution_id ON instances (parent_instance_id, parent_execution_id);
+
+DROP TABLE IF EXISTS pending_events;
+CREATE TABLE pending_events (
+  id bigserial NOT NULL PRIMARY KEY,
+  event_id varchar(128) NOT NULL,
+  sequence_id bigserial NOT NULL,
+  instance_id varchar(128) NOT NULL,
+  execution_id varchar(128) NOT NULL,
+  event_type int NOT NULL,
+  timestamp timestamptz NOT NULL,
+  schedule_event_id bigserial NOT NULL,
+  visible_at timestamptz NULL
+);
+
+CREATE INDEX idx_pending_events_inid_exid ON pending_events (instance_id, execution_id);
+CREATE INDEX idx_pending_events_inid_exid_visible_at_schedule_event_id ON pending_events (instance_id, execution_id, visible_at, schedule_event_id);
+
+DROP TABLE IF EXISTS history;
+CREATE TABLE IF NOT EXISTS history (
+  id bigserial NOT NULL PRIMARY KEY,
+  event_id varchar(128) NOT NULL,
+  sequence_id bigserial NOT NULL,
+  instance_id varchar(128) NOT NULL,
+  execution_id varchar(128) NOT NULL,
+  event_type int NOT NULL,
+  timestamp timestamptz NOT NULL,
+  schedule_event_id bigserial NOT NULL,
+  visible_at timestamptz NULL
+);
+
+CREATE INDEX idx_history_instance_id_execution_id ON history (instance_id, execution_id);
+CREATE INDEX idx_history_instance_id_execution_id_sequence_id ON history (instance_id, execution_id, sequence_id);
+
+DROP TABLE IF EXISTS activities;
+CREATE TABLE IF NOT EXISTS activities (
+  id bigserial NOT NULL PRIMARY KEY,
+  activity_id varchar(128) NOT NULL,
+  instance_id varchar(128) NOT NULL,
+  execution_id varchar(128) NOT NULL,
+  event_type int NOT NULL,
+  queue varchar(128) DEFAULT '' NOT NULL,
+  timestamp timestamptz NOT NULL,
+  schedule_event_id bigserial NOT NULL,
+  visible_at timestamptz NULL,
+  locked_until timestamptz NULL,
+  worker VARCHAR(64) NULL
+);
+
+CREATE UNIQUE INDEX idx_activities_instance_id_execution_id_activity_id_worker ON activities (instance_id, execution_id, activity_id, worker);
+CREATE INDEX idx_activities_locked_until_queue ON activities (locked_until, queue);
+
+DROP TABLE IF EXISTS attributes;
+CREATE TABLE attributes (
+  id BIGSERIAL NOT NULL PRIMARY KEY,
+  event_id varchar(128) NOT NULL,
+  instance_id varchar(128) NOT NULL,
+  execution_id varchar(128) NOT NULL,
+  data bytea NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_attributes_instance_id_execution_id_event_id on attributes (instance_id, execution_id, event_id);
+CREATE INDEX idx_attributes_event_id on attributes (event_id);

--- a/internal/workflows/migrations/sqlite/000001_initial.down.sql
+++ b/internal/workflows/migrations/sqlite/000001_initial.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS `instances`;
+DROP TABLE IF EXISTS `pending_events`;
+DROP TABLE IF EXISTS `history`;
+DROP TABLE IF EXISTS `activities`;

--- a/internal/workflows/migrations/sqlite/000001_initial.up.sql
+++ b/internal/workflows/migrations/sqlite/000001_initial.up.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS `instances` (
+  `id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `parent_instance_id` TEXT NULL,
+  `parent_execution_id` TEXT NULL,
+  `parent_schedule_event_id` INTEGER NULL,
+  `metadata` TEXT NULL,
+  `state` INTEGER NOT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `completed_at` DATETIME NULL,
+  `locked_until` DATETIME NULL,
+  `sticky_until` DATETIME NULL,
+  `worker` TEXT NULL,
+  PRIMARY KEY(`id`, `execution_id`)
+);
+
+CREATE INDEX IF NOT EXISTS `idx_instances_id_execution_id` ON `instances` (`id`, `execution_id`);
+CREATE INDEX IF NOT EXISTS `idx_instances_locked_until_completed_at` ON `instances` (`locked_until`, `sticky_until`, `completed_at`, `worker`);
+CREATE INDEX IF NOT EXISTS `idx_instances_parent_instance_id_parent_execution_id` ON `instances` (`parent_instance_id`, `parent_execution_id`);
+
+CREATE TABLE IF NOT EXISTS `pending_events` (
+  `id` TEXT,
+  `sequence_id` INTEGER NOT NULL,
+  `instance_id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `event_type` INTEGER NOT NULL,
+  `timestamp` DATETIME NOT NULL,
+  `schedule_event_id` INT NOT NULL,
+  `attributes` BLOB NOT NULL,
+  `visible_at` DATETIME NULL,
+  PRIMARY KEY(`id`, `instance_id`)
+);
+
+CREATE INDEX IF NOT EXISTS `idx_pending_events_instance_id_execution_id_visible_at_schedule_event_id` ON `pending_events` (`instance_id`, `execution_id`, `visible_at`, `schedule_event_id`);
+
+CREATE TABLE IF NOT EXISTS `history` (
+  `id` TEXT,
+  `sequence_id` INTEGER NOT NULL,
+  `instance_id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `event_type` INTEGER NOT NULL,
+  `timestamp` DATETIME NOT NULL,
+  `schedule_event_id` INT NOT NULL,
+  `attributes` BLOB NOT NULL,
+  `visible_at` DATETIME NULL,
+  PRIMARY KEY(`id`, `instance_id`)
+);
+
+CREATE INDEX IF NOT EXISTS `idx_history_instance_sequence_id` ON `history` (`instance_id`, `execution_id`, `sequence_id`);
+
+CREATE TABLE IF NOT EXISTS `activities` (
+  `id` TEXT PRIMARY KEY,
+  `instance_id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `event_type` INTEGER NOT NULL,
+  `timestamp` DATETIME NOT NULL,
+  `schedule_event_id` INT NOT NULL,
+  `attributes` BLOB NOT NULL,
+  `visible_at` DATETIME NULL,
+  `locked_until` DATETIME NULL,
+  `worker` TEXT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `idx_activities_id_worker` ON `activities` (`id`, `worker`);
+CREATE INDEX IF NOT EXISTS `idx_activities_locked_until` ON `activities` (`locked_until`);
+CREATE INDEX IF NOT EXISTS `idx_activities_instance_id_execution_id_worker` ON `activities` (`instance_id`, `execution_id`, `worker`);

--- a/internal/workflows/migrations/sqlite/000002_add_attributes_table.down.sql
+++ b/internal/workflows/migrations/sqlite/000002_add_attributes_table.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `activities` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `activities` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `activities`.`id` = `attributes`.`id` AND `activities`.`instance_id` = `attributes`.`instance_id` AND `activities`.`execution_id` = `attributes`.`execution_id`;
+
+ALTER TABLE `history` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `history` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `history`.`id` = `attributes`.`id` AND `history`.`instance_id` = `attributes`.`instance_id` AND `history`.`execution_id` = `attributes`.`execution_id`;
+
+ALTER TABLE `pending_events` ADD COLUMN `attributes` BLOB NULL;
+UPDATE `pending_events` SET `attributes` = `attributes`.`data` FROM `attributes` WHERE `pending_events`.`id` = `attributes`.`id` AND `pending_events`.`instance_id` = `attributes`.`instance_id` AND `pending_events`.`execution_id` = `attributes`.`execution_id`;
+
+DROP TABLE `attributes`;

--- a/internal/workflows/migrations/sqlite/000002_add_attributes_table.up.sql
+++ b/internal/workflows/migrations/sqlite/000002_add_attributes_table.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `attributes` (
+  `id` TEXT NOT NULL,
+  `instance_id` TEXT NOT NULL,
+  `execution_id` TEXT NOT NULL,
+  `data` BLOB NOT NULL,
+  PRIMARY KEY(`id`, `instance_id`, `execution_id`)
+);
+
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `activities`;
+ALTER TABLE `activities` DROP COLUMN `attributes`;
+
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `history`;
+ALTER TABLE `history` DROP COLUMN `attributes`;
+
+INSERT OR IGNORE INTO `attributes` (`id`, `instance_id`, `execution_id`, `data`) SELECT `id`, `instance_id`, `execution_id`, `attributes` FROM `pending_events`;
+ALTER TABLE `pending_events` DROP COLUMN `attributes`;

--- a/internal/workflows/migrations/sqlite/000003_add_queue.down.sql
+++ b/internal/workflows/migrations/sqlite/000003_add_queue.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `instances` DROP COLUMN `queue`;
+ALTER TABLE `activities` DROP COLUMN `queue`;
+
+DROP INDEX IF EXISTS `idx_instances_locked_until_completed_at_queue`;
+CREATE INDEX `idx_instances_locked_until_completed_at` ON `instances` (`completed_at`, `locked_until`, `sticky_until`, `worker`);
+
+DROP INDEX IF EXISTS `idx_activities_instance_id_execution_id_activity_id_worker_queue`;
+CREATE INDEX `idx_activities_instance_id_execution_id_worker` ON `activities` (`instance_id`, `execution_id`, `id`, `worker`);

--- a/internal/workflows/migrations/sqlite/000003_add_queue.up.sql
+++ b/internal/workflows/migrations/sqlite/000003_add_queue.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `instances` ADD COLUMN `queue` NVARCHAR(128) DEFAULT '';
+
+DROP INDEX IF EXISTS `idx_instances_locked_until_completed_at` ;
+CREATE INDEX `idx_instances_locked_until_completed_at_queue` ON `instances` (`completed_at`, `locked_until`, `sticky_until`, `worker`, `queue`);
+
+ALTER TABLE `activities` ADD COLUMN `queue` NVARCHAR(128) DEFAULT '';
+
+DROP INDEX IF EXISTS `idx_activities_instance_id_execution_id_worker`;
+CREATE INDEX `idx_activities_instance_id_execution_id_worker_queue` ON `activities` (`instance_id`, `execution_id`, `worker`, `queue`);
+
+DROP INDEX IF EXISTS `idx_activities_locked_until`;
+CREATE INDEX `idx_activities_locked_until_queue` ON `activities` (`locked_until`, `queue`);

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -3,6 +3,8 @@ package workflows
 import (
 	"context"
 	"database/sql"
+	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -11,22 +13,38 @@ import (
 	"github.com/cschleiden/go-workflows/backend/postgres"
 	"github.com/cschleiden/go-workflows/backend/sqlite"
 	"github.com/cschleiden/go-workflows/client"
+	wfcore "github.com/cschleiden/go-workflows/core"
 	"github.com/cschleiden/go-workflows/registry"
 	wfworker "github.com/cschleiden/go-workflows/worker"
 	wflib "github.com/cschleiden/go-workflows/workflow"
+	"github.com/golang-migrate/migrate/v4"
+	migratedatabase "github.com/golang-migrate/migrate/v4/database"
+	migratepostgres "github.com/golang-migrate/migrate/v4/database/postgres"
+	migratesqlite "github.com/golang-migrate/migrate/v4/database/sqlite"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
-	"github.com/rmorlok/authproxy/internal/database"
+	apdatabase "github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
 const (
 	DefaultQueue = wflib.QueueDefault
+
+	workflowMigrationsTable = "authproxy_workflows_schema_migrations"
 )
+
+//go:embed migrations/postgres/*.sql migrations/sqlite/*.sql
+var migrationsFS embed.FS
 
 type Runtime struct {
 	backend wfbackend.Backend
 	client  *client.Client
 	db      *sql.DB
+}
+
+type Client interface {
+	CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error)
+	GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error)
 }
 
 func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *slog.Logger) (*Runtime, error) {
@@ -58,11 +76,11 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 		)
 	case *sconfig.DatabasePostgres:
 		var err error
-		db, err = database.OpenInstrumentedSQL(
+		db, err = apdatabase.OpenInstrumentedSQL(
 			"pgx",
 			cfg.GetDsn(),
-			database.DBSystemPostgreSQL,
-			database.WithTelemetry(telemetry, root.Telemetry),
+			apdatabase.DBSystemPostgreSQL,
+			apdatabase.WithTelemetry(telemetry, root.Telemetry),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("open workflow postgres database: %w", err)
@@ -93,35 +111,62 @@ func Migrate(root *sconfig.Root, logger *slog.Logger) error {
 		return fmt.Errorf("database configuration is required")
 	}
 
-	backendOptions := []wfbackend.BackendOption{
-		wfbackend.WithLogger(logger),
-	}
-
 	switch cfg := root.Database.InnerVal.(type) {
 	case *sconfig.DatabaseSqlite:
-		b := sqlite.NewSqliteBackend(
-			cfg.Path,
-			sqlite.WithApplyMigrations(false),
-			sqlite.WithBackendOptions(backendOptions...),
-		)
-		defer b.Close()
-		return b.Migrate()
+		db, err := sql.Open("sqlite", fmt.Sprintf("file:%v?_txlock=immediate", cfg.Path))
+		if err != nil {
+			return fmt.Errorf("open workflow sqlite database: %w", err)
+		}
+		defer db.Close()
+		return migrateDB(db, "sqlite", "migrations/sqlite")
 	case *sconfig.DatabasePostgres:
-		db, err := database.OpenInstrumentedSQL("pgx", cfg.GetDsn(), database.DBSystemPostgreSQL)
+		db, err := apdatabase.OpenInstrumentedSQL("pgx", cfg.GetDsn(), apdatabase.DBSystemPostgreSQL)
 		if err != nil {
 			return fmt.Errorf("open workflow postgres database: %w", err)
 		}
 		defer db.Close()
 
-		b := postgres.NewPostgresBackendWithDB(
-			db,
-			postgres.WithApplyMigrations(false),
-			postgres.WithBackendOptions(backendOptions...),
-		)
-		return b.Migrate()
+		return migrateDB(db, "postgres", "migrations/postgres")
 	default:
 		return fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
 	}
+}
+
+func migrateDB(db *sql.DB, driverName string, sourcePath string) error {
+	var (
+		driver migratedatabase.Driver
+		err    error
+	)
+	switch driverName {
+	case "postgres":
+		driver, err = migratepostgres.WithInstance(db, &migratepostgres.Config{
+			MigrationsTable: workflowMigrationsTable,
+		})
+	case "sqlite":
+		driver, err = migratesqlite.WithInstance(db, &migratesqlite.Config{
+			MigrationsTable: workflowMigrationsTable,
+		})
+	default:
+		return fmt.Errorf("workflow migration driver %q is not supported", driverName)
+	}
+	if err != nil {
+		return fmt.Errorf("creating workflow migration instance: %w", err)
+	}
+
+	source, err := iofs.New(migrationsFS, sourcePath)
+	if err != nil {
+		return fmt.Errorf("creating workflow migration source: %w", err)
+	}
+
+	m, err := migrate.NewWithInstance("iofs", source, driverName, driver)
+	if err != nil {
+		return fmt.Errorf("creating workflow migration: %w", err)
+	}
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("running workflow migrations: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Runtime) Backend() wfbackend.Backend {


### PR DESCRIPTION
## Summary

- replaces the `core:disconnect_connection` Asynq handler with the versioned `core.connection.disconnect.v1` workflow
- registers disconnect workflow activities on the worker service and starts disconnect workflows from `DisconnectConnection`
- extends encrypted task tokens and `/tasks/{encryptedTaskInfo}` polling to support workflow-backed operations
- isolates go-workflows migrations from AuthProxy main DB migrations with a dedicated migration table while keeping workflow state in the primary DB
- updates the OAuth disconnect revocation integration test to drain the workflow worker path

Closes #523.

## Tests

- `go test ./internal/workflows ./internal/core ./internal/routes ./internal/tasks ./internal/service/worker ./internal/service/api ./internal/service/public`
- `go test -tags integration ./oauth2 -run DisconnectRevocation -count=1` from `integration_tests`
- `./scripts/preflight.sh`