### PR TITLE
Document connector lifecycle workflow operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In-depth guides live under [`docs/`](docs/README.md):
 - [Labels and annotations](docs/labels.md) — the label system, system labels under `apxy/`, carry-forward through namespaces and connectors, label selectors.
 - [Telemetry](docs/telemetry.md) — OpenTelemetry traces, metrics, and logs; OTLP configuration, label projection, signal coverage, and the local Grafana dev stack.
 - [Background tasks](docs/background_tasks.md) — running the worker, monitoring queues.
+- [Connector lifecycle operations](docs/connector-lifecycle.md) — disconnect-all and archive workflows, task polling, timeout semantics.
 - [Blob storage](docs/blob_storage.md) — viewing data stored in MinIO / S3.
 - [Redis insight](docs/redis_insight.md) — viewing data stored in Redis.
 
@@ -593,6 +594,7 @@ The full set of long-form guides lives under [`docs/`](docs/README.md):
 | Label system, system labels, carry-forward, selectors | [docs/labels.md](docs/labels.md) |
 | OpenTelemetry traces / metrics / logs, OTLP config, label projection, dev Grafana stack | [docs/telemetry.md](docs/telemetry.md) |
 | Managing background tasks | [docs/background_tasks.md](docs/background_tasks.md) |
+| Connector lifecycle workflows and task polling | [docs/connector-lifecycle.md](docs/connector-lifecycle.md) |
 | Viewing data stored in Blob Storage (request logs, etc.) | [docs/blob_storage.md](docs/blob_storage.md) |
 | Viewing data stored in Redis | [docs/redis_insight.md](docs/redis_insight.md) |
 | Terraform provider — resource reference | [terraform/provider/docs/resources/](terraform/provider/docs/resources/) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 
 - **[Telemetry](telemetry.md)** — OpenTelemetry traces / metrics / logs across all services, OTLP exporter configuration, label projection, the metrics catalog, and the local Grafana + Tempo + Loki + Prometheus dev stack under `docker compose --profile observability`.
 - **[Background tasks](background_tasks.md)** — running the worker, monitoring queues with Asynqmon.
+- **[Connector lifecycle operations](connector-lifecycle.md)** — disconnect-all and archive workflows, task polling, timeout semantics, and workflow names.
 - **[Workflow versioning](workflows.md)** — naming and evolution conventions for go-workflows-backed background work.
 - **[Blob storage](blob_storage.md)** — viewing data stored in MinIO / S3 (full request bodies, etc.).
 - **[Redis insight](redis_insight.md)** — viewing data stored in Redis (rate-limit counters, session state, etc.).

