### PR TITLE
Add demo shell telemetry links

### DIFF
--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -76,6 +76,7 @@ ADMIN_PRIVATE_KEY_PATH=./demos/shell/dev_keys/demo-shell \
 AUTHPROXY_ADMIN_UI_URL=http://localhost:5174 \
 AUTHPROXY_MARKETPLACE_URL=http://localhost:5173 \
 AUTHPROXY_AUTH_URL=http://localhost:8080 \
+AUTHPROXY_GRAFANA_URL=http://localhost:3000 \
 DEV_FRONTEND_URL=http://localhost:5175 \
 go run ./demos/shell/backend
 # → listens on http://localhost:8888
@@ -126,8 +127,18 @@ The backend reads the following env vars:
 | `AUTHPROXY_ADMIN_UI_URL`  | ✅        | Base URL of the admin SPA                                                   |
 | `AUTHPROXY_MARKETPLACE_URL` | ✅      | Base URL of the marketplace SPA                                             |
 | `AUTHPROXY_AUTH_URL`      | ⛔        | Optional today; kept for future routes that call back into AuthProxy        |
+| `AUTHPROXY_GRAFANA_URL`   | ⛔        | Optional Grafana base URL; enables telemetry links in the shell             |
+| `AUTHPROXY_GRAFANA_APP_METRICS_URL` | ⛔ | Optional override for the app-metrics dashboard link                        |
+| `AUTHPROXY_GRAFANA_EXPLORE_URL` | ⛔   | Optional override for the Grafana Explore link                              |
 | `DEV_FRONTEND_URL`        | ⛔        | If set, `GET /` redirects here instead of serving the embedded build        |
 | `PORT`                    | ⛔        | Default `8888`                                                              |
+
+The frontend reads `/config.json` from the backend at runtime. When
+`AUTHPROXY_GRAFANA_URL` is set, the backend returns links to Grafana,
+the provisioned AuthProxy App Metrics dashboard, and Explore. In Vite
+dev mode, `/config.json` and `/sso` are proxied to the backend; override
+`AUTHPROXY_DEMO_SHELL_BACKEND_URL` if the backend is not on
+`http://localhost:8888`.
 
 ## Why one signing key, not three
 

--- a/demos/shell/backend/main.go
+++ b/demos/shell/backend/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -47,6 +48,12 @@ var demoDestinations = map[string]string{
 	"marketplace": "AUTHPROXY_MARKETPLACE_URL",
 }
 
+type telemetryLink struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
 type settings struct {
 	addr                string
 	adminPrivateKeyPath string
@@ -54,6 +61,7 @@ type settings struct {
 	authUrl             string
 	destinationUrls     map[string]string
 	devFrontendUrl      string
+	telemetryLinks      []telemetryLink
 	tokenTtl            time.Duration
 }
 
@@ -90,8 +98,49 @@ func loadSettings() settings {
 		// is served from the embedded FS.
 		devFrontendUrl:  os.Getenv("DEV_FRONTEND_URL"),
 		destinationUrls: destURLs,
+		telemetryLinks:  loadTelemetryLinks(),
 		tokenTtl:        15 * time.Minute,
 	}
+}
+
+func loadTelemetryLinks() []telemetryLink {
+	grafanaURL := strings.TrimRight(strings.TrimSpace(os.Getenv("AUTHPROXY_GRAFANA_URL")), "/")
+	appMetricsURL := strings.TrimSpace(os.Getenv("AUTHPROXY_GRAFANA_APP_METRICS_URL"))
+	exploreURL := strings.TrimSpace(os.Getenv("AUTHPROXY_GRAFANA_EXPLORE_URL"))
+
+	if grafanaURL != "" {
+		if appMetricsURL == "" {
+			appMetricsURL = grafanaURL + "/d/authproxy-app-metrics-demo/authproxy-app-metrics?orgId=1&from=now-1h&to=now"
+		}
+		if exploreURL == "" {
+			exploreURL = grafanaURL + "/explore?orgId=1"
+		}
+	}
+
+	links := make([]telemetryLink, 0, 3)
+	if grafanaURL != "" {
+		links = append(links, telemetryLink{
+			Label:       "Grafana",
+			Description: "Open the demo observability workspace.",
+			URL:         grafanaURL,
+		})
+	}
+	if appMetricsURL != "" {
+		links = append(links, telemetryLink{
+			Label:       "App metrics",
+			Description: "View request, resource, connection, and rate-limit telemetry.",
+			URL:         appMetricsURL,
+		})
+	}
+	if exploreURL != "" {
+		links = append(links, telemetryLink{
+			Label:       "Explore",
+			Description: "Query telemetry directly in Grafana.",
+			URL:         exploreURL,
+		})
+	}
+
+	return links
 }
 
 // signTokenFor mints a JWT signed by the admin keypair, claiming the
