### PR TITLE
Add GCP KMS support for unified keys

### DIFF
--- a/docs/key-model-migration.md
+++ b/docs/key-model-migration.md
@@ -286,6 +286,12 @@ cannot be deleted immediately after creation. Set `AUTH_PROXY_AWS_KMS_KEY_ID_V2`
 to a second accessible key ID or alias to exercise metadata advancement and
 rewrap under new provider material.
 
+Google Cloud KMS integration tests require an existing symmetric encryption
+CryptoKey. Google Cloud KMS does not expose an AWS-style `GenerateDataKey` API,
+so AuthProxy uses `GenerateRandomBytes` for provider-generated DEK bytes and
+then wraps the DEK with `Encrypt`; the DEK row stores the CryptoKeyVersion used
+for wrapping.
+
 ## Implementation Order
 
 The child issues under #605 are intended to land in this rough order:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rmorlok/authproxy
 go 1.24.5
 
 require (
+	cloud.google.com/go/kms v1.22.0
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/Masterminds/squirrel v1.5.4
@@ -31,6 +32,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/googleapis/gax-go/v2 v2.15.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/vault/api v1.22.0
 	github.com/hibiken/asynq v0.25.1
@@ -78,10 +80,12 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.120.0 // indirect
 	cloud.google.com/go/auth v0.16.4 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
@@ -135,7 +139,6 @@ require (
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
-	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.2 h1:qgFRAGEmd8z6dJ/qyEchAuL9jpswyODjA2lS+w234g8=
 cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCSkUHE=
+cloud.google.com/go/kms v1.22.0 h1:dBRIj7+GDeeEvatJeTB19oYZNV0aj6wEqSIT/7gLqtk=
+cloud.google.com/go/kms v1.22.0/go.mod h1:U7mf8Sva5jpOb4bxYZdtw/9zsbIjrklYwPcvMk34AL8=
+cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFsS/PrE=
+cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 cloud.google.com/go/secretmanager v1.16.0 h1:19QT7ZsLJ8FSP1k+4esQvuCD7npMJml6hYzilxVyT+k=
 cloud.google.com/go/secretmanager v1.16.0/go.mod h1://C/e4I8D26SDTz1f3TQcddhcmiC3rMEl0S1Cakvs3Q=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -119,6 +119,33 @@ Notes:
 - For CI, provide `GCP_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS_JSON` (the full service account key JSON) as repository secrets. The GitHub Actions workflow writes the JSON to a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
 - The workflow runs only on pushes to `main` (and manual `workflow_dispatch`) to avoid exposing the GCP secrets to PRs from forks.
 
+## GCP KMS Integration Test
+
+This test hits real Google Cloud KMS and is gated behind the `gcp` build tag and an env flag.
+
+Requirements:
+- GCP credentials available via Application Default Credentials.
+- `AUTH_PROXY_GCP_KMS_TEST=1` set to opt in.
+- `AUTH_PROXY_GCP_KMS_KEY_NAME` set to an existing symmetric encryption CryptoKey resource name, or `GCP_PROJECT_ID`, `AUTH_PROXY_GCP_KMS_LOCATION`, `AUTH_PROXY_GCP_KMS_KEY_RING`, and `AUTH_PROXY_GCP_KMS_CRYPTO_KEY` set to its components.
+- IAM permissions: `cloudkms.cryptoKeys.get`, `cloudkms.cryptoKeyVersions.useToEncrypt`, `cloudkms.cryptoKeyVersions.useToDecrypt`, and `cloudkms.locations.generateRandomBytes`.
+
+Optional:
+- `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` set to a second accessible CryptoKey to exercise provider metadata advancement and DEK rewrap.
+- `AUTH_PROXY_GCP_KMS_ENDPOINT` set to override the KMS endpoint.
+
+Run:
+```bash
+cd integration_tests
+AUTH_PROXY_GCP_KMS_TEST=1 \
+  AUTH_PROXY_GCP_KMS_KEY_NAME=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper \
+  GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
+  go test -tags "integration,gcp" -v ./encrypt/...
+```
+
+Notes:
+- The test does not create or delete KMS keys because Google Cloud KMS keys are long-lived resources.
+- GCP KMS DEK generation uses `GenerateRandomBytes` and then wraps the generated DEK with the configured CryptoKey.
+
 ## HashiCorp Vault Integration Test
 
 This test hits a running HashiCorp Vault server and is gated behind the `vault` build tag and an env flag. Unlike the AWS and GCP tests, Vault runs locally (in dev mode) both on developer machines and in CI — no external credentials required.

--- a/integration_tests/encrypt/gcp_kms_test.go
+++ b/integration_tests/encrypt/gcp_kms_test.go
@@ -1,0 +1,159 @@
+//go:build integration && gcp
+
+package encrypt_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gcpKMSTestEnv        = "AUTH_PROXY_GCP_KMS_TEST"
+	gcpKMSKeyNameEnv     = "AUTH_PROXY_GCP_KMS_KEY_NAME"
+	gcpKMSKeyNameV2Env   = "AUTH_PROXY_GCP_KMS_KEY_NAME_V2"
+	gcpKMSLocationEnv    = "AUTH_PROXY_GCP_KMS_LOCATION"
+	gcpKMSKeyRingEnv     = "AUTH_PROXY_GCP_KMS_KEY_RING"
+	gcpKMSCryptoKeyEnv   = "AUTH_PROXY_GCP_KMS_CRYPTO_KEY"
+	gcpKMSEndpointEnv    = "AUTH_PROXY_GCP_KMS_ENDPOINT"
+	gcpKMSProviderString = string(sconfig.ProviderTypeGcpKMS)
+)
+
+func TestGcpKMSKeySyncAndReencrypt(t *testing.T) {
+	if os.Getenv(gcpKMSTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", gcpKMSTestEnv)
+	}
+
+	keyName := gcpKMSKeyNameFromEnv(t, "")
+
+	ctx := context.Background()
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+
+	namespace := fmt.Sprintf("root.gcp-kms-test-%d", time.Now().UnixNano())
+	keyID := apid.New(apid.PrefixKey)
+
+	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
+		Path:  namespace,
+		KeyId: &keyID,
+	}))
+
+	keyData := gcpKMSKeyData(keyName)
+	keyDataJSON, err := json.Marshal(&keyData)
+	require.NoError(t, err)
+
+	encKeyData, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSON)
+	require.NoError(t, err)
+
+	require.NoError(t, env.Db.CreateKey(ctx, &database.Key{
+		Id:               keyID,
+		Namespace:        namespace,
+		MaterialType:     database.KeyMaterialTypeExternal,
+		EncryptedKeyData: &encKeyData,
+		State:            database.KeyStateActive,
+	}))
+
+	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyID, &keyData)
+	require.Equal(t, gcpKMSProviderString, currentV1.Provider)
+	require.Equal(t, keyName, currentV1.ProviderID)
+	require.NotEmpty(t, currentV1.ProviderVersion)
+	require.NotNil(t, currentV1.ProtectedData)
+	require.Equal(t, gcpKMSProviderString, currentV1.ProtectedData.Type)
+	require.NotEmpty(t, currentV1.ProtectedData.WrappedData)
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	plaintext := "gcp-kms-test"
+	encrypted, err := env.DM.GetEncryptService().EncryptStringForNamespace(ctx, namespace, plaintext)
+	require.NoError(t, err)
+	require.Equal(t, currentV1.Id, encrypted.ID)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, env.Db.CreateActor(ctx, &database.Actor{
+		Id:           actorID,
+		Namespace:    namespace,
+		ExternalId:   "gcp-kms-test-actor",
+		EncryptedKey: &encrypted,
+	}))
+
+	keyNameV2 := gcpKMSKeyNameFromEnv(t, "_V2")
+	if keyNameV2 != "" {
+		keyDataV2 := gcpKMSKeyData(keyNameV2)
+		keyDataJSONV2, err := json.Marshal(&keyDataV2)
+		require.NoError(t, err)
+
+		encKeyDataV2, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSONV2)
+		require.NoError(t, err)
+		_, err = env.Db.UpdateKey(ctx, keyID, map[string]interface{}{
+			"encrypted_key_data": encKeyDataV2,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+		require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+		currentV2, err := env.Db.GetCurrentDataEncryptionKeyForKey(ctx, keyID)
+		require.NoError(t, err)
+		require.Equal(t, currentV1.Id, currentV2.Id)
+		require.Equal(t, keyNameV2, currentV2.ProviderID)
+		require.NotEqual(t, currentV1.ProviderVersion, currentV2.ProviderVersion)
+		require.NotEqual(t, currentV1.ProtectedData.WrappedData, currentV2.ProtectedData.WrappedData)
+	} else {
+		t.Logf("%s is not set; skipping GCP KMS metadata advancement rewrap path", gcpKMSKeyNameV2Env)
+	}
+
+	require.NoError(t, runReencryptAll(ctx, env))
+
+	updated, err := env.Db.GetActor(ctx, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.EncryptedKey)
+	require.Equal(t, currentV1.Id, updated.EncryptedKey.ID)
+	require.Equal(t, encrypted.Data, updated.EncryptedKey.Data)
+
+	decrypted, err := env.DM.GetEncryptService().DecryptString(ctx, *updated.EncryptedKey)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+}
+
+func gcpKMSKeyData(keyName string) sconfig.KeyData {
+	return sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataGcpKMS{
+			GcpKMSKeyName:  keyName,
+			GcpKMSEndpoint: os.Getenv(gcpKMSEndpointEnv),
+		},
+	}
+}
+
+func gcpKMSKeyNameFromEnv(t *testing.T, suffix string) string {
+	t.Helper()
+
+	if suffix == "_V2" {
+		return os.Getenv(gcpKMSKeyNameV2Env)
+	}
+
+	keyName := os.Getenv(gcpKMSKeyNameEnv)
+	if keyName != "" {
+		return keyName
+	}
+
+	projectID := os.Getenv(gcpProjectIDEnv)
+	location := os.Getenv(gcpKMSLocationEnv)
+	keyRing := os.Getenv(gcpKMSKeyRingEnv)
+	cryptoKey := os.Getenv(gcpKMSCryptoKeyEnv)
+	if projectID == "" || location == "" || keyRing == "" || cryptoKey == "" {
+		t.Skipf("set %s or %s, %s, %s, and %s", gcpKMSKeyNameEnv, gcpProjectIDEnv, gcpKMSLocationEnv, gcpKMSKeyRingEnv, gcpKMSCryptoKeyEnv)
+	}
+
+	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", projectID, location, keyRing, cryptoKey)
+}

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -27,10 +27,13 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.120.0 // indirect
 	cloud.google.com/go/auth v0.16.4 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/kms v1.22.0 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -8,6 +8,10 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.2 h1:qgFRAGEmd8z6dJ/qyEchAuL9jpswyODjA2lS+w234g8=
 cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCSkUHE=
