### PR TITLE
Generate DEKs for unified data encryption keys

### DIFF
--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -61,8 +61,8 @@ func ensureDataEncryptionKeyForKey(
 	encryptionKeyId apid.ID,
 	kd *config.KeyData,
 ) (bool, error) {
-	if kd == nil || !kd.RequiresDataEncryptionKeys() {
-		return false, nil
+	if kd == nil {
+		return false, errors.New("key data is nil")
 	}
 
 	current, err := db.GetCurrentDataEncryptionKeyForKey(ctx, encryptionKeyId)
@@ -88,6 +88,25 @@ func ensureDataEncryptionKeyForKey(
 	}
 
 	return false, nil
+}
+
+func shouldManageDataEncryptionKeysForKey(key *database.Key) bool {
+	if key == nil {
+		return false
+	}
+	if key.State != database.KeyStateActive {
+		return false
+	}
+	if key.Usage != database.KeyUsageDataEncryption {
+		return false
+	}
+
+	switch key.MaterialType {
+	case database.KeyMaterialTypeSymmetric, database.KeyMaterialTypeExternal:
+		return true
+	default:
+		return false
+	}
 }
 
 func generateDataEncryptionKeysToDatabase(
@@ -134,8 +153,25 @@ func generateDataEncryptionKeysToDatabase(
 	}
 
 	var result *multierror.Error
+	generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, globalEncryptionKeyID, sa.GlobalAESKey)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to reconcile data encryption key for global key"))
+	} else {
+		if generated {
+			logger.Info("generated data encryption key", "key_id", globalEncryptionKeyID)
+		}
+
+		err = syncKeyVersionsForKeyToDatabase(ctx, db, keyVersionIdDataCache, globalEncryptionKeyID, sa.GlobalAESKey)
+		if err != nil {
+			result = multierror.Append(result, errors.Wrap(err, "failed to sync global key data after data encryption key generation"))
+		}
+	}
+
 	_, err = db.EnumerateKeysInDependencyOrder(ctx, func(keys []*database.Key, _ int) (keepGoing pagination.KeepGoing, err error) {
 		for _, key := range keys {
+			if key.Id == globalEncryptionKeyID {
+				continue
+			}
 			if key.EncryptedKeyData == nil {
 				continue
 			}
@@ -166,13 +202,15 @@ func generateDataEncryptionKeysToDatabase(
 				continue
 			}
 
-			generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, key.Id, &keyData)
-			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to reconcile data encryption key for key ID %s", key.Id))
-				continue
-			}
-			if generated {
-				logger.Info("generated data encryption key", "encryption_key_id", key.Id)
+			if shouldManageDataEncryptionKeysForKey(key) {
+				generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, key.Id, &keyData)
+				if err != nil {
+					result = multierror.Append(result, errors.Wrapf(err, "failed to reconcile data encryption key for key ID %s", key.Id))
+					continue
+				}
+				if generated {
+					logger.Info("generated data encryption key", "key_id", key.Id)
+				}
 			}
 
 			err = syncKeyVersionsForKeyToDatabase(ctx, db, keyVersionIdDataCache, key.Id, &keyData)

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -26,7 +26,7 @@ type mockKMSGenerateTestEnv struct {
 	ekID      apid.ID
 }
 
-func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTestEnv {
+func setupGenerateTest(t *testing.T, keyDataFactory func() *sconfig.KeyData) mockKMSGenerateTestEnv {
 	t.Helper()
 
 	sconfig.ResetKeyDataMockRegistry()
@@ -59,10 +59,7 @@ func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTes
 	require.NoError(t, err)
 	require.Len(t, globalVersions, 1)
 
-	kmsKeyData := sconfig.NewKeyDataMockKMS("namespace-kms")
-	if kmsVersions {
-		sconfig.KeyDataMockKMSAddVersion("namespace-kms", "mock-kms-key", "v1", util.MustGenerateSecureRandomKey(32))
-	}
+	keyData := keyDataFactory()
 
 	ekID := apid.New(apid.PrefixKey)
 	namespace := "root.kms"
@@ -75,7 +72,7 @@ func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTes
 		Id:               ekID,
 		Namespace:        namespace,
 		State:            database.KeyStateActive,
-		EncryptedKeyData: encryptKeyDataForTest(t, globalVersions[0].Id, globalKeyBytes, kmsKeyData),
+		EncryptedKeyData: encryptKeyDataForTest(t, globalVersions[0].Id, globalKeyBytes, keyData),
 	}))
 
 	return mockKMSGenerateTestEnv{
@@ -87,6 +84,28 @@ func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTes
 		namespace: namespace,
 		ekID:      ekID,
 	}
+}
+
+func setupMockKMSGenerateTest(t *testing.T, kmsVersions bool) mockKMSGenerateTestEnv {
+	t.Helper()
+
+	return setupGenerateTest(t, func() *sconfig.KeyData {
+		kmsKeyData := sconfig.NewKeyDataMockKMS("namespace-kms")
+		if kmsVersions {
+			sconfig.KeyDataMockKMSAddVersion("namespace-kms", "mock-kms-key", "v1", util.MustGenerateSecureRandomKey(32))
+		}
+		return kmsKeyData
+	})
+}
+
+func setupMockSecretGenerateTest(t *testing.T, keyBytes []byte) mockKMSGenerateTestEnv {
+	t.Helper()
+
+	return setupGenerateTest(t, func() *sconfig.KeyData {
+		keyData := sconfig.NewKeyDataMock("namespace-secret")
+		sconfig.KeyDataMockAddVersion("namespace-secret", "mock-secret-key", "v1", keyBytes)
+		return keyData
+	})
 }
 
 func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
