### PR TITLE
Add workflow monitoring Admin API endpoints

### DIFF
--- a/internal/routes/workflow_monitoring.go
+++ b/internal/routes/workflow_monitoring.go
@@ -1,0 +1,381 @@
+package routes
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	wfbackend "github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/backend/history"
+	wfcore "github.com/cschleiden/go-workflows/core"
+	"github.com/cschleiden/go-workflows/diag"
+	"github.com/gin-gonic/gin"
+	auth "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+type WorkflowMonitoringRoutes struct {
+	auth            auth.A
+	backend         diag.Backend
+	cursorEncryptor pagination.CursorEncryptor
+}
+
+func NewWorkflowMonitoringRoutes(
+	auth auth.A,
+	backend diag.Backend,
+	cursorEncryptor pagination.CursorEncryptor,
+) *WorkflowMonitoringRoutes {
+	return &WorkflowMonitoringRoutes{
+		auth:            auth,
+		backend:         backend,
+		cursorEncryptor: cursorEncryptor,
+	}
+}
+
+type workflowListCursor struct {
+	AfterInstanceID  string `json:"after_instance_id"`
+	AfterExecutionID string `json:"after_execution_id"`
+	Count            int    `json:"count"`
+}
+
+type WorkflowInstanceRefJson = schemaapi.WorkflowInstanceRefJson
+type WorkflowHistoryEventJson = schemaapi.WorkflowHistoryEventJson
+type WorkflowInstanceInfoJson = schemaapi.WorkflowInstanceInfoJson
+type WorkflowInstanceTreeJson = schemaapi.WorkflowInstanceTreeJson
+type ListWorkflowInstancesResponseJson = schemaapi.ListWorkflowInstancesResponseJson
+type ListWorkflowHistoryResponseJson = schemaapi.ListWorkflowHistoryResponseJson
+
+func workflowInstanceFromParams(gctx *gin.Context) (*wfcore.WorkflowInstance, bool) {
+	instanceID := gctx.Param("instance_id")
+	executionID := gctx.Param("execution_id")
+	if instanceID == "" || executionID == "" {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("instance_id and execution_id are required"))
+		return nil, false
+	}
+
+	return wfcore.NewWorkflowInstance(instanceID, executionID), true
+}
+
+func workflowInstanceToJson(instance *wfcore.WorkflowInstance) *schemaapi.WorkflowInstanceJson {
+	if instance == nil {
+		return nil
+	}
+
+	return &schemaapi.WorkflowInstanceJson{
+		InstanceID:  instance.InstanceID,
+		ExecutionID: instance.ExecutionID,
+		Parent:      workflowInstanceToJson(instance.Parent),
+	}
+}
+
+func workflowInstanceStateToJson(state wfcore.WorkflowInstanceState) string {
+	switch state {
+	case wfcore.WorkflowInstanceStateActive:
+		return "active"
+	case wfcore.WorkflowInstanceStateContinuedAsNew:
+		return "continued_as_new"
+	case wfcore.WorkflowInstanceStateFinished:
+		return "finished"
+	default:
+		return "unknown"
+	}
+}
+
+func workflowInstanceRefToJson(ref *diag.WorkflowInstanceRef) *WorkflowInstanceRefJson {
+	if ref == nil {
+		return nil
+	}
+
+	return &WorkflowInstanceRefJson{
+		Instance:    workflowInstanceToJson(ref.Instance),
+		CreatedAt:   ref.CreatedAt,
+		CompletedAt: ref.CompletedAt,
+		State:       workflowInstanceStateToJson(ref.State),
+		Queue:       ref.Queue,
+	}
+}
+
+func workflowInstanceRefsToJson(refs []*diag.WorkflowInstanceRef) []*WorkflowInstanceRefJson {
+	result := make([]*WorkflowInstanceRefJson, 0, len(refs))
+	for _, ref := range refs {
+		result = append(result, workflowInstanceRefToJson(ref))
+	}
+	return result
+}
+
+func workflowHistoryEventsToJson(events []*history.Event) []*WorkflowHistoryEventJson {
+	result := make([]*WorkflowHistoryEventJson, 0, len(events))
+	for _, event := range events {
+		result = append(result, &WorkflowHistoryEventJson{
+			ID:              event.ID,
+			SequenceID:      event.SequenceID,
+			Type:            event.Type.String(),
+			Timestamp:       event.Timestamp,
+			ScheduleEventID: event.ScheduleEventID,
+			Attributes:      event.Attributes,
+			VisibleAt:       event.VisibleAt,
+		})
+	}
+
+	return result
+}
+
+func workflowInstanceTreeToJson(tree *diag.WorkflowInstanceTree) *WorkflowInstanceTreeJson {
+	if tree == nil {
+		return nil
+	}
+
+	children := make([]*WorkflowInstanceTreeJson, 0, len(tree.Children))
+	for _, child := range tree.Children {
+		children = append(children, workflowInstanceTreeToJson(child))
+	}
+
+	return &WorkflowInstanceTreeJson{
+		WorkflowInstanceRefJson: workflowInstanceRefToJson(tree.WorkflowInstanceRef),
+		WorkflowName:            tree.WorkflowName,
+		Error:                   tree.Error,
+		Children:                children,
+	}
+}
+
+func writeWorkflowBackendError(gctx *gin.Context, publicMessage string, err error) {
+	switch {
+	case errors.Is(err, wfbackend.ErrInstanceNotFound):
+		apgin.WriteError(gctx, nil, httperr.NotFound("workflow instance not found", httperr.WithInternalErr(err)))
+	case errors.Is(err, wfbackend.ErrInstanceNotFinished):
+		apgin.WriteError(gctx, nil, httperr.Conflict("workflow instance is not finished", httperr.WithInternalErr(err)))
+	default:
+		apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg(publicMessage, httperr.WithInternalErr(err)))
+	}
+}
+
+func (r *WorkflowMonitoringRoutes) listInstances(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	count := 25
+	afterInstanceID := ""
+	afterExecutionID := ""
+
+	if cursorStr := gctx.Query("cursor"); cursorStr != "" {
+		cursor, err := pagination.ParseCursor[workflowListCursor](ctx, r.cursorEncryptor, cursorStr)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("invalid cursor"))
+			return
+		}
+		count = cursor.Count
+		afterInstanceID = cursor.AfterInstanceID
+		afterExecutionID = cursor.AfterExecutionID
+	} else if countStr := gctx.Query("limit"); countStr != "" {
+		parsed, err := strconv.Atoi(countStr)
+		if err != nil || parsed < 1 {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("invalid limit parameter"))
+			return
+		}
+		count = parsed
+	}
+
+	if count > 100 {
+		count = 100
+	}
+
+	items, err := r.backend.GetWorkflowInstances(ctx, afterInstanceID, afterExecutionID, count+1)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to list workflow instances", err)
+		return
+	}
+
+	var cursor string
+	if len(items) > count {
+		items = items[:count]
+		last := items[len(items)-1]
+		if last != nil && last.Instance != nil {
+			cursor, _ = pagination.MakeCursor(ctx, r.cursorEncryptor, &workflowListCursor{
+				AfterInstanceID:  last.Instance.InstanceID,
+				AfterExecutionID: last.Instance.ExecutionID,
+				Count:            count,
+			})
+		}
+	}
+
+	gctx.PureJSON(http.StatusOK, ListWorkflowInstancesResponseJson{
+		Items:  workflowInstanceRefsToJson(items),
+		Cursor: cursor,
+	})
+}
+
+func (r *WorkflowMonitoringRoutes) getInstance(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	instance, ok := workflowInstanceFromParams(gctx)
+	if !ok {
+		return
+	}
+
+	instanceRef, err := r.backend.GetWorkflowInstance(ctx, instance)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to get workflow instance", err)
+		return
+	}
+	if instanceRef == nil {
+		apgin.WriteError(gctx, nil, httperr.NotFound("workflow instance not found"))
+		return
+	}
+
+	historyEvents, err := r.backend.GetWorkflowInstanceHistory(ctx, instanceRef.Instance, nil)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to get workflow history", err)
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, &WorkflowInstanceInfoJson{
+		WorkflowInstanceRefJson: workflowInstanceRefToJson(instanceRef),
+		History:                 workflowHistoryEventsToJson(historyEvents),
+	})
+}
+
+func (r *WorkflowMonitoringRoutes) getHistory(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	instance, ok := workflowInstanceFromParams(gctx)
+	if !ok {
+		return
+	}
+
+	instanceRef, err := r.backend.GetWorkflowInstance(ctx, instance)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to get workflow instance", err)
+		return
+	}
+	if instanceRef == nil {
+		apgin.WriteError(gctx, nil, httperr.NotFound("workflow instance not found"))
+		return
+	}
+
+	historyEvents, err := r.backend.GetWorkflowInstanceHistory(ctx, instanceRef.Instance, nil)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to get workflow history", err)
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, ListWorkflowHistoryResponseJson{Items: workflowHistoryEventsToJson(historyEvents)})
+}
+
+func (r *WorkflowMonitoringRoutes) getTree(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	instance, ok := workflowInstanceFromParams(gctx)
+	if !ok {
+		return
+	}
+
+	tree, err := r.backend.GetWorkflowTree(ctx, instance)
+	if err != nil {
+		writeWorkflowBackendError(gctx, "failed to get workflow tree", err)
+		return
+	}
+	if tree == nil {
+		apgin.WriteError(gctx, nil, httperr.NotFound("workflow instance tree not found"))
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, workflowInstanceTreeToJson(tree))
+}
+
+func (r *WorkflowMonitoringRoutes) cancelInstance(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	instance, ok := workflowInstanceFromParams(gctx)
+	if !ok {
+		return
+	}
+
+	if err := r.backend.CancelWorkflowInstance(ctx, instance, history.NewWorkflowCancellationEvent(time.Now())); err != nil {
+		writeWorkflowBackendError(gctx, "failed to cancel workflow instance", err)
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func (r *WorkflowMonitoringRoutes) removeInstance(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	val.MarkValidated()
+
+	instance, ok := workflowInstanceFromParams(gctx)
+	if !ok {
+		return
+	}
+
+	if err := r.backend.RemoveWorkflowInstance(ctx, instance); err != nil {
+		writeWorkflowBackendError(gctx, "failed to remove workflow instance", err)
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func (r *WorkflowMonitoringRoutes) Register(g gin.IRouter) {
+	g.GET(
+		"/workflow-monitoring/instances",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("list").
+			Build(),
+		r.listInstances,
+	)
+	g.GET(
+		"/workflow-monitoring/instances/:instance_id/:execution_id",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("get").
+			Build(),
+		r.getInstance,
+	)
+	g.GET(
+		"/workflow-monitoring/instances/:instance_id/:execution_id/history",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("get").
+			Build(),
+		r.getHistory,
+	)
+	g.GET(
+		"/workflow-monitoring/instances/:instance_id/:execution_id/tree",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("get").
+			Build(),
+		r.getTree,
+	)
+	g.POST(
+		"/workflow-monitoring/instances/:instance_id/:execution_id/_cancel",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("manage").
+			Build(),
+		r.cancelInstance,
+	)
+	g.DELETE(
+		"/workflow-monitoring/instances/:instance_id/:execution_id",
+		r.auth.NewRequiredBuilder().
+			ForResource("workflow_monitoring").
+			ForVerb("manage").
+			Build(),
+		r.removeInstance,
+	)
+}

--- a/internal/routes/workflow_monitoring_test.go
+++ b/internal/routes/workflow_monitoring_test.go
@@ -1,0 +1,409 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	wfbackend "github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/backend/history"
+	"github.com/cschleiden/go-workflows/backend/metrics"
+	wfcore "github.com/cschleiden/go-workflows/core"
+	"github.com/cschleiden/go-workflows/diag"
+	wflib "github.com/cschleiden/go-workflows/workflow"
+	"github.com/gin-gonic/gin"
+	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestWorkflowMonitoringRoutes(t *testing.T) {
+	type TestSetup struct {
+		Gin     *gin.Engine
+		Auth    *auth2.AuthTestUtil
+		Backend *fakeWorkflowMonitoringBackend
+	}
+
+	setup := func(t *testing.T, cfg config.C) *TestSetup {
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+		_, auth, authUtil := auth2.TestAuthServiceWithDb(sconfig.ServiceIdApi, cfg, db)
+		backend := &fakeWorkflowMonitoringBackend{}
+		routes := NewWorkflowMonitoringRoutes(auth, backend, pagination.NewRandomCursorEncryptor())
+
+		r := apgin.ForTest(nil)
+		routes.Register(r)
+
+		return &TestSetup{
+			Gin:     r,
+			Auth:    authUtil,
+			Backend: backend,
+		}
+	}
+
+	t.Run("list instances", func(t *testing.T) {
+		t.Run("unauthorized", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/workflow-monitoring/instances", nil)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+
+		t.Run("forbidden", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.Auth.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/workflow-monitoring/instances",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "task_monitoring", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("success", func(t *testing.T) {
+			tu := setup(t, nil)
+			createdAt := time.Now().UTC()
+			tu.Backend.instances = []*diag.WorkflowInstanceRef{
+				{
+					Instance:  wfcore.NewWorkflowInstance("wf-a", "exec-a"),
+					CreatedAt: createdAt,
+					State:     wfcore.WorkflowInstanceStateActive,
+					Queue:     "default",
+				},
+				{
+					Instance:  wfcore.NewWorkflowInstance("wf-b", "exec-b"),
+					CreatedAt: createdAt.Add(-time.Minute),
+					State:     wfcore.WorkflowInstanceStateFinished,
+					Queue:     "default",
+				},
+			}
+
+			w := httptest.NewRecorder()
+			req, err := tu.Auth.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/workflow-monitoring/instances?limit=1",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "workflow_monitoring", "list"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, 2, tu.Backend.listCount)
+
+			var resp ListWorkflowInstancesResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Len(t, resp.Items, 1)
+			require.Equal(t, "wf-a", resp.Items[0].Instance.InstanceID)
+			require.NotEmpty(t, resp.Cursor)
+		})
+	})
+
+	t.Run("get instance includes history", func(t *testing.T) {
+		tu := setup(t, nil)
+		instance := wfcore.NewWorkflowInstance("wf-a", "exec-a")
+		tu.Backend.instance = &diag.WorkflowInstanceRef{
+			Instance: instance,
+			State:    wfcore.WorkflowInstanceStateFinished,
+			Queue:    "default",
+		}
+		tu.Backend.history = []*history.Event{
+			history.NewPendingEvent(time.Now(), history.EventType_WorkflowExecutionStarted, nil),
+		}
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/workflow-monitoring/instances/wf-a/exec-a",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "get"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp WorkflowInstanceInfoJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "wf-a", resp.Instance.InstanceID)
+		require.Len(t, resp.History, 1)
+		require.Equal(t, "WorkflowExecutionStarted", resp.History[0].Type)
+	})
+
+	t.Run("history not found", func(t *testing.T) {
+		tu := setup(t, nil)
+		tu.Backend.historyErr = wfbackend.ErrInstanceNotFound
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/workflow-monitoring/instances/missing/exec/history",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "get"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("tree success", func(t *testing.T) {
+		tu := setup(t, nil)
+		tu.Backend.tree = &diag.WorkflowInstanceTree{
+			WorkflowInstanceRef: &diag.WorkflowInstanceRef{
+				Instance: wfcore.NewWorkflowInstance("wf-a", "exec-a"),
+				State:    wfcore.WorkflowInstanceStateActive,
+			},
+			WorkflowName: "core.connection.disconnect.v1",
+		}
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/workflow-monitoring/instances/wf-a/exec-a/tree",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "get"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp WorkflowInstanceTreeJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "core.connection.disconnect.v1", resp.WorkflowName)
+	})
+
+	t.Run("cancel requires manage", func(t *testing.T) {
+		tu := setup(t, nil)
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodPost,
+			"/workflow-monitoring/instances/wf-a/exec-a/_cancel",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "list"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusForbidden, w.Code)
+		require.False(t, tu.Backend.cancelCalled)
+	})
+
+	t.Run("cancel success", func(t *testing.T) {
+		tu := setup(t, nil)
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodPost,
+			"/workflow-monitoring/instances/wf-a/exec-a/_cancel",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "manage"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.True(t, tu.Backend.cancelCalled)
+		require.Equal(t, "wf-a", tu.Backend.cancelInstance.InstanceID)
+	})
+
+	t.Run("remove unfinished maps to conflict", func(t *testing.T) {
+		tu := setup(t, nil)
+		tu.Backend.removeErr = wfbackend.ErrInstanceNotFinished
+
+		w := httptest.NewRecorder()
+		req, err := tu.Auth.NewSignedRequestForActorExternalId(
+			http.MethodDelete,
+			"/workflow-monitoring/instances/wf-a/exec-a",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.**", "workflow_monitoring", "manage"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code)
+	})
+}
+
+type fakeWorkflowMonitoringBackend struct {
+	instances []*diag.WorkflowInstanceRef
+	instance  *diag.WorkflowInstanceRef
+	history   []*history.Event
+	tree      *diag.WorkflowInstanceTree
+
+	listErr     error
+	instanceErr error
+	historyErr  error
+	treeErr     error
+	cancelErr   error
+	removeErr   error
+
+	listCount      int
+	cancelCalled   bool
+	cancelInstance *wfcore.WorkflowInstance
+	removeCalled   bool
+	removeInstance *wfcore.WorkflowInstance
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowInstances(ctx context.Context, afterInstanceID, afterExecutionID string, count int) ([]*diag.WorkflowInstanceRef, error) {
+	f.listCount = count
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.instances, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowInstance(ctx context.Context, instance *wfcore.WorkflowInstance) (*diag.WorkflowInstanceRef, error) {
+	if f.instanceErr != nil {
+		return nil, f.instanceErr
+	}
+	return f.instance, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowTree(ctx context.Context, instance *wfcore.WorkflowInstance) (*diag.WorkflowInstanceTree, error) {
+	if f.treeErr != nil {
+		return nil, f.treeErr
+	}
+	return f.tree, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) CreateWorkflowInstance(ctx context.Context, instance *wflib.Instance, event *history.Event) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) CancelWorkflowInstance(ctx context.Context, instance *wflib.Instance, cancelEvent *history.Event) error {
+	f.cancelCalled = true
+	f.cancelInstance = instance
+	return f.cancelErr
+}
+
+func (f *fakeWorkflowMonitoringBackend) RemoveWorkflowInstance(ctx context.Context, instance *wflib.Instance) error {
+	f.removeCalled = true
+	f.removeInstance = instance
+	return f.removeErr
+}
+
+func (f *fakeWorkflowMonitoringBackend) RemoveWorkflowInstances(ctx context.Context, options ...wfbackend.RemovalOption) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error) {
+	return wfcore.WorkflowInstanceStateActive, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error) {
+	if f.historyErr != nil {
+		return nil, f.historyErr
+	}
+	return f.history, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) SignalWorkflow(ctx context.Context, instanceID string, event *history.Event) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) PrepareWorkflowQueues(ctx context.Context, queues []wflib.Queue) error {
+	return nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) PrepareActivityQueues(ctx context.Context, queues []wflib.Queue) error {
+	return nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetWorkflowTask(ctx context.Context, queues []wflib.Queue) (*wfbackend.WorkflowTask, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) ExtendWorkflowTask(ctx context.Context, task *wfbackend.WorkflowTask) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) CompleteWorkflowTask(ctx context.Context, task *wfbackend.WorkflowTask, state wfcore.WorkflowInstanceState, executedEvents, activityEvents, timerEvents []*history.Event, workflowEvents []*history.WorkflowEvent) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetActivityTask(ctx context.Context, queues []wflib.Queue) (*wfbackend.ActivityTask, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) ExtendActivityTask(ctx context.Context, task *wfbackend.ActivityTask) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) CompleteActivityTask(ctx context.Context, task *wfbackend.ActivityTask, result *history.Event) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeWorkflowMonitoringBackend) GetStats(ctx context.Context) (*wfbackend.Stats, error) {
+	return &wfbackend.Stats{}, nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) Tracer() trace.Tracer {
+	return trace.NewNoopTracerProvider().Tracer("test")
+}
+
+func (f *fakeWorkflowMonitoringBackend) Metrics() metrics.Client {
+	return noopWorkflowMetrics{}
+}
+
+func (f *fakeWorkflowMonitoringBackend) Options() *wfbackend.Options {
+	return wfbackend.ApplyOptions()
+}
+
+func (f *fakeWorkflowMonitoringBackend) Close() error {
+	return nil
+}
+
+func (f *fakeWorkflowMonitoringBackend) FeatureSupported(feature wfbackend.Feature) bool {
+	return true
+}
+
+type noopWorkflowMetrics struct{}
+
+func (noopWorkflowMetrics) Counter(name string, tags metrics.Tags, value int64) {}
+
+func (noopWorkflowMetrics) Distribution(name string, tags metrics.Tags, value float64) {}
+
+func (noopWorkflowMetrics) Gauge(name string, tags metrics.Tags, value int64) {}
+
+func (noopWorkflowMetrics) Timing(name string, tags metrics.Tags, duration time.Duration) {}
+
+func (noopWorkflowMetrics) WithTags(tags metrics.Tags) metrics.Client {
+	return noopWorkflowMetrics{}
+}

--- a/internal/schema/api/auxiliary.go
+++ b/internal/schema/api/auxiliary.go
@@ -206,3 +206,50 @@ type ListSchedulerEntriesResponseJson struct {
 type ListQueueHistoryResponseJson struct {
 	Items []*DailyStatsJson `json:"items" yaml:"items"`
 }
+
+type WorkflowInstanceJson struct {
+	InstanceID  string                `json:"instance_id" yaml:"instance_id"`
+	ExecutionID string                `json:"execution_id" yaml:"execution_id"`
+	Parent      *WorkflowInstanceJson `json:"parent,omitempty" yaml:"parent,omitempty"`
+}
+
+type WorkflowInstanceRefJson struct {
+	Instance    *WorkflowInstanceJson `json:"instance,omitempty" yaml:"instance,omitempty"`
+	CreatedAt   time.Time             `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	CompletedAt *time.Time            `json:"completed_at,omitempty" yaml:"completed_at,omitempty"`
+	State       string                `json:"state" yaml:"state"`
+	Queue       string                `json:"queue" yaml:"queue"`
+}
+
+type WorkflowHistoryEventJson struct {
+	ID              string      `json:"id,omitempty" yaml:"id,omitempty"`
+	SequenceID      int64       `json:"sequence_id,omitempty" yaml:"sequence_id,omitempty"`
+	Type            string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Timestamp       time.Time   `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	ScheduleEventID int64       `json:"schedule_event_id,omitempty" yaml:"schedule_event_id,omitempty"`
+	Attributes      interface{} `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+	VisibleAt       *time.Time  `json:"visible_at,omitempty" yaml:"visible_at,omitempty"`
+}
+
+type WorkflowInstanceInfoJson struct {
+	*WorkflowInstanceRefJson
+
+	History []*WorkflowHistoryEventJson `json:"history,omitempty" yaml:"history,omitempty"`
+}
+
+type WorkflowInstanceTreeJson struct {
+	*WorkflowInstanceRefJson
+
+	WorkflowName string                      `json:"workflow_name,omitempty" yaml:"workflow_name,omitempty"`
+	Error        bool                        `json:"error,omitempty" yaml:"error,omitempty"`
+	Children     []*WorkflowInstanceTreeJson `json:"children,omitempty" yaml:"children,omitempty"`
+}
+
+type ListWorkflowInstancesResponseJson struct {
+	Items  []*WorkflowInstanceRefJson `json:"items" yaml:"items"`
+	Cursor string                     `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+}
+
+type ListWorkflowHistoryResponseJson struct {
+	Items []*WorkflowHistoryEventJson `json:"items" yaml:"items"`
+}

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -180,6 +180,15 @@ func GetGinServer(
 		dm.GetAsyncInspector(),
 		dm.GetEncryptService(),
 	)
+	workflowDiagnostics, err := dm.GetWorkflowRuntime().DiagnosticBackend()
+	if err != nil {
+		return nil, nil, err
+	}
+	routesWorkflowMonitoring := common_routes.NewWorkflowMonitoringRoutes(
+		authService,
+		workflowDiagnostics,
+		dm.GetEncryptService(),
+	)
 
 	api := server.Group("/api/v1")
 
@@ -191,6 +200,7 @@ func GetGinServer(
 	routesRequestEvents.Register(api)
 	routesActors.Register(api)
 	routesTaskMonitoring.Register(api)
+	routesWorkflowMonitoring.Register(api)
 
 	if service.SupportsSession() && service.SupportsUi() {
 		routesSession := common_routes.NewSessionRoutes(

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cschleiden/go-workflows/backend/sqlite"
 	"github.com/cschleiden/go-workflows/client"
 	wfcore "github.com/cschleiden/go-workflows/core"
+	"github.com/cschleiden/go-workflows/diag"
 	"github.com/cschleiden/go-workflows/registry"
 	wfworker "github.com/cschleiden/go-workflows/worker"
 	wflib "github.com/cschleiden/go-workflows/workflow"
@@ -171,6 +172,19 @@ func migrateDB(db *sql.DB, driverName string, sourcePath string) error {
 
 func (r *Runtime) Backend() wfbackend.Backend {
 	return r.backend
+}
+
+func (r *Runtime) DiagnosticBackend() (diag.Backend, error) {
+	if r == nil || r.backend == nil {
+		return nil, fmt.Errorf("workflow runtime is required")
+	}
+
+	backend, ok := r.backend.(diag.Backend)
+	if !ok {
+		return nil, fmt.Errorf("workflow backend does not support diagnostics")
+	}
+
+	return backend, nil
 }
 
 func (r *Runtime) Client() *client.Client {


### PR DESCRIPTION
## Summary
- Add `/api/v1/workflow-monitoring/instances` Admin API endpoints for listing workflow instances with cursor pagination.
- Add instance detail, history, and tree endpoints backed by go-workflows diagnostics APIs.
- Add cancel and remove management endpoints gated by `workflow_monitoring:manage`.
- Add AuthProxy-owned workflow monitoring response DTOs and focused route tests for read/manage permission separation and error mapping.

Closes #520.

## Verification
- `env GOCACHE=/tmp/authproxy-go-build AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/routes -run TestWorkflowMonitoringRoutes -count=1`
- `env GOCACHE=/tmp/authproxy-go-build AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/routes ./internal/workflows ./internal/service ./internal/service/admin_api`
- `./scripts/preflight.sh`
- push hook preflight passed
