### PR TITLE
Add KMS DEK generation policy task

### DIFF
--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -11,11 +11,13 @@ graph TD
         AWS[AWS Secrets Manager]
         GCP[GCP Secret Manager]
         HCV[HashiCorp Vault]
+        KMS[Cloud KMS / HSM]
         ENV[Environment Variables]
         FILE[File System]
     end
 
     subgraph "Encrypt Service"
+        DEKS[DEK Generator]
         SYNC[Key Sync Loop]
         CACHE[In-Memory Cache]
         ENC[AES-GCM Encrypt/Decrypt]
@@ -32,6 +34,8 @@ graph TD
     HCV --> SYNC
     ENV --> SYNC
     FILE --> SYNC
+    KMS --> DEKS
+    DEKS --> DB
     SYNC --> DB
     SYNC --> CACHE
     CACHE --> ENC
@@ -96,19 +100,27 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 | **File** | `path` | Reads key bytes from a file. Supports `~` expansion. |
 | **Value** | `value` | Inline string value. Development/testing only. |
 | **Random Bytes** | `num_bytes` | Generates secure random bytes at startup. Useful for ephemeral/dev keys. |
+| **KMS-backed providers** | provider-specific | Generate AuthProxy DEKs and wrap them with a provider-held KEK. The KEK never leaves the provider. |
 
 Cloud providers (AWS, GCP, Vault) support caching via `cache_ttl` and return multiple versions when the underlying secret has been rotated.
 
+KMS-backed providers are different from secret-backed providers. Secret-backed providers return AES key bytes directly to AuthProxy. KMS-backed providers generate or wrap data encryption keys (DEKs) and persist only the wrapped DEK in `data_encryption_keys`. The application-facing `encryption_key_versions` table still drives encryption and re-encryption; for KMS-backed versions, `encryption_key_versions.provider_id` points at the `dek_...` row that contains the protected DEK material.
+
 ## Key Sync and Rotation
 
-Two sync processes keep encryption keys current:
+Three processes keep encryption keys current:
 
 ```mermaid
 sequenceDiagram
     participant Provider as Key Provider<br/>(AWS/GCP/Vault/etc)
+    participant DEKTask as DEK Generation Task<br/>(every 15 min)
     participant SyncTask as Sync Task<br/>(every 15 min)
     participant DB as Database
     participant Memory as In-Memory Cache<br/>(every 5 min)
+
+    DEKTask->>Provider: Generate/wrap DEK when policy requires
+    Provider-->>DEKTask: wrapped DEK + provider metadata
+    DEKTask->>DB: Insert data_encryption_keys row
 
     SyncTask->>Provider: ListVersions()
     Provider-->>SyncTask: versions + key bytes
@@ -123,13 +135,23 @@ sequenceDiagram
     Note over Memory: Rebuild caches atomically
 ```
 
+### DEK Generation (every 15 minutes)
+
+KMS-backed namespace keys do not create usable `encryption_key_versions` directly from provider key bytes. Instead, the DEK generation task walks encryption keys in dependency order, decrypts each key's `KeyData` config, and applies `system_auth.data_encryption_keys` policy:
+
+1. If `ensure_current` is true (the default) and a KMS-backed key has no current DEK, generate one.
+2. If the current DEK is older than `rotation_interval` (default 90 days), generate a new current DEK.
+3. Persist only provider metadata and protected DEK material in `data_encryption_keys`.
+4. Sync the key's `encryption_key_versions` after generation so nested child key configs can be decrypted in the same traversal.
+
 ### Config-to-Database Sync (every 15 minutes)
 
 1. Acquires a Redis distributed lock to prevent concurrent syncs
 2. Syncs the global key first, then enumerates entity keys in dependency order (breadth-first from root) so parent keys are available to decrypt child key configs
