### PR TITLE
Track workflow-backed task terminal failures

### DIFF
--- a/internal/routes/tasks.go
+++ b/internal/routes/tasks.go
@@ -3,9 +3,11 @@ package routes
 import (
 	"errors"
 	"net/http"
+	"reflect"
 	"time"
 
 	wfbackend "github.com/cschleiden/go-workflows/backend"
+	wfhistory "github.com/cschleiden/go-workflows/backend/history"
 	wfcore "github.com/cschleiden/go-workflows/core"
 	"github.com/gin-gonic/gin"
 	"github.com/hibiken/asynq"
@@ -103,6 +105,53 @@ func WorkflowTaskInfoToJson(encryptedId string, ti *tasks.TaskInfo, state wfcore
 	}
 }
 
+func WorkflowTaskInfoStateFromHistory(state wfcore.WorkflowInstanceState, historyEvents []*wfhistory.Event) TaskState {
+	switch state {
+	case wfcore.WorkflowInstanceStateActive:
+		return TaskStateActive
+	case wfcore.WorkflowInstanceStateContinuedAsNew:
+		return TaskStateCompleted
+	case wfcore.WorkflowInstanceStateFinished:
+		for i := len(historyEvents) - 1; i >= 0; i-- {
+			event := historyEvents[i]
+			if event == nil {
+				continue
+			}
+			switch event.Type {
+			case wfhistory.EventType_WorkflowExecutionCanceled, wfhistory.EventType_WorkflowExecutionTerminated:
+				return TaskStateFailed
+			case wfhistory.EventType_WorkflowExecutionFinished:
+				if workflowCompletionHasError(event.Attributes) {
+					return TaskStateFailed
+				}
+				return TaskStateCompleted
+			}
+		}
+		return TaskStateCompleted
+	default:
+		return TaskStateUnknown
+	}
+}
+
+func workflowCompletionHasError(attrs any) bool {
+	v := reflect.ValueOf(attrs)
+	if !v.IsValid() {
+		return false
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+
+	errorField := v.FieldByName("Error")
+	return errorField.IsValid() && !errorField.IsZero()
+}
+
 // @Summary		Get task status
 // @Description	Get the status of a background task by its encrypted task info
 // @Tags			tasks
@@ -170,7 +219,23 @@ func (r *TaskRoutes) get(gctx *gin.Context) {
 			return
 		}
 
-		gctx.PureJSON(http.StatusOK, WorkflowTaskInfoToJson(encryptedTaskInfo, ti, state))
+		var historyEvents []*wfhistory.Event
+		if state == wfcore.WorkflowInstanceStateFinished {
+			historyEvents, err = r.workflowClient.GetWorkflowInstanceHistory(ctx, instance, nil)
+			if err != nil {
+				if errors.Is(err, wfbackend.ErrInstanceNotFound) {
+					apgin.WriteError(gctx, nil, httperr.NotFound("task not found"))
+					return
+				}
+
+				apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("failed to load task", httperr.WithInternalErr(err)))
+				return
+			}
+		}
+
+		resp := WorkflowTaskInfoToJson(encryptedTaskInfo, ti, state)
+		resp.State = WorkflowTaskInfoStateFromHistory(state, historyEvents)
+		gctx.PureJSON(http.StatusOK, resp)
 		return
 	}
 

--- a/internal/routes/tasks_test.go
+++ b/internal/routes/tasks_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/backend/history"
 	"github.com/cschleiden/go-workflows/client"
 	wfcore "github.com/cschleiden/go-workflows/core"
 	wflib "github.com/cschleiden/go-workflows/workflow"
@@ -31,8 +32,10 @@ import (
 )
 
 type fakeTaskWorkflowClient struct {
-	state wfcore.WorkflowInstanceState
-	err   error
+	state      wfcore.WorkflowInstanceState
+	history    []*history.Event
+	err        error
+	historyErr error
 
 	requestedInstance *wflib.Instance
 }
@@ -46,10 +49,16 @@ func (f *fakeTaskWorkflowClient) GetWorkflowInstanceState(ctx context.Context, i
 	return f.state, f.err
 }
 
