### PR TITLE
Add DEK runtime table APIs

### DIFF
--- a/internal/database/data_encryption_key.go
+++ b/internal/database/data_encryption_key.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 const DataEncryptionKeysTable = "data_encryption_keys"
@@ -223,13 +225,121 @@ func (s *service) GetDataEncryptionKey(ctx context.Context, id apid.ID) (*DataEn
 	return &result, nil
 }
 
-func (s *service) ListDataEncryptionKeysForKey(ctx context.Context, encryptionKeyId apid.ID) ([]*DataEncryptionKey, error) {
+func (s *service) GetCurrentDataEncryptionKeyForKey(ctx context.Context, keyId apid.ID) (*DataEncryptionKey, error) {
+	var result DataEncryptionKey
+	err := s.sq.
+		Select(result.cols()...).
+		From(DataEncryptionKeysTable).
+		Where(sq.Eq{
+			"key_id":     keyId,
+			"is_current": true,
+			"deleted_at": nil,
+		}).
+		OrderBy("created_at DESC", "id DESC").
+		Limit(1).
+		RunWith(s.db).
+		QueryRow().
+		Scan(result.fields()...)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to get current data encryption key: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (s *service) ClearCurrentDataEncryptionKeyFlagForKey(ctx context.Context, keyId apid.ID) error {
+	now := apctx.GetClock(ctx).Now()
+	_, err := s.sq.
+		Update(DataEncryptionKeysTable).
+		Set("is_current", false).
+		Set("updated_at", now).
+		Where(sq.Eq{
+			"key_id":     keyId,
+			"is_current": true,
+			"deleted_at": nil,
+		}).
+		RunWith(s.db).
+		Exec()
+	if err != nil {
+		return fmt.Errorf("failed to clear current data encryption key flag for key %s: %w", keyId, err)
+	}
+
+	return nil
+}
+
+func (s *service) SetDataEncryptionKeyCurrentFlag(ctx context.Context, id apid.ID, isCurrent bool) error {
+	now := apctx.GetClock(ctx).Now()
+
+	return s.transaction(func(tx *sql.Tx) error {
+		var keyId apid.ID
+		err := s.sq.
+			Select("key_id").
+			From(DataEncryptionKeysTable).
+			Where(sq.Eq{
+				"id":         id,
+				"deleted_at": nil,
+			}).
+			RunWith(tx).
+			QueryRow().
+			Scan(&keyId)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to get data encryption key: %w", err)
+		}
+
+		if isCurrent {
+			if _, err := s.sq.
+				Update(DataEncryptionKeysTable).
+				Set("is_current", false).
+				Set("updated_at", now).
+				Where(sq.Eq{
+					"key_id":     keyId,
+					"deleted_at": nil,
+				}).
+				RunWith(tx).
+				Exec(); err != nil {
+				return fmt.Errorf("failed to clear current data encryption keys: %w", err)
+			}
+		}
+
+		result, err := s.sq.
+			Update(DataEncryptionKeysTable).
+			Set("is_current", isCurrent).
+			Set("updated_at", now).
+			Where(sq.Eq{
+				"id":         id,
+				"deleted_at": nil,
+			}).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return fmt.Errorf("failed to set data encryption key current flag: %w", err)
+		}
+
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to set data encryption key current flag: %w", err)
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+
+		return nil
+	})
+}
+
+func (s *service) ListDataEncryptionKeysForKey(ctx context.Context, keyId apid.ID) ([]*DataEncryptionKey, error) {
 	var result DataEncryptionKey
 	rows, err := s.sq.
 		Select(result.cols()...).
 		From(DataEncryptionKeysTable).
 		Where(sq.Eq{
-			"key_id":     encryptionKeyId,
+			"key_id":     keyId,
 			"deleted_at": nil,
 		}).
 		OrderBy("created_at ASC", "id ASC").
@@ -250,4 +360,63 @@ func (s *service) ListDataEncryptionKeysForKey(ctx context.Context, encryptionKe
 	}
 
 	return results, rows.Err()
+}
+
+func (s *service) EnumerateDataEncryptionKeysForKey(
+	ctx context.Context,
+	keyId apid.ID,
+	callback func(deks []*DataEncryptionKey, lastPage bool) (keepGoing pagination.KeepGoing, err error),
+) error {
+	const pageSize = 100
+	offset := uint64(0)
+
+	for {
+		rows, err := s.sq.
+			Select(util.ToPtr(DataEncryptionKey{}).cols()...).
+			From(DataEncryptionKeysTable).
+			Where(sq.Eq{
+				"key_id":     keyId,
+				"deleted_at": nil,
+			}).
+			OrderBy("created_at ASC", "id ASC").
+			Limit(pageSize + 1).
+			Offset(offset).
+			RunWith(s.db).
+			Query()
+		if err != nil {
+			return fmt.Errorf("failed to enumerate data encryption keys: %w", err)
+		}
+
+		var results []*DataEncryptionKey
+		for rows.Next() {
+			var dek DataEncryptionKey
+			if err := rows.Scan(dek.fields()...); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan data encryption key: %w", err)
+			}
+			results = append(results, &dek)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to enumerate data encryption keys: %w", err)
+		}
+		rows.Close()
+
+		lastPage := len(results) <= pageSize
+		if len(results) > pageSize {
+			results = results[:pageSize]
+		}
+
+		keepGoing, err := callback(results, lastPage)
+		if err != nil {
+			return err
+		}
+		if keepGoing == pagination.Stop || lastPage {
+			break
+		}
+
+		offset += pageSize
+	}
+
+	return nil
 }

