### PR TITLE
Add connector predicate schema support

### DIFF
--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -115,9 +115,8 @@ func NewOAuth2Connector(connectorID apid.ID, displayName string, provider *OAuth
 	for _, id := range opts.Scopes {
 		scopes = append(scopes, connectors.Scope{Id: id, Reason: "integration test"})
 	}
-	notRequired := false
 	for _, id := range opts.OptionalScopes {
-		scopes = append(scopes, connectors.Scope{Id: id, Required: &notRequired, Reason: "integration test"})
+		scopes = append(scopes, connectors.Scope{Id: id, Required: connectors.NewScopeRequiredBool(false), Reason: "integration test"})
 	}
 
 	auth := &connectors.AuthOAuth2{

--- a/internal/auth_methods/oauth2/scope_mismatch_test.go
+++ b/internal/auth_methods/oauth2/scope_mismatch_test.go
@@ -10,8 +10,7 @@ import (
 func TestDetectScopeMismatch(t *testing.T) {
 	required := func(id string) sconfig.Scope { return sconfig.Scope{Id: id} }
 	optional := func(id string) sconfig.Scope {
-		f := false
-		return sconfig.Scope{Id: id, Required: &f}
+		return sconfig.Scope{Id: id, Required: sconfig.NewScopeRequiredBool(false)}
 	}
 
 	tests := []struct {

--- a/internal/core/connection_setup_flow_test.go
+++ b/internal/core/connection_setup_flow_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,17 +22,17 @@ func TestManifestSetupFlowIfJavascript(t *testing.T) {
 				{
 					Id:         "cfg_false",
 					JsonSchema: workspaceSchema,
-					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+					If:         &common.Predicate{Javascript: `cfg.region === "us"`},
 				},
 				{
 					Id:         "label_true",
 					JsonSchema: workspaceSchema,
-					If:         &cschema.SetupFlowStepIf{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
+					If:         &common.Predicate{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
 				},
 				{
 					Id:         "annotation_true",
 					JsonSchema: workspaceSchema,
-					If:         &cschema.SetupFlowStepIf{Javascript: `annotations["setup-mode"] === "advanced"`},
+					If:         &common.Predicate{Javascript: `annotations["setup-mode"] === "advanced"`},
 				},
 			},
 		},
@@ -68,7 +69,7 @@ func TestManifestSetupFlowIfJavascriptVerifyBoundary(t *testing.T) {
 				{
 					Id:         "us_only",
 					JsonSchema: regionSchema,
-					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+					If:         &common.Predicate{Javascript: `cfg.region === "us"`},
 				},
 			},
 		},
@@ -98,7 +99,7 @@ func TestManifestSetupFlowIfJavascriptError(t *testing.T) {
 				{
 					Id:         "broken",
 					JsonSchema: workspaceSchema,
-					If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region ===`},
+					If:         &common.Predicate{Javascript: `cfg.region ===`},
 				},
 			},
 		},

--- a/internal/core/service_connection_reconfigure_test.go
+++ b/internal/core/service_connection_reconfigure_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,7 +120,7 @@ func TestReconfigure(t *testing.T) {
 					{
 						Id:         "us_only",
 						JsonSchema: workspaceSchema,
-						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+						If:         &common.Predicate{Javascript: `cfg.region === "us"`},
 					},
 					{Id: "workspace", Title: "Select Workspace", JsonSchema: workspaceSchema},
 				},

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -223,7 +223,7 @@ func TestSubmitForm(t *testing.T) {
 					{
 						Id:         "us_only",
 						JsonSchema: workspaceSchema,
-						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+						If:         &common.Predicate{Javascript: `cfg.region === "us"`},
 					},
 					{Id: "workspace", JsonSchema: workspaceSchema},
 				},
@@ -413,7 +413,7 @@ func TestGetCurrentSetupStepResponse(t *testing.T) {
 					{
 						Id:         "us_only",
 						JsonSchema: workspaceSchema,
-						If:         &cschema.SetupFlowStepIf{Javascript: `cfg.region === "us"`},
+						If:         &common.Predicate{Javascript: `cfg.region === "us"`},
 					},
 					{Id: "workspace", Title: "Select Workspace", JsonSchema: workspaceSchema},
 				},

--- a/internal/schema/common/predicate.go
+++ b/internal/schema/common/predicate.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apjs"
+)
+
+// Predicate defines a JavaScript condition evaluated by runtime with a
+// caller-defined set of variables in scope. Runtime requires the fragment to
+// return a boolean.
+type Predicate struct {
+	Javascript string `json:"javascript" yaml:"javascript"`
+}
+
+func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
+	if p == nil {
+		return nil
+	}
+	result := &multierror.Error{}
+	if strings.TrimSpace(p.Javascript) == "" {
+		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript is required"))
+		return result.ErrorOrNil()
+	}
+	if _, err := apjs.EvaluateBoolean(p.Javascript, vars); err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript must evaluate to a boolean: %v", err))
+	}
+	return result.ErrorOrNil()
+}

--- a/internal/schema/common/predicate_test.go
+++ b/internal/schema/common/predicate_test.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPredicateValidate(t *testing.T) {
+	vars := map[string]any{
+		"cfg":         map[string]any{},
+		"labels":      map[string]string{},
+		"annotations": map[string]string{},
+	}
+
+	t.Run("accepts boolean result", func(t *testing.T) {
+		p := &Predicate{Javascript: `cfg.enabled === true`}
+		require.NoError(t, p.Validate(&ValidationContext{Path: "predicate"}, vars))
+	})
+
+	t.Run("rejects blank javascript", func(t *testing.T) {
+		p := &Predicate{Javascript: " \n\t "}
+		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "predicate.javascript")
+	})
+
+	t.Run("rejects syntax errors", func(t *testing.T) {
+		p := &Predicate{Javascript: `cfg.enabled ===`}
+		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must evaluate to a boolean")
+	})
+
+	t.Run("rejects non boolean results", func(t *testing.T) {
+		p := &Predicate{Javascript: `cfg.enabled`}
+		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must evaluate to a boolean")
+	})
+}

--- a/internal/schema/common/schema.json
+++ b/internal/schema/common/schema.json
@@ -27,6 +27,20 @@
       ],
       "description": "Identifies the kind of traffic flowing through the proxy."
     },
+    "Predicate": {
+      "type": "object",
+      "required": [
+        "javascript"
+      ],
+      "properties": {
+        "javascript": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "description": "A JavaScript predicate that must evaluate to a boolean."
+    },
     "UUID": {
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$",

--- a/internal/schema/common/schema_test.go
+++ b/internal/schema/common/schema_test.go
@@ -112,6 +112,44 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		{
+			Name: "Predicate",
+			Schema: `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/test.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["test"],
+  "properties": {
+	"test": {
+		"$ref": "./schema.json#/$defs/Predicate"
+    }
+  }
+}`,
+			Tests: []test{
+				{
+					Name:  "valid",
+					Valid: true,
+					Data:  `{"test": {"javascript": "cfg.enabled === true"}}`,
+				},
+				{
+					Name:  "missing javascript",
+					Valid: false,
+					Data:  `{"test": {}}`,
+				},
+				{
+					Name:  "empty javascript",
+					Valid: false,
+					Data:  `{"test": {"javascript": ""}}`,
+				},
+				{
+					Name:  "additional property",
+					Valid: false,
+					Data:  `{"test": {"javascript": "true", "type": "javascript"}}`,
+				},
+			},
+		},
+		{
 			Name: "Cron",
 			Schema: `
 {

--- a/internal/schema/config/reexport.go
+++ b/internal/schema/config/reexport.go
@@ -56,8 +56,15 @@ type (
 	Connectors              = connectors.Connectors
 	PKCEMethod              = connectors.PKCEMethod
 	OAuth2GrantType         = connectors.OAuth2GrantType
+	Predicate               = common.Predicate
 	Scope                   = connectors.Scope
+	ScopeRequired           = connectors.ScopeRequired
 	TokenEndpointAuthMethod = connectors.TokenEndpointAuthMethod
+)
+
+var (
+	NewScopeRequiredBool      = connectors.NewScopeRequiredBool
+	NewScopeRequiredPredicate = connectors.NewScopeRequiredPredicate
 )
 
 // Re-export constants from the connectors sub-package

--- a/internal/schema/config/root_test.go
+++ b/internal/schema/config/root_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -81,7 +80,7 @@ connectors:
 							},
 							{
 								Id:       "https://www.googleapis.com/auth/drive.activity.readonly",
-								Required: util.ToPtr(false),
+								Required: NewScopeRequiredBool(false),
 								Reason:   "We need to be able to see what's been going on in drive\n",
 							},
 						},

--- a/internal/schema/resources/connectors/auth_oauth2.go
+++ b/internal/schema/resources/connectors/auth_oauth2.go
@@ -156,8 +156,8 @@ func (a *AuthOAuth2) Clone() AuthImpl {
 	}
 
 	scopes := make([]Scope, 0, len(a.Scopes))
-	for _, scope := range a.Scopes {
-		scopes = append(scopes, scope)
+	for i := range a.Scopes {
+		scopes = append(scopes, a.Scopes[i].Clone())
 	}
 	clone.Scopes = scopes
 
@@ -247,6 +247,12 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 	hasSecret := a.ClientSecret != nil && a.ClientSecret.InnerVal != nil
 	if grantType == OAuth2GrantAuthorizationCode && !hasClientId {
 		result = multierror.Append(result, vc.NewErrorfForField("client_id", "is required"))
+	}
+
+	for i := range a.Scopes {
+		if err := a.Scopes[i].Validate(vc.PushField("scopes").PushIndex(i)); err != nil {
+			result = multierror.Append(result, err)
+		}
 	}
 
 	method := a.GetTokenEndpointAuthMethodOrDefault()

--- a/internal/schema/resources/connectors/auth_oauth2_scope.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope.go
@@ -1,16 +1,164 @@
 package connectors
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"gopkg.in/yaml.v3"
+)
+
 type Scope struct {
-	Id       string `json:"id" yaml:"id"`
-	Required *bool  `json:"required,omitempty" yaml:"required,omitempty"`
-	Reason   string `json:"reason" yaml:"reason"`
+	Id       string            `json:"id" yaml:"id"`
+	If       *common.Predicate `json:"if,omitempty" yaml:"if,omitempty"`
+	Required *ScopeRequired    `json:"required,omitempty" yaml:"required,omitempty"`
+	Reason   string            `json:"reason" yaml:"reason"`
 }
 
 func (s *Scope) IsRequired() bool {
-	if s.Required == nil {
-		// If unspecified, assume required
+	if s == nil || s.Required == nil {
+		// If unspecified, assume required.
 		return true
 	}
 
-	return *s.Required
+	return s.Required.IsRequired()
+}
+
+func (s *Scope) Validate(vc *common.ValidationContext) error {
+	if s == nil {
+		return nil
+	}
+	result := &multierror.Error{}
+	if err := s.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := s.Required.Validate(vc.PushField("required")); err != nil {
+		result = multierror.Append(result, err)
+	}
+	return result.ErrorOrNil()
+}
+
+func (s Scope) Clone() Scope {
+	clone := s
+	if s.If != nil {
+		p := *s.If
+		clone.If = &p
+	}
+	if s.Required != nil {
+		clone.Required = s.Required.Clone()
+	}
+	return clone
+}
+
+// ScopeRequired preserves the existing `required: true|false` shape while
+// allowing a dynamic predicate object at the same YAML key.
+type ScopeRequired struct {
+	Bool      *bool             `json:"-" yaml:"-"`
+	Predicate *common.Predicate `json:"-" yaml:"-"`
+}
+
+func NewScopeRequiredBool(value bool) *ScopeRequired {
+	return &ScopeRequired{Bool: &value}
+}
+
+func NewScopeRequiredPredicate(predicate *common.Predicate) *ScopeRequired {
+	return &ScopeRequired{Predicate: predicate}
+}
+
+func (r *ScopeRequired) IsRequired() bool {
+	if r == nil || r.Bool == nil {
+		// Runtime evaluates Predicate in the OAuth runtime work. Until then,
+		// preserve the historical required-by-default behavior.
+		return true
+	}
+	return *r.Bool
+}
+
+func (r *ScopeRequired) Clone() *ScopeRequired {
+	if r == nil {
+		return nil
+	}
+	clone := &ScopeRequired{}
+	if r.Bool != nil {
+		b := *r.Bool
+		clone.Bool = &b
+	}
+	if r.Predicate != nil {
+		p := *r.Predicate
+		clone.Predicate = &p
+	}
+	return clone
+}
+
+func (r *ScopeRequired) Validate(vc *common.ValidationContext) error {
+	if r == nil || r.Predicate == nil {
+		return nil
+	}
+	return r.Predicate.Validate(vc, connectorPredicateValidationVars())
+}
+
+func (r ScopeRequired) MarshalJSON() ([]byte, error) {
+	if r.Predicate != nil {
+		return json.Marshal(r.Predicate)
+	}
+	if r.Bool != nil {
+		return json.Marshal(*r.Bool)
+	}
+	return []byte("null"), nil
+}
+
+func (r *ScopeRequired) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return fmt.Errorf("required must be a boolean or predicate object")
+	}
+
+	var boolValue bool
+	if err := json.Unmarshal(data, &boolValue); err == nil {
+		r.Bool = &boolValue
+		r.Predicate = nil
+		return nil
+	}
+
+	var predicate common.Predicate
+	if err := json.Unmarshal(data, &predicate); err == nil {
+		r.Bool = nil
+		r.Predicate = &predicate
+		return nil
+	}
+
+	return fmt.Errorf("required must be a boolean or predicate object")
+}
+
+func (r ScopeRequired) MarshalYAML() (any, error) {
+	if r.Predicate != nil {
+		return r.Predicate, nil
+	}
+	if r.Bool != nil {
+		return *r.Bool, nil
+	}
+	return nil, nil
+}
+
+func (r *ScopeRequired) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		return fmt.Errorf("required must be a boolean or predicate object")
+	}
+
+	var boolValue bool
+	if err := value.Decode(&boolValue); err == nil {
+		r.Bool = &boolValue
+		r.Predicate = nil
+		return nil
+	}
+
+	var predicate common.Predicate
+	if err := value.Decode(&predicate); err == nil {
+		r.Bool = nil
+		r.Predicate = &predicate
+		return nil
+	}
+
+	return fmt.Errorf("required must be a boolean or predicate object")
 }

--- a/internal/schema/resources/connectors/auth_oauth2_scope_test.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope_test.go
@@ -2,7 +2,6 @@ package connectors
 
 import (
 	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -38,19 +37,76 @@ reason: We need to be able to view the files
 			assert.Equal("We need to be able to view the files", scope.Reason)
 			assert.False(scope.IsRequired())
 		})
+		t.Run("allowed to use dynamic required", func(t *testing.T) {
+			data := `id: https://www.googleapis.com/auth/drive.activity.readonly
+required:
+  javascript: cfg.sync_activity === true
+reason: We need to be able to see what's been going on in drive
+`
+			scope := &Scope{}
+			err := yaml.Unmarshal([]byte(data), scope)
+			assert.NoError(err)
+			require.NotNil(t, scope.Required)
+			require.NotNil(t, scope.Required.Predicate)
+			assert.Equal("cfg.sync_activity === true", scope.Required.Predicate.Javascript)
+			assert.True(scope.IsRequired())
+		})
+		t.Run("allowed to use conditional inclusion", func(t *testing.T) {
+			data := `id: https://www.googleapis.com/auth/drive.readwrite
+if:
+  javascript: cfg.push_files === true
+reason: We need to be able to write the files
+`
+			scope := &Scope{}
+			err := yaml.Unmarshal([]byte(data), scope)
+			assert.NoError(err)
+			require.NotNil(t, scope.If)
+			assert.Equal("cfg.push_files === true", scope.If.Javascript)
+		})
 	})
 
 	t.Run("yaml gen", func(t *testing.T) {
 		t.Run("defaults to required", func(t *testing.T) {
 			data := &Scope{
 				Id:       "https://www.googleapis.com/auth/drive.readonly",
-				Required: util.ToPtr(false),
+				Required: NewScopeRequiredBool(false),
 				Reason:   "We need to be able to view the files",
 			}
 			assert.Equal(`id: https://www.googleapis.com/auth/drive.readonly
 required: false
 reason: We need to be able to view the files
 `, common.MustMarshalToYamlString(data))
+		})
+		t.Run("dynamic required", func(t *testing.T) {
+			data := &Scope{
+				Id: "https://www.googleapis.com/auth/drive.activity.readonly",
+				Required: NewScopeRequiredPredicate(&common.Predicate{
+					Javascript: "cfg.sync_activity === true",
+				}),
+				Reason: "We need to be able to see what's been going on in drive",
+			}
+			assert.Equal(`id: https://www.googleapis.com/auth/drive.activity.readonly
+required:
+    javascript: cfg.sync_activity === true
+reason: We need to be able to see what's been going on in drive
+`, common.MustMarshalToYamlString(data))
+		})
+	})
+
+	t.Run("validate", func(t *testing.T) {
+		t.Run("rejects blank if javascript", func(t *testing.T) {
+			scope := &Scope{If: &common.Predicate{Javascript: " \n\t "}}
+			err := scope.Validate(&common.ValidationContext{Path: "scope"})
+			assert.Error(err)
+			assert.Contains(err.Error(), "scope.if.javascript")
+		})
+		t.Run("rejects blank required javascript", func(t *testing.T) {
+			scope := &Scope{
+				Required: NewScopeRequiredPredicate(&common.Predicate{Javascript: " "}),
+			}
+			err := scope.Validate(&common.ValidationContext{Path: "scope"})
+			assert.Error(err)
+			assert.Contains(err.Error(), "scope.required.javascript")
 		})
 	})
 }

