### PR TITLE
Fix archive workflow activity logging

### DIFF
--- a/internal/core/workflow_archive_connector_test.go
+++ b/internal/core/workflow_archive_connector_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -133,7 +134,7 @@ func TestArchiveConnectorStartsWorkflow(t *testing.T) {
 func TestArchiveConnectorVersionActivitiesTransitionStates(t *testing.T) {
 	ctx := context.Background()
 	_, db := database.MustApplyBlankTestDbConfig(t, nil)
-	svc := &service{db: db}
+	svc := &service{db: db, logger: slog.Default()}
 	connectorID := apid.New(apid.PrefixConnectorVersion)
 
 	upsertConnectorVersion(t, db, connectorID, 1, database.ConnectorVersionStatePrimary)
@@ -157,7 +158,7 @@ func TestArchiveConnectorVersionActivitiesTransitionStates(t *testing.T) {
 func TestArchiveConnectorVersionActivitiesReturnNotFound(t *testing.T) {
 	ctx := context.Background()
 	_, db := database.MustApplyBlankTestDbConfig(t, nil)
-	svc := &service{db: db}
+	svc := &service{db: db, logger: slog.Default()}
 	connectorID := apid.New(apid.PrefixConnectorVersion)
 
 	require.ErrorIs(t, svc.prepareArchiveConnectorVersionsV1(ctx, connectorID), database.ErrNotFound)


### PR DESCRIPTION
## Summary
- inject a logger into the archive workflow activity tests that call service methods requiring `service.logger`
- keep the production archive workflow activity behavior unchanged

## Main-branch failure addressed
- `Golang Codebase` failed on `main` in run `27473805850` because `TestArchiveConnectorVersionActivitiesTransitionStates` built `&service{db: db}` and then called an activity that uses `s.logger.With(...)`.
- The separate `Build Image` failure timed out while pulling BuildKit from Docker Hub, which prevented the demo-shell image tag and caused the later manual demo deploy to fail image-tag verification. No repo code had executed in that matrix leg.

## Validation
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -run TestArchiveConnectorVersionActivities -count=1`
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -count=1`
- `./scripts/preflight.sh`
