### PR TITLE
Fix demo deploy smoke before manual seeding

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -357,7 +357,7 @@ jobs:
             exit 1
           done
 
-      - name: Smoke test (demo connectors)
+      - name: Smoke test (live service)
         id: smoke
         timeout-minutes: 10
         env:
@@ -375,7 +375,7 @@ jobs:
           echo "Smoke-testing ${SMOKE_BASE_URL}"
           cd integration_tests
           SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
-            go test -tags smoke ./smoke -run TestRemote -count=1 -v
+            go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary
- narrow Deploy Demo smoke coverage to the unseeded OAuth proxy smoke test
- keep seeded connector verification out of Deploy Demo now that demo seeding is a manual workflow

## Evidence
- Deploy Demo run 27347579360 completed Kustomize render/apply, workload rollout, and TLS readiness, then failed because seeded connector smoke found no manual seed data
- go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 (from integration_tests)
- ./scripts/preflight.sh

Closes #565