### PR TITLE
Deploy dev environments with Kustomize

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,7 +13,7 @@ name: Deploy Dev
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, closed]
 
 permissions:
   actions: read
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   deploy:
     if: >
+      github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'deploy:demo')
     runs-on: ubuntu-latest
@@ -38,10 +39,9 @@ jobs:
 
     env:
       RELEASE_NAME: dev
-      CHART_PATH: deploy/charts/authproxy-demo
+      KUSTOMIZE_OVERLAY: deploy/kustomize/authproxy-demo/overlays/dev
       DEV_DOMAIN: ${{ vars.DEV_DOMAIN || 'dev.authproxy.net' }}
-      DEV_CLUSTER_ISSUER: ${{ vars.DEV_CLUSTER_ISSUER || 'letsencrypt-prod' }}
-      DEV_TLS_WILDCARD_SUBDOMAINS: ${{ vars.DEV_TLS_WILDCARD_SUBDOMAINS || 'false' }}
+      DEV_CLUSTER_ISSUER: ${{ vars.DEV_CLUSTER_ISSUER || 'letsencrypt-prod-dns01' }}
       REGISTRY: ghcr.io
       PR_NUMBER: ${{ github.event.pull_request.number }}
       BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
@@ -51,11 +51,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.16.4
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -193,15 +188,6 @@ jobs:
             --region "${{ vars.AWS_REGION }}"
           kubectl get nodes -o wide
 
-      - name: Register Helm repos for subcharts
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo update
-
-      - name: helm dependency update
-        run: helm dependency update "${CHART_PATH}"
-
       - name: Provision dev namespace secrets
         env:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
@@ -255,15 +241,12 @@ jobs:
             echo "Reusing ${RELEASE_NAME}-actors"
           fi
 
-      - name: Recover stuck Helm release
+      - name: Clear stale seed job
         env:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
         run: |
           set -euo pipefail
 
-          # Helm hook Jobs can outlive an atomic uninstall / failed install.
-          # Dev environments are disposable, so clear stale hook resources
-          # before each install to avoid waiting on an old Job's pods.
           kubectl -n "${RELEASE_NS}" delete job "${RELEASE_NAME}-seed" \
             --ignore-not-found --wait=false
           kubectl -n "${RELEASE_NS}" delete configmap "${RELEASE_NAME}-seed-config" \
@@ -282,47 +265,50 @@ jobs:
             exit 1
           fi
 
-          if ! helm status "${RELEASE_NAME}" -n "${RELEASE_NS}" >/dev/null 2>&1; then
-            echo "No existing ${RELEASE_NAME} release in ${RELEASE_NS}."
-            exit 0
+      - name: Render Kustomize overlay
+        id: render
+        env:
+          RELEASE_NS: ${{ steps.env.outputs.namespace }}
+          DEV_HOSTNAME: ${{ steps.env.outputs.hostname }}
+          IMAGE_TAG: ${{ steps.env.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          manifest="${RUNNER_TEMP}/dev-kustomize.yaml"
+
+          find "${KUSTOMIZE_OVERLAY}" -type f -name '*.yaml' -print0 \
+            | xargs -0 perl -0pi -e 's/branch\.dev\.authproxy\.net/$ENV{DEV_HOSTNAME}/g; s/authproxy-dev-placeholder/$ENV{RELEASE_NS}/g; s/letsencrypt-prod-dns01/$ENV{DEV_CLUSTER_ISSUER}/g'
+
+          find "${KUSTOMIZE_OVERLAY}" -type f -name kustomization.yaml -print0 \
+            | xargs -0 perl -0pi -e 's#(name: ghcr\.io/rmorlok/(?:authproxy|authproxy-demo-shell|authproxy-demo-seed)\n\s+newTag: )main#${1}$ENV{IMAGE_TAG}#g'
+
+          kubectl kustomize "${KUSTOMIZE_OVERLAY}" > "${manifest}"
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
+
+          grep -Fq "namespace: ${RELEASE_NS}" "${manifest}"
+          grep -Fq "host: ${DEV_HOSTNAME}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "provider: miniredis" "${manifest}"
+          grep -Fq "provider: filesystem" "${manifest}"
+          if grep -Eq "name: dev-(postgresql|redis-master|minio)$" "${manifest}"; then
+            echo "Dev Kustomize render leaked backing service workloads" >&2
+            exit 1
           fi
 
-          status="$(helm status "${RELEASE_NAME}" -n "${RELEASE_NS}" -o json | jq -r '.info.status // ""')"
-          echo "Existing ${RELEASE_NAME} release status: ${status}"
-
-          case "${status}" in
-            deployed)
-              echo "Release is deployed; normal upgrade can proceed."
-              ;;
-            *)
-              echo "Resetting disposable dev release stuck in ${status:-unknown} state."
-              helm uninstall "${RELEASE_NAME}" -n "${RELEASE_NS}" --wait --timeout 5m || true
-              ;;
-          esac
-
-      - name: helm upgrade --install
+      - name: Apply Kustomize manifest
         env:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
         run: |
           set -euo pipefail
