### PR TITLE
Add filesystem blob storage provider

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -92,6 +92,8 @@ jobs:
             >"${manifest}"
 
           grep -q "provider: miniredis" "${manifest}"
+          grep -q "provider: filesystem" "${manifest}"
+          grep -q "mountPath: /tmp/authproxy-blobs" "${manifest}"
 
           if grep -Eq "name: dev-(db|redis-creds|minio-creds|postgresql|redis|minio)|AUTHPROXY_(DB|REDIS)_PASSWORD|root-password|kind: StatefulSet" "${manifest}"; then
             echo "Slim dev render leaked dependency credentials or workloads" >&2

--- a/deploy/charts/authproxy-demo/README.md
+++ b/deploy/charts/authproxy-demo/README.md
@@ -171,8 +171,8 @@ correctly.
 The Deploy Dev workflow uses `dev-slim-values.yaml` to keep PR
 environments small. That profile disables the Postgres, Redis, and
 MinIO subcharts, then configures the embedded AuthProxy chart to use
-SQLite files under `/tmp`, the in-process `miniredis` provider, and no
-S3 blob store. This is intentionally disposable: a pod restart can lose
+SQLite files under `/tmp`, the in-process `miniredis` provider, and
+filesystem blob storage under `/tmp/authproxy-blobs`. This is intentionally disposable: a pod restart can lose
 database, queue, session, and full-request blob state, but the next dev
 deploy reseeds the catalog and actors.
 

--- a/deploy/charts/authproxy-demo/dev-slim-values.yaml
+++ b/deploy/charts/authproxy-demo/dev-slim-values.yaml
@@ -23,6 +23,11 @@ authproxy:
     existingSecret: ""
   s3:
     enabled: false
+  blobStorage:
+    provider: filesystem
+    filesystem:
+      path: /tmp/authproxy-blobs
+      emptyDir: true
   appMetrics:
     shareMainDatabase: true
     fullRequestRecording: never

--- a/deploy/charts/authproxy/README.md
+++ b/deploy/charts/authproxy/README.md
@@ -64,7 +64,8 @@ The chart exposes typed values for the common connectivity blocks. See
 | `ingress`        | Single Ingress with path → port-name routing                          |
 | `database`       | Postgres or SQLite connectivity (+ `existingSecret` for credentials)  |
 | `redis`          | Redis connectivity (+ optional `existingSecret`)                      |
-| `s3`             | Optional S3-compatible blob storage for request-log payloads          |
+| `s3`             | Legacy S3-compatible blob storage inputs                              |
+| `blobStorage`    | Request-log blob storage provider, including local filesystem mode    |
 | `jwt`            | Secret mount + key paths for JWT signing material                     |
 | `encryptionKeys` | Secret mount + path for the global AES key                            |
 | `actors`         | Secret mount + ACL permissions for admin actor keypairs               |
