### PR TITLE
Add connector archive workflow

### DIFF
--- a/internal/core/service_connector_lifecycle.go
+++ b/internal/core/service_connector_lifecycle.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
@@ -37,9 +36,21 @@ func (s *service) DisconnectConnectorConnections(
 // ArchiveConnector archives a connector. First it disconnects all connections for the
 // connector and then it archives the connector.
 func (s *service) ArchiveConnector(
-	_ context.Context,
-	_ apid.ID,
-	_ iface.ConnectorLifecycleOptions,
+	ctx context.Context,
+	id apid.ID,
+	opts iface.ConnectorLifecycleOptions,
 ) (*tasks.TaskInfo, error) {
-	return nil, httperr.New(http.StatusNotImplemented, "connector archive workflow is not implemented")
+	if id == apid.Nil {
+		return nil, httperr.BadRequest("connector id is required")
+	}
+	if s.wc == nil {
+		return nil, fmt.Errorf("workflow client is not configured")
+	}
+
+	instance, err := s.startArchiveConnectorWorkflow(ctx, id, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return tasks.FromWorkflowInstance(instance, WorkflowNameArchiveConnectorV1, string(apworkflows.DefaultQueue)), nil
 }

--- a/internal/core/workflow_archive_connector.go
+++ b/internal/core/workflow_archive_connector.go
@@ -1,5 +1,168 @@
 package core
 
-const (
-	WorkflowNameArchiveConnectorV1               = "core.connector.archive.v1"
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cschleiden/go-workflows/client"
+	"github.com/cschleiden/go-workflows/registry"
+	wflib "github.com/cschleiden/go-workflows/workflow"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 )
+
+const (
+	WorkflowNameArchiveConnectorV1 = "core.connector.archive.v1"
+
+	ActivityNameArchiveConnectorPrepareVersionsV1  = "core.connector.archive.prepare_versions.v1"
+	ActivityNameArchiveConnectorFinalizeVersionsV1 = "core.connector.archive.finalize_versions.v1"
+)
+
+type archiveConnectorWorkflowInputV1 struct {
+	ConnectorID apid.ID       `json:"connector_id"` // ConnectorID is the durable identifier for the connector to archive.
+	Timeout     time.Duration `json:"timeout"`      // Timeout is the maximum duration allowed for child disconnect workflows.
+}
+
+func (s *service) startArchiveConnectorWorkflow(
+	ctx context.Context,
+	connectorID apid.ID,
+	opts iface.ConnectorLifecycleOptions,
+) (*wflib.Instance, error) {
+	return s.wc.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
+		InstanceID: archiveConnectorWorkflowInstanceID(connectorID),
+		Queue:      apworkflows.DefaultQueue,
+	}, WorkflowNameArchiveConnectorV1, archiveConnectorWorkflowInputV1{
+		ConnectorID: connectorID,
+		Timeout:     opts.Timeout,
+	})
+}
+
+func archiveConnectorWorkflowInstanceID(connectorID apid.ID) string {
+	return fmt.Sprintf("%s:%s", WorkflowNameArchiveConnectorV1, connectorID)
+}
+
+func archiveConnectorWorkflowV1(ctx wflib.Context, input archiveConnectorWorkflowInputV1) error {
+	if _, err := wflib.ExecuteActivity[any](
+		ctx,
+		wflib.DefaultActivityOptions,
+		ActivityNameArchiveConnectorPrepareVersionsV1,
+		input.ConnectorID,
+	).Get(ctx); err != nil {
+		return err
+	}
+
+	if _, err := wflib.CreateSubWorkflowInstance[any](
+		ctx,
+		wflib.SubWorkflowOptions{
+			InstanceID: disconnectConnectorConnectionsWorkflowInstanceID(input.ConnectorID),
+			Queue:      apworkflows.DefaultQueue,
+		},
+		WorkflowNameDisconnectConnectorConnectionsV1,
+		disconnectConnectorConnectionsWorkflowInputV1{
+			ConnectorID: input.ConnectorID,
+			Timeout:     input.Timeout,
+		},
+	).Get(ctx); err != nil {
+		return err
+	}
+
+	_, err := wflib.ExecuteActivity[any](
+		ctx,
+		wflib.DefaultActivityOptions,
+		ActivityNameArchiveConnectorFinalizeVersionsV1,
+		input.ConnectorID,
+	).Get(ctx)
+	return err
+}
+
+func validateArchiveConnectorWorkflowConnectorID(connectorID apid.ID) error {
+	if connectorID == apid.Nil {
+		return fmt.Errorf("connector id not specified")
+	}
+	return connectorID.ValidatePrefix(apid.PrefixConnectorVersion)
+}
+
+func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
+	if err := validateArchiveConnectorWorkflowConnectorID(connectorID); err != nil {
+		return err
+	}
+
+	found := false
+	err := s.db.ListConnectorVersionsBuilder().
+		ForId(connectorID).
+		Enumerate(ctx, func(page pagination.PageResult[database.ConnectorVersion]) (pagination.KeepGoing, error) {
+			for _, version := range page.Results {
+				found = true
+				switch version.State {
+				case database.ConnectorVersionStateDraft:
+					if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateArchived); err != nil {
+						return pagination.Stop, err
+					}
+				case database.ConnectorVersionStatePrimary:
+					if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateActive); err != nil {
+						return pagination.Stop, err
+					}
+				}
+			}
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return err
+	}
+	if !found {
+		return database.ErrNotFound
+	}
+	return nil
+}
+
+func (s *service) finalizeArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
+	if err := validateArchiveConnectorWorkflowConnectorID(connectorID); err != nil {
+		return err
+	}
+
+	found := false
+	err := s.db.ListConnectorVersionsBuilder().
+		ForId(connectorID).
+		Enumerate(ctx, func(page pagination.PageResult[database.ConnectorVersion]) (pagination.KeepGoing, error) {
+			for _, version := range page.Results {
+				found = true
+				if version.State == database.ConnectorVersionStateArchived {
+					continue
+				}
+				if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateArchived); err != nil {
+					return pagination.Stop, err
+				}
+			}
+			return pagination.Continue, nil
+		})
+	if err != nil {
+		return err
+	}
+	if !found {
+		return database.ErrNotFound
+	}
+	return nil
+}
+
+func (s *service) registerArchiveConnectorWorkflow(worker workflowRegistrar) error {
+	if err := worker.RegisterWorkflow(
+		archiveConnectorWorkflowV1,
+		registry.WithName(WorkflowNameArchiveConnectorV1),
+	); err != nil {
+		return err
+	}
+	if err := worker.RegisterActivity(
+		s.prepareArchiveConnectorVersionsV1,
+		registry.WithName(ActivityNameArchiveConnectorPrepareVersionsV1),
+	); err != nil {
+		return err
+	}
+	return worker.RegisterActivity(
+		s.finalizeArchiveConnectorVersionsV1,
+		registry.WithName(ActivityNameArchiveConnectorFinalizeVersionsV1),
+	)
+}

