### PR TITLE
Add Kustomize scaffold for demo/dev deploys

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -6,12 +6,14 @@ on:
     branches: [main]
     paths:
       - 'deploy/charts/**'
+      - 'deploy/kustomize/**'
       - '.github/workflows/helm-chart-ci.yml'
       - '.github/ct.yaml'
   pull_request:
     branches: [main]
     paths:
       - 'deploy/charts/**'
+      - 'deploy/kustomize/**'
       - '.github/workflows/helm-chart-ci.yml'
       - '.github/ct.yaml'
 
@@ -97,6 +99,29 @@ jobs:
 
           if grep -Eq "name: dev-(db|redis-creds|minio-creds|postgresql|redis|minio)|AUTHPROXY_(DB|REDIS)_PASSWORD|root-password|kind: StatefulSet" "${manifest}"; then
             echo "Slim dev render leaked dependency credentials or workloads" >&2
+            exit 1
+          fi
+
+      - name: Verify Kustomize demo/dev renders
+        run: |
+          set -euo pipefail
+          demo_manifest="$(mktemp)"
+          dev_manifest="$(mktemp)"
+
+          kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo >"${demo_manifest}"
+          kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev >"${dev_manifest}"
+
+          grep -q "name: demo-authproxy" "${demo_manifest}"
+          grep -q "host: demo-postgresql" "${demo_manifest}"
+          grep -q "address: demo-redis-master:6379" "${demo_manifest}"
+          grep -q "secretName: demo-jwt" "${demo_manifest}"
+
+          grep -q "name: dev-authproxy" "${dev_manifest}"
+          grep -q "provider: miniredis" "${dev_manifest}"
+          grep -q "provider: filesystem" "${dev_manifest}"
+
+          if grep -Eq "name: dev-(postgresql|redis-master|minio)$" "${dev_manifest}"; then
+            echo "Kustomize dev render leaked backing service workloads" >&2
             exit 1
           fi
 

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -1,0 +1,33 @@
+# AuthProxy Demo Kustomize Manifests
+
+This tree is the Kustomize replacement scaffold for the demo/dev deployment
+path. The customer-facing Helm chart remains in `deploy/charts/authproxy`;
+these manifests are only for hosted demo environments.
+
+The base contains the shared AuthProxy, demo-shell, and go-oauth2-server
+workloads. Overlays choose backing services and public hostnames:
+
+- `overlays/demo` targets `demo.authproxy.net` and includes Postgres, Redis,
+  and MinIO backing workloads.
+- `overlays/dev` targets an example per-branch namespace and keeps the slim
+  dev profile: SQLite, embedded miniredis, and filesystem blob storage.
+
+Render locally:
+
+```bash
+kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
+kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
+```
+
+Secrets are still created by workflow/setup steps. The overlays expect names
+that match the existing release convention after `namePrefix` is applied:
+
+- `<env>-jwt`
+- `<env>-encryption`
+- `<env>-actors`
+- `<env>-demo-shell-key`
+- `<env>-db` and `<env>-redis-creds` for the demo overlay
+
+Seeding is intentionally not modeled here. Demo seeding will move to a manual
+workflow, while dev seeding will be run by the per-branch deploy workflow after
+the environment is applied.

--- a/deploy/kustomize/authproxy-demo/base/authproxy.yaml
+++ b/deploy/kustomize/authproxy-demo/base/authproxy.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authproxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authproxy
+  labels:
+    app.kubernetes.io/name: authproxy
+    app.kubernetes.io/component: authproxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authproxy
+      app.kubernetes.io/component: authproxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authproxy
+        app.kubernetes.io/component: authproxy
+    spec:
+      serviceAccountName: authproxy
+      containers:
+        - name: authproxy
+          image: ghcr.io/rmorlok/authproxy:main
+          imagePullPolicy: Always
+          args:
+            - serve
+            - --config=/etc/authproxy/config.yaml
+            - admin-api,api,public,worker
+          ports:
+            - name: public
+              containerPort: 8080
+            - name: api
+              containerPort: 8081
+            - name: admin-api
+              containerPort: 8082
+            - name: worker-health
+              containerPort: 8083
+          envFrom:
+            - secretRef:
+                name: db
+                optional: true
+            - secretRef:
+                name: redis-creds
+                optional: true
+            - secretRef:
+                name: minio-creds
+                optional: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: public
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: public
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/authproxy/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: jwt-keys
+              mountPath: /etc/authproxy/keys/jwt
+              readOnly: true
+            - name: encryption-keys
+              mountPath: /etc/authproxy/keys/encryption
+              readOnly: true
+            - name: actors-keys
+              mountPath: /etc/authproxy/keys/actors
+              readOnly: true
+            - name: blob-storage
+              mountPath: /tmp/authproxy-blobs
+      volumes:
+        - name: config
+          configMap:
+            name: authproxy-config
+        - name: jwt-keys
+          secret:
+            secretName: authproxy-jwt-placeholder
+        - name: encryption-keys
+          secret:
+            secretName: authproxy-encryption-placeholder
+        - name: actors-keys
+          secret:
+            secretName: authproxy-actors-placeholder
+        - name: blob-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authproxy
+  labels:
+    app.kubernetes.io/name: authproxy
+    app.kubernetes.io/component: authproxy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: authproxy
+    app.kubernetes.io/component: authproxy
+  ports:
+    - name: public
+      port: 8080
+      targetPort: public
+    - name: api
+      port: 8081
+      targetPort: api
+    - name: admin-api
+      port: 8082
+      targetPort: admin-api
+    - name: worker-health
+      port: 8083
+      targetPort: worker-health

