### PR TITLE
Define connector lifecycle API contract

### DIFF
--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"context"
+	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -14,6 +15,10 @@ import (
 )
 
 type ConnectorVersionId = database.ConnectorVersionId
+
+type ConnectorLifecycleOptions struct {
+	Timeout time.Duration
+}
 
 // C is the interface for the core service that implements primary business logic and binds the system together.
 type C interface {
@@ -74,6 +79,12 @@ type C interface {
 
 	// GetOrCreateDraftConnectorVersion returns the existing draft version, or creates a new one by cloning the latest version.
 	GetOrCreateDraftConnectorVersion(ctx context.Context, id apid.ID) (ConnectorVersion, error)
+
+	// DisconnectConnectorConnections starts a workflow that disconnects all connections for a connector.
+	DisconnectConnectorConnections(ctx context.Context, id apid.ID, opts ConnectorLifecycleOptions) (taskInfo *tasks.TaskInfo, err error)
+
+	// ArchiveConnector starts a workflow that archives a connector after disconnecting its connections.
+	ArchiveConnector(ctx context.Context, id apid.ID, opts ConnectorLifecycleOptions) (taskInfo *tasks.TaskInfo, err error)
 
 	/*
 	 *

--- a/internal/core/service_connector_lifecycle.go
+++ b/internal/core/service_connector_lifecycle.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/tasks"
+)
+
+const (
+	WorkflowNameDisconnectConnectorConnectionsV1 = "core.connector.disconnect_all.v1"
+	WorkflowNameArchiveConnectorV1               = "core.connector.archive.v1"
+)
+
+func (s *service) DisconnectConnectorConnections(
+	_ context.Context,
+	_ apid.ID,
+	_ iface.ConnectorLifecycleOptions,
+) (*tasks.TaskInfo, error) {
+	return nil, httperr.New(http.StatusNotImplemented, "connector disconnect-all workflow is not implemented")
+}
+
+func (s *service) ArchiveConnector(
+	_ context.Context,
+	_ apid.ID,
+	_ iface.ConnectorLifecycleOptions,
+) (*tasks.TaskInfo, error) {
+	return nil, httperr.New(http.StatusNotImplemented, "connector archive workflow is not implemented")
+}

--- a/internal/httperr/error.go
+++ b/internal/httperr/error.go
@@ -115,6 +115,8 @@ func StatusText(status int) string {
 		return "Unprocessable Entity"
 	case 500:
 		return "Internal Server Error"
+	case 501:
+		return "Not Implemented"
 	case 502:
 		return "Bad Gateway"
 	case 503:

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -150,6 +150,22 @@ func parseConnectorID(gctx *gin.Context) (apid.ID, *httperr.Error) {
 	return id, nil
 }
 
+func parseConnectorVersionID(gctx *gin.Context) (connectorVersionID, *httperr.Error) {
+	id, herr := parseConnectorID(gctx)
+	if herr != nil {
+		return connectorVersionID{}, herr
+	}
+	versionStr := gctx.Param("version")
+	if versionStr == "" {
+		return connectorVersionID{}, httperr.BadRequest("version is required")
+	}
+	version, err := strconv.ParseUint(versionStr, 10, 64)
+	if err != nil {
+		return connectorVersionID{}, httperr.BadRequest("failed to parse version as an integer")
+	}
+	return connectorVersionID{ConnectorID: id, Version: version}, nil
+}
+
 func connectorVersionStatesToAPI(states database.ConnectorVersionStates) schemaapi.ConnectorVersionStates {
 	if states == nil {
 		return nil
@@ -178,45 +194,24 @@ func (r *ConnectorsRoutes) get(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
 
-	connectorId, err := apid.Parse(connectorIdStr)
+	c, err := r.loadConnectorByID(ctx, connectorId)
 	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
 	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	result := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if result.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(result.Error)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if len(result.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	c := result.Results[0]
 
 	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
 		apgin.WriteError(gctx, nil, httpErr)
@@ -333,46 +328,19 @@ func (r *ConnectorsRoutes) getVersion(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorVersionId, httpErr := parseConnectorVersionID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
+	connectorId := connectorVersionId.ConnectorID
+	version := connectorVersionId.Version
 
 	b := r.connectors.
 		ListConnectorVersionsBuilder().
 		ForId(connectorId).
 		Limit(1)
-
-	versionStr := gctx.Param("version")
-
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
 
 	b = b.ForVersion(version)
 
@@ -426,23 +394,9 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 	var err error
 	var ex connIface.ListConnectorVersionsExecutor
 
-	connectorIdStr := gctx.Param("id")
-
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
@@ -610,22 +564,9 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
@@ -727,46 +668,25 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
 
 	// Verify the connector exists and check auth
-	connectorResult := r.connectors.
-		ListConnectorsBuilder().
-		ForId(connectorId).
-		Limit(1).
-		FetchPage(ctx)
-
-	if connectorResult.Error != nil {
-		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(connectorResult.Error)))
+	connector, err := r.loadConnectorByID(ctx, connectorId)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
 	}
-
-	if len(connectorResult.Results) == 0 {
-		apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
-		val.MarkErrorReturn()
-		return
-	}
-
-	connector := connectorResult.Results[0]
 	if httpErr := val.ValidateHttpStatusError(connector); httpErr != nil {
 		apgin.WriteError(gctx, nil, httpErr)
 		return
@@ -851,39 +771,14 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorVersionId, httpErr := parseConnectorVersionID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
+	connectorId := connectorVersionId.ConnectorID
+	version := connectorVersionId.Version
 
 	var req UpdateConnectorRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
@@ -1133,43 +1028,17 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	connectorIdStr := gctx.Param("id")
-	if connectorIdStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
+	connectorVersionId, httpErr := parseConnectorVersionID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
-
-	connectorId, err := apid.Parse(connectorIdStr)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid id format"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if connectorId == apid.Nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("id is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	versionStr := gctx.Param("version")
-	if versionStr == "" {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("version is required"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	version, err := strconv.ParseUint(versionStr, 10, 64)
-	if err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("failed to parse version as an integer"))
-		val.MarkErrorReturn()
-		return
-	}
+	connectorId := connectorVersionId.ConnectorID
+	version := connectorVersionId.Version
 
 	req := ForceConnectorVersionStateRequestJson{}
-	err = gctx.BindJSON(&req)
-	if err != nil {
+	if err := gctx.BindJSON(&req); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
 		val.MarkErrorReturn()
 		return
@@ -1774,34 +1643,19 @@ func (r *ConnectorsRoutes) Register(g gin.IRouter) {
 }
 
 func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C, e encrypt.E) *ConnectorsRoutes {
-	parseConnectorVersionID := func(gctx *gin.Context) (connectorVersionID, *httperr.Error) {
-		id, herr := parseConnectorID(gctx)
-		if herr != nil {
-			return connectorVersionID{}, herr
-		}
-		versionStr := gctx.Param("version")
-		if versionStr == "" {
-			return connectorVersionID{}, httperr.BadRequest("version is required")
-		}
-		version, err := strconv.ParseUint(versionStr, 10, 64)
-		if err != nil {
-			return connectorVersionID{}, httperr.BadRequest("failed to parse version as an integer")
-		}
-		return connectorVersionID{ConnectorID: id, Version: version}, nil
+	routes := &ConnectorsRoutes{
+		cfg:         cfg,
+		authService: authService,
+		connectors:  c,
+		encrypt:     e,
 	}
 
 	getConnector := func(ctx context.Context, id apid.ID) (key_value.Resource, error) {
-		result := c.ListConnectorsBuilder().
-			ForId(id).
-			Limit(1).
-			FetchPage(ctx)
-		if result.Error != nil {
-			return nil, result.Error
-		}
-		if len(result.Results) == 0 {
+		connector, err := routes.loadConnectorByID(ctx, id)
+		if errors.Is(err, core.ErrNotFound) {
 			return nil, database.ErrNotFound
 		}
-		return result.Results[0], nil
+		return connector, err
 	}
 
 	getConnectorVersion := func(ctx context.Context, id connectorVersionID) (key_value.Resource, error) {
@@ -2051,14 +1905,10 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C, e encr
 		Delete:       deleteVersionAnnotations,
 	}
 
-	return &ConnectorsRoutes{
-		cfg:                  cfg,
-		authService:          authService,
-		connectors:           c,
-		encrypt:              e,
-		labelsAdapter:        labelsAdapter,
-		annotsAdapter:        annotsAdapter,
-		versionLabelsAdapter: versionLabelsAdapter,
-		versionAnnotsAdapter: versionAnnotsAdapter,
-	}
+	routes.labelsAdapter = labelsAdapter
+	routes.annotsAdapter = annotsAdapter
+	routes.versionLabelsAdapter = versionLabelsAdapter
+	routes.versionAnnotsAdapter = versionAnnotsAdapter
+
+	return routes
 }

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -14,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core"
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
@@ -21,6 +23,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/tasks"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -33,6 +36,8 @@ type ListConnectorVersionsResponseJson = schemaapi.ListConnectorVersionsResponse
 type CreateConnectorRequestJson = schemaapi.CreateConnectorRequestJson
 type UpdateConnectorRequestJson = schemaapi.UpdateConnectorRequestJson
 type CreateConnectorVersionRequestJson = schemaapi.CreateConnectorVersionRequestJson
+type ConnectorLifecycleRequestJson = schemaapi.ConnectorLifecycleRequestJson
+type ConnectorLifecycleResponseJson = schemaapi.ConnectorLifecycleResponseJson
 type ForceConnectorVersionStateRequestJson = schemaapi.ForceConnectorVersionStateRequestJson
 
 type OpenAPIListConnectorsResponseJson = schemaapiopenapi.ListConnectorsResponseJson
@@ -41,6 +46,8 @@ type OpenAPIListConnectorVersionsResponseJson = schemaapiopenapi.ListConnectorVe
 type OpenAPICreateConnectorRequestJson = schemaapiopenapi.CreateConnectorRequestJson
 type OpenAPIUpdateConnectorRequestJson = schemaapiopenapi.UpdateConnectorRequestJson
 type OpenAPICreateConnectorVersionRequestJson = schemaapiopenapi.CreateConnectorVersionRequestJson
+type OpenAPIConnectorLifecycleRequestJson = schemaapiopenapi.ConnectorLifecycleRequestJson
+type OpenAPIConnectorLifecycleResponseJson = schemaapiopenapi.ConnectorLifecycleResponseJson
 
 func ConnectorToJson(c connIface.Connector) ConnectorJson {
 	result := ConnectorVersionToConnectorJson(c)
@@ -119,10 +126,28 @@ type ConnectorsRoutes struct {
 	cfg                  config.C
 	connectors           connIface.C
 	authService          auth.A
+	encrypt              encrypt.E
 	labelsAdapter        key_value.Adapter[apid.ID]
 	annotsAdapter        key_value.Adapter[apid.ID]
 	versionLabelsAdapter key_value.Adapter[connectorVersionID]
 	versionAnnotsAdapter key_value.Adapter[connectorVersionID]
+}
+
+const defaultConnectorLifecycleTimeout = 10 * time.Minute
+
+func parseConnectorID(gctx *gin.Context) (apid.ID, *httperr.Error) {
+	idStr := gctx.Param("id")
+	if idStr == "" {
+		return apid.Nil, httperr.BadRequest("id is required")
+	}
+	id, err := apid.Parse(idStr)
+	if err != nil {
+		return apid.Nil, httperr.BadRequest("invalid id format")
+	}
+	if id == apid.Nil {
+		return apid.Nil, httperr.BadRequest("id is required")
+	}
+	return id, nil
 }
 
 func connectorVersionStatesToAPI(states database.ConnectorVersionStates) schemaapi.ConnectorVersionStates {
@@ -1196,6 +1221,194 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 	gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(cv))
 }
 
+func (r *ConnectorsRoutes) loadConnectorByID(ctx context.Context, connectorId apid.ID) (connIface.Connector, error) {
+	result := r.connectors.
+		ListConnectorsBuilder().
+		ForId(connectorId).
+		Limit(1).
+		FetchPage(ctx)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if len(result.Results) == 0 {
+		return nil, core.ErrNotFound
+	}
+	return result.Results[0], nil
+}
+
+func (r *ConnectorsRoutes) parseLifecycleRequest(gctx *gin.Context) (connIface.ConnectorLifecycleOptions, bool) {
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	req := ConnectorLifecycleRequestJson{}
+	if gctx.Request.Body != http.NoBody && gctx.Request.ContentLength != 0 {
+		if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+			val.MarkErrorReturn()
+			return connIface.ConnectorLifecycleOptions{}, false
+		}
+	}
+
+	timeout := defaultConnectorLifecycleTimeout
+	if req.TimeoutSeconds != nil {
+		if *req.TimeoutSeconds <= 0 {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("timeout_seconds must be greater than zero"))
+			val.MarkErrorReturn()
+			return connIface.ConnectorLifecycleOptions{}, false
+		}
+		timeout = time.Duration(*req.TimeoutSeconds) * time.Second
+	}
+
+	return connIface.ConnectorLifecycleOptions{Timeout: timeout}, true
+}
+
+func (r *ConnectorsRoutes) writeLifecycleTaskResponse(
+	gctx *gin.Context,
+	connectorID apid.ID,
+	taskInfo *tasks.TaskInfo,
+) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	if taskInfo == nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerErrorMsg("connector lifecycle task was not started"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	ra := auth.MustGetAuthFromGinContext(gctx)
+	taskId, err := taskInfo.
+		BindToActor(ra.MustGetActor()).
+		ToSecureEncryptedString(ctx, r.encrypt)
+	if err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	gctx.PureJSON(http.StatusOK, ConnectorLifecycleResponseJson{
+		TaskId:      taskId,
+		ConnectorId: connectorID,
+	})
+}
+
+// @Summary		Disconnect all connector connections
+// @Description	Start a workflow that disconnects all connections for a connector
+// @Tags			connectors
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string							true	"Connector UUID"
+// @Param			request	body		OpenAPIConnectorLifecycleRequestJson	false	"Lifecycle operation options"
+// @Success		200		{object}	OpenAPIConnectorLifecycleResponseJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Failure		501		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/connectors/{id}/_disconnect_all [post]
+func (r *ConnectorsRoutes) disconnectAll(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	connector, err := r.loadConnectorByID(ctx, connectorId)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(connector); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	opts, ok := r.parseLifecycleRequest(gctx)
+	if !ok {
+		return
+	}
+
+	taskInfo, err := r.connectors.DisconnectConnectorConnections(ctx, connectorId, opts)
+	if err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	r.writeLifecycleTaskResponse(gctx, connectorId, taskInfo)
+}
+
+// @Summary		Archive connector
+// @Description	Start a workflow that archives a connector after disconnecting its connections
+// @Tags			connectors
+// @Accept			json
+// @Produce		json
+// @Param			id		path		string							true	"Connector UUID"
+// @Param			request	body		OpenAPIConnectorLifecycleRequestJson	false	"Lifecycle operation options"
+// @Success		200		{object}	OpenAPIConnectorLifecycleResponseJson
+// @Failure		400		{object}	ErrorResponse
+// @Failure		401		{object}	ErrorResponse
+// @Failure		403		{object}	ErrorResponse
+// @Failure		404		{object}	ErrorResponse
+// @Failure		500		{object}	ErrorResponse
+// @Failure		501		{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/connectors/{id}/_archive [post]
+func (r *ConnectorsRoutes) archive(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	connectorId, httpErr := parseConnectorID(gctx)
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		val.MarkErrorReturn()
+		return
+	}
+
+	connector, err := r.loadConnectorByID(ctx, connectorId)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if httpErr := val.ValidateHttpStatusError(connector); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	opts, ok := r.parseLifecycleRequest(gctx)
+	if !ok {
+		return
+	}
+
+	taskInfo, err := r.connectors.ArchiveConnector(ctx, connectorId, opts)
+	if err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+
+	r.writeLifecycleTaskResponse(gctx, connectorId, taskInfo)
+}
+
 // @Summary		Get all annotations for a connector
 // @Description	Get all annotations associated with a connector's latest version
 // @Tags			connectors
@@ -1398,6 +1611,22 @@ func (r *ConnectorsRoutes) Register(g gin.IRouter) {
 			Build(),
 		r.createVersion,
 	)
+	g.POST("/connectors/:id/_disconnect_all",
+		r.authService.NewRequiredBuilder().
+			ForResource("connectors").
+			ForIdField("id").
+			ForVerb("disconnect_all").
+			Build(),
+		r.disconnectAll,
+	)
+	g.POST("/connectors/:id/_archive",
+		r.authService.NewRequiredBuilder().
+			ForResource("connectors").
+			ForIdField("id").
+			ForVerb("archive").
+			Build(),
+		r.archive,
+	)
 	g.PATCH("/connectors/:id/versions/:version",
 		r.authService.NewRequiredBuilder().
 			ForResource("connectors").
@@ -1544,22 +1773,7 @@ func (r *ConnectorsRoutes) Register(g gin.IRouter) {
 	)
 }
 
-func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *ConnectorsRoutes {
-	parseConnectorID := func(gctx *gin.Context) (apid.ID, *httperr.Error) {
-		idStr := gctx.Param("id")
-		if idStr == "" {
-			return apid.Nil, httperr.BadRequest("id is required")
-		}
-		id, err := apid.Parse(idStr)
-		if err != nil {
-			return apid.Nil, httperr.BadRequest("invalid id format")
-		}
-		if id == apid.Nil {
-			return apid.Nil, httperr.BadRequest("id is required")
-		}
-		return id, nil
-	}
-
+func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C, e encrypt.E) *ConnectorsRoutes {
 	parseConnectorVersionID := func(gctx *gin.Context) (connectorVersionID, *httperr.Error) {
 		id, herr := parseConnectorID(gctx)
 		if herr != nil {
@@ -1841,6 +2055,7 @@ func NewConnectorsRoutes(cfg config.C, authService auth.A, c connIface.C) *Conne
 		cfg:                  cfg,
 		authService:          authService,
 		connectors:           c,
+		encrypt:              e,
 		labelsAdapter:        labelsAdapter,
 		annotsAdapter:        annotsAdapter,
 		versionLabelsAdapter: versionLabelsAdapter,

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	asynqmock "github.com/rmorlok/authproxy/internal/apasynq/mock"
@@ -19,6 +21,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apredis/mock"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
+	connIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
@@ -26,16 +29,49 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/tasks"
 	"github.com/rmorlok/authproxy/internal/test_utils"
 	"github.com/rmorlok/authproxy/internal/util"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 	"github.com/stretchr/testify/require"
 )
 
+type fakeConnectorLifecycleCore struct {
+	connIface.C
+	disconnectOpts []connIface.ConnectorLifecycleOptions
+	archiveOpts    []connIface.ConnectorLifecycleOptions
+}
+
+func (f *fakeConnectorLifecycleCore) DisconnectConnectorConnections(
+	_ context.Context,
+	_ apid.ID,
+	opts connIface.ConnectorLifecycleOptions,
+) (*tasks.TaskInfo, error) {
+	f.disconnectOpts = append(f.disconnectOpts, opts)
+	return tasks.FromWorkflowInstance(&wflib.Instance{
+		InstanceID:  fmt.Sprintf("workflow-disconnect-%d", len(f.disconnectOpts)),
+		ExecutionID: fmt.Sprintf("workflow-execution-%d", len(f.disconnectOpts)),
+	}, core.WorkflowNameDisconnectConnectorConnectionsV1, string(apworkflows.DefaultQueue)), nil
+}
+
+func (f *fakeConnectorLifecycleCore) ArchiveConnector(
+	_ context.Context,
+	_ apid.ID,
+	opts connIface.ConnectorLifecycleOptions,
+) (*tasks.TaskInfo, error) {
+	f.archiveOpts = append(f.archiveOpts, opts)
+	return tasks.FromWorkflowInstance(&wflib.Instance{
+		InstanceID:  fmt.Sprintf("workflow-archive-%d", len(f.archiveOpts)),
+		ExecutionID: fmt.Sprintf("workflow-execution-%d", len(f.archiveOpts)),
+	}, core.WorkflowNameArchiveConnectorV1, string(apworkflows.DefaultQueue)), nil
+}
+
 func TestConnectors(t *testing.T) {
 	type TestSetup struct {
-		Gin      *gin.Engine
-		Cfg      config.C
-		AuthUtil *auth2.AuthTestUtil
+		Gin           *gin.Engine
+		Cfg           config.C
+		AuthUtil      *auth2.AuthTestUtil
+		LifecycleCore *fakeConnectorLifecycleCore
 	}
 
 	setup := func(t *testing.T, cfg config.C) *TestSetup {
@@ -82,18 +118,138 @@ func TestConnectors(t *testing.T) {
 		h := httpf2.CreateFactory(cfg, rs, nil, aplog.NewNoopLogger())
 		c := core.NewCoreService(cfg, db, e, rs, h, ac, test_utils.NewTestLogger())
 		require.NoError(t, c.Migrate(context.Background()))
+		lifecycleCore := &fakeConnectorLifecycleCore{C: c}
 
-		cr := NewConnectorsRoutes(cfg, auth, c)
+		cr := NewConnectorsRoutes(cfg, auth, lifecycleCore, e)
 
 		r := apgin.ForTest(nil)
 		cr.Register(r)
 
 		return &TestSetup{
-			Gin:      r,
-			Cfg:      cfg,
-			AuthUtil: authUtil,
+			Gin:           r,
+			Cfg:           cfg,
+			AuthUtil:      authUtil,
+			LifecycleCore: lifecycleCore,
 		}
 	}
+
+	t.Run("connector lifecycle operations", func(t *testing.T) {
+		t.Run("disconnect all unauthorized", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodPost, "/connectors/cxr_test0000000000001/_disconnect_all", nil)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+
+		t.Run("archive malformed id", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors/bad-connector/_archive",
+				nil,
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("disconnect all forbidden without lifecycle permission", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors/cxr_test0000000000001/_disconnect_all",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connectors", "get"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("archive rejects invalid timeout", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors/cxr_test0000000000001/_archive",
+				util.JsonToReader(ConnectorLifecycleRequestJson{TimeoutSeconds: util.ToPtr(int64(0))}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connectors", "archive"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Empty(t, tu.LifecycleCore.archiveOpts)
+		})
+
+		t.Run("disconnect all starts workflow task", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors/cxr_test0000000000001/_disconnect_all",
+				util.JsonToReader(ConnectorLifecycleRequestJson{TimeoutSeconds: util.ToPtr(int64(600))}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connectors", "disconnect_all"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ConnectorLifecycleResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.NotEmpty(t, resp.TaskId)
+			require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.ConnectorId)
+			require.Len(t, tu.LifecycleCore.disconnectOpts, 1)
+			require.Equal(t, 600*time.Second, tu.LifecycleCore.disconnectOpts[0].Timeout)
+		})
+
+		t.Run("archive starts workflow task with default timeout", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors/cxr_test0000000000001/_archive",
+				nil,
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connectors", "archive"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp ConnectorLifecycleResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.NotEmpty(t, resp.TaskId)
+			require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.ConnectorId)
+			require.Len(t, tu.LifecycleCore.archiveOpts, 1)
+			require.Equal(t, 600*time.Second, tu.LifecycleCore.archiveOpts[0].Timeout)
+		})
+	})
 
 	t.Run("connectors", func(t *testing.T) {
 		t.Run("get", func(t *testing.T) {

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -66,12 +66,87 @@ func (f *fakeConnectorLifecycleCore) ArchiveConnector(
 	}, core.WorkflowNameArchiveConnectorV1, string(apworkflows.DefaultQueue)), nil
 }
 
+func TestParseConnectorID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Params = gin.Params{{Key: "id", Value: "cxr_test0000000000001"}}
+
+		id, httpErr := parseConnectorID(gctx)
+		require.Nil(t, httpErr)
+		require.Equal(t, apid.MustParse("cxr_test0000000000001"), id)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+		id, httpErr := parseConnectorID(gctx)
+		require.Equal(t, apid.Nil, id)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+		require.Equal(t, "id is required", httpErr.Error())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Params = gin.Params{{Key: "id", Value: "bad-connector"}}
+
+		id, httpErr := parseConnectorID(gctx)
+		require.Equal(t, apid.Nil, id)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+		require.Equal(t, "invalid id format", httpErr.Error())
+	})
+}
+
+func TestParseConnectorVersionID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Params = gin.Params{
+			{Key: "id", Value: "cxr_test0000000000001"},
+			{Key: "version", Value: "42"},
+		}
+
+		id, httpErr := parseConnectorVersionID(gctx)
+		require.Nil(t, httpErr)
+		require.Equal(t, connectorVersionID{
+			ConnectorID: apid.MustParse("cxr_test0000000000001"),
+			Version:     42,
+		}, id)
+	})
+
+	t.Run("missing version", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Params = gin.Params{{Key: "id", Value: "cxr_test0000000000001"}}
+
+		id, httpErr := parseConnectorVersionID(gctx)
+		require.Equal(t, connectorVersionID{}, id)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+		require.Equal(t, "version is required", httpErr.Error())
+	})
+
+	t.Run("invalid version", func(t *testing.T) {
+		gctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gctx.Params = gin.Params{
+			{Key: "id", Value: "cxr_test0000000000001"},
+			{Key: "version", Value: "latest"},
+		}
+
+		id, httpErr := parseConnectorVersionID(gctx)
+		require.Equal(t, connectorVersionID{}, id)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+		require.Equal(t, "failed to parse version as an integer", httpErr.Error())
+	})
+}
+
 func TestConnectors(t *testing.T) {
 	type TestSetup struct {
 		Gin           *gin.Engine
 		Cfg           config.C
 		AuthUtil      *auth2.AuthTestUtil
 		LifecycleCore *fakeConnectorLifecycleCore
+		Routes        *ConnectorsRoutes
 	}
 
 	setup := func(t *testing.T, cfg config.C) *TestSetup {
@@ -130,8 +205,27 @@ func TestConnectors(t *testing.T) {
 			Cfg:           cfg,
 			AuthUtil:      authUtil,
 			LifecycleCore: lifecycleCore,
+			Routes:        cr,
 		}
 	}
+
+	t.Run("route helpers", func(t *testing.T) {
+		t.Run("load connector by id", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			connector, err := tu.Routes.loadConnectorByID(context.Background(), apid.MustParse("cxr_test0000000000001"))
+			require.NoError(t, err)
+			require.Equal(t, apid.MustParse("cxr_test0000000000001"), connector.GetId())
+		})
+
+		t.Run("load connector by id not found", func(t *testing.T) {
+			tu := setup(t, nil)
+
+			connector, err := tu.Routes.loadConnectorByID(context.Background(), apid.MustParse("cxr_nonexistent00099"))
+			require.Nil(t, connector)
+			require.ErrorIs(t, err, core.ErrNotFound)
+		})
+	})
 
 	t.Run("connector lifecycle operations", func(t *testing.T) {
 		t.Run("disconnect all unauthorized", func(t *testing.T) {

--- a/internal/schema/api/connectors.go
+++ b/internal/schema/api/connectors.go
@@ -94,6 +94,23 @@ type CreateConnectorVersionRequestJson struct {
 	Annotations *map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
+// ConnectorLifecycleRequestJson is the request body for connector-level
+// lifecycle operations that run asynchronously.
+//
+//	@Description	Request to run a connector lifecycle operation
+type ConnectorLifecycleRequestJson struct {
+	TimeoutSeconds *int64 `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty" example:"600"`
+}
+
+// ConnectorLifecycleResponseJson is returned after starting a connector-level
+// lifecycle workflow.
+//
+//	@Description	Response for connector lifecycle operation
+type ConnectorLifecycleResponseJson struct {
+	TaskId      string  `json:"task_id" yaml:"task_id"`
+	ConnectorId apid.ID `json:"connector_id" yaml:"connector_id" swaggertype:"string" example:"cxr_test550e8400abcde"`
+}
+
 // ForceConnectorVersionStateRequestJson is the request body for
 // PUT /connectors/:id/versions/:version/_force_state.
 //

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -124,6 +124,21 @@ type CreateConnectorVersionRequestJson struct {
 	Annotations *map[string]string `json:"annotations,omitempty"`
 }
 
+// ConnectorLifecycleRequestJson documents connector lifecycle operation bodies.
+//
+//	@Description	Request to run a connector lifecycle operation
+type ConnectorLifecycleRequestJson struct {
+	TimeoutSeconds *int64 `json:"timeout_seconds,omitempty" example:"600"`
+}
+
+// ConnectorLifecycleResponseJson documents connector lifecycle operation responses.
+//
+//	@Description	Response for connector lifecycle operation
+type ConnectorLifecycleResponseJson struct {
+	TaskId      string  `json:"task_id"`
+	ConnectorId apid.ID `json:"connector_id" swaggertype:"string" example:"cxr_test550e8400abcde"`
+}
+
 // ListEncryptionKeysResponseJson documents the paginated encryption-key list response.
 //
 //	@Description	Paginated list of encryption keys

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -636,6 +636,25 @@
       },
       "additionalProperties": false
     },
+    "ConnectorLifecycleRequest": {
+      "type": "object",
+      "properties": {
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConnectorLifecycleResponse": {
+      "type": "object",
+      "properties": {
+        "task_id": { "type": "string" },
+        "connector_id": { "type": "string" }
+      },
+      "required": ["task_id", "connector_id"],
+      "additionalProperties": false
+    },
     "ForceConnectorVersionStateRequest": {
       "type": "object",
       "properties": {

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -93,6 +93,8 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "create connector", ref: "./schema.json#/$defs/CreateConnectorRequest", file: "valid-create-connector.json"},
 		{name: "update connector", ref: "./schema.json#/$defs/UpdateConnectorRequest", file: "valid-update-connector.json"},
 		{name: "create connector version", ref: "./schema.json#/$defs/CreateConnectorVersionRequest", file: "valid-create-connector-version.json"},
+		{name: "connector lifecycle request", ref: "./schema.json#/$defs/ConnectorLifecycleRequest", file: "valid-connector-lifecycle-request.json"},
+		{name: "connector lifecycle response", ref: "./schema.json#/$defs/ConnectorLifecycleResponse", file: "valid-connector-lifecycle-response.json"},
 		{name: "force connector version state", ref: "./schema.json#/$defs/ForceConnectorVersionStateRequest", file: "valid-force-connector-version-state.json"},
 		{name: "rate limit", ref: "./schema.json#/$defs/RateLimit", file: "valid-rate-limit.json"},
 		{name: "list rate limits", ref: "./schema.json#/$defs/ListRateLimitsResponse", file: "valid-list-rate-limits.json"},

--- a/internal/schema/api/test_data/valid-connector-lifecycle-request.json
+++ b/internal/schema/api/test_data/valid-connector-lifecycle-request.json
@@ -1,0 +1,3 @@
+{
+  "timeout_seconds": 600
+}

--- a/internal/schema/api/test_data/valid-connector-lifecycle-response.json
+++ b/internal/schema/api/test_data/valid-connector-lifecycle-response.json
@@ -1,0 +1,4 @@
+{
+  "task_id": "encrypted-task-info",
+  "connector_id": "cxr_test0000000000001"
+}

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -134,6 +134,7 @@ func GetGinServer(
 		dm.GetConfig(),
 		authService,
 		dm.GetCoreService(),
+		dm.GetEncryptService(),
 	)
 	routesConnections := common_routes.NewConnectionsRoutes(
 		dm.GetConfig(),

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -2917,6 +2917,168 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/connectors/{id}/_archive": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that archives a connector after disconnecting its connections",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Archive connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{id}/_disconnect_all": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that disconnects all connections for a connector",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Disconnect all connector connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connectors/{id}/annotations": {
             "get": {
                 "security": [
@@ -8233,6 +8395,29 @@ const docTemplateadmin_api = `{
                     "example": "configured"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleRequestJson": {
+            "description": "Request to run a connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleResponseJson": {
+            "description": "Response for connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "example": "cxr_test550e8400abcde"
+                },
+                "task_id": {
                     "type": "string"
                 }
             }

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -2911,6 +2911,168 @@
                 }
             }
         },
+        "/connectors/{id}/_archive": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that archives a connector after disconnecting its connections",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Archive connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{id}/_disconnect_all": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that disconnects all connections for a connector",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Disconnect all connector connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connectors/{id}/annotations": {
             "get": {
                 "security": [
@@ -8227,6 +8389,29 @@
                     "example": "configured"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleRequestJson": {
+            "description": "Request to run a connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleResponseJson": {
+            "description": "Response for connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "example": "cxr_test550e8400abcde"
+                },
+                "task_id": {
                     "type": "string"
                 }
             }

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -502,6 +502,22 @@ definitions:
       updated_at:
         type: string
     type: object
+  routes.OpenAPIConnectorLifecycleRequestJson:
+    description: Request to run a connector lifecycle operation
+    properties:
+      timeout_seconds:
+        example: 600
+        type: integer
+    type: object
+  routes.OpenAPIConnectorLifecycleResponseJson:
+    description: Response for connector lifecycle operation
+    properties:
+      connector_id:
+        example: cxr_test550e8400abcde
+        type: string
+      task_id:
+        type: string
+    type: object
   routes.OpenAPIConnectorVersionJson:
     description: Detailed connector version information
     properties:
@@ -2863,6 +2879,111 @@ paths:
       security:
       - BearerAuth: []
       summary: Update connector
+      tags:
+      - connectors
+  /connectors/{id}/_archive:
+    post:
+      consumes:
+      - application/json
+      description: Start a workflow that archives a connector after disconnecting
+        its connections
+      parameters:
+      - description: Connector UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Lifecycle operation options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIConnectorLifecycleRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIConnectorLifecycleResponseJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Archive connector
+      tags:
+      - connectors
+  /connectors/{id}/_disconnect_all:
+    post:
+      consumes:
+      - application/json
+      description: Start a workflow that disconnects all connections for a connector
+      parameters:
+      - description: Connector UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Lifecycle operation options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIConnectorLifecycleRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIConnectorLifecycleResponseJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Disconnect all connector connections
       tags:
       - connectors
   /connectors/{id}/annotations:

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -95,6 +95,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		dm.GetConfig(),
 		authService,
 		dm.GetCoreService(),
+		dm.GetEncryptService(),
 	)
 	routesConnections := common_routes.NewConnectionsRoutes(
 		dm.GetConfig(),

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -2917,6 +2917,168 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/connectors/{id}/_archive": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that archives a connector after disconnecting its connections",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Archive connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{id}/_disconnect_all": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that disconnects all connections for a connector",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Disconnect all connector connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connectors/{id}/annotations": {
             "get": {
                 "security": [
@@ -8233,6 +8395,29 @@ const docTemplateApi = `{
                     "example": "configured"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleRequestJson": {
+            "description": "Request to run a connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleResponseJson": {
+            "description": "Response for connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "example": "cxr_test550e8400abcde"
+                },
+                "task_id": {
                     "type": "string"
                 }
             }

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -2911,6 +2911,168 @@
                 }
             }
         },
+        "/connectors/{id}/_archive": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that archives a connector after disconnecting its connections",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Archive connector",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/connectors/{id}/_disconnect_all": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start a workflow that disconnects all connections for a connector",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "connectors"
+                ],
+                "summary": "Disconnect all connector connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connector UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Lifecycle operation options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIConnectorLifecycleResponseJson"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/connectors/{id}/annotations": {
             "get": {
                 "security": [
@@ -8227,6 +8389,29 @@
                     "example": "configured"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleRequestJson": {
+            "description": "Request to run a connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
+                }
+            }
+        },
+        "routes.OpenAPIConnectorLifecycleResponseJson": {
+            "description": "Response for connector lifecycle operation",
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "example": "cxr_test550e8400abcde"
+                },
+                "task_id": {
                     "type": "string"
                 }
             }

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -502,6 +502,22 @@ definitions:
       updated_at:
         type: string
     type: object
+  routes.OpenAPIConnectorLifecycleRequestJson:
+    description: Request to run a connector lifecycle operation
+    properties:
+      timeout_seconds:
+        example: 600
+        type: integer
+    type: object
+  routes.OpenAPIConnectorLifecycleResponseJson:
+    description: Response for connector lifecycle operation
+    properties:
+      connector_id:
+        example: cxr_test550e8400abcde
+        type: string
+      task_id:
+        type: string
+    type: object
   routes.OpenAPIConnectorVersionJson:
     description: Detailed connector version information
     properties:
@@ -2863,6 +2879,111 @@ paths:
       security:
       - BearerAuth: []
       summary: Update connector
+      tags:
+      - connectors
+  /connectors/{id}/_archive:
+    post:
+      consumes:
+      - application/json
+      description: Start a workflow that archives a connector after disconnecting
+        its connections
+      parameters:
+      - description: Connector UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Lifecycle operation options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIConnectorLifecycleRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIConnectorLifecycleResponseJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Archive connector
+      tags:
+      - connectors
+  /connectors/{id}/_disconnect_all:
+    post:
+      consumes:
+      - application/json
+      description: Start a workflow that disconnects all connections for a connector
+      parameters:
+      - description: Connector UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Lifecycle operation options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIConnectorLifecycleRequestJson'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPIConnectorLifecycleResponseJson'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Disconnect all connector connections
       tags:
       - connectors
   /connectors/{id}/annotations:

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -171,7 +171,9 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 
 		routesConnectors := common_routes.NewConnectorsRoutes(
 			dm.GetConfig(),
-			authService, dm.GetCoreService(),
+			authService,
+			dm.GetCoreService(),
+			dm.GetEncryptService(),
 		)
 		routesConnectors.Register(api)
 

--- a/sdks/js/src/connectors.ts
+++ b/sdks/js/src/connectors.ts
@@ -67,6 +67,15 @@ export interface ListConnectorVersionsParams {
     order_by?: string;
 }
 
+export interface ConnectorLifecycleRequest {
+    timeout_seconds?: number;
+}
+
+export interface ConnectorLifecycleResponse {
+    task_id: string;
+    connector_id: string;
+}
+
 /**
  * Get a list of all available connectors
  */
@@ -114,6 +123,26 @@ export const forceConnectorVersionState = (id: string, version: number, state: C
     const request: ForceConnectorVersionStateRequest = { state };
     return client.put<ForceConnectorVersionStateResponse>(
         `/api/v1/connectors/${id}/versions/${version}/_force_state`,
+        request
+    );
+};
+
+/**
+ * Disconnect all connections for a connector.
+ */
+export const disconnectAllConnectorConnections = (id: string, request?: ConnectorLifecycleRequest) => {
+    return client.post<ConnectorLifecycleResponse>(
+        `/api/v1/connectors/${id}/_disconnect_all`,
+        request
+    );
+};
+
+/**
+ * Archive a connector after disconnecting its connections.
+ */
+export const archiveConnector = (id: string, request?: ConnectorLifecycleRequest) => {
+    return client.post<ConnectorLifecycleResponse>(
+        `/api/v1/connectors/${id}/_archive`,
         request
     );
 };
@@ -180,6 +209,8 @@ export const connectors = {
     listVersions: listConnectorVersions,
     getVersion: getConnectorVersion,
     force_version_state: forceConnectorVersionState,
+    disconnectAll: disconnectAllConnectorConnections,
+    archive: archiveConnector,
     getAnnotations: getConnectorAnnotations,
     getAnnotation: getConnectorAnnotation,
     putAnnotation: putConnectorAnnotation,


### PR DESCRIPTION
Closes #570.

## Summary

- adds connector lifecycle contract endpoints for `POST /connectors/{id}/_disconnect_all` and `POST /connectors/{id}/_archive`
- introduces dedicated permissions via the route resource checks: `connectors:disconnect_all` and `connectors:archive`
- adds the shared `{ "timeout_seconds": 600 }` request payload, default 10 minute timeout handling, and `{ "task_id", "connector_id" }` task response contract
- wires the contract through OpenAPI/schema generation and the JS SDK connector helpers

The core methods intentionally return `501 Not Implemented` until the workflow execution work lands in the follow-up issues. Route tests use a fake lifecycle core so this PR validates the API/permission/task-token contract without starting placeholder workflow instances.

## Tests

- `go test ./internal/httperr ./internal/schema/api ./internal/core ./internal/routes ./internal/service/...`
- `go test ./...`
- `yarn workspace @authproxy/api typecheck`
- `./scripts/preflight.sh`