+cloud.google.com/go/kms v1.22.0 h1:dBRIj7+GDeeEvatJeTB19oYZNV0aj6wEqSIT/7gLqtk=
+cloud.google.com/go/kms v1.22.0/go.mod h1:U7mf8Sva5jpOb4bxYZdtw/9zsbIjrklYwPcvMk34AL8=
+cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFsS/PrE=
+cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 cloud.google.com/go/secretmanager v1.16.0 h1:19QT7ZsLJ8FSP1k+4esQvuCD7npMJml6hYzilxVyT+k=
 cloud.google.com/go/secretmanager v1.16.0/go.mod h1://C/e4I8D26SDTz1f3TQcddhcmiC3rMEl0S1Cakvs3Q=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=

--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -96,6 +96,7 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 | **AWS Secrets Manager** | `aws_secret_id`, `aws_region` | Fetches secret value from AWS. Supports `aws_secret_key` for JSON extraction. Caches with configurable TTL. |
 | **AWS KMS** | `aws_kms_key_id`, `aws_region` | Uses AWS KMS to generate, wrap, and unwrap DEKs. The KMS key material never leaves AWS; AuthProxy persists only wrapped DEKs and provider metadata. Supports `aws_credentials`, `aws_kms_endpoint`, and `cache_ttl`. |
 | **GCP Secret Manager** | `gcp_secret_name`, `gcp_project` | Fetches from Google Cloud. Defaults to `latest` version. |