--- a/docs/connector-lifecycle.md
+++ b/docs/connector-lifecycle.md
@@ -1,0 +1,117 @@
+# Connector Lifecycle Operations
+
+AuthProxy exposes connector-wide lifecycle operations for administrative cleanup:
+
+- `POST /connectors/{id}/_disconnect_all`
+- `POST /connectors/{id}/_archive`
+
+Both endpoints start go-workflows-backed background work and return a `task_id` that can be polled with `GET /tasks/{task_id}`. They run on the normal worker service, share the application database through the workflow backend, and use the same task polling contract as other long-running work.
+
+## Choosing An Operation
+
+Use **disconnect all** when a connector should remain available, but every current connection for that connector version should be disconnected and removed. This is the operational cleanup action for compromised credentials, connector configuration problems, or a deliberate reset before users reconnect. It does not change connector version state.
+
+Use **archive** when a connector version is being retired. Archive first prepares the connector versions so no new connections can be created, then disconnects existing connections, then archives all versions of the connector after the disconnect work reaches a terminal state.
+
+The archive preparation step moves draft versions to `archived` and moves the current primary version to `active`. Moving the primary version out of `primary` prevents new connections while existing connections are being cleaned up. After cleanup, the finalize step moves every remaining version for that connector to `archived`.
+
+## Request Shape
+
+Both endpoints accept an optional JSON body:
+
+```json
+{
+  "timeout_seconds": 600
+}
+```
+
+`timeout_seconds` must be greater than zero. If omitted, AuthProxy uses the default connector lifecycle timeout of 600 seconds.
+
+The caller needs `connectors:disconnect_all` permission for disconnect-all and `connectors:archive` permission for archive, scoped to the connector namespace and id.
+
+## Task Polling
+
+The start response contains a secure task token:
+
+```json
+{
+  "task_id": "encrypted-task-info",
+  "connector_id": "cxr_..."
+}
+```
+
+Poll it with:
+
+```http
+GET /tasks/{task_id}
+```
+
+Workflow-backed connector lifecycle tasks usually report these states:
+
+- `active`: the workflow is still running.
+- `completed`: the workflow reached its intended terminal state.
+- `failed`: the workflow was canceled, terminated, or completed with an error.
+- `unknown`: the workflow state could not be resolved.
+
+For compatibility with Asynq-backed tasks, the task schema also includes `pending`, `scheduled`, and `retry`. Treat those as in-progress states when building generic task polling clients.
+
+## Timeout And Forced Terminal Semantics
+
+Disconnect-all starts one child `core.connection.disconnect.v1` workflow for each relevant connection. Relevant connections are in `setup`, `configured`, `disabled`, or `disconnecting` state.
+
+The parent workflow keeps a five-second reserve from the requested timeout when scheduling child connection disconnect workflows. For example, a 600-second connector lifecycle timeout gives each child disconnect workflow up to 595 seconds and leaves the parent time to force any remaining connections to a terminal local state.
+
+When the parent timeout expires, or when a child disconnect workflow returns an error, the parent forces those remaining connections to `disconnected` and soft-deletes them. This means a `completed` connector lifecycle task means AuthProxy local state is terminal. It does not guarantee that every third-party token revocation succeeded; provider revocation failures can be exhausted by the child workflow and then finalized locally so the connector-level operation can finish.
+
+Archive uses the same disconnect-all workflow as a child. Its requested timeout is passed through to that child operation, so the timeout bounds connection cleanup. The archive preparation and finalize steps are short database state transitions that run immediately before and after the child disconnect-all workflow.
+
+## Concurrency
+
+Connector lifecycle workflow instance ids are deterministic:
+
+- `core.connector.disconnect_all.v1:<connector_id>`
+- `core.connector.archive.v1:<connector_id>`
+
+This prevents duplicate disconnect-all or archive workflows from running for the same connector at the same time. After a workflow completes, AuthProxy can start a new execution with the same workflow instance id, which allows a connector to be disconnected again after new connections are created.
+
+Archive invokes disconnect-all with the same connector-specific disconnect-all instance id. If a disconnect-all workflow for the connector is already active, starting archive for that connector will fail instead of creating a competing cleanup workflow.
+
+## Durable Workflow Names
+
+The connector lifecycle workflows and activities use durable names that are stored in workflow history:
+
+```text
+core.connector.disconnect_all.v1
+core.connector.disconnect_all.list_connections.v1
+core.connector.disconnect_all.force_remaining.v1
+core.connector.archive.v1
+core.connector.archive.prepare_versions.v1
+core.connector.archive.finalize_versions.v1
+```
+
+These names follow the versioning rules in [Workflow versioning](workflows.md). Breaking changes must add a new `vN` workflow or activity name and keep the old registration available for at least one deployment window so in-flight customer workflows can continue replaying after an upgrade.
+
+## Verification Matrix
+
+The connector lifecycle integration tests cover the workflow-backed polling path and the final data effects:
+
+- `TestDisconnectRevocation_RevokesProviderTokensAndBlocksFutureProxy`
+- `TestDisconnectRevocation_RevocationFailureStillCompletesDisconnect`
+- `TestConnectorDisconnectAll_DisconnectsTargetConnectionsOnly`
+- `TestConnectorDisconnectAll_RevocationFailureStillCompletes`
+- `TestConnectorArchive_ArchivesVersionsAndDisconnectsConnections`
+- `TestConnectorArchive_RevocationFailureStillArchives`
+
+Run them against the default PostgreSQL provider:
+
+```bash
+cd integration_tests
+go test -tags integration ./oauth2 -run 'TestDisconnectRevocation|TestConnectorDisconnectAll|TestConnectorArchive' -count=1
+```
+
+Run the same workflow shapes against SQLite:
+
+```bash
+cd integration_tests
+AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags integration ./oauth2 -run 'TestDisconnectRevocation|TestConnectorDisconnectAll|TestConnectorArchive' -count=1
+```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -25,6 +25,8 @@ Current examples:
 core.connection.disconnect.v1
 core.connection.disconnect.revoke_credentials.v1
 core.connection.disconnect.finalize.v1