-3. For each key, calls `ListVersions()` on the provider and reconciles against `encryption_key_versions`: creates new records, removes stale ones, updates `is_current`
-4. Walks all namespaces in depth order and resolves each namespace's `target_encryption_key_version_id` by inheritance
-5. Sets a Redis sentinel key (15-minute TTL) to rate-limit syncs
+3. For secret-backed keys, calls `ListVersions()` on the provider. For KMS-backed keys, loads existing `data_encryption_keys` rows and unwraps them through the provider.
+4. Reconciles against `encryption_key_versions`: creates new records, removes stale ones, updates `is_current`
+5. Walks all namespaces in depth order and resolves each namespace's `target_encryption_key_version_id` by inheritance
+6. Sets a Redis sentinel key (15-minute TTL) to rate-limit syncs
 
 ### Database-to-Memory Sync (every 5 minutes)
 

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -1,0 +1,220 @@
+package encrypt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	iconfig "github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+)
+
+const (
+	TaskTypeGenerateDataEncryptionKeys = "encrypt:generate_data_encryption_keys"
+)
+
+func NewGenerateDataEncryptionKeysTask() *asynq.Task {
+	return asynq.NewTask(TaskTypeGenerateDataEncryptionKeys, nil)
+}
+
+func currentDataEncryptionKey(deks []*database.DataEncryptionKey) *database.DataEncryptionKey {
+	var current *database.DataEncryptionKey
+	for _, dek := range deks {
+		if !dek.IsCurrent {
+			continue
+		}
+		if current == nil || dek.CreatedAt.After(current.CreatedAt) {
+			current = dek
+		}
+	}
+	return current
+}
+
+func createDataEncryptionKey(
+	ctx context.Context,
+	db database.DB,
+	encryptionKeyId apid.ID,
+	generator config.KeyDataGeneratesDataEncryptionKeys,
+) (*database.DataEncryptionKey, error) {
+	generated, err := generator.GenerateDataEncryptionKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dek := &database.DataEncryptionKey{
+		EncryptionKeyId: encryptionKeyId,
+		Provider:        string(generated.Provider),
+		ProviderID:      generated.ProviderID,
+		ProviderVersion: generated.ProviderVersion,
+		ProtectedData:   &generated.ProtectedData,
+		IsCurrent:       true,
+	}
+	if err := db.CreateDataEncryptionKey(ctx, dek); err != nil {
+		return nil, err
+	}
+
+	return dek, nil
+}
+
+func ensureDataEncryptionKeyForKey(
+	ctx context.Context,
+	db database.DB,
+	policy *config.DataEncryptionKeys,
+	encryptionKeyId apid.ID,
+	kd *config.KeyData,
+) (bool, error) {
+	if kd == nil || !kd.RequiresDataEncryptionKeys() {
+		return false, nil
+	}
+
+	generator, ok := kd.InnerVal.(config.KeyDataGeneratesDataEncryptionKeys)
+	if !ok {
+		return false, fmt.Errorf("key data provider %q requires DEKs but cannot generate them", kd.GetProviderType())
+	}
+
+	deks, err := db.ListDataEncryptionKeysForEncryptionKey(ctx, encryptionKeyId)
+	if err != nil {
+		return false, err
+	}
+
+	current := currentDataEncryptionKey(deks)
+	if current == nil {
+		if !policy.ShouldEnsureCurrent() {
+			return false, nil
+		}
+		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, generator); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	if policy.ShouldRotate(apctx.GetClock(ctx).Now(), current.CreatedAt) {
+		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, generator); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func generateDataEncryptionKeysToDatabase(
+	ctx context.Context,
+	cfg iconfig.C,
+	db database.DB,
+	logger *slog.Logger,
+	redis apredis.Client,
+) error {
+	logger.Info("generating data encryption keys")
+	defer logger.Info("generating data encryption keys complete")
+
+	if redis != nil {
+		m := apredis.NewMutex(
+			redis,
+			"encrypt:generate_deks",
+			apredis.MutexOptionLockFor(30*time.Second),
+			apredis.MutexOptionRetryFor(31*time.Second),
+			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+			apredis.MutexOptionDetailedLockMetadata(),
+		)
+		err := m.Lock(context.Background())
+		if err != nil {
+			return errors.Wrap(err, "failed to establish lock for data encryption key generation")
+		}
+		defer m.Unlock(context.Background())
+	}
+
+	if cfg == nil || cfg.GetRoot() == nil {
+		return errors.New("no configuration available")
+	}
+
+	sa := cfg.GetRoot().SystemAuth
+	if sa.GlobalAESKey == nil {
+		return errors.New("no global AES key configured")
+	}
+
+	policy := sa.DataEncryptionKeys
+	keyVersionIdDataCache := make(map[apid.ID]config.KeyVersionInfo)
+
+	err := syncKeyVersionsForKeyToDatabase(ctx, db, keyVersionIdDataCache, globalEncryptionKeyID, sa.GlobalAESKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to sync global key data")
+	}
+
+	var result *multierror.Error
+	_, err = db.EnumerateEncryptionKeysInDependencyOrder(ctx, func(keys []*database.EncryptionKey, _ int) (keepGoing pagination.KeepGoing, err error) {
+		for _, key := range keys {
+			if key.EncryptedKeyData == nil {
+				continue
+			}
+
+			ef := key.EncryptedKeyData
+			kvi, ok := keyVersionIdDataCache[ef.ID]
+			if !ok {
+				result = multierror.Append(result, fmt.Errorf("key version info not found for key ID %s key version %s", key.Id, ef.ID))
+				continue
+			}
+
+			decodedData, err := base64.StdEncoding.DecodeString(ef.Data)
+			if err != nil {
+				result = multierror.Append(result, errors.Wrapf(err, "failed to decode base64 string for key id %s", key.Id))
+				continue
+			}
+
+			decryptedData, err := decryptWithKey(kvi.Data, decodedData)
+			if err != nil {
+				result = multierror.Append(result, errors.Wrapf(err, "failed to decrypt key id %s with key data from %s", key.Id, ef.ID))
+				continue
+			}
+
+			var keyData config.KeyData
+			err = json.Unmarshal(decryptedData, &keyData)
+			if err != nil {
+				result = multierror.Append(result, errors.Wrapf(err, "failed to unmarshal key data for key ID %s", key.Id))
+				continue
+			}
+
+			generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, key.Id, &keyData)
+			if err != nil {
+				result = multierror.Append(result, errors.Wrapf(err, "failed to reconcile data encryption key for key ID %s", key.Id))
+				continue
+			}
+			if generated {
+				logger.Info("generated data encryption key", "encryption_key_id", key.Id)
+			}
+
+			err = syncKeyVersionsForKeyToDatabase(ctx, db, keyVersionIdDataCache, key.Id, &keyData)
+			if err != nil {
+				result = multierror.Append(result, errors.Wrapf(err, "failed to sync key data for key ID %s", key.Id))
+				continue
+			}
+		}
+
+		return pagination.Continue, nil
+	})
+	if err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	err = reconcileNamespaceEncryptionTargets(ctx, db, logger)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to update namespace target encryption key versions"))
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (h *EncryptServiceTaskHandler) handleGenerateDataEncryptionKeys(ctx context.Context, _ *asynq.Task) error {
+	return generateDataEncryptionKeysToDatabase(ctx, h.cfg, h.db, h.logger, h.redis)
+}

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -1,0 +1,182 @@
+package encrypt
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
+	clock "k8s.io/utils/clock/testing"
+)
+
+type mockKMSGenerateTestEnv struct {
+	ctx       context.Context
+	clock     *clock.FakeClock
+	cfg       config.C
+	db        database.DB
+	logger    *slog.Logger
+	namespace string
+	ekID      apid.ID
+}
+
+func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTestEnv {
+	t.Helper()
+
+	sconfig.ResetKeyDataMockRegistry()
+	sconfig.ResetKeyDataMockKMSRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+	t.Cleanup(sconfig.ResetKeyDataMockKMSRegistry)
+
+	now := time.Date(2026, time.June, 13, 10, 0, 0, 0, time.UTC)
+	fakeClock := clock.NewFakeClock(now)
+	ctx := apctx.NewBuilderBackground().WithClock(fakeClock).Build()
+	logger := slog.Default()
+
+	globalKeyBytes := util.MustGenerateSecureRandomKey(32)
+	globalKD := sconfig.NewKeyDataMock("global-kms-parent")
+	sconfig.KeyDataMockAddVersion("global-kms-parent", "global-key", "v1", globalKeyBytes)
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+			DataEncryptionKeys: &sconfig.DataEncryptionKeys{
+				RotationInterval: &sconfig.HumanDuration{Duration: time.Hour},
+			},
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+	require.NoError(t, syncKeysVersionsToDatabase(ctx, cfg, db, logger, nil))
+
+	globalVersions, err := db.ListEncryptionKeyVersionsForEncryptionKey(ctx, globalEncryptionKeyID)
+	require.NoError(t, err)
+	require.Len(t, globalVersions, 1)
+
+	kmsKeyData := sconfig.NewKeyDataMockKMS("namespace-kms")
+	if kmsVersions {
+		sconfig.KeyDataMockKMSAddVersion("namespace-kms", "mock-kms-key", "v1", util.MustGenerateSecureRandomKey(32))
+	}
+
+	ekID := apid.New(apid.PrefixEncryptionKey)
+	namespace := "root.kms"
+	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{
+		Path:            namespace,
+		EncryptionKeyId: &ekID,
+	}))
+
+	require.NoError(t, db.CreateEncryptionKey(ctx, &database.EncryptionKey{
+		Id:               ekID,
+		Namespace:        namespace,
+		State:            database.EncryptionKeyStateActive,
+		EncryptedKeyData: encryptKeyDataForTest(t, globalVersions[0].Id, globalKeyBytes, kmsKeyData),
+	}))
+
+	return mockKMSGenerateTestEnv{
+		ctx:       ctx,
+		clock:     fakeClock,
+		cfg:       cfg,
+		db:        db,
+		logger:    logger,
+		namespace: namespace,
+		ekID:      ekID,
+	}
+}
+
+func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
+	t.Run("creates first dek and synced key version", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, true)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		deks, err := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, deks, 1)
+		require.True(t, deks[0].Id.HasPrefix(apid.PrefixDataEncryptionKey))
+		require.True(t, deks[0].IsCurrent)
+		require.Equal(t, string(sconfig.ProviderTypeMockKMS), deks[0].Provider)
+		require.Equal(t, "mock-kms-key", deks[0].ProviderID)
+		require.Equal(t, "v1", deks[0].ProviderVersion)
+		require.NotEmpty(t, deks[0].ProtectedData.WrappedData)
+
+		versions, err := env.db.ListEncryptionKeyVersionsForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, versions, 1)
+		require.Equal(t, string(deks[0].Id), versions[0].ProviderID)
+		require.True(t, versions[0].IsCurrent)
+
+		enc := newTestService(env.cfg, env.db)
+		encrypted, err := enc.EncryptStringForNamespace(env.ctx, env.namespace, "generated dek")
+		require.NoError(t, err)
+		require.Equal(t, versions[0].Id, encrypted.ID)
+		decrypted, err := enc.DecryptString(env.ctx, encrypted)
+		require.NoError(t, err)
+		require.Equal(t, "generated dek", decrypted)
+	})
+
+	t.Run("does not create duplicate when policy is satisfied", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, true)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		deks, err := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, deks, 1)
+	})
+
+	t.Run("rotates when current dek exceeds policy age", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, true)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+		firstCurrent, err := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, firstCurrent, 1)
+
+		sconfig.KeyDataMockKMSAddVersion("namespace-kms", "mock-kms-key", "v2", util.MustGenerateSecureRandomKey(32))
+		env.clock.Step(2 * time.Hour)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		deks, err := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, deks, 2)
+		require.False(t, deks[0].IsCurrent)
+		require.True(t, deks[1].IsCurrent)
+		require.Equal(t, "v2", deks[1].ProviderVersion)
+
+		versions, err := env.db.ListEncryptionKeyVersionsForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, versions, 2)
+		require.Equal(t, string(deks[1].Id), versions[1].ProviderID)
+		require.True(t, versions[1].IsCurrent)
+	})
+
+	t.Run("does not create first dek when ensure current is disabled", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, true)
+		env.cfg.GetRoot().SystemAuth.DataEncryptionKeys.EnsureCurrent = util.ToPtr(false)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		deks, err := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Empty(t, deks)
+	})
+
+	t.Run("returns provider errors without creating partial dek", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, false)
+
+		err := generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
+		require.ErrorContains(t, err, "no current version")
+
+		deks, listErr := env.db.ListDataEncryptionKeysForEncryptionKey(env.ctx, env.ekID)
+		require.NoError(t, listErr)
+		require.Empty(t, deks)
+	})
+}

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -159,6 +159,76 @@ func syncKeyVersionsForKeyToDatabase(
 	return nil
 }
 
