### PR TITLE
Pin demo OAuth provider image

### DIFF
--- a/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
+++ b/deploy/charts/authproxy-demo/templates/go-oauth2-server.yaml
@@ -26,7 +26,11 @@ spec:
     spec:
       containers:
         - name: go-oauth2-server
+          {{- if .Values.goOauth2Server.image.digest }}
+          image: "{{ .Values.goOauth2Server.image.repository }}@{{ .Values.goOauth2Server.image.digest }}"
+          {{- else }}
           image: "{{ .Values.goOauth2Server.image.repository }}:{{ .Values.goOauth2Server.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.goOauth2Server.image.pullPolicy }}
           command: ["go-oauth2-server"]
           # go-oauth2-server's entrypoint is a CLI; test mode uses an

--- a/deploy/charts/authproxy-demo/values.yaml
+++ b/deploy/charts/authproxy-demo/values.yaml
@@ -54,10 +54,11 @@ goOauth2Server:
   enabled: true
   image:
     # go-oauth2-server image — see https://github.com/rmorlok/go-oauth2-server.
-    # Upstream's default branch is `master`, so that's the tag the Build
-    # Image workflow over there publishes.
+    # Upstream's default branch is `master`; pin the digest here so demo
+    # deploys advance only when AuthProxy explicitly updates this dependency.
     repository: ghcr.io/rmorlok/go-oauth2-server
     tag: "master"
+    digest: "sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources:


### PR DESCRIPTION
## Summary

- pins the demo go-oauth2-server image to the current multi-arch digest that includes `/test/api-key-resource-policy`
- teaches the demo chart to render `repository@digest` when `goOauth2Server.image.digest` is set
- keeps the existing `master` tag as human context and leaves `pullPolicy: IfNotPresent` because the digest is immutable

## Diagnosis

The live demo deployment was running `ghcr.io/rmorlok/go-oauth2-server:master` with `imagePullPolicy: IfNotPresent`.
The running pod started on 2026-06-02 and was using digest `sha256:bf45df85d3b6374c0f0e075457634f4f0986e0ab9240951bd25ee8ebe439595c`, which predates the API-key test resource endpoint.

The current upstream `master` commit is `7832e95ca73a8928a04589770479c352ffe98e3f` and the current GHCR multi-arch digest is `sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3`.

## Validation

- `helm lint deploy/charts/authproxy-demo`
- `helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test`
- `helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.authproxy.net --set goOauth2Server.image.digest= --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test`
- `./scripts/preflight.sh`