--- a/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
+++ b/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-shell
+  labels:
+    app.kubernetes.io/name: demo-shell
+    app.kubernetes.io/component: demo-shell
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo-shell
+      app.kubernetes.io/component: demo-shell
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: demo-shell
+        app.kubernetes.io/component: demo-shell
+    spec:
+      containers:
+        - name: demo-shell
+          image: ghcr.io/rmorlok/authproxy-demo-shell:main
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8888
+          env:
+            - name: PORT
+              value: "8888"
+            - name: ADMIN_USERNAME
+              value: demo-shell
+            - name: ADMIN_PRIVATE_KEY_PATH
+              value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_AUTH_URL
+              value: https://marketplace.demo.authproxy.net
+            - name: AUTHPROXY_MARKETPLACE_URL
+              value: https://marketplace.demo.authproxy.net
+            - name: AUTHPROXY_ADMIN_UI_URL
+              value: https://admin.demo.authproxy.net
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          volumeMounts:
+            - name: admin-key
+              mountPath: /etc/authproxy/demo-shell
+              readOnly: true
+      volumes:
+        - name: admin-key
+          secret:
+            secretName: demo-shell-key-placeholder
+            items:
+              - key: private
+                path: private
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-shell
+  labels:
+    app.kubernetes.io/name: demo-shell
+    app.kubernetes.io/component: demo-shell
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: demo-shell
+    app.kubernetes.io/component: demo-shell
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kustomize/authproxy-demo/base/go-oauth2-server.yaml
+++ b/deploy/kustomize/authproxy-demo/base/go-oauth2-server.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-oauth2-server
+  labels:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: go-oauth2-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: go-oauth2-server
+      app.kubernetes.io/component: go-oauth2-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: go-oauth2-server
+        app.kubernetes.io/component: go-oauth2-server
+    spec:
+      containers:
+        - name: go-oauth2-server
+          image: ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3
+          imagePullPolicy: IfNotPresent
+          command:
+            - go-oauth2-server
+          args:
+            - runserver
+            - --test-mode
+            - --test-port
+            - "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /test/health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-oauth2-server
+  labels:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: go-oauth2-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: go-oauth2-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kustomize/authproxy-demo/base/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - authproxy.yaml
+  - demo-shell.yaml
+  - go-oauth2-server.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: authproxy-demo

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -1,0 +1,61 @@
+public:
+  port: 8080
+  base_url: https://marketplace.demo.authproxy.net
+  enable_proxy: true
+  static: {}
+api:
+  port: 8081
+admin_api:
+  port: 8082
+  ui:
+    enabled: true
+    base_url: https://admin.demo.authproxy.net
+    initiate_session_url: https://demo.authproxy.net/
+  static: {}
+worker:
+  health_check_port: 8083
+database:
+  provider: postgres
+  auto_migrate: true
+  host: demo-postgresql
+  port: 5432
+  user: authproxy
+  database: authproxy
+  sslmode: disable
+  password:
+    env_var: AUTHPROXY_DB_PASSWORD
+redis:
+  provider: redis
+  address: demo-redis-master:6379
+  db: 0
+  password:
+    env_var: AUTHPROXY_REDIS_PASSWORD
+host_application:
+  initiate_session_url: https://demo.authproxy.net/
+connectors:
+  auto_migrate: true
+  load_from_list: []
+app_metrics:
+  auto_migrate: true
+  database:
+    provider: sqlite
+    path: /tmp/authproxy-app-metrics.db
+  request_events:
+    full_request_recording: never
+system_auth:
+  jwt_signing_key:
+    public_key:
+      path: /etc/authproxy/keys/jwt/system.pub
+    private_key:
+      path: /etc/authproxy/keys/jwt/system
+  global_aes_key:
+    path: /etc/authproxy/keys/encryption/global_aes.key
+  actors:
+    keys_path: /etc/authproxy/keys/actors
+    permissions:
+      root:
+        - act:*
+        - con:*
+        - conn:*
+        - ns:*
+        - px:*

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: authproxy
+          envFrom:
+            - secretRef:
+                name: demo-db
+                optional: true
+            - secretRef:
+                name: demo-redis-creds
+                optional: true
+            - secretRef:
+                name: demo-minio-creds
+                optional: true
+      volumes:
+        - name: jwt-keys
+          secret:
+            secretName: demo-jwt
+        - name: encryption-keys
+          secret:
+            secretName: demo-encryption
+        - name: actors-keys
+          secret:
+            secretName: demo-actors