--- a/internal/core/workflow_archive_connector.go
+++ b/internal/core/workflow_archive_connector.go
@@ -42,7 +42,7 @@ func (s *service) startArchiveConnectorWorkflow(
 }
 
 // archiveConnectorWorkflowInstanceID returns a standardized identifier for the workflow instance. This name
-// guarantees tha only one instance of the workflow runs at a time.
+// guarantees that only one instance of the workflow runs at a time.
 func archiveConnectorWorkflowInstanceID(connectorID apid.ID) string {
 	return fmt.Sprintf("%s:%s", WorkflowNameArchiveConnectorV1, connectorID)
 }

--- a/internal/core/workflow_archive_connector.go
+++ b/internal/core/workflow_archive_connector.go
@@ -41,6 +41,8 @@ func (s *service) startArchiveConnectorWorkflow(
 	})
 }
 
+// archiveConnectorWorkflowInstanceID returns a standardized identifier for the workflow instance. This name
+// guarantees tha only one instance of the workflow runs at a time.
 func archiveConnectorWorkflowInstanceID(connectorID apid.ID) string {
 	return fmt.Sprintf("%s:%s", WorkflowNameArchiveConnectorV1, connectorID)
 }
@@ -86,7 +88,18 @@ func validateArchiveConnectorWorkflowConnectorID(connectorID apid.ID) error {
 	return connectorID.ValidatePrefix(apid.PrefixConnectorVersion)
 }
 