+func (f *fakeTaskWorkflowClient) GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error) {
+	f.requestedInstance = instance
+	return f.history, f.historyErr
+}
+
 func TestTasks(t *testing.T) {
 	type TestSetup struct {
 		Gin            *gin.Engine
 		Cfg            config.C
+		AuthService    auth2.A
 		AuthUtil       *auth2.AuthTestUtil
 		MockInspector  *mock.MockInspector
 		WorkflowClient *fakeTaskWorkflowClient
@@ -77,6 +86,7 @@ func TestTasks(t *testing.T) {
 		return &TestSetup{
 			Gin:            r,
 			Cfg:            cfg,
+			AuthService:    auth,
 			AuthUtil:       authUtil,
 			MockInspector:  mockInspector,
 			WorkflowClient: workflowClient,
@@ -86,6 +96,26 @@ func TestTasks(t *testing.T) {
 
 	t.Run("get task", func(t *testing.T) {
 		tu := setup(t, nil)
+
+		workflowToken := func(t *testing.T, tu *TestSetup, mutate func(*tasks.TaskInfo)) string {
+			t.Helper()
+
+			taskInfo := &tasks.TaskInfo{
+				TrackedVia:          tasks.TrackedViaWorkflow,
+				WorkflowInstanceId:  "workflow-instance-id",
+				WorkflowExecutionId: "workflow-execution-id",
+				WorkflowName:        "core.connection.disconnect.v1",
+				WorkflowQueue:       "default",
+			}
+			if mutate != nil {
+				mutate(taskInfo)
+			}
+
+			ctx := context.Background()
+			encryptedTaskInfo, err := taskInfo.ToSecureEncryptedString(ctx, tu.EncryptService)
+			require.NoError(t, err)
+			return encryptedTaskInfo
+		}
 
 		t.Run("unauthorized", func(t *testing.T) {
 			w := httptest.NewRecorder()
@@ -317,51 +347,92 @@ func TestTasks(t *testing.T) {
 		})
 
 		t.Run("workflow success", func(t *testing.T) {
-			tu := setup(t, nil)
-			taskInfo := &tasks.TaskInfo{
-				TrackedVia:          tasks.TrackedViaWorkflow,
-				WorkflowInstanceId:  "workflow-instance-id",
-				WorkflowExecutionId: "workflow-execution-id",
-				WorkflowName:        "core.connection.disconnect.v1",
-				WorkflowQueue:       "default",
+			tests := []struct {
+				name      string
+				state     wfcore.WorkflowInstanceState
+				history   []*history.Event
+				wantState TaskState
+			}{
+				{
+					name:      "active",
+					state:     wfcore.WorkflowInstanceStateActive,
+					wantState: TaskStateActive,
+				},
+				{
+					name:      "continued as new",
+					state:     wfcore.WorkflowInstanceStateContinuedAsNew,
+					wantState: TaskStateCompleted,
+				},
+				{
+					name:  "finished",
+					state: wfcore.WorkflowInstanceStateFinished,
+					history: []*history.Event{
+						{
+							Type:       history.EventType_WorkflowExecutionFinished,
+							Attributes: &history.ExecutionCompletedAttributes{},
+						},
+					},
+					wantState: TaskStateCompleted,
+				},
+				{
+					name:  "finished with error",
+					state: wfcore.WorkflowInstanceStateFinished,
+					history: []*history.Event{
+						{
+							Type: history.EventType_WorkflowExecutionFinished,
+							Attributes: &struct {
+								Error string
+							}{Error: "workflow failed"},
+						},
+					},
+					wantState: TaskStateFailed,
+				},
+				{
+					name:  "canceled",
+					state: wfcore.WorkflowInstanceStateFinished,
+					history: []*history.Event{
+						{
+							Type: history.EventType_WorkflowExecutionCanceled,
+						},
+					},
+					wantState: TaskStateFailed,
+				},
+				{
+					name:      "unknown workflow state",
+					state:     wfcore.WorkflowInstanceState(99),
+					wantState: TaskStateUnknown,
+				},
 			}
 
-			ctx := context.Background()
-			encryptedTaskInfo, err := taskInfo.ToSecureEncryptedString(ctx, tu.EncryptService)
-			require.NoError(t, err)
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					tu := setup(t, nil)
+					encryptedTaskInfo := workflowToken(t, tu, nil)
+					tu.WorkflowClient.state = tc.state
+					tu.WorkflowClient.history = tc.history
 
-			tu.WorkflowClient.state = wfcore.WorkflowInstanceStateFinished
+					w := httptest.NewRecorder()
+					req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+					require.NoError(t, err)
 
-			w := httptest.NewRecorder()
-			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
-			require.NoError(t, err)
+					tu.Gin.ServeHTTP(w, req)
+					require.Equal(t, http.StatusOK, w.Code)
 
-			tu.Gin.ServeHTTP(w, req)
-			require.Equal(t, http.StatusOK, w.Code)
-
-			var resp TaskInfoJson
-			err = json.Unmarshal(w.Body.Bytes(), &resp)
-			require.NoError(t, err)
-			require.Equal(t, encryptedTaskInfo, resp.Id)
-			require.Equal(t, "core.connection.disconnect.v1", resp.Type)
-			require.Equal(t, string(TaskStateCompleted), string(resp.State))
-			require.Equal(t, "workflow-instance-id", tu.WorkflowClient.requestedInstance.InstanceID)
-			require.Equal(t, "workflow-execution-id", tu.WorkflowClient.requestedInstance.ExecutionID)
+					var resp TaskInfoJson
+					err = json.Unmarshal(w.Body.Bytes(), &resp)
+					require.NoError(t, err)
+					require.Equal(t, encryptedTaskInfo, resp.Id)
+					require.Equal(t, "core.connection.disconnect.v1", resp.Type)
+					require.Equal(t, string(tc.wantState), string(resp.State))
+					require.Equal(t, "workflow-instance-id", tu.WorkflowClient.requestedInstance.InstanceID)
+					require.Equal(t, "workflow-execution-id", tu.WorkflowClient.requestedInstance.ExecutionID)
+				})
+			}
 		})
 
 		t.Run("workflow not found", func(t *testing.T) {
 			tu := setup(t, nil)
-			taskInfo := &tasks.TaskInfo{
-				TrackedVia:          tasks.TrackedViaWorkflow,
-				WorkflowInstanceId:  "workflow-instance-id",
-				WorkflowExecutionId: "workflow-execution-id",
-				WorkflowName:        "core.connection.disconnect.v1",
-			}
-
-			ctx := context.Background()
-			encryptedTaskInfo, err := taskInfo.ToSecureEncryptedString(ctx, tu.EncryptService)
-			require.NoError(t, err)
-
+			encryptedTaskInfo := workflowToken(t, tu, nil)
 			tu.WorkflowClient.err = backend.ErrInstanceNotFound
 
 			w := httptest.NewRecorder()
@@ -370,6 +441,63 @@ func TestTasks(t *testing.T) {
 
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusNotFound, w.Code)
+		})
+
+		t.Run("workflow client error", func(t *testing.T) {
+			tu := setup(t, nil)
+			encryptedTaskInfo := workflowToken(t, tu, nil)
+			tu.WorkflowClient.err = errors.New("workflow backend unavailable")
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusInternalServerError, w.Code)
+		})
+
+		t.Run("workflow history error", func(t *testing.T) {
+			tu := setup(t, nil)
+			encryptedTaskInfo := workflowToken(t, tu, nil)
+			tu.WorkflowClient.state = wfcore.WorkflowInstanceStateFinished
+			tu.WorkflowClient.historyErr = errors.New("workflow history unavailable")
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusInternalServerError, w.Code)
+		})
+
+		t.Run("workflow tracking not configured", func(t *testing.T) {
+			tu := setup(t, nil)
+			tr := NewTaskRoutes(tu.Cfg, tu.AuthService, tu.EncryptService, tu.MockInspector, nil)
+			tu.Gin = apgin.ForTest(nil)
+			tr.Register(tu.Gin)
+
+			encryptedTaskInfo := workflowToken(t, tu, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusInternalServerError, w.Code)
+		})
+
+		t.Run("missing workflow data", func(t *testing.T) {
+			tu := setup(t, nil)
+			encryptedTaskInfo := workflowToken(t, tu, func(taskInfo *tasks.TaskInfo) {
+				taskInfo.WorkflowInstanceId = ""
+			})
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(http.MethodGet, "/tasks/"+encryptedTaskInfo, nil, "root", "some-actor", aschema.NoPermissions())
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusInternalServerError, w.Code)
 		})
 	})
 }

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	wfbackend "github.com/cschleiden/go-workflows/backend"
+	"github.com/cschleiden/go-workflows/backend/history"
 	"github.com/cschleiden/go-workflows/backend/postgres"
 	"github.com/cschleiden/go-workflows/backend/sqlite"
 	"github.com/cschleiden/go-workflows/client"