@@ -86,6 +87,10 @@ Secrets by name. You provision them once and pass the names via `existingSecret`
 | `database.existingSecret` *(optional)* | `AUTHPROXY_DB_PASSWORD`                            |
 | `redis.existingSecret` *(optional)* | `AUTHPROXY_REDIS_PASSWORD`                            |
 | `s3.existingSecret` *(optional)*    | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`          |
+
+For disposable environments, set `blobStorage.provider=filesystem`; the chart
+mounts an `emptyDir` at `blobStorage.filesystem.path` by default. Persistent
+deployments should continue to use S3-compatible storage.
 
 ## Compatibility
 

--- a/deploy/charts/authproxy/templates/NOTES.txt
+++ b/deploy/charts/authproxy/templates/NOTES.txt
@@ -34,7 +34,7 @@ either enable `ingress.enabled` in your values or port-forward, e.g.:
 {{- if not .Values.jwt.existingSecret }}{{- $missing = append $missing "jwt.existingSecret" }}{{- end }}
 {{- if not .Values.encryptionKeys.existingSecret }}{{- $missing = append $missing "encryptionKeys.existingSecret" }}{{- end }}
 {{- if not .Values.actors.existingSecret }}{{- $missing = append $missing "actors.existingSecret (admin actor keys; chart starts without it but admin API calls won't auth)" }}{{- end }}
-{{- if and .Values.s3.enabled (not .Values.s3.existingSecret) (not .Values.serviceAccount.annotations) }}{{- $missing = append $missing "s3.existingSecret (or serviceAccount.annotations for IRSA)" }}{{- end }}
+{{- if and (eq (default "" .Values.blobStorage.provider) "") .Values.s3.enabled (not .Values.s3.existingSecret) (not .Values.serviceAccount.annotations) }}{{- $missing = append $missing "s3.existingSecret (or serviceAccount.annotations for IRSA)" }}{{- end }}
 {{- if $missing }}
 
 NOTE: the following secret references are unset and the pod will fail to

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -161,23 +161,32 @@ template syntax.
 {{- else -}}
 {{-   $metricsDb = .Values.appMetrics.database -}}
 {{- end -}}
-{{- $appMetrics := dict
-      "auto_migrate" .Values.appMetrics.autoMigrate
-      "database" $metricsDb
-      "request_events" (dict
-        "full_request_recording" .Values.appMetrics.fullRequestRecording) -}}
-{{- $_ := set $cfg "app_metrics" $appMetrics -}}
-
-{{/* --- s3 (request-log blob storage) --- */}}
-{{- if .Values.s3.enabled -}}
+{{/* --- request-log blob storage --- */}}
+{{- $blobStorage := dict -}}
+{{- $blobProvider := default "" .Values.blobStorage.provider -}}
+{{- if eq $blobProvider "filesystem" -}}
+{{-   $blobStorage = dict "provider" "filesystem" "path" .Values.blobStorage.filesystem.path -}}
+{{- else if eq $blobProvider "memory" -}}
+{{-   $blobStorage = dict "provider" "memory" -}}
+{{- else if .Values.s3.enabled -}}
 {{-   $s3 := dict "provider" "s3" "bucket" .Values.s3.bucket "force_path_style" .Values.s3.forcePathStyle -}}
 {{-   if .Values.s3.region -}}{{- $_ := set $s3 "region" .Values.s3.region -}}{{- end -}}
 {{-   if .Values.s3.endpoint -}}{{- $_ := set $s3 "endpoint" .Values.s3.endpoint -}}{{- end -}}
 {{-   if .Values.s3.prefix -}}{{- $_ := set $s3 "prefix" .Values.s3.prefix -}}{{- end -}}
 {{-   $creds := dict "type" "implicit" -}}
 {{-   $_ := set $s3 "credentials" $creds -}}
-{{-   $_ := set $cfg "blob_storage" $s3 -}}
+{{-   $blobStorage = $s3 -}}
 {{- end -}}
+
+{{- $appMetrics := dict
+      "auto_migrate" .Values.appMetrics.autoMigrate
+      "database" $metricsDb
+      "request_events" (dict
+        "full_request_recording" .Values.appMetrics.fullRequestRecording) -}}
+{{- if $blobStorage -}}
+{{-   $_ := set $appMetrics "blob_storage" $blobStorage -}}
+{{- end -}}
+{{- $_ := set $cfg "app_metrics" $appMetrics -}}
 
 {{/* --- crypto material file paths --- */}}
 {{- if .Values.jwt.existingSecret -}}

--- a/deploy/charts/authproxy/templates/deployment.yaml
+++ b/deploy/charts/authproxy/templates/deployment.yaml
@@ -116,6 +116,10 @@ spec:
               mountPath: {{ $.Values.actors.mountPath }}
               readOnly: true
             {{- end }}
+            {{- if and (eq .Values.blobStorage.provider "filesystem") .Values.blobStorage.filesystem.emptyDir }}
+            - name: blob-storage
+              mountPath: {{ .Values.blobStorage.filesystem.path }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
@@ -135,6 +139,10 @@ spec:
         - name: actors-keys
           secret:
             secretName: {{ tpl . $ }}
+        {{- end }}
+        {{- if and (eq .Values.blobStorage.provider "filesystem") .Values.blobStorage.filesystem.emptyDir }}
+        - name: blob-storage
+          emptyDir: {}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -175,6 +175,22 @@
       }
     },
 
+    "blobStorage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string", "enum": ["", "filesystem", "memory"] },
+        "filesystem": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path":     { "type": "string" },
+            "emptyDir": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
     "jwt": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -195,6 +195,19 @@ s3:
   # Leave empty when using IRSA (set `serviceAccount.annotations` instead).
   existingSecret: ""
 
+# -- Blob storage provider for request-log payloads. Leave provider empty to
+# preserve legacy behavior: S3 is rendered when `s3.enabled=true`, otherwise
+# blob storage is omitted and AuthProxy uses its in-memory fallback.
+blobStorage:
+  # -- Provider: `filesystem`, `memory`, or empty for legacy S3/omitted behavior.
+  provider: ""
+  filesystem:
+    # -- Local directory used when provider=filesystem.
+    path: /var/lib/authproxy/blob-storage
+    # -- Mount an emptyDir at `path`. Disable if the image already provides
+    # a writable directory or another volume is mounted through extra manifests.
+    emptyDir: true
+
 # -- JWT signing key pair, mounted into the container as files (paths are
 # substituted into the rendered config). The chart only references the
 # Secret; customers create it.

--- a/internal/apblob/filesystem.go
+++ b/internal/apblob/filesystem.go
@@ -1,0 +1,121 @@
+package apblob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+type FilesystemClient struct {
+	root string
+}
+
+func NewFilesystemClient(cfg *config.BlobStorageFilesystem) (Client, error) {
+	if cfg == nil {
+		return nil, errors.New("filesystem blob storage config is required")
+	}
+	if strings.TrimSpace(cfg.Path) == "" {
+		return nil, errors.New("filesystem blob storage path is required")
+	}
+
+	root, err := filepath.Abs(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve filesystem blob storage path: %w", err)
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("create filesystem blob storage root: %w", err)
+	}
+
+	return &FilesystemClient{root: root}, nil
+}
+
+func (c *FilesystemClient) Put(ctx context.Context, input PutInput) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	p, err := c.pathFor(input.Key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return fmt.Errorf("create filesystem blob storage directory: %w", err)
+	}
+	if err := os.WriteFile(p, input.Data, 0o600); err != nil {
+		return fmt.Errorf("write filesystem blob: %w", err)
+	}
+	return nil
+}
+
+func (c *FilesystemClient) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	p, err := c.pathFor(key)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrBlobNotFound
+		}
+		return nil, fmt.Errorf("read filesystem blob: %w", err)
+	}
+	return data, nil
+}
+
+func (c *FilesystemClient) Delete(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	p, err := c.pathFor(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete filesystem blob: %w", err)
+	}
+	return nil
+}
+
+func (c *FilesystemClient) pathFor(key string) (string, error) {
+	if key == "" {
+		return "", errors.New("blob key is required")
+	}
+	if strings.ContainsRune(key, '\x00') {
+		return "", fmt.Errorf("invalid blob key %q: null byte is not allowed", key)
+	}
+	if strings.Contains(key, "\\") {
+		return "", fmt.Errorf("invalid blob key %q: backslashes are not allowed", key)
+	}
+	if path.IsAbs(key) {
+		return "", fmt.Errorf("invalid blob key %q: absolute paths are not allowed", key)
+	}
+	for _, part := range strings.Split(key, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("invalid blob key %q: empty, dot, and dot-dot path segments are not allowed", key)
+		}
+	}
+
+	cleaned := path.Clean(key)
+	p := filepath.Join(c.root, filepath.FromSlash(cleaned))
+	rel, err := filepath.Rel(c.root, p)
+	if err != nil {
+		return "", fmt.Errorf("resolve filesystem blob path: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid blob key %q: path escapes blob storage root", key)
+	}
+	return p, nil
+}
+
+var _ Client = (*FilesystemClient)(nil)

--- a/internal/apblob/filesystem_test.go
+++ b/internal/apblob/filesystem_test.go
@@ -1,0 +1,135 @@
+package apblob
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+func newTestFilesystemClient(t *testing.T) (*FilesystemClient, string) {
+	t.Helper()
+	root := t.TempDir()
+	client, err := NewFilesystemClient(&config.BlobStorageFilesystem{
+		Provider: config.BlobStorageProviderFilesystem,
+		Path:     root,
+	})
+	require.NoError(t, err)
+	fs, ok := client.(*FilesystemClient)
+	require.True(t, ok)
+	return fs, root
+}
+
+func TestFilesystemClient_PutAndGet(t *testing.T) {
+	ctx := context.Background()
+	c, root := newTestFilesystemClient(t)
+
+	require.NoError(t, c.Put(ctx, PutInput{
+		Key:  "root/demo/request.enc",
+		Data: []byte("hello world"),
+	}))
+
+	data, err := c.Get(ctx, "root/demo/request.enc")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello world"), data)
+
+	onDisk, err := os.ReadFile(filepath.Join(root, "root", "demo", "request.enc"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello world"), onDisk)
+}
+
+func TestFilesystemClient_GetNotFound(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newTestFilesystemClient(t)
+
+	_, err := c.Get(ctx, "root/missing.enc")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlobNotFound))
+}
+
+func TestFilesystemClient_PutOverwrite(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newTestFilesystemClient(t)
+
+	require.NoError(t, c.Put(ctx, PutInput{Key: "root/k.enc", Data: []byte("v1")}))
+	require.NoError(t, c.Put(ctx, PutInput{Key: "root/k.enc", Data: []byte("v2")}))
+
+	data, err := c.Get(ctx, "root/k.enc")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v2"), data)
+}
+
+func TestFilesystemClient_Delete(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newTestFilesystemClient(t)
+
+	require.NoError(t, c.Put(ctx, PutInput{Key: "root/k.enc", Data: []byte("v")}))
+	require.NoError(t, c.Delete(ctx, "root/k.enc"))
+
+	_, err := c.Get(ctx, "root/k.enc")
+	assert.True(t, errors.Is(err, ErrBlobNotFound))
+}
+
+func TestFilesystemClient_DeleteNonexistent(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newTestFilesystemClient(t)
+
+	require.NoError(t, c.Delete(ctx, "root/nonexistent.enc"))
+}
+
+func TestFilesystemClient_DataIsolation(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newTestFilesystemClient(t)
+
+	original := []byte("original")
+	require.NoError(t, c.Put(ctx, PutInput{Key: "root/k.enc", Data: original}))
+	original[0] = 'X'
+
+	data, err := c.Get(ctx, "root/k.enc")
+	require.NoError(t, err)
+	assert.Equal(t, byte('o'), data[0])
+
+	data[0] = 'Y'
+	data2, err := c.Get(ctx, "root/k.enc")
+	require.NoError(t, err)
+	assert.Equal(t, byte('o'), data2[0])
+}
+
+func TestFilesystemClient_RejectsUnsafeKeys(t *testing.T) {
+	ctx := context.Background()
+	c, root := newTestFilesystemClient(t)
+
+	for _, key := range []string{
+		"",
+		"/absolute",
+		"../escape",
+		"root/../escape",
+		"root//double",
+		"./root",
+		"root/.",
+		"root/\x00/null",
+		`root\windows`,
+	} {
+		t.Run(key, func(t *testing.T) {
+			err := c.Put(ctx, PutInput{Key: key, Data: []byte("x")})
+			require.Error(t, err)
+		})
+	}
+
+	_, err := os.Stat(filepath.Join(filepath.Dir(root), "escape"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestNewFilesystemClient_RequiresPath(t *testing.T) {
+	client, err := NewFilesystemClient(&config.BlobStorageFilesystem{
+		Provider: config.BlobStorageProviderFilesystem,
+	})
+	require.Error(t, err)
+	assert.Nil(t, client)
+}

--- a/internal/apblob/from_config.go
+++ b/internal/apblob/from_config.go
@@ -17,6 +17,8 @@ func NewFromConfig(ctx context.Context, cfg *config.BlobStorage) (Client, error)
 	switch v := cfg.InnerVal.(type) {
 	case *config.BlobStorageMemory:
 		return NewMemoryClient(), nil
+	case *config.BlobStorageFilesystem:
+		return NewFilesystemClient(v)
 	case *config.BlobStorageS3:
 		return NewS3Client(ctx, v)
 	default:

--- a/internal/apblob/from_config_test.go
+++ b/internal/apblob/from_config_test.go
@@ -42,3 +42,19 @@ func TestNewFromConfig_MemoryProvider(t *testing.T) {
 	_, ok := client.(*MemoryClient)
 	assert.True(t, ok, "memory provider should return *MemoryClient")
 }
+
+func TestNewFromConfig_FilesystemProvider(t *testing.T) {
+	cfg := &config.BlobStorage{
+		InnerVal: &config.BlobStorageFilesystem{
+			Provider: config.BlobStorageProviderFilesystem,
+			Path:     t.TempDir(),
+		},
+	}
+
+	client, err := NewFromConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	_, ok := client.(*FilesystemClient)
+	assert.True(t, ok, "filesystem provider should return *FilesystemClient")
+}

--- a/internal/schema/config/blob_storage.go
+++ b/internal/schema/config/blob_storage.go
@@ -3,8 +3,9 @@ package config
 type BlobStorageProvider string
 
 const (
-	BlobStorageProviderS3     BlobStorageProvider = "s3"
-	BlobStorageProviderMemory BlobStorageProvider = "memory"
+	BlobStorageProviderS3         BlobStorageProvider = "s3"
+	BlobStorageProviderMemory     BlobStorageProvider = "memory"
+	BlobStorageProviderFilesystem BlobStorageProvider = "filesystem"
 )
 
 // BlobStorageImpl is the interface implemented by concrete blob storage configurations.

--- a/internal/schema/config/blob_storage_filesystem.go
+++ b/internal/schema/config/blob_storage_filesystem.go
@@ -1,0 +1,10 @@
+package config
+
+type BlobStorageFilesystem struct {
+	Provider BlobStorageProvider `json:"provider" yaml:"provider"`
+	Path     string              `json:"path" yaml:"path"`
+}
+
+func (b *BlobStorageFilesystem) GetProvider() BlobStorageProvider {
+	return BlobStorageProviderFilesystem
+}

--- a/internal/schema/config/blob_storage_serialization_json.go
+++ b/internal/schema/config/blob_storage_serialization_json.go
@@ -26,6 +26,8 @@ func (b *BlobStorage) UnmarshalJSON(data []byte) error {
 		switch BlobStorageProvider(fmt.Sprintf("%v", provider)) {
 		case BlobStorageProviderMemory:
 			t = &BlobStorageMemory{}
+		case BlobStorageProviderFilesystem:
+			t = &BlobStorageFilesystem{}
 		case BlobStorageProviderS3:
 			t = &BlobStorageS3{}
 		default:

--- a/internal/schema/config/blob_storage_serialization_test.go
+++ b/internal/schema/config/blob_storage_serialization_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBlobStorage_JSONFilesystem(t *testing.T) {
+	var bs BlobStorage
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"provider": "filesystem",
+		"path": "/tmp/authproxy/blobs"
+	}`), &bs))
+
+	fs, ok := bs.InnerVal.(*BlobStorageFilesystem)
+	require.True(t, ok)
+	assert.Equal(t, BlobStorageProviderFilesystem, fs.Provider)
+	assert.Equal(t, "/tmp/authproxy/blobs", fs.Path)
+
+	data, err := json.Marshal(&bs)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"provider": "filesystem",
+		"path": "/tmp/authproxy/blobs"
+	}`, string(data))
+}
+
+func TestBlobStorage_YAMLFilesystem(t *testing.T) {
+	var bs BlobStorage
+	require.NoError(t, yaml.Unmarshal([]byte(`
+provider: filesystem
+path: /tmp/authproxy/blobs
+`), &bs))
+
+	fs, ok := bs.InnerVal.(*BlobStorageFilesystem)
+	require.True(t, ok)
+	assert.Equal(t, BlobStorageProviderFilesystem, fs.Provider)
+	assert.Equal(t, "/tmp/authproxy/blobs", fs.Path)
+
+	data, err := yaml.Marshal(&bs)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "provider: filesystem")
+	assert.Contains(t, string(data), "path: /tmp/authproxy/blobs")
+}

--- a/internal/schema/config/blob_storage_serialization_yaml.go
+++ b/internal/schema/config/blob_storage_serialization_yaml.go
@@ -36,6 +36,11 @@ fieldLoop:
 					Provider: BlobStorageProviderMemory,
 				}
 				break fieldLoop
+			case BlobStorageProviderFilesystem:
+				bs = &BlobStorageFilesystem{
+					Provider: BlobStorageProviderFilesystem,
+				}
+				break fieldLoop
 			case BlobStorageProviderS3:
 				bs = &BlobStorageS3{
 					Provider: BlobStorageProviderS3,

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -585,10 +585,20 @@
       "required": ["provider"],
       "additionalProperties": false
     },
+    "BlobStorageFilesystem": {
+      "type": "object",
+      "properties": {
+        "provider": { "const": "filesystem" },
+        "path": { "type": "string" }
+      },
+      "required": ["provider", "path"],
+      "additionalProperties": false
+    },
     "BlobStorage": {
       "oneOf": [
         { "$ref": "#/$defs/BlobStorageS3" },
-        { "$ref": "#/$defs/BlobStorageMemory" }
+        { "$ref": "#/$defs/BlobStorageMemory" },
+        { "$ref": "#/$defs/BlobStorageFilesystem" }
       ]
     },
     "ServiceAdminApi": {

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -635,6 +635,54 @@ func TestSchemaDefinitions(t *testing.T) {
 			},
 		},
 		{
+			Name: "BlobStorage",
+			Schema: `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/config/test.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["test"],
+  "properties": {
+	"test": {
+		"$ref": "./schema.json#/$defs/BlobStorage"
+    }
+  }
+}`,
+			Tests: []test{
+				{
+					Name:  "s3 minimal",
+					Valid: true,
+					Data:  `{"test": {"provider": "s3", "bucket": "request-logs"}}`,
+				},
+				{
+					Name:  "memory",
+					Valid: true,
+					Data:  `{"test": {"provider": "memory"}}`,
+				},
+				{
+					Name:  "filesystem",
+					Valid: true,
+					Data:  `{"test": {"provider": "filesystem", "path": "/tmp/authproxy/blobs"}}`,
+				},
+				{
+					Name:  "filesystem missing path",
+					Valid: false,
+					Data:  `{"test": {"provider": "filesystem"}}`,
+				},
+				{
+					Name:  "filesystem extra property",
+					Valid: false,
+					Data:  `{"test": {"provider": "filesystem", "path": "/tmp/authproxy/blobs", "bucket": "x"}}`,
+				},
+				{
+					Name:  "unknown provider",
+					Valid: false,
+					Data:  `{"test": {"provider": "unknown"}}`,
+				},
+			},
+		},
+		{
 			Name: "ConfiguredActor",
 			Schema: `
 {


### PR DESCRIPTION
## Summary

- adds `blob_storage.provider: filesystem` config support and an `apblob` filesystem client
- stores blob keys as slash-separated paths under a configured root while rejecting absolute, empty, dot, dot-dot, null-byte, and backslash path segments
- adds Helm `blobStorage.provider=filesystem` support with an `emptyDir` mount, and wires the per-branch slim profile to use `/tmp/authproxy-blobs`
- moves rendered chart blob storage under `app_metrics.blob_storage`, where the app metrics runtime reads it

Closes #546.

## Validation

- `go test ./internal/apblob -count=1`
- `go test ./internal/schema/config -run 'TestBlobStorage|TestSchemaDefinitions|Test_Schema' -count=1`
- `go test ./internal/apblob ./internal/schema/config -count=1`
- `go test ./internal/app_metrics -run TestGetFullLog_BlobStore -count=1`
- `helm lint deploy/charts/authproxy`
- `helm lint deploy/charts/authproxy-demo`
- `helm template ap deploy/charts/authproxy --set database.provider=sqlite --set database.path=/tmp/authproxy.db --set redis.provider=miniredis --set blobStorage.provider=filesystem --set blobStorage.filesystem.path=/tmp/authproxy-blobs --set jwt.existingSecret=authproxy-jwt --set encryptionKeys.existingSecret=authproxy-encryption --set actors.existingSecret=authproxy-actors --set hostApplication.initiateSessionUrl=http://placeholder.invalid/login`
- `helm template dev deploy/charts/authproxy-demo -f deploy/charts/authproxy-demo/dev-slim-values.yaml --set global.hostname=branch.dev.authproxy.net --set authproxy.image.repository=ghcr.io/rmorlok/authproxy --set authproxy.image.tag=test --set demoShell.image.tag=test --set seed.image.tag=test`
- `./scripts/preflight.sh`