@@ -156,6 +205,24 @@ func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
 	}
 }
 
+func configHandler(s settings) http.HandlerFunc {
+	type response struct {
+		TelemetryLinks []telemetryLink `json:"telemetryLinks"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response{TelemetryLinks: s.telemetryLinks}); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+	}
+}
+
 // frontendHandler serves the SPA. In production, it serves the embedded
 // build at embed/dist/. In dev (DEV_FRONTEND_URL set), it 302-redirects
 // to the vite dev server so HMR + source maps work.
@@ -188,6 +255,7 @@ func main() {
 	s := loadSettings()
 
 	mux := http.NewServeMux()
+	mux.Handle("GET /config.json", configHandler(s))
 	mux.Handle("POST /sso", ssoHandler(s, logger))
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/demos/shell/backend/main_test.go
+++ b/demos/shell/backend/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTelemetryLinksFromGrafanaBaseURL(t *testing.T) {
+	t.Setenv("AUTHPROXY_GRAFANA_URL", "https://demo.example.test/grafana/")
+	t.Setenv("AUTHPROXY_GRAFANA_APP_METRICS_URL", "")
+	t.Setenv("AUTHPROXY_GRAFANA_EXPLORE_URL", "")
+
+	links := loadTelemetryLinks()
+
+	require.Equal(t, []telemetryLink{
+		{
+			Label:       "Grafana",
+			Description: "Open the demo observability workspace.",
+			URL:         "https://demo.example.test/grafana",
+		},
+		{
+			Label:       "App metrics",
+			Description: "View request, resource, connection, and rate-limit telemetry.",
+			URL:         "https://demo.example.test/grafana/d/authproxy-app-metrics-demo/authproxy-app-metrics?orgId=1&from=now-1h&to=now",
+		},
+		{
+			Label:       "Explore",
+			Description: "Query telemetry directly in Grafana.",
+			URL:         "https://demo.example.test/grafana/explore?orgId=1",
+		},
+	}, links)
+}
+
+func TestLoadTelemetryLinksAllowsExplicitURLsWithoutGrafanaBaseURL(t *testing.T) {
+	t.Setenv("AUTHPROXY_GRAFANA_URL", "")
+	t.Setenv("AUTHPROXY_GRAFANA_APP_METRICS_URL", "https://grafana.example.test/d/app")
+	t.Setenv("AUTHPROXY_GRAFANA_EXPLORE_URL", "https://grafana.example.test/explore")
+
+	links := loadTelemetryLinks()
+
+	require.Equal(t, []telemetryLink{
+		{
+			Label:       "App metrics",
+			Description: "View request, resource, connection, and rate-limit telemetry.",
+			URL:         "https://grafana.example.test/d/app",
+		},
+		{
+			Label:       "Explore",
+			Description: "Query telemetry directly in Grafana.",
+			URL:         "https://grafana.example.test/explore",
+		},
+	}, links)
+}
+
+func TestConfigHandlerReturnsTelemetryLinks(t *testing.T) {
+	links := []telemetryLink{{
+		Label:       "Grafana",
+		Description: "Open the demo observability workspace.",
+		URL:         "https://demo.example.test/grafana",
+	}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config.json", nil)
+
+	configHandler(settings{telemetryLinks: links}).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var body struct {
+		TelemetryLinks []telemetryLink `json:"telemetryLinks"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	require.Equal(t, links, body.TelemetryLinks)
+}

--- a/demos/shell/frontend/src/App.tsx
+++ b/demos/shell/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // Demo actor identities. The same three names are pre-created on the
 // AuthProxy side by the umbrella chart's seed job (A11 / #300); each maps
@@ -27,11 +27,49 @@ const DESTINATIONS: Array<{ id: 'admin' | 'marketplace'; label: string }> = [
   { id: 'admin', label: 'Admin UI' },
 ];
 
+type TelemetryLink = {
+  label: string;
+  description: string;
+  url: string;
+};
+
+type ShellConfig = {
+  telemetryLinks?: TelemetryLink[];
+};
+
 export function App() {
   const [actor, setActor] = useState(ACTORS[0]!.id);
   const [destination, setDestination] = useState<'admin' | 'marketplace'>('marketplace');
+  const [telemetryLinks, setTelemetryLinks] = useState<TelemetryLink[]>([]);
 
   const actorMeta = ACTORS.find((a) => a.id === actor)!;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadConfig() {
+      try {
+        const response = await fetch('/config.json');
+        if (!response.ok) {
+          return;
+        }
+        const config = (await response.json()) as ShellConfig;
+        if (!cancelled) {
+          setTelemetryLinks(config.telemetryLinks ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          setTelemetryLinks([]);
+        }
+      }
+    }
+
+    void loadConfig();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="shell">
@@ -71,6 +109,20 @@ export function App() {
 
         <button type="submit">Sign in</button>
       </form>
+
+      {telemetryLinks.length > 0 && (
+        <section className="telemetry" aria-labelledby="telemetry-heading">
+          <h2 id="telemetry-heading">Telemetry</h2>
+          <div className="telemetry-links">
+            {telemetryLinks.map((link) => (
+              <a key={link.url} href={link.url} className="telemetry-link">
+                <span>{link.label}</span>
+                <small>{link.description}</small>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
 
       <footer>
         Demo environment only — never ship this shell to customers.

--- a/demos/shell/frontend/src/styles.css
+++ b/demos/shell/frontend/src/styles.css
@@ -14,7 +14,7 @@ body {
 
 .shell {
   width: 100%;
-  max-width: 480px;
+  max-width: 560px;
 }
 
 h1 {
@@ -31,7 +31,7 @@ h1 {
 
 .card {
   background: light-dark(#fff, #2a2a2e);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -78,6 +78,43 @@ button[type='submit'] {
 
 button[type='submit']:hover {
   background: #1d4ed8;
+}
+
+.telemetry {
+  margin-top: 1.25rem;
+}
+
+h2 {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.telemetry-links {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.telemetry-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 5.5rem;
+  padding: 1rem;
+  border: 1px solid light-dark(#d8d8dc, #444);
+  border-radius: 8px;
+  background: light-dark(#fff, #242428);
+  color: inherit;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.telemetry-link:hover {
+  border-color: #2563eb;
+}
+
+.telemetry-link > span {
+  font-weight: 700;
 }
 
 footer {

--- a/demos/shell/frontend/vite.config.ts
+++ b/demos/shell/frontend/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
 
   const port = Number(process.env.AUTHPROXY_DEMO_SHELL_UI_PORT) || 5175;
   const base = process.env.VITE_BASE_URL || '/';
+  const backendUrl = process.env.AUTHPROXY_DEMO_SHELL_BACKEND_URL || 'http://localhost:8888';
 
   return {
     base,
@@ -23,6 +24,10 @@ export default defineConfig(({ mode }) => {
     server: {
       port,
       strictPort: true,
+      proxy: {
+        '/config.json': backendUrl,
+        '/sso': backendUrl,
+      },
     },
     build: {
       // Output into ../backend/embed/dist so the Go //go:embed directive in

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -186,7 +186,9 @@ admin UI as `demo-admin`. Pick **fresh-user** + **Marketplace UI** →
 empty marketplace, no connections.
 
 Grafana is available at `https://<hostname>/grafana` when
-`grafana.enabled=true` (the default). The chart provisions:
+`grafana.enabled=true` (the default). The demo shell receives that URL
+as `AUTHPROXY_GRAFANA_URL` and renders links to Grafana, the App Metrics
+dashboard, and Explore next to the SSO controls. The chart provisions:
 
 - `AuthProxy` datasource (`uid: authproxy-app-metrics`) pointed at the
   in-cluster AuthProxy API service.

--- a/deploy/charts/authproxy-demo/templates/demo-shell.yaml
+++ b/deploy/charts/authproxy-demo/templates/demo-shell.yaml
@@ -48,6 +48,10 @@ spec:
               value: "https://marketplace.{{ .Values.global.hostname }}"
             - name: AUTHPROXY_ADMIN_UI_URL
               value: "https://admin.{{ .Values.global.hostname }}"
+            {{- if .Values.grafana.enabled }}
+            - name: AUTHPROXY_GRAFANA_URL
+              value: "https://{{ .Values.global.hostname }}/grafana"
+            {{- end }}
           volumeMounts:
             - name: admin-key
               mountPath: /etc/authproxy/demo-shell


### PR DESCRIPTION
Closes #514.

## Summary
- Expose demo-shell runtime config at /config.json with optional Grafana, App Metrics dashboard, and Explore links.
- Render telemetry links in the demo shell when Grafana URLs are configured.
- Wire the demo Helm chart to set AUTHPROXY_GRAFANA_URL when Grafana is enabled, and document local/chart overrides.
- Add Vite dev proxies for /config.json and /sso so local shell development routes backend calls correctly.

## Verification
- go test ./demos/shell/backend
- yarn workspace @authproxy/demo-shell typecheck
- yarn workspace @authproxy/demo-shell build
- helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.example.test --skip-schema-validation --show-only templates/demo-shell.yaml
- ./scripts/preflight.sh
- Browser smoke at http://localhost:18888 confirmed Telemetry links render with no console errors

Note: plain helm template without --skip-schema-validation currently fails on existing authproxy subchart schema drift for services.adminApi/services.public passthrough keys, before this change's template is rendered.