-          helm upgrade --install "${RELEASE_NAME}" "${CHART_PATH}" \
-            -f "${CHART_PATH}/dev-slim-values.yaml" \
-            --namespace "${RELEASE_NS}" \
-            --atomic \
-            --wait --timeout 10m \
-            --set "global.hostname=${{ steps.env.outputs.hostname }}" \
-            --set "global.clusterIssuer=${DEV_CLUSTER_ISSUER}" \
-            --set "ingress.wildcardSubdomains=${DEV_TLS_WILDCARD_SUBDOMAINS}" \
-            --set "authproxy.image.tag=${{ steps.env.outputs.image_tag }}" \
-            --set "authproxy.image.pullPolicy=Always" \
-            --set-string "authproxy.podAnnotations.demo\.authproxy\.net/image-revision=${{ github.sha }}" \
-            --set "demoShell.image.tag=${{ steps.env.outputs.image_tag }}" \
-            --set "demoShell.image.pullPolicy=Always" \
-            --set-string "demoShell.podAnnotations.demo\.authproxy\.net/image-revision=${{ github.sha }}" \
-            --set "seed.image.tag=${{ steps.env.outputs.image_tag }}" \
-            --set "seed.image.pullPolicy=Always" \
-            --set "grafana.enabled=false" \
-            --set "grafanaAuthProxy.enabled=false"
+          manifest="${{ steps.render.outputs.manifest }}"
+
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}"
+
+          for deployment in "${RELEASE_NAME}-authproxy" "${RELEASE_NAME}-demo-shell"; do
+            kubectl -n "${RELEASE_NS}" patch "deployment/${deployment}" \
+              --type merge \
+              -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"demo.authproxy.net/image-revision\":\"${PR_HEAD_SHA}\"}}}}}"
+          done
 
       - name: Wait for workload rollouts
         timeout-minutes: 5
@@ -333,33 +319,67 @@ jobs:
           for d in \
             "${RELEASE_NAME}-authproxy" \
             "${RELEASE_NAME}-demo-shell" \
-            "${RELEASE_NAME}-grafana" \
             "${RELEASE_NAME}-go-oauth2-server"
           do
-            if ! kubectl -n "${RELEASE_NS}" get "deployment/$d" >/dev/null 2>&1; then
-              echo "Skipping $d; deployment is not rendered."
-              continue
-            fi
             kubectl -n "${RELEASE_NS}" rollout status "deployment/$d" --timeout=5m
           done
 
-      - name: Wait for TLS certificate
+      - name: Wait for TLS certificates
         timeout-minutes: 20
         env:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
         run: |
           set -euo pipefail
