### PR TITLE
Add smoke coverage for seeded demo connectors

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -280,7 +280,7 @@ jobs:
           kubectl -n "${RELEASE_NS}" get certificate,order,challenge || true
           exit 1
 
-      - name: Smoke test (OAuth flow)
+      - name: Smoke test (demo connectors)
         id: smoke
         timeout-minutes: 10
         env:
@@ -298,7 +298,7 @@ jobs:
           echo "Smoke-testing ${SMOKE_BASE_URL}"
           cd integration_tests
           SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
-            go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
+            go test -tags smoke ./smoke -run TestRemote -count=1 -v
 
       - name: helm rollback (on failure)
         if: failure() && steps.pre.outputs.previous_revision != ''

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -360,7 +360,7 @@ jobs:
           kubectl -n "${RELEASE_NS}" get certificate,order,challenge || true
           exit 1
 
-      - name: Smoke test (OAuth flow)
+      - name: Smoke test (demo connectors)
         id: smoke
         timeout-minutes: 10
         env:
@@ -382,7 +382,7 @@ jobs:
             echo "Smoke-testing ${SMOKE_BASE_URL}"
             cd integration_tests
             SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
-              go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
+              go test -tags smoke ./smoke -run TestRemote -count=1 -v
           } 2>&1 | tee "${log_path}"
 
       - name: Post smoke failure comment

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -124,6 +124,27 @@ func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connec
 	return created
 }
 
+func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []schemaapi.ConnectorJson {
+	t.Helper()
+
+	endpoint := h.PublicURL + "/api/v1/connectors?limit=100"
+	if labelSelector != "" {
+		endpoint += "&label_selector=" + url.QueryEscape(labelSelector)
+	}
+
+	var list schemaapi.ListConnectorsResponseJson
+	h.doSigned(t, h.UserActorExternalID, http.MethodGet, endpoint, nil, true, http.StatusOK, &list)
+	return list.Items
+}
+
+func (h *RemoteAuthProxy) FindConnectorBySeedKey(t *testing.T, seedKey string) schemaapi.ConnectorJson {
+	t.Helper()
+
+	connectors := h.ListConnectors(t, "demo.authproxy.net/seed-key="+seedKey)
+	require.Lenf(t, connectors, 1, "expected exactly one seeded connector with key %q; got %d", seedKey, len(connectors))
+	return connectors[0]
+}
+
 func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID apid.ID, version uint64, state string) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
@@ -153,6 +174,63 @@ func (h *RemoteAuthProxy) InitiateOAuth2Connection(t *testing.T, connectorID api
 	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, redirect.Type)
 	require.NotEmpty(t, redirect.RedirectUrl)
 	return redirect.Id.String(), redirect.RedirectUrl