--- a/internal/database/data_encryption_key_test.go
+++ b/internal/database/data_encryption_key_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -56,6 +57,37 @@ func TestDataEncryptionKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, listed, 1)
 		require.Equal(t, dek.Id, listed[0].Id)
+
+		current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, ekID)
+		require.NoError(t, err)
+		require.Equal(t, dek.Id, current.Id)
+	})
+
+	t.Run("enumerate by key", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		ctx := apctx.NewBuilderBackground().Build()
+		ekID := apid.New(apid.PrefixKey)
+		otherKeyID := apid.New(apid.PrefixKey)
+
+		first := validTestDataEncryptionKey(ekID, "v1", false)
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, first))
+		second := validTestDataEncryptionKey(ekID, "v2", false)
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, second))
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, validTestDataEncryptionKey(otherKeyID, "v1", false)))
+
+		var ids []apid.ID
+		var sawLastPage bool
+		err := db.EnumerateDataEncryptionKeysForKey(ctx, ekID, func(deks []*DataEncryptionKey, lastPage bool) (pagination.KeepGoing, error) {
+			sawLastPage = lastPage
+			for _, dek := range deks {
+				ids = append(ids, dek.Id)
+				require.Equal(t, ekID, dek.KeyId)
+			}
+			return pagination.Continue, nil
+		})
+		require.NoError(t, err)
+		require.True(t, sawLastPage)
+		require.ElementsMatch(t, []apid.ID{first.Id, second.Id}, ids)
 	})
 
 	t.Run("new current clears previous current", func(t *testing.T) {
@@ -76,6 +108,71 @@ func TestDataEncryptionKey(t *testing.T) {
 		gotSecond, err := db.GetDataEncryptionKey(ctx, second.Id)
 		require.NoError(t, err)
 		require.True(t, gotSecond.IsCurrent)
+
+		current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, ekID)
+		require.NoError(t, err)
+		require.Equal(t, second.Id, current.Id)
+	})
+
+	t.Run("current flag updates", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		now := time.Date(1985, time.October, 26, 1, 20, 0, 0, time.UTC)
+		fakeClock := clock.NewFakeClock(now)
+		ctx := apctx.NewBuilderBackground().WithClock(fakeClock).Build()
+
+		ekID := apid.New(apid.PrefixKey)
+		otherKeyID := apid.New(apid.PrefixKey)
+
+		first := validTestDataEncryptionKey(ekID, "v1", true)
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, first))
+
+		second := validTestDataEncryptionKey(ekID, "v2", false)
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, second))
+
+		other := validTestDataEncryptionKey(otherKeyID, "v1", true)
+		require.NoError(t, db.CreateDataEncryptionKey(ctx, other))
+
+		current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, ekID)
+		require.NoError(t, err)
+		require.Equal(t, first.Id, current.Id)
+
+		fakeClock.Step(time.Hour)
+		require.NoError(t, db.SetDataEncryptionKeyCurrentFlag(ctx, second.Id, true))
+
+		gotFirst, err := db.GetDataEncryptionKey(ctx, first.Id)
+		require.NoError(t, err)
+		require.False(t, gotFirst.IsCurrent)
+
+		gotSecond, err := db.GetDataEncryptionKey(ctx, second.Id)
+		require.NoError(t, err)
+		require.True(t, gotSecond.IsCurrent)
+		require.True(t, now.Add(time.Hour).Equal(gotSecond.UpdatedAt))
+
+		current, err = db.GetCurrentDataEncryptionKeyForKey(ctx, ekID)
+		require.NoError(t, err)
+		require.Equal(t, second.Id, current.Id)
+
+		otherCurrent, err := db.GetCurrentDataEncryptionKeyForKey(ctx, otherKeyID)
+		require.NoError(t, err)
+		require.Equal(t, other.Id, otherCurrent.Id)
+
+		fakeClock.Step(time.Hour)
+		require.NoError(t, db.ClearCurrentDataEncryptionKeyFlagForKey(ctx, ekID))
+
+		_, err = db.GetCurrentDataEncryptionKeyForKey(ctx, ekID)
+		require.ErrorIs(t, err, ErrNotFound)
+
+		otherCurrent, err = db.GetCurrentDataEncryptionKeyForKey(ctx, otherKeyID)
+		require.NoError(t, err)
+		require.Equal(t, other.Id, otherCurrent.Id)
+	})
+
+	t.Run("current flag update missing id", func(t *testing.T) {
+		_, db := MustApplyBlankTestDbConfig(t, nil)
+		ctx := apctx.NewBuilderBackground().Build()
+
+		err := db.SetDataEncryptionKeyCurrentFlag(ctx, apid.New(apid.PrefixDataEncryptionKey), true)
+		require.ErrorIs(t, err, ErrNotFound)
 	})
 
 	t.Run("validation", func(t *testing.T) {

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -242,7 +242,15 @@ type DB interface {
 
 	CreateDataEncryptionKey(ctx context.Context, dek *DataEncryptionKey) error
 	GetDataEncryptionKey(ctx context.Context, id apid.ID) (*DataEncryptionKey, error)
-	ListDataEncryptionKeysForKey(ctx context.Context, encryptionKeyId apid.ID) ([]*DataEncryptionKey, error)
+	GetCurrentDataEncryptionKeyForKey(ctx context.Context, keyId apid.ID) (*DataEncryptionKey, error)
+	ClearCurrentDataEncryptionKeyFlagForKey(ctx context.Context, keyId apid.ID) error
+	SetDataEncryptionKeyCurrentFlag(ctx context.Context, id apid.ID, isCurrent bool) error
+	ListDataEncryptionKeysForKey(ctx context.Context, keyId apid.ID) ([]*DataEncryptionKey, error)
+	EnumerateDataEncryptionKeysForKey(
+		ctx context.Context,
+		keyId apid.ID,
+		callback func(deks []*DataEncryptionKey, lastPage bool) (keepGoing pagination.KeepGoing, err error),
+	) error
 
 	/*
 	 * Rate Limits

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -300,6 +300,20 @@ func (mr *MockDBMockRecorder) CheckNonceValidAndMarkUsed(ctx, nonce, retainRecor
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckNonceValidAndMarkUsed", reflect.TypeOf((*MockDB)(nil).CheckNonceValidAndMarkUsed), ctx, nonce, retainRecordUntil)
 }
 
+// ClearCurrentDataEncryptionKeyFlagForKey mocks base method.
+func (m *MockDB) ClearCurrentDataEncryptionKeyFlagForKey(ctx context.Context, keyId apid.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearCurrentDataEncryptionKeyFlagForKey", ctx, keyId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearCurrentDataEncryptionKeyFlagForKey indicates an expected call of ClearCurrentDataEncryptionKeyFlagForKey.
+func (mr *MockDBMockRecorder) ClearCurrentDataEncryptionKeyFlagForKey(ctx, keyId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCurrentDataEncryptionKeyFlagForKey", reflect.TypeOf((*MockDB)(nil).ClearCurrentDataEncryptionKeyFlagForKey), ctx, keyId)
+}
+
 // ClearCurrentFlagForKey mocks base method.
 func (m *MockDB) ClearCurrentFlagForKey(ctx context.Context, encryptionKeyId apid.ID) error {
 	m.ctrl.T.Helper()
@@ -803,6 +817,20 @@ func (mr *MockDBMockRecorder) EnsureNamespaceByPath(ctx, path interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureNamespaceByPath", reflect.TypeOf((*MockDB)(nil).EnsureNamespaceByPath), ctx, path)
 }
 
+// EnumerateDataEncryptionKeysForKey mocks base method.
+func (m *MockDB) EnumerateDataEncryptionKeysForKey(ctx context.Context, keyId apid.ID, callback func([]*database.DataEncryptionKey, bool) (pagination.KeepGoing, error)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnumerateDataEncryptionKeysForKey", ctx, keyId, callback)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnumerateDataEncryptionKeysForKey indicates an expected call of EnumerateDataEncryptionKeysForKey.
+func (mr *MockDBMockRecorder) EnumerateDataEncryptionKeysForKey(ctx, keyId, callback interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnumerateDataEncryptionKeysForKey", reflect.TypeOf((*MockDB)(nil).EnumerateDataEncryptionKeysForKey), ctx, keyId, callback)
+}
+
 // EnumerateEncryptionKeyVersionsForKey mocks base method.
 func (m *MockDB) EnumerateEncryptionKeyVersionsForKey(ctx context.Context, ekId apid.ID, callback func([]*database.EncryptionKeyVersion, bool) (pagination.KeepGoing, error)) error {
 	m.ctrl.T.Helper()
@@ -1007,6 +1035,21 @@ func (m *MockDB) GetConnectorVersions(ctx context.Context, requested []database.
 func (mr *MockDBMockRecorder) GetConnectorVersions(ctx, requested interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorVersions", reflect.TypeOf((*MockDB)(nil).GetConnectorVersions), ctx, requested)
+}
+
+// GetCurrentDataEncryptionKeyForKey mocks base method.
+func (m *MockDB) GetCurrentDataEncryptionKeyForKey(ctx context.Context, keyId apid.ID) (*database.DataEncryptionKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentDataEncryptionKeyForKey", ctx, keyId)
+	ret0, _ := ret[0].(*database.DataEncryptionKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentDataEncryptionKeyForKey indicates an expected call of GetCurrentDataEncryptionKeyForKey.
+func (mr *MockDBMockRecorder) GetCurrentDataEncryptionKeyForKey(ctx, keyId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentDataEncryptionKeyForKey", reflect.TypeOf((*MockDB)(nil).GetCurrentDataEncryptionKeyForKey), ctx, keyId)
 }
 
 // GetCurrentEncryptionKeyVersionForKey mocks base method.
@@ -1351,18 +1394,18 @@ func (mr *MockDBMockRecorder) ListConnectorsFromCursor(ctx, cursor interface{}) 
 }
 
 // ListDataEncryptionKeysForKey mocks base method.
-func (m *MockDB) ListDataEncryptionKeysForKey(ctx context.Context, encryptionKeyId apid.ID) ([]*database.DataEncryptionKey, error) {
+func (m *MockDB) ListDataEncryptionKeysForKey(ctx context.Context, keyId apid.ID) ([]*database.DataEncryptionKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDataEncryptionKeysForKey", ctx, encryptionKeyId)
+	ret := m.ctrl.Call(m, "ListDataEncryptionKeysForKey", ctx, keyId)
 	ret0, _ := ret[0].([]*database.DataEncryptionKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDataEncryptionKeysForKey indicates an expected call of ListDataEncryptionKeysForKey.
-func (mr *MockDBMockRecorder) ListDataEncryptionKeysForKey(ctx, encryptionKeyId interface{}) *gomock.Call {
+func (mr *MockDBMockRecorder) ListDataEncryptionKeysForKey(ctx, keyId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataEncryptionKeysForKey", reflect.TypeOf((*MockDB)(nil).ListDataEncryptionKeysForKey), ctx, encryptionKeyId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataEncryptionKeysForKey", reflect.TypeOf((*MockDB)(nil).ListDataEncryptionKeysForKey), ctx, keyId)
 }
 
 // ListEncryptionKeyVersionsForKey mocks base method.
@@ -1842,6 +1885,20 @@ func (m *MockDB) SetCursorEncryptor(e pagination.CursorEncryptor) {
 func (mr *MockDBMockRecorder) SetCursorEncryptor(e interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCursorEncryptor", reflect.TypeOf((*MockDB)(nil).SetCursorEncryptor), e)
+}
+
+// SetDataEncryptionKeyCurrentFlag mocks base method.
+func (m *MockDB) SetDataEncryptionKeyCurrentFlag(ctx context.Context, id apid.ID, isCurrent bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDataEncryptionKeyCurrentFlag", ctx, id, isCurrent)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetDataEncryptionKeyCurrentFlag indicates an expected call of SetDataEncryptionKeyCurrentFlag.
+func (mr *MockDBMockRecorder) SetDataEncryptionKeyCurrentFlag(ctx, id, isCurrent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataEncryptionKeyCurrentFlag", reflect.TypeOf((*MockDB)(nil).SetDataEncryptionKeyCurrentFlag), ctx, id, isCurrent)
 }
 
 // SetEncryptionKeyVersionCurrentFlag mocks base method.

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -28,19 +28,6 @@ func NewGenerateDataEncryptionKeysTask() *asynq.Task {
 	return asynq.NewTask(TaskTypeGenerateDataEncryptionKeys, nil)
 }
 
-func currentDataEncryptionKey(deks []*database.DataEncryptionKey) *database.DataEncryptionKey {
-	var current *database.DataEncryptionKey
-	for _, dek := range deks {
-		if !dek.IsCurrent {
-			continue
-		}
-		if current == nil || dek.CreatedAt.After(current.CreatedAt) {
-			current = dek
-		}
-	}
-	return current
-}
-
 func createDataEncryptionKey(
 	ctx context.Context,
 	db database.DB,
@@ -83,12 +70,11 @@ func ensureDataEncryptionKeyForKey(
 		return false, fmt.Errorf("key data provider %q requires DEKs but cannot generate them", kd.GetProviderType())
 	}
 
-	deks, err := db.ListDataEncryptionKeysForKey(ctx, encryptionKeyId)
-	if err != nil {
+	current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, encryptionKeyId)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		return false, err
 	}
 
-	current := currentDataEncryptionKey(deks)
 	if current == nil {
 		if !policy.ShouldEnsureCurrent() {
 			return false, nil


### PR DESCRIPTION
## Summary
- Add current-DEK database APIs for data_encryption_keys, including current lookup, current flag set/clear, and per-key enumeration.
- Update DEK generation to use GetCurrentDataEncryptionKeyForKey instead of listing and scanning rows locally.
- Expand DEK database tests for create/get/list/current behavior, current flag updates, missing current behavior, and per-key enumeration.
- Regenerate the database mock.

## Tests
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test ./internal/database
- ./scripts/preflight.sh

Closes #609