@@ -104,6 +123,13 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Equal(t, "mock-kms-key", deks[0].ProviderID)
 		require.Equal(t, "v1", deks[0].ProviderVersion)
 		require.NotEmpty(t, deks[0].ProtectedData.WrappedData)
+
+		globalDEKs, err := env.db.ListDataEncryptionKeysForKey(env.ctx, globalEncryptionKeyID)
+		require.NoError(t, err)
+		require.Len(t, globalDEKs, 1)
+		require.True(t, globalDEKs[0].IsCurrent)
+		require.Equal(t, string(sconfig.ProviderTypeMock), globalDEKs[0].Provider)
+		require.Equal(t, sconfig.KeyVersionProtectedDataTypeAuthProxyAESGCM, globalDEKs[0].ProtectedData.Type)
 
 		versions, err := env.db.ListEncryptionKeyVersionsForKey(env.ctx, env.ekID)
 		require.NoError(t, err)
@@ -129,6 +155,10 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		deks, err := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
 		require.NoError(t, err)
 		require.Len(t, deks, 1)
+
+		globalDEKs, err := env.db.ListDataEncryptionKeysForKey(env.ctx, globalEncryptionKeyID)
+		require.NoError(t, err)
+		require.Len(t, globalDEKs, 1)
 	})
 
 	t.Run("rotates when current dek exceeds policy age", func(t *testing.T) {
@@ -156,6 +186,14 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Len(t, versions, 2)
 		require.Equal(t, string(deks[1].Id), versions[1].ProviderID)
 		require.True(t, versions[1].IsCurrent)
+
+		globalDEKs, err := env.db.ListDataEncryptionKeysForKey(env.ctx, globalEncryptionKeyID)
+		require.NoError(t, err)
+		require.Len(t, globalDEKs, 2)
+		require.False(t, globalDEKs[0].IsCurrent)
+		require.True(t, globalDEKs[1].IsCurrent)
+		require.Equal(t, string(sconfig.ProviderTypeMock), globalDEKs[1].Provider)
+		require.Equal(t, "v1", globalDEKs[1].ProviderVersion)
 	})
 
 	t.Run("does not create first dek when ensure current is disabled", func(t *testing.T) {
@@ -167,6 +205,32 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		deks, err := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
 		require.NoError(t, err)
 		require.Empty(t, deks)
+
+		globalDEKs, err := env.db.ListDataEncryptionKeysForKey(env.ctx, globalEncryptionKeyID)
+		require.NoError(t, err)
+		require.Empty(t, globalDEKs)
+	})
+
+	t.Run("creates authproxy generated dek for secret-backed key", func(t *testing.T) {
+		env := setupMockSecretGenerateTest(t, util.MustGenerateSecureRandomKey(32))
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		deks, err := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, deks, 1)
+		require.True(t, deks[0].IsCurrent)
+		require.Equal(t, string(sconfig.ProviderTypeMock), deks[0].Provider)
+		require.Equal(t, "mock-secret-key", deks[0].ProviderID)
+		require.Equal(t, "v1", deks[0].ProviderVersion)
+		require.NotNil(t, deks[0].ProtectedData)
+		require.Equal(t, sconfig.KeyVersionProtectedDataTypeAuthProxyAESGCM, deks[0].ProtectedData.Type)
+		require.NotEmpty(t, deks[0].ProtectedData.WrappedData)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+		deks, err = env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
+		require.NoError(t, err)
+		require.Len(t, deks, 1)
 	})
 
 	t.Run("returns provider errors without creating partial dek", func(t *testing.T) {
@@ -174,6 +238,21 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 
 		err := generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
 		require.ErrorContains(t, err, "no current version")
+
+		deks, listErr := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
+		require.NoError(t, listErr)
+		require.Empty(t, deks)
+
+		globalDEKs, listErr := env.db.ListDataEncryptionKeysForKey(env.ctx, globalEncryptionKeyID)
+		require.NoError(t, listErr)
+		require.Len(t, globalDEKs, 1)
+	})
+
+	t.Run("returns fallback provider errors without creating partial dek", func(t *testing.T) {
+		env := setupMockSecretGenerateTest(t, []byte("bad"))
+
+		err := generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
+		require.ErrorContains(t, err, "failed to create DEK wrapping cipher")
 
 		deks, listErr := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
 		require.NoError(t, listErr)

--- a/internal/schema/config/data_encryption_keys.go
+++ b/internal/schema/config/data_encryption_keys.go
@@ -10,14 +10,14 @@ import (
 const defaultDataEncryptionKeyRotationInterval = 90 * 24 * time.Hour
 
 // DataEncryptionKeys configures lifecycle management for generated DEKs used by
-// KMS-backed namespace encryption keys.
+// data-encryption keys.
 type DataEncryptionKeys struct {
 	// RotationInterval is how old the current DEK can be before a new current DEK
 	// is generated. Defaults to 90 days.
 	RotationInterval *HumanDuration `json:"rotation_interval,omitempty" yaml:"rotation_interval,omitempty"`
 
 	// EnsureCurrent controls whether the DEK generator creates a current DEK
-	// when a KMS-backed encryption key has none. Defaults to true.
+	// when a data-encryption key has none. Defaults to true.
 	EnsureCurrent *bool `json:"ensure_current,omitempty" yaml:"ensure_current,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Generate and rotate current DEKs for active unified data-encryption keys, including the global key.
- Use the generalized provider facade so native KMS-style providers generate DEKs directly while secret-backed providers use AuthProxy-generated random DEKs wrapped by provider key material.
- Keep generation idempotent under repeated runs and update tests for first creation, no-op, rotation, native generation, fallback generation, and provider failures.
- Update DEK lifecycle config comments to match the broadened unified-key model.

## Tests
- go test ./internal/encrypt ./internal/schema/config
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...
- ./scripts/preflight.sh

Closes #611