### PR TITLE
Use dedicated app metrics migration table

### DIFF
--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -106,37 +106,13 @@ template syntax.
 
 {{/* --- app_metrics (server unconditionally wires up the metrics store) --- */}}
 {{/*
-  The app_metrics migrator + the main DB migrator share golang-migrate's
-  default `schema_migrations` table, so they can't run against the same
-  schema. For SQLite that means a sibling file (default path with an
-  `.app-metrics` suffix); for Postgres, app_metrics uses tables prefixed
-  inside the same DB and conflicts are not observed in practice.
-
   Server-side this used to be `http_logging`; renamed to `app_metrics`
   with the request-event capture moved under a `request_events`
   sub-block. See internal/schema/config/app_metrics.go.
 */}}
-{{/*
-  When shareMainDatabase is true we pick a per-provider strategy that
-  avoids the golang-migrate `schema_migrations` collision:
-    - SQLite: sibling file path (`<main>.app-metrics`).
-    - Postgres: app_metrics gets pinned to an ephemeral SQLite file
-      under /tmp instead of sharing the main Postgres database.
-      Postgres-share would have to either (a) create a second
-      database on the same server, or (b) pass an
-      `x-migrations-table` URI param the Go migrator picks up.
-      Both are bigger lifts than warranted for a demo; flip
-      `shareMainDatabase: false` + supply your own
-      `appMetrics.database` block for production-grade setups.
-*/}}
 {{- $metricsDb := dict -}}
 {{- if .Values.appMetrics.shareMainDatabase -}}
-{{-   if eq .Values.database.provider "sqlite" -}}
-{{-     $sharedPath := printf "%s.app-metrics" .Values.database.path -}}
-{{-     $metricsDb = dict "provider" "sqlite" "path" $sharedPath -}}
-{{-   else -}}
-{{-     $metricsDb = dict "provider" "sqlite" "path" "/tmp/authproxy-app-metrics.db" -}}
-{{-   end -}}
+{{-   $metricsDb = $db -}}
 {{- else -}}
 {{-   $metricsDb = .Values.appMetrics.database -}}
 {{- end -}}

--- a/docs/app_metrics.md
+++ b/docs/app_metrics.md
@@ -4,7 +4,7 @@ AuthProxy stores Admin UI-facing application metrics in the `app_metrics` store.
 
 ## Configuration
 
-`app_metrics` is required because request-event listing and metrics queries are routed through it. In development the store can use SQLite, Postgres, or ClickHouse. Deployed environments should prefer ClickHouse or a dedicated Postgres database when request volume is high.
+`app_metrics` is required because request-event listing and metrics queries are routed through it. In development the store can use the same SQLite or Postgres database as the primary application database; app_metrics tracks its migrations in `app_metrics_schema_migrations` so it does not conflict with the primary `schema_migrations` table. Deployed environments should prefer ClickHouse or a dedicated Postgres database when request volume is high.
 
 ```yaml
 app_metrics:
@@ -28,7 +28,7 @@ Key settings:
 
 | Setting | Purpose |
 |---|---|
-| `app_metrics.database` | Dedicated database for request events and resource sample tables. |
+| `app_metrics.database` | Database for request events and resource sample tables; can be shared with the primary application database for development. |
 | `app_metrics.resource_snapshot_interval` | Cadence for the worker snapshot job. Defaults to `15m`. |
 | `app_metrics.request_events.full_request_recording` | Controls when full request/response bodies are captured. |
 | `app_metrics.blob_storage` | Stores full request/response payloads when capture is enabled. |

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -153,6 +153,7 @@ func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 
 	driver, err := chmigrate.WithInstance(migrationConn, &chmigrate.Config{
 		DatabaseName:          dbName,
+		MigrationsTable:       appMetricsMigrationsTable,
 		MultiStatementEnabled: true,
 	})
 	if err != nil {

--- a/internal/app_metrics/provider_migration_test.go
+++ b/internal/app_metrics/provider_migration_test.go
@@ -1,0 +1,37 @@
+package app_metrics
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLMigrateUsesAppMetricsSchemaMigrationsTable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "shared.sqlite3")
+	cfg := &sconfig.Database{InnerVal: &sconfig.DatabaseSqlite{Path: dbPath}}
+
+	db, err := sql.Open(cfg.GetDriver(), cfg.GetDsn())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE schema_migrations (version uint64, dirty bool);
+		INSERT INTO schema_migrations (version, dirty) VALUES (999, false);
+	`)
+	require.NoError(t, err)
+
+	store, _, _ := buildSqlStorePairNoMigrate(t, cfg)
+	require.NoError(t, store.(*sqlRecordStore).Migrate(context.Background()))
+
+	var mainVersion int
+	require.NoError(t, db.QueryRow("SELECT version FROM schema_migrations").Scan(&mainVersion))
+	require.Equal(t, 999, mainVersion)
+
+	var appMetricsVersion int
+	require.NoError(t, db.QueryRow("SELECT version FROM app_metrics_schema_migrations").Scan(&appMetricsVersion))
+	require.Greater(t, appMetricsVersion, 0)
+}

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -13,8 +13,9 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang-migrate/migrate/v4"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
+	migratedb "github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -27,13 +28,15 @@ import (
 //go:embed migrations/**/*.sql
 var appMetricsMigrationsFs embed.FS
 
