### PR TITLE
Add timeout payload to connection disconnect

### DIFF
--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -20,6 +20,10 @@ type ConnectorLifecycleOptions struct {
 	Timeout time.Duration
 }
 
+type ConnectionDisconnectOptions struct {
+	Timeout time.Duration
+}
+
 // C is the interface for the core service that implements primary business logic and binds the system together.
 type C interface {
 	/*
@@ -94,7 +98,7 @@ type C interface {
 
 	// DisconnectConnection disconnects a connection. This is a state transition that queues work to do any cleanup
 	// with the 3rd party.
-	DisconnectConnection(ctx context.Context, id apid.ID) (taskInfo *tasks.TaskInfo, err error)
+	DisconnectConnection(ctx context.Context, id apid.ID, opts ConnectionDisconnectOptions) (taskInfo *tasks.TaskInfo, err error)
 
 	// AbortConnection aborts an in-progress connection setup, revoking any credentials and deleting the connection.
 	// Only valid for connections with a non-null setup_step.

--- a/internal/core/service_connection_disconnect.go
+++ b/internal/core/service_connection_disconnect.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/tasks"
@@ -14,6 +15,7 @@ import (
 func (s *service) DisconnectConnection(
 	ctx context.Context,
 	id apid.ID,
+	opts iface.ConnectionDisconnectOptions,
 ) (taskInfo *tasks.TaskInfo, err error) {
 	s.logger.Info("disconnecting connection", "id", id)
 	err = s.db.SetConnectionState(ctx, id, database.ConnectionStateDisconnecting)
@@ -27,7 +29,7 @@ func (s *service) DisconnectConnection(
 	}
 
 	s.logger.Info("starting disconnect connection workflow", "id", id)
-	instance, err := s.startDisconnectConnectionWorkflow(ctx, id)
+	instance, err := s.startDisconnectConnectionWorkflow(ctx, id, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +39,6 @@ func (s *service) DisconnectConnection(
 		"id", id,
 		"workflow_instance_id", instance.InstanceID,
 		"workflow_execution_id", instance.ExecutionID,
-		)
+	)
 	return tasks.FromWorkflowInstance(instance, WorkflowNameDisconnectConnectionV1, string(apworkflows.DefaultQueue)), nil
 }

--- a/internal/core/service_connection_disconnect_test.go
+++ b/internal/core/service_connection_disconnect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/cschleiden/go-workflows/client"
 	wflib "github.com/cschleiden/go-workflows/workflow"
@@ -15,6 +16,7 @@ import (
 	mockAsynq "github.com/rmorlok/authproxy/internal/apasynq/mock"
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockLog "github.com/rmorlok/authproxy/internal/aplog/mock"
+	"github.com/rmorlok/authproxy/internal/core/iface"
 	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
 	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +74,9 @@ func TestDisconnectConnection(t *testing.T) {
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnecting).
 			Return(nil)
 
-		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
+		taskInfo, err := svc.DisconnectConnection(ctx, connectionId, iface.ConnectionDisconnectOptions{
+			Timeout: 5 * time.Minute,
+		})
 
 		assert.NoError(t, err)
 		require.NotNil(t, taskInfo)
@@ -81,7 +85,11 @@ func TestDisconnectConnection(t *testing.T) {
 		assert.Equal(t, "workflow-execution-id", taskInfo.WorkflowExecutionId)
 		assert.Equal(t, WorkflowNameDisconnectConnectionV1, taskInfo.WorkflowName)
 		assert.Equal(t, WorkflowNameDisconnectConnectionV1, workflowClient.workflow)
-		assert.Equal(t, []any{connectionId}, workflowClient.args)
+		require.Len(t, workflowClient.args, 1)
+		input, ok := workflowClient.args[0].(disconnectConnectionWorkflowInputV1)
+		require.True(t, ok)
+		assert.Equal(t, connectionId, input.ConnectionID)
+		assert.Equal(t, 5*time.Minute, input.Timeout)
 		assert.Contains(t, workflowClient.options.InstanceID, connectionId)
 	})
 
@@ -93,7 +101,7 @@ func TestDisconnectConnection(t *testing.T) {
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnecting).
 			Return(database.ErrNotFound)
 
-		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
+		taskInfo, err := svc.DisconnectConnection(ctx, connectionId, iface.ConnectionDisconnectOptions{})
 
 		assert.Error(t, err)
 		assert.Nil(t, taskInfo)
@@ -107,7 +115,7 @@ func TestDisconnectConnection(t *testing.T) {
 			SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateDisconnecting).
 			Return(errors.New("some error"))
 
-		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
+		taskInfo, err := svc.DisconnectConnection(ctx, connectionId, iface.ConnectionDisconnectOptions{})
 
 		assert.Error(t, err)
 		assert.Nil(t, taskInfo)
@@ -123,7 +131,7 @@ func TestDisconnectConnection(t *testing.T) {
 
 		workflowClient.err = errors.New("workflow error")
 
-		taskInfo, err := svc.DisconnectConnection(ctx, connectionId)
+		taskInfo, err := svc.DisconnectConnection(ctx, connectionId, iface.ConnectionDisconnectOptions{})
 
 		assert.Error(t, err)
 		assert.Nil(t, taskInfo)

--- a/internal/core/workflow_archive_connector_test.go
+++ b/internal/core/workflow_archive_connector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/test_utils"
 	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -133,7 +134,7 @@ func TestArchiveConnectorStartsWorkflow(t *testing.T) {
 func TestArchiveConnectorVersionActivitiesTransitionStates(t *testing.T) {
 	ctx := context.Background()
 	_, db := database.MustApplyBlankTestDbConfig(t, nil)
-	svc := &service{db: db}
+	svc := &service{db: db, logger: test_utils.NewTestLogger()}
 	connectorID := apid.New(apid.PrefixConnectorVersion)
 
 	upsertConnectorVersion(t, db, connectorID, 1, database.ConnectorVersionStatePrimary)
@@ -157,7 +158,7 @@ func TestArchiveConnectorVersionActivitiesTransitionStates(t *testing.T) {
 func TestArchiveConnectorVersionActivitiesReturnNotFound(t *testing.T) {
 	ctx := context.Background()
 	_, db := database.MustApplyBlankTestDbConfig(t, nil)
-	svc := &service{db: db}
+	svc := &service{db: db, logger: test_utils.NewTestLogger()}
 	connectorID := apid.New(apid.PrefixConnectorVersion)
 
 	require.ErrorIs(t, svc.prepareArchiveConnectorVersionsV1(ctx, connectorID), database.ErrNotFound)

--- a/internal/core/workflow_disconnect_connection.go
+++ b/internal/core/workflow_disconnect_connection.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/cschleiden/go-workflows/registry"
 	wflib "github.com/cschleiden/go-workflows/workflow"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/util/retry"
 	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
@@ -19,6 +21,7 @@ const (
 
 	ActivityNameDisconnectConnectionRevokeCredentialsV1 = "core.connection.disconnect.revoke_credentials.v1"
 	ActivityNameDisconnectConnectionFinalizeV1          = "core.connection.disconnect.finalize.v1"
+	ActivityNameDisconnectConnectionForceV1             = "core.connection.disconnect.force.v1"
 )
 
 // maxRevokeAttempts caps the number of times a revoke operation is retried
@@ -27,21 +30,82 @@ const (
 // because a 3rd-party revoke endpoint is misbehaving.
 const maxRevokeAttempts = 3
 
-func disconnectConnectionWorkflowV1(ctx wflib.Context, connectionId string) error {
-	if _, err := wflib.ExecuteActivity[any](
-		ctx,
+type disconnectConnectionWorkflowInputV1 struct {
+	ConnectionID apid.ID       `json:"connection_id"` // ConnectionID is the durable identifier for the connection to disconnect.
+	Timeout      time.Duration `json:"timeout"`       // Timeout is the maximum duration allowed for the disconnect workflow.
+}
+
+func disconnectConnectionWorkflowV1(ctx wflib.Context, input disconnectConnectionWorkflowInputV1) error {
+	activityCtx, cancelActivities := wflib.WithCancel(ctx)
+	defer cancelActivities()
+
+	timerCtx, cancelTimer := wflib.WithCancel(ctx)
+	timer := wflib.ScheduleTimer(
+		timerCtx,
+		input.Timeout,
+		wflib.WithTimerName("disconnect-timeout"),
+	)
+	defer cancelTimer()
+
+	disconnectFuture := wflib.ExecuteActivity[any](
+		activityCtx,
 		disconnectConnectionRevokeActivityOptions(),
 		ActivityNameDisconnectConnectionRevokeCredentialsV1,
-		connectionId,
-	).Get(ctx); err != nil {
+		input.ConnectionID,
+	)
+
+	timedOut := false
+	if err := waitForDisconnectConnectionStepV1(ctx, timer, disconnectFuture, cancelActivities, &timedOut); err != nil {
 		return err
 	}
 
+	if timedOut {
+		return forceDisconnectConnectionV1(ctx, input.ConnectionID)
+	}
+
+	disconnectFuture = wflib.ExecuteActivity[any](
+		activityCtx,
+		wflib.DefaultActivityOptions,
+		ActivityNameDisconnectConnectionFinalizeV1,
+		input.ConnectionID,
+	)
+	if err := waitForDisconnectConnectionStepV1(ctx, timer, disconnectFuture, cancelActivities, &timedOut); err != nil {
+		return err
+	}
+	if timedOut {
+		return forceDisconnectConnectionV1(ctx, input.ConnectionID)
+	}
+
+	cancelTimer()
+	return nil
+}
+
+func waitForDisconnectConnectionStepV1(
+	ctx wflib.Context,
+	timer wflib.Future[any],
+	step wflib.Future[any],
+	cancelActivities wflib.CancelFunc,
+	timedOut *bool,
+) error {
+	var stepErr error
+	wflib.Select(ctx,
+		wflib.Await(timer, func(_ wflib.Context, _ wflib.Future[any]) {
+			*timedOut = true
+			cancelActivities()
+		}),
+		wflib.Await(step, func(ctx wflib.Context, future wflib.Future[any]) {
+			_, stepErr = future.Get(ctx)
+		}),
+	)
+	return stepErr
+}
+
+func forceDisconnectConnectionV1(ctx wflib.Context, connectionID apid.ID) error {
 	_, err := wflib.ExecuteActivity[any](
 		ctx,
 		wflib.DefaultActivityOptions,
-		ActivityNameDisconnectConnectionFinalizeV1,
-		connectionId,
+		ActivityNameDisconnectConnectionForceV1,
+		connectionID,
 	).Get(ctx)
 	return err
 }
@@ -69,9 +133,15 @@ func (s *service) registerDisconnectConnectionWorkflow(worker workflowRegistrar)
 	); err != nil {
 		return err
 	}
-	return worker.RegisterActivity(
+	if err := worker.RegisterActivity(
 		s.finalizeDisconnectConnectionV1,
 		registry.WithName(ActivityNameDisconnectConnectionFinalizeV1),
+	); err != nil {
+		return err
+	}
+	return worker.RegisterActivity(
+		s.forceDisconnectConnectionV1,
+		registry.WithName(ActivityNameDisconnectConnectionForceV1),
 	)
 }
 
@@ -83,14 +153,21 @@ func disconnectConnectionWorkflowInstanceID(connectionId apid.ID) string {
 	return fmt.Sprintf("%s:%s", WorkflowNameDisconnectConnectionV1, connectionId)
 }
 
-func (s *service) startDisconnectConnectionWorkflow(ctx context.Context, connectionId apid.ID) (*wflib.Instance, error) {
+func (s *service) startDisconnectConnectionWorkflow(
+	ctx context.Context,
+	connectionId apid.ID,
+	opts iface.ConnectionDisconnectOptions,
+) (*wflib.Instance, error) {
 	if s.wc == nil {
 		return nil, fmt.Errorf("workflow client is not configured")
 	}
 	return s.wc.CreateWorkflowInstance(ctx, client.WorkflowInstanceOptions{
 		InstanceID: disconnectConnectionWorkflowInstanceID(connectionId),
 		Queue:      apworkflows.DefaultQueue,
-	}, WorkflowNameDisconnectConnectionV1, connectionId)
+	}, WorkflowNameDisconnectConnectionV1, disconnectConnectionWorkflowInputV1{
+		ConnectionID: connectionId,
+		Timeout:      opts.Timeout,
+	})
 }
 
 // revokeDisconnectConnectionCredentialsV1 is the revoke activity for disconnect connection.
@@ -160,7 +237,7 @@ func (s *service) finalizeDisconnectConnectionV1(ctx context.Context, id apid.ID
 		"workflow", WorkflowNameDisconnectConnectionV1,
 		"activity", ActivityNameDisconnectConnectionFinalizeV1,
 		"connection_id", id,
-		)
+	)
 	logger.Info("disconnect connection finalize activity started")
 	defer logger.Info("disconnect connection finalize activity completed")
 
@@ -183,5 +260,22 @@ func (s *service) finalizeDisconnectConnectionV1(ctx context.Context, id apid.ID
 		return err
 	}
 
+	return nil
+}
+
+func (s *service) forceDisconnectConnectionV1(ctx context.Context, id apid.ID) error {
+	if id == apid.Nil {
+		return fmt.Errorf("connection id not specified")
+	}
+	if err := id.ValidatePrefix(apid.PrefixConnection); err != nil {
+		return err
+	}
+
+	if err := s.db.SetConnectionState(ctx, id, database.ConnectionStateDisconnected); err != nil && !errors.Is(err, database.ErrNotFound) {
+		return err
+	}
+	if err := s.db.DeleteConnection(ctx, id); err != nil && !errors.Is(err, database.ErrNotFound) {
+		return err
+	}
 	return nil
 }

--- a/internal/core/workflow_disconnect_connection_test.go
+++ b/internal/core/workflow_disconnect_connection_test.go
@@ -171,13 +171,16 @@ func TestWorkflowDisconnectConnection(t *testing.T) {
 
 // This test asserts that the real workflow will invoke the activities that are part of it.
 func TestDisconnectConnectionWorkflowV1ExecutesRegisteredActivities(t *testing.T) {
-	connectionId := apid.New(apid.PrefixConnection).String()
+	connectionId := apid.New(apid.PrefixConnection)
 	workflowTester := tester.NewWorkflowTester[any](disconnectConnectionWorkflowV1)
 
-	revokeActivity := func(context.Context, string) error {
+	revokeActivity := func(context.Context, apid.ID) error {
 		return nil
 	}
-	finalizeActivity := func(context.Context, string) error {
+	finalizeActivity := func(context.Context, apid.ID) error {
+		return nil
+	}
+	forceActivity := func(context.Context, apid.ID) error {
 		return nil
 	}
 
@@ -200,8 +203,62 @@ func TestDisconnectConnectionWorkflowV1ExecutesRegisteredActivities(t *testing.T
 		Return(nil).
 		Once().
 		NotBefore(revokeCall)
+	workflowTester.
+		OnActivityByName(
+			ActivityNameDisconnectConnectionForceV1,
+			forceActivity,
+			testifymock.Anything,
+			connectionId,
+		).
+		Return(nil).
+		Maybe()
 
-	workflowTester.Execute(context.Background(), connectionId)
+	workflowTester.Execute(context.Background(), disconnectConnectionWorkflowInputV1{
+		ConnectionID: connectionId,
+		Timeout:      time.Minute,
+	})
+
+	require.True(t, workflowTester.WorkflowFinished())
+	_, err := workflowTester.WorkflowResult()
+	require.NoError(t, err)
+	workflowTester.AssertExpectations(t)
+}
+
+func TestDisconnectConnectionWorkflowV1ForcesOnTimeout(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	workflowTester := tester.NewWorkflowTester[any](disconnectConnectionWorkflowV1)
+
+	revokeActivity := func(ctx context.Context, _ apid.ID) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	forceActivity := func(context.Context, apid.ID) error {
+		return nil
+	}
+
+	workflowTester.
+		OnActivityByName(
+			ActivityNameDisconnectConnectionRevokeCredentialsV1,
+			revokeActivity,
+			testifymock.Anything,
+			connectionId,
+		).
+		Return(context.Canceled).
+		Maybe()
+	workflowTester.
+		OnActivityByName(
+			ActivityNameDisconnectConnectionForceV1,
+			forceActivity,
+			testifymock.Anything,
+			connectionId,
+		).
+		Return(nil).
+		Once()
+
+	workflowTester.Execute(context.Background(), disconnectConnectionWorkflowInputV1{
+		ConnectionID: connectionId,
+		Timeout:      time.Millisecond,
+	})
 
 	require.True(t, workflowTester.WorkflowFinished())
 	_, err := workflowTester.WorkflowResult()
@@ -225,5 +282,8 @@ func TestRegisterDisconnectConnectionWorkflowV1DurableNames(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = reg.GetActivity(ActivityNameDisconnectConnectionFinalizeV1)
+	require.NoError(t, err)
+
+	_, err = reg.GetActivity(ActivityNameDisconnectConnectionForceV1)
 	require.NoError(t, err)
 }

--- a/internal/core/workflow_disconnect_connector_connections.go
+++ b/internal/core/workflow_disconnect_connector_connections.go
@@ -21,6 +21,8 @@ const (
 
 	ActivityNameDisconnectConnectorConnectionsListConnectionsV1 = "core.connector.disconnect_all.list_connections.v1"
 	ActivityNameDisconnectConnectorConnectionsForceRemainingV1  = "core.connector.disconnect_all.force_remaining.v1"
+
+	disconnectConnectorConnectionsParentReserve = 5 * time.Second
 )
 
 type disconnectConnectorConnectionsWorkflowInputV1 struct {
@@ -68,6 +70,7 @@ func disconnectConnectorConnectionsWorkflowV1(ctx wflib.Context, input disconnec
 	defer cancelChildren()
 
 	pending := make(map[apid.ID]wflib.Future[any], len(connectionIDs))
+	childTimeout := disconnectConnectorConnectionChildTimeout(input.Timeout)
 	for _, connectionID := range connectionIDs {
 		pending[connectionID] = wflib.CreateSubWorkflowInstance[any](
 			childCtx,
@@ -76,7 +79,10 @@ func disconnectConnectorConnectionsWorkflowV1(ctx wflib.Context, input disconnec
 				Queue:      apworkflows.DefaultQueue,
 			},
 			WorkflowNameDisconnectConnectionV1,
-			connectionID,
+			disconnectConnectionWorkflowInputV1{
+				ConnectionID: connectionID,
+				Timeout:      childTimeout,
+			},
 		)
 	}
 
@@ -137,6 +143,13 @@ func disconnectConnectorConnectionsWorkflowV1(ctx wflib.Context, input disconnec
 		connectionsToForce,
 	).Get(ctx)
 	return err
+}
+
+func disconnectConnectorConnectionChildTimeout(parentTimeout time.Duration) time.Duration {
+	if parentTimeout <= disconnectConnectorConnectionsParentReserve {
+		return parentTimeout
+	}
+	return parentTimeout - disconnectConnectorConnectionsParentReserve
 }
 
 // listDisconnectConnectorConnectionsV1 is the activity to list all connections that are relevant to

--- a/internal/core/workflow_disconnect_connector_connections_test.go
+++ b/internal/core/workflow_disconnect_connector_connections_test.go
@@ -30,7 +30,7 @@ func TestDisconnectConnectorConnectionsWorkflowV1ExecutesChildWorkflows(t *testi
 	forceActivity := func(context.Context, []apid.ID) error {
 		return nil
 	}
-	childWorkflow := func(wflib.Context, string) error {
+	childWorkflow := func(wflib.Context, disconnectConnectionWorkflowInputV1) error {
 		return nil
 	}
 
@@ -49,7 +49,10 @@ func TestDisconnectConnectorConnectionsWorkflowV1ExecutesChildWorkflows(t *testi
 				WorkflowNameDisconnectConnectionV1,
 				childWorkflow,
 				testifymock.Anything,
-				connectionID.String(),
+				disconnectConnectionWorkflowInputV1{
+					ConnectionID: connectionID,
+					Timeout:      time.Minute - disconnectConnectorConnectionsParentReserve,
+				},
 			).
 			Return(nil).
 			Once()
@@ -86,7 +89,7 @@ func TestDisconnectConnectorConnectionsWorkflowV1ForcesFailedChildren(t *testing
 	forceActivity := func(context.Context, []apid.ID) error {
 		return nil
 	}
-	childWorkflow := func(wflib.Context, string) error {
+	childWorkflow := func(wflib.Context, disconnectConnectionWorkflowInputV1) error {
 		return errors.New("child failed")
 	}
 
@@ -104,7 +107,10 @@ func TestDisconnectConnectorConnectionsWorkflowV1ForcesFailedChildren(t *testing
 			WorkflowNameDisconnectConnectionV1,
 			childWorkflow,
 			testifymock.Anything,
-			connectionID.String(),
+			disconnectConnectionWorkflowInputV1{
+				ConnectionID: connectionID,
+				Timeout:      time.Minute - disconnectConnectorConnectionsParentReserve,
+			},
 		).
 		Return(nil, errors.New("child failed")).
 		Once()
@@ -140,7 +146,7 @@ func TestDisconnectConnectorConnectionsWorkflowV1ForcesRemainingOnTimeout(t *tes
 	forceActivity := func(context.Context, []apid.ID) error {
 		return nil
 	}
-	childWorkflow := func(ctx wflib.Context, _ string) error {
+	childWorkflow := func(ctx wflib.Context, _ disconnectConnectionWorkflowInputV1) error {
 		return wflib.Sleep(ctx, time.Hour)
 	}
 
@@ -182,6 +188,12 @@ func TestDisconnectConnectorConnectionChildWorkflowInstanceIDUsesConnectionWorkf
 		WorkflowNameDisconnectConnectionV1+":"+connectionID.String(),
 		disconnectConnectionWorkflowInstanceID(connectionID),
 	)
+}
+
+func TestDisconnectConnectorConnectionChildTimeout(t *testing.T) {
+	require.Equal(t, 55*time.Second, disconnectConnectorConnectionChildTimeout(time.Minute))
+	require.Equal(t, 5*time.Second, disconnectConnectorConnectionChildTimeout(5*time.Second))
+	require.Equal(t, time.Second, disconnectConnectorConnectionChildTimeout(time.Second))
 }
 
 func TestDisconnectConnectorConnectionsWorkflowInstanceID(t *testing.T) {

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -50,6 +51,7 @@ type ConnectionState = schemaapi.ConnectionState
 type ConnectionHealthState = schemaapi.ConnectionHealthState
 type ConnectionJson = schemaapi.ConnectionJson
 type ListConnectionResponseJson = schemaapi.ListConnectionResponseJson
+type DisconnectConnectionRequestJson = schemaapi.DisconnectConnectionRequestJson
 type DisconnectResponseJson = schemaapi.DisconnectResponseJson
 type ForceStateRequestJson = schemaapi.ForceConnectionStateRequestJson
 type UpdateConnectionRequestJson = schemaapi.UpdateConnectionRequestJson
@@ -57,6 +59,7 @@ type ProxyResponse = schemaapi.ProxyResponseJson
 
 type OpenAPIConnectionJson = schemaapiopenapi.ConnectionJson
 type OpenAPIListConnectionResponseJson = schemaapiopenapi.ListConnectionResponseJson
+type OpenAPIDisconnectConnectionRequestJson = schemaapiopenapi.DisconnectConnectionRequestJson
 type OpenAPIDisconnectResponseJson = schemaapiopenapi.DisconnectResponseJson
 type ProxyRequest = schemaapiopenapi.ProxyRequestJson
 type OpenAPIProxyResponseJson = schemaapiopenapi.ProxyResponseJson
@@ -469,6 +472,7 @@ func (r *ConnectionsRoutes) get(gctx *gin.Context) {
 // @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Connection UUID"
+// @Param			request	body		OpenAPIDisconnectConnectionRequestJson	false	"Disconnect options"
 // @Success		200	{object}	OpenAPIDisconnectResponseJson
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
@@ -505,7 +509,12 @@ func (r *ConnectionsRoutes) disconnect(gctx *gin.Context) {
 		return
 	}
 
-	ti, err := r.core.DisconnectConnection(ctx, id)
+	opts, ok := r.parseConnectionDisconnectRequest(gctx)
+	if !ok {
+		return
+	}
+
+	ti, err := r.core.DisconnectConnection(ctx, id, opts)
 	if err != nil {
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
@@ -533,6 +542,31 @@ func (r *ConnectionsRoutes) disconnect(gctx *gin.Context) {
 	}
 
 	gctx.PureJSON(http.StatusOK, response)
+}
+
+func (r *ConnectionsRoutes) parseConnectionDisconnectRequest(gctx *gin.Context) (coreIface.ConnectionDisconnectOptions, bool) {
+	val := auth.MustGetValidatorFromGinContext(gctx)
+
+	req := DisconnectConnectionRequestJson{}
+	if gctx.Request.Body != http.NoBody && gctx.Request.ContentLength != 0 {
+		if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+			val.MarkErrorReturn()
+			return coreIface.ConnectionDisconnectOptions{}, false
+		}
+	}
+
+	timeout := defaultConnectorLifecycleTimeout
+	if req.TimeoutSeconds != nil {
+		if *req.TimeoutSeconds <= 0 {
+			apgin.WriteError(gctx, nil, httperr.BadRequest("timeout_seconds must be greater than zero"))
+			val.MarkErrorReturn()
+			return coreIface.ConnectionDisconnectOptions{}, false
+		}
+		timeout = time.Duration(*req.TimeoutSeconds) * time.Second
+	}
+
+	return coreIface.ConnectionDisconnectOptions{Timeout: timeout}, true
 }
 
 // @Summary		Abort connection setup

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -484,6 +484,38 @@ func TestConnections(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusForbidden, w.Code)
 		})
+
+		t.Run("rejects invalid timeout", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+u.String()+"/_disconnect",
+				util.JsonToReader(DisconnectConnectionRequestJson{TimeoutSeconds: util.ToPtr(int64(0))}),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "disconnect"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("rejects invalid json", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/"+u.String()+"/_disconnect",
+				util.JsonToReader("{invalid json}"),
+				"root",
+				"some-actor",
+				aschema.PermissionsSingle("root.**", "connections", "disconnect"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
 	})
 
 	t.Run("initiate connection", func(t *testing.T) {

--- a/internal/schema/api/connections.go
+++ b/internal/schema/api/connections.go
@@ -53,6 +53,13 @@ type DisconnectResponseJson struct {
 	Connection ConnectionJson `json:"connection" yaml:"connection"`
 }
 
+// DisconnectConnectionRequestJson is the optional request body for POST /connections/:id/_disconnect.
+//
+//	@Description	Request to disconnect a connection
+type DisconnectConnectionRequestJson struct {
+	TimeoutSeconds *int64 `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty" example:"600"`
+}
+
 // ForceConnectionStateRequestJson is the request body for PUT /connections/:id/_force_state.
 //
 //	@Description	Request to force a connection state

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -96,6 +96,13 @@ type DisconnectResponseJson struct {
 	Connection interface{} `json:"connection"`
 }
 
+// DisconnectConnectionRequestJson documents connection disconnect operation bodies.
+//
+//	@Description	Request body for connection disconnect operations
+type DisconnectConnectionRequestJson struct {
+	TimeoutSeconds *int64 `json:"timeout_seconds,omitempty" example:"600"`
+}
+
 // CreateConnectorRequestJson documents the connector creation body.
 //
 //	@Description	Request to create a new connector

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -185,6 +185,16 @@
       "required": ["items"],
       "additionalProperties": false
     },
+    "DisconnectConnectionRequest": {
+      "type": "object",
+      "properties": {
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "DisconnectResponse": {
       "type": "object",
       "properties": {

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -70,6 +70,7 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "data source option", ref: "./schema.json#/$defs/DataSourceOption", file: "valid-data-source-option.json"},
 		{name: "connection", ref: "./schema.json#/$defs/Connection", file: "valid-connection.json"},
 		{name: "list connections", ref: "./schema.json#/$defs/ListConnectionResponse", file: "valid-list-connections.json"},
+		{name: "disconnect connection request", ref: "./schema.json#/$defs/DisconnectConnectionRequest", file: "valid-disconnect-connection-request.json"},
 		{name: "disconnect response", ref: "./schema.json#/$defs/DisconnectResponse", file: "valid-disconnect-response.json"},
 		{name: "force connection state", ref: "./schema.json#/$defs/ForceConnectionStateRequest", file: "valid-force-connection-state.json"},
 		{name: "update connection", ref: "./schema.json#/$defs/UpdateConnectionRequest", file: "valid-update-connection.json"},

--- a/internal/schema/api/test_data/valid-disconnect-connection-request.json
+++ b/internal/schema/api/test_data/valid-disconnect-connection-request.json
@@ -1,0 +1,3 @@
+{
+  "timeout_seconds": 600
+}

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -1561,6 +1561,14 @@ const docTemplateadmin_api = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Disconnect options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIDisconnectConnectionRequestJson"
+                        }
                     }
                 ],
                 "responses": {
@@ -8528,6 +8536,16 @@ const docTemplateadmin_api = `{
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
+                }
+            }
+        },
+        "routes.OpenAPIDisconnectConnectionRequestJson": {
+            "description": "Request body for connection disconnect operations",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -1555,6 +1555,14 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Disconnect options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIDisconnectConnectionRequestJson"
+                        }
                     }
                 ],
                 "responses": {
@@ -8522,6 +8530,16 @@
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
+                }
+            }
+        },
+        "routes.OpenAPIDisconnectConnectionRequestJson": {
+            "description": "Request body for connection disconnect operations",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -594,6 +594,13 @@ definitions:
         example: root.acme
         type: string
     type: object
+  routes.OpenAPIDisconnectConnectionRequestJson:
+    description: Request body for connection disconnect operations
+    properties:
+      timeout_seconds:
+        example: 600
+        type: integer
+    type: object
   routes.OpenAPIDisconnectResponseJson:
     description: Response for disconnect operation
     properties:
@@ -1988,6 +1995,11 @@ paths:
         name: id
         required: true
         type: string
+      - description: Disconnect options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIDisconnectConnectionRequestJson'
       produces:
       - application/json
       responses:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -1561,6 +1561,14 @@ const docTemplateApi = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Disconnect options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIDisconnectConnectionRequestJson"
+                        }
                     }
                 ],
                 "responses": {
@@ -8528,6 +8536,16 @@ const docTemplateApi = `{
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
+                }
+            }
+        },
+        "routes.OpenAPIDisconnectConnectionRequestJson": {
+            "description": "Request body for connection disconnect operations",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -1555,6 +1555,14 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Disconnect options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPIDisconnectConnectionRequestJson"
+                        }
                     }
                 ],
                 "responses": {
@@ -8522,6 +8530,16 @@
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
+                }
+            }
+        },
+        "routes.OpenAPIDisconnectConnectionRequestJson": {
+            "description": "Request body for connection disconnect operations",
+            "type": "object",
+            "properties": {
+                "timeout_seconds": {
+                    "type": "integer",
+                    "example": 600
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -594,6 +594,13 @@ definitions:
         example: root.acme
         type: string
     type: object
+  routes.OpenAPIDisconnectConnectionRequestJson:
+    description: Request body for connection disconnect operations
+    properties:
+      timeout_seconds:
+        example: 600
+        type: integer
+    type: object
   routes.OpenAPIDisconnectResponseJson:
     description: Response for disconnect operation
     properties:
@@ -1988,6 +1995,11 @@ paths:
         name: id
         required: true
         type: string
+      - description: Disconnect options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/routes.OpenAPIDisconnectConnectionRequestJson'
       produces:
       - application/json
       responses:

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -156,6 +156,10 @@ export interface DataSourceOption {
 }
 
 // Disconnect models
+export interface DisconnectConnectionRequest {
+    timeout_seconds?: number;
+}
+
 export interface DisconnectResponseJson {
     task_id: string;
     connection: Connection;
@@ -237,8 +241,11 @@ export const submitConnection = (
 /**
  * Disconnect a connection
  */
-export const disconnectConnection = (id: string) => {
-    return client.post<DisconnectResponseJson>(`/api/v1/connections/${id}/_disconnect`);
+export const disconnectConnection = (id: string, request?: DisconnectConnectionRequest) => {
+    return client.post<DisconnectResponseJson>(
+        `/api/v1/connections/${id}/_disconnect`,
+        request
+    );
 };
 
 /**


### PR DESCRIPTION
## Summary

- adds optional `{ "timeout_seconds": 600 }` support to `POST /connections/{id}/_disconnect`
- updates `core.connection.disconnect.v1` in place with structured input and timeout handling
- propagates bounded child disconnect timeouts from connector disconnect-all workflows
- updates API schema, Swagger docs, JS SDK typing, and route/core workflow tests

Closes #577

## Tests

- `go test ./internal/schema/api ./internal/core ./internal/routes`
- `go test ./...`
- `yarn workspace @authproxy/api typecheck`
- `./scripts/preflight.sh`
