### PR TITLE
Add DEK provider wrapping abstraction

### DIFF
--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -32,9 +32,9 @@ func createDataEncryptionKey(
 	ctx context.Context,
 	db database.DB,
 	encryptionKeyId apid.ID,
-	generator config.KeyDataGeneratesDataEncryptionKeys,
+	kd *config.KeyData,
 ) (*database.DataEncryptionKey, error) {
-	generated, err := generator.GenerateDataEncryptionKey(ctx)
+	generated, err := kd.GenerateDataEncryptionKey(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -65,11 +65,6 @@ func ensureDataEncryptionKeyForKey(
 		return false, nil
 	}
 
-	generator, ok := kd.InnerVal.(config.KeyDataGeneratesDataEncryptionKeys)
-	if !ok {
-		return false, fmt.Errorf("key data provider %q requires DEKs but cannot generate them", kd.GetProviderType())
-	}
-
 	current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, encryptionKeyId)
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		return false, err
@@ -79,14 +74,14 @@ func ensureDataEncryptionKeyForKey(
 		if !policy.ShouldEnsureCurrent() {
 			return false, nil
 		}
-		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, generator); err != nil {
+		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, kd); err != nil {
 			return false, err
 		}
 		return true, nil
 	}
 
 	if policy.ShouldRotate(apctx.GetClock(ctx).Now(), current.CreatedAt) {
-		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, generator); err != nil {
+		if _, err := createDataEncryptionKey(ctx, db, encryptionKeyId, kd); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/internal/schema/config/key_data.go
+++ b/internal/schema/config/key_data.go
@@ -22,8 +22,8 @@ type KeyDataType interface {
 }
 
 // DataEncryptionKeyInfo is the database-visible metadata for a persisted DEK.
-// KMS-style providers use these rows to unwrap DEKs and expose them as
-// application-facing encryption key versions.
+// Providers use these rows to unwrap DEKs and expose runtime key bytes without
+// storing provider key versions in the database.
 type DataEncryptionKeyInfo struct {
 	ID              string
 	EncryptionKeyID string
@@ -34,9 +34,18 @@ type DataEncryptionKeyInfo struct {
 	IsCurrent       bool
 }
 
-// GeneratedDataEncryptionKey is protected DEK material produced by a KMS-style
-// provider. The plaintext DEK may be returned for tests, but callers should only
-// persist the provider metadata and ProtectedData.
+// KeyWrappingKeyInfo identifies the provider key material currently used to
+// wrap DEKs. The wrapping key bytes are deliberately not exposed here.
+type KeyWrappingKeyInfo struct {
+	Provider        ProviderType
+	ProviderID      string
+	ProviderVersion string
+	Metadata        map[string]string
+}
+
+// GeneratedDataEncryptionKey is protected DEK material produced by a key data
+// provider. The plaintext DEK is returned for immediate cache use by callers,
+// but only the provider metadata and ProtectedData should be persisted.
 type GeneratedDataEncryptionKey struct {
 	Provider        ProviderType
 	ProviderID      string
@@ -53,8 +62,21 @@ type KeyDataRequiresDataEncryptionKeys interface {
 	ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error)
 }
 
+// KeyDataWrapsDataEncryptionKeys is implemented by providers that manage DEK
+// wrapping themselves. Providers that expose raw key bytes do not need to
+// implement this; the KeyData facade can wrap and unwrap with the current
+// KeyVersionInfo.Data.
+type KeyDataWrapsDataEncryptionKeys interface {
+	CurrentWrappingKey(ctx context.Context) (KeyWrappingKeyInfo, error)
+	WrapDataEncryptionKey(ctx context.Context, dek []byte) (GeneratedDataEncryptionKey, error)
+	UnwrapDataEncryptionKey(ctx context.Context, dek DataEncryptionKeyInfo) ([]byte, error)
+}
+
 // KeyDataGeneratesDataEncryptionKeys is implemented by providers that can
-// generate and wrap a new DEK for persistence in data_encryption_keys.
+// natively generate and wrap a new DEK for persistence in data_encryption_keys.
+// KeyData itself also exposes GenerateDataEncryptionKey, falling back to
+// AuthProxy-generated random bytes plus provider wrapping when this interface
+// is not implemented by the inner provider.
 type KeyDataGeneratesDataEncryptionKeys interface {
 	GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error)
 }

--- a/internal/schema/config/key_data_dek.go
+++ b/internal/schema/config/key_data_dek.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	// DataEncryptionKeySize is the byte size for AuthProxy-generated DEKs.
+	DataEncryptionKeySize = 32
+
+	// KeyVersionProtectedDataTypeAuthProxyAESGCM is the protected-data type used
+	// when AuthProxy generates DEK bytes and wraps them with provider key bytes.
+	KeyVersionProtectedDataTypeAuthProxyAESGCM = "authproxy_aes_gcm"
+
+	protectedDataMetadataWrappingProvider        = "wrapping_provider"
+	protectedDataMetadataWrappingProviderID      = "wrapping_provider_id"
+	protectedDataMetadataWrappingProviderVersion = "wrapping_provider_version"
+)
+
+// CurrentWrappingKey returns the provider key identity that would be used for
+// DEK wrapping right now. Providers that do not manage wrapping themselves derive
+// this from their current KeyVersionInfo without exposing key bytes.
+func (kd *KeyData) CurrentWrappingKey(ctx context.Context) (KeyWrappingKeyInfo, error) {
+	if kd == nil || kd.InnerVal == nil {
+		return KeyWrappingKeyInfo{}, errors.New("key data is nil")
+	}
+
+	if wrapper, ok := kd.InnerVal.(KeyDataWrapsDataEncryptionKeys); ok {
+		return wrapper.CurrentWrappingKey(ctx)
+	}
+
+	current, err := kd.InnerVal.GetCurrentVersion(ctx)
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+	if len(current.Data) == 0 {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("current key data for provider %q does not expose wrapping bytes", current.Provider)
+	}
+
+	return KeyWrappingKeyInfo{
+		Provider:        current.Provider,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+	}, nil
+}
+
+// GenerateDataEncryptionKey returns a new DEK wrapped by this key data provider.
+// Native KMS-style generators can override this through the inner provider;
+// otherwise AuthProxy generates 32 random bytes and wraps them through the
+// provider's current key material.
+func (kd *KeyData) GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error) {
+	if kd == nil || kd.InnerVal == nil {
+		return GeneratedDataEncryptionKey{}, errors.New("key data is nil")
+	}
+
+	if generator, ok := kd.InnerVal.(KeyDataGeneratesDataEncryptionKeys); ok {
+		return generator.GenerateDataEncryptionKey(ctx)
+	}
+
+	dek, err := generateAuthProxyDataEncryptionKey()
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	return kd.WrapDataEncryptionKey(ctx, dek)
+}
+
+// WrapDataEncryptionKey wraps the provided plaintext DEK and returns the
+// metadata needed to persist it. Providers with native wrapping can override
+// this; ordinary secret-backed providers use AES-GCM with their current key
+// material.
+func (kd *KeyData) WrapDataEncryptionKey(ctx context.Context, dek []byte) (GeneratedDataEncryptionKey, error) {
+	if kd == nil || kd.InnerVal == nil {
+		return GeneratedDataEncryptionKey{}, errors.New("key data is nil")
+	}
+	if len(dek) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("data encryption key is empty")
+	}
+
+	if wrapper, ok := kd.InnerVal.(KeyDataWrapsDataEncryptionKeys); ok {
+		return wrapper.WrapDataEncryptionKey(ctx, dek)
+	}
+
+	current, err := kd.InnerVal.GetCurrentVersion(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	if len(current.Data) == 0 {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("current key data for provider %q does not expose wrapping bytes", current.Provider)
+	}
+
+	protected, err := wrapDataEncryptionKeyWithAESGCM(current.Data, current, dek)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	return GeneratedDataEncryptionKey{
+		Provider:        current.Provider,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+		ProtectedData:   protected,
+		Data:            append([]byte(nil), dek...),
+	}, nil
+}
+
+// UnwrapDataEncryptionKey returns the plaintext DEK bytes for a persisted DEK
+// row. The provider version recorded on the DEK chooses the wrapping key
+// version, allowing providers that retain historical key material to unwrap
+// older DEKs during rewrap.
+func (kd *KeyData) UnwrapDataEncryptionKey(ctx context.Context, dek DataEncryptionKeyInfo) ([]byte, error) {
+	if kd == nil || kd.InnerVal == nil {
+		return nil, errors.New("key data is nil")
+	}
+
+	if wrapper, ok := kd.InnerVal.(KeyDataWrapsDataEncryptionKeys); ok {
+		return wrapper.UnwrapDataEncryptionKey(ctx, dek)
+	}
+
+	if dek.ProtectedData == nil || dek.ProtectedData.IsZero() {
+		return nil, errors.New("data encryption key protected data is empty")
+	}
+	if dek.ProtectedData.Type != KeyVersionProtectedDataTypeAuthProxyAESGCM {
+		return nil, fmt.Errorf("unsupported protected data type %q", dek.ProtectedData.Type)
+	}
+
+	version, err := kd.InnerVal.GetVersion(ctx, dek.ProviderVersion)
+	if err != nil {
+		return nil, err
+	}
+	if version.Provider != dek.Provider {
+		return nil, fmt.Errorf("data encryption key provider %q does not match wrapping provider %q", dek.Provider, version.Provider)
+	}
+	if dek.ProviderID != "" && version.ProviderID != dek.ProviderID {
+		return nil, fmt.Errorf("data encryption key provider id %q does not match wrapping provider id %q", dek.ProviderID, version.ProviderID)
+	}
+	if len(version.Data) == 0 {
+		return nil, fmt.Errorf("key data for provider %q version %q does not expose wrapping bytes", version.Provider, version.ProviderVersion)
+	}
+
+	return unwrapDataEncryptionKeyWithAESGCM(version.Data, *dek.ProtectedData)
+}
+
+func generateAuthProxyDataEncryptionKey() ([]byte, error) {
+	dek := make([]byte, DataEncryptionKeySize)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return nil, fmt.Errorf("failed to generate data encryption key: %w", err)
+	}
+	return dek, nil
+}
+
+func wrapDataEncryptionKeyWithAESGCM(
+	wrappingKey []byte,
+	info KeyVersionInfo,
+	dek []byte,
+) (KeyVersionProtectedData, error) {
+	block, err := aes.NewCipher(wrappingKey)
+	if err != nil {
+		return KeyVersionProtectedData{}, fmt.Errorf("failed to create DEK wrapping cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return KeyVersionProtectedData{}, fmt.Errorf("failed to create DEK wrapping GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return KeyVersionProtectedData{}, fmt.Errorf("failed to generate DEK wrapping nonce: %w", err)
+	}
+
+	encrypted := gcm.Seal(nonce, nonce, dek, nil)
+	return KeyVersionProtectedData{
+		Type:        KeyVersionProtectedDataTypeAuthProxyAESGCM,
+		WrappedData: base64.StdEncoding.EncodeToString(encrypted),
+		Metadata: map[string]string{
+			protectedDataMetadataWrappingProvider:        string(info.Provider),
+			protectedDataMetadataWrappingProviderID:      info.ProviderID,
+			protectedDataMetadataWrappingProviderVersion: info.ProviderVersion,
+		},
+	}, nil
+}
+
+func unwrapDataEncryptionKeyWithAESGCM(wrappingKey []byte, protected KeyVersionProtectedData) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(protected.WrappedData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode wrapped data encryption key: %w", err)
+	}
+
+	block, err := aes.NewCipher(wrappingKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DEK unwrapping cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DEK unwrapping GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(decoded) < nonceSize {
+		return nil, errors.New("wrapped data encryption key is too short")
+	}
+
+	return gcm.Open(nil, decoded[:nonceSize], decoded[nonceSize:], nil)
+}
+
+var _ KeyDataGeneratesDataEncryptionKeys = (*KeyData)(nil)
+var _ KeyDataWrapsDataEncryptionKeys = (*KeyData)(nil)

--- a/internal/schema/config/key_data_dek_test.go
+++ b/internal/schema/config/key_data_dek_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyDataAuthProxyGeneratedDataEncryptionKey(t *testing.T) {
+	ctx := context.Background()
+
+	ResetKeyDataMockRegistry()
+	t.Cleanup(ResetKeyDataMockRegistry)
+
+	kd := NewKeyDataMock("authproxy-generated-dek")
+	wrappingKey := util.MustGenerateSecureRandomKey(32)
+	KeyDataMockAddVersion("authproxy-generated-dek", "mock-key", "v1", wrappingKey)
+
+	current, err := kd.CurrentWrappingKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeMock, current.Provider)
+	require.Equal(t, "mock-key", current.ProviderID)
+	require.Equal(t, "v1", current.ProviderVersion)
+
+	generated, err := kd.GenerateDataEncryptionKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeMock, generated.Provider)
+	require.Equal(t, "mock-key", generated.ProviderID)
+	require.Equal(t, "v1", generated.ProviderVersion)
+	require.Len(t, generated.Data, DataEncryptionKeySize)
+	require.Equal(t, KeyVersionProtectedDataTypeAuthProxyAESGCM, generated.ProtectedData.Type)
+	require.Equal(t, string(ProviderTypeMock), generated.ProtectedData.Metadata[protectedDataMetadataWrappingProvider])
+	require.Equal(t, "mock-key", generated.ProtectedData.Metadata[protectedDataMetadataWrappingProviderID])
+	require.Equal(t, "v1", generated.ProtectedData.Metadata[protectedDataMetadataWrappingProviderVersion])
+	require.NotEmpty(t, generated.ProtectedData.WrappedData)
+
+	unwrapped, err := kd.UnwrapDataEncryptionKey(ctx, DataEncryptionKeyInfo{
+		ID:              "dek_generated",
+		EncryptionKeyID: "key_generated",
+		Provider:        generated.Provider,
+		ProviderID:      generated.ProviderID,
+		ProviderVersion: generated.ProviderVersion,
+		ProtectedData:   &generated.ProtectedData,
+	})
+	require.NoError(t, err)
+	require.Equal(t, generated.Data, unwrapped)
+}
+
+func TestKeyDataWrapsExplicitDataEncryptionKey(t *testing.T) {
+	ctx := context.Background()
+
+	ResetKeyDataMockRegistry()
+	t.Cleanup(ResetKeyDataMockRegistry)
+
+	kd := NewKeyDataMock("explicit-dek")
+	KeyDataMockAddVersion("explicit-dek", "mock-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	dek := util.MustGenerateSecureRandomKey(DataEncryptionKeySize)
+	wrapped, err := kd.WrapDataEncryptionKey(ctx, dek)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeMock, wrapped.Provider)
+	require.Equal(t, "mock-key", wrapped.ProviderID)
+	require.Equal(t, "v1", wrapped.ProviderVersion)
+	require.Equal(t, KeyVersionProtectedDataTypeAuthProxyAESGCM, wrapped.ProtectedData.Type)
+
+	unwrapped, err := kd.UnwrapDataEncryptionKey(ctx, DataEncryptionKeyInfo{
+		ID:              "dek_explicit",
+		EncryptionKeyID: "key_explicit",
+		Provider:        wrapped.Provider,
+		ProviderID:      wrapped.ProviderID,
+		ProviderVersion: wrapped.ProviderVersion,
+		ProtectedData:   &wrapped.ProtectedData,
+	})
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+	require.Equal(t, dek, wrapped.Data)
+}
+
+func TestKeyDataNativeGeneratedDataEncryptionKey(t *testing.T) {
+	ctx := context.Background()
+
+	ResetKeyDataMockKMSRegistry()
+	t.Cleanup(ResetKeyDataMockKMSRegistry)
+
+	kd := NewKeyDataMockKMS("native-generated-dek")
+	KeyDataMockKMSAddVersion("native-generated-dek", "mock-kms-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	_, isNativeGenerator := kd.InnerVal.(KeyDataGeneratesDataEncryptionKeys)
+	require.True(t, isNativeGenerator)
+	_, isWrapper := kd.InnerVal.(KeyDataWrapsDataEncryptionKeys)
+	require.True(t, isWrapper)
+
+	current, err := kd.CurrentWrappingKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeMockKMS, current.Provider)
+	require.Equal(t, "mock-kms-key", current.ProviderID)
+	require.Equal(t, "v1", current.ProviderVersion)
+
+	generated, err := kd.GenerateDataEncryptionKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeMockKMS, generated.Provider)
+	require.Equal(t, "mock-kms-key", generated.ProviderID)
+	require.Equal(t, "v1", generated.ProviderVersion)
+	require.Len(t, generated.Data, DataEncryptionKeySize)
+	require.Equal(t, string(ProviderTypeMockKMS), generated.ProtectedData.Type)
+	require.Equal(t, "v1", generated.ProtectedData.Metadata["kek_version"])
+
+	unwrapped, err := kd.UnwrapDataEncryptionKey(ctx, DataEncryptionKeyInfo{
+		ID:              "dek_native",
+		EncryptionKeyID: "key_native",
+		Provider:        generated.Provider,
+		ProviderID:      generated.ProviderID,
+		ProviderVersion: generated.ProviderVersion,
+		ProtectedData:   &generated.ProtectedData,
+	})
+	require.NoError(t, err)
+	require.Equal(t, generated.Data, unwrapped)
+}