-const entryRecordsTable = "app_metrics_request_events"
+const (
+	appMetricsMigrationsTable = "app_metrics_schema_migrations"
+	entryRecordsTable         = "app_metrics_request_events"
+)
 
 // --- SQL RecordStore ---
 
 type sqlRecordStore struct {
 	db                *sql.DB
-	uri               string
 	provider          config.DatabaseProvider
 	cfg               *config.Database
 	logger            *slog.Logger
@@ -48,7 +51,6 @@ func NewSqlRecordStore(cfg *config.Database, logger *slog.Logger, opts ...databa
 
 	return &sqlRecordStore{
 		db:                db,
-		uri:               cfg.GetUri(),
 		provider:          cfg.GetProvider(),
 		cfg:               cfg,
 		logger:            logger.With("sub_component", "store"),
@@ -178,8 +180,14 @@ func (s *sqlRecordStore) Migrate(ctx context.Context) error {
 		return fmt.Errorf("failed to load app metrics migrations for '%s': %w", provider, err)
 	}
 
-	m, err := migrate.NewWithSourceInstance("iofs", d, s.uri)
+	driver, err := s.newMigrationDriver()
 	if err != nil {
+		return fmt.Errorf("failed to setup app metrics migration driver: %w", err)
+	}
+
+	m, err := migrate.NewWithInstance("iofs", d, provider, driver)
+	if err != nil {
+		_ = driver.Close()
 		return fmt.Errorf("failed to setup app metrics migrations: %w", err)
 	}
 	defer func() {
@@ -199,6 +207,35 @@ func (s *sqlRecordStore) Migrate(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *sqlRecordStore) newMigrationDriver() (migratedb.Driver, error) {
+	migrationConn, err := sql.Open(s.cfg.GetDriver(), s.cfg.GetDsn())
+	if err != nil {
+		return nil, err
+	}
+
+	switch s.cfg.GetProvider() {
+	case config.DatabaseProviderPostgres:
+		driver, err := postgres.WithInstance(migrationConn, &postgres.Config{
+			MigrationsTable: appMetricsMigrationsTable,
+		})
+		if err != nil {
+			_ = migrationConn.Close()
+		}
+		return driver, err
+	case config.DatabaseProviderSqlite:
+		driver, err := sqlite3.WithInstance(migrationConn, &sqlite3.Config{
+			MigrationsTable: appMetricsMigrationsTable,
+		})
+		if err != nil {
+			_ = migrationConn.Close()
+		}
+		return driver, err
+	default:
+		_ = migrationConn.Close()
+		return nil, fmt.Errorf("unsupported SQL app metrics provider %q", s.cfg.GetProvider())
+	}
 }
 
 func (s *sqlRecordStore) Ping(ctx context.Context) bool {


### PR DESCRIPTION
## Summary
- run app_metrics SQL migrations with a dedicated app_metrics_schema_migrations table
- use the same app_metrics migration table for ClickHouse
- let the Helm chart's shareMainDatabase path reuse the primary database block
- document shared dev database support and add a SQLite coexistence regression test

## Tests
- go test ./internal/app_metrics -count=1
- helm template authproxy deploy/charts/authproxy
- ./scripts/preflight.sh