+func reconcileNamespaceEncryptionTargets(
+	ctx context.Context,
+	db database.DB,
+	logger *slog.Logger,
+) error {
+	// effectiveEKV maps namespace path -> resolved target EKV ID, declared outside the callback
+	// so it persists across pages (depth ordering ensures parents are processed first).
+	effectiveEKV := make(map[string]apid.ID)
+
+	return db.EnumerateNamespaceEncryptionTargets(ctx,
+		func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
+			var updates []database.NamespaceTargetEncryptionKeyVersionUpdate
+
+			for _, target := range targets {
+				var resolvedEKVID apid.ID
+
+				if target.EncryptionKeyId != nil {
+					// Namespace has its own encryption key; look up its current version
+					currentEKV, err := db.GetCurrentEncryptionKeyVersionForEncryptionKey(ctx, *target.EncryptionKeyId)
+					if err != nil {
+						logger.Warn("failed to get current encryption key version for namespace encryption key",
+							"namespace", target.Path,
+							"encryption_key_id", *target.EncryptionKeyId,
+							"error", err,
+						)
+						continue
+					}
+					resolvedEKVID = currentEKV.Id
+				} else {
+					// Inherit from nearest ancestor with a resolved EKV
+					prefixes := namespace.SplitNamespacePathToPrefixes(target.Path)
+					found := false
+					for i := len(prefixes) - 2; i >= 0; i-- {
+						if ekvID, ok := effectiveEKV[prefixes[i]]; ok {
+							resolvedEKVID = ekvID
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						// Fall back to the global key's current version
+						globalEKV, err := db.GetCurrentEncryptionKeyVersionForEncryptionKey(ctx, globalEncryptionKeyID)
+						if err != nil {
+							logger.Warn("failed to get current encryption key version for global key",
+								"namespace", target.Path,
+								"error", err,
+							)
+							continue
+						}
+						resolvedEKVID = globalEKV.Id
+					}
+				}
+
+				effectiveEKV[target.Path] = resolvedEKVID
+
+				// Only emit an update if the value actually changed
+				if target.TargetEncryptionKeyVersionId == nil || *target.TargetEncryptionKeyVersionId != resolvedEKVID {
+					updates = append(updates, database.NamespaceTargetEncryptionKeyVersionUpdate{
+						Path:                         target.Path,
+						TargetEncryptionKeyVersionId: resolvedEKVID,
+					})
+				}
+			}
+
+			return updates, pagination.Continue, nil
+		},
+	)
+}
+
 // syncKeysVersionsToDatabase is the standalone function that syncs key versions into the database. It lists
 // all keys and makes sure the version for those keys are accurate. It can be called directly during startup
 // without constructing a task handler. When redis is provided, it uses a sentinel key to rate-limit syncs.