+// prepareArchiveConnectorVersionsV1 is the activity that prepares the archive connector workflow by moving
+// draft state connector versions to archived and primary versions to active. This prevents any future
+// connections from being made while the existing connections are cleaned up.
 func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
+	logger := s.logger.With(
+		"workflow", WorkflowNameDisconnectConnectionV1,
+		"activity", ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		"connector_id", connectorID,
+	)
+	logger.Info("prepare connector versions started")
+	defer logger.Info("prepare connector versions completed")
+
 	if err := validateArchiveConnectorWorkflowConnectorID(connectorID); err != nil {
 		return err
 	}
@@ -99,11 +112,15 @@ func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connect
 				found = true
 				switch version.State {
 				case database.ConnectorVersionStateDraft:
+					logger.Info("archiving draft connector version", "version_id", version.Id)
 					if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateArchived); err != nil {
+						logger.Info("failed archiving draft connector version", "version_id", version.Id, "error", err)
 						return pagination.Stop, err
 					}
 				case database.ConnectorVersionStatePrimary:
+					logger.Info("moving version to primary", "version_id", version.Id)
 					if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateActive); err != nil {
+						logger.Info("failed moving primary to active", "version_id", version.Id, "error", err)
 						return pagination.Stop, err
 					}
 				}
@@ -119,7 +136,17 @@ func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connect
 	return nil
 }
 
+// finalizeArchiveConnectorVersionsV1 is the activity that runs after all connections have been cleand up. It moves
+// all versions of the connector to the archived state.
 func (s *service) finalizeArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
+	logger := s.logger.With(
+		"workflow", WorkflowNameDisconnectConnectionV1,
+		"activity", ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		"connector_id", connectorID,
+	)
+	logger.Info("finalize connector versions started")
+	defer logger.Info("finalize connector versions completed")
+
 	if err := validateArchiveConnectorWorkflowConnectorID(connectorID); err != nil {
 		return err
 	}
@@ -133,7 +160,10 @@ func (s *service) finalizeArchiveConnectorVersionsV1(ctx context.Context, connec
 				if version.State == database.ConnectorVersionStateArchived {
 					continue
 				}
+
+				logger.Info("archiving connector version", "version_id", version.Id)
 				if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateArchived); err != nil {
+					logger.Info("failed archiving connector version", "version_id", version.Id, "error", err)
 					return pagination.Stop, err
 				}
 			}