+}
+
+func (h *RemoteAuthProxy) InitiateAPIKeyConnection(t *testing.T, connectorID apid.ID) (connectionID, stepID string) {
+	t.Helper()
+
+	var form schemaapi.ConnectionSetupForm
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
+		ConnectorId:   connectorID,
+		IntoNamespace: h.Namespace,
+	}, true, http.StatusOK, &form)
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeForm, form.Type)
+	require.NotEmpty(t, form.StepId)
+	return form.Id.String(), form.StepId
+}
+
+func (h *RemoteAuthProxy) SubmitAPIKeyCredentials(t *testing.T, connectionID, stepID, apiKey string) schemaapi.ConnectionSetupResponseType {
+	t.Helper()
+
+	rawData, err := json.Marshal(map[string]string{"api_key": apiKey})
+	require.NoError(t, err)
+
+	var generic struct {
+		Type schemaapi.ConnectionSetupResponseType `json:"type"`
+	}
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_submit", schemaapi.SubmitConnectionRequest{
+		StepId: stepID,
+		Data:   rawData,
+	}, true, http.StatusOK, &generic)
+	require.NotEmpty(t, generic.Type)
+	return generic.Type
+}
+
+func (h *RemoteAuthProxy) WaitForSetupComplete(t *testing.T, connectionID string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastType schemaapi.ConnectionSetupResponseType
+	var lastError string
+	for time.Now().Before(deadline) {
+		var generic struct {
+			Type  schemaapi.ConnectionSetupResponseType `json:"type"`
+			Error string                                `json:"error,omitempty"`
+		}
+		h.doSigned(t, h.UserActorExternalID, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID+"/_setup_step", nil, true, http.StatusOK, &generic)
+		lastType = generic.Type
+		lastError = generic.Error
+
+		switch generic.Type {
+		case schemaapi.ConnectionSetupResponseTypeComplete:
+			return
+		case schemaapi.ConnectionSetupResponseTypeError:
+			require.FailNowf(t, "connection setup failed", "connection %s setup error: %s", connectionID, generic.Error)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	require.FailNowf(t, "connection setup did not complete",
+		"connection %s did not complete within %s; last type=%q error=%q", connectionID, timeout, lastType, lastError)
 }
 
 func (h *RemoteAuthProxy) FollowOAuth2Redirect(t *testing.T, redirectURL string) string {

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -120,11 +121,115 @@ func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 		"proxied resource call should use bearer auth, got %q", authHeader)
 }
 
+func TestRemoteSeededConnectorsSmoke(t *testing.T) {
+	if *smokeBaseURL == "" {
+		t.Skip("set SMOKE_BASE_URL or pass -base-url")
+	}
+	if *smokeAdminKey == "" {
+		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
+	}
+
+	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
+		BaseURL:         *smokeBaseURL,
+		AdminPrivateKey: *smokeAdminKey,
+	})
+	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
+
+	t.Run("catalog contains expected seeded connectors", func(t *testing.T) {
+		items := rig.ListConnectors(t, "demo=true")
+		bySeedKey := map[string]api.ConnectorJson{}
+		for _, item := range items {
+			if key := item.Labels["demo.authproxy.net/seed-key"]; key != "" {
+				bySeedKey[key] = item
+			}
+		}
+
+		expected := map[string]string{
+			"demo-readme-noauth":   "Demo README Resource",
+			"demo-api-key-bearer":  "Demo API Key: Bearer Token",
+			"demo-oauth-simple":    "Demo OAuth: Basic Authorization",
+			"demo-oauth-tenant":    "Demo OAuth: Tenant Selection",
+			"demo-oauth-configure": "Demo OAuth: Resource Configuration",
+		}
+		for seedKey, displayName := range expected {
+			connector, ok := bySeedKey[seedKey]
+			require.Truef(t, ok, "missing seeded connector %q (%s); present seed keys: %v", seedKey, displayName, sortedKeys(bySeedKey))
+			require.Equalf(t, displayName, connector.DisplayName, "seeded connector %q display name changed", seedKey)
+			require.Equalf(t, api.ConnectorVersionStatePrimary, connector.State, "seeded connector %q should be primary", seedKey)
+		}
+	})
+
+	t.Run("seeded basic OAuth connector completes and proxies", func(t *testing.T) {
+		startedAt := time.Now().Add(-1 * time.Second)
+		connector := rig.FindConnectorBySeedKey(t, "demo-oauth-simple")
+		connectionID, redirectURL := rig.InitiateOAuth2Connection(t, connector.Id, rig.PublicURL+"/connections")
+
+		authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
+		authorizeParams := parseQuery(t, authorizeURL)
+		require.Equal(t, "demo-oauth-simple", authorizeParams.Get("client_id"))
+		require.Equal(t, rig.PublicURL+"/oauth2/callback", authorizeParams.Get("redirect_uri"))
+		require.NotEmpty(t, authorizeParams.Get("state"))
+
+		callback := provider.Authorize(helpers.AuthorizeRequest{
+			ClientID:    "demo-oauth-simple",
+			Username:    "demo-oauth-user@example.test",
+			RedirectURI: authorizeParams.Get("redirect_uri"),
+			Scope:       authorizeParams.Get("scope"),
+			State:       authorizeParams.Get("state"),
+			Decision:    helpers.AuthorizeApprove,
+		})
+		require.NotEmpty(t, callback.RedirectURL)
+
+		finalLocation := rig.DeliverOAuth2Callback(t, callback.RedirectURL)
+		assert.Truef(t, strings.HasPrefix(finalLocation, rig.PublicURL+"/connections"),
+			"expected callback to land on marketplace connections page, got %q", finalLocation)
+
+		proxyResp := rig.DoProxyRequest(t, connectionID, provider.ResourceURL("/echo"), http.MethodGet)
+		require.Equal(t, http.StatusOK, proxyResp.StatusCode)
+
+		tokenReqs := provider.Requests(helpers.RequestsFilter{
+			Endpoint: helpers.EndpointToken,
+			ClientID: "demo-oauth-simple",
+			Since:    startedAt,
+		})
+		require.NotEmpty(t, tokenReqs, "provider should record seeded OAuth token exchange")
+	})
+
+	t.Run("seeded API key connector completes and proxies", func(t *testing.T) {
+		connector := rig.FindConnectorBySeedKey(t, "demo-api-key-bearer")
+		connectionID, stepID := rig.InitiateAPIKeyConnection(t, connector.Id)
+		respType := rig.SubmitAPIKeyCredentials(t, connectionID, stepID, "demo-api-key")
+		switch respType {
+		case api.ConnectionSetupResponseTypeComplete:
+		case api.ConnectionSetupResponseTypeVerifying:
+			rig.WaitForSetupComplete(t, connectionID, 2*time.Minute)
+		default:
+			require.Failf(t, "unexpected API-key submit response", "got setup response type %q", respType)
+		}
+
+		proxyResp := rig.DoProxyRequest(t, connectionID, rig.ProviderURL+"/test/api-key-resource/demo-api-key", http.MethodGet)
+		require.Equal(t, http.StatusOK, proxyResp.StatusCode)
+		body, ok := proxyResp.BodyJson.(map[string]any)
+		require.Truef(t, ok, "expected JSON body from API-key resource, got %#v", proxyResp.BodyJson)
+		require.Equal(t, "api-key", body["auth"])
+		require.Equal(t, "/test/api-key-resource/demo-api-key", body["path"])
+	})
+}
+
 func parseQuery(t *testing.T, rawURL string) url.Values {
 	t.Helper()
 	parsed, err := url.Parse(rawURL)
 	require.NoError(t, err)
 	return parsed.Query()
+}
+
+func sortedKeys(connectors map[string]api.ConnectorJson) []string {
+	keys := make([]string, 0, len(connectors))
+	for key := range connectors {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func lastFormValue(form map[string][]string, key string) string {


### PR DESCRIPTION
## Summary
- add a remote smoke test that verifies the seeded demo catalog contains the expected connector keys and display names
- exercise the seeded basic OAuth connector end-to-end using the seeded go-oauth2-server client/user
- exercise the seeded API-key connector by submitting `demo-api-key`, waiting for verification, and proxying to the provider API-key resource
- run all remote smoke tests from demo/dev deploy workflows with `-run TestRemote`

Closes #501.

## Tests
- go test -tags smoke ./smoke -run TestRemote -count=1 -v (from integration_tests; skips without SMOKE env vars)
- ./scripts/preflight.sh