@@ -263,70 +333,7 @@ func syncKeysVersionsToDatabase(
 		result = multierror.Append(result, err)
 	}
 
-	// Update target encryption key version for each namespace.
-	// effectiveEKV maps namespace path -> resolved target EKV ID, declared outside the callback
-	// so it persists across pages (depth ordering ensures parents are processed first).
-	effectiveEKV := make(map[string]apid.ID)
-
-	err = db.EnumerateNamespaceEncryptionTargets(ctx,
-		func(targets []database.NamespaceEncryptionTarget, lastPage bool) ([]database.NamespaceTargetEncryptionKeyVersionUpdate, pagination.KeepGoing, error) {
-			var updates []database.NamespaceTargetEncryptionKeyVersionUpdate
-
-			for _, target := range targets {
-				var resolvedEKVID apid.ID
-
-				if target.EncryptionKeyId != nil {
-					// Namespace has its own encryption key; look up its current version
-					currentEKV, err := db.GetCurrentEncryptionKeyVersionForEncryptionKey(ctx, *target.EncryptionKeyId)
-					if err != nil {
-						logger.Warn("failed to get current encryption key version for namespace encryption key",
-							"namespace", target.Path,
-							"encryption_key_id", *target.EncryptionKeyId,
-							"error", err,
-						)
-						continue
-					}
-					resolvedEKVID = currentEKV.Id
-				} else {
-					// Inherit from nearest ancestor with a resolved EKV
-					prefixes := namespace.SplitNamespacePathToPrefixes(target.Path)
-					found := false
-					for i := len(prefixes) - 2; i >= 0; i-- {
-						if ekvID, ok := effectiveEKV[prefixes[i]]; ok {
-							resolvedEKVID = ekvID
-							found = true
-							break
-						}
-					}
-
-					if !found {
-						// Fall back to the global key's current version
-						globalEKV, err := db.GetCurrentEncryptionKeyVersionForEncryptionKey(ctx, globalEncryptionKeyID)
-						if err != nil {
-							logger.Warn("failed to get current encryption key version for global key",
-								"namespace", target.Path,
-								"error", err,
-							)
-							continue
-						}
-						resolvedEKVID = globalEKV.Id
-					}
-				}
-
-				effectiveEKV[target.Path] = resolvedEKVID
-
-				// Only emit an update if the value actually changed
-				if target.TargetEncryptionKeyVersionId == nil || *target.TargetEncryptionKeyVersionId != resolvedEKVID {
-					updates = append(updates, database.NamespaceTargetEncryptionKeyVersionUpdate{
-						Path:                         target.Path,
-						TargetEncryptionKeyVersionId: resolvedEKVID,
-					})
-				}
-			}
-
-			return updates, pagination.Continue, nil
-		},
-	)
+	err = reconcileNamespaceEncryptionTargets(ctx, db, logger)
 	if err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to update namespace target encryption key versions"))
 	}

