### PR TITLE
Replace encryption key schema with keys

### DIFF
--- a/internal/apid/apid.go
+++ b/internal/apid/apid.go
@@ -31,7 +31,7 @@ const (
 	PrefixRequestEvents        Prefix = "req_"
 	PrefixCorrelation          Prefix = "cor_"
 	PrefixJwtId                Prefix = "jti_"
-	PrefixEncryptionKey        Prefix = "ek_"
+	PrefixEncryptionKey        Prefix = "key_"
 	PrefixEncryptionKeyVersion Prefix = "ekv_"
 	PrefixDataEncryptionKey    Prefix = "dek_"
 	PrefixSession              Prefix = "sess_"

--- a/internal/database/AGENTS.md
+++ b/internal/database/AGENTS.md
@@ -129,10 +129,10 @@ When using `rawDb.Exec()` for test setup, **do not use `?` placeholders** — th
 
 ```go
 // WRONG — fails on PostgreSQL
-rawDb.Exec(`UPDATE namespaces SET encryption_key_id = ? WHERE path = 'root'`, ekId)
+rawDb.Exec(`UPDATE namespaces SET key_id = ? WHERE path = 'root'`, ekId)
 
 // CORRECT — works on both
-rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET encryption_key_id = '%s' WHERE path = 'root'`, ekId))
+rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET key_id = '%s' WHERE path = 'root'`, ekId))
 ```
 
 ### Timezone Handling in Tests

