### PR TITLE
Evaluate setup step if conditions at runtime

### DIFF
--- a/internal/apjs/condition.go
+++ b/internal/apjs/condition.go
@@ -1,0 +1,36 @@
+package apjs
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// EvaluateBoolean runs a JavaScript expression with the supplied variables in
+// scope and returns its boolean result. The expression must evaluate to a
+// boolean; undefined, null, and other result types are rejected so callers can
+// fail closed instead of guessing intent.
+func EvaluateBoolean(expression string, vars map[string]any) (bool, error) {
+	vm := goja.New()
+
+	for name, value := range vars {
+		if err := vm.Set(name, value); err != nil {
+			return false, fmt.Errorf("failed to set %q in JS runtime: %w", name, err)
+		}
+	}
+
+	result, err := vm.RunString(expression)
+	if err != nil {
+		return false, fmt.Errorf("JS expression error: %w", err)
+	}
+	if goja.IsUndefined(result) || goja.IsNull(result) {
+		return false, fmt.Errorf("JS expression returned %s", result)
+	}
+
+	exported := result.Export()
+	b, ok := exported.(bool)
+	if !ok {
+		return false, fmt.Errorf("JS expression must return a boolean, got %T", exported)
+	}
+	return b, nil
+}

--- a/internal/apjs/condition_test.go
+++ b/internal/apjs/condition_test.go
@@ -1,0 +1,53 @@
+package apjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateBoolean(t *testing.T) {
+	vars := map[string]any{
+		"cfg": map[string]any{
+			"region": "eu",
+			"plan":   "enterprise",
+		},
+		"labels": map[string]string{
+			"apxy/cxr/type": "salesforce",
+		},
+		"annotations": map[string]string{
+			"setup-mode": "advanced",
+		},
+	}
+
+	t.Run("true", func(t *testing.T) {
+		result, err := EvaluateBoolean(`cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"`, vars)
+		require.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("false", func(t *testing.T) {
+		result, err := EvaluateBoolean(`cfg.region === "us"`, vars)
+		require.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("missing data is available to javascript", func(t *testing.T) {
+		result, err := EvaluateBoolean(`cfg.missing === undefined && labels.missing === undefined && annotations.missing === undefined`, vars)
+		require.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("non boolean return rejected", func(t *testing.T) {
+		_, err := EvaluateBoolean(`cfg.region`, vars)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must return a boolean")
+	})
+
+	t.Run("javascript error rejected", func(t *testing.T) {
+		_, err := EvaluateBoolean(`cfg.region ===`, vars)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JS expression error")
+	})
+}

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -29,6 +29,13 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 		return nil, httperr.BadRequest("data sources are only available during configure steps")
 	}
 
+	flow := c.s.buildManifestSetupFlow(c)
+	if _, ok, err := flow.StepById(ctx, setupStep.Id()); err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	} else if !ok {
+		return nil, httperr.BadRequest("current setup step is not eligible for data sources")
+	}
+
 	step, ok := connector.SetupFlow.FindStepById(setupStep.Id())
 	if !ok {
 		return nil, httperr.InternalServerErrorMsg("current setup step not found in connector definition")

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -25,7 +25,10 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 	}
 
 	flow := c.s.buildManifestSetupFlow(c)
-	next, hasNext := flow.NextStep(current.Id())
+	next, hasNext, err := flow.NextStep(ctx, current.Id())
+	if err != nil {
+		return iface.PostAuthOutcome{}, fmt.Errorf("failed to evaluate setup flow: %w", err)
+	}
 	if !hasNext {
 		if _, err := c.completeFlow(ctx); err != nil {
 			return iface.PostAuthOutcome{}, err

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -159,8 +159,21 @@ func (c *connection) renderResumeResponse(ctx context.Context, flow iface.Manife
 			CanRetry: true,
 		}, nil
 	}
-	step, ok := flow.StepById(setupStep.Id())
+	step, ok, err := flow.StepById(ctx, setupStep.Id())
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if !ok {
+		if flow.ContainsStep(setupStep.Id()) {
+			next, hasNext, err := flow.NextStep(ctx, setupStep.Id())
+			if err != nil {
+				return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+			}
+			if !hasNext {
+				return c.completeFlow(ctx)
+			}
+			return c.advanceToStep(ctx, next, flow, "")
+		}
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("current setup step %q not in manifest", setupStep.String()))
 	}
 	return c.renderStepResponse(ctx, flow, step, iface.RenderRedirectOptions{})

--- a/internal/core/connection_setup_flow.go
+++ b/internal/core/connection_setup_flow.go
@@ -9,6 +9,7 @@ import (
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/aptmpl"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/core/setup_token"
@@ -72,9 +73,9 @@ func (s *service) buildManifestSetupFlow(c iface.Connection) iface.ManifestSetup
 	}
 
 	return &manifestFlow{
-		steps:         steps,
-		hasProbes:     connector.HasProbes(),
-		authBoundary:  authBoundary,
+		steps:        steps,
+		hasProbes:    connector.HasProbes(),
+		authBoundary: authBoundary,
 	}
 }
 
@@ -99,6 +100,7 @@ func newSchemaFormStep(c iface.Connection, spec *cschema.SetupFlowStep) iface.Ma
 		Description: spec.Description,
 		JsonSchema:  json.RawMessage(spec.JsonSchema),
 		UiSchema:    json.RawMessage(spec.UiSchema),
+		IsEligible:  newSchemaStepEligibility(c, spec),
 		OnSubmit: func(ctx context.Context, data json.RawMessage) error {
 			existing, err := c.GetConfiguration(ctx)
 			if err != nil {
@@ -127,6 +129,7 @@ func (s *service) newSchemaRedirectStep(c iface.Connection, spec *cschema.SetupF
 		Id:          spec.Id,
 		Title:       spec.Title,
 		Description: spec.Description,
+		IsEligible:  newSchemaStepEligibility(c, spec),
 		Render: func(ctx context.Context, opts iface.RenderRedirectOptions) (iface.RedirectInfo, error) {
 			if spec.Redirect == nil || spec.Redirect.URL == "" {
 				return iface.RedirectInfo{}, fmt.Errorf("redirect step %q has no URL configured", spec.Id)
@@ -167,6 +170,41 @@ func (s *service) newSchemaRedirectStep(c iface.Connection, spec *cschema.SetupF
 	})
 }
 
+func newSchemaStepEligibility(c iface.Connection, spec *cschema.SetupFlowStep) func(context.Context) (bool, error) {
+	if spec.If == nil {
+		return nil
+	}
+	return func(ctx context.Context) (bool, error) {
+		cfg, err := c.GetConfiguration(ctx)
+		if err != nil {
+			return false, fmt.Errorf("step %q: get connection configuration: %w", spec.Id, err)
+		}
+		if cfg == nil {
+			cfg = map[string]any{}
+		}
+
+		labels := c.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		annotations := c.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		ok, err := apjs.EvaluateBoolean(spec.If.Javascript, map[string]any{
+			"cfg":         cfg,
+			"labels":      labels,
+			"annotations": annotations,
+		})
+		if err != nil {
+			return false, fmt.Errorf("step %q if.javascript: %w", spec.Id, err)
+		}
+		return ok, nil
+	}
+}
+
 // mintReturnURL mints a setup_token and returns the public-endpoint URL
 // (/setup/connections/{id}/{advance|abort}?token=<jti>) that substitutes
 // for the corresponding placeholder in a redirect step's URL template.
@@ -205,46 +243,74 @@ type manifestFlow struct {
 	authBoundary int // index in steps after which verify slots in when hasProbes
 }
 
-func (f *manifestFlow) Steps() []iface.ManifestSetupStep {
-	// Defensive copy so callers can't mutate the underlying slice.
-	out := make([]iface.ManifestSetupStep, len(f.steps))
-	copy(out, f.steps)
-	return out
-}
-
-func (f *manifestFlow) StepById(id string) (iface.ManifestSetupStep, bool) {
-	if id == "" {
-		return nil, false
-	}
-	if id == iface.NewVerifyStep().Id() && f.hasProbes {
-		return iface.NewVerifyStep(), true
-	}
-	for _, s := range f.steps {
-		if s.Id() == id {
-			return s, true
+func (f *manifestFlow) Steps(ctx context.Context) ([]iface.ManifestSetupStep, error) {
+	out := make([]iface.ManifestSetupStep, 0, len(f.steps))
+	for i := range f.steps {
+		eligible, err := f.isStepEligible(ctx, i)
+		if err != nil {
+			return nil, err
+		}
+		if eligible {
+			out = append(out, f.steps[i])
 		}
 	}
-	return nil, false
+	return out, nil
 }
 
-func (f *manifestFlow) FirstStep() iface.ManifestSetupStep {
-	if len(f.steps) == 0 {
-		return nil
+func (f *manifestFlow) StepById(ctx context.Context, id string) (iface.ManifestSetupStep, bool, error) {
+	if id == "" {
+		return nil, false, nil
 	}
-	return f.steps[0]
+	if id == iface.NewVerifyStep().Id() && f.hasProbes {
+		return iface.NewVerifyStep(), true, nil
+	}
+	for i, s := range f.steps {
+		if s.Id() != id {
+			continue
+		}
+		eligible, err := f.isStepEligible(ctx, i)
+		if err != nil {
+			return nil, false, err
+		}
+		return s, eligible, nil
+	}
+	return nil, false, nil
 }
 
-func (f *manifestFlow) NextStep(currentId string) (iface.ManifestSetupStep, bool) {
+func (f *manifestFlow) ContainsStep(id string) bool {
+	if id == "" {
+		return false
+	}
+	if id == iface.NewVerifyStep().Id() && f.hasProbes {
+		return true
+	}
+	for _, step := range f.steps {
+		if step.Id() == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *manifestFlow) FirstStep(ctx context.Context) (iface.ManifestSetupStep, error) {
+	if f.hasProbes && f.authBoundary >= 0 {
+		step, ok, err := f.nextEligibleStep(ctx, 0, f.authBoundary)
+		if err != nil || ok {
+			return step, err
+		}
+		return iface.NewVerifyStep(), nil
+	}
+	step, _, err := f.nextEligibleStep(ctx, 0, len(f.steps)-1)
+	return step, err
+}
+
+func (f *manifestFlow) NextStep(ctx context.Context, currentId string) (iface.ManifestSetupStep, bool, error) {
 	verifyId := iface.NewVerifyStep().Id()
 
 	// Coming out of verify: jump to the step right after the auth boundary
 	// (the first configure step, typically).
 	if currentId == verifyId {
-		next := f.authBoundary + 1
-		if next < 0 || next >= len(f.steps) {
-			return nil, false
-		}
-		return f.steps[next], true
+		return f.nextEligibleStep(ctx, f.authBoundary+1, len(f.steps)-1)
 	}
 
 	for i, step := range f.steps {
@@ -252,14 +318,45 @@ func (f *manifestFlow) NextStep(currentId string) (iface.ManifestSetupStep, bool
 			continue
 		}
 		// Verify insertion: when the current step is the last one in the
-		// credential-establishing phase, transition to verify next.
-		if f.hasProbes && i == f.authBoundary {
-			return iface.NewVerifyStep(), true
+		// credential-establishing phase, transition to verify next. Gated-off
+		// steps in the same phase are skipped before verify is considered.
+		if f.hasProbes && i <= f.authBoundary {
+			next, ok, err := f.nextEligibleStep(ctx, i+1, f.authBoundary)
+			if err != nil || ok {
+				return next, ok, err
+			}
+			return iface.NewVerifyStep(), true, nil
 		}
-		if i+1 < len(f.steps) {
-			return f.steps[i+1], true
-		}
-		return nil, false
+		return f.nextEligibleStep(ctx, i+1, len(f.steps)-1)
 	}
-	return nil, false
+	return nil, false, nil
+}
+
+func (f *manifestFlow) nextEligibleStep(ctx context.Context, start int, end int) (iface.ManifestSetupStep, bool, error) {
+	if start < 0 {
+		start = 0
+	}
+	if end >= len(f.steps) {
+		end = len(f.steps) - 1
+	}
+	if start > end {
+		return nil, false, nil
+	}
+	for i := start; i <= end; i++ {
+		eligible, err := f.isStepEligible(ctx, i)
+		if err != nil {
+			return nil, false, err
+		}
+		if eligible {
+			return f.steps[i], true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func (f *manifestFlow) isStepEligible(ctx context.Context, idx int) (bool, error) {
+	if idx < 0 || idx >= len(f.steps) {
+		return false, nil
+	}
+	return f.steps[idx].IsEligible(ctx)
 }

--- a/internal/core/connection_setup_flow_test.go
+++ b/internal/core/connection_setup_flow_test.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestSetupFlowIfJavascript(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+		Configure: &cschema.SetupFlowPhase{
+			Steps: []cschema.SetupFlowStep{
+				{
+					Id:         "cfg_false",
+					JsonSchema: workspaceSchema,
+					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+				},
+				{
+					Id:         "label_true",
+					JsonSchema: workspaceSchema,
+					If:         &cschema.SetupFlowStepIf{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
+				},
+				{
+					Id:         "annotation_true",
+					JsonSchema: workspaceSchema,
+					If:         &cschema.SetupFlowStepIf{Javascript: `annotations["setup-mode"] === "advanced"`},
+				},
+			},
+		},
+	})
+	setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
+	conn.Labels = map[string]string{"apxy/cxr/type": "salesforce"}
+	conn.Annotations = map[string]string{"setup-mode": "advanced"}
+
+	flow := conn.s.buildManifestSetupFlow(conn)
+	steps, err := flow.Steps(context.Background())
+	require.NoError(t, err)
+	require.Len(t, steps, 2)
+	assert.Equal(t, "label_true", steps[0].Id())
+	assert.Equal(t, "annotation_true", steps[1].Id())
+
+	first, err := flow.FirstStep(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "label_true", first.Id())
+
+	next, ok, err := flow.NextStep(context.Background(), "label_true")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "annotation_true", next.Id())
+}
+
+func TestManifestSetupFlowIfJavascriptVerifyBoundary(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+		Preconnect: &cschema.SetupFlowPhase{
+			Steps: []cschema.SetupFlowStep{
+				{
+					Id:         "us_only",
+					JsonSchema: regionSchema,
+					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+				},
+			},
+		},
+		Configure: &cschema.SetupFlowPhase{
+			Steps: []cschema.SetupFlowStep{
+				{Id: "workspace", JsonSchema: workspaceSchema},
+			},
+		},
+	})
+	setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
+	conn.cv.GetDefinition().Probes = []cschema.Probe{{Id: "ping"}}
+
+	flow := conn.s.buildManifestSetupFlow(conn)
+	first, err := flow.FirstStep(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "apxy:verify", first.Id())
+}
+
+func TestManifestSetupFlowIfJavascriptError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+		Configure: &cschema.SetupFlowPhase{
+			Steps: []cschema.SetupFlowStep{
+				{
+					Id:         "broken",
+					JsonSchema: workspaceSchema,
+					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region ===`},
+				},
+			},
+		},
+	})
+
+	flow := conn.s.buildManifestSetupFlow(conn)
+	_, err := flow.FirstStep(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "if.javascript")
+}
+
+func setConnectionConfigFixture(t *testing.T, conn *connection, cfg map[string]any) {
+	t.Helper()
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	ef, err := conn.s.encrypt.EncryptStringForNamespace(context.Background(), conn.Namespace, string(data))
+	require.NoError(t, err)
+	conn.EncryptedConfiguration = &ef
+}

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -22,7 +22,10 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 	}
 
 	flow := c.s.buildManifestSetupFlow(c)
-	next, hasNext := flow.NextStep(cschema.SetupStepVerify.Id())
+	next, hasNext, err := flow.NextStep(ctx, cschema.SetupStepVerify.Id())
+	if err != nil {
+		return fmt.Errorf("failed to evaluate setup flow after verify: %w", err)
+	}
 	if !hasNext {
 		if _, err := c.completeFlow(ctx); err != nil {
 			return err

--- a/internal/core/iface/manifest_setup_step.go
+++ b/internal/core/iface/manifest_setup_step.go
@@ -113,6 +113,12 @@ type ManifestSetupStep interface {
 	// carries request-scoped values (ReturnToUrl) the step may need to mint
 	// the URL.
 	RenderRedirect(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
+
+	// IsEligible reports whether this step should currently participate in
+	// the setup flow. Auth-method-emitted steps and apxy:* pseudo-steps are
+	// always eligible; connector-authored steps may use this to evaluate an
+	// if.javascript condition against the connection state.
+	IsEligible(ctx context.Context) (bool, error)
 }
 
 // ManifestSetupFlow is the ordered, fully-materialized setup flow for a
@@ -122,26 +128,32 @@ type ManifestSetupStep interface {
 // apxy:auth_failed) and the verify step (apxy:verify) are addressable by id
 // but not part of the linear order returned by Steps() / NextStep().
 type ManifestSetupFlow interface {
-	// Steps returns the ordered, linear steps a user walks through during
-	// setup. Implicit terminal steps (verify_failed, auth_failed) and the
-	// verify pseudo-step are not included; use StepById for those.
-	Steps() []ManifestSetupStep
+	// Steps returns the ordered, eligible linear steps a user walks through
+	// during setup. Implicit terminal steps (verify_failed, auth_failed) and
+	// the verify pseudo-step are not included; use StepById for those.
+	Steps(ctx context.Context) ([]ManifestSetupStep, error)
 
-	// StepById returns the step with the given id, including implicit
-	// terminal/verify pseudo-steps. Returns false if the id is unknown.
-	StepById(id string) (ManifestSetupStep, bool)
+	// StepById returns the eligible step with the given id, including the
+	// implicit verify pseudo-step. Returns false if the id is unknown or known
+	// but currently ineligible.
+	StepById(ctx context.Context, id string) (ManifestSetupStep, bool, error)
+
+	// ContainsStep reports whether id belongs to a manifest step regardless of
+	// current eligibility. Used by resume paths to distinguish stale gated-off
+	// steps from corrupted setup state.
+	ContainsStep(id string) bool
 
 	// FirstStep returns the first step in the linear flow. Returns nil if
 	// the flow has no linear steps (a connector with no preconnect, no
 	// auth-emitted steps, and no configure — which means setup is already
 	// complete on initiate).
-	FirstStep() ManifestSetupStep
+	FirstStep(ctx context.Context) (ManifestSetupStep, error)
 
 	// NextStep returns the step that follows the step with the given id in
 	// the linear flow, or false when currentId is the final linear step.
 	// Pseudo-steps (verify, verify_failed, auth_failed) are not part of the
 	// linear successor relation.
-	NextStep(currentId string) (ManifestSetupStep, bool)
+	NextStep(ctx context.Context, currentId string) (ManifestSetupStep, bool, error)
 }
 
 // FormStepConfig configures NewFormStep. All fields are optional except Id
@@ -155,6 +167,7 @@ type FormStepConfig struct {
 	JsonSchema  json.RawMessage
 	UiSchema    json.RawMessage
 	OnSubmit    func(ctx context.Context, data json.RawMessage) error
+	IsEligible  func(ctx context.Context) (bool, error)
 }
 
 // NewFormStep returns a form-type ManifestSetupStep backed by the supplied
@@ -169,6 +182,7 @@ type RedirectStepConfig struct {
 	Id          string
 	Title       string
 	Description string
+	IsEligible  func(ctx context.Context) (bool, error)
 	// Render resolves the redirect URL when the flow runner reaches this
 	// step. Required.
 	Render func(ctx context.Context, opts RenderRedirectOptions) (RedirectInfo, error)
@@ -210,6 +224,13 @@ func (s *formStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (R
 	return RedirectInfo{}, ErrRedirectNotSupported
 }
 
+func (s *formStep) IsEligible(ctx context.Context) (bool, error) {
+	if s.cfg.IsEligible == nil {
+		return true, nil
+	}
+	return s.cfg.IsEligible(ctx)
+}
+
 type redirectStep struct {
 	cfg RedirectStepConfig
 }
@@ -232,6 +253,13 @@ func (s *redirectStep) RenderRedirect(ctx context.Context, opts RenderRedirectOp
 	return s.cfg.Render(ctx, opts)
 }
 
+func (s *redirectStep) IsEligible(ctx context.Context) (bool, error) {
+	if s.cfg.IsEligible == nil {
+		return true, nil
+	}
+	return s.cfg.IsEligible(ctx)
+}
+
 // verifyStep is the synthetic apxy:verify pseudo-step. Stateless — no
 // configuration is needed since its sole purpose is to mark "probes are
 // running; the UI should display Verifying."
@@ -250,4 +278,8 @@ func (s *verifyStep) OnSubmit(_ context.Context, _ json.RawMessage) error {
 
 func (s *verifyStep) RenderRedirect(_ context.Context, _ RenderRedirectOptions) (RedirectInfo, error) {
 	return RedirectInfo{}, ErrRedirectNotSupported
+}
+
+func (s *verifyStep) IsEligible(_ context.Context) (bool, error) {
+	return true, nil
 }

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -86,7 +86,11 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 	}
 
 	flow := s.buildManifestSetupFlow(connection)
-	first := flow.FirstStep()
+	first, err := flow.FirstStep(ctx)
+	if err != nil {
+		val.MarkErrorReturn()
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if first == nil {
 		// No setup steps to walk through — the connection is immediately
 		// considered configured.

--- a/internal/core/service_connection_reauth.go
+++ b/internal/core/service_connection_reauth.go
@@ -48,7 +48,10 @@ func (s *service) ReauthConnection(ctx context.Context, id apid.ID, returnToUrl 
 	}
 
 	flow := s.buildManifestSetupFlow(conn)
-	first := flow.FirstStep()
+	first, err := flow.FirstStep(ctx)
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if first == nil {
 		return nil, httperr.BadRequest("connector has no setup flow to reauth through")
 	}

--- a/internal/core/service_connection_reconfigure.go
+++ b/internal/core/service_connection_reconfigure.go
@@ -23,10 +23,20 @@ func (c *connection) Reconfigure(ctx context.Context) (iface.ConnectionSetupResp
 	}
 
 	flow := c.s.buildManifestSetupFlow(c)
-	firstConfigureId := connector.SetupFlow.Configure.Steps[0].Id
-	step, ok := flow.StepById(firstConfigureId)
-	if !ok {
-		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("first configure step %q missing from manifest", firstConfigureId))
+	var step iface.ManifestSetupStep
+	for i := range connector.SetupFlow.Configure.Steps {
+		candidateId := connector.SetupFlow.Configure.Steps[i].Id
+		candidate, ok, err := flow.StepById(ctx, candidateId)
+		if err != nil {
+			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+		}
+		if ok {
+			step = candidate
+			break
+		}
+	}
+	if step == nil {
+		return c.completeFlow(ctx)
 	}
 	// Reconfigure never feeds a return-to-url through; configure is purely
 	// in-marketplace form interaction.

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -108,6 +108,34 @@ func TestReconfigure(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Equal(t, iface.ConnectionSetupResponseTypeForm, resp.GetType())
 	})
+
+	t.Run("skips ineligible configure steps", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{
+						Id:         "us_only",
+						JsonSchema: workspaceSchema,
+						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+					},
+					{Id: "workspace", Title: "Select Workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		})
+		conn.State = database.ConnectionStateConfigured
+		setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
+
+		resp, err := conn.Reconfigure(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
+		assert.Equal(t, "workspace", resp.(*iface.ConnectionSetupForm).StepId)
+	})
 }
 
 func ptrStr(s string) *string {

--- a/internal/core/service_connection_retry.go
+++ b/internal/core/service_connection_retry.go
@@ -28,7 +28,10 @@ func (s *service) RetryConnectionSetup(ctx context.Context, id apid.ID, returnTo
 	}
 
 	flow := s.buildManifestSetupFlow(conn)
-	first := flow.FirstStep()
+	first, err := flow.FirstStep(ctx)
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if first == nil {
 		return nil, httperr.BadRequest("connector has no setup flow to retry")
 	}

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -23,7 +23,10 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 	}
 
 	flow := c.s.buildManifestSetupFlow(c)
-	current, ok := flow.StepById(setupStep.Id())
+	current, ok, err := flow.StepById(ctx, setupStep.Id())
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if !ok {
 		return nil, httperr.InternalServerErrorMsg("current setup step is not addressable in manifest")
 	}
@@ -35,7 +38,10 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		return nil, err
 	}
 
-	next, hasNext := flow.NextStep(current.Id())
+	next, hasNext, err := flow.NextStep(ctx, current.Id())
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
+	}
 	if !hasNext {
 		return c.completeFlow(ctx)
 	}

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -212,6 +212,40 @@ func TestSubmitForm(t *testing.T) {
 		assert.Equal(t, iface.ConnectionSetupResponseTypeComplete, resp.GetType())
 	})
 
+	t.Run("skips next step when submitted config makes condition false", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sf := &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "region", JsonSchema: regionSchema},
+					{
+						Id:         "us_only",
+						JsonSchema: workspaceSchema,
+						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+					},
+					{Id: "workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		}
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
+		step := cschema.MustNewSetupStep("region")
+		conn.SetupStep = &step
+
+		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
+
+		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
+			StepId: "region",
+			Data:   json.RawMessage(`{"region":"eu"}`),
+		})
+		require.NoError(t, err)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
+		assert.Equal(t, "workspace", resp.(*iface.ConnectionSetupForm).StepId)
+	})
+
 	t.Run("merges data from multiple steps", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -359,6 +393,38 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 		conn, _ := newTestConnectionWithSetupFlow(t, ctrl, sf)
 		step := cschema.MustNewSetupStep("workspace")
 		conn.SetupStep = &step
+
+		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
+		require.NoError(t, err)
+		require.IsType(t, &iface.ConnectionSetupForm{}, resp)
+
+		form := resp.(*iface.ConnectionSetupForm)
+		assert.Equal(t, "workspace", form.StepId)
+		assert.Equal(t, "Select Workspace", form.StepTitle)
+	})
+
+	t.Run("advances past ineligible stored step on resume", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sf := &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{
+						Id:         "us_only",
+						JsonSchema: workspaceSchema,
+						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+					},
+					{Id: "workspace", Title: "Select Workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		}
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, sf)
+		setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
+		step := cschema.MustNewSetupStep("us_only")
+		conn.SetupStep = &step
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		resp, err := conn.GetCurrentSetupStepResponse(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Evaluate setup-flow if.javascript conditions with cfg, labels, and annotations in scope
- Make setup-flow traversal context-aware so clients only see eligible steps across initiate, submit, resume, reauth, retry, post-auth, verify, reconfigure, and data-source paths
- Add focused tests for true/false JavaScript results, non-boolean/error cases, cfg-updated submit skipping, resume skipping, reconfigure skipping, and verify-boundary behavior

Closes #624.
Closes #625.
Part of #506.

## Tests
- go test ./internal/apjs ./internal/core
- go test ./internal/...
- ./scripts/preflight.sh