--- a/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-shell
+spec:
+  template:
+    spec:
+      containers:
+        - name: demo-shell
+          env:
+            - name: PORT
+              value: "8888"
+            - name: ADMIN_USERNAME
+              value: demo-shell
+            - name: ADMIN_PRIVATE_KEY_PATH
+              value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_AUTH_URL
+              value: https://marketplace.demo.authproxy.net
+            - name: AUTHPROXY_MARKETPLACE_URL
+              value: https://marketplace.demo.authproxy.net
+            - name: AUTHPROXY_ADMIN_UI_URL
+              value: https://admin.demo.authproxy.net
+      volumes:
+        - name: admin-key
+          secret:
+            secretName: demo-demo-shell-key
+            items:
+              - key: private
+                path: private

--- a/deploy/kustomize/authproxy-demo/overlays/demo/ingress.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/ingress.yaml
@@ -1,0 +1,69 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod-dns01
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: demo-authproxy-tls
+      hosts:
+        - demo.authproxy.net
+        - marketplace.demo.authproxy.net
+        - admin.demo.authproxy.net
+  rules:
+    - host: demo.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-shell
+                port:
+                  name: http
+    - host: marketplace.demo.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authproxy
+                port:
+                  name: public
+    - host: admin.demo.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authproxy
+                port:
+                  name: admin-api
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-oauth2-server
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod-dns01
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: demo-go-oauth2-server-tls
+      hosts:
+        - oauth2.demo.authproxy.net
+  rules:
+    - host: oauth2.demo.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: go-oauth2-server
+                port:
+                  name: http

--- a/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: demo
+namePrefix: demo-
+
+resources:
+  - ../../base
+  - ingress.yaml
+  - minio.yaml
+  - postgres.yaml
+  - redis.yaml
+
+configMapGenerator:
+  - name: authproxy-config
+    files:
+      - config.yaml=authproxy-config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - path: authproxy-secrets.yaml
+  - path: demo-shell-env.yaml

--- a/deploy/kustomize/authproxy-demo/overlays/demo/minio.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/minio.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/component: object-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/component: object-storage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        app.kubernetes.io/component: object-storage
+    spec:
+      containers:
+        - name: minio
+          image: docker.io/bitnamilegacy/minio:2024.11.7-debian-12-r0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 9000
+          env:
+            - name: MINIO_ROOT_USER
+              value: authproxy
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: demo-minio-creds
+                  key: root-password
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/component: object-storage
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/component: object-storage
+  ports:
+    - name: api
+      port: 9000
+      targetPort: api

--- a/deploy/kustomize/authproxy-demo/overlays/demo/postgres.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/postgres.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: database
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:17.2.0-debian-12-r6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRESQL_USERNAME
+              value: authproxy
+            - name: POSTGRESQL_DATABASE
+              value: authproxy
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: demo-db
+                  key: AUTHPROXY_DB_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql

