### PR TITLE
Document conditional setup flow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In-depth guides live under [`docs/`](docs/README.md):
 - [CLI (`ap`)](docs/cli.md) — config file shape, signing keys, every command (list, sign-jwt, signing-proxy, proxy + curl/wget modes, …).
 - [Rate limits](docs/rate-limits.md) — defining rate-limit resources, the connector-level reactive 429 handler, and the request-log attribution fields.
 - [Labels and annotations](docs/labels.md) — the label system, system labels under `apxy/`, carry-forward through namespaces and connectors, label selectors.
+- [Connector setup flow](docs/connector-setup-flow.md) — preconnect/configure steps, conditional `if.javascript` steps, redirect steps, and data sources.
 - [Telemetry](docs/telemetry.md) — OpenTelemetry traces, metrics, and logs; OTLP configuration, label projection, signal coverage, and the local Grafana dev stack.
 - [Background tasks](docs/background_tasks.md) — running the worker, monitoring queues.
 - [Connector lifecycle operations](docs/connector-lifecycle.md) — disconnect-all and archive workflows, task polling, timeout semantics.
@@ -592,6 +593,7 @@ The full set of long-form guides lives under [`docs/`](docs/README.md):
 | `ap` CLI — config file, signing keys, every command | [docs/cli.md](docs/cli.md) |
 | Define rate-limit resources, connector reactive 429 handling, log attribution | [docs/rate-limits.md](docs/rate-limits.md) |
 | Label system, system labels, carry-forward, selectors | [docs/labels.md](docs/labels.md) |