+core.connector.disconnect_all.v1
+core.connector.archive.v1
 ```
 
 Rules:

--- a/internal/core/workflow_archive_connector.go
+++ b/internal/core/workflow_archive_connector.go
@@ -93,8 +93,8 @@ func validateArchiveConnectorWorkflowConnectorID(connectorID apid.ID) error {
 // connections from being made while the existing connections are cleaned up.
 func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
 	logger := s.logger.With(
-		"workflow", WorkflowNameDisconnectConnectionV1,
-		"activity", ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		"workflow", WorkflowNameArchiveConnectorV1,
+		"activity", ActivityNameArchiveConnectorPrepareVersionsV1,
 		"connector_id", connectorID,
 	)
 	logger.Info("prepare connector versions started")
@@ -118,7 +118,7 @@ func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connect
 						return pagination.Stop, err
 					}
 				case database.ConnectorVersionStatePrimary:
-					logger.Info("moving version to primary", "version_id", version.Id)
+					logger.Info("moving primary connector version to active", "version_id", version.Id)
 					if err := s.db.SetConnectorVersionState(ctx, version.Id, version.Version, database.ConnectorVersionStateActive); err != nil {
 						logger.Info("failed moving primary to active", "version_id", version.Id, "error", err)
 						return pagination.Stop, err
@@ -136,12 +136,12 @@ func (s *service) prepareArchiveConnectorVersionsV1(ctx context.Context, connect
 	return nil
 }
 
-// finalizeArchiveConnectorVersionsV1 is the activity that runs after all connections have been cleand up. It moves
+// finalizeArchiveConnectorVersionsV1 is the activity that runs after all connections have been cleaned up. It moves
 // all versions of the connector to the archived state.
 func (s *service) finalizeArchiveConnectorVersionsV1(ctx context.Context, connectorID apid.ID) error {
 	logger := s.logger.With(
-		"workflow", WorkflowNameDisconnectConnectionV1,
-		"activity", ActivityNameDisconnectConnectionRevokeCredentialsV1,
+		"workflow", WorkflowNameArchiveConnectorV1,
+		"activity", ActivityNameArchiveConnectorFinalizeVersionsV1,
 		"connector_id", connectorID,
 	)
 	logger.Info("finalize connector versions started")

--- a/internal/core/workflow_disconnect_connector_connections.go
+++ b/internal/core/workflow_disconnect_connector_connections.go
@@ -27,7 +27,7 @@ const (
 
 type disconnectConnectorConnectionsWorkflowInputV1 struct {
 	ConnectorID apid.ID       `json:"connector_id"` // The connector id for which all connections will be disconnected
-	Timeout     time.Duration `json:"timeout"`      // ...
+	Timeout     time.Duration `json:"timeout"`      // Maximum time before remaining child disconnects are forced terminal.
 }
 
 func (s *service) startDisconnectConnectorConnectionsWorkflow(


### PR DESCRIPTION
## Summary
- add an operator guide for connector disconnect-all and archive workflows, including permissions, task polling, timeouts, forced terminal behavior, concurrency, durable workflow names, and the Postgres/SQLite verification matrix
- link the guide from the README, docs index, and workflow-versioning examples
- correct archive workflow activity log metadata and a couple of stale comments/messages

Closes #574.

## Tests
- go test ./internal/core -run 'Test.*Connector.*Workflow|TestDisconnectConnector|TestArchiveConnector' -count=1
- cd integration_tests && go test -tags integration ./oauth2 -run 'TestDisconnectRevocation|TestConnectorDisconnectAll|TestConnectorArchive' -count=1
- cd integration_tests && AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags integration ./oauth2 -run 'TestDisconnectRevocation|TestConnectorDisconnectAll|TestConnectorArchive' -count=1
- ./scripts/preflight.sh