--- a/internal/core/workflow_archive_connector_test.go
+++ b/internal/core/workflow_archive_connector_test.go
@@ -1,0 +1,197 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cschleiden/go-workflows/registry"
+	"github.com/cschleiden/go-workflows/tester"
+	wflib "github.com/cschleiden/go-workflows/workflow"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
+	testifymock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveConnectorWorkflowV1ExecutesRegisteredSteps(t *testing.T) {
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	timeout := 5 * time.Minute
+	workflowTester := tester.NewWorkflowTester[any](archiveConnectorWorkflowV1)
+
+	prepareActivity := func(context.Context, apid.ID) error {
+		return nil
+	}
+	finalizeActivity := func(context.Context, apid.ID) error {
+		return nil
+	}
+	disconnectAllWorkflow := func(wflib.Context, disconnectConnectorConnectionsWorkflowInputV1) error {
+		return nil
+	}
+
+	prepareCall := workflowTester.
+		OnActivityByName(
+			ActivityNameArchiveConnectorPrepareVersionsV1,
+			prepareActivity,
+			testifymock.Anything,
+			connectorID,
+		).
+		Return(nil).
+		Once()
+	disconnectCall := workflowTester.
+		OnSubWorkflowByName(
+			WorkflowNameDisconnectConnectorConnectionsV1,
+			disconnectAllWorkflow,
+			testifymock.Anything,
+			disconnectConnectorConnectionsWorkflowInputV1{
+				ConnectorID: connectorID,
+				Timeout:     timeout,
+			},
+		).
+		Return(nil).
+		Once().
+		NotBefore(prepareCall)
+	workflowTester.
+		OnActivityByName(
+			ActivityNameArchiveConnectorFinalizeVersionsV1,
+			finalizeActivity,
+			testifymock.Anything,
+			connectorID,
+		).
+		Return(nil).
+		Once().
+		NotBefore(disconnectCall)
+
+	workflowTester.Execute(context.Background(), archiveConnectorWorkflowInputV1{
+		ConnectorID: connectorID,
+		Timeout:     timeout,
+	})
+
+	require.True(t, workflowTester.WorkflowFinished())
+	_, err := workflowTester.WorkflowResult()
+	require.NoError(t, err)
+	workflowTester.AssertExpectations(t)
+}
+
+func TestArchiveConnectorWorkflowInstanceID(t *testing.T) {
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	require.Equal(
+		t,
+		WorkflowNameArchiveConnectorV1+":"+connectorID.String(),
+		archiveConnectorWorkflowInstanceID(connectorID),
+	)
+}
+
+func TestRegisterArchiveConnectorWorkflowV1DurableNames(t *testing.T) {
+	reg := registry.New()
+	svc := &service{}
+
+	require.NoError(t, svc.registerArchiveConnectorWorkflow(reg))
+
+	_, err := reg.GetWorkflow(WorkflowNameArchiveConnectorV1)
+	require.NoError(t, err)
+
+	_, err = reg.GetActivity(ActivityNameArchiveConnectorPrepareVersionsV1)
+	require.NoError(t, err)
+
+	_, err = reg.GetActivity(ActivityNameArchiveConnectorFinalizeVersionsV1)
+	require.NoError(t, err)
+}
+
+func TestArchiveConnectorStartsWorkflow(t *testing.T) {
+	ctx := context.Background()
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+	workflowClient := &fakeDisconnectWorkflowClient{
+		instance: &wflib.Instance{
+			InstanceID:  "workflow-instance",
+			ExecutionID: "workflow-execution",
+		},
+	}
+	svc := &service{wc: workflowClient}
+
+	taskInfo, err := svc.ArchiveConnector(ctx, connectorID, iface.ConnectorLifecycleOptions{
+		Timeout: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, taskInfo)
+	require.Equal(t, WorkflowNameArchiveConnectorV1, taskInfo.WorkflowName)
+	require.Equal(t, apworkflows.DefaultQueue, workflowClient.options.Queue)
+	require.Equal(t, WorkflowNameArchiveConnectorV1, workflowClient.workflow)
+	require.Len(t, workflowClient.args, 1)
+	require.Equal(t, archiveConnectorWorkflowInstanceID(connectorID), workflowClient.options.InstanceID)
+
+	input, ok := workflowClient.args[0].(archiveConnectorWorkflowInputV1)
+	require.True(t, ok)
+	require.Equal(t, connectorID, input.ConnectorID)
+	require.Equal(t, 5*time.Minute, input.Timeout)
+}
+
+func TestArchiveConnectorVersionActivitiesTransitionStates(t *testing.T) {
+	ctx := context.Background()
+	_, db := database.MustApplyBlankTestDbConfig(t, nil)
+	svc := &service{db: db}
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+
+	upsertConnectorVersion(t, db, connectorID, 1, database.ConnectorVersionStatePrimary)
+	upsertConnectorVersion(t, db, connectorID, 2, database.ConnectorVersionStatePrimary)
+	upsertConnectorVersion(t, db, connectorID, 3, database.ConnectorVersionStateDraft)
+
+	require.NoError(t, svc.prepareArchiveConnectorVersionsV1(ctx, connectorID))
+	requireConnectorVersionState(t, db, connectorID, 1, database.ConnectorVersionStateActive)
+	requireConnectorVersionState(t, db, connectorID, 2, database.ConnectorVersionStateActive)
+	requireConnectorVersionState(t, db, connectorID, 3, database.ConnectorVersionStateArchived)
+
+	require.NoError(t, svc.prepareArchiveConnectorVersionsV1(ctx, connectorID))
+	require.NoError(t, svc.finalizeArchiveConnectorVersionsV1(ctx, connectorID))
+	requireConnectorVersionState(t, db, connectorID, 1, database.ConnectorVersionStateArchived)
+	requireConnectorVersionState(t, db, connectorID, 2, database.ConnectorVersionStateArchived)
+	requireConnectorVersionState(t, db, connectorID, 3, database.ConnectorVersionStateArchived)
+
+	require.NoError(t, svc.finalizeArchiveConnectorVersionsV1(ctx, connectorID))
+}
+
+func TestArchiveConnectorVersionActivitiesReturnNotFound(t *testing.T) {
+	ctx := context.Background()
+	_, db := database.MustApplyBlankTestDbConfig(t, nil)
+	svc := &service{db: db}
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+
+	require.ErrorIs(t, svc.prepareArchiveConnectorVersionsV1(ctx, connectorID), database.ErrNotFound)
+	require.ErrorIs(t, svc.finalizeArchiveConnectorVersionsV1(ctx, connectorID), database.ErrNotFound)
+}
+
+func upsertConnectorVersion(
+	t *testing.T,
+	db database.DB,
+	connectorID apid.ID,
+	version uint64,
+	state database.ConnectorVersionState,
+) {
+	t.Helper()
+	require.NoError(t, db.UpsertConnectorVersion(context.Background(), &database.ConnectorVersion{
+		Id:                  connectorID,
+		Version:             version,
+		Namespace:           sconfig.RootNamespace,
+		State:               state,
+		Hash:                "hash",
+		EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("ekv_test000000000001"), Data: "encrypted-definition"},
+		Labels:              database.Labels{"type": "test"},
+	}))
+}
+
+func requireConnectorVersionState(
+	t *testing.T,
+	db database.DB,
+	connectorID apid.ID,
+	version uint64,
+	expected database.ConnectorVersionState,
+) {
+	t.Helper()
+	connectorVersion, err := db.GetConnectorVersion(context.Background(), connectorID, version)
+	require.NoError(t, err)
+	require.Equal(t, expected, connectorVersion.State)
+}

--- a/internal/core/workflows.go
+++ b/internal/core/workflows.go
@@ -15,6 +15,7 @@ func (s *service) RegisterWorkflows(worker *apworkflows.Worker) error {
 	registerFns := []func(workflowRegistrar) error{
 		s.registerDisconnectConnectionWorkflow,
 		s.registerDisconnectConnectorConnectionsWorkflow,
+		s.registerArchiveConnectorWorkflow,
 	}
 
 	for _, registerFn := range registerFns {


### PR DESCRIPTION
## Summary

- implements `core.connector.archive.v1` with prepare/finalize version-state activities
- wires `ArchiveConnector` to return a workflow-backed task on the default workflow queue
- registers durable workflow/activity names and covers orchestration plus DB-backed state transitions

Closes #571

## Tests

- `go test ./internal/core`
- `go test ./...`
- `./scripts/preflight.sh`