+| Connector setup flow, conditional steps, redirect steps, data sources | [docs/connector-setup-flow.md](docs/connector-setup-flow.md) |
 | OpenTelemetry traces / metrics / logs, OTLP config, label projection, dev Grafana stack | [docs/telemetry.md](docs/telemetry.md) |
 | Managing background tasks | [docs/background_tasks.md](docs/background_tasks.md) |
 | Connector lifecycle workflows and task polling | [docs/connector-lifecycle.md](docs/connector-lifecycle.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 - **[CLI (`ap`)](cli.md)** — config file shape (`~/.authproxy.yaml`), RS256 vs HS256 signing keys, every command (list, sign-jwt / verify-jwt, signing-proxy, the connection-scoped streaming `proxy` with `curl`/`wget` modes, marketplace helpers).
 - **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
 - **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
+- **[Connector setup flow](connector-setup-flow.md)** — author preconnect/configure steps, conditional `if.javascript` steps, redirect steps, and configure-time data sources.
 - **[Application metrics](app_metrics.md)** — configure the app metrics store, query request-event and resource metrics, and understand supported aggregations and dimensions.
 
 ## Operational guides

--- a/docs/connector-setup-flow.md
+++ b/docs/connector-setup-flow.md
@@ -1,0 +1,168 @@
+# Connector Setup Flow
+
+Connector setup flows let a connector collect configuration before and after credentials are established. The setup flow is authored in connector YAML and returned to clients one eligible step at a time.
+
+## Phases
+
+```yaml
+setup_flow:
+  preconnect:
+    steps: []
+  configure:
+    steps: []
+```
+
+`preconnect` steps run before the auth method establishes credentials. Use them for values needed by the auth flow itself, such as a tenant, region, or instance URL.
+
+`configure` steps run after credentials are available. Use them for connection-specific choices such as workspace selection, sync settings, or other post-auth options. Configure form steps can define `data_sources` because AuthProxy can call the upstream API through the authenticated proxy at that point.
+
+Auth-method steps and AuthProxy pseudo-steps are inserted by the runtime. Connector YAML cannot conditionally hide or override them. In particular:
+
+- Auth-method steps, such as OAuth redirect or API-key credential collection, are always eligible.
+- `apxy:verify` is always eligible when verification is needed.
+- Connector-authored step ids must not start with `apxy:`.
+
+## Form Steps
+
+Form steps are the default step type. They use JSON Schema for submitted data and optional JSONForms UI Schema for layout.
+
+```yaml
+setup_flow:
+  preconnect:
+    steps:
+      - id: region
+        title: Region
+        json_schema:
+          type: object
+          required:
+            - region
+          properties:
+            region:
+              type: string
+              enum:
+                - us
+                - eu
+```
+
+When a form step is submitted, AuthProxy validates the payload against the step's `json_schema` and merges only top-level fields declared in `properties` into the connection configuration.
+
+## Redirect Steps
+
+Redirect steps send the user to an off-platform URL before continuing setup. Set `type: redirect` and provide `redirect.url`.
+
+```yaml
+setup_flow:
+  preconnect:
+    steps:
+      - id: external_setup
+        type: redirect
+        title: External setup
+        redirect:
+          url: https://setup.example.com/start?done={{RETURN_ADVANCE}}&cancel={{RETURN_ABORT}}
+```
+
+Redirect URLs support `{{cfg.field_name}}` mustache references plus two runtime placeholders:
+
+- `{{RETURN_ADVANCE}}`: a signed one-time-use URL that advances the connection to the next step.
+- `{{RETURN_ABORT}}`: a signed one-time-use URL that aborts the in-flight setup.
+
+Redirect steps cannot define `json_schema`, `ui_schema`, or `data_sources`.
+
+## Conditional Steps
+
+Connector-authored form and redirect steps can include an `if.javascript` condition. AuthProxy evaluates the condition server-side each time it resolves the current or next setup step. Clients only receive steps whose condition is true.
+
+```yaml
+setup_flow:
+  configure:
+    steps:
+      - id: advanced_options
+        title: Advanced options
+        if:
+          javascript: |
+            cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"
+        json_schema:
+          type: object
+          properties:
+            sync_mode:
+              type: string
+```
+
+The JavaScript must evaluate to a boolean. Syntax errors, thrown errors, `null`, `undefined`, and non-boolean results fail the setup request instead of guessing the connector author's intent.
+
+The JavaScript runtime exposes these variables:
+
+| Variable | Shape | Description |
+|---|---|---|
+| `cfg` | object | The connection configuration collected by submitted setup steps so far. It is `{}` when no configuration has been saved yet. |
+| `labels` | object | The connection labels available to the runtime, including carried-forward system labels such as `apxy/cxr/type`. |
+| `annotations` | object | The connection annotations available to the runtime. It is `{}` when none are present. |
+
+Conditions are useful when a later step depends on an earlier answer, a connector label, or an operator-supplied annotation:
+
+```yaml
+setup_flow:
+  preconnect:
+    steps:
+      - id: region
+        title: Region
+        json_schema:
+          type: object
+          required:
+            - region
+          properties:
+            region:
+              type: string
+              enum:
+                - us
+                - eu
+  configure:
+    steps:
+      - id: workspace
+        title: Workspace
+        json_schema:
+          type: object
+          required:
+            - workspace_id
+          properties:
+            workspace_id:
+              type: string
+              x-data-source: workspaces
+        data_sources:
+          workspaces:
+            proxy_request:
+              method: GET
+              url: https://api.example.com/workspaces
+            transform: data.map(w => ({ value: w.id, label: w.name }))
+      - id: eu_sync_options
+        title: EU sync options
+        if:
+          javascript: |
+            cfg.region === "eu" && annotations["setup-mode"] === "advanced"
+        json_schema:
+          type: object
+          properties:
+            sync_mode:
+              type: string
+              enum:
+                - standard
+                - restricted
+```
+
+## Runtime Behavior
+
+AuthProxy applies step conditions consistently across setup APIs:
+
+- Initiating setup starts at the first eligible step.
+- Submitting a step advances to the next eligible step.
+- Resuming setup advances past a stored step that has become ineligible.
+- Reconfiguring a ready connection starts at the first eligible configure step.
+- Data sources are available only for the current eligible configure step.
+
+If all connector-authored steps in a phase are ineligible, the runtime skips that phase. Auth-method and verification steps still run according to the connector's auth method and probe configuration.
+
+## Migration Notes
+
+Adding, removing, or changing `if.javascript` changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path for configuration changes.
+
+Existing in-flight connections are evaluated against the connector version they are using. If a connection resumes while its stored step is now ineligible, AuthProxy advances it to the next eligible step rather than returning the ineligible step to the client.

--- a/internal/schema/resources/connectors/README.md
+++ b/internal/schema/resources/connectors/README.md
@@ -3,3 +3,5 @@
 This package defines connector resource configuration: auth methods, setup flow, probes, rate-limiting behavior, telemetry settings, labels, and connector metadata.
 
 Use this package for connector shapes that are shared between config, core logic, and future API DTOs. API-specific request/response wrappers belong in `internal/schema/api`.
+
+Connector-author setup-flow guidance lives in [`docs/connector-setup-flow.md`](../../../../docs/connector-setup-flow.md).


### PR DESCRIPTION
## Summary
- add a connector setup-flow guide covering preconnect/configure phases, form and redirect steps, data sources, and if.javascript conditions
- document the JavaScript context contract for cfg, labels, and annotations plus runtime behavior for skipped steps
- link the new guide from the repo docs indexes and connector schema package README

## Verification
- ./scripts/preflight.sh

Closes #626