-          cert_name="${RELEASE_NAME}-demo-tls"
-          if kubectl -n "${RELEASE_NS}" wait \
-            --for=condition=Ready \
-            "certificate/${cert_name}" \
-            --timeout=18m; then
-            exit 0
+          for cert_name in "${RELEASE_NAME}-branch-wildcard-tls" "${RELEASE_NAME}-subdomain-wildcard-tls"; do
+            echo "Waiting for certificate/${cert_name}..."
+            if kubectl -n "${RELEASE_NS}" wait \
+              --for=condition=Ready \
+              "certificate/${cert_name}" \
+              --timeout=18m; then
+              continue
+            fi
+
+            kubectl -n "${RELEASE_NS}" describe "certificate/${cert_name}" || true
+            kubectl -n "${RELEASE_NS}" get certificate,order,challenge || true
+            exit 1
+          done
+
+      - name: Render seed job
+        id: seed
+        env:
+          RELEASE_NS: ${{ steps.env.outputs.namespace }}
+        run: |
+          set -euo pipefail
+          manifest="${RUNNER_TEMP}/dev-seed.yaml"
+
+          kubectl kustomize "${KUSTOMIZE_OVERLAY}/seed" > "${manifest}"
+
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
+          grep -Fq "namespace: ${RELEASE_NS}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-seed:${{ steps.env.outputs.image_tag }}" "${manifest}"
+          grep -Fq "value: http://dev-authproxy:8082" "${manifest}"
+          grep -Fq "base_url: http://dev-go-oauth2-server" "${manifest}"
+
+      - name: Run seed job
+        env:
+          RELEASE_NS: ${{ steps.env.outputs.namespace }}
+        run: |
+          set -euo pipefail
+          manifest="${{ steps.seed.outputs.manifest }}"
+
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}"
+
+          if ! kubectl -n "${RELEASE_NS}" wait \
+            --for=condition=complete "job/${RELEASE_NAME}-seed" \
+            --timeout=10m; then
+            kubectl -n "${RELEASE_NS}" describe "job/${RELEASE_NAME}-seed" || true
+            kubectl -n "${RELEASE_NS}" logs "job/${RELEASE_NAME}-seed" \
+              --all-containers --tail=-1 || true
+            exit 1
           fi
 
-          kubectl -n "${RELEASE_NS}" describe "certificate/${cert_name}" || true
-          kubectl -n "${RELEASE_NS}" get certificate,order,challenge || true
-          exit 1
+          kubectl -n "${RELEASE_NS}" logs "job/${RELEASE_NAME}-seed" \
+            --all-containers --tail=-1
 
       - name: Smoke test (demo connectors)
         id: smoke
@@ -505,13 +525,8 @@ jobs:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
         run: |
           set +e
-          echo "::group::Helm status"
-          helm status "${RELEASE_NAME}" -n "${RELEASE_NS}"
-          helm history "${RELEASE_NAME}" -n "${RELEASE_NS}"
-          echo "::endgroup::"
-
           echo "::group::Kubernetes resources"
-          kubectl -n "${RELEASE_NS}" get all,certificate,order,challenge -o wide
+          kubectl -n "${RELEASE_NS}" get all,ingress,certificate,order,challenge -o wide
           echo "::endgroup::"
 
           echo "::group::Pods"
@@ -543,4 +558,83 @@ jobs:
             echo "- Namespace: \`${{ steps.env.outputs.namespace }}\`"
             echo "- Hostname:  \`https://${{ steps.env.outputs.hostname }}/\`"
             echo "- Image tag: \`${{ steps.env.outputs.image_tag }}\`"