--- a/internal/schema/config/key_data_mock_kms.go
+++ b/internal/schema/config/key_data_mock_kms.go
@@ -153,27 +153,14 @@ func (m *KeyDataMockKMS) ListVersions(ctx context.Context) ([]KeyVersionInfo, er
 	return m.ListVersionsWithDataEncryptionKeys(ctx, nil)
 }
 
-func (m *KeyDataMockKMS) ListVersionsWithDataEncryptionKeys(_ context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error) {
+func (m *KeyDataMockKMS) ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error) {
 	var result []KeyVersionInfo
 	for _, dekInfo := range deks {
 		if dekInfo.Provider != ProviderTypeMockKMS {
 			continue
 		}
-		if dekInfo.ProtectedData == nil || dekInfo.ProtectedData.IsZero() {
-			continue
-		}
 
-		kekVersion := dekInfo.ProtectedData.Metadata["kek_version"]
-		if kekVersion == "" {
-			kekVersion = dekInfo.ProviderVersion
-		}
-
-		kek, err := m.version(dekInfo.ProviderID, kekVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		dekBytes, err := mockKMSUnwrap(kek.KeyEncryptionKey, *dekInfo.ProtectedData)
+		dekBytes, err := m.UnwrapDataEncryptionKey(ctx, dekInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -190,15 +177,35 @@ func (m *KeyDataMockKMS) ListVersionsWithDataEncryptionKeys(_ context.Context, d
 	return result, nil
 }
 
-func (m *KeyDataMockKMS) GenerateDataEncryptionKey(_ context.Context) (GeneratedDataEncryptionKey, error) {
+func (m *KeyDataMockKMS) CurrentWrappingKey(_ context.Context) (KeyWrappingKeyInfo, error) {
+	current, err := m.currentVersion()
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	return KeyWrappingKeyInfo{
+		Provider:        ProviderTypeMockKMS,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+	}, nil
+}
+
+func (m *KeyDataMockKMS) GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error) {
+	dek, err := generateAuthProxyDataEncryptionKey()
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate mock kms data key: %w", err)
+	}
+
+	return m.WrapDataEncryptionKey(ctx, dek)
+}
+
+func (m *KeyDataMockKMS) WrapDataEncryptionKey(_ context.Context, dek []byte) (GeneratedDataEncryptionKey, error) {
 	current, err := m.currentVersion()
 	if err != nil {
 		return GeneratedDataEncryptionKey{}, err
 	}
-
-	dek := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
-		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate mock kms data key: %w", err)
+	if len(dek) == 0 {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("data encryption key is empty")
 	}
 
 	protected, err := mockKMSWrap(current.KeyEncryptionKey, current.ProviderVersion, dek)
@@ -211,8 +218,29 @@ func (m *KeyDataMockKMS) GenerateDataEncryptionKey(_ context.Context) (Generated
 		ProviderID:      current.ProviderID,
 		ProviderVersion: current.ProviderVersion,
 		ProtectedData:   protected,
-		Data:            dek,
+		Data:            append([]byte(nil), dek...),
 	}, nil
+}
+
+func (m *KeyDataMockKMS) UnwrapDataEncryptionKey(_ context.Context, dekInfo DataEncryptionKeyInfo) ([]byte, error) {
+	if dekInfo.Provider != ProviderTypeMockKMS {
+		return nil, fmt.Errorf("unsupported mock kms provider %q", dekInfo.Provider)
+	}
+	if dekInfo.ProtectedData == nil || dekInfo.ProtectedData.IsZero() {
+		return nil, fmt.Errorf("data encryption key protected data is empty")
+	}
+
+	kekVersion := dekInfo.ProtectedData.Metadata["kek_version"]
+	if kekVersion == "" {
+		kekVersion = dekInfo.ProviderVersion
+	}
+
+	kek, err := m.version(dekInfo.ProviderID, kekVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return mockKMSUnwrap(kek.KeyEncryptionKey, *dekInfo.ProtectedData)
 }
 
 func (m *KeyDataMockKMS) GetProviderType() ProviderType {
@@ -296,4 +324,5 @@ func mockKMSDecrypt(key []byte, data []byte) ([]byte, error) {
 
 var _ KeyDataType = (*KeyDataMockKMS)(nil)
 var _ KeyDataRequiresDataEncryptionKeys = (*KeyDataMockKMS)(nil)
+var _ KeyDataWrapsDataEncryptionKeys = (*KeyDataMockKMS)(nil)
 var _ KeyDataGeneratesDataEncryptionKeys = (*KeyDataMockKMS)(nil)


### PR DESCRIPTION
## Summary
- Add KeyData wrapping-key, wrap, unwrap, and DEK generation facade methods.
- Provide the AuthProxy-generated fallback path for providers that expose current key bytes but do not natively generate DEKs.
- Adapt mock KMS to the explicit wrap/unwrap abstraction while preserving its native generator path.
- Update DEK generation to call the generalized KeyData facade.
- Add config tests for AuthProxy-generated, explicit wrapped, and native mock KMS DEK paths.

## Tests
- go test ./internal/schema/config ./internal/encrypt
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...
- ./scripts/preflight.sh

Closes #610