--- a/internal/encrypt/tasks.go
+++ b/internal/encrypt/tasks.go
@@ -18,12 +18,17 @@ type EncryptServiceTaskHandler struct {
 }
 
 func (h *EncryptServiceTaskHandler) RegisterTasks(mux *asynq.ServeMux) {
+	mux.HandleFunc(TaskTypeGenerateDataEncryptionKeys, h.handleGenerateDataEncryptionKeys)
 	mux.HandleFunc(TaskTypeSyncKeysToDatabase, h.handleSyncKeysToDatabase)
 	mux.HandleFunc(TaskTypeReencryptAll, h.handleReencryptAll)
 }
 
 func (h *EncryptServiceTaskHandler) GetCronTasks() []*asynq.PeriodicTaskConfig {
 	return []*asynq.PeriodicTaskConfig{
+		{
+			Cronspec: "*/15 * * * *", // every 15 minutes
+			Task:     NewGenerateDataEncryptionKeysTask(),
+		},
 		{
 			Cronspec: "*/15 * * * *", // every 15 minutes
 			Task:     NewSyncKeysToDatabaseTask(),

--- a/internal/schema/config/data_encryption_keys.go
+++ b/internal/schema/config/data_encryption_keys.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+const defaultDataEncryptionKeyRotationInterval = 90 * 24 * time.Hour
+
+// DataEncryptionKeys configures lifecycle management for generated DEKs used by
+// KMS-backed namespace encryption keys.
+type DataEncryptionKeys struct {
+	// RotationInterval is how old the current DEK can be before a new current DEK
+	// is generated. Defaults to 90 days.
+	RotationInterval *HumanDuration `json:"rotation_interval,omitempty" yaml:"rotation_interval,omitempty"`
+
+	// EnsureCurrent controls whether the DEK generator creates a current DEK
+	// when a KMS-backed encryption key has none. Defaults to true.
+	EnsureCurrent *bool `json:"ensure_current,omitempty" yaml:"ensure_current,omitempty"`
+}
+
+func (d *DataEncryptionKeys) Validate(vc *common.ValidationContext) error {
+	result := &multierror.Error{}
+
+	if d == nil {
+		return nil
+	}
+
+	if d.RotationInterval != nil && d.RotationInterval.Duration < 0 {
+		result = multierror.Append(result, vc.PushField("rotation_interval").NewErrorf(
+			"must be greater than or equal to 0, got %s",
+			d.RotationInterval.Duration,
+		))
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (d *DataEncryptionKeys) GetRotationInterval() time.Duration {
+	if d == nil || d.RotationInterval == nil {
+		return defaultDataEncryptionKeyRotationInterval
+	}
+
+	return d.RotationInterval.Duration
+}
+
+func (d *DataEncryptionKeys) ShouldEnsureCurrent() bool {
+	if d == nil || d.EnsureCurrent == nil {
+		return true
+	}
+
+	return *d.EnsureCurrent
+}
+
+func (d *DataEncryptionKeys) ShouldRotate(now time.Time, currentCreatedAt time.Time) bool {
+	interval := d.GetRotationInterval()
+	if interval == 0 {
+		return false
+	}
+
+	return !currentCreatedAt.Add(interval).After(now)
+}

--- a/internal/schema/config/data_encryption_keys_test.go
+++ b/internal/schema/config/data_encryption_keys_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataEncryptionKeysPolicy(t *testing.T) {
+	now := time.Date(2026, time.June, 13, 12, 0, 0, 0, time.UTC)
+
+	require.Equal(t, 90*24*time.Hour, (*DataEncryptionKeys)(nil).GetRotationInterval())
+	require.True(t, (*DataEncryptionKeys)(nil).ShouldEnsureCurrent())
+	require.False(t, (&DataEncryptionKeys{EnsureCurrent: util.ToPtr(false)}).ShouldEnsureCurrent())
+
+	policy := &DataEncryptionKeys{RotationInterval: &HumanDuration{Duration: time.Hour}}
+	require.False(t, policy.ShouldRotate(now, now.Add(-59*time.Minute)))
+	require.True(t, policy.ShouldRotate(now, now.Add(-time.Hour)))
+
+	disabled := &DataEncryptionKeys{RotationInterval: &HumanDuration{}}
+	require.False(t, disabled.ShouldRotate(now, now.Add(-365*24*time.Hour)))
+
+	invalid := &DataEncryptionKeys{RotationInterval: &HumanDuration{Duration: -time.Second}}
+	require.Error(t, invalid.Validate(&common.ValidationContext{Path: "$"}))
+}

--- a/internal/schema/config/key_data.go
+++ b/internal/schema/config/key_data.go
@@ -34,12 +34,29 @@ type DataEncryptionKeyInfo struct {
 	IsCurrent       bool
 }
 
+// GeneratedDataEncryptionKey is protected DEK material produced by a KMS-style
+// provider. The plaintext DEK may be returned for tests, but callers should only
+// persist the provider metadata and ProtectedData.
+type GeneratedDataEncryptionKey struct {
+	Provider        ProviderType
+	ProviderID      string
+	ProviderVersion string
+	ProtectedData   KeyVersionProtectedData
+	Data            []byte
+}
+
 // KeyDataRequiresDataEncryptionKeys is implemented by providers that resolve
 // key bytes from persisted DEK rows instead of directly listing key bytes from
 // the provider. Implementing this interface on the provider signals to the
 // encryption service to do a pre-load of DEKs from the database.
 type KeyDataRequiresDataEncryptionKeys interface {
 	ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error)
+}
+
+// KeyDataGeneratesDataEncryptionKeys is implemented by providers that can
+// generate and wrap a new DEK for persistence in data_encryption_keys.
+type KeyDataGeneratesDataEncryptionKeys interface {
+	GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error)
 }
 
 type KeyData struct {

--- a/internal/schema/config/key_data_mock_kms.go
+++ b/internal/schema/config/key_data_mock_kms.go
@@ -190,6 +190,31 @@ func (m *KeyDataMockKMS) ListVersionsWithDataEncryptionKeys(_ context.Context, d
 	return result, nil
 }
 
+func (m *KeyDataMockKMS) GenerateDataEncryptionKey(_ context.Context) (GeneratedDataEncryptionKey, error) {
+	current, err := m.currentVersion()
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	dek := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate mock kms data key: %w", err)
+	}
+
+	protected, err := mockKMSWrap(current.KeyEncryptionKey, current.ProviderVersion, dek)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	return GeneratedDataEncryptionKey{
+		Provider:        ProviderTypeMockKMS,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+		ProtectedData:   protected,
+		Data:            dek,
+	}, nil
+}
+
 func (m *KeyDataMockKMS) GetProviderType() ProviderType {
 	return ProviderTypeMockKMS
 }
@@ -271,3 +296,4 @@ func mockKMSDecrypt(key []byte, data []byte) ([]byte, error) {
 
 var _ KeyDataType = (*KeyDataMockKMS)(nil)
 var _ KeyDataRequiresDataEncryptionKeys = (*KeyDataMockKMS)(nil)
+var _ KeyDataGeneratesDataEncryptionKeys = (*KeyDataMockKMS)(nil)

--- a/internal/schema/config/root.go
+++ b/internal/schema/config/root.go
@@ -65,6 +65,10 @@ func (r *Root) Validate() error {
 		result = multierror.Append(result, err)
 	}
 
+	if err := r.SystemAuth.DataEncryptionKeys.Validate(vc.PushField("system_auth").PushField("data_encryption_keys")); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	return result.ErrorOrNil()
 }
 

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -793,10 +793,21 @@
           "type": "boolean"
         },
         "actors": { "$ref": "#/$defs/ConfiguredActors" },
-        "global_aes_key": { "$ref": "#/$defs/KeyData" }
+        "global_aes_key": { "$ref": "#/$defs/KeyData" },
+        "data_encryption_keys": { "$ref": "#/$defs/DataEncryptionKeys" }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "DataEncryptionKeys": {
+      "type": "object",
+      "properties": {
+        "rotation_interval": {
+          "$ref": "../common/schema.json#/$defs/HumanDuration"
+        },
+        "ensure_current": { "type": "boolean" }
+      },
+      "additionalProperties": false
     },
     "Key": {
       "oneOf": [

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -901,6 +901,11 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"global_aes_key": {"env_var_base64": "GLOBAL_AES_KEY"}}}`,
 				},
 				{
+					Name:  "data encryption key policy",
+					Valid: true,
+					Data:  `{"test": {"data_encryption_keys": {"rotation_interval": "24h", "ensure_current": true}}}`,
+				},
+				{
 					Name:  "actors as external source",
 					Valid: true,
 					Data:  `{"test": {"actors": {"keys_path": "/keys/actors"}}}`,

--- a/internal/schema/config/system_auth.go
+++ b/internal/schema/config/system_auth.go
@@ -5,12 +5,13 @@ import (
 )
 
 type SystemAuth struct {
-	JwtSigningKey       *Key              `json:"jwt_signing_key" yaml:"jwt_signing_key"`
-	JwtIssuerVal        string            `json:"jwt_issuer" yaml:"jwt_issuer"`
-	JwtTokenDurationVal time.Duration     `json:"jwt_token_duration" yaml:"jwt_token_duration"`
-	DisableXSRF         bool              `json:"disable_xsrf" yaml:"disable_xsrf"`
-	Actors              *ConfiguredActors `json:"actors" yaml:"actors"`
-	GlobalAESKey        *KeyData          `json:"global_aes_key" yaml:"global_aes_key"`
+	JwtSigningKey       *Key                `json:"jwt_signing_key" yaml:"jwt_signing_key"`
+	JwtIssuerVal        string              `json:"jwt_issuer" yaml:"jwt_issuer"`
+	JwtTokenDurationVal time.Duration       `json:"jwt_token_duration" yaml:"jwt_token_duration"`
+	DisableXSRF         bool                `json:"disable_xsrf" yaml:"disable_xsrf"`
+	Actors              *ConfiguredActors   `json:"actors" yaml:"actors"`
+	GlobalAESKey        *KeyData            `json:"global_aes_key" yaml:"global_aes_key"`
+	DataEncryptionKeys  *DataEncryptionKeys `json:"data_encryption_keys,omitempty" yaml:"data_encryption_keys,omitempty"`
 }
 
 func (sa *SystemAuth) JwtIssuer() string {


### PR DESCRIPTION
## Summary

- adds `system_auth.data_encryption_keys` policy settings for KMS DEK lifecycle management
- adds `encrypt:generate_data_encryption_keys` to create first/current DEKs and rotate them by age
- extends KMS-style key providers with a DEK generation interface and wires mock KMS through it
- documents the split between DEK generation, `data_encryption_keys`, and `encryption_key_versions`

Closes #598.

## Validation

- `go test ./internal/schema/config ./internal/database ./internal/encrypt`
- `go test ./internal/schema/config ./internal/database ./internal/encrypt ./internal/core ./internal/routes`
- `set -a && source .env && set +a && go test ./internal/database ./internal/encrypt`
- `./scripts/preflight.sh`