+            echo "- Renderer:  \`kubectl kustomize ${KUSTOMIZE_OVERLAY}\`"
+            echo "- Seeded:    \`kubectl kustomize ${KUSTOMIZE_OVERLAY}/seed\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  teardown:
+    if: >
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'deploy:demo')
+    runs-on: ubuntu-latest
+    environment: gha-eks
+    timeout-minutes: 15
+
+    env:
+      DEV_DOMAIN: ${{ vars.DEV_DOMAIN || 'dev.authproxy.net' }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+
+    steps:
+      - name: Resolve environment names
+        id: env
+        run: |
+          set -euo pipefail
+
+          # Keep this slugging in sync with the deploy job so closed PRs
+          # delete the same namespace they created.
+          label="$(printf '%s' "${BRANCH_NAME}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+          if [ -z "${label}" ]; then
+            label="pr-${PR_NUMBER}"
+          fi
+
+          label="${label:0:59}"
+          label="$(printf '%s' "${label}" | sed -E 's/-+$//')"
+          if [ -z "${label}" ]; then
+            label="pr-${PR_NUMBER}"
+          fi
+
+          namespace="dev-${label}"
+          hostname="${label}.${DEV_DOMAIN}"
+
+          {
+            echo "label=${label}"
+            echo "namespace=${namespace}"
+            echo "hostname=${hostname}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Namespace: ${namespace}"
+          echo "Hostname:  https://${hostname}/"
+
+      - name: Assume GH Actions role via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Wire kubeconfig
+        run: |
+          aws eks update-kubeconfig \
+            --name "${{ vars.EKS_CLUSTER }}" \
+            --region "${{ vars.AWS_REGION }}"
+
+      - name: Delete dev namespace
+        run: |
+          kubectl delete namespace "${{ steps.env.outputs.namespace }}" \
+            --ignore-not-found \
+            --wait=true \
+            --timeout=10m
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Dev teardown"
+            echo ""
+            echo "- Result:    ${{ job.status }}"
+            echo "- Namespace: \`${{ steps.env.outputs.namespace }}\`"
+            echo "- Hostname:  \`https://${{ steps.env.outputs.hostname }}/\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -53,9 +53,8 @@ system_auth:
   actors:
     keys_path: /etc/authproxy/keys/actors
     permissions:
-      root:
-        - act:*
-        - con:*
-        - conn:*
-        - ns:*
-        - px:*
+      - namespace: root.**
+        resources:
+          - "*"
+        verbs:
+          - "*"

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -46,9 +46,8 @@ system_auth:
   actors:
     keys_path: /etc/authproxy/keys/actors
     permissions:
-      root:
-        - act:*
-        - con:*
-        - conn:*
-        - ns:*
-        - px:*
+      - namespace: root.**
+        resources:
+          - "*"
+        verbs:
+          - "*"

--- a/deploy/kustomize/authproxy-demo/overlays/dev/ingress.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/ingress.yaml
@@ -7,11 +7,12 @@ metadata:
 spec:
   ingressClassName: nginx
   tls:
-    - secretName: dev-authproxy-tls
+    - secretName: dev-branch-wildcard-tls
       hosts:
-        - branch.dev.authproxy.net
-        - marketplace.branch.dev.authproxy.net
-        - admin.branch.dev.authproxy.net
+        - "*.dev.authproxy.net"
+    - secretName: dev-subdomain-wildcard-tls
+      hosts:
+        - "*.branch.dev.authproxy.net"
   rules:
     - host: branch.dev.authproxy.net
       http:
@@ -48,12 +49,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: go-oauth2-server
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod-dns01
 spec:
   ingressClassName: nginx
   tls:
-    - secretName: dev-go-oauth2-server-tls
+    - secretName: dev-subdomain-wildcard-tls
       hosts:
         - oauth2.branch.dev.authproxy.net
   rules:

--- a/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
@@ -16,6 +16,12 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 
+images:
+  - name: ghcr.io/rmorlok/authproxy
+    newTag: main
+  - name: ghcr.io/rmorlok/authproxy-demo-shell
+    newTag: main
+
 patches:
   - path: authproxy-secrets.yaml
   - path: demo-shell-env.yaml

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: authproxy-dev-placeholder
+namePrefix: dev-
+
+resources:
+  - seed-config.yaml
+  - seed-job.yaml
+
+images:
+  - name: ghcr.io/rmorlok/authproxy-demo-seed
+    newTag: main
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: authproxy-demo

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -1,0 +1,272 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seed-config
+data:
+  seed.yaml: |
+    actors:
+      - external_id: "demo-admin"
+        namespace: "root"
+        labels:
+          demo: "true"
+          role: "admin"
+      - external_id: "demo-user"
+        namespace: "root"
+        labels:
+          demo: "true"
+          role: "user"
+      - external_id: "fresh-user"
+        namespace: "root"
+        labels:
+          demo: "true"
+          role: "user"
+      - external_id: "grafana"
+        namespace: "root"
+        labels:
+          demo: "true"
+          role: "datasource"
+    oauth2_test_provider:
+      api_key_resource_policies:
+      - key: demo-api-key
+        path: /test/api-key-resource/demo-api-key
+        placement: bearer
+      base_url: http://dev-go-oauth2-server
+      clients:
+      - key: demo-oauth-simple
+        redirect_uri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-simple-secret
+        token_endpoint_auth_method: client_secret_post
+      - key: demo-oauth-tenant
+        redirect_uri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-tenant-secret
+        token_endpoint_auth_method: client_secret_post
+      - key: demo-oauth-configure
+        redirect_uri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-configure-secret
+        token_endpoint_auth_method: client_secret_post
+      resource_policies:
+      - path: /test/resource/demo-resources
+        required_scope: resources
+      users:
+      - display_name: Demo OAuth User
+        email: demo-oauth-user@example.test
+        password: demo-password
+        sub: demo-oauth-user
+        username: demo-oauth-user@example.test
+    connectors:
+      - definition:
+          auth:
+            type: no-auth
+          description: 'This connector is intentionally simple: it demonstrates that the
+            demo-seed job can publish connector definitions into the Marketplace catalog
+            during install and upgrade. Follow-up demo connectors show OAuth, API key auth,
+            pre-connect tenant selection, and post-connect configuration.'
+          display_name: Demo README Resource
+          highlight: A no-auth catalog entry used to verify demo seeding.
+          labels:
+            demo: "true"
+            type: demo-readme-noauth
+          logo:
+            base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJEZW1vIFJFQURNRSBSZXNvdXJjZSBsb2dvIj48cmVjdCB3aWR0aD0iMjgwIiBoZWlnaHQ9IjE0MCIgcng9IjEyIiBmaWxsPSIjMEIzRDJFIi8+PHBhdGggZD0iTTYyIDk2VjQ0aDM1YzE3IDAgMjggMTAgMjggMjZzLTExIDI2LTI4IDI2SDYyWm0yMC0xN2gxNGM2IDAgMTAtMyAxMC05cy00LTktMTAtOUg4MnYxOFptNjQgMTdWNDRoMjB2MzVoMzV2MTdoLTU1WiIgZmlsbD0iI0ZGRkZGRiIvPjwvc3ZnPg==
+            mime_type: image/svg+xml
+        key: demo-readme-noauth
+        labels:
+          auth_method: no_auth
+          demo: "true"
+          showcase: catalog
+        namespace: root
+      - definition:
+          auth:
+            placement:
+              type: bearer
+            type: api-key
+          description: 'This connector demonstrates AuthProxy API-key setup and proxying.
+            Enter `demo-api-key` when prompted; it is an intentionally fake key accepted
+            only by the demo provider. AuthProxy stores the key as an encrypted credential,
+            injects it as `Authorization: Bearer demo-api-key` on proxy requests, and verifies
+            it with a probe so wrong keys are easy to spot.'
+          display_name: 'Demo API Key: Bearer Token'
+          highlight: Creates a connection from a static demo API key.
+          labels:
+            demo: "true"
+            type: demo-api-key-bearer
+          logo:
+            base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJBUEkgS2V5IERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iI0M4NDYzMCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTExNiA3MGg3NG0tMjAtMTYgMTYgMTYtMTYgMTYiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5BSzwvdGV4dD48L3N2Zz4=
+            mime_type: image/svg+xml
+          probes:
+          - failure_threshold: 1
+            id: verify-api-key
+            proxy_http:
+              method: GET
+              url: http://dev-go-oauth2-server/test/api-key-resource/demo-api-key
+        key: demo-api-key-bearer
+        labels:
+          auth_method: api-key
+          demo: "true"
+          showcase: api-key
+        namespace: root
+      - definition:
+          auth:
+            authorization:
+              endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
+            client_id: demo-oauth-simple
+            client_secret: demo-oauth-simple-secret
+            scopes:
+            - id: read
+              reason: Read basic profile information from the demo provider.
+            - id: profile
+              reason: Show how connectors explain why each requested OAuth scope is needed.
+            token:
+              endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
+            type: OAuth2
+          description: 'This connector demonstrates AuthProxy''s simplest OAuth path: the
+            user clicks Connect, approves access in the demo OAuth provider, and AuthProxy
+            stores the resulting tokens for proxy requests. Use provider username `demo-oauth-user@example.test`
+            and password `demo-password` when the consent screen asks you to sign in.'
+          display_name: 'Demo OAuth: Basic Authorization'
+          highlight: A plain OAuth authorization-code connection with no extra setup.
+          labels:
+            demo: "true"
+            type: demo-oauth-simple
+          logo:
+            base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJTdHJhaWdodCBPQXV0aCBEZW1vIGxvZ28iPjxyZWN0IHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiByeD0iMTIiIGZpbGw9IiMxNjVERkYiLz48Y2lyY2xlIGN4PSI3NiIgY3k9IjcwIiByPSIzNCIgZmlsbD0icmdiYSgyNTUsMjU1LDI1NSwwLjE4KSIvPjxwYXRoIGQ9Ik0xOTAgNDhjMTIgMCAyMiAxMCAyMiAyMnMtMTAgMjItMjIgMjJoLTQ4Yy0xMiAwLTIyLTEwLTIyLTIyczEwLTIyIDIyLTIyaDQ4Wm0tNDggMTZhNiA2IDAgMCAwIDAgMTJoNDhhNiA2IDAgMCAwIDAtMTJoLTQ4WiIgZmlsbD0iI2ZmZiIgb3BhY2l0eT0iMC45NSIvPjx0ZXh0IHg9Ijc2IiB5PSI4MiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iI2ZmZiIgZm9udC1mYW1pbHk9IkludGVyLCBBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIzNCIgZm9udC13ZWlnaHQ9IjgwMCI+U088L3RleHQ+PC9zdmc+
+            mime_type: image/svg+xml
+        key: demo-oauth-simple
+        labels:
+          auth_method: oauth2
+          demo: "true"
+          showcase: simple-oauth
+        namespace: root
+      - definition:
+          auth:
+            authorization:
+              endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
+              query_overrides:
+                tenant: '{{cfg.tenant}}'
+            client_id: demo-oauth-tenant
+            client_secret: demo-oauth-tenant-secret
+            scopes:
+            - id: read
+              reason: Read access after the selected tenant has authorized the app.
+            - id: profile
+              reason: Display which demo user approved the tenant-scoped connection.
+            token:
+              endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
+            type: OAuth2
+          description: This connector demonstrates pre-connect setup. AuthProxy asks for
+            a pretend tenant before redirecting to OAuth, then makes that value available
+            to OAuth endpoint templates. In a real connector this pattern selects the customer's
+            regional login host or tenant-specific authorization parameters before credentials
+            are requested.
+          display_name: 'Demo OAuth: Tenant Selection'
+          highlight: Collects a pretend tenant before starting OAuth.
+          labels:
+            demo: "true"
+            type: demo-oauth-tenant
+          logo:
+            base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJUZW5hbnQgU2VsZWN0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzdBM0U5RCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5UUzwvdGV4dD48L3N2Zz4=
+            mime_type: image/svg+xml
+          setup_flow:
+            preconnect:
+              steps:
+              - description: This pre-connect step runs before OAuth. The value is saved
+                  into connection configuration and can be used to shape provider-specific
+                  OAuth URLs.
+                id: tenant
+                json_schema:
+                  properties:
+                    tenant:
+                      description: Try `northwind`, `globex`, or any short tenant slug.
+                        The demo provider accepts all values; the field exists to show pre-auth
+                        configuration.
+                      minLength: 2
+                      title: Demo tenant
+                      type: string
+                  required:
+                  - tenant
+                  type: object
+                title: Choose a pretend tenant
+                ui_schema:
+                  elements:
+                  - scope: '#/properties/tenant'
+                    type: Control
+                  type: VerticalLayout
+        key: demo-oauth-tenant
+        labels:
+          auth_method: oauth2
+          demo: "true"
+          showcase: preconnect
+        namespace: root
+      - definition:
+          auth:
+            authorization:
+              endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
+            client_id: demo-oauth-configure
+            client_secret: demo-oauth-configure-secret
+            scopes:
+            - id: read
+              reason: Complete the OAuth flow against the demo provider.
+            - id: resources
+              reason: Fetch the pretend resource list used by the post-connect configuration
+                step.
+            token:
+              endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
+            type: OAuth2
+          description: This connector demonstrates post-connect configuration. After OAuth
+            succeeds, AuthProxy calls a demo provider resource endpoint through the new
+            connection and turns the response into selectable pretend resources. This is
+            the pattern for connectors that must discover workspaces, projects, calendars,
+            or folders after credentials exist.
+          display_name: 'Demo OAuth: Resource Configuration'
+          highlight: Uses OAuth first, then fetches configuration choices through the proxy.
+          labels:
+            demo: "true"
+            type: demo-oauth-configure
+          logo:
+            base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJSZXNvdXJjZSBDb25maWd1cmF0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzBCN0E1QSIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5SQzwvdGV4dD48L3N2Zz4=
+            mime_type: image/svg+xml
+          setup_flow:
+            configure:
+              steps:
+              - data_sources:
+                  demo_resources:
+                    proxy_request:
+                      headers:
+                        Accept: application/json
+                      method: GET
+                      url: http://dev-go-oauth2-server/test/resource/demo-resources
+                    transform: 'Array.isArray(data.resources) ? data.resources.map(r =>
+                      ({ value: r.id || r.value, label: r.name || r.label || r.id || r.value
+                      })) : [{ value: ''project-alpha'', label: ''Project Alpha (demo)''
+                      }, { value: ''workspace-north'', label: ''North Workspace (demo)''
+                      }, { value: ''reports-folder'', label: ''Reports Folder (demo)'' }]'
+                description: This post-connect step is populated by a data source request
+                  through the authenticated proxy. The options stand in for provider resources
+                  such as projects, calendars, or workspaces.
+                id: select_resource
+                json_schema:
+                  properties:
+                    resource_id:
+                      description: Options are loaded after OAuth using the new connection's
+                        credentials.
+                      title: Demo resource
+                      type: string
+                      x-data-source: demo_resources
+                  required:
+                  - resource_id
+                  type: object
+                title: Select a pretend resource
+                ui_schema:
+                  elements:
+                  - scope: '#/properties/resource_id'
+                    type: Control
+                  type: VerticalLayout
+        key: demo-oauth-configure
+        labels:
+          auth_method: oauth2
+          demo: "true"
+          showcase: postconnect-configure
+        namespace: root

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-job.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-job.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seed
+  labels:
+    app.kubernetes.io/name: authproxy-demo-seed
+    app.kubernetes.io/component: demo-seed
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authproxy-demo-seed
+        app.kubernetes.io/component: demo-seed
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: demo-seed
+          image: ghcr.io/rmorlok/authproxy-demo-seed:main
+          imagePullPolicy: Always
+          env:
+            - name: ADMIN_API_URL
+              value: "http://dev-authproxy:8082"
+            - name: ADMIN_USERNAME
+              value: "demo-shell"
+            - name: ADMIN_PRIVATE_KEY_PATH
+              value: "/etc/authproxy/demo-shell/private"
+            - name: SEED_CONFIG_PATH
+              value: "/etc/authproxy/seed/seed.yaml"
+          volumeMounts:
+            - name: admin-key
+              mountPath: /etc/authproxy/demo-shell
+              readOnly: true
+            - name: seed-config
+              mountPath: /etc/authproxy/seed
+              readOnly: true
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+      volumes:
+        - name: admin-key
+          secret:
+            secretName: dev-demo-shell-key
+            items:
+              - key: private
+                path: private
+        - name: seed-config
+          configMap:
+            name: seed-config


### PR DESCRIPTION
## Summary
- replace the per-branch Deploy Dev Helm install with Kustomize render/apply
- keep the dev overlay on SQLite, miniredis, and filesystem blob storage, with render guardrails against Postgres/Redis/MinIO workloads
- add a Kustomize seed overlay that runs after rollout, and add closed-PR namespace teardown

Closes #564

## Validation
- rendered dev overlay with fake PR namespace/hostname/tag and checked hostnames, images, miniredis, filesystem blobs, and no backing-service workloads
- rendered dev seed overlay with fake PR namespace/hostname/tag and checked seed image, admin API URL, OAuth provider URL, callback URL, and authorize URL
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-dev.yml")'
- ./scripts/preflight.sh