### PR TITLE
Slim per-branch dev deploy storage

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -306,6 +306,7 @@ jobs:
         run: |
           set -euo pipefail
           helm upgrade --install "${RELEASE_NAME}" "${CHART_PATH}" \
+            -f "${CHART_PATH}/dev-slim-values.yaml" \
             --namespace "${RELEASE_NS}" \
             --atomic \
             --wait --timeout 10m \

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -166,6 +166,19 @@ redirects between root-relative `/web/*` paths. The marketplace and
 admin UIs also use subdomains so their root-relative Vite assets resolve
 correctly.
 
+## Per-branch dev storage profile
+
+The Deploy Dev workflow uses `dev-slim-values.yaml` to keep PR
+environments small. That profile disables the Postgres, Redis, and
+MinIO subcharts, then configures the embedded AuthProxy chart to use
+SQLite files under `/tmp`, the in-process `miniredis` provider, and no
+S3 blob store. This is intentionally disposable: a pod restart can lose
+database, queue, session, and full-request blob state, but the next dev
+deploy reseeds the catalog and actors.
+
+Do not use the slim profile for `demo.authproxy.net`. The persistent
+demo environment uses the chart defaults: Postgres, Redis, and MinIO.
+
 ## Wildcard TLS
 
 For per-branch dev environments, use a DNS-01 ClusterIssuer and set:

--- a/deploy/charts/authproxy-demo/dev-slim-values.yaml
+++ b/deploy/charts/authproxy-demo/dev-slim-values.yaml
@@ -1,0 +1,37 @@
+# Dev-only profile for per-branch deployments.
+#
+# This intentionally trades durability for lower cluster footprint:
+# - SQLite files live in the AuthProxy pod's writable /tmp.
+# - Redis is replaced by the embedded miniredis provider.
+# - S3/MinIO blob storage is omitted; full request body capture should
+#   remain disabled for this profile.
+#
+# Do not use this profile for demo.authproxy.net or customer installs.
+
+secrets:
+  autoGenerate: false
+
+authproxy:
+  database:
+    provider: sqlite
+    path: /tmp/authproxy-dev.db
+    autoMigrate: true
+    existingSecret: ""
+  redis:
+    provider: miniredis
+    address: ""
+    existingSecret: ""
+  s3:
+    enabled: false
+  appMetrics:
+    shareMainDatabase: true
+    fullRequestRecording: never
+
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+
+minio:
+  enabled: false

--- a/deploy/charts/authproxy/templates/NOTES.txt
+++ b/deploy/charts/authproxy/templates/NOTES.txt
@@ -29,8 +29,8 @@ either enable `ingress.enabled` in your values or port-forward, e.g.:
 {{- end }}
 
 {{- $missing := list }}
-{{- if not .Values.database.existingSecret }}{{- $missing = append $missing "database.existingSecret" }}{{- end }}
-{{- if not .Values.redis.existingSecret }}{{- $missing = append $missing "redis.existingSecret" }}{{- end }}
+{{- if and (eq .Values.database.provider "postgres") (not .Values.database.existingSecret) }}{{- $missing = append $missing "database.existingSecret" }}{{- end }}
+{{- if and (eq (default "redis" .Values.redis.provider) "redis") (not .Values.redis.existingSecret) }}{{- $missing = append $missing "redis.existingSecret" }}{{- end }}
 {{- if not .Values.jwt.existingSecret }}{{- $missing = append $missing "jwt.existingSecret" }}{{- end }}
 {{- if not .Values.encryptionKeys.existingSecret }}{{- $missing = append $missing "encryptionKeys.existingSecret" }}{{- end }}
 {{- if not .Values.actors.existingSecret }}{{- $missing = append $missing "actors.existingSecret (admin actor keys; chart starts without it but admin API calls won't auth)" }}{{- end }}

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -99,12 +99,17 @@ template syntax.
 {{- $_ := set $cfg "database" $db -}}
 
 {{/* --- redis --- */}}
-{{- $redis := dict "provider" "redis" "address" (tpl .Values.redis.address $) "db" .Values.redis.db -}}
-{{- if .Values.redis.username -}}
-{{-   $_ := set $redis "username" (tpl .Values.redis.username $) -}}
-{{- end -}}
-{{- if .Values.redis.existingSecret -}}
-{{-   $_ := set $redis "password" (dict "env_var" "AUTHPROXY_REDIS_PASSWORD") -}}
+{{- $redisProvider := default "redis" .Values.redis.provider -}}
+{{- $redis := dict "provider" $redisProvider -}}
+{{- if eq $redisProvider "redis" -}}
+{{-   $_ := set $redis "address" (tpl .Values.redis.address $) -}}
+{{-   $_ := set $redis "db" .Values.redis.db -}}
+{{-   if .Values.redis.username -}}
+{{-     $_ := set $redis "username" (tpl .Values.redis.username $) -}}
+{{-   end -}}
+{{-   if .Values.redis.existingSecret -}}
+{{-     $_ := set $redis "password" (dict "env_var" "AUTHPROXY_REDIS_PASSWORD") -}}
+{{-   end -}}
 {{- end -}}
 {{- $_ := set $cfg "redis" $redis -}}
 

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -153,6 +153,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "provider":       { "type": "string", "enum": ["redis", "miniredis"] },
         "address":        { "type": "string" },
         "username":       { "type": "string" },
         "db":             { "type": "integer", "minimum": 0 },

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -166,6 +166,9 @@ database:
 # -- Redis connectivity. Required for sessions, async tasks, rate-limit
 # cache, and OAuth round-trip state.
 redis:
+  # -- Provider: `redis` for an external Redis server, or `miniredis`
+  # for an embedded in-process store suitable only for tests/disposable dev.
+  provider: redis
   # -- host:port (required).
   address: ""
   # -- Optional Redis username (Redis 6 ACLs).


### PR DESCRIPTION
## Summary

- adds a dev-only Helm values profile that disables Postgres, Redis, and MinIO for per-branch deployments
- configures per-branch dev AuthProxy pods to use SQLite under `/tmp` plus the embedded `miniredis` provider
- wires Deploy Dev to use the slim profile while leaving the persistent demo chart defaults on Postgres, Redis, and MinIO

Closes #545.

## Notes

This is intentionally disposable for PR environments: pod restarts can lose SQLite, session, queue, and request-body blob state. The existing seed job should repopulate the demo catalog and actors on the next deploy. Full request body recording remains disabled in this profile because there is no blob store.

Follow-up tickets:

- #546 tracks adding a filesystem blob storage provider.
- #547 tracks documenting the slim profile more broadly after the first deployment path lands.

## Validation

- `helm lint deploy/charts/authproxy`
- `helm lint deploy/charts/authproxy-demo`
- `helm template dev deploy/charts/authproxy-demo -f deploy/charts/authproxy-demo/dev-slim-values.yaml --set global.hostname=branch.dev.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test`
- `helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test`
- `helm template ap deploy/charts/authproxy --set database.provider=sqlite --set database.path=/tmp/authproxy.db --set redis.provider=miniredis --set jwt.existingSecret=authproxy-jwt --set encryptionKeys.existingSecret=authproxy-encryption --set actors.existingSecret=authproxy-actors --set hostApplication.initiateSessionUrl=http://placeholder.invalid/login`
- `./scripts/preflight.sh`
