### PR TITLE
Add AWS KMS support under unified key model

### DIFF
--- a/docs/key-model-migration.md
+++ b/docs/key-model-migration.md
@@ -281,6 +281,11 @@ The provider tests should prove:
 - Encrypted application data uses `dek_` ids and remains decryptable after
   provider rotation and DEK rewrap.
 
+AWS KMS integration tests require an existing symmetric KMS key because KMS keys
+cannot be deleted immediately after creation. Set `AUTH_PROXY_AWS_KMS_KEY_ID_V2`
+to a second accessible key ID or alias to exercise metadata advancement and
+rewrap under new provider material.
+
 ## Implementation Order
 
 The child issues under #605 are intended to land in this rough order:

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/XSAM/otelsql v0.41.0
 	github.com/alicebob/miniredis/v2 v2.35.0
-	github.com/aws/aws-sdk-go-v2 v1.41.2
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
+	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2
 	github.com/bsm/redislock v0.9.4
@@ -88,8 +89,8 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
@@ -100,7 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
-	github.com/aws/smithy-go v1.24.1 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
 github.com/aws/aws-sdk-go-v2 v1.41.2/go.mod h1:IvvlAZQXvTXznUPfRVfryiG1fbzE2NGK6m9u39YQ+S4=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.32.9 h1:ktda/mtAydeObvJXlHzyGpK1xcsLaP16zfUPDGoW90A=
@@ -47,8 +49,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBc
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 h1:F43zk1vemYIqPAwhjTjYIz0irU2EY7sOb/F5eJ3HuyM=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18/go.mod h1:w1jdlZXrGKaJcNoL+Nnrj+k5wlpGXqnNrKoP22HvAug=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 h1:xCeWVjj0ki0l3nruoyP2slHsGArMxeiiaoPN5QZH6YQ=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18/go.mod h1:r/eLGuGCBw6l36ZRWiw6PaZwPXb6YOj+i/7MizNl5/k=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R50aTBHkA7vu0lK+k=
@@ -61,6 +67,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMooz
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu/eJC0Lh9adJa3M1xREcndxLNZlve2U=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 h1:PEgVSsWtR8NNxsDxFL2Ywisi7R+1EFQARGsT4q3mWwI=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4/go.mod h1:3EeKyDGPGSCEphG2OolwNGNF45RvQIfm27AYYpfEWrw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2 h1:hezAo5AQM0moD4qitsn8bZuc2WE/MmP+cySGfJWEi1A=
@@ -75,6 +83,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
 github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
 github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -57,6 +57,33 @@ Notes:
 - The test creates a short-lived secret and deletes it at the end.
 - For CI, provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` via secrets.
 
+## AWS KMS Integration Test
+
+This test hits real AWS KMS and is gated behind the `aws` build tag and an env flag.
+
+Requirements:
+- AWS credentials available via the standard AWS SDK chain.
+- `AWS_REGION` set.
+- `AUTH_PROXY_AWS_KMS_TEST=1` set to opt in.
+- `AUTH_PROXY_AWS_KMS_KEY_ID` set to an existing symmetric KMS key ID, key ARN, alias name, or alias ARN.
+- IAM permissions: `kms:DescribeKey`, `kms:GenerateDataKey`, `kms:Encrypt`, `kms:Decrypt`.
+
+Optional:
+- `AUTH_PROXY_AWS_KMS_KEY_ID_V2` set to a second accessible symmetric KMS key to exercise provider metadata advancement and DEK rewrap.
+- `AUTH_PROXY_AWS_KMS_ENDPOINT` set to override the KMS endpoint.
+
+Run:
+```bash
+cd integration_tests
+AUTH_PROXY_AWS_KMS_TEST=1 AWS_REGION=us-east-1 \\
+  AUTH_PROXY_AWS_KMS_KEY_ID=alias/authproxy-test \\
+  go test -tags "integration,aws" -v ./encrypt/...
+```
+
+Notes:
+- The test does not create or delete KMS keys because AWS KMS keys have delayed deletion windows.
+- For CI, provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` via secrets.
+
 ## GCP Secret Manager Integration Test
 
 This test hits real GCP Secret Manager and is gated behind the `gcp` build tag and an env flag.