--- a/deploy/kustomize/authproxy-demo/overlays/demo/redis.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/redis.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: docker.io/bitnamilegacy/redis:7.4.1-debian-12-r2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "no"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: demo-redis-creds
+                  key: AUTHPROXY_REDIS_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -1,0 +1,54 @@
+public:
+  port: 8080
+  base_url: https://marketplace.branch.dev.authproxy.net
+  enable_proxy: true
+  static: {}
+api:
+  port: 8081
+admin_api:
+  port: 8082
+  ui:
+    enabled: true
+    base_url: https://admin.branch.dev.authproxy.net
+    initiate_session_url: https://branch.dev.authproxy.net/
+  static: {}
+worker:
+  health_check_port: 8083
+database:
+  provider: sqlite
+  auto_migrate: true
+  path: /tmp/authproxy-dev.db
+redis:
+  provider: miniredis
+host_application:
+  initiate_session_url: https://branch.dev.authproxy.net/
+connectors:
+  auto_migrate: true
+  load_from_list: []
+app_metrics:
+  auto_migrate: true
+  database:
+    provider: sqlite
+    path: /tmp/authproxy-dev.db.app-metrics
+  request_events:
+    full_request_recording: never
+  blob_storage:
+    provider: filesystem
+    path: /tmp/authproxy-blobs
+system_auth:
+  jwt_signing_key:
+    public_key:
+      path: /etc/authproxy/keys/jwt/system.pub
+    private_key:
+      path: /etc/authproxy/keys/jwt/system
+  global_aes_key:
+    path: /etc/authproxy/keys/encryption/global_aes.key
+  actors:
+    keys_path: /etc/authproxy/keys/actors
+    permissions:
+      root:
+        - act:*
+        - con:*
+        - conn:*
+        - ns:*
+        - px:*

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: authproxy
+          envFrom:
+            - secretRef:
+                name: dev-db
+                optional: true
+            - secretRef:
+                name: dev-redis-creds
+                optional: true
+            - secretRef:
+                name: dev-minio-creds
+                optional: true
+      volumes:
+        - name: jwt-keys
+          secret:
+            secretName: dev-jwt
+        - name: encryption-keys
+          secret:
+            secretName: dev-encryption
+        - name: actors-keys
+          secret:
+            secretName: dev-actors

--- a/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-shell
+spec:
+  template:
+    spec:
+      containers:
+        - name: demo-shell
+          env:
+            - name: PORT
+              value: "8888"
+            - name: ADMIN_USERNAME
+              value: demo-shell
+            - name: ADMIN_PRIVATE_KEY_PATH
+              value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_AUTH_URL
+              value: https://marketplace.branch.dev.authproxy.net
+            - name: AUTHPROXY_MARKETPLACE_URL
+              value: https://marketplace.branch.dev.authproxy.net
+            - name: AUTHPROXY_ADMIN_UI_URL
+              value: https://admin.branch.dev.authproxy.net
+      volumes:
+        - name: admin-key
+          secret:
+            secretName: dev-demo-shell-key
+            items:
+              - key: private
+                path: private

--- a/deploy/kustomize/authproxy-demo/overlays/dev/ingress.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/ingress.yaml
@@ -1,0 +1,69 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod-dns01
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: dev-authproxy-tls
+      hosts:
+        - branch.dev.authproxy.net
+        - marketplace.branch.dev.authproxy.net
+        - admin.branch.dev.authproxy.net
+  rules:
+    - host: branch.dev.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-shell
+                port:
+                  name: http
+    - host: marketplace.branch.dev.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authproxy
+                port:
+                  name: public
+    - host: admin.branch.dev.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authproxy
+                port:
+                  name: admin-api
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-oauth2-server
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod-dns01
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: dev-go-oauth2-server-tls
+      hosts:
+        - oauth2.branch.dev.authproxy.net
+  rules:
+    - host: oauth2.branch.dev.authproxy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: go-oauth2-server
+                port:
+                  name: http

--- a/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: authproxy-dev-placeholder
+namePrefix: dev-
+
+resources:
+  - ../../base
+  - ingress.yaml
+
+configMapGenerator:
+  - name: authproxy-config
+    files:
+      - config.yaml=authproxy-config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - path: authproxy-secrets.yaml
+  - path: demo-shell-env.yaml


### PR DESCRIPTION
## Summary
- Add a Kustomize scaffold for hosted AuthProxy demo/dev deployments under deploy/kustomize/authproxy-demo
- Keep the demo overlay on Postgres/Redis/MinIO-style backing workloads while keeping dev on SQLite, miniredis, and filesystem blob storage
- Add a CI render check so both Kustomize overlays stay parseable and preserve the expected demo/dev storage split

Closes #561

## Validation
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
- local CI render check block from helm-chart-ci.yml
- ./scripts/preflight.sh

Note: kubectl apply --dry-run=client attempted to contact the EKS API for discovery through AWS exec auth in this sandbox and failed on blocked AWS network access, so validation is limited to Kustomize rendering and repo preflight for this scaffold PR.