### PR TITLE
Share Postgres pool with workflow runtime

### DIFF
--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -213,8 +213,12 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 	// This ensures each test gets a fresh, clean database.
 	// MustApplyBlankTestDbConfig reads connection info from POSTGRES_TEST_* env vars
 	// and updates cfg.GetRoot().Database to point at the new isolated database.
-	cfg, _ = database.MustApplyBlankTestDbConfig(t, cfg)
-	require.NoError(t, workflows.Migrate(cfg.GetRoot(), cfg.GetRoot().GetRootLogger()))
+	cfg, _, rawDb := database.MustApplyBlankTestDbConfigRaw(t, cfg)
+	require.NoError(t, workflows.Migrate(
+		cfg.GetRoot(),
+		cfg.GetRoot().GetRootLogger(),
+		workflows.WithPostgresMigrationDB(rawDb),
+	))
 
 	// Merge test-specific connectors into config
 	if len(opts.Connectors) > 0 {

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -15,9 +15,9 @@ import (
 	chmigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -27,7 +27,7 @@ type clickhouseRecordStore struct {
 	logger *slog.Logger
 }
 
-func NewClickhouseRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...database.Option) RecordStore {
+func NewClickhouseRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...sqlh.Option) RecordStore {
 	chCfg, ok := cfg.InnerVal.(*config.DatabaseClickhouse)
 	if !ok {
 		panic(fmt.Sprintf("expected *config.DatabaseClickhouse, got %T", cfg))
@@ -38,7 +38,7 @@ func NewClickhouseRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts 
 		panic(fmt.Errorf("failed to convert clickhouse config to options: %w", err))
 	}
 
-	db := database.OpenInstrumentedConnector(clickhouse.Connector(chOpts), database.DBSystemClickHouse, dbOpts...)
+	db := sqlh.OpenInstrumentedConnector(clickhouse.Connector(chOpts), sqlh.DBSystemClickHouse, dbOpts...)
 	s := &clickhouseRecordStore{
 		db:     db,
 		cfg:    chCfg,
@@ -198,7 +198,7 @@ type clickhouseRecordRetriever struct {
 	logger          *slog.Logger
 }
 
-func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...database.Option) RecordRetriever {
+func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...sqlh.Option) RecordRetriever {
 	chCfg, ok := cfg.InnerVal.(*config.DatabaseClickhouse)
 	if !ok {
 		panic(fmt.Sprintf("expected *config.DatabaseClickhouse, got %T", cfg))
@@ -209,7 +209,7 @@ func NewClickhouseRecordRetriever(cfg *config.Database, cursorEncryptor paginati
 		panic(fmt.Errorf("failed to convert clickhouse config to options: %w", err))
 	}
 
-	db := database.OpenInstrumentedConnector(clickhouse.Connector(options), database.DBSystemClickHouse, dbOpts...)
+	db := sqlh.OpenInstrumentedConnector(clickhouse.Connector(options), sqlh.DBSystemClickHouse, dbOpts...)
 	return &clickhouseRecordRetriever{
 		db:              db,
 		cfg:             chCfg,

--- a/internal/app_metrics/provider_factory.go
+++ b/internal/app_metrics/provider_factory.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -15,11 +15,11 @@ import (
 func dbSystemFor(p config.DatabaseProvider) string {
 	switch p {
 	case config.DatabaseProviderPostgres:
-		return database.DBSystemPostgreSQL
+		return sqlh.DBSystemPostgreSQL
 	case config.DatabaseProviderSqlite:
-		return database.DBSystemSQLite
+		return sqlh.DBSystemSQLite
 	case config.DatabaseProviderClickhouse:
-		return database.DBSystemClickHouse
+		return sqlh.DBSystemClickHouse
 	default:
 		return ""
 	}
@@ -27,9 +27,9 @@ func dbSystemFor(p config.DatabaseProvider) string {
 
 // NewRecordStore creates a RecordStore based on the app metrics database configuration.
 // dbOpts are forwarded to the underlying instrumented DB constructor —
-// callers pass database.WithTelemetry(...) to enable spans + metrics on the
+// callers pass sqlh.WithTelemetry(...) to enable spans + metrics on the
 // request-events database tier.
-func NewRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...database.Option) RecordStore {
+func NewRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...sqlh.Option) RecordStore {
 	provider := cfg.GetProvider()
 
 	switch provider {
@@ -45,7 +45,7 @@ func NewRecordStore(cfg *config.Database, logger *slog.Logger, dbOpts ...databas
 }
 
 // NewRecordRetriever creates a RecordRetriever based on the app metrics database configuration.
-func NewRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...database.Option) RecordRetriever {
+func NewRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, dbOpts ...sqlh.Option) RecordRetriever {
 	provider := cfg.GetProvider()
 	switch provider {
 	case config.DatabaseProviderSqlite:

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -40,8 +41,8 @@ type sqlRecordStore struct {
 	placeholderFormat sq.PlaceholderFormat
 }
 
-func NewSqlRecordStore(cfg *config.Database, logger *slog.Logger, opts ...database.Option) RecordStore {
-	db, err := database.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
+func NewSqlRecordStore(cfg *config.Database, logger *slog.Logger, opts ...sqlh.Option) RecordStore {
+	db, err := sqlh.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
 	if err != nil {
 		panic(fmt.Errorf("failed to open app metrics database: %w", err))
 	}
@@ -217,8 +218,8 @@ type sqlRecordRetriever struct {
 	placeholderFormat sq.PlaceholderFormat
 }
 
-func NewSqlRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, opts ...database.Option) RecordRetriever {
-	db, err := database.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
+func NewSqlRecordRetriever(cfg *config.Database, cursorEncryptor pagination.CursorEncryptor, logger *slog.Logger, opts ...sqlh.Option) RecordRetriever {
+	db, err := sqlh.OpenInstrumentedSQL(cfg.GetDriver(), cfg.GetDsn(), dbSystemFor(cfg.GetProvider()), opts...)
 	if err != nil {
 		panic(fmt.Errorf("failed to open app metrics database for retrieval: %w", err))
 	}

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apblob"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -161,14 +161,14 @@ func (ss *StorageService) Migrate(ctx context.Context) error {
 
 // NewStorageService that will store app metrics records and full request/response details.
 // dbOpts are forwarded to the underlying DB constructors — pass
-// database.WithTelemetry(...) to instrument the request-events database tier.
+// sqlh.WithTelemetry(...) to instrument the request-events database tier.
 func NewStorageService(
 	ctx context.Context,
 	cfg *config.AppMetrics,
 	cursorEncryptor pagination.CursorEncryptor,
 	encryptor Encryptor,
 	logger *slog.Logger,
-	dbOpts ...database.Option,
+	dbOpts ...sqlh.Option,
 ) (*StorageService, error) {
 	logger = logger.With("service", "app_metrics")
 	if cfg == nil {

--- a/internal/app_metrics/telemetry_test.go
+++ b/internal/app_metrics/telemetry_test.go
@@ -13,8 +13,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
-	"github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 )
 
 // requestLogTelemetryFixture wires an OTel SDK with an in-memory span
@@ -93,7 +93,7 @@ func TestRequestEvents_SqlStoreEmitsSpansWhenTelemetryEnabled(t *testing.T) {
 	tel := &sconfig.Telemetry{Enabled: enabledPtr(true)}
 
 	cfg := newSqliteRequestEventsConfig(t)
-	store := NewSqlRecordStore(cfg, newNoopLogger(), database.WithTelemetry(fx.providers, tel))
+	store := NewSqlRecordStore(cfg, newNoopLogger(), sqlh.WithTelemetry(fx.providers, tel))
 
 	runProbeQuery(t, store)
 

--- a/internal/database/service.go
+++ b/internal/database/service.go
@@ -3,64 +3,27 @@ package database
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log"
 	"log/slog"
-	"os"
 
 	sq "github.com/Masterminds/squirrel"
-	_ "github.com/jackc/pgx/v5/stdlib"
-	_ "github.com/mattn/go-sqlite3"
-	"github.com/mitchellh/go-homedir"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
-// NewConnectionForRoot creates a new database connection from the specified configuration. The type of the database
-// returned will be determined by the configuration. Optional Options enable
-// telemetry instrumentation; without them the returned sql.DB is a plain,
-// uninstrumented driver connection identical to the historic behaviour.
-func NewConnectionForRoot(root *config.Root, logger *slog.Logger, opts ...Option) (DB, error) {
-	switch v := root.Database.InnerVal.(type) {
-	case *config.DatabaseSqlite:
-		return NewSqliteConnection(v, logger, opts...)
-	case *config.DatabasePostgres:
-		return NewPostgresConnection(v, logger, opts...)
-	default:
-		return nil, errors.New("database type not supported")
+// NewService creates the AuthProxy database service using an already-open and
+// fully configured database/sql handle. The caller owns the SQL handle and is
+// responsible for closing it.
+func NewService(db *sql.DB, dbConfig config.DatabaseImpl, logger *slog.Logger) (DB, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database handle is required")
 	}
-}
-
-// NewSqliteConnection creates a new database connection to a SQLite database.
-func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger, opts ...Option) (DB, error) {
-	path := dbConfig.Path
-	_, err := os.Stat(path)
-	if err != nil {
-		// attempt home path expansion
-		path, err = homedir.Expand(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to expand path; could not load sqlite database path '%s': %w", dbConfig.Path, err)
-		}
+	if dbConfig == nil {
+		return nil, fmt.Errorf("database configuration is required")
 	}
-
-	_, err = os.Stat(path)
-	if err != nil {
-		// Attempt to create file
-		file, err := os.Create(path)
-		if err != nil {
-			return nil, fmt.Errorf("could not load sqlite database path '%s'; failed to create: %w", dbConfig.Path, err)
-		}
-		defer file.Close()
-	}
-
-	db, err := openInstrumentedDB("sqlite3", dbConfig.GetDsn(), DBSystemSQLite, resolveOpts(opts))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open sqlite database '%s': %w", dbConfig.GetDsn(), err)
-	}
-
 	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("failed to ping sqlite database '%s': %w", dbConfig.GetDsn(), err)
+		return nil, fmt.Errorf("failed to ping database '%s': %w", dbConfig.GetDsn(), err)
 	}
 
 	return &service{
@@ -68,27 +31,7 @@ func NewSqliteConnection(dbConfig *config.DatabaseSqlite, l *slog.Logger, opts .
 		sq:              sq.StatementBuilder.PlaceholderFormat(dbConfig.GetPlaceholderFormat()),
 		db:              db,
 		cursorEncryptor: pagination.NewRandomCursorEncryptor(),
-		logger:          l,
-	}, nil
-}
-
-// NewPostgresConnection creates a new database connection to a Postgres database.
-func NewPostgresConnection(dbConfig *config.DatabasePostgres, l *slog.Logger, opts ...Option) (DB, error) {
-	db, err := openInstrumentedDB("pgx", dbConfig.GetDsn(), DBSystemPostgreSQL, resolveOpts(opts))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open postgres database '%s': %w", dbConfig.GetDsn(), err)
-	}
-
-	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("failed to ping postgres database '%s': %w", dbConfig.GetDsn(), err)
-	}
-
-	return &service{
-		cfg:             dbConfig,
-		sq:              sq.StatementBuilder.PlaceholderFormat(dbConfig.GetPlaceholderFormat()),
-		db:              db,
-		cursorEncryptor: pagination.NewRandomCursorEncryptor(),
-		logger:          l,
+		logger:          logger,
 	}, nil
 }
 

--- a/internal/database/test_db.go
+++ b/internal/database/test_db.go
@@ -14,6 +14,8 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/peterldowns/pgtestdb"
 	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"github.com/rmorlok/authproxy/internal/config"
@@ -119,13 +121,17 @@ func mustApplyBlankSqliteTestDbConfig(t testing.TB, cfg config.C) (config.C, DB,
 		Path: tempFilePath,
 	}}
 
-	db, err := NewConnectionForRoot(root, root.GetRootLogger())
+	rawDb, err := sql.Open("sqlite3", root.Database.GetDsn())
 	if err != nil {
 		t.Fatalf("failed to connect sqlite test database: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = db.(*service).db.Close()
+		_ = rawDb.Close()
 	})
+	db, err := NewService(rawDb, root.Database.InnerVal, root.GetRootLogger())
+	if err != nil {
+		t.Fatalf("failed to construct sqlite test database: %v", err)
+	}
 
 	if err := db.Migrate(context.Background()); err != nil {
 		t.Fatalf("failed to migrate sqlite test database: %v", err)
@@ -138,7 +144,7 @@ func mustApplyBlankSqliteTestDbConfig(t testing.TB, cfg config.C) (config.C, DB,
 		t.Fatalf("failed to create root namespace: %v", err)
 	}
 
-	return cfg, db, db.(*service).db
+	return cfg, db, rawDb
 }
 
 func mustApplyBlankPostgresTestDbConfig(t testing.TB, cfg config.C) (config.C, DB, *sql.DB) {
@@ -150,14 +156,14 @@ func mustApplyBlankPostgresTestDbConfig(t testing.TB, cfg config.C) (config.C, D
 	defer func() { <-postgresTestLimiter }()
 
 	adminConfig := pgtestdb.Config{
-		DriverName:                  "pgx",
-		User:                        util.GetEnvDefault("POSTGRES_TEST_USER", "postgres"),
-		Password:                    util.GetEnvDefault("POSTGRES_TEST_PASSWORD", "postgres"),
-		Host:                        util.GetEnvDefault("POSTGRES_TEST_HOST", "localhost"),
-		Port:                        util.GetEnvDefault("POSTGRES_TEST_PORT", "5432"),
-		Database:                    util.GetEnvDefault("POSTGRES_TEST_DATABASE", "postgres"),
-		Options:                     util.GetEnvDefault("POSTGRES_TEST_OPTIONS", "sslmode=disable"),
-		ForceTerminateConnections:   true,
+		DriverName:                "pgx",
+		User:                      util.GetEnvDefault("POSTGRES_TEST_USER", "postgres"),
+		Password:                  util.GetEnvDefault("POSTGRES_TEST_PASSWORD", "postgres"),
+		Host:                      util.GetEnvDefault("POSTGRES_TEST_HOST", "localhost"),
+		Port:                      util.GetEnvDefault("POSTGRES_TEST_PORT", "5432"),
+		Database:                  util.GetEnvDefault("POSTGRES_TEST_DATABASE", "postgres"),
+		Options:                   util.GetEnvDefault("POSTGRES_TEST_OPTIONS", "sslmode=disable"),
+		ForceTerminateConnections: true,
 	}
 
 	migrator := golangmigrator.New(

--- a/internal/schema/config/database_postgres.go
+++ b/internal/schema/config/database_postgres.go
@@ -23,6 +23,10 @@ type DatabasePostgres struct {
 	Database                  *StringValue      `json:"database" yaml:"database"`
 	SSLMode                   *StringValue      `json:"sslmode,omitempty" yaml:"sslmode,omitempty"`
 	Params                    map[string]string `json:"params,omitempty" yaml:"params,omitempty"`
+	MaxOpenConns              *IntegerValue     `json:"max_open_conns,omitempty" yaml:"max_open_conns,omitempty"`
+	MaxIdleConns              *IntegerValue     `json:"max_idle_conns,omitempty" yaml:"max_idle_conns,omitempty"`
+	ConnMaxLifetime           *HumanDuration    `json:"conn_max_lifetime,omitempty" yaml:"conn_max_lifetime,omitempty"`
+	ConnMaxIdleTime           *HumanDuration    `json:"conn_max_idle_time,omitempty" yaml:"conn_max_idle_time,omitempty"`
 	AutoMigrate               bool              `json:"auto_migrate,omitempty" yaml:"auto_migrate,omitempty"`
 	AutoMigrationLockDuration *HumanDuration    `json:"auto_migration_lock_duration,omitempty" yaml:"auto_migration_lock_duration,omitempty"`
 	SoftDeleteRetention       *HumanDuration    `json:"soft_delete_retention,omitempty" yaml:"soft_delete_retention,omitempty"`
@@ -154,6 +158,34 @@ func (d *DatabasePostgres) Validate(vc *common.ValidationContext) error {
 			result = multierror.Append(result, vc.NewErrorfForField("port", "port must be between 1 and 65535, got %d", port))
 		}
 	}
+	result = multierror.Append(result, validateNonNegativeInteger(vc, "max_open_conns", d.MaxOpenConns))
+	result = multierror.Append(result, validateNonNegativeInteger(vc, "max_idle_conns", d.MaxIdleConns))
+	result = multierror.Append(result, validateNonNegativeDuration(vc, "conn_max_lifetime", d.ConnMaxLifetime))
+	result = multierror.Append(result, validateNonNegativeDuration(vc, "conn_max_idle_time", d.ConnMaxIdleTime))
 
 	return result.ErrorOrNil()
+}
+
+func validateNonNegativeInteger(vc *common.ValidationContext, field string, value *IntegerValue) error {
+	if value == nil {
+		return nil
+	}
+	v, err := value.GetValue(context.Background())
+	if err != nil {
+		return vc.NewErrorfForField(field, "invalid value: %v", err)
+	}
+	if v < 0 {
+		return vc.NewErrorfForField(field, "must be greater than or equal to 0, got %d", v)
+	}
+	return nil
+}
+
+func validateNonNegativeDuration(vc *common.ValidationContext, field string, value *HumanDuration) error {
+	if value == nil {
+		return nil
+	}
+	if value.Duration < 0 {
+		return vc.NewErrorfForField(field, "must be greater than or equal to 0, got %s", value.Duration)
+	}
+	return nil
 }

--- a/internal/schema/config/database_test.go
+++ b/internal/schema/config/database_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/assert"
@@ -34,19 +35,27 @@ func TestDatabase(t *testing.T) {
       password: secret
       database: authproxy
       sslmode: disable
+      max_open_conns: 25
+      max_idle_conns: 5
+      conn_max_lifetime: 30m
+      conn_max_idle_time: 5m
       params:
         application_name: authproxy-tests
 `
 			var db Database
 			assert.NoError(yaml.Unmarshal([]byte(data), &db))
 			assert.Equal(Database{InnerVal: &DatabasePostgres{
-				Provider: DatabaseProviderPostgres,
-				Host:     common.NewStringValueDirectInline("localhost"),
-				Port:     common.NewIntegerValueDirectInline(5432),
-				User:     common.NewStringValueDirectInline("test"),
-				Password: common.NewStringValueDirectInline("secret"),
-				Database: common.NewStringValueDirectInline("authproxy"),
-				SSLMode:  common.NewStringValueDirectInline("disable"),
+				Provider:        DatabaseProviderPostgres,
+				Host:            common.NewStringValueDirectInline("localhost"),
+				Port:            common.NewIntegerValueDirectInline(5432),
+				User:            common.NewStringValueDirectInline("test"),
+				Password:        common.NewStringValueDirectInline("secret"),
+				Database:        common.NewStringValueDirectInline("authproxy"),
+				SSLMode:         common.NewStringValueDirectInline("disable"),
+				MaxOpenConns:    common.NewIntegerValueDirectInline(25),
+				MaxIdleConns:    common.NewIntegerValueDirectInline(5),
+				ConnMaxLifetime: &HumanDuration{Duration: 30 * time.Minute},
+				ConnMaxIdleTime: &HumanDuration{Duration: 5 * time.Minute},
 				Params: map[string]string{
 					"application_name": "authproxy-tests",
 				},

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -277,6 +277,8 @@ func Serve(cfg config.C) {
 
 	dm.AutoMigrateAll()
 
+	defer dm.ShutdownDatabase()
+	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()
 
 	server, healthChecker, err := GetGinServer(dm)

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -180,6 +180,8 @@ func Serve(cfg config.C) {
 
 	dm.AutoMigrateAll()
 
+	defer dm.ShutdownDatabase()
+	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()
 
 	server, healthChecker, err := GetGinServer(dm)

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -2,12 +2,18 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
+	"math"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/hibiken/asynq"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/mitchellh/go-homedir"
 	"github.com/rmorlok/authproxy/internal/apasynq"
 	"github.com/rmorlok/authproxy/internal/apauth/tasks"
 	authSync "github.com/rmorlok/authproxy/internal/apauth/tasks"
@@ -23,6 +29,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/ratelimit"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/rmorlok/authproxy/internal/workflows"
 )
@@ -37,6 +44,7 @@ type DependencyManager struct {
 	logBuilder        aplog.Builder
 	logger            *slog.Logger
 	r                 apredis.Client
+	sqlDB             *sql.DB
 	db                database.DB
 	httpf             httpf.F
 	logRetriever      app_metrics.LogRetriever
@@ -215,10 +223,10 @@ func (dm *DependencyManager) GetRedisClient() apredis.Client {
 func (dm *DependencyManager) GetDatabase() database.DB {
 	if dm.db == nil {
 		var err error
-		dm.db, err = database.NewConnectionForRoot(
-			dm.GetConfigRoot(),
+		dm.db, err = database.NewService(
+			dm.GetSQLDB(),
+			dm.GetConfigRoot().Database.InnerVal,
 			dm.GetLogger(),
-			database.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
 		)
 		if err != nil {
 			panic(err)
@@ -226,6 +234,129 @@ func (dm *DependencyManager) GetDatabase() database.DB {
 	}
 
 	return dm.db
+}
+
+func (dm *DependencyManager) GetSQLDB() *sql.DB {
+	if dm.sqlDB == nil {
+		db, err := dm.openConfiguredSQLDB()
+		if err != nil {
+			panic(err)
+		}
+		dm.sqlDB = db
+	}
+	return dm.sqlDB
+}
+
+func (dm *DependencyManager) openConfiguredSQLDB() (*sql.DB, error) {
+	root := dm.GetConfigRoot()
+	if root == nil || root.Database == nil || root.Database.InnerVal == nil {
+		return nil, fmt.Errorf("database configuration is required")
+	}
+
+	switch cfg := root.Database.InnerVal.(type) {
+	case *sconfig.DatabaseSqlite:
+		if err := ensureSqliteDatabaseFile(cfg.Path); err != nil {
+			return nil, err
+		}
+		return sqlh.OpenInstrumentedSQL(
+			"sqlite3",
+			cfg.GetDsn(),
+			sqlh.DBSystemSQLite,
+			sqlh.WithTelemetry(dm.GetTelemetry(), root.Telemetry),
+		)
+	case *sconfig.DatabasePostgres:
+		db, err := sqlh.OpenInstrumentedSQL(
+			"pgx",
+			cfg.GetDsn(),
+			sqlh.DBSystemPostgreSQL,
+			sqlh.WithTelemetry(dm.GetTelemetry(), root.Telemetry),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open postgres database '%s': %w", cfg.GetDsn(), err)
+		}
+		if err := applyPostgresPoolSettings(db, cfg); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("failed to configure postgres database pool: %w", err)
+		}
+		return db, nil
+	default:
+		return nil, fmt.Errorf("database type not supported")
+	}
+}
+
+func ensureSqliteDatabaseFile(configPath string) error {
+	path := configPath
+	if _, err := os.Stat(path); err != nil {
+		expanded, expandErr := homedir.Expand(path)
+		if expandErr != nil {
+			return fmt.Errorf("failed to expand path; could not load sqlite database path '%s': %w", configPath, expandErr)
+		}
+		path = expanded
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("could not load sqlite database path '%s'; failed to create: %w", configPath, err)
+	}
+	return file.Close()
+}
+
+func applyPostgresPoolSettings(db *sql.DB, dbConfig *sconfig.DatabasePostgres) error {
+	if db == nil || dbConfig == nil {
+		return nil
+	}
+
+	ctx := context.Background()
+	if dbConfig.MaxOpenConns != nil {
+		value, err := databasePoolInt(ctx, "max_open_conns", dbConfig.MaxOpenConns)
+		if err != nil {
+			return err
+		}
+		db.SetMaxOpenConns(value)
+	}
+	if dbConfig.MaxIdleConns != nil {
+		value, err := databasePoolInt(ctx, "max_idle_conns", dbConfig.MaxIdleConns)
+		if err != nil {
+			return err
+		}
+		db.SetMaxIdleConns(value)
+	}
+	if dbConfig.ConnMaxLifetime != nil {
+		db.SetConnMaxLifetime(dbConfig.ConnMaxLifetime.Duration)
+	}
+	if dbConfig.ConnMaxIdleTime != nil {
+		db.SetConnMaxIdleTime(dbConfig.ConnMaxIdleTime.Duration)
+	}
+
+	return nil
+}
+
+func databasePoolInt(ctx context.Context, name string, value *sconfig.IntegerValue) (int, error) {
+	v, err := value.GetValue(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", name, err)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to 0", name)
+	}
+	if v > int64(math.MaxInt) {
+		return 0, fmt.Errorf("%s is too large: %d", name, v)
+	}
+	return int(v), nil
+}
+
+func (dm *DependencyManager) ShutdownDatabase() {
+	if dm.sqlDB == nil {
+		return
+	}
+	if err := dm.sqlDB.Close(); err != nil {
+		dm.GetLogger().Warn("failed to close database", "error", err)
+	}
+	dm.sqlDB = nil
 }
 
 // AutoMigrateDatabase will attempt to migrate the database if the root config has auto migrate enabled.
@@ -253,6 +384,7 @@ func (dm *DependencyManager) AutoMigrateDatabase() {
 			if err := workflows.Migrate(
 				dm.GetConfigRoot(),
 				dm.GetLogBuilder().WithComponent("workflows").Build(),
+				workflows.WithPostgresMigrationDB(dm.GetSQLDB()),
 			); err != nil {
 				panic(fmt.Errorf("failed to migrate workflow database: %w", err))
 			}
@@ -270,7 +402,7 @@ func (dm *DependencyManager) GetAppMetricsService() *app_metrics.StorageService 
 			pagination.NewRandomCursorEncryptor(),
 			dm.GetEncryptService(),
 			dm.GetLogger(),
-			database.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
+			sqlh.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
 		)
 
 		if err != nil {
@@ -401,6 +533,7 @@ func (dm *DependencyManager) GetWorkflowRuntime() *workflows.Runtime {
 			dm.GetConfigRoot(),
 			dm.GetTelemetry(),
 			dm.GetLogBuilder().WithComponent("workflows").Build(),
+			workflows.WithPostgresDB(dm.GetSQLDB()),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to construct workflow runtime: %w", err))

--- a/internal/service/dependency_manager_test.go
+++ b/internal/service/dependency_manager_test.go
@@ -2,10 +2,14 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterPingAndRunPings_AllOk(t *testing.T) {
@@ -67,4 +71,32 @@ func TestRunPings_ContextCancellation(t *testing.T) {
 	results, allOk := dm.RunPings(ctx)
 	assert.False(t, allOk)
 	assert.False(t, results["slow"])
+}
+
+func TestApplyPostgresPoolSettings(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = applyPostgresPoolSettings(db, &config.DatabasePostgres{
+		MaxOpenConns:    common.NewIntegerValueDirectInline(7),
+		MaxIdleConns:    common.NewIntegerValueDirectInline(3),
+		ConnMaxLifetime: &config.HumanDuration{Duration: 30 * time.Minute},
+		ConnMaxIdleTime: &config.HumanDuration{Duration: 5 * time.Minute},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 7, db.Stats().MaxOpenConnections)
+}
+
+func TestApplyPostgresPoolSettingsRejectsInvalidValues(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = applyPostgresPoolSettings(db, &config.DatabasePostgres{
+		MaxOpenConns: common.NewIntegerValueDirectInline(-1),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_open_conns")
 }

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -273,6 +273,8 @@ func Serve(cfg config.C) {
 
 	dm.AutoMigrateAll()
 
+	defer dm.ShutdownDatabase()
+	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()
 
 	server, healthChecker, err := GetGinServer(dm)

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -100,6 +100,7 @@ func Serve(cfg config.C) {
 	})
 
 	dm.AutoMigrateAll()
+	defer dm.ShutdownDatabase()
 	defer dm.GetEncryptService().Shutdown()
 	defer dm.ShutdownWorkflowRuntime()
 

--- a/internal/sqlh/telemetry.go
+++ b/internal/sqlh/telemetry.go
@@ -1,4 +1,4 @@
-package database
+package sqlh
 
 import (
 	"database/sql"

--- a/internal/sqlh/telemetry_test.go
+++ b/internal/sqlh/telemetry_test.go
@@ -1,13 +1,15 @@
-package database
+package sqlh
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -63,7 +65,7 @@ func (f *dbTelemetryFixture) readMetrics(t *testing.T) metricdata.ResourceMetric
 // newSqliteDBWith opens a fresh SQLite-backed DB using the supplied
 // telemetry options and returns it ready for use. The DB file is cleaned up
 // at test end.
-func newSqliteDBWith(t *testing.T, opts ...Option) DB {
+func newSqliteDBWith(t *testing.T, opts ...Option) *sql.DB {
 	t.Helper()
 	tempPath := filepath.Join(
 		os.TempDir(),
@@ -73,11 +75,11 @@ func newSqliteDBWith(t *testing.T, opts ...Option) DB {
 	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(tempPath)) })
 
 	cfg := &sconfig.DatabaseSqlite{Path: tempPath}
-	db, err := NewSqliteConnection(cfg, nil, opts...)
+	rawDB, err := openInstrumentedDB("sqlite3", cfg.GetDsn(), DBSystemSQLite, resolveOpts(opts))
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.(*service).db.Close() })
+	t.Cleanup(func() { _ = rawDB.Close() })
 
-	return db
+	return rawDB
 }
 
 func boolPtr(b bool) *bool { return &b }
@@ -88,8 +90,8 @@ func TestDBTelemetry_QueryEmitsSpanAndMetric(t *testing.T) {
 
 	db := newSqliteDBWith(t, WithTelemetry(fx.providers, tel))
 
-	// Issue a trivial query that doesn't depend on migrations.
-	require.True(t, db.Ping(context.Background()))
+	_, err := db.ExecContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
 
 	gotSpans := fx.spans.Ended()
 	require.NotEmpty(t, gotSpans, "instrumented query must produce at least one span")
@@ -107,7 +109,8 @@ func TestDBTelemetry_NoOpWhenTelemetryDisabled(t *testing.T) {
 	// Disabled telemetry: no providers attached, so the constructor must
 	// fall through to plain sql.Open and emit nothing.
 	db := newSqliteDBWith(t /* no options */)
-	require.True(t, db.Ping(context.Background()))
+	_, err := db.ExecContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
 
 	require.Empty(t, fx.spans.Ended(), "no spans expected when telemetry isn't wired in")
 	rm := fx.readMetrics(t)
@@ -122,7 +125,8 @@ func TestDBTelemetry_NoOpWhenProvidersDisabled(t *testing.T) {
 	tel := &sconfig.Telemetry{} // Enabled is nil → IsEnabled() == false
 
 	db := newSqliteDBWith(t, WithTelemetry(aptelemetry.NoopProviders(), tel))
-	require.True(t, db.Ping(context.Background()))
+	_, err := db.ExecContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
 
 	require.Empty(t, fx.spans.Ended())
 	rm := fx.readMetrics(t)
@@ -140,7 +144,8 @@ func TestDBTelemetry_NoOpWhenBothSignalsOff(t *testing.T) {
 	}
 
 	db := newSqliteDBWith(t, WithTelemetry(fx.providers, tel))
-	require.True(t, db.Ping(context.Background()))
+	_, err := db.ExecContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
 
 	require.Empty(t, fx.spans.Ended())
 	rm := fx.readMetrics(t)

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -25,7 +25,6 @@ import (
 	migratesqlite "github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
-	apdatabase "github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
@@ -42,6 +41,7 @@ type Runtime struct {
 	backend wfbackend.Backend
 	client  *client.Client
 	db      *sql.DB
+	closeDB bool
 }
 
 type Client interface {
@@ -50,9 +50,26 @@ type Client interface {
 	GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error)
 }
 
-func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *slog.Logger) (*Runtime, error) {
+type RuntimeOption func(*runtimeOptions)
+
+type runtimeOptions struct {
+	postgresDB *sql.DB
+}
+
+func WithPostgresDB(db *sql.DB) RuntimeOption {
+	return func(o *runtimeOptions) {
+		o.postgresDB = db
+	}
+}
+
+func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *slog.Logger, opts ...RuntimeOption) (*Runtime, error) {
 	if root == nil || root.Database == nil {
 		return nil, fmt.Errorf("database configuration is required")
+	}
+
+	runtimeOpts := &runtimeOptions{}
+	for _, opt := range opts {
+		opt(runtimeOpts)
 	}
 
 	backendOptions := []wfbackend.BackendOption{
@@ -63,8 +80,9 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 	}
 
 	var (
-		b  wfbackend.Backend
-		db *sql.DB
+		b       wfbackend.Backend
+		db      *sql.DB
+		closeDB bool
 	)
 
 	switch cfg := root.Database.InnerVal.(type) {
@@ -78,18 +96,11 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 			sqlite.WithBackendOptions(backendOptions...),
 		)
 	case *sconfig.DatabasePostgres:
-		var err error
-		db, err = apdatabase.OpenInstrumentedSQL(
-			"pgx",
-			cfg.GetDsn(),
-			apdatabase.DBSystemPostgreSQL,
-			apdatabase.WithTelemetry(telemetry, root.Telemetry),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("open workflow postgres database: %w", err)
+		db = runtimeOpts.postgresDB
+		if db == nil {
+			return nil, fmt.Errorf("workflow postgres database handle is required")
 		}
 		if err := db.Ping(); err != nil {
-			_ = db.Close()
 			return nil, fmt.Errorf("ping workflow postgres database: %w", err)
 		}
 
@@ -106,12 +117,30 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 		backend: b,
 		client:  client.New(b),
 		db:      db,
+		closeDB: closeDB,
 	}, nil
 }
 
-func Migrate(root *sconfig.Root, logger *slog.Logger) error {
+type MigrateOption func(*migrateOptions)
+
+type migrateOptions struct {
+	postgresDB *sql.DB
+}
+
+func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
+	return func(o *migrateOptions) {
+		o.postgresDB = db
+	}
+}
+
+func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) error {
 	if root == nil || root.Database == nil {
 		return fmt.Errorf("database configuration is required")
+	}
+
+	migrateOpts := &migrateOptions{}
+	for _, opt := range opts {
+		opt(migrateOpts)
 	}
 
 	switch cfg := root.Database.InnerVal.(type) {
@@ -123,11 +152,10 @@ func Migrate(root *sconfig.Root, logger *slog.Logger) error {
 		defer db.Close()
 		return migrateDB(db, "sqlite", "migrations/sqlite")
 	case *sconfig.DatabasePostgres:
-		db, err := apdatabase.OpenInstrumentedSQL("pgx", cfg.GetDsn(), apdatabase.DBSystemPostgreSQL)
-		if err != nil {
-			return fmt.Errorf("open workflow postgres database: %w", err)
+		db := migrateOpts.postgresDB
+		if db == nil {
+			return fmt.Errorf("workflow postgres database handle is required")
 		}
-		defer db.Close()
 
 		return migrateDB(db, "postgres", "migrations/postgres")
 	default:
@@ -226,7 +254,7 @@ func (r *Runtime) Close() error {
 	if r.backend != nil {
 		closeErr = r.backend.Close()
 	}
-	if r.db != nil {
+	if r.closeDB && r.db != nil {
 		if err := r.db.Close(); err != nil && closeErr == nil {
 			closeErr = err
 		}

--- a/internal/workflows/runtime_test.go
+++ b/internal/workflows/runtime_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/require"
 )
@@ -42,4 +44,30 @@ func TestMigrateSqliteAndRuntimePing(t *testing.T) {
 	defer runtime.Close()
 
 	require.True(t, runtime.Ping(context.Background()))
+}
+
+func TestNewRuntimePostgresBorrowedDBIsNotClosed(t *testing.T) {
+	root := &config.Root{
+		Database: &config.Database{
+			InnerVal: &config.DatabasePostgres{
+				Provider: config.DatabaseProviderPostgres,
+				Host:     common.NewStringValueDirectInline("localhost"),
+				Port:     common.NewIntegerValueDirectInline(5432),
+				User:     common.NewStringValueDirectInline("authproxy"),
+				Password: common.NewStringValueDirectInline("authproxy"),
+				Database: common.NewStringValueDirectInline("authproxy"),
+			},
+		},
+	}
+	logger := slog.New(slog.DiscardHandler)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	runtime, err := NewRuntime(root, nil, logger, WithPostgresDB(db))
+	require.NoError(t, err)
+
+	require.NoError(t, runtime.Close())
+	require.NoError(t, db.Ping())
 }


### PR DESCRIPTION
## Summary

- move primary app SQL pool ownership into DependencyManager for both SQLite and Postgres
- construct internal/database over an already-open *sql.DB plus database dialect config
- let workflow runtime and workflow migrations borrow the DependencyManager-owned Postgres pool instead of opening their own
- add optional Postgres database pool settings and apply them when DependencyManager opens the pool
- shut down workflow runtime and the owned SQL pool from API, public, admin, and worker services

Closes #533

## Tests

- go test ./internal/schema/config ./internal/database ./internal/workflows ./internal/service/...
- ./scripts/preflight.sh