### PR TITLE
Add setup flow if.javascript schema

### DIFF
--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -202,6 +202,20 @@
           "additionalProperties": {
             "$ref": "#/$defs/DataSourceDef"
           }
+        },
+        "if": {
+          "$ref": "#/$defs/SetupFlowStepIf"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SetupFlowStepIf": {
+      "type": "object",
+      "required": ["javascript"],
+      "properties": {
+        "javascript": {
+          "type": "string",
+          "minLength": 1
         }
       },
       "additionalProperties": false

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -382,9 +382,35 @@ type SetupFlowStep struct {
 	// form steps.
 	DataSources map[string]DataSourceDef `json:"data_sources,omitempty" yaml:"data_sources,omitempty"`
 
+	// If optionally gates this user-authored setup step. Runtime evaluates the
+	// configured condition server-side; clients only see eligible steps.
+	If *SetupFlowStepIf `json:"if,omitempty" yaml:"if,omitempty"`
+
 	// Redirect carries the redirect-step-specific configuration. Required
 	// when Type == redirect; must be absent otherwise.
 	Redirect *SetupFlowStepRedirect `json:"redirect,omitempty" yaml:"redirect,omitempty"`
+}
+
+// SetupFlowStepIf defines the condition that controls whether a user-authored
+// setup step participates in a connection setup flow. Auth-method-emitted
+// steps and apxy:* pseudo-steps are not represented in connector YAML and
+// therefore cannot be gated through this schema.
+type SetupFlowStepIf struct {
+	// Javascript is a JavaScript fragment evaluated with cfg, labels, and
+	// annotations variables in scope. Runtime work requires the fragment to
+	// return a boolean.
+	Javascript string `json:"javascript" yaml:"javascript"`
+}
+
+func (i *SetupFlowStepIf) Validate(vc *common.ValidationContext) error {
+	if i == nil {
+		return nil
+	}
+	result := &multierror.Error{}
+	if strings.TrimSpace(i.Javascript) == "" {
+		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript is required"))
+	}
+	return result.ErrorOrNil()
 }
 
 // SetupFlowStepRedirect describes a redirect-kind step's destination. The
@@ -431,6 +457,10 @@ func (s *SetupFlowStep) Validate(vc *common.ValidationContext, seenIds map[strin
 
 	if !s.Type.IsValid() {
 		result = multierror.Append(result, vc.NewErrorfForField("type", "type must be %q or %q (got %q)", SetupFlowStepTypeForm, SetupFlowStepTypeRedirect, s.Type))
+	}
+
+	if err := s.If.Validate(vc.PushField("if")); err != nil {
+		result = multierror.Append(result, err)
 	}
 
 	switch s.Type.Normalized() {

--- a/internal/schema/resources/connectors/setup_flow_test.go
+++ b/internal/schema/resources/connectors/setup_flow_test.go
@@ -84,6 +84,57 @@ func TestSetupFlowValidation(t *testing.T) {
 		assert.NoError(t, sf.Validate(vc))
 	})
 
+	t.Run("valid conditional step", func(t *testing.T) {
+		sf := &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "advanced_options",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						If: &SetupFlowStepIf{
+							Javascript: `cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"`,
+						},
+					},
+				},
+			},
+		}
+		assert.NoError(t, sf.Validate(vc))
+	})
+
+	t.Run("conditional step missing javascript", func(t *testing.T) {
+		sf := &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "advanced_options",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						If:         &SetupFlowStepIf{},
+					},
+				},
+			},
+		}
+		err := sf.Validate(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "javascript is required")
+	})
+
+	t.Run("conditional step rejects blank javascript", func(t *testing.T) {
+		sf := &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "advanced_options",
+						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						If:         &SetupFlowStepIf{Javascript: " \n\t "},
+					},
+				},
+			},
+		}
+		err := sf.Validate(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "javascript is required")
+	})
+
 	t.Run("duplicate step id across phases", func(t *testing.T) {
 		sf := &SetupFlow{
 			Preconnect: &SetupFlowPhase{
@@ -754,6 +805,8 @@ func TestSetupFlowYAMLRoundtrip(t *testing.T) {
 		step2 := connector.SetupFlow.Configure.Steps[1]
 		assert.Equal(t, "sync_options", step2.Id)
 		assert.Empty(t, step2.DataSources)
+		require.NotNil(t, step2.If)
+		assert.Equal(t, "cfg.region === \"eu\" && labels[\"apxy/cxr/type\"] === \"acme-crm\"\n", step2.If.Javascript)
 
 		// Validate
 		vc := &common.ValidationContext{Path: "connector"}
@@ -777,6 +830,9 @@ func TestSetupFlowYAMLRoundtrip(t *testing.T) {
 					{
 						Id:         "workspace",
 						JsonSchema: common.RawJSON(`{"type":"object"}`),
+						If: &SetupFlowStepIf{
+							Javascript: `annotations["setup-mode"] !== "basic"`,
+						},
 						DataSources: map[string]DataSourceDef{
 							"items": {
 								ProxyRequest: &DataSourceProxyRequest{
@@ -803,6 +859,8 @@ func TestSetupFlowYAMLRoundtrip(t *testing.T) {
 		assert.Equal(t, "tenant", parsed.Preconnect.Steps[0].Id)
 		require.True(t, parsed.HasConfigure())
 		assert.Equal(t, "workspace", parsed.Configure.Steps[0].Id)
+		require.NotNil(t, parsed.Configure.Steps[0].If)
+		assert.Equal(t, `annotations["setup-mode"] !== "basic"`, parsed.Configure.Steps[0].If.Javascript)
 		require.NotNil(t, parsed.Configure.Steps[0].DataSources["items"].ProxyRequest)
 		assert.Equal(t, "GET", parsed.Configure.Steps[0].DataSources["items"].ProxyRequest.Method)
 		assert.Equal(t, "application/json", parsed.Configure.Steps[0].DataSources["items"].ProxyRequest.Headers["Accept"])

--- a/internal/schema/resources/connectors/test_data/invalid-setup-flow-if-missing-javascript.yaml
+++ b/internal/schema/resources/connectors/test_data/invalid-setup-flow-if-missing-javascript.yaml
@@ -1,0 +1,21 @@
+# $schema: ./schema.json
+
+labels:
+  type: conditional-no-script
+display_name: Conditional Setup
+logo:
+  public_url: https://example.com/conditional.png
+description: |
+  Connector with an invalid conditional setup step.
+auth:
+  type: no-auth
+setup_flow:
+  configure:
+    steps:
+      - id: advanced_options
+        if: {}
+        json_schema:
+          type: object
+          properties:
+            sync_mode:
+              type: string

--- a/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-setup-flow.yaml
+++ b/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-setup-flow.yaml
@@ -66,6 +66,9 @@ setup_flow:
             transform: "data.map(w => ({ value: w.id, label: w.name }))"
       - id: sync_options
         title: "Sync Options"
+        if:
+          javascript: |
+            cfg.region === "eu" && labels["apxy/cxr/type"] === "acme-crm"
         json_schema:
           type: object
           properties:


### PR DESCRIPTION
## Summary
- Add the setup-flow step if.javascript schema/model field
- Validate that conditional setup steps provide non-blank JavaScript
- Add YAML/JSON round-trip coverage and schema fixtures for the new shape

Closes #623.
Part of #506.

## Tests
- go test ./internal/schema/resources/connectors
- go test ./internal/schema/config
- ./scripts/preflight.sh