### PR TITLE
Restore Grafana to demo Kustomize deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -18,6 +18,8 @@ name: Deploy Demo
 #     and demo-minio-creds.
 #   - Repo secret AWS_ROLE_ARN.
 #   - Repo variables AWS_REGION, EKS_CLUSTER, and DEMO_HOSTNAME.
+#   - Optional repo variable GRAFANA_AUTHPROXY_PLUGIN_INSTALL to override
+#     Grafana's GF_INSTALL_PLUGINS value.
 
 on:
   workflow_run:
@@ -136,11 +138,35 @@ jobs:
             --region "${{ vars.AWS_REGION }}"
           kubectl get nodes -o wide
 
+      - name: Provision Grafana datasource JWT
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
+
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-encryption" \
+            -o jsonpath='{.data.global_aes\.key}' \
+            | base64 -d > "${workdir}/global_aes.key"
+          chmod 600 "${workdir}/global_aes.key"
+
+          go run ./cmd/cli sign-jwt \
+            --actorId grafana \
+            --apis api,admin-api \
+            --grafana-preset logs \
+            --secretKeyPath "${workdir}/global_aes.key" \
+            > "${workdir}/grafana.jwt"
+
+          kubectl -n "${RELEASE_NS}" create secret generic authproxy-grafana-jwt \
+            --from-file=jwt="${workdir}/grafana.jwt" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
+
       - name: Render Kustomize overlay
         id: render
         env:
           DEMO_HOSTNAME: ${{ vars.DEMO_HOSTNAME || 'demo.authproxy.net' }}
           DEMO_CLUSTER_ISSUER: ${{ vars.DEMO_CLUSTER_ISSUER || 'letsencrypt-prod-dns01' }}
