### PR TITLE
Add workflow guardrail tests

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -132,6 +132,18 @@ Before merging a workflow change:
 - Admin and task-monitoring surfaces can still resolve in-flight instances created before the change.
 - Documentation identifies when the old version can be retired.
 
+## Local Checks
+
+Run workflow guardrails locally before merging workflow changes:
+
+```bash
+./scripts/check-workflows.sh
+```
+
+This script runs focused workflow tests that exercise the disconnect pilot workflow with the go-workflows tester and verify its durable workflow/activity names remain registered. It is also called by `./scripts/preflight.sh`.
+
+The current pinned go-workflows release does not package the analyzer mentioned by newer go-workflows documentation, so AuthProxy relies on these local tests for now. When the dependency exposes an analyzer package that matches the pinned release, add it to this check or CI without replacing the registration tests; the tests protect AuthProxy's versioning convention directly.
+
 ## Retirement
 
 Old versions can be removed only when all of the following are true:

--- a/internal/core/task_disconnect_connection.go
+++ b/internal/core/task_disconnect_connection.go
@@ -21,6 +21,11 @@ const (
 	ActivityNameDisconnectConnectionFinalizeV1          = "core.connection.disconnect.finalize.v1"
 )
 
+type workflowRegistrar interface {
+	RegisterWorkflow(workflow wflib.Workflow, opts ...registry.RegisterOption) error
+	RegisterActivity(activity wflib.Activity, opts ...registry.RegisterOption) error
+}
+
 // maxRevokeAttempts caps the number of times a revoke operation is retried
 // inside a single disconnect task invocation. After exhausting attempts, the
 // disconnect proceeds so a connection cannot get stuck in `disconnecting`
@@ -56,7 +61,7 @@ func disconnectConnectionRevokeActivityOptions() wflib.ActivityOptions {
 	return opts
 }
 
-func (s *service) registerDisconnectConnectionWorkflow(worker *apworkflows.Worker) error {
+func (s *service) registerDisconnectConnectionWorkflow(worker workflowRegistrar) error {
 	if err := worker.RegisterWorkflow(
 		disconnectConnectionWorkflowV1,
 		registry.WithName(WorkflowNameDisconnectConnectionV1),

--- a/internal/core/task_disconnect_connection_workflow_test.go
+++ b/internal/core/task_disconnect_connection_workflow_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cschleiden/go-workflows/registry"
+	"github.com/cschleiden/go-workflows/tester"
+	"github.com/rmorlok/authproxy/internal/apid"
+	testifymock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisconnectConnectionWorkflowV1ExecutesRegisteredActivities(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection).String()
+	workflowTester := tester.NewWorkflowTester[any](disconnectConnectionWorkflowV1)
+
+	revokeActivity := func(context.Context, string) error {
+		return nil
+	}
+	finalizeActivity := func(context.Context, string) error {
+		return nil
+	}
+
+	revokeCall := workflowTester.
+		OnActivityByName(
+			ActivityNameDisconnectConnectionRevokeCredentialsV1,
+			revokeActivity,
+			testifymock.Anything,
+			connectionId,
+		).
+		Return(nil).
+		Once()
+	workflowTester.
+		OnActivityByName(
+			ActivityNameDisconnectConnectionFinalizeV1,
+			finalizeActivity,
+			testifymock.Anything,
+			connectionId,
+		).
+		Return(nil).
+		Once().
+		NotBefore(revokeCall)
+
+	workflowTester.Execute(context.Background(), connectionId)
+
+	require.True(t, workflowTester.WorkflowFinished())
+	_, err := workflowTester.WorkflowResult()
+	require.NoError(t, err)
+	workflowTester.AssertExpectations(t)
+}
+
+func TestRegisterDisconnectConnectionWorkflowV1DurableNames(t *testing.T) {
+	reg := registry.New()
+	svc := &service{}
+
+	require.NoError(t, svc.registerDisconnectConnectionWorkflow(reg))
+
+	_, err := reg.GetWorkflow(WorkflowNameDisconnectConnectionV1)
+	require.NoError(t, err)
+
+	_, err = reg.GetActivity(ActivityNameDisconnectConnectionRevokeCredentialsV1)
+	require.NoError(t, err)
+
+	_, err = reg.GetActivity(ActivityNameDisconnectConnectionFinalizeV1)
+	require.NoError(t, err)
+}

--- a/internal/core/task_disconnect_connection_workflow_test.go
+++ b/internal/core/task_disconnect_connection_workflow_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// This test asserts that the real workflow will invoke the activities that are part of it.
 func TestDisconnectConnectionWorkflowV1ExecutesRegisteredActivities(t *testing.T) {
 	connectionId := apid.New(apid.PrefixConnection).String()
 	workflowTester := tester.NewWorkflowTester[any](disconnectConnectionWorkflowV1)
@@ -50,6 +51,9 @@ func TestDisconnectConnectionWorkflowV1ExecutesRegisteredActivities(t *testing.T
 	workflowTester.AssertExpectations(t)
 }
 
+// This test just verifies that the workflow and activities are registered with the correct durable names. This
+// test can be removed once these names are removed, as part of the defined lifecycle for when workflow versions
+// must be maintained.
 func TestRegisterDisconnectConnectionWorkflowV1DurableNames(t *testing.T) {
 	reg := registry.New()
 	svc := &service{}

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+go test ./internal/core -run 'TestDisconnectConnectionWorkflowV1|TestRegisterDisconnectConnectionWorkflowV1' -count=1

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -38,6 +38,9 @@ say "Checking integration_tests module (go list -mod=readonly)"
   go list -mod=readonly ./... >/dev/null
 )
 
+say "Checking workflow guardrails"
+"$ROOT_DIR/scripts/check-workflows.sh" >/dev/null
+
 say "Checking schema package layout"
 "$ROOT_DIR/scripts/check-schema-layout.sh" >/dev/null
 


### PR DESCRIPTION
## Summary

- add go-workflows tester coverage for the disconnect connection workflow
- verify the disconnect workflow and activity durable names stay registered
- add a local workflow guardrail script and run it from preflight
- document how to run workflow guardrails locally and note the analyzer gap in the pinned go-workflows release

Closes #521

## Tests

- ./scripts/check-workflows.sh
- go test ./internal/core
- ./scripts/preflight.sh