--- a/internal/database/data_encryption_key.go
+++ b/internal/database/data_encryption_key.go
@@ -3,6 +3,8 @@ package database
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -16,26 +18,68 @@ import (
 
 const DataEncryptionKeysTable = "data_encryption_keys"
 
+type DataEncryptionKeyProviderMetadata map[string]string
+
+func (m DataEncryptionKeyProviderMetadata) Value() (driver.Value, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal data encryption key provider metadata: %w", err)
+	}
+	return string(b), nil
+}
+
+func (m *DataEncryptionKeyProviderMetadata) Scan(value interface{}) error {
+	if value == nil {
+		*m = nil
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			*m = nil
+			return nil
+		}
+		data = []byte(v)
+	case []byte:
+		if len(v) == 0 {
+			*m = nil
+			return nil
+		}
+		data = v
+	default:
+		return fmt.Errorf("cannot scan %T into DataEncryptionKeyProviderMetadata", value)
+	}
+
+	return json.Unmarshal(data, m)
+}
+
 type DataEncryptionKey struct {
-	Id              apid.ID
-	EncryptionKeyId apid.ID
-	Provider        string
-	ProviderID      string
-	ProviderVersion string
-	ProtectedData   *sconfig.KeyVersionProtectedData
-	IsCurrent       bool
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	DeletedAt       *time.Time
+	Id               apid.ID
+	EncryptionKeyId  apid.ID
+	Provider         string
+	ProviderID       string
+	ProviderVersion  string
+	ProviderMetadata DataEncryptionKeyProviderMetadata
+	ProtectedData    *sconfig.KeyVersionProtectedData
+	IsCurrent        bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	DeletedAt        *time.Time
 }
 
 func (d *DataEncryptionKey) cols() []string {
 	return []string{
 		"id",
-		"encryption_key_id",
+		"key_id",
 		"provider",
 		"provider_id",
 		"provider_version",
+		"provider_metadata",
 		"protected_data",
 		"is_current",
 		"created_at",
@@ -51,6 +95,7 @@ func (d *DataEncryptionKey) fields() []any {
 		&d.Provider,
 		&d.ProviderID,
 		&d.ProviderVersion,
+		&d.ProviderMetadata,
 		&d.ProtectedData,
 		&d.IsCurrent,
 		&d.CreatedAt,
@@ -66,6 +111,7 @@ func (d *DataEncryptionKey) values() []any {
 		d.Provider,
 		d.ProviderID,
 		d.ProviderVersion,
+		d.ProviderMetadata,
 		d.ProtectedData,
 		d.IsCurrent,
 		d.CreatedAt,
@@ -132,8 +178,8 @@ func (s *service) CreateDataEncryptionKey(ctx context.Context, dek *DataEncrypti
 				Set("is_current", false).
 				Set("updated_at", now).
 				Where(sq.Eq{
-					"encryption_key_id": dek.EncryptionKeyId,
-					"deleted_at":        nil,
+					"key_id":     dek.EncryptionKeyId,
+					"deleted_at": nil,
 				}).
 				RunWith(tx).
 				Exec(); err != nil {
@@ -183,8 +229,8 @@ func (s *service) ListDataEncryptionKeysForEncryptionKey(ctx context.Context, en
 		Select(result.cols()...).
 		From(DataEncryptionKeysTable).
 		Where(sq.Eq{
-			"encryption_key_id": encryptionKeyId,
-			"deleted_at":        nil,
+			"key_id":     encryptionKeyId,
+			"deleted_at": nil,
 		}).
 		OrderBy("created_at ASC", "id ASC").
 		RunWith(s.db).

--- a/internal/database/data_encryption_key_test.go
+++ b/internal/database/data_encryption_key_test.go
@@ -23,6 +23,9 @@ func TestDataEncryptionKey(t *testing.T) {
 			Provider:        "mock_kms",
 			ProviderID:      "provider-key",
 			ProviderVersion: "v1",
+			ProviderMetadata: DataEncryptionKeyProviderMetadata{
+				"rotation": "r1",
+			},
 			ProtectedData: &sconfig.KeyVersionProtectedData{
 				Type:        "mock_kms",
 				WrappedData: "wrapped",
@@ -43,6 +46,7 @@ func TestDataEncryptionKey(t *testing.T) {
 		require.Equal(t, "mock_kms", got.Provider)
 		require.Equal(t, "provider-key", got.ProviderID)
 		require.Equal(t, "v1", got.ProviderVersion)
+		require.Equal(t, "r1", got.ProviderMetadata["rotation"])
 		require.True(t, got.IsCurrent)
 		require.NotNil(t, got.ProtectedData)
 		require.Equal(t, "wrapped", got.ProtectedData.WrappedData)

--- a/internal/database/encryption_key.go
+++ b/internal/database/encryption_key.go
@@ -26,11 +26,47 @@ func init() {
 	})
 }
 
-const EncryptionKeysTable = "encryption_keys"
+const EncryptionKeysTable = "keys"
 
 // GlobalEncryptionKeyID is the ID of the global encryption key created by migration. It is the root
 // of the encryption key hierarchy and must not be deleted.
-var GlobalEncryptionKeyID = apid.ID("ek_global")
+var GlobalEncryptionKeyID = apid.ID("key_global")
+
+type EncryptionKeyUsage string
+
+const (
+	EncryptionKeyUsageDataEncryption EncryptionKeyUsage = "data_encryption"
+)
+
+func IsValidEncryptionKeyUsage[T string | EncryptionKeyUsage](usage T) bool {
+	switch EncryptionKeyUsage(usage) {
+	case EncryptionKeyUsageDataEncryption:
+		return true
+	default:
+		return false
+	}
+}
+
+type EncryptionKeyMaterialType string
+
+const (
+	EncryptionKeyMaterialTypeSymmetric EncryptionKeyMaterialType = "symmetric"
+	EncryptionKeyMaterialTypePublic    EncryptionKeyMaterialType = "public"
+	EncryptionKeyMaterialTypePrivate   EncryptionKeyMaterialType = "private"
+	EncryptionKeyMaterialTypeExternal  EncryptionKeyMaterialType = "external"
+)
+
+func IsValidEncryptionKeyMaterialType[T string | EncryptionKeyMaterialType](materialType T) bool {
+	switch EncryptionKeyMaterialType(materialType) {
+	case EncryptionKeyMaterialTypeSymmetric,
+		EncryptionKeyMaterialTypePublic,
+		EncryptionKeyMaterialTypePrivate,
+		EncryptionKeyMaterialTypeExternal:
+		return true
+	default:
+		return false
+	}
+}
 
 type EncryptionKeyState string
 
@@ -71,6 +107,8 @@ func IsValidEncryptionKeyOrderByField[T string | EncryptionKeyOrderByField](fiel
 type EncryptionKey struct {
 	Id               apid.ID
 	Namespace        string
+	Usage            EncryptionKeyUsage
+	MaterialType     EncryptionKeyMaterialType
 	EncryptedKeyData *encfield.EncryptedField
 	State            EncryptionKeyState
 	Labels           Labels
@@ -89,6 +127,8 @@ func (ek *EncryptionKey) cols() []string {
 	return []string{
 		"id",
 		"namespace",
+		"usage",
+		"material_type",
 		"encrypted_key_data",
 		"state",
 		"labels",
@@ -104,6 +144,8 @@ func (ek *EncryptionKey) fields() []any {
 	return []any{
 		&ek.Id,
 		&ek.Namespace,
+		&ek.Usage,
+		&ek.MaterialType,
 		&ek.EncryptedKeyData,
 		&ek.State,
 		&ek.Labels,
@@ -119,6 +161,8 @@ func (ek *EncryptionKey) values() []any {
 	return []any{
 		ek.Id,
 		ek.Namespace,
+		ek.Usage,
+		ek.MaterialType,
 		ek.EncryptedKeyData,
 		ek.State,
 		ek.Labels,
@@ -131,6 +175,12 @@ func (ek *EncryptionKey) values() []any {
 }
 
 func (ek *EncryptionKey) normalize() {
+	if ek.Usage == "" {
+		ek.Usage = EncryptionKeyUsageDataEncryption
+	}
+	if ek.MaterialType == "" {
+		ek.MaterialType = EncryptionKeyMaterialTypeSymmetric
+	}
 	if ek.State == "" {
 		ek.State = EncryptionKeyStateActive
 	}
@@ -147,6 +197,14 @@ func (ek *EncryptionKey) Validate() error {
 
 	if ek.Namespace == "" {
 		result = multierror.Append(result, errors.New("namespace is required"))
+	}
+
+	if !IsValidEncryptionKeyUsage(ek.Usage) {
+		result = multierror.Append(result, errors.New("invalid encryption key usage"))
+	}
+
+	if !IsValidEncryptionKeyMaterialType(ek.MaterialType) {
+		result = multierror.Append(result, errors.New("invalid encryption key material type"))
 	}
 
 	if !IsValidEncryptionKeyState(ek.State) {
@@ -823,7 +881,7 @@ func (s *service) ListEncryptionKeysFromCursor(ctx context.Context, cursor strin
 }
 
 // EnumerateEncryptionKeysInDependencyOrder walks all non-deleted encryption keys in breadth-first
-// order rooted at the global key (ek_global). Encryption keys form a tree: the root key has nil
+// order rooted at the global key (key_global). Encryption keys form a tree: the root key has nil
 // EncryptedKeyData, while every other key's EncryptedKeyData.ID references an encryption_key_version
 // row whose encryption_key_id points to the parent encryption key. The method loads all keys and
 // key-version mappings into memory, builds this tree, then invokes the callback once per depth level

--- a/internal/database/encryption_key_test.go
+++ b/internal/database/encryption_key_test.go
@@ -39,8 +39,8 @@ func TestEncryptionKey(t *testing.T) {
 		require.Equal(t, EncryptionKeyStateActive, got.State)
 		gotUser, _ := SplitUserAndApxyLabels(got.Labels)
 		require.Equal(t, Labels{"env": "test"}, gotUser)
-		require.Equal(t, string(ek.Id), got.Labels["apxy/ek/-/id"])
-		require.Equal(t, "root", got.Labels["apxy/ek/-/ns"])
+		require.Equal(t, string(ek.Id), got.Labels["apxy/key/-/id"])
+		require.Equal(t, "root", got.Labels["apxy/key/-/ns"])
 
 		// Update state via UpdateEncryptionKey
 		later := now.Add(time.Hour)
@@ -135,7 +135,7 @@ func TestEncryptionKey(t *testing.T) {
 		require.NoError(t, err)
 		updatedUser, _ := SplitUserAndApxyLabels(updated.Labels)
 		require.Equal(t, Labels{"new-label": "value"}, updatedUser)
-		require.Equal(t, string(ek.Id), updated.Labels["apxy/ek/-/id"])
+		require.Equal(t, string(ek.Id), updated.Labels["apxy/key/-/id"])
 
 		// DeleteLabels
 		updated, err = db.DeleteEncryptionKeyLabels(ctx, ek.Id, []string{"new-label"})
@@ -222,12 +222,12 @@ func TestEncryptionKey(t *testing.T) {
 			require.NoError(t, db.CreateEncryptionKey(ctx, ek))
 		}
 
-		// List all (5 created + 1 seeded ek_global from migration)
+		// List all (5 created + 1 seeded key_global from migration)
 		result := db.ListEncryptionKeysBuilder().FetchPage(ctx)
 		require.NoError(t, result.Error)
 		require.Len(t, result.Results, 6)
 
-		// Filter by state (4 active created + 1 seeded ek_global)
+		// Filter by state (4 active created + 1 seeded key_global)
 		result = db.ListEncryptionKeysBuilder().ForState(EncryptionKeyStateActive).FetchPage(ctx)
 		require.NoError(t, result.Error)
 		require.Len(t, result.Results, 5)
@@ -242,7 +242,7 @@ func TestEncryptionKey(t *testing.T) {
 		require.Len(t, result.Results, 2)
 		require.True(t, result.HasMore)
 
-		// Namespace matcher (5 created + 1 seeded ek_global, all in "root")
+		// Namespace matcher (5 created + 1 seeded key_global, all in "root")
 		result = db.ListEncryptionKeysBuilder().ForNamespaceMatcher("root").FetchPage(ctx)
 		require.NoError(t, result.Error)
 		require.Len(t, result.Results, 6)
@@ -278,7 +278,7 @@ func TestEncryptionKey(t *testing.T) {
 	})
 
 	t.Run("EnumerateInDependencyOrder/single_root", func(t *testing.T) {
-		// The seeded ek_global is the only key; it should appear at depth 0.
+		// The seeded key_global is the only key; it should appear at depth 0.
 		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
@@ -304,12 +304,12 @@ func TestEncryptionKey(t *testing.T) {
 		require.Len(t, levels, 1)
 		require.Equal(t, 0, levels[0].depth)
 		require.Len(t, levels[0].ids, 1)
-		require.Equal(t, apid.ID("ek_global"), levels[0].ids[0])
+		require.Equal(t, apid.ID("key_global"), levels[0].ids[0])
 	})
 
 	t.Run("EnumerateInDependencyOrder/three_levels", func(t *testing.T) {
 		// Build a 3-level tree:
-		//   ek_global (root, seeded)
+		//   key_global (root, seeded)
 		//     ├── childA (depth 1)
 		//     └── childB (depth 1)
 		//           └── grandchild (depth 2)
@@ -317,10 +317,10 @@ func TestEncryptionKey(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		// Create an encryption key version for ek_global so children can reference it
+		// Create an encryption key version for key_global so children can reference it
 		ekvGlobal := &EncryptionKeyVersion{
 			Id:              apid.New(apid.PrefixEncryptionKeyVersion),
-			EncryptionKeyId: "ek_global",
+			EncryptionKeyId: "key_global",
 			Provider:        "local",
 			ProviderID:      "global-key",
 			ProviderVersion: "v1",
@@ -329,7 +329,7 @@ func TestEncryptionKey(t *testing.T) {
 		}
 		require.NoError(t, db.CreateEncryptionKeyVersion(ctx, ekvGlobal))
 
-		// Create childA encrypted by ek_global's version
+		// Create childA encrypted by key_global's version
 		childA := &EncryptionKey{
 			Id:        apid.New(apid.PrefixEncryptionKey),
 			Namespace: "root",
@@ -341,7 +341,7 @@ func TestEncryptionKey(t *testing.T) {
 		}
 		require.NoError(t, db.CreateEncryptionKey(ctx, childA))
 
-		// Create childB encrypted by ek_global's version
+		// Create childB encrypted by key_global's version
 		childB := &EncryptionKey{
 			Id:        apid.New(apid.PrefixEncryptionKey),
 			Namespace: "root",
@@ -400,7 +400,7 @@ func TestEncryptionKey(t *testing.T) {
 		// Depth 0: root only
 		require.Equal(t, 0, levels[0].depth)
 		require.Len(t, levels[0].ids, 1)
-		require.True(t, levels[0].ids[apid.ID("ek_global")])
+		require.True(t, levels[0].ids[apid.ID("key_global")])
 
 		// Depth 1: childA and childB
 		require.Equal(t, 1, levels[1].depth)
@@ -423,7 +423,7 @@ func TestEncryptionKey(t *testing.T) {
 		// Create a child so there would be depth 1
 		ekvGlobal := &EncryptionKeyVersion{
 			Id:              apid.New(apid.PrefixEncryptionKeyVersion),
-			EncryptionKeyId: "ek_global",
+			EncryptionKeyId: "key_global",
 			Provider:        "local",
 			ProviderID:      "global-key",
 			ProviderVersion: "v1",
@@ -460,7 +460,7 @@ func TestEncryptionKey(t *testing.T) {
 
 		ekvGlobal := &EncryptionKeyVersion{
 			Id:              apid.New(apid.PrefixEncryptionKeyVersion),
-			EncryptionKeyId: "ek_global",
+			EncryptionKeyId: "key_global",
 			Provider:        "local",
 			ProviderID:      "global-key",
 			ProviderVersion: "v1",
@@ -493,7 +493,7 @@ func TestEncryptionKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, orphans)
 		// Only the root should remain
-		require.Equal(t, []apid.ID{"ek_global"}, allIDs)
+		require.Equal(t, []apid.ID{"key_global"}, allIDs)
 	})
 
 	t.Run("EnumerateInDependencyOrder/orphaned_key_returned", func(t *testing.T) {
@@ -522,7 +522,7 @@ func TestEncryptionKey(t *testing.T) {
 		})
 		require.NoError(t, err)
 		// Only root in the walk; orphan is not walked
-		require.Equal(t, []apid.ID{"ek_global"}, allIDs)
+		require.Equal(t, []apid.ID{"key_global"}, allIDs)
 		// Orphan is returned separately
 		require.Len(t, orphans, 1)
 		require.Equal(t, orphan.Id, orphans[0].Id)

--- a/internal/database/labels_propagate.go
+++ b/internal/database/labels_propagate.go
@@ -594,7 +594,7 @@ func (s *service) ReconcileCarryForwardLabels(ctx context.Context, batchSize int
 		{name: "connector_versions", walk: s.reconcileConnectorVersions},
 		{name: "connections", walk: s.reconcileConnections},
 		{name: "actors", walk: s.reconcileActors},
-		{name: "encryption_keys", walk: s.reconcileEncryptionKeys},
+		{name: "keys", walk: s.reconcileEncryptionKeys},
 		{name: "rate_limits", walk: s.reconcileRateLimits},
 	}
 

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -443,7 +443,7 @@ func TestApidPrefixToLabelToken(t *testing.T) {
 	require.Equal(t, "cxr", ApidPrefixToLabelToken(apid.PrefixConnectorVersion))
 	require.Equal(t, "cxn", ApidPrefixToLabelToken(apid.PrefixConnection))
 	require.Equal(t, "act", ApidPrefixToLabelToken(apid.PrefixActor))
-	require.Equal(t, "ek", ApidPrefixToLabelToken(apid.PrefixEncryptionKey))
+	require.Equal(t, "key", ApidPrefixToLabelToken(apid.PrefixEncryptionKey))
 	require.Equal(t, "", ApidPrefixToLabelToken(apid.Prefix("")))
 }
 
@@ -488,10 +488,10 @@ func TestBuildCarriedLabels(t *testing.T) {
 
 	t.Run("forwards apxy/ keys as-is", func(t *testing.T) {
 		parent := Labels{
-			"pig":            "oink",
-			"apxy/ns/dog":    "woof",
-			"apxy/cxr/-/id":  "cxr_abc",
-			"apxy/cxr/-/ns":  "/foo",
+			"pig":           "oink",
+			"apxy/ns/dog":   "woof",
+			"apxy/cxr/-/id": "cxr_abc",
+			"apxy/cxr/-/ns": "/foo",
 		}
 		out := BuildCarriedLabels("cxr", parent)
 		require.Equal(t, Labels{
@@ -515,10 +515,10 @@ func TestBuildCarriedLabels(t *testing.T) {
 func TestSplitAndMergeUserAndApxyLabels(t *testing.T) {
 	t.Run("split partitions by prefix", func(t *testing.T) {
 		all := Labels{
-			"team":           "platform",
-			"env":            "prod",
-			"apxy/cxn/-/id":  "cxn_abc",
-			"apxy/cxr/type":  "google_drive",
+			"team":          "platform",
+			"env":           "prod",
+			"apxy/cxn/-/id": "cxn_abc",
+			"apxy/cxr/type": "google_drive",
 		}
 		user, apxy := SplitUserAndApxyLabels(all)
 		require.Equal(t, Labels{"team": "platform", "env": "prod"}, user)
@@ -537,8 +537,8 @@ func TestSplitAndMergeUserAndApxyLabels(t *testing.T) {
 
 	t.Run("merge round-trips", func(t *testing.T) {
 		all := Labels{
-			"team":           "platform",
-			"apxy/cxn/-/id":  "cxn_abc",
+			"team":          "platform",
+			"apxy/cxn/-/id": "cxn_abc",
 		}
 		user, apxy := SplitUserAndApxyLabels(all)
 		merged := MergeApxyAndUserLabels(user, apxy)
@@ -580,8 +580,8 @@ func TestMergeUpsertLabels(t *testing.T) {
 
 	t.Run("caller apxy labels override stored apxy labels for the same key", func(t *testing.T) {
 		caller := Labels{
-			"team":             "platform",
-			"apxy/cxr/source":  "config",
+			"team":            "platform",
+			"apxy/cxr/source": "config",
 		}
 		existing := Labels{
 			"apxy/cxr/source": "api",
@@ -664,10 +664,10 @@ func TestInjectNamespaceSelfImplicitLabels(t *testing.T) {
 func TestApplyParentCarryForward(t *testing.T) {
 	t.Run("merges user labels with parent carry-forward", func(t *testing.T) {
 		parent := Labels{
-			"type":          "google_drive",
-			"apxy/ns/-/id":  "root",
-			"apxy/ns/-/ns":  "root",
-			"apxy/ns/dog":   "woof",
+			"type":         "google_drive",
+			"apxy/ns/-/id": "root",
+			"apxy/ns/-/ns": "root",
+			"apxy/ns/dog":  "woof",
 		}
 		out := ApplyParentCarryForward(
 			Labels{"subscription_level": "pro"},

--- a/internal/database/migrations/postgres/000001_init.down.sql
+++ b/internal/database/migrations/postgres/000001_init.down.sql
@@ -1,4 +1,4 @@
-drop table if exists encryption_keys;
+drop table if exists keys;
 drop table if exists used_nonces;
 drop table if exists oauth2_tokens;
 drop table if exists namespaces;

--- a/internal/database/migrations/postgres/000001_init.up.sql
+++ b/internal/database/migrations/postgres/000001_init.up.sql
@@ -65,9 +65,9 @@ create table namespaces
     path                                   text primary key,
     depth                                  integer,
     state                                  text,
-    encryption_key_id                      text,
-    target_encryption_key_version_id       text,
-    target_encryption_key_version_updated_at timestamptz,
+    key_id                                 text,
+    target_data_encryption_key_id          text,
+    target_data_encryption_key_updated_at  timestamptz,
     labels                                 jsonb,
     annotations                            jsonb,
     created_at                             timestamptz,
@@ -105,9 +105,11 @@ create table used_nonces
 create index idx_used_nonces_retain_until
     on used_nonces (retain_until);
 
-create table encryption_keys (
+create table keys (
     id                 text primary key,
     namespace          text not null,
+    usage              text not null default 'data_encryption',
+    material_type      text not null default 'symmetric',
     encrypted_key_data jsonb,
     state              text not null default 'active',
     labels             jsonb,
@@ -118,12 +120,14 @@ create table encryption_keys (
     deleted_at         timestamptz
 );
 
-create index idx_encryption_keys_deleted_at on encryption_keys (deleted_at);
-create index idx_encryption_keys_namespace on encryption_keys (deleted_at, namespace);
+create index idx_keys_deleted_at on keys (deleted_at);
+create index idx_keys_namespace on keys (deleted_at, namespace);
 
-insert into encryption_keys (
+insert into keys (
     id,
     namespace,
+    usage,
+    material_type,
     encrypted_key_data,
     state,
     labels,
@@ -131,8 +135,10 @@ insert into encryption_keys (
     updated_at,
     deleted_at
 ) values (
-    'ek_global',
+    'key_global',
     'root',
+    'data_encryption',
+    'symmetric',
     null,
     'active',
     '{}',

--- a/internal/database/migrations/postgres/000011_create_data_encryption_keys.up.sql
+++ b/internal/database/migrations/postgres/000011_create_data_encryption_keys.up.sql
@@ -1,9 +1,10 @@
 create table data_encryption_keys (
     id                text primary key,
-    encryption_key_id text not null,
+    key_id            text not null,
     provider          text not null,
     provider_id       text not null,
     provider_version  text not null,
+    provider_metadata jsonb,
     protected_data    jsonb not null,
     is_current        boolean not null default false,
     created_at        timestamptz not null,
@@ -11,4 +12,4 @@ create table data_encryption_keys (
     deleted_at        timestamptz
 );
 
-create index idx_dek_scope_current on data_encryption_keys (deleted_at, encryption_key_id, is_current);
+create index idx_dek_scope_current on data_encryption_keys (deleted_at, key_id, is_current);

--- a/internal/database/migrations/sqlite/000001_init.down.sql
+++ b/internal/database/migrations/sqlite/000001_init.down.sql
@@ -1,5 +1,5 @@
 -- Note that go-migrate will refuse to actually migrate down at this revision, so it won't invoke this.
-drop table main.encryption_keys;
+drop table main.keys;
 
 drop index main.idx_actors_deleted_at;
 drop index main.idx_actors_email;
@@ -19,4 +19,3 @@ drop table main.oauth2_tokens;
 
 drop index main.idx_used_nonces_retain_until;
 drop table main.used_nonces;
-

--- a/internal/database/migrations/sqlite/000001_init.up.sql
+++ b/internal/database/migrations/sqlite/000001_init.up.sql
@@ -65,9 +65,9 @@ create table namespaces
     path                                   text primary key,
     depth                                  integer,
     state                                  text,
-    encryption_key_id                      text,
-    target_encryption_key_version_id       text,
-    target_encryption_key_version_updated_at datetime,
+    key_id                                 text,
+    target_data_encryption_key_id          text,
+    target_data_encryption_key_updated_at  datetime,
     labels                                 text,
     annotations                            text,
     created_at                             datetime,
@@ -105,9 +105,11 @@ create table used_nonces
 create index idx_used_nonces_retain_until
     on used_nonces (retain_until);
 
-create table encryption_keys (
+create table keys (
     id                 text primary key,
     namespace          text not null,
+    usage              text not null default 'data_encryption',
+    material_type      text not null default 'symmetric',
     encrypted_key_data text,
     state              text not null default 'active',
     labels             text,
@@ -118,12 +120,14 @@ create table encryption_keys (
     deleted_at         datetime
 );
 
-create index idx_encryption_keys_deleted_at on encryption_keys (deleted_at);
-create index idx_encryption_keys_namespace on encryption_keys (deleted_at, namespace);
+create index idx_keys_deleted_at on keys (deleted_at);
+create index idx_keys_namespace on keys (deleted_at, namespace);
 
-insert into encryption_keys (
+insert into keys (
     id,
     namespace,
+    usage,
+    material_type,
     encrypted_key_data,
     state,
     labels,
@@ -131,8 +135,10 @@ insert into encryption_keys (
     updated_at,
     deleted_at
 ) values (
-    'ek_global',
+    'key_global',
     'root',
+    'data_encryption',
+    'symmetric',
     null,
     'active',
     '{}',

--- a/internal/database/migrations/sqlite/000011_create_data_encryption_keys.up.sql
+++ b/internal/database/migrations/sqlite/000011_create_data_encryption_keys.up.sql
@@ -1,9 +1,10 @@
 create table data_encryption_keys (
     id                text primary key,
-    encryption_key_id text not null,
+    key_id            text not null,
     provider          text not null,
     provider_id       text not null,
     provider_version  text not null,
+    provider_metadata text,
     protected_data    text not null,
     is_current        integer not null default 0,
     created_at        datetime not null,
@@ -11,4 +12,4 @@ create table data_encryption_keys (
     deleted_at        datetime
 );
 
-create index idx_dek_scope_current on data_encryption_keys (deleted_at, encryption_key_id, is_current);
+create index idx_dek_scope_current on data_encryption_keys (deleted_at, key_id, is_current);

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -26,11 +26,14 @@ type Namespace struct {
 	depth           uint64
 	State           NamespaceState
 	EncryptionKeyId *apid.ID
-	Labels          Labels
-	Annotations     Annotations
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	DeletedAt       *time.Time
+	// TargetEncryptionKeyVersionId is a transitional name. The database column is
+	// target_data_encryption_key_id and the value is a dek_ id under the new model.
+	TargetEncryptionKeyVersionId *apid.ID
+	Labels                       Labels
+	Annotations                  Annotations
+	CreatedAt                    time.Time
+	UpdatedAt                    time.Time
+	DeletedAt                    *time.Time
 }
 
 func (ns *Namespace) GetNamespace() string {
@@ -42,7 +45,8 @@ func (ns *Namespace) cols() []string {
 		"path",
 		"depth",
 		"state",
-		"encryption_key_id",
+		"key_id",
+		"target_data_encryption_key_id",
 		"labels",
 		"annotations",
 		"created_at",
@@ -57,6 +61,7 @@ func (ns *Namespace) fields() []any {
 		&ns.depth,
 		&ns.State,
 		&ns.EncryptionKeyId,
+		&ns.TargetEncryptionKeyVersionId,
 		&ns.Labels,
 		&ns.Annotations,
 		&ns.CreatedAt,
@@ -71,6 +76,7 @@ func (ns *Namespace) values() []any {
 		ns.depth,
 		ns.State,
 		ns.EncryptionKeyId,
+		ns.TargetEncryptionKeyVersionId,
 		ns.Labels,
 		ns.Annotations,
 		ns.CreatedAt,
@@ -422,7 +428,7 @@ func (s *service) SetNamespaceEncryptionKeyId(ctx context.Context, path string, 
 	dbResult, err := s.sq.
 		Update(NamespacesTable).
 		Set("updated_at", now).
-		Set("encryption_key_id", ekId).
+		Set("key_id", ekId).
 		Where(sq.Eq{"path": path, "deleted_at": nil}).
 		RunWith(s.db).
 		Exec()
@@ -968,7 +974,7 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 
 	for {
 		rows, err := s.sq.
-			Select("path", "depth", "encryption_key_id", "target_encryption_key_version_id").
+			Select("path", "depth", "key_id", "target_data_encryption_key_id").
 			From(NamespacesTable).
 			Where(sq.Eq{"deleted_at": nil}).
 			OrderBy("depth, path").
@@ -1007,8 +1013,8 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 			for _, u := range updates {
 				_, err := s.sq.
 					Update(NamespacesTable).
-					Set("target_encryption_key_version_id", u.TargetEncryptionKeyVersionId).
-					Set("target_encryption_key_version_updated_at", now).
+					Set("target_data_encryption_key_id", u.TargetEncryptionKeyVersionId).
+					Set("target_data_encryption_key_updated_at", now).
 					Set("updated_at", now).
 					Where(sq.Eq{"path": u.Path}).
 					RunWith(s.db).

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1617,16 +1617,16 @@ INSERT INTO namespaces
 
 			ekId1 := apid.New(apid.PrefixEncryptionKey)
 			ekId2 := apid.New(apid.PrefixEncryptionKey)
-			ekvId1 := apid.New(apid.PrefixEncryptionKeyVersion)
+			dekId1 := apid.New(apid.PrefixDataEncryptionKey)
 
 			_, err = rawDb.Exec(fmt.Sprintf(`
 INSERT INTO namespaces
-(path, depth, state, encryption_key_id, target_encryption_key_version_id, created_at, updated_at, deleted_at) VALUES
+(path, depth, state, key_id, target_data_encryption_key_id, created_at, updated_at, deleted_at) VALUES
 ('root',           0, 'active', NULL,  NULL,  '2023-10-01 00:00:00', '2023-10-01 00:00:00', null),
 ('root.ns1',       1, 'active', '%s',  NULL,  '2023-10-02 00:00:00', '2023-10-02 00:00:00', null),
 ('root.ns2',       1, 'active', '%s',  '%s',  '2023-10-03 00:00:00', '2023-10-03 00:00:00', null),
 ('root.ns3',       1, 'active', NULL,  NULL,  '2023-10-04 00:00:00', '2023-10-04 00:00:00', '2023-10-05 00:00:00')
-`, ekId1, ekId2, ekvId1))
+`, ekId1, ekId2, dekId1))
 			require.NoError(t, err)
 
 			var collected []NamespaceEncryptionTarget
@@ -1658,7 +1658,7 @@ INSERT INTO namespaces
 			require.NotNil(t, collected[2].EncryptionKeyId)
 			require.Equal(t, ekId2, *collected[2].EncryptionKeyId)
 			require.NotNil(t, collected[2].TargetEncryptionKeyVersionId)
-			require.Equal(t, ekvId1, *collected[2].TargetEncryptionKeyVersionId)
+			require.Equal(t, dekId1, *collected[2].TargetEncryptionKeyVersionId)
 		})
 
 		t.Run("callback can update target encryption key version", func(t *testing.T) {
@@ -1671,11 +1671,11 @@ INSERT INTO namespaces
 			require.NoError(t, err)
 
 			ekId := apid.New(apid.PrefixEncryptionKey)
-			newEkvId := apid.New(apid.PrefixEncryptionKeyVersion)
+			newDekId := apid.New(apid.PrefixDataEncryptionKey)
 
 			_, err = rawDb.Exec(fmt.Sprintf(`
 INSERT INTO namespaces
-(path, depth, state, encryption_key_id, created_at, updated_at, deleted_at) VALUES
+(path, depth, state, key_id, created_at, updated_at, deleted_at) VALUES
 ('root',       0, 'active', NULL, '2023-10-01 00:00:00', '2023-10-01 00:00:00', null),
 ('root.ns1',   1, 'active', '%s', '2023-10-02 00:00:00', '2023-10-02 00:00:00', null)
 `, ekId))
@@ -1688,7 +1688,7 @@ INSERT INTO namespaces
 						if t.EncryptionKeyId != nil {
 							updates = append(updates, NamespaceTargetEncryptionKeyVersionUpdate{
 								Path:                         t.Path,
-								TargetEncryptionKeyVersionId: newEkvId,
+								TargetEncryptionKeyVersionId: newDekId,
 							})
 						}
 					}
@@ -1702,11 +1702,11 @@ INSERT INTO namespaces
 			var targetUpdatedAt *time.Time
 			var updatedAt time.Time
 			err = rawDb.QueryRow(
-				`SELECT target_encryption_key_version_id, target_encryption_key_version_updated_at, updated_at FROM namespaces WHERE path = 'root.ns1'`,
+				`SELECT target_data_encryption_key_id, target_data_encryption_key_updated_at, updated_at FROM namespaces WHERE path = 'root.ns1'`,
 			).Scan(&targetEkvId, &targetUpdatedAt, &updatedAt)
 			require.NoError(t, err)
 			require.NotNil(t, targetEkvId)
-			require.Equal(t, newEkvId, *targetEkvId)
+			require.Equal(t, newDekId, *targetEkvId)
 			require.NotNil(t, targetUpdatedAt)
 			require.True(t, now.Equal(*targetUpdatedAt), "targetUpdatedAt should match the clock time")
 			require.True(t, now.Equal(updatedAt), "updatedAt should match the clock time")
@@ -1714,7 +1714,7 @@ INSERT INTO namespaces
 			// Verify namespace without encryption key was NOT updated
 			var rootTargetEkvId *apid.ID
 			err = rawDb.QueryRow(
-				`SELECT target_encryption_key_version_id FROM namespaces WHERE path = 'root'`,
+				`SELECT target_data_encryption_key_id FROM namespaces WHERE path = 'root'`,
 			).Scan(&rootTargetEkvId)
 			require.NoError(t, err)
 			require.Nil(t, rootTargetEkvId)

--- a/internal/database/reencrypt_registry.go
+++ b/internal/database/reencrypt_registry.go
@@ -181,7 +181,7 @@ func (s *service) queryReEncryptionPage(
 	pageSize uint64,
 	offset uint64,
 ) ([]ReEncryptionTarget, int, error) {
-	// Build select columns: PK cols (qualified) + encrypted cols (qualified) + target EKV ID
+	// Build select columns: PK cols (qualified) + encrypted cols (qualified) + target DEK ID.
 	var selectCols []string
 	for _, pk := range reg.PrimaryKeyCols {
 		selectCols = append(selectCols, reg.Table+"."+pk)
@@ -189,7 +189,7 @@ func (s *service) queryReEncryptionPage(
 	for _, ec := range reg.EncryptedCols {
 		selectCols = append(selectCols, reg.Table+"."+ec)
 	}
-	selectCols = append(selectCols, "namespaces.target_encryption_key_version_id")
+	selectCols = append(selectCols, "namespaces.target_data_encryption_key_id")
 
 	// Build base query
 	q := s.sq.
@@ -224,7 +224,7 @@ func (s *service) queryReEncryptionPage(
 
 	// WHERE conditions
 	q = q.Where(sq.Eq{reg.Table + ".deleted_at": nil})
-	q = q.Where(sq.NotEq{"namespaces.target_encryption_key_version_id": nil})
+	q = q.Where(sq.NotEq{"namespaces.target_data_encryption_key_id": nil})
 	q = q.Where(sq.Eq{NamespacesTable + ".deleted_at": nil})
 
 	// OR condition: at least one encrypted col doesn't match the target
@@ -238,7 +238,7 @@ func (s *service) queryReEncryptionPage(
 			jsonIdExpr = fmt.Sprintf("COALESCE(json_extract(%s, '$.id'), '')", qualifiedCol)
 		}
 		orConditions = append(orConditions, sq.Expr(
-			fmt.Sprintf("(%s != namespaces.target_encryption_key_version_id AND %s IS NOT NULL)", jsonIdExpr, qualifiedCol),
+			fmt.Sprintf("(%s != namespaces.target_data_encryption_key_id AND %s IS NOT NULL)", jsonIdExpr, qualifiedCol),
 		))
 	}
 	if len(orConditions) == 1 {

--- a/internal/database/reencrypt_registry_test.go
+++ b/internal/database/reencrypt_registry_test.go
@@ -34,11 +34,11 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
 		// Set up namespace with target EKV
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		// Create actor with mismatched EKV
@@ -79,9 +79,9 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		// Create actor with matching EKV
@@ -115,10 +115,10 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		// Create connection in root namespace
@@ -158,10 +158,10 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		connId := apid.New(apid.PrefixConnection)
@@ -205,10 +205,10 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		connId := apid.New(apid.PrefixConnection)
@@ -246,10 +246,10 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		cvId := apid.New(apid.PrefixConnectorVersion)
@@ -286,9 +286,9 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		// Create actor with NULL encrypted_key
@@ -320,10 +320,10 @@ func TestReEncryptRegistry(t *testing.T) {
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		targetEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		targetEKVId := apid.New(apid.PrefixDataEncryptionKey)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
-		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
+		_, err := rawDb.Exec(fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = 'root'`, string(targetEKVId)))
 		require.NoError(t, err)
 
 		actorId := apid.New(apid.PrefixActor)
@@ -377,12 +377,12 @@ func TestReEncryptRegistry(t *testing.T) {
 		require.Empty(t, allTargets)
 	})
 
-	t.Run("namespace with NULL target_encryption_key_version_id skipped", func(t *testing.T) {
+	t.Run("namespace with NULL target_data_encryption_key_id skipped", func(t *testing.T) {
 		_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
 		now := time.Date(2024, time.March, 15, 10, 0, 0, 0, time.UTC)
 		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
-		oldEKVId := apid.New(apid.PrefixEncryptionKeyVersion)
+		oldEKVId := apid.New(apid.PrefixDataEncryptionKey)
 
 		// Create actor with encrypted key but namespace has no target EKV (NULL by default)
 		actorId := apid.New(apid.PrefixActor)

--- a/internal/database/schema_test.go
+++ b/internal/database/schema_test.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyModelSchema(t *testing.T) {
+	_, _, rawDb := MustApplyBlankTestDbConfigRaw(t, nil)
+
+	t.Run("keys table replaces encryption_keys", func(t *testing.T) {
+		requireQueryable(t, rawDb, "SELECT id, namespace, usage, material_type, encrypted_key_data, state FROM keys LIMIT 0")
+
+		_, err := rawDb.Query("SELECT id FROM encryption_keys LIMIT 0")
+		require.Error(t, err)
+	})
+
+	t.Run("global key uses key prefix and target defaults", func(t *testing.T) {
+		var id, usage, materialType, state string
+		err := rawDb.QueryRow("SELECT id, usage, material_type, state FROM keys WHERE id = 'key_global'").
+			Scan(&id, &usage, &materialType, &state)
+		require.NoError(t, err)
+		require.Equal(t, "key_global", id)
+		require.Equal(t, string(EncryptionKeyUsageDataEncryption), usage)
+		require.Equal(t, string(EncryptionKeyMaterialTypeSymmetric), materialType)
+		require.Equal(t, string(EncryptionKeyStateActive), state)
+	})
+
+	t.Run("namespaces use key and target DEK columns", func(t *testing.T) {
+		requireQueryable(t, rawDb, "SELECT key_id, target_data_encryption_key_id, target_data_encryption_key_updated_at FROM namespaces LIMIT 0")
+	})
+
+	t.Run("data encryption keys reference keys", func(t *testing.T) {
+		requireQueryable(t, rawDb, "SELECT key_id, provider_metadata, protected_data FROM data_encryption_keys LIMIT 0")
+	})
+}
+
+func requireQueryable(t *testing.T, q queryer, query string) {
+	t.Helper()
+	rows, err := q.Query(query)
+	require.NoError(t, err)
+	require.NoError(t, rows.Close())
+}
+
+type queryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}

--- a/internal/encrypt/task_reencrypt_test.go
+++ b/internal/encrypt/task_reencrypt_test.go
@@ -91,11 +91,11 @@ func (env *reencryptTestEnv) addGlobalV2(t *testing.T) (apid.ID, []byte) {
 	return "", nil
 }
 
-// setNamespaceTarget sets the target_encryption_key_version_id for a namespace.
+// setNamespaceTarget sets the target_data_encryption_key_id for a namespace.
 func (env *reencryptTestEnv) setNamespaceTarget(t *testing.T, namespacePath string, ekvId apid.ID) {
 	t.Helper()
 	_, err := env.rawDb.Exec(
-		fmt.Sprintf(`UPDATE namespaces SET target_encryption_key_version_id = '%s' WHERE path = '%s'`, string(ekvId), namespacePath),
+		fmt.Sprintf(`UPDATE namespaces SET target_data_encryption_key_id = '%s' WHERE path = '%s'`, string(ekvId), namespacePath),
 	)
 	require.NoError(t, err)
 }

--- a/internal/schema/api/encryption_keys.go
+++ b/internal/schema/api/encryption_keys.go
@@ -19,7 +19,7 @@ const (
 //
 //	@Description	Encryption key API response
 type EncryptionKeyJson struct {
-	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"ek_test550e8400abcde"`
+	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"key_test550e8400abcd"`
 	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
 	State       EncryptionKeyState `json:"state" yaml:"state" swaggertype:"string" example:"active"`
 	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/internal/schema/api/namespace.go
+++ b/internal/schema/api/namespace.go
@@ -17,7 +17,7 @@ const (
 type NamespaceJson struct {
 	Path            string            `json:"path" yaml:"path" example:"root.acme"`
 	State           NamespaceState    `json:"state" yaml:"state" swaggertype:"string" example:"active"`
-	EncryptionKeyId *string           `json:"encryption_key_id,omitempty" yaml:"encryption_key_id,omitempty" example:"ek_test550e8400abcde"`
+	EncryptionKeyId *string           `json:"encryption_key_id,omitempty" yaml:"encryption_key_id,omitempty" example:"key_test550e8400abcd"`
 	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	CreatedAt       time.Time         `json:"created_at" yaml:"created_at"`
@@ -51,10 +51,10 @@ type ListNamespacesResponseJson struct {
 
 // SetNamespaceEncryptionKeyRequestJson sets the encryption key used by a namespace.
 type SetNamespaceEncryptionKeyRequestJson struct {
-	EncryptionKeyId string `json:"encryption_key_id" yaml:"encryption_key_id" example:"ek_test550e8400abcde"`
+	EncryptionKeyId string `json:"encryption_key_id" yaml:"encryption_key_id" example:"key_test550e8400abcd"`
 }
 
 // NamespaceEncryptionKeyJson is the namespace encryption-key lookup response.
 type NamespaceEncryptionKeyJson struct {
-	EncryptionKeyId string `json:"encryption_key_id" yaml:"encryption_key_id" example:"ek_test550e8400abcde"`
+	EncryptionKeyId string `json:"encryption_key_id" yaml:"encryption_key_id" example:"key_test550e8400abcd"`
 }

--- a/internal/schema/api/test_data/valid-encryption-key.json
+++ b/internal/schema/api/test_data/valid-encryption-key.json
@@ -1,5 +1,5 @@
 {
-  "id": "ek_test550e8400abcde",
+  "id": "key_test550e8400abcd",
   "namespace": "root.acme",
   "state": "active",
   "labels": {

--- a/internal/schema/api/test_data/valid-list-encryption-keys.json
+++ b/internal/schema/api/test_data/valid-list-encryption-keys.json
@@ -1,7 +1,7 @@
 {
   "items": [
     {
-      "id": "ek_test550e8400abcde",
+      "id": "key_test550e8400abcd",
       "namespace": "root.acme",
       "state": "disabled",
       "created_at": "2026-01-02T03:04:05Z",

--- a/internal/schema/api/test_data/valid-namespace-encryption-key.json
+++ b/internal/schema/api/test_data/valid-namespace-encryption-key.json
@@ -1,3 +1,3 @@
 {
-  "encryption_key_id": "ek_test550e8400abcde"
+  "encryption_key_id": "key_test550e8400abcd"
 }

--- a/internal/schema/api/test_data/valid-namespace.json
+++ b/internal/schema/api/test_data/valid-namespace.json
@@ -1,7 +1,7 @@
 {
   "path": "root.acme",
   "state": "active",
-  "encryption_key_id": "ek_test550e8400abcde",
+  "encryption_key_id": "key_test550e8400abcd",
   "labels": {
     "team": "platform"
   },

--- a/internal/schema/api/test_data/valid-set-namespace-encryption-key.json
+++ b/internal/schema/api/test_data/valid-set-namespace-encryption-key.json
@@ -1,3 +1,3 @@
 {
-  "encryption_key_id": "ek_test550e8400abcde"
+  "encryption_key_id": "key_test550e8400abcd"
 }

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -7829,7 +7829,7 @@ const docTemplateadmin_api = `{
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -7898,7 +7898,7 @@ const docTemplateadmin_api = `{
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8228,7 +8228,7 @@ const docTemplateadmin_api = `{
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8338,7 +8338,7 @@ const docTemplateadmin_api = `{
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -7823,7 +7823,7 @@
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -7892,7 +7892,7 @@
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8222,7 +8222,7 @@
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8332,7 +8332,7 @@
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -88,7 +88,7 @@ definitions:
       created_at:
         type: string
       id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -136,7 +136,7 @@ definitions:
       created_at:
         type: string
       encryption_key_id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -371,7 +371,7 @@ definitions:
       created_at:
         type: string
       id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -453,7 +453,7 @@ definitions:
       created_at:
         type: string
       encryption_key_id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -7829,7 +7829,7 @@ const docTemplateApi = `{
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -7898,7 +7898,7 @@ const docTemplateApi = `{
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8228,7 +8228,7 @@ const docTemplateApi = `{
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8338,7 +8338,7 @@ const docTemplateApi = `{
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -7823,7 +7823,7 @@
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -7892,7 +7892,7 @@
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8222,7 +8222,7 @@
                 },
                 "id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",
@@ -8332,7 +8332,7 @@
                 },
                 "encryption_key_id": {
                     "type": "string",
-                    "example": "ek_test550e8400abcde"
+                    "example": "key_test550e8400abcd"
                 },
                 "labels": {
                     "type": "object",

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -88,7 +88,7 @@ definitions:
       created_at:
         type: string
       id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -136,7 +136,7 @@ definitions:
       created_at:
         type: string
       encryption_key_id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -371,7 +371,7 @@ definitions:
       created_at:
         type: string
       id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:
@@ -453,7 +453,7 @@ definitions:
       created_at:
         type: string
       encryption_key_id:
-        example: ek_test550e8400abcde
+        example: key_test550e8400abcd
         type: string
       labels:
         additionalProperties:

--- a/terraform/provider/docs/data-sources/authproxy_encryption_key.md
+++ b/terraform/provider/docs/data-sources/authproxy_encryption_key.md
@@ -6,7 +6,7 @@ Reads an existing AuthProxy encryption key.
 
 ```hcl
 data "authproxy_encryption_key" "main" {
-  id = "ek_abc123"
+  id = "key_abc123"
 }
 ```
 

--- a/terraform/provider/docs/resources/authproxy_encryption_key.md
+++ b/terraform/provider/docs/resources/authproxy_encryption_key.md
@@ -31,5 +31,5 @@ resource "authproxy_encryption_key" "main" {
 Encryption keys can be imported by ID:
 
 ```bash
-terraform import authproxy_encryption_key.example ek_abc123
+terraform import authproxy_encryption_key.example key_abc123
 ```


### PR DESCRIPTION
Parent: #605
Issue: #608
Base branch: `codex/key-model-migration`

## Summary

- Replaces the database `encryption_keys` table with `keys` in SQLite and PostgreSQL migrations.
- Moves general key ids from `ek_` to `key_`, including the seeded `key_global`.
- Adds `usage` and `material_type` fields to the transitional `EncryptionKey` database model.
- Renames namespace and DEK schema columns to `key_id` and `target_data_encryption_key_id`.
- Adds optional DEK `provider_metadata` storage for future rewrap detection.
- Updates schema fixtures, Swagger output, and Terraform examples to use `key_` ids.

## Validation

- `go test ./internal/database`
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test ./internal/database`
- `go test ./internal/schema/api ./internal/apid ./internal/database ./internal/encrypt`
- `go test ./internal/routes ./internal/schema/api ./internal/apid ./internal/database ./internal/encrypt`
- `./scripts/preflight.sh`
