### PR TITLE
Wire Grafana links into demo shell

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -265,6 +265,7 @@ jobs:
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
           grep -Fq "image: docker.io/grafana/grafana:11.5.2" "${manifest}"
           grep -Fq "host: ${DEMO_HOSTNAME}" "${manifest}"
+          grep -Fq "value: https://${DEMO_HOSTNAME}/grafana" "${manifest}"
           if [ -n "${GRAFANA_PLUGIN_INSTALL}" ]; then
             grep -Fq "value: ${GRAFANA_PLUGIN_INSTALL}" "${manifest}"
           fi

--- a/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
@@ -20,6 +20,8 @@ spec:
               value: https://marketplace.demo.authproxy.net
             - name: AUTHPROXY_ADMIN_UI_URL
               value: https://admin.demo.authproxy.net
+            - name: AUTHPROXY_GRAFANA_URL
+              value: https://demo.authproxy.net/grafana
       volumes:
         - name: admin-key
           secret:


### PR DESCRIPTION
## Summary
- set AUTHPROXY_GRAFANA_URL in the demo shell Kustomize overlay so /config.json returns Grafana telemetry links
- add a Deploy Demo render assertion for the Grafana shell URL

## Verification
- curl -fsS https://demo.authproxy.net/config.json returned {"telemetryLinks":[]} before the change
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo | rg -n "AUTHPROXY_GRAFANA_URL|https://demo.authproxy.net/grafana"
- ./scripts/preflight.sh

## Notes
Local kubectl access to the live deployment was blocked by an expired AWS SSO token, so I confirmed the user-visible state through the public demo shell config endpoint.