+| **GCP KMS** | `gcp_kms_key_name` or `gcp_project`, `gcp_location`, `gcp_key_ring`, `gcp_crypto_key` | Uses Google Cloud KMS to generate DEK bytes, wrap/unwrap DEKs with the configured CryptoKey, and track the CryptoKeyVersion used for wrapping. Supports ADC, `gcp_credentials_file`, `gcp_credentials_json`, `gcp_kms_endpoint`, and `cache_ttl`. |
 | **HashiCorp Vault** | `vault_address`, `vault_path` | KV v1/v2 auto-detection. Reads `VAULT_TOKEN` from env if not configured. Exponential backoff retry. |
 | **Environment Variable** | `env_var` | Reads key bytes from an environment variable (also available as base64-encoded variant). |
 | **File** | `path` | Reads key bytes from a file. Supports `~` expansion. |

--- a/internal/schema/config/key_data_gcp_kms.go
+++ b/internal/schema/config/key_data_gcp_kms.go
@@ -1,0 +1,490 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cloudkms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/option"
+)
+
+const (
+	gcpKMSProtectedDataType = string(ProviderTypeGcpKMS)
+
+	gcpKMSMetadataConfiguredKeyName = "gcp_kms_configured_key_name"
+	gcpKMSMetadataCryptoKeyName     = "gcp_kms_crypto_key_name"
+	gcpKMSMetadataCryptoKeyVersion  = "gcp_kms_crypto_key_version"
+	gcpKMSMetadataProtectionLevel   = "gcp_kms_protection_level"
+)
+
+// gcpKMSClient is the subset of the Google Cloud KMS API used by KeyDataGcpKMS.
+type gcpKMSClient interface {
+	GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest, opts ...gax.CallOption) (*kmspb.CryptoKey, error)
+	GenerateRandomBytes(ctx context.Context, req *kmspb.GenerateRandomBytesRequest, opts ...gax.CallOption) (*kmspb.GenerateRandomBytesResponse, error)
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+	Close() error
+}
+
+// KeyDataGcpKMS uses Google Cloud KMS as a wrapping-key provider for data encryption keys.
+type KeyDataGcpKMS struct {
+	GcpKMSKeyName      string       `json:"gcp_kms_key_name,omitempty" yaml:"gcp_kms_key_name,omitempty"`
+	GcpProject         string       `json:"gcp_project,omitempty" yaml:"gcp_project,omitempty"`
+	GcpLocation        string       `json:"gcp_location,omitempty" yaml:"gcp_location,omitempty"`
+	GcpKeyRing         string       `json:"gcp_key_ring,omitempty" yaml:"gcp_key_ring,omitempty"`
+	GcpCryptoKey       string       `json:"gcp_crypto_key,omitempty" yaml:"gcp_crypto_key,omitempty"`
+	GcpKMSEndpoint     string       `json:"gcp_kms_endpoint,omitempty" yaml:"gcp_kms_endpoint,omitempty"`
+	GcpCredentialsFile string       `json:"gcp_credentials_file,omitempty" yaml:"gcp_credentials_file,omitempty"`
+	GcpCredentialsJSON *StringValue `json:"gcp_credentials_json,omitempty" yaml:"gcp_credentials_json,omitempty"`
+	CacheTTL           string       `json:"cache_ttl,omitempty" yaml:"cache_ttl,omitempty"`
+
+	cache keyDataCache
+
+	// clientFactory overrides the default Google Cloud KMS client creation for testing.
+	clientFactory func(ctx context.Context) (gcpKMSClient, error)
+}
+
+func (kg *KeyDataGcpKMS) initCache() error {
+	if kg.cache.fetchCurrent != nil {
+		return nil
+	}
+
+	if kg.CacheTTL != "" {
+		ttl, err := time.ParseDuration(kg.CacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid cache_ttl for gcp kms key data: %w", err)
+		}
+		kg.cache.ttl = ttl
+	}
+
+	kg.cache.fetchCurrent = kg.fetchCurrentVersion
+	kg.cache.fetchVersion = kg.fetchVersion
+	kg.cache.fetchList = kg.fetchListVersions
+	return nil
+}
+
+func (kg *KeyDataGcpKMS) providerID() (string, error) {
+	return kg.cryptoKeyName()
+}
+
+func (kg *KeyDataGcpKMS) fetchCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	current, err := kg.CurrentWrappingKey(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+
+	return KeyVersionInfo{
+		Provider:        current.Provider,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+		IsCurrent:       true,
+	}, nil
+}
+
+func (kg *KeyDataGcpKMS) fetchVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	current, err := kg.fetchCurrentVersion(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+	if current.ProviderVersion == version {
+		return current, nil
+	}
+
+	providerID, err := kg.providerID()
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+
+	return KeyVersionInfo{
+		Provider:        ProviderTypeGcpKMS,
+		ProviderID:      providerID,
+		ProviderVersion: version,
+	}, nil
+}
+
+func (kg *KeyDataGcpKMS) fetchListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	current, err := kg.fetchCurrentVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []KeyVersionInfo{current}, nil
+}
+
+func (kg *KeyDataGcpKMS) GetCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	if err := kg.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return kg.cache.GetCurrentVersion(ctx)
+}
+
+func (kg *KeyDataGcpKMS) GetVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	if err := kg.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return kg.cache.GetVersion(ctx, version)
+}
+
+func (kg *KeyDataGcpKMS) ListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	if err := kg.initCache(); err != nil {
+		return nil, err
+	}
+	return kg.cache.ListVersions(ctx)
+}
+
+func (kg *KeyDataGcpKMS) ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error) {
+	var result []KeyVersionInfo
+	for _, dekInfo := range deks {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if dekInfo.Provider != ProviderTypeGcpKMS {
+			continue
+		}
+
+		dekBytes, err := kg.UnwrapDataEncryptionKey(ctx, dekInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, KeyVersionInfo{
+			Provider:        ProviderTypeGcpKMS,
+			ProviderID:      dekInfo.ID,
+			ProviderVersion: dekInfo.ProviderVersion,
+			Data:            dekBytes,
+			IsCurrent:       dekInfo.IsCurrent,
+		})
+	}
+
+	return result, nil
+}
+
+func (kg *KeyDataGcpKMS) CurrentWrappingKey(ctx context.Context) (KeyWrappingKeyInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	keyName, err := kg.cryptoKeyName()
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	client, err := kg.getClient(ctx)
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+	defer client.Close()
+
+	out, err := client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+		Name: keyName,
+	})
+	if err != nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("failed to get GCP KMS crypto key %s: %w", keyName, err)
+	}
+	if out == nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("GCP KMS crypto key %s returned no metadata", keyName)
+	}
+
+	metadata := kg.providerMetadataFromCryptoKey(out, keyName)
+	version := gcpKMSProviderVersionFromMetadata(metadata)
+	if version == "" {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("GCP KMS crypto key %s returned no primary version", keyName)
+	}
+
+	providerID := gcpKMSCryptoKeyNameFromMetadata(metadata)
+	if providerID == "" {
+		providerID = keyName
+	}
+
+	return KeyWrappingKeyInfo{
+		Provider:        ProviderTypeGcpKMS,
+		ProviderID:      providerID,
+		ProviderVersion: version,
+		Metadata:        metadata,
+	}, nil
+}
+
+func (kg *KeyDataGcpKMS) GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	location, err := kg.locationName()
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := kg.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	defer client.Close()
+
+	out, err := client.GenerateRandomBytes(ctx, &kmspb.GenerateRandomBytesRequest{
+		Location:        location,
+		LengthBytes:     DataEncryptionKeySize,
+		ProtectionLevel: kmspb.ProtectionLevel_HSM,
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate data encryption key bytes with GCP KMS location %s: %w", location, err)
+	}
+	if out == nil || len(out.Data) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("GCP KMS GenerateRandomBytes returned empty data")
+	}
+	if len(out.Data) != DataEncryptionKeySize {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("GCP KMS GenerateRandomBytes returned %d bytes; expected %d", len(out.Data), DataEncryptionKeySize)
+	}
+
+	return kg.WrapDataEncryptionKey(ctx, out.Data)
+}
+
+func (kg *KeyDataGcpKMS) WrapDataEncryptionKey(ctx context.Context, dek []byte) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	if len(dek) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("data encryption key is empty")
+	}
+
+	current, err := kg.CurrentWrappingKey(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := kg.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	defer client.Close()
+
+	out, err := client.Encrypt(ctx, &kmspb.EncryptRequest{
+		Name:      current.ProviderID,
+		Plaintext: dek,
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to wrap data encryption key with GCP KMS crypto key %s: %w", current.ProviderID, err)
+	}
+	if out == nil || len(out.Ciphertext) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("GCP KMS Encrypt returned empty ciphertext")
+	}
+
+	metadata := copyStringMap(current.Metadata)
+	if out.Name != "" {
+		metadata[gcpKMSMetadataCryptoKeyVersion] = out.Name
+		if cryptoKeyName := gcpKMSCryptoKeyNameFromVersion(out.Name); cryptoKeyName != "" {
+			metadata[gcpKMSMetadataCryptoKeyName] = cryptoKeyName
+		}
+	}
+	if out.ProtectionLevel != kmspb.ProtectionLevel_PROTECTION_LEVEL_UNSPECIFIED {
+		metadata[gcpKMSMetadataProtectionLevel] = out.ProtectionLevel.String()
+	}
+
+	providerID := gcpKMSCryptoKeyNameFromMetadata(metadata)
+	if providerID == "" {
+		providerID = current.ProviderID
+	}
+	version := gcpKMSProviderVersionFromMetadata(metadata)
+	if version == "" {
+		version = current.ProviderVersion
+	}
+
+	return GeneratedDataEncryptionKey{
+		Provider:         ProviderTypeGcpKMS,
+		ProviderID:       providerID,
+		ProviderVersion:  version,
+		ProviderMetadata: metadata,
+		ProtectedData:    gcpKMSProtectedData(out.Ciphertext, metadata),
+		Data:             append([]byte(nil), dek...),
+	}, nil
+}
+
+func (kg *KeyDataGcpKMS) UnwrapDataEncryptionKey(ctx context.Context, dekInfo DataEncryptionKeyInfo) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if dekInfo.Provider != ProviderTypeGcpKMS {
+		return nil, fmt.Errorf("unsupported GCP KMS provider %q", dekInfo.Provider)
+	}
+	if dekInfo.ProtectedData == nil || dekInfo.ProtectedData.IsZero() {
+		return nil, errors.New("data encryption key protected data is empty")
+	}
+	if dekInfo.ProtectedData.Type != gcpKMSProtectedDataType {
+		return nil, fmt.Errorf("unsupported GCP KMS protected data type %q", dekInfo.ProtectedData.Type)
+	}
+
+	wrapped, err := base64.StdEncoding.DecodeString(dekInfo.ProtectedData.WrappedData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode GCP KMS wrapped data: %w", err)
+	}
+
+	keyName, err := kg.decryptKeyName(dekInfo.ProtectedData.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kg.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	out, err := client.Decrypt(ctx, &kmspb.DecryptRequest{
+		Name:       keyName,
+		Ciphertext: wrapped,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to unwrap data encryption key with GCP KMS crypto key %s: %w", keyName, err)
+	}
+	if out == nil || len(out.Plaintext) == 0 {
+		return nil, errors.New("GCP KMS Decrypt returned empty plaintext")
+	}
+
+	return append([]byte(nil), out.Plaintext...), nil
+}
+
+func (kg *KeyDataGcpKMS) GetProviderType() ProviderType {
+	return ProviderTypeGcpKMS
+}
+
+func (kg *KeyDataGcpKMS) getClient(ctx context.Context) (gcpKMSClient, error) {
+	if kg.clientFactory != nil {
+		return kg.clientFactory(ctx)
+	}
+	return kg.newKMSClient(ctx)
+}
+
+func (kg *KeyDataGcpKMS) newKMSClient(ctx context.Context) (*cloudkms.KeyManagementClient, error) {
+	opts := []option.ClientOption{}
+
+	if kg.GcpKMSEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(kg.GcpKMSEndpoint))
+	}
+
+	if kg.GcpCredentialsFile != "" && kg.GcpCredentialsJSON != nil && kg.GcpCredentialsJSON.HasValue(ctx) {
+		return nil, errors.New("only one of gcp_credentials_file or gcp_credentials_json may be configured")
+	}
+	if kg.GcpCredentialsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(kg.GcpCredentialsFile))
+	}
+	if kg.GcpCredentialsJSON != nil && kg.GcpCredentialsJSON.HasValue(ctx) {
+		credsJSON, err := kg.GcpCredentialsJSON.GetValue(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get gcp credentials json: %w", err)
+		}
+		opts = append(opts, option.WithCredentialsJSON([]byte(credsJSON)))
+	}
+
+	client, err := cloudkms.NewKeyManagementClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gcp kms client: %w", err)
+	}
+	return client, nil
+}
+
+func (kg *KeyDataGcpKMS) cryptoKeyName() (string, error) {
+	if kg.GcpKMSKeyName != "" {
+		return kg.GcpKMSKeyName, nil
+	}
+	if kg.GcpProject == "" || kg.GcpLocation == "" || kg.GcpKeyRing == "" || kg.GcpCryptoKey == "" {
+		return "", errors.New("gcp kms key data requires either gcp_kms_key_name or gcp_project, gcp_location, gcp_key_ring, and gcp_crypto_key")
+	}
+	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", kg.GcpProject, kg.GcpLocation, kg.GcpKeyRing, kg.GcpCryptoKey), nil
+}
+
+func (kg *KeyDataGcpKMS) locationName() (string, error) {
+	if kg.GcpProject != "" && kg.GcpLocation != "" {
+		return fmt.Sprintf("projects/%s/locations/%s", kg.GcpProject, kg.GcpLocation), nil
+	}
+
+	keyName, err := kg.cryptoKeyName()
+	if err != nil {
+		return "", err
+	}
+	location := gcpKMSLocationNameFromCryptoKey(keyName)
+	if location == "" {
+		return "", fmt.Errorf("failed to derive gcp kms location from crypto key %s", keyName)
+	}
+	return location, nil
+}
+
+func (kg *KeyDataGcpKMS) decryptKeyName(metadata map[string]string) (string, error) {
+	if keyName := gcpKMSCryptoKeyNameFromMetadata(metadata); keyName != "" {
+		return keyName, nil
+	}
+	return kg.cryptoKeyName()
+}
+
+func (kg *KeyDataGcpKMS) providerMetadataFromCryptoKey(key *kmspb.CryptoKey, configuredKeyName string) map[string]string {
+	result := map[string]string{
+		gcpKMSMetadataConfiguredKeyName: configuredKeyName,
+	}
+	if key == nil {
+		return result
+	}
+	if key.Name != "" {
+		result[gcpKMSMetadataCryptoKeyName] = key.Name
+	}
+	if key.Primary != nil {
+		if key.Primary.Name != "" {
+			result[gcpKMSMetadataCryptoKeyVersion] = key.Primary.Name
+		}
+		if key.Primary.ProtectionLevel != kmspb.ProtectionLevel_PROTECTION_LEVEL_UNSPECIFIED {
+			result[gcpKMSMetadataProtectionLevel] = key.Primary.ProtectionLevel.String()
+		}
+	}
+	return result
+}
+
+func gcpKMSProviderVersionFromMetadata(metadata map[string]string) string {
+	return metadata[gcpKMSMetadataCryptoKeyVersion]
+}
+
+func gcpKMSCryptoKeyNameFromMetadata(metadata map[string]string) string {
+	if keyName := metadata[gcpKMSMetadataCryptoKeyName]; keyName != "" {
+		return keyName
+	}
+	if version := metadata[gcpKMSMetadataCryptoKeyVersion]; version != "" {
+		return gcpKMSCryptoKeyNameFromVersion(version)
+	}
+	return ""
+}
+
+func gcpKMSCryptoKeyNameFromVersion(versionName string) string {
+	const marker = "/cryptoKeyVersions/"
+	idx := strings.LastIndex(versionName, marker)
+	if idx < 0 {
+		return ""
+	}
+	return versionName[:idx]
+}
+
+func gcpKMSLocationNameFromCryptoKey(keyName string) string {
+	const marker = "/keyRings/"
+	idx := strings.Index(keyName, marker)
+	if idx < 0 {
+		return ""
+	}
+	prefix := keyName[:idx]
+	if !strings.Contains(prefix, "/locations/") {
+		return ""
+	}
+	return prefix
+}
+
+func gcpKMSProtectedData(ciphertext []byte, metadata map[string]string) KeyVersionProtectedData {
+	return KeyVersionProtectedData{
+		Type:        gcpKMSProtectedDataType,
+		WrappedData: base64.StdEncoding.EncodeToString(ciphertext),
+		Metadata:    copyStringMap(metadata),
+	}
+}
+
+var _ KeyDataType = (*KeyDataGcpKMS)(nil)
+var _ KeyDataRequiresDataEncryptionKeys = (*KeyDataGcpKMS)(nil)
+var _ KeyDataWrapsDataEncryptionKeys = (*KeyDataGcpKMS)(nil)
+var _ KeyDataGeneratesDataEncryptionKeys = (*KeyDataGcpKMS)(nil)