@@ -46,6 +47,7 @@ type Runtime struct {
 type Client interface {
 	CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error)
 	GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error)
+	GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error)
 }
 
 func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *slog.Logger) (*Runtime, error) {
@@ -187,8 +189,20 @@ func (r *Runtime) DiagnosticBackend() (diag.Backend, error) {
 	return backend, nil
 }
 
-func (r *Runtime) Client() *client.Client {
-	return r.client
+func (r *Runtime) Client() Client {
+	return r
+}
+
+func (r *Runtime) CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error) {
+	return r.client.CreateWorkflowInstance(ctx, options, workflow, args...)
+}
+
+func (r *Runtime) GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error) {
+	return r.client.GetWorkflowInstanceState(ctx, instance)
+}
+
+func (r *Runtime) GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error) {
+	return r.backend.GetWorkflowInstanceHistory(ctx, instance, lastSequenceID)
 }
 
 func (r *Runtime) Ping(ctx context.Context) bool {


### PR DESCRIPTION
## Summary
- Extend the AuthProxy workflow client interface so task polling can inspect workflow history for terminal executions.
- Map workflow completion errors, cancellations, and terminations to the existing task `failed` state while preserving active/completed mappings.
- Expand `/tasks/{encryptedTaskInfo}` route tests for workflow-backed tokens across active, completed, failed, canceled, missing, not-found, and backend error cases.

Closes #524

## Verification
- `go test ./internal/routes -run TestTasks -count=1`
- `go test ./internal/routes ./internal/workflows ./internal/service ./internal/core -count=1`
- `./scripts/preflight.sh`