--- a/integration_tests/encrypt/aws_kms_test.go
+++ b/integration_tests/encrypt/aws_kms_test.go
@@ -1,0 +1,141 @@
+//go:build integration && aws
+
+package encrypt_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	awsKMSTestEnv        = "AUTH_PROXY_AWS_KMS_TEST"
+	awsKMSKeyIDEnv       = "AUTH_PROXY_AWS_KMS_KEY_ID"
+	awsKMSKeyIDV2Env     = "AUTH_PROXY_AWS_KMS_KEY_ID_V2"
+	awsKMSEndpointEnv    = "AUTH_PROXY_AWS_KMS_ENDPOINT"
+	awsKMSProviderString = string(sconfig.ProviderTypeAwsKMS)
+)
+
+func TestAwsKMSKeySyncAndReencrypt(t *testing.T) {
+	if os.Getenv(awsKMSTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", awsKMSTestEnv)
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		t.Skip("AWS_REGION is not set")
+	}
+	keyID := os.Getenv(awsKMSKeyIDEnv)
+	if keyID == "" {
+		t.Skipf("%s is not set", awsKMSKeyIDEnv)
+	}
+
+	ctx := context.Background()
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+
+	namespace := fmt.Sprintf("root.aws-kms-test-%d", time.Now().UnixNano())
+	keyIDAuthProxy := apid.New(apid.PrefixKey)
+
+	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
+		Path:  namespace,
+		KeyId: &keyIDAuthProxy,
+	}))
+
+	keyData := awsKMSKeyData(keyID, region)
+	keyDataJSON, err := json.Marshal(&keyData)
+	require.NoError(t, err)
+
+	encKeyData, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSON)
+	require.NoError(t, err)
+
+	require.NoError(t, env.Db.CreateKey(ctx, &database.Key{
+		Id:               keyIDAuthProxy,
+		Namespace:        namespace,
+		MaterialType:     database.KeyMaterialTypeExternal,
+		EncryptedKeyData: &encKeyData,
+		State:            database.KeyStateActive,
+	}))
+
+	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyIDAuthProxy, &keyData)
+	require.Equal(t, awsKMSProviderString, currentV1.Provider)
+	require.Equal(t, keyID, currentV1.ProviderID)
+	require.NotEmpty(t, currentV1.ProviderVersion)
+	require.NotNil(t, currentV1.ProtectedData)
+	require.Equal(t, awsKMSProviderString, currentV1.ProtectedData.Type)
+	require.NotEmpty(t, currentV1.ProtectedData.WrappedData)
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	plaintext := "aws-kms-test"
+	encrypted, err := env.DM.GetEncryptService().EncryptStringForNamespace(ctx, namespace, plaintext)
+	require.NoError(t, err)
+	require.Equal(t, currentV1.Id, encrypted.ID)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, env.Db.CreateActor(ctx, &database.Actor{
+		Id:           actorID,
+		Namespace:    namespace,
+		ExternalId:   "aws-kms-test-actor",
+		EncryptedKey: &encrypted,
+	}))
+
+	keyIDV2 := os.Getenv(awsKMSKeyIDV2Env)
+	if keyIDV2 != "" {
+		keyDataV2 := awsKMSKeyData(keyIDV2, region)
+		keyDataJSONV2, err := json.Marshal(&keyDataV2)
+		require.NoError(t, err)
+
+		encKeyDataV2, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSONV2)
+		require.NoError(t, err)
+		_, err = env.Db.UpdateKey(ctx, keyIDAuthProxy, map[string]interface{}{
+			"encrypted_key_data": encKeyDataV2,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+		require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+		currentV2, err := env.Db.GetCurrentDataEncryptionKeyForKey(ctx, keyIDAuthProxy)
+		require.NoError(t, err)
+		require.Equal(t, currentV1.Id, currentV2.Id)
+		require.Equal(t, keyIDV2, currentV2.ProviderID)
+		require.NotEqual(t, currentV1.ProviderVersion, currentV2.ProviderVersion)
+		require.NotEqual(t, currentV1.ProtectedData.WrappedData, currentV2.ProtectedData.WrappedData)
+	} else {
+		t.Logf("%s is not set; skipping AWS KMS metadata advancement rewrap path", awsKMSKeyIDV2Env)
+	}
+
+	require.NoError(t, runReencryptAll(ctx, env))
+
+	updated, err := env.Db.GetActor(ctx, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.EncryptedKey)
+	require.Equal(t, currentV1.Id, updated.EncryptedKey.ID)
+	require.Equal(t, encrypted.Data, updated.EncryptedKey.Data)
+
+	decrypted, err := env.DM.GetEncryptService().DecryptString(ctx, *updated.EncryptedKey)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+}
+
+func awsKMSKeyData(keyID string, region string) sconfig.KeyData {
+	return sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataAwsKMS{
+			AwsKMSKeyID:    keyID,
+			AwsRegion:      region,
+			AwsKMSEndpoint: os.Getenv(awsKMSEndpointEnv),
+		},
+	}
+}

--- a/integration_tests/encrypt/helpers_test.go
+++ b/integration_tests/encrypt/helpers_test.go
@@ -42,8 +42,11 @@ func createDataEncryptionKeyForIntegrationTest(
 		Provider:        string(generated.Provider),
 		ProviderID:      generated.ProviderID,
 		ProviderVersion: generated.ProviderVersion,
-		ProtectedData:   &generated.ProtectedData,
-		IsCurrent:       true,
+		ProviderMetadata: database.DataEncryptionKeyProviderMetadata(
+			generated.ProviderMetadata,
+		),
+		ProtectedData: &generated.ProtectedData,
+		IsCurrent:     true,
 	}
 	require.NoError(t, db.CreateDataEncryptionKey(ctx, dek))
 

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -10,10 +10,11 @@ replace github.com/Masterminds/squirrel v1.5.4 => github.com/jack-t/squirrel v1.
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0
-	github.com/aws/aws-sdk-go-v2 v1.41.2
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2
 	github.com/chromedp/chromedp v0.14.2
+	github.com/cschleiden/go-workflows v1.4.2
 	github.com/gin-gonic/gin v1.11.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