+          GRAFANA_PLUGIN_INSTALL: ${{ vars.GRAFANA_AUTHPROXY_PLUGIN_INSTALL || 'rmorlok-authproxy-datasource' }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
@@ -151,13 +177,17 @@ jobs:
 
           perl -0pi -e 's|(name: ghcr\.io/rmorlok/authproxy\n\s+newTag: )main|${1}$ENV{IMAGE_TAG}|g; s|(name: ghcr\.io/rmorlok/authproxy-demo-shell\n\s+newTag: )main|${1}$ENV{IMAGE_TAG}|g' \
             "${KUSTOMIZE_OVERLAY}/kustomization.yaml"
+          perl -0pi -e '$r=$ENV{GRAFANA_PLUGIN_INSTALL}; s/__GRAFANA_PLUGIN_INSTALL__/$r/g' \
+            "${KUSTOMIZE_OVERLAY}/grafana.yaml"
 
           kubectl kustomize "${KUSTOMIZE_OVERLAY}" > "${manifest}"
           echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
 
-          grep -q "image: ghcr.io/rmorlok/authproxy:${IMAGE_TAG}" "${manifest}"
-          grep -q "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
-          grep -q "host: ${DEMO_HOSTNAME}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "image: docker.io/grafana/grafana:11.5.2" "${manifest}"
+          grep -Fq "host: ${DEMO_HOSTNAME}" "${manifest}"
+          grep -Fq "value: ${GRAFANA_PLUGIN_INSTALL}" "${manifest}"
 
       - name: Apply Kustomize manifest
         run: |
@@ -168,7 +198,7 @@ jobs:
             | kubectl apply -f -
           kubectl -n "${RELEASE_NS}" apply -f "${manifest}"
 
-          for deployment in "${RELEASE_NAME}-authproxy" "${RELEASE_NAME}-demo-shell"; do
+          for deployment in "${RELEASE_NAME}-authproxy" "${RELEASE_NAME}-demo-shell" "${RELEASE_NAME}-grafana"; do
             kubectl -n "${RELEASE_NS}" patch "deployment/${deployment}" \
               --type merge \
               -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"demo.authproxy.net/image-revision\":\"${{ steps.tag.outputs.sha }}\"}}}}}"
@@ -189,12 +219,13 @@ jobs:
             "${RELEASE_NAME}-postgresql" \
             "${RELEASE_NAME}-redis-master" \
             "${RELEASE_NAME}-minio" \
+            "${RELEASE_NAME}-grafana" \
           ; do
             kubectl -n "${RELEASE_NS}" describe "deployment/$d"
             echo
           done
           echo "## Recent pod logs"
-          for selector in authproxy demo-shell go-oauth2-server; do
+          for selector in authproxy demo-shell go-oauth2-server grafana; do
             kubectl -n "${RELEASE_NS}" logs \
               -l "app.kubernetes.io/name=${selector}" \
               --all-containers --tail=120
@@ -216,6 +247,7 @@ jobs:
             "${RELEASE_NAME}-authproxy" \
             "${RELEASE_NAME}-demo-shell" \
             "${RELEASE_NAME}-go-oauth2-server" \
+            "${RELEASE_NAME}-grafana" \
           ; do
             echo "Waiting for $d..."
             kubectl -n "${RELEASE_NS}" rollout status "deployment/$d" --timeout=10m
@@ -269,6 +301,7 @@ jobs:
             echo "- Image tag:   \`${{ steps.tag.outputs.tag }}\`"
             echo "- Commit:      \`${{ steps.tag.outputs.sha }}\`"
             echo "- Hostname:    \`https://${{ vars.DEMO_HOSTNAME || 'demo.authproxy.net' }}/\`"
+            echo "- Grafana:     \`https://${{ vars.DEMO_HOSTNAME || 'demo.authproxy.net' }}/grafana\`"
             echo "- Renderer:    \`kubectl kustomize ${KUSTOMIZE_OVERLAY}\`"
             echo "- Seeding:     manual via \`Seed Demo\` workflow"
             echo "- Rollback:    rerun this workflow with a previous image tag"

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -21,7 +21,9 @@ kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
 
 `Deploy Demo` renders `overlays/demo`, rewrites the checked-out overlay with
 the selected image tag and configured hostname, and applies the resulting
-manifest with `kubectl apply`.
+manifest with `kubectl apply`. The demo overlay includes Grafana at
+`https://<hostname>/grafana` with the AuthProxy datasource and sample app
+metrics dashboard provisioned from Kustomize ConfigMaps.
 
 Secrets are still created by workflow/setup steps. The overlays expect names
 that match the existing release convention after `namePrefix` is applied:

--- a/deploy/kustomize/authproxy-demo/overlays/demo/dashboards/authproxy-app-metrics.json
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/dashboards/authproxy-app-metrics.json
@@ -1,0 +1,558 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.0",
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.namespaces",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Namespaces"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.connectors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Connectors"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.connections",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Connections"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.actors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "Actors"
+        },
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "metric": "resources.rate_limits",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "RateLimits"
+        }
+      ],
+      "title": "Resource Counts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["state", "health_state"],
+          "metric": "resources.connections",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection States",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["mode", "namespace"],
+          "metric": "resources.rate_limits",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Rate Limit Attribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "req"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["method"],
+          "metric": "request_events",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "errors"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "count",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["response_status_code", "connector_id"],
+          "metric": "request_events.errors",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregation": "p95",
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "groupBy": ["connector_id"],
+          "metric": "request_events.duration_ms",
+          "namespace": "$namespace",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "rmorlok-authproxy-datasource",
+        "uid": "authproxy-app-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "rmorlok-authproxy-datasource",
+            "uid": "authproxy-app-metrics"
+          },
+          "queryType": "request_events",
+          "refId": "A",
+          "requestFilters": {
+            "connectorId": "$connector",
+            "connectionId": "$connection",
+            "labelSelector": "$label_selector",
+            "namespace": "$namespace",
+            "statusCodeRange": "$status"
+          }
+        }
+      ],
+      "title": "Request Event Metadata",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": ["authproxy", "app-metrics", "demo"],
+  "templating": {
+    "list": [
+      {
+        "allValue": "root.**",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "namespaces",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "type": "namespaces"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": "All connectors",
+          "value": ""
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "connectors",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Connector",
+        "multi": false,
+        "name": "connector",
+        "options": [],
+        "query": {
+          "namespace": "$namespace",
+          "type": "connectors"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": "All connections",
+          "value": ""
+        },
+        "datasource": {
+          "type": "rmorlok-authproxy-datasource",
+          "uid": "authproxy-app-metrics"
+        },
+        "definition": "connections",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Connection",
+        "multi": false,
+        "name": "connection",
+        "options": [],
+        "query": {
+          "connectorId": "$connector",
+          "namespace": "$namespace",
+          "type": "connections"
+        },
+        "refresh": 1,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "Any status",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Status",
+        "multi": false,
+        "name": "status",
+        "options": [
+          {
+            "selected": true,
+            "text": "Any status",
+            "value": ""
+          },
+          {
+            "selected": false,
+            "text": "2xx",
+            "value": "2xx"
+          },
+          {
+            "selected": false,
+            "text": "3xx",
+            "value": "3xx"
+          },
+          {
+            "selected": false,
+            "text": "4xx",
+            "value": "4xx"
+          },
+          {
+            "selected": false,
+            "text": "5xx",
+            "value": "5xx"
+          }
+        ],
+        "query": ",2xx,3xx,4xx,5xx",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Label selector",
+        "name": "label_selector",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AuthProxy App Metrics",
+  "uid": "authproxy-app-metrics-demo",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+data:
+  authproxy-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: AuthProxy
+        uid: authproxy-app-metrics
+        type: rmorlok-authproxy-datasource
+        access: proxy
+        editable: true
+        jsonData:
+          baseUrl: http://demo-authproxy:8081
+        secureJsonData:
+          jwt: ${AUTHPROXY_GRAFANA_JWT}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+data:
+  authproxy-dashboards.yaml: |-
+    apiVersion: 1
+    providers:
+      - name: AuthProxy
+        orgId: 1
+        folder: AuthProxy
+        type: file
+        disableDeletion: false
+        allowUiUpdates: true
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/component: observability
+    spec:
+      containers:
+        - name: grafana
+          image: docker.io/grafana/grafana:11.5.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: GF_INSTALL_PLUGINS
+              value: "__GRAFANA_PLUGIN_INSTALL__"
+            - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
+              value: rmorlok-authproxy-datasource
+            - name: GF_SERVER_ROOT_URL
+              value: "%(protocol)s://%(domain)s/grafana/"
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
+            - name: AUTHPROXY_GRAFANA_JWT
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-grafana-jwt
+                  key: jwt
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: datasource
+              mountPath: /etc/grafana/provisioning/datasources/authproxy-datasource.yaml
+              subPath: authproxy-datasource.yaml
+              readOnly: true
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards/authproxy-dashboards.yaml
+              subPath: authproxy-dashboards.yaml
+              readOnly: true
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+      volumes:
+        - name: datasource
+          configMap:
+            name: grafana-datasource
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kustomize/authproxy-demo/overlays/demo/ingress.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/ingress.yaml
@@ -16,6 +16,13 @@ spec:
     - host: demo.authproxy.net
       http:
         paths:
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
@@ -6,6 +6,7 @@ namePrefix: demo-
 
 resources:
   - ../../base
+  - grafana.yaml
   - ingress.yaml
   - minio.yaml
   - postgres.yaml
@@ -15,6 +16,9 @@ configMapGenerator:
   - name: authproxy-config
     files:
       - config.yaml=authproxy-config.yaml
+  - name: grafana-dashboards
+    files:
+      - authproxy-app-metrics.json=dashboards/authproxy-app-metrics.json
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## Summary
- Add Grafana back to the demo Kustomize overlay as native Deployment/Service resources
- Provision the AuthProxy datasource and app metrics dashboard through Kustomize ConfigMaps
- Route `/grafana` on the demo apex host to Grafana
- Restore Deploy Demo's Grafana datasource JWT generation, plugin install override, rollout wait, diagnostics, and summary URL

Follow-up to the Grafana review comment on #569.

## Validation
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
- local temp-copy simulation of Deploy Demo's render/rewrite path with a URL-style GRAFANA_AUTHPROXY_PLUGIN_INSTALL value
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-demo.yml")'
- ./scripts/preflight.sh