--- a/internal/schema/resources/connectors/auth_test.go
+++ b/internal/schema/resources/connectors/auth_test.go
@@ -43,7 +43,7 @@ func TestAuth(t *testing.T) {
 						},
 						{
 							Id:       "https://www.googleapis.com/auth/drive.activity.readonly",
-							Required: util.ToPtr(false),
+							Required: NewScopeRequiredBool(false),
 							Reason:   "We need to be able to see what's been going on in drive\n",
 						},
 					},
@@ -81,12 +81,12 @@ func TestAuth(t *testing.T) {
 					Scopes: []Scope{
 						{
 							Id:       "https://www.googleapis.com/auth/drive.readonly",
-							Required: util.ToPtr(true),
+							Required: NewScopeRequiredBool(true),
 							Reason:   "We need to be able to view the files\n",
 						},
 						{
 							Id:       "https://www.googleapis.com/auth/drive.activity.readonly",
-							Required: util.ToPtr(false),
+							Required: NewScopeRequiredBool(false),
 							Reason:   "We need to be able to see what's been going on in drive\n",
 						},
 					},

--- a/internal/schema/resources/connectors/connector_test.go
+++ b/internal/schema/resources/connectors/connector_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -69,12 +68,12 @@ func TestConnectorRoundtrip(t *testing.T) {
 						Scopes: []Scope{
 							{
 								Id:       "scope1",
-								Required: util.ToPtr(true),
+								Required: NewScopeRequiredBool(true),
 								Reason:   "Required for basic functionality",
 							},
 							{
 								Id:       "scope2",
-								Required: util.ToPtr(false),
+								Required: NewScopeRequiredBool(false),
 								Reason:   "Optional for advanced features",
 							},
 						},

--- a/internal/schema/resources/connectors/predicate.go
+++ b/internal/schema/resources/connectors/predicate.go
@@ -1,0 +1,9 @@
+package connectors
+
+func connectorPredicateValidationVars() map[string]any {
+	return map[string]any{
+		"cfg":         map[string]any{},
+		"labels":      map[string]string{},
+		"annotations": map[string]string{},
+	}
+}

--- a/internal/schema/resources/connectors/probe.go
+++ b/internal/schema/resources/connectors/probe.go
@@ -42,6 +42,11 @@ type Probe struct {
 	// Http defines the probe as using a raw HTTP request as the probe.
 	Http *ProbeHttp `json:"http,omitempty" yaml:"http,omitempty"`
 
+	// If optionally disables this probe for a connection. Runtime evaluates
+	// the configured condition server-side with cfg, labels, and annotations
+	// variables in scope.
+	If *common.Predicate `json:"if,omitempty" yaml:"if,omitempty"`
+
 	// FailureThreshold is the number of consecutive failures that must occur
 	// before the connection's health_state flips to unhealthy. Defaults to
 	// DefaultProbeFailureThreshold when omitted. Must be ≥ 1 when set.
@@ -85,6 +90,10 @@ func (p *Probe) Validate(vc *common.ValidationContext) error {
 
 	if typeCount != 1 {
 		result = multierror.Append(result, vc.NewErrorf("exactly one of proxy_http or http must be defined"))
+	}
+
+	if err := p.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
+		result = multierror.Append(result, err)
 	}
 
 	if p.Period != nil && p.Cron != nil {

--- a/internal/schema/resources/connectors/probe_test.go
+++ b/internal/schema/resources/connectors/probe_test.go
@@ -60,6 +60,28 @@ func TestProbe_Validate_AcceptsValidThresholds(t *testing.T) {
 	}
 }
 
+func TestProbe_Validate_IfPredicate(t *testing.T) {
+	t.Run("accepts conditional probe", func(t *testing.T) {
+		p := &Probe{
+			Id:   "ping",
+			If:   &common.Predicate{Javascript: `cfg.has_calendar === true`},
+			Http: &ProbeHttp{Method: "GET", URL: "https://example.com"},
+		}
+		require.NoError(t, p.Validate(&common.ValidationContext{}))
+	})
+
+	t.Run("rejects blank javascript", func(t *testing.T) {
+		p := &Probe{
+			Id:   "ping",
+			If:   &common.Predicate{Javascript: " \n\t "},
+			Http: &ProbeHttp{Method: "GET", URL: "https://example.com"},
+		}
+		err := p.Validate(&common.ValidationContext{Path: "probe"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "probe.if.javascript")
+	})
+}
+
 func TestProbe_Validate_RejectsZero(t *testing.T) {
 	t.Run("failure_threshold = 0", func(t *testing.T) {
 		p := &Probe{

--- a/internal/schema/resources/connectors/schema-oauth.json
+++ b/internal/schema/resources/connectors/schema-oauth.json
@@ -7,8 +7,14 @@
         "id": {
           "type": "string"
         },
+        "if": {
+          "$ref": "../../common/schema.json#/$defs/Predicate"
+        },
         "required": {
-          "type": "boolean"
+          "oneOf": [
+            { "type": "boolean" },
+            { "$ref": "../../common/schema.json#/$defs/Predicate" }
+          ]
         },
         "reason": {
           "type": "string"

--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -94,6 +94,9 @@
         "http": {
           "$ref": "#/$defs/ProbeHttp"
         },
+        "if": {
+          "$ref": "../../common/schema.json#/$defs/Predicate"
+        },
         "failure_threshold": {
           "type": "integer",
           "minimum": 1
@@ -204,18 +207,7 @@
           }
         },
         "if": {
-          "$ref": "#/$defs/SetupFlowStepIf"
-        }
-      },
-      "additionalProperties": false
-    },
-    "SetupFlowStepIf": {
-      "type": "object",
-      "required": ["javascript"],
-      "properties": {
-        "javascript": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "../../common/schema.json#/$defs/Predicate"
         }
       },
       "additionalProperties": false

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -384,33 +384,11 @@ type SetupFlowStep struct {
 
 	// If optionally gates this user-authored setup step. Runtime evaluates the
 	// configured condition server-side; clients only see eligible steps.
-	If *SetupFlowStepIf `json:"if,omitempty" yaml:"if,omitempty"`
+	If *common.Predicate `json:"if,omitempty" yaml:"if,omitempty"`
 
 	// Redirect carries the redirect-step-specific configuration. Required
 	// when Type == redirect; must be absent otherwise.
 	Redirect *SetupFlowStepRedirect `json:"redirect,omitempty" yaml:"redirect,omitempty"`
-}
-
-// SetupFlowStepIf defines the condition that controls whether a user-authored
-// setup step participates in a connection setup flow. Auth-method-emitted
-// steps and apxy:* pseudo-steps are not represented in connector YAML and
-// therefore cannot be gated through this schema.
-type SetupFlowStepIf struct {
-	// Javascript is a JavaScript fragment evaluated with cfg, labels, and
-	// annotations variables in scope. Runtime work requires the fragment to
-	// return a boolean.
-	Javascript string `json:"javascript" yaml:"javascript"`
-}
-
-func (i *SetupFlowStepIf) Validate(vc *common.ValidationContext) error {
-	if i == nil {
-		return nil
-	}
-	result := &multierror.Error{}
-	if strings.TrimSpace(i.Javascript) == "" {
-		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript is required"))
-	}
-	return result.ErrorOrNil()
 }
 
 // SetupFlowStepRedirect describes a redirect-kind step's destination. The
@@ -459,7 +437,7 @@ func (s *SetupFlowStep) Validate(vc *common.ValidationContext, seenIds map[strin
 		result = multierror.Append(result, vc.NewErrorfForField("type", "type must be %q or %q (got %q)", SetupFlowStepTypeForm, SetupFlowStepTypeRedirect, s.Type))
 	}
 
-	if err := s.If.Validate(vc.PushField("if")); err != nil {
+	if err := s.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/schema/resources/connectors/setup_flow_test.go
+++ b/internal/schema/resources/connectors/setup_flow_test.go
@@ -91,7 +91,7 @@ func TestSetupFlowValidation(t *testing.T) {
 					{
 						Id:         "advanced_options",
 						JsonSchema: common.RawJSON(`{"type":"object"}`),
-						If: &SetupFlowStepIf{
+						If: &common.Predicate{
 							Javascript: `cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"`,
 						},
 					},
@@ -108,7 +108,7 @@ func TestSetupFlowValidation(t *testing.T) {
 					{
 						Id:         "advanced_options",
 						JsonSchema: common.RawJSON(`{"type":"object"}`),
-						If:         &SetupFlowStepIf{},
+						If:         &common.Predicate{},
 					},
 				},
 			},
@@ -125,7 +125,7 @@ func TestSetupFlowValidation(t *testing.T) {
 					{
 						Id:         "advanced_options",
 						JsonSchema: common.RawJSON(`{"type":"object"}`),
-						If:         &SetupFlowStepIf{Javascript: " \n\t "},
+						If:         &common.Predicate{Javascript: " \n\t "},
 					},
 				},
 			},
@@ -830,7 +830,7 @@ func TestSetupFlowYAMLRoundtrip(t *testing.T) {
 					{
 						Id:         "workspace",
 						JsonSchema: common.RawJSON(`{"type":"object"}`),
-						If: &SetupFlowStepIf{
+						If: &common.Predicate{
 							Javascript: `annotations["setup-mode"] !== "basic"`,
 						},
 						DataSources: map[string]DataSourceDef{

--- a/internal/schema/resources/connectors/test_data/invalid-oauth-scope-if-missing-javascript.yaml
+++ b/internal/schema/resources/connectors/test_data/invalid-oauth-scope-if-missing-javascript.yaml
@@ -1,0 +1,20 @@
+# $schema: ./schema.json
+
+labels:
+  type: google-drive
+display_name: Google Drive
+description: Invalid scope predicate example
+auth:
+  type: OAuth2
+  client_id:
+    env_var: GOOGLE_CLIENT_ID
+  client_secret:
+    env_var: GOOGLE_CLIENT_SECRET
+  authorization:
+    endpoint: https://accounts.google.com/o/oauth2/v2/auth
+  token:
+    endpoint: https://oauth2.googleapis.com/token
+  scopes:
+    - id: https://www.googleapis.com/auth/drive.file
+      if: {}
+      reason: We need to be able to write files

--- a/internal/schema/resources/connectors/test_data/invalid-oauth-scope-required-missing-javascript.yaml
+++ b/internal/schema/resources/connectors/test_data/invalid-oauth-scope-required-missing-javascript.yaml
@@ -1,0 +1,20 @@
+# $schema: ./schema.json
+
+labels:
+  type: google-drive
+display_name: Google Drive
+description: Invalid dynamic required predicate example
+auth:
+  type: OAuth2
+  client_id:
+    env_var: GOOGLE_CLIENT_ID
+  client_secret:
+    env_var: GOOGLE_CLIENT_SECRET
+  authorization:
+    endpoint: https://accounts.google.com/o/oauth2/v2/auth
+  token:
+    endpoint: https://oauth2.googleapis.com/token
+  scopes:
+    - id: https://www.googleapis.com/auth/drive.activity.readonly
+      required: {}
+      reason: We need to be able to see activity

--- a/internal/schema/resources/connectors/test_data/invalid-probe-if-missing-javascript.yaml
+++ b/internal/schema/resources/connectors/test_data/invalid-probe-if-missing-javascript.yaml
@@ -1,0 +1,15 @@
+# $schema: ./schema.json
+
+labels:
+  type: google-drive
+display_name: Google Drive
+description: Invalid probe predicate example
+auth:
+  type: no-auth
+probes:
+  - id: drive-health
+    period: 1m
+    if: {}
+    http:
+      method: GET
+      url: https://example.com/health

--- a/internal/schema/resources/connectors/test_data/valid-conditional-scopes-and-probes.yaml
+++ b/internal/schema/resources/connectors/test_data/valid-conditional-scopes-and-probes.yaml
@@ -1,0 +1,37 @@
+# $schema: ./schema.json
+
+labels:
+  type: google-drive
+display_name: Google Drive
+logo:
+  public_url: https://example.com/logo.png
+description: Conditional scope and probe example
+auth:
+  type: OAuth2
+  client_id:
+    env_var: GOOGLE_CLIENT_ID
+  client_secret:
+    env_var: GOOGLE_CLIENT_SECRET
+  authorization:
+    endpoint: https://accounts.google.com/o/oauth2/v2/auth
+  token:
+    endpoint: https://oauth2.googleapis.com/token
+  scopes:
+    - id: https://www.googleapis.com/auth/drive.readonly
+      reason: We need to be able to view the files
+    - id: https://www.googleapis.com/auth/drive.file
+      if:
+        javascript: cfg.push_files === true
+      reason: We need to be able to write files
+    - id: https://www.googleapis.com/auth/drive.activity.readonly
+      required:
+        javascript: cfg.sync_activity === true
+      reason: We need to be able to see activity
+probes:
+  - id: drive-health
+    period: 1m
+    if:
+      javascript: cfg.has_drive === true
+    proxy_http:
+      method: GET
+      url: https://www.googleapis.com/drive/v3/about


### PR DESCRIPTION
## Summary
- add a shared connector Predicate schema/type for JavaScript boolean conditions
- add OAuth scope if.javascript and dynamic required.javascript while preserving required: true/false
- add probe if.javascript schema support and validation fixtures

## Verification
- go test ./internal/schema/resources/connectors
- go test ./internal/schema/config
- go test ./internal/auth_methods/oauth2
- go test ./internal/schema/resources/connectors ./internal/schema/config ./internal/auth_methods/oauth2
- go test ./internal/...
- ./scripts/preflight.sh

Closes #646