@@ -45,20 +46,21 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
-	github.com/aws/smithy-go v1.24.1 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/bsm/redislock v0.9.4 // indirect
@@ -74,7 +76,6 @@ require (
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
-	github.com/cschleiden/go-workflows v1.4.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -43,8 +43,8 @@ github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUS
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
-github.com/aws/aws-sdk-go-v2 v1.41.2/go.mod h1:IvvlAZQXvTXznUPfRVfryiG1fbzE2NGK6m9u39YQ+S4=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.32.9 h1:ktda/mtAydeObvJXlHzyGpK1xcsLaP16zfUPDGoW90A=
@@ -53,10 +53,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.9 h1:sWvTKsyrMlJGEuj/WgrwilpoJ6Xa
 github.com/aws/aws-sdk-go-v2/credentials v1.19.9/go.mod h1:+J44MBhmfVY/lETFiKI+klz0Vym2aCmIjqgClMmW82w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 h1:F43zk1vemYIqPAwhjTjYIz0irU2EY7sOb/F5eJ3HuyM=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18/go.mod h1:w1jdlZXrGKaJcNoL+Nnrj+k5wlpGXqnNrKoP22HvAug=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 h1:xCeWVjj0ki0l3nruoyP2slHsGArMxeiiaoPN5QZH6YQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18/go.mod h1:r/eLGuGCBw6l36ZRWiw6PaZwPXb6YOj+i/7MizNl5/k=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R50aTBHkA7vu0lK+k=
@@ -69,6 +69,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMooz
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu/eJC0Lh9adJa3M1xREcndxLNZlve2U=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 h1:PEgVSsWtR8NNxsDxFL2Ywisi7R+1EFQARGsT4q3mWwI=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4/go.mod h1:3EeKyDGPGSCEphG2OolwNGNF45RvQIfm27AYYpfEWrw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2 h1:hezAo5AQM0moD4qitsn8bZuc2WE/MmP+cySGfJWEi1A=
@@ -81,8 +83,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 h1:0jbJeuEHlwKJ9PfXtpSFc4M
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14/go.mod h1:sTGThjphYE4Ohw8vJiRStAcu3rbjtXRsdNB0TvZ5wwo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/pJ1jOWYlFDJTjRQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
-github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
-github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -94,6 +94,7 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 | Provider | Config Field | Description |
 |---|---|---|
 | **AWS Secrets Manager** | `aws_secret_id`, `aws_region` | Fetches secret value from AWS. Supports `aws_secret_key` for JSON extraction. Caches with configurable TTL. |
+| **AWS KMS** | `aws_kms_key_id`, `aws_region` | Uses AWS KMS to generate, wrap, and unwrap DEKs. The KMS key material never leaves AWS; AuthProxy persists only wrapped DEKs and provider metadata. Supports `aws_credentials`, `aws_kms_endpoint`, and `cache_ttl`. |
 | **GCP Secret Manager** | `gcp_secret_name`, `gcp_project` | Fetches from Google Cloud. Defaults to `latest` version. |
 | **HashiCorp Vault** | `vault_address`, `vault_path` | KV v1/v2 auto-detection. Reads `VAULT_TOKEN` from env if not configured. Exponential backoff retry. |
 | **Environment Variable** | `env_var` | Reads key bytes from an environment variable (also available as base64-encoded variant). |
@@ -102,7 +103,7 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 | **Random Bytes** | `num_bytes` | Generates secure random bytes at startup. Useful for ephemeral/dev keys. |
 | **KMS-backed providers** | provider-specific | Generate AuthProxy DEKs and wrap them with a provider-held KEK. The KEK never leaves the provider. |
 
-Cloud providers (AWS, GCP, Vault) support caching via `cache_ttl` and report provider-version metadata when the underlying secret has been rotated.
+Cloud providers (AWS, GCP, Vault) support caching via `cache_ttl` and report provider-version metadata when the underlying secret or KMS material has been rotated.
 
 KMS-backed providers are different from secret-backed providers. Secret-backed providers return AES key bytes directly to AuthProxy. KMS-backed providers generate or wrap data encryption keys (DEKs) and persist only the wrapped DEK in `data_encryption_keys`. Runtime encryption and re-encryption are driven by the current DEK for the namespace key.
 

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -44,8 +44,11 @@ func createDataEncryptionKey(
 		Provider:        string(generated.Provider),
 		ProviderID:      generated.ProviderID,
 		ProviderVersion: generated.ProviderVersion,
-		ProtectedData:   &generated.ProtectedData,
-		IsCurrent:       true,
+		ProviderMetadata: database.DataEncryptionKeyProviderMetadata(
+			generated.ProviderMetadata,
+		),
+		ProtectedData: &generated.ProtectedData,
+		IsCurrent:     true,
 	}
 	if err := db.CreateDataEncryptionKey(ctx, dek); err != nil {
 		return nil, err

--- a/internal/schema/config/key_data.go
+++ b/internal/schema/config/key_data.go
@@ -47,11 +47,12 @@ type KeyWrappingKeyInfo struct {
 // provider. The plaintext DEK is returned for immediate cache use by callers,
 // but only the provider metadata and ProtectedData should be persisted.
 type GeneratedDataEncryptionKey struct {
-	Provider        ProviderType
-	ProviderID      string
-	ProviderVersion string
-	ProtectedData   KeyVersionProtectedData
-	Data            []byte
+	Provider         ProviderType
+	ProviderID       string
+	ProviderVersion  string
+	ProviderMetadata map[string]string
+	ProtectedData    KeyVersionProtectedData
+	Data             []byte
 }
 
 // KeyDataRequiresDataEncryptionKeys is implemented by providers that resolve

--- a/internal/schema/config/key_data_aws_kms.go
+++ b/internal/schema/config/key_data_aws_kms.go
@@ -1,0 +1,437 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+const (
+	awsKMSProtectedDataType = string(ProviderTypeAwsKMS)
+
+	awsKMSMetadataConfiguredKeyID = "aws_kms_configured_key_id"
+	awsKMSMetadataKeyARN          = "aws_kms_key_arn"
+	awsKMSMetadataKeyMaterialID   = "aws_kms_key_material_id"
+)
+
+// awsKMSClient is the subset of the AWS KMS API used by KeyDataAwsKMS.
+type awsKMSClient interface {
+	DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+	GenerateDataKey(ctx context.Context, params *kms.GenerateDataKeyInput, optFns ...func(*kms.Options)) (*kms.GenerateDataKeyOutput, error)
+	Encrypt(ctx context.Context, params *kms.EncryptInput, optFns ...func(*kms.Options)) (*kms.EncryptOutput, error)
+	Decrypt(ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error)
+}
+
+// KeyDataAwsKMS uses AWS KMS as a wrapping-key provider for data encryption keys.
+type KeyDataAwsKMS struct {
+	AwsKMSKeyID    string          `json:"aws_kms_key_id" yaml:"aws_kms_key_id"`
+	AwsRegion      string          `json:"aws_region,omitempty" yaml:"aws_region,omitempty"`
+	AwsKMSEndpoint string          `json:"aws_kms_endpoint,omitempty" yaml:"aws_kms_endpoint,omitempty"`
+	Credentials    *AwsCredentials `json:"aws_credentials,omitempty" yaml:"aws_credentials,omitempty"`
+	CacheTTL       string          `json:"cache_ttl,omitempty" yaml:"cache_ttl,omitempty"`
+
+	cache keyDataCache
+
+	// clientFactory overrides the default AWS client creation for testing.
+	clientFactory func(ctx context.Context) (awsKMSClient, error)
+}
+
+func (ka *KeyDataAwsKMS) initCache() error {
+	if ka.cache.fetchCurrent != nil {
+		return nil
+	}
+
+	if ka.CacheTTL != "" {
+		ttl, err := time.ParseDuration(ka.CacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid cache_ttl for aws kms key data: %w", err)
+		}
+		ka.cache.ttl = ttl
+	}
+
+	ka.cache.fetchCurrent = ka.fetchCurrentVersion
+	ka.cache.fetchVersion = ka.fetchVersion
+	ka.cache.fetchList = ka.fetchListVersions
+	return nil
+}
+
+func (ka *KeyDataAwsKMS) providerID() string {
+	return ka.AwsKMSKeyID
+}
+
+func (ka *KeyDataAwsKMS) fetchCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	current, err := ka.CurrentWrappingKey(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+
+	return KeyVersionInfo{
+		Provider:        current.Provider,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+		IsCurrent:       true,
+	}, nil
+}
+
+func (ka *KeyDataAwsKMS) fetchVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	current, err := ka.fetchCurrentVersion(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+	if current.ProviderVersion == version {
+		return current, nil
+	}
+
+	return KeyVersionInfo{
+		Provider:        ProviderTypeAwsKMS,
+		ProviderID:      ka.providerID(),
+		ProviderVersion: version,
+	}, nil
+}
+
+func (ka *KeyDataAwsKMS) fetchListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	current, err := ka.fetchCurrentVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []KeyVersionInfo{current}, nil
+}
+
+func (ka *KeyDataAwsKMS) GetCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	if err := ka.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return ka.cache.GetCurrentVersion(ctx)
+}
+
+func (ka *KeyDataAwsKMS) GetVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	if err := ka.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return ka.cache.GetVersion(ctx, version)
+}
+
+func (ka *KeyDataAwsKMS) ListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	if err := ka.initCache(); err != nil {
+		return nil, err
+	}
+	return ka.cache.ListVersions(ctx)
+}
+
+func (ka *KeyDataAwsKMS) ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error) {
+	var result []KeyVersionInfo
+	for _, dekInfo := range deks {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if dekInfo.Provider != ProviderTypeAwsKMS {
+			continue
+		}
+
+		dekBytes, err := ka.UnwrapDataEncryptionKey(ctx, dekInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, KeyVersionInfo{
+			Provider:        ProviderTypeAwsKMS,
+			ProviderID:      dekInfo.ID,
+			ProviderVersion: dekInfo.ProviderVersion,
+			Data:            dekBytes,
+			IsCurrent:       dekInfo.IsCurrent,
+		})
+	}
+
+	return result, nil
+}
+
+func (ka *KeyDataAwsKMS) CurrentWrappingKey(ctx context.Context) (KeyWrappingKeyInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	client, err := ka.getClient(ctx)
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	out, err := client.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(ka.AwsKMSKeyID),
+	})
+	if err != nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("failed to describe AWS KMS key %s: %w", ka.AwsKMSKeyID, err)
+	}
+	if out.KeyMetadata == nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("AWS KMS describe key %s returned no metadata", ka.AwsKMSKeyID)
+	}
+
+	metadata := ka.providerMetadataFromKeyMetadata(out.KeyMetadata)
+	version := awsKMSProviderVersionFromMetadata(metadata)
+	if version == "" {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("AWS KMS key %s returned no usable provider version", ka.AwsKMSKeyID)
+	}
+
+	return KeyWrappingKeyInfo{
+		Provider:        ProviderTypeAwsKMS,
+		ProviderID:      ka.providerID(),
+		ProviderVersion: version,
+		Metadata:        metadata,
+	}, nil
+}
+
+func (ka *KeyDataAwsKMS) GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := ka.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	out, err := client.GenerateDataKey(ctx, &kms.GenerateDataKeyInput{
+		KeyId:   aws.String(ka.AwsKMSKeyID),
+		KeySpec: kmstypes.DataKeySpecAes256,
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate data encryption key with AWS KMS key %s: %w", ka.AwsKMSKeyID, err)
+	}
+	if len(out.Plaintext) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("AWS KMS GenerateDataKey returned empty plaintext")
+	}
+	if len(out.CiphertextBlob) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("AWS KMS GenerateDataKey returned empty ciphertext")
+	}
+
+	metadata := ka.providerMetadataFromKMSResult(out.KeyId, out.KeyMaterialId)
+	if metadata[awsKMSMetadataKeyARN] == "" || metadata[awsKMSMetadataKeyMaterialID] == "" {
+		current, err := ka.CurrentWrappingKey(ctx)
+		if err != nil {
+			return GeneratedDataEncryptionKey{}, err
+		}
+		for k, v := range current.Metadata {
+			if metadata[k] == "" {
+				metadata[k] = v
+			}
+		}
+	}
+	version := awsKMSProviderVersionFromMetadata(metadata)
+	protected := awsKMSProtectedData(out.CiphertextBlob, metadata)
+
+	return GeneratedDataEncryptionKey{
+		Provider:         ProviderTypeAwsKMS,
+		ProviderID:       ka.providerID(),
+		ProviderVersion:  version,
+		ProviderMetadata: metadata,
+		ProtectedData:    protected,
+		Data:             append([]byte(nil), out.Plaintext...),
+	}, nil
+}
+
+func (ka *KeyDataAwsKMS) WrapDataEncryptionKey(ctx context.Context, dek []byte) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	if len(dek) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("data encryption key is empty")
+	}
+
+	current, err := ka.CurrentWrappingKey(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := ka.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	out, err := client.Encrypt(ctx, &kms.EncryptInput{
+		KeyId:     aws.String(ka.AwsKMSKeyID),
+		Plaintext: dek,
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to wrap data encryption key with AWS KMS key %s: %w", ka.AwsKMSKeyID, err)
+	}
+	if len(out.CiphertextBlob) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("AWS KMS Encrypt returned empty ciphertext")
+	}
+
+	metadata := copyStringMap(current.Metadata)
+	if out.KeyId != nil && *out.KeyId != "" {
+		metadata[awsKMSMetadataKeyARN] = *out.KeyId
+	}
+
+	return GeneratedDataEncryptionKey{
+		Provider:         ProviderTypeAwsKMS,
+		ProviderID:       current.ProviderID,
+		ProviderVersion:  current.ProviderVersion,
+		ProviderMetadata: metadata,
+		ProtectedData:    awsKMSProtectedData(out.CiphertextBlob, metadata),
+		Data:             append([]byte(nil), dek...),
+	}, nil
+}
+
+func (ka *KeyDataAwsKMS) UnwrapDataEncryptionKey(ctx context.Context, dekInfo DataEncryptionKeyInfo) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if dekInfo.Provider != ProviderTypeAwsKMS {
+		return nil, fmt.Errorf("unsupported AWS KMS provider %q", dekInfo.Provider)
+	}
+	if dekInfo.ProtectedData == nil || dekInfo.ProtectedData.IsZero() {
+		return nil, errors.New("data encryption key protected data is empty")
+	}
+	if dekInfo.ProtectedData.Type != awsKMSProtectedDataType {
+		return nil, fmt.Errorf("unsupported AWS KMS protected data type %q", dekInfo.ProtectedData.Type)
+	}
+
+	wrapped, err := base64.StdEncoding.DecodeString(dekInfo.ProtectedData.WrappedData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode AWS KMS wrapped data: %w", err)
+	}
+
+	client, err := ka.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	input := &kms.DecryptInput{
+		CiphertextBlob: wrapped,
+	}
+	if keyID := awsKMSDecryptKeyID(dekInfo.ProtectedData.Metadata); keyID != "" {
+		input.KeyId = aws.String(keyID)
+	}
+
+	out, err := client.Decrypt(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unwrap data encryption key with AWS KMS key %s: %w", ka.AwsKMSKeyID, err)
+	}
+	if len(out.Plaintext) == 0 {
+		return nil, errors.New("AWS KMS Decrypt returned empty plaintext")
+	}
+
+	return append([]byte(nil), out.Plaintext...), nil
+}
+
+func (ka *KeyDataAwsKMS) GetProviderType() ProviderType {
+	return ProviderTypeAwsKMS
+}
+
+func (ka *KeyDataAwsKMS) getClient(ctx context.Context) (awsKMSClient, error) {
+	if ka.clientFactory != nil {
+		return ka.clientFactory(ctx)
+	}
+	return ka.newKMSClient(ctx)
+}
+
+func (ka *KeyDataAwsKMS) newKMSClient(ctx context.Context) (*kms.Client, error) {
+	opts := []func(*awsconfig.LoadOptions) error{}
+
+	if ka.AwsRegion != "" {
+		opts = append(opts, awsconfig.WithRegion(ka.AwsRegion))
+	}
+
+	if ka.Credentials != nil {
+		credOpts, err := ka.Credentials.GetAwsConfigLoadOptions(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get aws credentials: %w", err)
+		}
+		opts = append(opts, credOpts...)
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load aws config: %w", err)
+	}
+
+	clientOpts := []func(*kms.Options){}
+	if ka.AwsKMSEndpoint != "" {
+		clientOpts = append(clientOpts, func(o *kms.Options) {
+			o.BaseEndpoint = aws.String(ka.AwsKMSEndpoint)
+		})
+	}
+
+	return kms.NewFromConfig(cfg, clientOpts...), nil
+}
+
+func (ka *KeyDataAwsKMS) providerMetadataFromKeyMetadata(metadata *kmstypes.KeyMetadata) map[string]string {
+	result := map[string]string{
+		awsKMSMetadataConfiguredKeyID: ka.AwsKMSKeyID,
+	}
+	if metadata == nil {
+		return result
+	}
+	if metadata.Arn != nil && *metadata.Arn != "" {
+		result[awsKMSMetadataKeyARN] = *metadata.Arn
+	} else if metadata.KeyId != nil && *metadata.KeyId != "" {
+		result[awsKMSMetadataKeyARN] = *metadata.KeyId
+	}
+	if metadata.CurrentKeyMaterialId != nil && *metadata.CurrentKeyMaterialId != "" {
+		result[awsKMSMetadataKeyMaterialID] = *metadata.CurrentKeyMaterialId
+	}
+	return result
+}
+
+func (ka *KeyDataAwsKMS) providerMetadataFromKMSResult(keyID *string, keyMaterialID *string) map[string]string {
+	result := map[string]string{
+		awsKMSMetadataConfiguredKeyID: ka.AwsKMSKeyID,
+	}
+	if keyID != nil && *keyID != "" {
+		result[awsKMSMetadataKeyARN] = *keyID
+	}
+	if keyMaterialID != nil && *keyMaterialID != "" {
+		result[awsKMSMetadataKeyMaterialID] = *keyMaterialID
+	}
+	return result
+}
+
+func awsKMSProviderVersionFromMetadata(metadata map[string]string) string {
+	keyVersionParts := make([]string, 0, 2)
+	if keyARN := metadata[awsKMSMetadataKeyARN]; keyARN != "" {
+		keyVersionParts = append(keyVersionParts, keyARN)
+	}
+	if materialID := metadata[awsKMSMetadataKeyMaterialID]; materialID != "" {
+		keyVersionParts = append(keyVersionParts, materialID)
+	}
+	return strings.Join(keyVersionParts, "/")
+}
+
+func awsKMSProtectedData(ciphertext []byte, metadata map[string]string) KeyVersionProtectedData {
+	return KeyVersionProtectedData{
+		Type:        awsKMSProtectedDataType,
+		WrappedData: base64.StdEncoding.EncodeToString(ciphertext),
+		Metadata:    copyStringMap(metadata),
+	}
+}
+
+func awsKMSDecryptKeyID(metadata map[string]string) string {
+	if keyARN := metadata[awsKMSMetadataKeyARN]; keyARN != "" {
+		return keyARN
+	}
+	return ""
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+var _ KeyDataType = (*KeyDataAwsKMS)(nil)
+var _ KeyDataRequiresDataEncryptionKeys = (*KeyDataAwsKMS)(nil)
+var _ KeyDataWrapsDataEncryptionKeys = (*KeyDataAwsKMS)(nil)
+var _ KeyDataGeneratesDataEncryptionKeys = (*KeyDataAwsKMS)(nil)

--- a/internal/schema/config/key_data_aws_kms_test.go
+++ b/internal/schema/config/key_data_aws_kms_test.go
@@ -1,0 +1,320 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type mockKMSClient struct {
+	describeKey     func(ctx context.Context, params *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
+	generateDataKey func(ctx context.Context, params *kms.GenerateDataKeyInput) (*kms.GenerateDataKeyOutput, error)
+	encrypt         func(ctx context.Context, params *kms.EncryptInput) (*kms.EncryptOutput, error)
+	decrypt         func(ctx context.Context, params *kms.DecryptInput) (*kms.DecryptOutput, error)
+}
+
+func (m *mockKMSClient) DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	if m.describeKey == nil {
+		return nil, errors.New("unexpected DescribeKey")
+	}
+	return m.describeKey(ctx, params)
+}
+
+func (m *mockKMSClient) GenerateDataKey(ctx context.Context, params *kms.GenerateDataKeyInput, _ ...func(*kms.Options)) (*kms.GenerateDataKeyOutput, error) {
+	if m.generateDataKey == nil {
+		return nil, errors.New("unexpected GenerateDataKey")
+	}
+	return m.generateDataKey(ctx, params)
+}
+
+func (m *mockKMSClient) Encrypt(ctx context.Context, params *kms.EncryptInput, _ ...func(*kms.Options)) (*kms.EncryptOutput, error) {
+	if m.encrypt == nil {
+		return nil, errors.New("unexpected Encrypt")
+	}
+	return m.encrypt(ctx, params)
+}
+
+func (m *mockKMSClient) Decrypt(ctx context.Context, params *kms.DecryptInput, _ ...func(*kms.Options)) (*kms.DecryptOutput, error) {
+	if m.decrypt == nil {
+		return nil, errors.New("unexpected Decrypt")
+	}
+	return m.decrypt(ctx, params)
+}
+
+func newTestAwsKMS(keyID string, mock *mockKMSClient) *KeyDataAwsKMS {
+	return &KeyDataAwsKMS{
+		AwsKMSKeyID: keyID,
+		clientFactory: func(ctx context.Context) (awsKMSClient, error) {
+			return mock, nil
+		},
+	}
+}
+
+func TestKeyDataAwsKMS_CurrentWrappingKey(t *testing.T) {
+	mock := &mockKMSClient{
+		describeKey: func(_ context.Context, params *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+			require.Equal(t, "alias/authproxy", *params.KeyId)
+			return &kms.DescribeKeyOutput{
+				KeyMetadata: &kmstypes.KeyMetadata{
+					Arn:                  aws.String("arn:aws:kms:us-east-1:123:key/key-1"),
+					KeyId:                aws.String("key-1"),
+					CurrentKeyMaterialId: aws.String("material-1"),
+					KeyState:             kmstypes.KeyStateEnabled,
+				},
+			}, nil
+		},
+	}
+
+	ka := newTestAwsKMS("alias/authproxy", mock)
+	current, err := ka.CurrentWrappingKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeAwsKMS, current.Provider)
+	assert.Equal(t, "alias/authproxy", current.ProviderID)
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/key-1/material-1", current.ProviderVersion)
+	assert.Equal(t, "alias/authproxy", current.Metadata[awsKMSMetadataConfiguredKeyID])
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/key-1", current.Metadata[awsKMSMetadataKeyARN])
+	assert.Equal(t, "material-1", current.Metadata[awsKMSMetadataKeyMaterialID])
+}
+
+func TestKeyDataAwsKMS_GenerateDataEncryptionKey(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("wrapped-by-kms")
+	mock := &mockKMSClient{
+		generateDataKey: func(_ context.Context, params *kms.GenerateDataKeyInput) (*kms.GenerateDataKeyOutput, error) {
+			require.Equal(t, "alias/authproxy", *params.KeyId)
+			require.Equal(t, kmstypes.DataKeySpecAes256, params.KeySpec)
+			return &kms.GenerateDataKeyOutput{
+				KeyId:          aws.String("arn:aws:kms:us-east-1:123:key/key-1"),
+				KeyMaterialId:  aws.String("material-1"),
+				Plaintext:      plaintext,
+				CiphertextBlob: ciphertext,
+			}, nil
+		},
+	}
+
+	ka := newTestAwsKMS("alias/authproxy", mock)
+	generated, err := ka.GenerateDataEncryptionKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeAwsKMS, generated.Provider)
+	assert.Equal(t, "alias/authproxy", generated.ProviderID)
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/key-1/material-1", generated.ProviderVersion)
+	assert.Equal(t, plaintext, generated.Data)
+	assert.Equal(t, awsKMSProtectedDataType, generated.ProtectedData.Type)
+	assert.Equal(t, "alias/authproxy", generated.ProviderMetadata[awsKMSMetadataConfiguredKeyID])
+	assert.Equal(t, "material-1", generated.ProviderMetadata[awsKMSMetadataKeyMaterialID])
+
+	decoded, err := base64.StdEncoding.DecodeString(generated.ProtectedData.WrappedData)
+	require.NoError(t, err)
+	assert.Equal(t, ciphertext, decoded)
+}
+
+func TestKeyDataAwsKMS_WrapAndUnwrapDataEncryptionKey(t *testing.T) {
+	dek := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("kms-ciphertext")
+	mock := &mockKMSClient{
+		describeKey: func(_ context.Context, _ *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+			return &kms.DescribeKeyOutput{
+				KeyMetadata: &kmstypes.KeyMetadata{
+					Arn:                  aws.String("arn:aws:kms:us-east-1:123:key/key-1"),
+					KeyId:                aws.String("key-1"),
+					CurrentKeyMaterialId: aws.String("material-1"),
+				},
+			}, nil
+		},
+		encrypt: func(_ context.Context, params *kms.EncryptInput) (*kms.EncryptOutput, error) {
+			require.Equal(t, "alias/authproxy", *params.KeyId)
+			require.Equal(t, dek, params.Plaintext)
+			return &kms.EncryptOutput{
+				KeyId:          aws.String("arn:aws:kms:us-east-1:123:key/key-1"),
+				CiphertextBlob: ciphertext,
+			}, nil
+		},
+		decrypt: func(_ context.Context, params *kms.DecryptInput) (*kms.DecryptOutput, error) {
+			require.Equal(t, ciphertext, params.CiphertextBlob)
+			require.NotNil(t, params.KeyId)
+			require.Equal(t, "arn:aws:kms:us-east-1:123:key/key-1", *params.KeyId)
+			return &kms.DecryptOutput{Plaintext: dek}, nil
+		},
+	}
+
+	ka := newTestAwsKMS("alias/authproxy", mock)
+	wrapped, err := ka.WrapDataEncryptionKey(context.Background(), dek)
+	require.NoError(t, err)
+	require.Equal(t, "arn:aws:kms:us-east-1:123:key/key-1/material-1", wrapped.ProviderVersion)
+
+	unwrapped, err := ka.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+		ID:              "dek_test",
+		Provider:        ProviderTypeAwsKMS,
+		ProviderID:      wrapped.ProviderID,
+		ProviderVersion: wrapped.ProviderVersion,
+		ProtectedData:   &wrapped.ProtectedData,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, dek, unwrapped)
+}
+
+func TestKeyDataAwsKMS_ListVersionsWithDataEncryptionKeys(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("kms-ciphertext")
+	protected := awsKMSProtectedData(ciphertext, map[string]string{
+		awsKMSMetadataKeyARN: "arn:aws:kms:us-east-1:123:key/key-1",
+	})
+	mock := &mockKMSClient{
+		decrypt: func(_ context.Context, params *kms.DecryptInput) (*kms.DecryptOutput, error) {
+			require.Equal(t, ciphertext, params.CiphertextBlob)
+			return &kms.DecryptOutput{Plaintext: plaintext}, nil
+		},
+	}
+
+	ka := newTestAwsKMS("alias/authproxy", mock)
+	versions, err := ka.ListVersionsWithDataEncryptionKeys(context.Background(), []DataEncryptionKeyInfo{
+		{
+			ID:              "dek_aws",
+			Provider:        ProviderTypeAwsKMS,
+			ProviderID:      "alias/authproxy",
+			ProviderVersion: "v1",
+			ProtectedData:   &protected,
+			IsCurrent:       true,
+		},
+		{
+			ID:       "dek_secret",
+			Provider: ProviderTypeAws,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "dek_aws", versions[0].ProviderID)
+	assert.Equal(t, plaintext, versions[0].Data)
+	assert.True(t, versions[0].IsCurrent)
+}
+
+func TestKeyDataAwsKMS_Caching(t *testing.T) {
+	callCount := 0
+	mock := &mockKMSClient{
+		describeKey: func(_ context.Context, _ *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+			callCount++
+			return &kms.DescribeKeyOutput{
+				KeyMetadata: &kmstypes.KeyMetadata{
+					Arn:                  aws.String("arn:aws:kms:us-east-1:123:key/key-1"),
+					KeyId:                aws.String("key-1"),
+					CurrentKeyMaterialId: aws.String("material-1"),
+				},
+			}, nil
+		},
+	}
+
+	ka := newTestAwsKMS("alias/authproxy", mock)
+	ka.CacheTTL = "1h"
+
+	ctx := context.Background()
+	_, err := ka.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+	_, err = ka.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount)
+}
+
+func TestKeyDataAwsKMS_Errors(t *testing.T) {
+	t.Run("invalid cache ttl", func(t *testing.T) {
+		ka := newTestAwsKMS("alias/authproxy", &mockKMSClient{})
+		ka.CacheTTL = "not-a-duration"
+		_, err := ka.GetCurrentVersion(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid cache_ttl")
+	})
+
+	t.Run("unsupported provider", func(t *testing.T) {
+		ka := newTestAwsKMS("alias/authproxy", &mockKMSClient{})
+		_, err := ka.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeAws,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported AWS KMS provider")
+	})
+
+	t.Run("unsupported protected data type", func(t *testing.T) {
+		ka := newTestAwsKMS("alias/authproxy", &mockKMSClient{})
+		_, err := ka.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeAwsKMS,
+			ProtectedData: &KeyVersionProtectedData{
+				Type:        "other",
+				WrappedData: base64.StdEncoding.EncodeToString([]byte("x")),
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported AWS KMS protected data type")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		called := false
+		ka := &KeyDataAwsKMS{
+			AwsKMSKeyID: "alias/authproxy",
+			clientFactory: func(context.Context) (awsKMSClient, error) {
+				called = true
+				return nil, fmt.Errorf("should not be called")
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := ka.GenerateDataEncryptionKey(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, called)
+	})
+}
+
+func TestKeyDataAwsKMS_GetProviderType(t *testing.T) {
+	ka := &KeyDataAwsKMS{}
+	assert.Equal(t, ProviderTypeAwsKMS, ka.GetProviderType())
+}
+
+func TestKeyDataAwsKMS_KeyDataSerialization(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"aws_kms_key_id": "alias/authproxy",
+			"aws_region": "us-east-1",
+			"aws_kms_endpoint": "http://localhost:4566",
+			"cache_ttl": "5m"
+		}`), &kd))
+
+		awsKMS, ok := kd.InnerVal.(*KeyDataAwsKMS)
+		require.True(t, ok)
+		assert.Equal(t, "alias/authproxy", awsKMS.AwsKMSKeyID)
+		assert.Equal(t, "us-east-1", awsKMS.AwsRegion)
+		assert.Equal(t, "http://localhost:4566", awsKMS.AwsKMSEndpoint)
+		assert.Equal(t, "5m", awsKMS.CacheTTL)
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, yaml.Unmarshal([]byte(`
+aws_kms_key_id: alias/authproxy
+aws_region: us-east-1
+aws_kms_endpoint: http://localhost:4566
+cache_ttl: 5m
+`), &kd))
+
+		awsKMS, ok := kd.InnerVal.(*KeyDataAwsKMS)
+		require.True(t, ok)
+		assert.Equal(t, "alias/authproxy", awsKMS.AwsKMSKeyID)
+		assert.Equal(t, "us-east-1", awsKMS.AwsRegion)
+		assert.Equal(t, "http://localhost:4566", awsKMS.AwsKMSEndpoint)
+		assert.Equal(t, "5m", awsKMS.CacheTTL)
+	})
+}

--- a/internal/schema/config/key_data_aws_kms_test.go
+++ b/internal/schema/config/key_data_aws_kms_test.go
@@ -191,7 +191,7 @@ func TestKeyDataAwsKMS_ListVersionsWithDataEncryptionKeys(t *testing.T) {
 		},
 		{
 			ID:       "dek_secret",
-			Provider: ProviderTypeAws,
+			Provider: ProviderTypeAwsSecretsManager,
 		},
 	})
 
@@ -241,7 +241,7 @@ func TestKeyDataAwsKMS_Errors(t *testing.T) {
 	t.Run("unsupported provider", func(t *testing.T) {
 		ka := newTestAwsKMS("alias/authproxy", &mockKMSClient{})
 		_, err := ka.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
-			Provider: ProviderTypeAws,
+			Provider: ProviderTypeAwsSecretsManager,
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported AWS KMS provider")

--- a/internal/schema/config/key_data_aws_secret.go
+++ b/internal/schema/config/key_data_aws_secret.go
@@ -64,7 +64,7 @@ func (ka *KeyDataAwsSecret) fetchCurrentVersion(ctx context.Context) (KeyVersion
 	}
 
 	return KeyVersionInfo{
-		Provider:        ProviderTypeAws,
+		Provider:        ProviderTypeAwsSecretsManager,
 		ProviderID:      ka.providerID(),
 		ProviderVersion: version,
 		Data:            data,
@@ -79,7 +79,7 @@ func (ka *KeyDataAwsSecret) fetchVersion(ctx context.Context, version string) (K
 	}
 
 	return KeyVersionInfo{
-		Provider:        ProviderTypeAws,
+		Provider:        ProviderTypeAwsSecretsManager,
 		ProviderID:      ka.providerID(),
 		ProviderVersion: version,
 		Data:            data,
@@ -171,7 +171,7 @@ func (ka *KeyDataAwsSecret) ListVersions(ctx context.Context) ([]KeyVersionInfo,
 }
 
 func (ka *KeyDataAwsSecret) GetProviderType() ProviderType {
-	return ProviderTypeAws
+	return ProviderTypeAwsSecretsManager
 }
 
 func (ka *KeyDataAwsSecret) getClient(ctx context.Context) (awsSecretsManagerClient, error) {

--- a/internal/schema/config/key_data_aws_secret_test.go
+++ b/internal/schema/config/key_data_aws_secret_test.go
@@ -54,7 +54,7 @@ func TestKeyDataAwsSecret_GetCurrentVersion(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []byte("my-secret-value"), info.Data)
 		assert.Equal(t, "v1", info.ProviderVersion)
-		assert.Equal(t, ProviderTypeAws, info.Provider)
+		assert.Equal(t, ProviderTypeAwsSecretsManager, info.Provider)
 		assert.Equal(t, "my-secret", info.ProviderID)
 		assert.True(t, info.IsCurrent)
 	})
@@ -515,7 +515,7 @@ func TestKeyDataAwsSecret_Caching(t *testing.T) {
 
 func TestKeyDataAwsSecret_GetProviderType(t *testing.T) {
 	ka := &KeyDataAwsSecret{}
-	assert.Equal(t, ProviderTypeAws, ka.GetProviderType())
+	assert.Equal(t, ProviderTypeAwsSecretsManager, ka.GetProviderType())
 }
 
 func TestKeyDataAwsSecret_ClientFactoryError(t *testing.T) {

--- a/internal/schema/config/key_data_serialization_json.go
+++ b/internal/schema/config/key_data_serialization_json.go
@@ -38,6 +38,8 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 		t = &KeyDataRandomBytes{}
 	} else if _, ok := valueMap["vault_address"]; ok {
 		t = &KeyDataVault{}
+	} else if _, ok := valueMap["aws_kms_key_id"]; ok {
+		t = &KeyDataAwsKMS{}
 	} else if _, ok := valueMap["aws_secret_id"]; ok {
 		t = &KeyDataAwsSecret{}
 	} else if _, ok := valueMap["gcp_secret_name"]; ok {
@@ -47,7 +49,7 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 	} else if _, ok := valueMap["mock_kms_id"]; ok {
 		t = &KeyDataMockKMS{}
 	} else {
-		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := json.Unmarshal(data, t); err != nil {

--- a/internal/schema/config/key_data_serialization_yaml.go
+++ b/internal/schema/config/key_data_serialization_yaml.go
@@ -50,6 +50,9 @@ fieldLoop:
 		case "vault_address":
 			keyData = &KeyDataVault{}
 			break fieldLoop
+		case "aws_kms_key_id":
+			keyData = &KeyDataAwsKMS{}
+			break fieldLoop
 		case "aws_secret_id":
 			keyData = &KeyDataAwsSecret{}
 			break fieldLoop
@@ -66,7 +69,7 @@ fieldLoop:
 	}
 
 	if keyData == nil {
-		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := value.Decode(keyData); err != nil {

--- a/internal/schema/config/key_version_info.go
+++ b/internal/schema/config/key_version_info.go
@@ -18,6 +18,7 @@ const (
 	ProviderTypeFile           ProviderType = "file"
 	ProviderTypeRandom         ProviderType = "random"
 	ProviderTypeAws            ProviderType = "aws"
+	ProviderTypeAwsKMS         ProviderType = "aws_kms"
 	ProviderTypeGcp            ProviderType = "gcp"
 	ProviderTypeHashicorpVault ProviderType = "hashicorpvault"
 	ProviderTypeRaw            ProviderType = "raw"

--- a/internal/schema/config/key_version_info.go
+++ b/internal/schema/config/key_version_info.go
@@ -11,17 +11,17 @@ import (
 type ProviderType string
 
 const (
-	ProviderTypeValue          ProviderType = "value"
-	ProviderTypeBase64         ProviderType = "base64"
-	ProviderTypeEnvVar         ProviderType = "env_var"
-	ProviderTypeEnvVarBase64   ProviderType = "env_var_base64"
-	ProviderTypeFile           ProviderType = "file"
-	ProviderTypeRandom         ProviderType = "random"
-	ProviderTypeAws            ProviderType = "aws"
-	ProviderTypeAwsKMS         ProviderType = "aws_kms"
-	ProviderTypeGcp            ProviderType = "gcp"
-	ProviderTypeHashicorpVault ProviderType = "hashicorpvault"
-	ProviderTypeRaw            ProviderType = "raw"
+	ProviderTypeValue             ProviderType = "value"
+	ProviderTypeBase64            ProviderType = "base64"
+	ProviderTypeEnvVar            ProviderType = "env_var"
+	ProviderTypeEnvVarBase64      ProviderType = "env_var_base64"
+	ProviderTypeFile              ProviderType = "file"
+	ProviderTypeRandom            ProviderType = "random"
+	ProviderTypeAwsSecretsManager ProviderType = "aws_secrets_manager"
+	ProviderTypeAwsKMS            ProviderType = "aws_kms"
+	ProviderTypeGcp               ProviderType = "gcp"
+	ProviderTypeHashicorpVault    ProviderType = "hashicorpvault"
+	ProviderTypeRaw               ProviderType = "raw"
 )
 
 // KeyVersionProtectedData stores provider-specific wrapped key material for

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -878,6 +878,18 @@
           },
           "required": ["num_bytes"],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "aws_kms_key_id": { "type": "string" },
+            "aws_region": { "type": "string" },
+            "aws_kms_endpoint": { "type": "string" },
+            "aws_credentials": { "$ref": "#/$defs/AwsCredentials" },
+            "cache_ttl": { "type": "string" }
+          },
+          "required": ["aws_kms_key_id"],
+          "additionalProperties": false
         }
       ]
     },

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -210,6 +210,11 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"num_bytes": 32}}`,
 				},
 				{
+					Name:  "aws kms",
+					Valid: true,
+					Data:  `{"test": {"aws_kms_key_id": "alias/authproxy", "aws_region": "us-east-1", "aws_kms_endpoint": "http://localhost:4566", "aws_credentials": {"type": "implicit"}, "cache_ttl": "5m"}}`,
+				},
+				{
 					Name:  "empty object",
 					Valid: false,
 					Data:  `{"test": {}}`,


### PR DESCRIPTION
## Summary
- add an aws_kms KeyData provider that uses AWS KMS GenerateDataKey, Encrypt, Decrypt, and DescribeKey for DEK lifecycle
- persist provider metadata on newly generated DEKs so sync can compare KMS wrapping state without immediate redundant rewraps
- add AWS KMS config schema/docs plus an opt-in integration test path with optional metadata-advancement rewrap coverage

## Tests
- go test ./internal/schema/config ./internal/encrypt -count=1
- go test -tags "integration,aws" ./encrypt -run TestAwsKMSKeySyncAndReencrypt -count=1 (from integration_tests; skips without AWS env)
- ./scripts/preflight.sh

Closes #617