--- a/internal/schema/config/key_data_gcp_kms_test.go
+++ b/internal/schema/config/key_data_gcp_kms_test.go
@@ -1,0 +1,369 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	testGcpKMSKeyName = "projects/test-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper"
+	testGcpKMSVersion = testGcpKMSKeyName + "/cryptoKeyVersions/1"
+)
+
+type mockGcpKMSClient struct {
+	getCryptoKey        func(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error)
+	generateRandomBytes func(ctx context.Context, req *kmspb.GenerateRandomBytesRequest) (*kmspb.GenerateRandomBytesResponse, error)
+	encrypt             func(ctx context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error)
+	decrypt             func(ctx context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error)
+	close               func() error
+}
+
+func (m *mockGcpKMSClient) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest, _ ...gax.CallOption) (*kmspb.CryptoKey, error) {
+	if m.getCryptoKey == nil {
+		return nil, errors.New("unexpected GetCryptoKey")
+	}
+	return m.getCryptoKey(ctx, req)
+}
+
+func (m *mockGcpKMSClient) GenerateRandomBytes(ctx context.Context, req *kmspb.GenerateRandomBytesRequest, _ ...gax.CallOption) (*kmspb.GenerateRandomBytesResponse, error) {
+	if m.generateRandomBytes == nil {
+		return nil, errors.New("unexpected GenerateRandomBytes")
+	}
+	return m.generateRandomBytes(ctx, req)
+}
+
+func (m *mockGcpKMSClient) Encrypt(ctx context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	if m.encrypt == nil {
+		return nil, errors.New("unexpected Encrypt")
+	}
+	return m.encrypt(ctx, req)
+}
+
+func (m *mockGcpKMSClient) Decrypt(ctx context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	if m.decrypt == nil {
+		return nil, errors.New("unexpected Decrypt")
+	}
+	return m.decrypt(ctx, req)
+}
+
+func (m *mockGcpKMSClient) Close() error {
+	if m.close != nil {
+		return m.close()
+	}
+	return nil
+}
+
+func newTestGcpKMS(keyName string, mock *mockGcpKMSClient) *KeyDataGcpKMS {
+	return &KeyDataGcpKMS{
+		GcpKMSKeyName: keyName,
+		clientFactory: func(context.Context) (gcpKMSClient, error) {
+			return mock, nil
+		},
+	}
+}
+
+func TestKeyDataGcpKMS_CurrentWrappingKey(t *testing.T) {
+	mock := &mockGcpKMSClient{
+		getCryptoKey: func(_ context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			return &kmspb.CryptoKey{
+				Name: testGcpKMSKeyName,
+				Primary: &kmspb.CryptoKeyVersion{
+					Name:            testGcpKMSVersion,
+					ProtectionLevel: kmspb.ProtectionLevel_HSM,
+				},
+			}, nil
+		},
+	}
+
+	kg := newTestGcpKMS(testGcpKMSKeyName, mock)
+	current, err := kg.CurrentWrappingKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeGcpKMS, current.Provider)
+	assert.Equal(t, testGcpKMSKeyName, current.ProviderID)
+	assert.Equal(t, testGcpKMSVersion, current.ProviderVersion)
+	assert.Equal(t, testGcpKMSKeyName, current.Metadata[gcpKMSMetadataConfiguredKeyName])
+	assert.Equal(t, testGcpKMSKeyName, current.Metadata[gcpKMSMetadataCryptoKeyName])
+	assert.Equal(t, testGcpKMSVersion, current.Metadata[gcpKMSMetadataCryptoKeyVersion])
+	assert.Equal(t, "HSM", current.Metadata[gcpKMSMetadataProtectionLevel])
+}
+
+func TestKeyDataGcpKMS_GenerateDataEncryptionKey(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("wrapped-by-gcp-kms")
+	mock := &mockGcpKMSClient{
+		generateRandomBytes: func(_ context.Context, req *kmspb.GenerateRandomBytesRequest) (*kmspb.GenerateRandomBytesResponse, error) {
+			require.Equal(t, "projects/test-project/locations/global", req.Location)
+			require.Equal(t, int32(DataEncryptionKeySize), req.LengthBytes)
+			require.Equal(t, kmspb.ProtectionLevel_HSM, req.ProtectionLevel)
+			return &kmspb.GenerateRandomBytesResponse{Data: plaintext}, nil
+		},
+		getCryptoKey: func(_ context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			return &kmspb.CryptoKey{
+				Name: testGcpKMSKeyName,
+				Primary: &kmspb.CryptoKeyVersion{
+					Name:            testGcpKMSVersion,
+					ProtectionLevel: kmspb.ProtectionLevel_HSM,
+				},
+			}, nil
+		},
+		encrypt: func(_ context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			require.Equal(t, plaintext, req.Plaintext)
+			return &kmspb.EncryptResponse{
+				Name:            testGcpKMSVersion,
+				Ciphertext:      ciphertext,
+				ProtectionLevel: kmspb.ProtectionLevel_HSM,
+			}, nil
+		},
+	}
+
+	kg := &KeyDataGcpKMS{
+		GcpProject:   "test-project",
+		GcpLocation:  "global",
+		GcpKeyRing:   "authproxy",
+		GcpCryptoKey: "dek-wrapper",
+		clientFactory: func(context.Context) (gcpKMSClient, error) {
+			return mock, nil
+		},
+	}
+	generated, err := kg.GenerateDataEncryptionKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeGcpKMS, generated.Provider)
+	assert.Equal(t, testGcpKMSKeyName, generated.ProviderID)
+	assert.Equal(t, testGcpKMSVersion, generated.ProviderVersion)
+	assert.Equal(t, plaintext, generated.Data)
+	assert.Equal(t, gcpKMSProtectedDataType, generated.ProtectedData.Type)
+	assert.Equal(t, testGcpKMSKeyName, generated.ProviderMetadata[gcpKMSMetadataConfiguredKeyName])
+	assert.Equal(t, testGcpKMSVersion, generated.ProviderMetadata[gcpKMSMetadataCryptoKeyVersion])
+
+	decoded, err := base64.StdEncoding.DecodeString(generated.ProtectedData.WrappedData)
+	require.NoError(t, err)
+	assert.Equal(t, ciphertext, decoded)
+}
+
+func TestKeyDataGcpKMS_WrapAndUnwrapDataEncryptionKey(t *testing.T) {
+	dek := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("gcp-kms-ciphertext")
+	mock := &mockGcpKMSClient{
+		getCryptoKey: func(_ context.Context, _ *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+			return &kmspb.CryptoKey{
+				Name: testGcpKMSKeyName,
+				Primary: &kmspb.CryptoKeyVersion{
+					Name:            testGcpKMSVersion,
+					ProtectionLevel: kmspb.ProtectionLevel_HSM,
+				},
+			}, nil
+		},
+		encrypt: func(_ context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			require.Equal(t, dek, req.Plaintext)
+			return &kmspb.EncryptResponse{
+				Name:            testGcpKMSVersion,
+				Ciphertext:      ciphertext,
+				ProtectionLevel: kmspb.ProtectionLevel_HSM,
+			}, nil
+		},
+		decrypt: func(_ context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			require.Equal(t, ciphertext, req.Ciphertext)
+			return &kmspb.DecryptResponse{Plaintext: dek}, nil
+		},
+	}
+
+	kg := newTestGcpKMS(testGcpKMSKeyName, mock)
+	wrapped, err := kg.WrapDataEncryptionKey(context.Background(), dek)
+	require.NoError(t, err)
+	require.Equal(t, testGcpKMSVersion, wrapped.ProviderVersion)
+
+	// Use a different configured key to prove decrypt follows the persisted DEK metadata.
+	unwrapper := newTestGcpKMS("projects/test-project/locations/global/keyRings/authproxy/cryptoKeys/new-wrapper", mock)
+	unwrapped, err := unwrapper.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+		ID:              "dek_test",
+		Provider:        ProviderTypeGcpKMS,
+		ProviderID:      wrapped.ProviderID,
+		ProviderVersion: wrapped.ProviderVersion,
+		ProtectedData:   &wrapped.ProtectedData,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, dek, unwrapped)
+}
+
+func TestKeyDataGcpKMS_ListVersionsWithDataEncryptionKeys(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	ciphertext := []byte("gcp-kms-ciphertext")
+	protected := gcpKMSProtectedData(ciphertext, map[string]string{
+		gcpKMSMetadataCryptoKeyName:    testGcpKMSKeyName,
+		gcpKMSMetadataCryptoKeyVersion: testGcpKMSVersion,
+	})
+	mock := &mockGcpKMSClient{
+		decrypt: func(_ context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error) {
+			require.Equal(t, testGcpKMSKeyName, req.Name)
+			require.Equal(t, ciphertext, req.Ciphertext)
+			return &kmspb.DecryptResponse{Plaintext: plaintext}, nil
+		},
+	}
+
+	kg := newTestGcpKMS(testGcpKMSKeyName, mock)
+	versions, err := kg.ListVersionsWithDataEncryptionKeys(context.Background(), []DataEncryptionKeyInfo{
+		{
+			ID:              "dek_gcp",
+			Provider:        ProviderTypeGcpKMS,
+			ProviderID:      testGcpKMSKeyName,
+			ProviderVersion: testGcpKMSVersion,
+			ProtectedData:   &protected,
+			IsCurrent:       true,
+		},
+		{
+			ID:       "dek_secret",
+			Provider: ProviderTypeGcp,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "dek_gcp", versions[0].ProviderID)
+	assert.Equal(t, plaintext, versions[0].Data)
+	assert.True(t, versions[0].IsCurrent)
+}
+
+func TestKeyDataGcpKMS_Caching(t *testing.T) {
+	callCount := 0
+	mock := &mockGcpKMSClient{
+		getCryptoKey: func(_ context.Context, _ *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+			callCount++
+			return &kmspb.CryptoKey{
+				Name: testGcpKMSKeyName,
+				Primary: &kmspb.CryptoKeyVersion{
+					Name: testGcpKMSVersion,
+				},
+			}, nil
+		},
+	}
+
+	kg := newTestGcpKMS(testGcpKMSKeyName, mock)
+	kg.CacheTTL = "1h"
+
+	ctx := context.Background()
+	_, err := kg.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+	_, err = kg.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount)
+}
+
+func TestKeyDataGcpKMS_Errors(t *testing.T) {
+	t.Run("invalid cache ttl", func(t *testing.T) {
+		kg := newTestGcpKMS(testGcpKMSKeyName, &mockGcpKMSClient{})
+		kg.CacheTTL = "not-a-duration"
+		_, err := kg.GetCurrentVersion(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid cache_ttl")
+	})
+
+	t.Run("missing key name", func(t *testing.T) {
+		kg := &KeyDataGcpKMS{}
+		_, err := kg.CurrentWrappingKey(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires either gcp_kms_key_name")
+	})
+
+	t.Run("unsupported provider", func(t *testing.T) {
+		kg := newTestGcpKMS(testGcpKMSKeyName, &mockGcpKMSClient{})
+		_, err := kg.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeGcp,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported GCP KMS provider")
+	})
+
+	t.Run("unsupported protected data type", func(t *testing.T) {
+		kg := newTestGcpKMS(testGcpKMSKeyName, &mockGcpKMSClient{})
+		_, err := kg.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeGcpKMS,
+			ProtectedData: &KeyVersionProtectedData{
+				Type:        "other",
+				WrappedData: base64.StdEncoding.EncodeToString([]byte("x")),
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported GCP KMS protected data type")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		called := false
+		kg := &KeyDataGcpKMS{
+			GcpKMSKeyName: testGcpKMSKeyName,
+			clientFactory: func(context.Context) (gcpKMSClient, error) {
+				called = true
+				return nil, fmt.Errorf("should not be called")
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := kg.GenerateDataEncryptionKey(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, called)
+	})
+}
+
+func TestKeyDataGcpKMS_GetProviderType(t *testing.T) {
+	kg := &KeyDataGcpKMS{}
+	assert.Equal(t, ProviderTypeGcpKMS, kg.GetProviderType())
+}
+
+func TestKeyDataGcpKMS_KeyDataSerialization(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"gcp_kms_key_name": "projects/test-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper",
+			"gcp_kms_endpoint": "localhost:8085",
+			"gcp_credentials_json": {"env_var": "GCP_CREDS_JSON"},
+			"cache_ttl": "5m"
+		}`), &kd))
+
+		gcpKMS, ok := kd.InnerVal.(*KeyDataGcpKMS)
+		require.True(t, ok)
+		assert.Equal(t, testGcpKMSKeyName, gcpKMS.GcpKMSKeyName)
+		assert.Equal(t, "localhost:8085", gcpKMS.GcpKMSEndpoint)
+		require.NotNil(t, gcpKMS.GcpCredentialsJSON)
+		assert.Equal(t, "5m", gcpKMS.CacheTTL)
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, yaml.Unmarshal([]byte(`
+gcp_project: test-project
+gcp_location: global
+gcp_key_ring: authproxy
+gcp_crypto_key: dek-wrapper
+gcp_credentials_file: /tmp/gcp-creds.json
+cache_ttl: 5m
+`), &kd))
+
+		gcpKMS, ok := kd.InnerVal.(*KeyDataGcpKMS)
+		require.True(t, ok)
+		assert.Equal(t, "test-project", gcpKMS.GcpProject)
+		assert.Equal(t, "global", gcpKMS.GcpLocation)
+		assert.Equal(t, "authproxy", gcpKMS.GcpKeyRing)
+		assert.Equal(t, "dek-wrapper", gcpKMS.GcpCryptoKey)
+		assert.Equal(t, "/tmp/gcp-creds.json", gcpKMS.GcpCredentialsFile)
+		assert.Equal(t, "5m", gcpKMS.CacheTTL)
+	})
+}

--- a/internal/schema/config/key_data_serialization_json.go
+++ b/internal/schema/config/key_data_serialization_json.go
@@ -42,6 +42,10 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 		t = &KeyDataAwsKMS{}
 	} else if _, ok := valueMap["aws_secret_id"]; ok {
 		t = &KeyDataAwsSecret{}
+	} else if _, ok := valueMap["gcp_kms_key_name"]; ok {
+		t = &KeyDataGcpKMS{}
+	} else if _, ok := valueMap["gcp_crypto_key"]; ok {
+		t = &KeyDataGcpKMS{}
 	} else if _, ok := valueMap["gcp_secret_name"]; ok {
 		t = &KeyDataGcpSecret{}
 	} else if _, ok := valueMap["mock_id"]; ok {
@@ -49,7 +53,7 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 	} else if _, ok := valueMap["mock_kms_id"]; ok {
 		t = &KeyDataMockKMS{}
 	} else {
-		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := json.Unmarshal(data, t); err != nil {

--- a/internal/schema/config/key_data_serialization_yaml.go
+++ b/internal/schema/config/key_data_serialization_yaml.go
@@ -56,6 +56,9 @@ fieldLoop:
 		case "aws_secret_id":
 			keyData = &KeyDataAwsSecret{}
 			break fieldLoop
+		case "gcp_kms_key_name", "gcp_crypto_key":
+			keyData = &KeyDataGcpKMS{}
+			break fieldLoop
 		case "gcp_secret_name":
 			keyData = &KeyDataGcpSecret{}
 			break fieldLoop
@@ -69,7 +72,7 @@ fieldLoop:
 	}
 
 	if keyData == nil {
-		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := value.Decode(keyData); err != nil {

--- a/internal/schema/config/key_version_info.go
+++ b/internal/schema/config/key_version_info.go
@@ -20,6 +20,7 @@ const (
 	ProviderTypeAwsSecretsManager ProviderType = "aws_secrets_manager"
 	ProviderTypeAwsKMS            ProviderType = "aws_kms"
 	ProviderTypeGcp               ProviderType = "gcp"
+	ProviderTypeGcpKMS            ProviderType = "gcp_kms"
 	ProviderTypeHashicorpVault    ProviderType = "hashicorpvault"
 	ProviderTypeRaw               ProviderType = "raw"
 )

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -890,6 +890,25 @@
           },
           "required": ["aws_kms_key_id"],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gcp_kms_key_name": { "type": "string" },
+            "gcp_project": { "type": "string" },
+            "gcp_location": { "type": "string" },
+            "gcp_key_ring": { "type": "string" },
+            "gcp_crypto_key": { "type": "string" },
+            "gcp_kms_endpoint": { "type": "string" },
+            "gcp_credentials_file": { "type": "string" },
+            "gcp_credentials_json": { "$ref": "../common/schema.json#/$defs/StringValue" },
+            "cache_ttl": { "type": "string" }
+          },
+          "anyOf": [
+            { "required": ["gcp_kms_key_name"] },
+            { "required": ["gcp_project", "gcp_location", "gcp_key_ring", "gcp_crypto_key"] }
+          ],
+          "additionalProperties": false
         }
       ]
     },

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -215,6 +215,21 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"aws_kms_key_id": "alias/authproxy", "aws_region": "us-east-1", "aws_kms_endpoint": "http://localhost:4566", "aws_credentials": {"type": "implicit"}, "cache_ttl": "5m"}}`,
 				},
 				{
+					Name:  "gcp kms full resource",
+					Valid: true,
+					Data:  `{"test": {"gcp_kms_key_name": "projects/test-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper", "gcp_kms_endpoint": "localhost:8085", "gcp_credentials_json": {"env_var": "GCP_CREDS_JSON"}, "cache_ttl": "5m"}}`,
+				},
+				{
+					Name:  "gcp kms components",
+					Valid: true,
+					Data:  `{"test": {"gcp_project": "test-project", "gcp_location": "global", "gcp_key_ring": "authproxy", "gcp_crypto_key": "dek-wrapper", "gcp_credentials_file": "/tmp/gcp-creds.json", "cache_ttl": "5m"}}`,
+				},
+				{
+					Name:  "gcp kms missing component",
+					Valid: false,
+					Data:  `{"test": {"gcp_project": "test-project", "gcp_location": "global", "gcp_crypto_key": "dek-wrapper"}}`,
+				},
+				{
 					Name:  "empty object",
 					Valid: false,
 					Data:  `{"test": {}}`,


### PR DESCRIPTION
## Summary
- add a Google Cloud KMS KeyData provider that generates DEK bytes with GenerateRandomBytes and wraps/unwraps DEKs with a configured CryptoKey
- track GCP CryptoKey/CryptoKeyVersion metadata on DEK rows so sync can detect stale wrapping material
- add schema/serialization support, unit coverage, docs, and an opt-in GCP KMS integration test

## Tests
- go test ./internal/schema/config -count=1
- go test ./internal/encrypt -run 'TestGenerateDataEncryptionKeysToDatabase|TestSyncKeysToDatabase' -count=1
- cd integration_tests && go test -tags "integration,gcp" ./encrypt -run TestGcpKMSKeySyncAndReencrypt -count=1
- ./scripts/preflight.sh

Closes #620