### PR TITLE
Gate generated demo dependency secrets

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -75,6 +75,29 @@ jobs:
         if: steps.changed.outputs.found == 'true'
         run: ct lint --config .github/ct.yaml --target-branch main
 
+      - name: Verify demo slim storage render
+        if: steps.changed.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          helm dependency build deploy/charts/authproxy-demo
+          manifest="$(mktemp)"
+          helm template dev deploy/charts/authproxy-demo \
+            -f deploy/charts/authproxy-demo/dev-slim-values.yaml \
+            --set global.hostname=branch.dev.authproxy.net \
+            --set authproxy.image.repository=ghcr.io/rmorlok/authproxy \
+            --set authproxy.image.tag=test \
+            --set demoShell.image.tag=test \
+            --set seed.image.tag=test \
+            --set secrets.autoGenerate=true \
+            >"${manifest}"
+
+          grep -q "provider: miniredis" "${manifest}"
+
+          if grep -Eq "name: dev-(db|redis-creds|minio-creds|postgresql|redis|minio)|AUTHPROXY_(DB|REDIS)_PASSWORD|root-password|kind: StatefulSet" "${manifest}"; then
+            echo "Slim dev render leaked dependency credentials or workloads" >&2
+            exit 1
+          fi
+
   install:
     runs-on: ubuntu-latest
     needs: lint

--- a/deploy/charts/authproxy-demo/templates/secrets.yaml
+++ b/deploy/charts/authproxy-demo/templates/secrets.yaml
@@ -24,7 +24,11 @@ the surrounding trim-stripping directives can't glue the last
 comment line into the apiVersion that follows.
 */}}
 {{- if .Values.secrets.autoGenerate }}
+{{- $dbProvider := default "postgres" .Values.authproxy.database.provider -}}
+{{- $redisProvider := default "redis" .Values.authproxy.redis.provider -}}
+{{- $minioEnabled := .Values.minio.enabled -}}
 
+{{- if eq $dbProvider "postgres" }}
 {{/* ---- DB password -------------------------------------------- */}}
 {{- $dbSecretName := printf "%s-db" .Release.Name -}}
 {{- $dbExisting := lookup "v1" "Secret" .Release.Namespace $dbSecretName -}}
@@ -44,6 +48,8 @@ type: Opaque
 data:
   AUTHPROXY_DB_PASSWORD: {{ $dbPw }}
 ---
+{{- end }}
+{{- if eq $redisProvider "redis" }}
 {{/* ---- Redis password ----------------------------------------- */}}
 {{- $redisSecretName := printf "%s-redis-creds" .Release.Name -}}
 {{- $redisExisting := lookup "v1" "Secret" .Release.Namespace $redisSecretName -}}
@@ -63,6 +69,8 @@ type: Opaque
 data:
   AUTHPROXY_REDIS_PASSWORD: {{ $redisPw }}
 ---
+{{- end }}
+{{- if $minioEnabled }}
 {{/* ---- MinIO root password ------------------------------------ */}}
 {{- $minioSecretName := printf "%s-minio-creds" .Release.Name -}}
 {{- $minioExisting := lookup "v1" "Secret" .Release.Namespace $minioSecretName -}}
@@ -85,4 +93,5 @@ data:
   # so the chart values stay clean.
   root-user: {{ "authproxy" | b64enc }}
   root-password: {{ $minioRoot }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- gates demo auto-generated DB, Redis, and MinIO dependency secrets on the matching storage mode
- adds a Helm Chart CI render guard for the slim dev profile
- verifies the slim profile renders `provider: miniredis` without generated dependency credentials, dependency workloads, or StatefulSets

Closes #548.

## Notes

The main miniredis config rendering support already landed with the slim dev profile. This PR closes the remaining umbrella-chart gap: when `secrets.autoGenerate=true`, the chart should not create unused dependency secrets for a SQLite/miniredis/no-MinIO deployment.

## Validation

- `helm lint deploy/charts/authproxy-demo`
- `helm template dev deploy/charts/authproxy-demo -f deploy/charts/authproxy-demo/dev-slim-values.yaml --set global.hostname=branch.dev.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test --set secrets.autoGenerate=true`
- `helm template demo deploy/charts/authproxy-demo --set global.hostname=demo.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test --set secrets.autoGenerate=true`
- `./scripts/preflight.sh`
