### PR TITLE
Evaluate OAuth scope predicates at runtime

### DIFF
--- a/internal/auth_methods/oauth2/auth_url.go
+++ b/internal/auth_methods/oauth2/auth_url.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/config"
-	"github.com/rmorlok/authproxy/internal/util"
 )
 
 func (o *oAuth2Connection) getPublicRedirectUrl(ctx context.Context, stateId apid.ID, actor IActorData) (string, error) {
@@ -79,9 +77,10 @@ func (o *oAuth2Connection) GenerateAuthUrl(ctx context.Context, actor IActorData
 		return "", fmt.Errorf("failed to get public callback url: %w", err)
 	}
 
-	scopes := util.Map(o.auth.Scopes, func(s config.Scope) string {
-		return s.Id
-	})
+	scopes, err := o.effectiveScopes(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve oauth2 scopes for connector %s: %w", cv.GetId(), err)
+	}
 
 	authEndpoint, err := o.renderMustache(ctx, o.auth.Authorization.Endpoint)
 	if err != nil {
@@ -99,7 +98,7 @@ func (o *oAuth2Connection) GenerateAuthUrl(ctx context.Context, actor IActorData
 	query.Set("access_type", "offline")
 	query.Set("response_type", "code")
 	query.Set("client_id", clientId)
-	query.Set("scope", strings.Join(scopes, " "))
+	query.Set("scope", JoinScopes(scopes))
 	query.Set("state", o.state.Id.String())
 
 	if o.auth.Authorization.PKCE != nil {

--- a/internal/auth_methods/oauth2/callback.go
+++ b/internal/auth_methods/oauth2/callback.go
@@ -272,8 +272,14 @@ func (o *oAuth2Connection) exchangeClientCredentialsInner(ctx context.Context) e
 	values := url.Values{
 		"grant_type": {"client_credentials"},
 	}
-	if scopes := JoinScopes(o.auth.Scopes); scopes != "" {
-		values.Set("scope", scopes)
+	effectiveScopes, err := o.effectiveScopes(ctx)
+	if err != nil {
+		err = fmt.Errorf("failed to resolve oauth2 scopes: %w", err)
+		o.emitAndRecordExchangeFailure(ctx, tokenExchangeInternalError, o.tokenExchangeAttrsFromConn(err))
+		return err
+	}
+	if scopeString := JoinScopes(effectiveScopes); scopeString != "" {
+		values.Set("scope", scopeString)
 	}
 
 	values, authHeader, err := applyTokenEndpointClientAuth(

--- a/internal/auth_methods/oauth2/proxy.go
+++ b/internal/auth_methods/oauth2/proxy.go
@@ -131,8 +131,13 @@ func (o *oAuth2Connection) refreshAccessTokenInner(ctx context.Context, token *d
 		values.Set("refresh_token", refreshToken)
 	} else {
 		values.Set("grant_type", "client_credentials")
-		if scopes := JoinScopes(o.auth.Scopes); scopes != "" {
-			values.Set("scope", scopes)
+		effectiveScopes, err := o.effectiveScopes(ctx)
+		if err != nil {
+			return nil, o.classifyAndRecordRefreshFailure(ctx, tokenRefreshInternalError, 0, "", 0,
+				fmt.Errorf("failed to resolve oauth2 scopes: %w", err))
+		}
+		if scopeString := JoinScopes(effectiveScopes); scopeString != "" {
+			values.Set("scope", scopeString)
 		}
 		persistOptions.PersistRefreshToken = false
 	}

--- a/internal/auth_methods/oauth2/scope_mismatch.go
+++ b/internal/auth_methods/oauth2/scope_mismatch.go
@@ -24,16 +24,21 @@ type scopeMismatchOutcome struct {
 // detectScopeMismatch compares the scopes declared on the connector against the scopes echoed
 // by the provider. The granted set falls back to the requested set when the provider omits the
 // `scope` parameter (RFC 6749 §5.1 — silent agreement to the request).
-func detectScopeMismatch(declared []sconfig.Scope, granted string) (scopeMismatchOutcome, error) {
+//
+// The declared scopes are expected to have had predicates resolved prior to calling this function.
+func detectScopeMismatch(declaredEffectiveScopes []sconfig.Scope, granted string) (scopeMismatchOutcome, error) {
 	grantedSet := scopeSet(granted)
 
 	var outcome scopeMismatchOutcome
-	declaredIds := make(map[string]struct{}, len(declared))
-	for _, s := range declared {
+	declaredIds := make(map[string]struct{}, len(declaredEffectiveScopes))
+	for _, s := range declaredEffectiveScopes {
 		declaredIds[s.Id] = struct{}{}
 		if _, ok := grantedSet[s.Id]; ok {
 			continue
 		}
+
+		// We can use nil here because these are effective scopes that have
+		// had predicates resolved.
 		required, err := s.IsRequired(nil)
 		if err != nil {
 			return scopeMismatchOutcome{}, fmt.Errorf("scope %q required: %w", s.Id, err)

--- a/internal/auth_methods/oauth2/scope_mismatch.go
+++ b/internal/auth_methods/oauth2/scope_mismatch.go
@@ -24,7 +24,7 @@ type scopeMismatchOutcome struct {
 // detectScopeMismatch compares the scopes declared on the connector against the scopes echoed
 // by the provider. The granted set falls back to the requested set when the provider omits the
 // `scope` parameter (RFC 6749 §5.1 — silent agreement to the request).
-func detectScopeMismatch(declared []sconfig.Scope, granted string) scopeMismatchOutcome {
+func detectScopeMismatch(declared []sconfig.Scope, granted string) (scopeMismatchOutcome, error) {
 	grantedSet := scopeSet(granted)
 
 	var outcome scopeMismatchOutcome
@@ -34,7 +34,11 @@ func detectScopeMismatch(declared []sconfig.Scope, granted string) scopeMismatch
 		if _, ok := grantedSet[s.Id]; ok {
 			continue
 		}
-		if s.IsRequired() {
+		required, err := s.IsRequired(nil)
+		if err != nil {
+			return scopeMismatchOutcome{}, fmt.Errorf("scope %q required: %w", s.Id, err)
+		}
+		if required {
 			outcome.missingRequired = append(outcome.missingRequired, s.Id)
 		} else {
 			outcome.missingOptional = append(outcome.missingOptional, s.Id)
@@ -48,7 +52,7 @@ func detectScopeMismatch(declared []sconfig.Scope, granted string) scopeMismatch
 	sort.Strings(outcome.missingRequired)
 	sort.Strings(outcome.missingOptional)
 	sort.Strings(outcome.extraGranted)
-	return outcome
+	return outcome, nil
 }
 
 // applyScopeMismatch records the outcome on the connection. Required-scope misses produce an

--- a/internal/auth_methods/oauth2/scope_mismatch_test.go
+++ b/internal/auth_methods/oauth2/scope_mismatch_test.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -70,10 +71,22 @@ func TestDetectScopeMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detectScopeMismatch(tt.declared, tt.granted)
+			got, err := detectScopeMismatch(tt.declared, tt.granted)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.wantRequired, got.missingRequired, "missingRequired")
 			assert.Equal(t, tt.wantOptional, got.missingOptional, "missingOptional")
 			assert.Equal(t, tt.wantExtraGranted, got.extraGranted, "extraGranted")
 		})
 	}
+}
+
+func TestDetectScopeMismatchRejectsUnresolvedDynamicRequired(t *testing.T) {
+	_, err := detectScopeMismatch([]sconfig.Scope{
+		{
+			Id:       "activity",
+			Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `cfg.sync_activity === true`}),
+		},
+	}, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `scope "activity" required`)
 }

--- a/internal/auth_methods/oauth2/scope_predicates.go
+++ b/internal/auth_methods/oauth2/scope_predicates.go
@@ -1,0 +1,92 @@
+package oauth2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/apjs"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope, error) {
+	if o.auth == nil || len(o.auth.Scopes) == 0 {
+		return nil, nil
+	}
+
+	var vars map[string]any
+	getVars := func() (map[string]any, error) {
+		if vars != nil {
+			return vars, nil
+		}
+		resolved, err := o.scopePredicateVars(ctx)
+		if err != nil {
+			return nil, err
+		}
+		vars = resolved
+		return vars, nil
+	}
+
+	scopes := make([]sconfig.Scope, 0, len(o.auth.Scopes))
+	for _, declared := range o.auth.Scopes {
+		scope := declared.Clone()
+		if scope.If != nil {
+			vars, err := getVars()
+			if err != nil {
+				return nil, err
+			}
+			ok, err := apjs.EvaluateBoolean(scope.If.Javascript, vars)
+			if err != nil {
+				return nil, fmt.Errorf("scope %q if.javascript: %w", scope.Id, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		if scope.Required != nil && scope.Required.Predicate != nil {
+			vars, err := getVars()
+			if err != nil {
+				return nil, err
+			}
+			required, err := apjs.EvaluateBoolean(scope.Required.Predicate.Javascript, vars)
+			if err != nil {
+				return nil, fmt.Errorf("scope %q required.javascript: %w", scope.Id, err)
+			}
+			scope.Required = sconfig.NewScopeRequiredBool(required)
+		}
+
+		scopes = append(scopes, scope)
+	}
+	return scopes, nil
+}
+
+func (o *oAuth2Connection) scopePredicateVars(ctx context.Context) (map[string]any, error) {
+	if o.connection == nil {
+		return nil, errors.New("connection is nil")
+	}
+
+	cfg, err := o.connection.GetConfiguration(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get connection configuration: %w", err)
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+
+	labels := o.connection.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	annotations := o.connection.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	return map[string]any{
+		"cfg":         cfg,
+		"labels":      labels,
+		"annotations": annotations,
+	}, nil
+}

--- a/internal/auth_methods/oauth2/scope_predicates.go
+++ b/internal/auth_methods/oauth2/scope_predicates.go
@@ -2,41 +2,28 @@ package oauth2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
+// effectiveScopes returns the computed, effective scopes for the the connection. It filters scopes
+// that are removed via predicates, and translates the required value to a concrete value rather than
+// a potentially requiring javascript evaluation.
 func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope, error) {
 	if o.auth == nil || len(o.auth.Scopes) == 0 {
 		return nil, nil
 	}
 
-	var vars map[string]any
-	getVars := func() (map[string]any, error) {
-		if vars != nil {
-			return vars, nil
-		}
-		if o.connection == nil {
-			return nil, errors.New("connection is nil")
-		}
-		resolved, err := o.connection.GetPredicateVars(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("get predicate vars: %w", err)
-		}
-		vars = resolved
-		return vars, nil
+	vars, err := o.connection.GetPredicateVars(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get predicate vars for effective scopes: %w", err)
 	}
 
 	scopes := make([]sconfig.Scope, 0, len(o.auth.Scopes))
 	for _, declared := range o.auth.Scopes {
 		scope := declared.Clone()
 		if scope.If != nil {
-			vars, err := getVars()
-			if err != nil {
-				return nil, err
-			}
 			ok, err := scope.If.GetValue(vars)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q if.javascript: %w", scope.Id, err)
@@ -47,10 +34,6 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 		}
 
 		if scope.Required != nil && scope.Required.Predicate != nil {
-			vars, err := getVars()
-			if err != nil {
-				return nil, err
-			}
 			required, err := scope.IsRequired(vars)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q required.javascript: %w", scope.Id, err)

--- a/internal/auth_methods/oauth2/scope_predicates.go
+++ b/internal/auth_methods/oauth2/scope_predicates.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/rmorlok/authproxy/internal/apjs"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
 
@@ -19,9 +18,12 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 		if vars != nil {
 			return vars, nil
 		}
-		resolved, err := o.scopePredicateVars(ctx)
+		if o.connection == nil {
+			return nil, errors.New("connection is nil")
+		}
+		resolved, err := o.connection.GetPredicateVars(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("get predicate vars: %w", err)
 		}
 		vars = resolved
 		return vars, nil
@@ -35,7 +37,7 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 			if err != nil {
 				return nil, err
 			}
-			ok, err := apjs.EvaluateBoolean(scope.If.Javascript, vars)
+			ok, err := scope.If.GetValue(vars)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q if.javascript: %w", scope.Id, err)
 			}
@@ -49,7 +51,7 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 			if err != nil {
 				return nil, err
 			}
-			required, err := apjs.EvaluateBoolean(scope.Required.Predicate.Javascript, vars)
+			required, err := scope.IsRequired(vars)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q required.javascript: %w", scope.Id, err)
 			}
@@ -59,34 +61,4 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 		scopes = append(scopes, scope)
 	}
 	return scopes, nil
-}
-
-func (o *oAuth2Connection) scopePredicateVars(ctx context.Context) (map[string]any, error) {
-	if o.connection == nil {
-		return nil, errors.New("connection is nil")
-	}
-
-	cfg, err := o.connection.GetConfiguration(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get connection configuration: %w", err)
-	}
-	if cfg == nil {
-		cfg = map[string]any{}
-	}
-
-	labels := o.connection.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
-	annotations := o.connection.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	return map[string]any{
-		"cfg":         cfg,
-		"labels":      labels,
-		"annotations": annotations,
-	}, nil
 }

--- a/internal/auth_methods/oauth2/scope_predicates_test.go
+++ b/internal/auth_methods/oauth2/scope_predicates_test.go
@@ -1,0 +1,473 @@
+package oauth2
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/config"
+	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
+	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genmock "gopkg.in/h2non/gentleman-mock.v2"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestEffectiveScopes_UsesConnectionPredicateContext(t *testing.T) {
+	o := &oAuth2Connection{
+		connection: &mockCore.Connection{
+			Configuration: map[string]any{
+				"push_files":    true,
+				"sync_activity": false,
+			},
+			Labels:      map[string]string{"env": "prod"},
+			Annotations: map[string]string{"tier": "gold"},
+		},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{Id: "read"},
+				{
+					Id: "write",
+					If: &common.Predicate{Javascript: `cfg.push_files === true &&
+						labels["env"] === "prod" &&
+						annotations["tier"] === "gold"`},
+				},
+				{
+					Id:       "activity",
+					Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `cfg.sync_activity === true`}),
+				},
+				{
+					Id: "admin",
+					If: &common.Predicate{Javascript: `labels["env"] === "dev"`},
+				},
+			},
+		},
+	}
+
+	got, err := o.effectiveScopes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"read", "write", "activity"}, []string{got[0].Id, got[1].Id, got[2].Id})
+	assert.True(t, got[0].IsRequired())
+	assert.True(t, got[1].IsRequired())
+	assert.False(t, got[2].IsRequired())
+}
+
+func TestEffectiveScopes_PredicateErrorIncludesScopeContext(t *testing.T) {
+	o := &oAuth2Connection{
+		connection: &mockCore.Connection{},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{
+					Id: "write",
+					If: &common.Predicate{Javascript: `cfg.enabled ===`},
+				},
+			},
+		},
+	}
+
+	_, err := o.effectiveScopes(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `scope "write" if.javascript`)
+}
+
+func TestGenerateAuthUrl_UsesEffectiveScopes(t *testing.T) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	o := &oAuth2Connection{
+		cfg: cfg,
+		connection: &configuredConnection{
+			Connection: &mockCore.Connection{
+				Id:            apid.New(apid.PrefixConnection),
+				Configuration: map[string]any{"push_files": false},
+				Labels:        map[string]string{"env": "prod"},
+			},
+			connectorVersion: &mockCore.ConnectorVersion{Id: apid.New(apid.PrefixConnectorVersion)},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:     cschema.AuthTypeOAuth2,
+			ClientId: common.NewStringValueDirect("client-id"),
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: "https://example.com/oauth/authorize",
+			},
+			Scopes: []cschema.Scope{
+				{Id: "read"},
+				{Id: "write", If: &common.Predicate{Javascript: `cfg.push_files === true`}},
+				{Id: "activity", If: &common.Predicate{Javascript: `labels["env"] === "prod"`}},
+			},
+		},
+		state: &state{Id: apid.New(apid.PrefixOauth2State)},
+	}
+
+	authURL, err := o.GenerateAuthUrl(context.Background(), &mockActorData{id: apid.New(apid.PrefixActor)})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	assert.Equal(t, "read activity", parsed.Query().Get("scope"))
+}
+
+func TestGenerateAuthUrl_ConditionalScopeError(t *testing.T) {
+	cfg := config.FromRoot(&sconfig.Root{
+		Public: sconfig.ServicePublic{
+			ServiceHttp: sconfig.ServiceHttp{
+				PortVal: common.NewIntegerValueDirect(8080),
+			},
+		},
+	})
+
+	o := &oAuth2Connection{
+		cfg: cfg,
+		connection: &configuredConnection{
+			Connection:       &mockCore.Connection{Id: apid.New(apid.PrefixConnection)},
+			connectorVersion: &mockCore.ConnectorVersion{Id: apid.New(apid.PrefixConnectorVersion)},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:     cschema.AuthTypeOAuth2,
+			ClientId: common.NewStringValueDirect("client-id"),
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: "https://example.com/oauth/authorize",
+			},
+			Scopes: []cschema.Scope{
+				{Id: "write", If: &common.Predicate{Javascript: `cfg.enabled ===`}},
+			},
+		},
+		state: &state{Id: apid.New(apid.PrefixOauth2State)},
+	}
+
+	_, err := o.GenerateAuthUrl(context.Background(), &mockActorData{id: apid.New(apid.PrefixActor)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve oauth2 scopes")
+	assert.Contains(t, err.Error(), `scope "write" if.javascript`)
+}
+
+func TestExchangeClientCredentials_UsesEffectiveScopes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	connectionId := apid.New(apid.PrefixConnection)
+	grantType := sconfig.OAuth2GrantClientCredentials
+
+	encryptedCredentials := encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_credentials"}
+	db.EXPECT().
+		GetActiveApiKeyCredential(gomock.Any(), connectionId).
+		Return(&database.ApiKeyCredential{
+			Id:                   apid.New(apid.PrefixApiKeyCredential),
+			ConnectionId:         connectionId,
+			EncryptedCredentials: encryptedCredentials,
+		}, nil)
+	encrypt.EXPECT().
+		DecryptString(gomock.Any(), encryptedCredentials).
+		Return(`{"client_id":"client-id","client_secret":"client-secret"}`, nil)
+	encrypt.EXPECT().
+		EncryptStringForEntity(gomock.Any(), gomock.Any(), "access-token").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"}, nil)
+	db.EXPECT().
+		InsertOAuth2Token(
+			gomock.Any(),
+			connectionId,
+			nil,
+			encfield.EncryptedField{},
+			encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"},
+			gomock.Any(),
+			"read activity",
+			"read activity",
+			gomock.Any(),
+		).
+		Return(&database.OAuth2Token{}, nil)
+
+	o := &oAuth2Connection{
+		db:      db,
+		encrypt: encrypt,
+		httpf:   h,
+		connection: &mockCore.Connection{
+			Id:            connectionId,
+			Configuration: map[string]any{"push_files": false, "sync_activity": true},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			GrantType:    &grantType,
+			ClientId:     common.NewStringValueDirect("client-id"),
+			ClientSecret: common.NewStringValueDirect("client-secret"),
+			Token: cschema.AuthOauth2Token{
+				Endpoint: "https://example.com/oauth/token",
+			},
+			Scopes: []cschema.Scope{
+				{Id: "read"},
+				{Id: "write", If: &common.Predicate{Javascript: `cfg.push_files === true`}},
+				{Id: "activity", If: &common.Predicate{Javascript: `cfg.sync_activity === true`}},
+			},
+		},
+	}
+
+	var capturedBody string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"access-token","expires_in":3600}`)
+
+	err := o.ExchangeClientCredentials(context.Background())
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+	assert.Equal(t, "read activity", form.Get("scope"))
+}
+
+func TestRefreshAccessToken_ClientCredentialsUsesEffectiveScopes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, r := apredis.MustApplyTestConfig(nil)
+	h := mockH.NewFactoryWithMockingClient(ctrl)
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	connectionId := apid.New(apid.PrefixConnection)
+	tokenId := apid.New(apid.PrefixOAuth2Token)
+	grantType := sconfig.OAuth2GrantClientCredentials
+
+	existing := &database.OAuth2Token{
+		Id:           tokenId,
+		ConnectionId: connectionId,
+	}
+	db.EXPECT().
+		GetOAuth2Token(gomock.Any(), connectionId).
+		Return(existing, nil)
+
+	encryptedCredentials := encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_credentials"}
+	db.EXPECT().
+		GetActiveApiKeyCredential(gomock.Any(), connectionId).
+		Return(&database.ApiKeyCredential{
+			Id:                   apid.New(apid.PrefixApiKeyCredential),
+			ConnectionId:         connectionId,
+			EncryptedCredentials: encryptedCredentials,
+		}, nil)
+	encrypt.EXPECT().
+		DecryptString(gomock.Any(), encryptedCredentials).
+		Return(`{"client_id":"client-id","client_secret":"client-secret"}`, nil)
+	encrypt.EXPECT().
+		EncryptStringForEntity(gomock.Any(), gomock.Any(), "new-access-token").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"}, nil)
+	db.EXPECT().
+		InsertOAuth2Token(
+			gomock.Any(),
+			connectionId,
+			&tokenId,
+			encfield.EncryptedField{},
+			encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"},
+			gomock.Any(),
+			"read activity",
+			"read activity",
+			gomock.Any(),
+		).
+		Return(&database.OAuth2Token{}, nil)
+
+	o := &oAuth2Connection{
+		db:      db,
+		encrypt: encrypt,
+		httpf:   h,
+		r:       r,
+		connection: &mockCore.Connection{
+			Id:            connectionId,
+			Configuration: map[string]any{"push_files": false, "sync_activity": true},
+		},
+		auth: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			GrantType:    &grantType,
+			ClientId:     common.NewStringValueDirect("client-id"),
+			ClientSecret: common.NewStringValueDirect("client-secret"),
+			Token: cschema.AuthOauth2Token{
+				Endpoint: "https://example.com/oauth/token",
+			},
+			Scopes: []cschema.Scope{
+				{Id: "read"},
+				{Id: "write", If: &common.Predicate{Javascript: `cfg.push_files === true`}},
+				{Id: "activity", If: &common.Predicate{Javascript: `cfg.sync_activity === true`}},
+			},
+		},
+	}
+
+	var capturedBody string
+	genmock.
+		New("https://example.com").
+		Post("/oauth/token").
+		MatchType("application/x-www-form-urlencoded").
+		AddMatcher(captureBody(&capturedBody)).
+		Reply(200).
+		AddHeader("Content-Type", "application/json").
+		BodyString(`{"access_token":"new-access-token","expires_in":3600}`)
+
+	_, err := o.refreshAccessToken(context.Background(), existing, refreshModeAlways)
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+	assert.Equal(t, "read activity", form.Get("scope"))
+}
+
+func TestCreateDbTokenFromResponse_UsesEffectiveScopesForOptionalDynamicRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	connectionId := apid.New(apid.PrefixConnection)
+
+	encrypt.EXPECT().
+		EncryptStringForEntity(gomock.Any(), gomock.Any(), "access-token").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"}, nil)
+	db.EXPECT().
+		InsertOAuth2Token(
+			gomock.Any(),
+			connectionId,
+			nil,
+			encfield.EncryptedField{},
+			encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"},
+			gomock.Any(),
+			"read",
+			"read activity",
+			gomock.Any(),
+		).
+		Return(&database.OAuth2Token{}, nil)
+
+	o := &oAuth2Connection{
+		db:      db,
+		encrypt: encrypt,
+		connection: &mockCore.Connection{
+			Id: connectionId,
+			Configuration: map[string]any{
+				"push_files":    false,
+				"sync_activity": false,
+			},
+		},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{Id: "read"},
+				{Id: "write", If: &common.Predicate{Javascript: `cfg.push_files === true`}},
+				{
+					Id:       "activity",
+					Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `cfg.sync_activity === true`}),
+				},
+			},
+		},
+	}
+
+	resp := test_utils.MockGentlemenGetResponse("https://example.com", "example", func(m *gock.Request) {
+		m.
+			Reply(200).
+			AddHeader("Content-Type", "application/json").
+			BodyString(`{"access_token":"access-token","scope":"read","expires_in":3600}`)
+	})
+
+	_, err := o.createDbTokenFromResponse(context.Background(), resp, nil)
+	require.NoError(t, err)
+}
+
+func TestCreateDbTokenFromResponse_UsesEffectiveScopesForRequiredDynamicRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockDb.NewMockDB(ctrl)
+	encrypt := mockEncrypt.NewMockE(ctrl)
+	connectionId := apid.New(apid.PrefixConnection)
+
+	encrypt.EXPECT().
+		EncryptStringForEntity(gomock.Any(), gomock.Any(), "access-token").
+		Return(encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"}, nil)
+	db.EXPECT().
+		InsertOAuth2Token(
+			gomock.Any(),
+			connectionId,
+			nil,
+			encfield.EncryptedField{},
+			encfield.EncryptedField{ID: "ekv_test", Data: "encrypted_access_token"},
+			gomock.Any(),
+			"read",
+			"read activity",
+			gomock.Any(),
+		).
+		Return(&database.OAuth2Token{}, nil)
+
+	o := &oAuth2Connection{
+		db:      db,
+		encrypt: encrypt,
+		connection: &mockCore.Connection{
+			Id:            connectionId,
+			Configuration: map[string]any{"sync_activity": true},
+		},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{Id: "read"},
+				{
+					Id:       "activity",
+					Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `cfg.sync_activity === true`}),
+				},
+			},
+		},
+	}
+
+	resp := test_utils.MockGentlemenGetResponse("https://example.com", "example", func(m *gock.Request) {
+		m.
+			Reply(200).
+			AddHeader("Content-Type", "application/json").
+			BodyString(`{"access_token":"access-token","scope":"read","expires_in":3600}`)
+	})
+
+	_, err := o.createDbTokenFromResponse(context.Background(), resp, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required oauth2 scopes were not granted")
+	assert.Contains(t, err.Error(), "activity")
+}
+
+func TestCreateDbTokenFromResponse_ScopePredicateError(t *testing.T) {
+	o := &oAuth2Connection{
+		connection: &mockCore.Connection{},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{
+					Id:       "activity",
+					Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `cfg.sync_activity ===`}),
+				},
+			},
+		},
+	}
+
+	resp := test_utils.MockGentlemenGetResponse("https://example.com", "example", func(m *gock.Request) {
+		m.
+			Reply(200).
+			AddHeader("Content-Type", "application/json").
+			BodyString(`{"access_token":"access-token","scope":"read","expires_in":3600}`)
+	})
+
+	_, err := o.createDbTokenFromResponse(context.Background(), resp, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve oauth2 scopes")
+	assert.Contains(t, err.Error(), `scope "activity" required.javascript`)
+}

--- a/internal/auth_methods/oauth2/scope_predicates_test.go
+++ b/internal/auth_methods/oauth2/scope_predicates_test.go
@@ -60,9 +60,15 @@ func TestEffectiveScopes_UsesConnectionPredicateContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 	assert.Equal(t, []string{"read", "write", "activity"}, []string{got[0].Id, got[1].Id, got[2].Id})
-	assert.True(t, got[0].IsRequired())
-	assert.True(t, got[1].IsRequired())
-	assert.False(t, got[2].IsRequired())
+	required, err := got[0].IsRequired(nil)
+	require.NoError(t, err)
+	assert.True(t, required)
+	required, err = got[1].IsRequired(nil)
+	require.NoError(t, err)
+	assert.True(t, required)
+	required, err = got[2].IsRequired(nil)
+	require.NoError(t, err)
+	assert.False(t, required)
 }
 
 func TestEffectiveScopes_PredicateErrorIncludesScopeContext(t *testing.T) {

--- a/internal/auth_methods/oauth2/token_response.go
+++ b/internal/auth_methods/oauth2/token_response.go
@@ -53,6 +53,12 @@ func (o *oAuth2Connection) createDbTokenFromResponseWithOptions(
 		return nil, errors.New("no access token in response")
 	}
 
+	effectiveScopes, err := o.effectiveScopes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve oauth2 scopes: %w", err)
+	}
+	requestedScopes := JoinScopes(effectiveScopes)
+
 	encryptedAccessToken, err := o.encrypt.EncryptStringForEntity(ctx, o.connection, jsonResp.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt access token: %w", err)
@@ -72,7 +78,6 @@ func (o *oAuth2Connection) createDbTokenFromResponseWithOptions(
 		o.logger.WarnContext(ctx, "oauth token response included refresh_token for client_credentials grant; discarding")
 	}
 
-	requestedScopes := JoinScopes(o.auth.Scopes)
 	scopes := requestedScopes
 	if jsonResp.Scope != "" {
 		scopes = jsonResp.Scope
@@ -114,7 +119,7 @@ func (o *oAuth2Connection) createDbTokenFromResponseWithOptions(
 		return nil, fmt.Errorf("failed to insert oauth2 token: %w", err)
 	}
 
-	mismatch := detectScopeMismatch(o.auth.Scopes, scopes)
+	mismatch := detectScopeMismatch(effectiveScopes, scopes)
 	if err := o.applyScopeMismatch(ctx, mismatch); err != nil {
 		return nil, err
 	}

--- a/internal/auth_methods/oauth2/token_response.go
+++ b/internal/auth_methods/oauth2/token_response.go
@@ -119,7 +119,10 @@ func (o *oAuth2Connection) createDbTokenFromResponseWithOptions(
 		return nil, fmt.Errorf("failed to insert oauth2 token: %w", err)
 	}
 
-	mismatch := detectScopeMismatch(effectiveScopes, scopes)
+	mismatch, err := detectScopeMismatch(effectiveScopes, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect oauth2 scope mismatch: %w", err)
+	}
 	if err := o.applyScopeMismatch(ctx, mismatch); err != nil {
 		return nil, err
 	}

--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -100,6 +100,32 @@ func (c *connection) GetConnectorVersionEntity() iface.ConnectorVersion {
 	return c.cv
 }
 
+func (c *connection) GetPredicateVars(ctx context.Context) (map[string]any, error) {
+	cfg, err := c.GetConfiguration(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get connection configuration: %w", err)
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+
+	labels := c.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	annotations := c.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	return map[string]any{
+		"cfg":         cfg,
+		"labels":      labels,
+		"annotations": annotations,
+	}, nil
+}
+
 func (c *connection) Logger() *slog.Logger {
 	return c.logger
 }

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -369,3 +369,62 @@ func TestConnectionGetMustacheContext(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to get connection configuration")
 	})
 }
+
+func TestConnectionGetPredicateVars(t *testing.T) {
+	t.Run("returns cfg labels and annotations", func(t *testing.T) {
+		e := encrypt.NewFakeEncryptService(false)
+		s := &service{encrypt: e, logger: aplog.NewNoopLogger()}
+		conn := newTestConnectionWithService(s)
+
+		ef, err := e.EncryptStringForNamespace(context.Background(), "root", `{"tenant":"acme"}`)
+		require.NoError(t, err)
+		conn.EncryptedConfiguration = &ef
+		conn.Labels = map[string]string{"env": "prod"}
+		conn.Annotations = map[string]string{"region": "us-east"}
+
+		data, err := conn.GetPredicateVars(context.Background())
+		require.NoError(t, err)
+
+		cfg, ok := data["cfg"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "acme", cfg["tenant"])
+
+		labels, ok := data["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "prod", labels["env"])
+
+		annotations, ok := data["annotations"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "us-east", annotations["region"])
+	})
+
+	t.Run("returns empty maps when values are absent", func(t *testing.T) {
+		conn := newTestConnection(cschema.Connector{})
+
+		data, err := conn.GetPredicateVars(context.Background())
+		require.NoError(t, err)
+
+		cfg, ok := data["cfg"].(map[string]any)
+		require.True(t, ok)
+		assert.Empty(t, cfg)
+
+		labels, ok := data["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Empty(t, labels)
+
+		annotations, ok := data["annotations"].(map[string]string)
+		require.True(t, ok)
+		assert.Empty(t, annotations)
+	})
+
+	t.Run("returns error on decrypt failure", func(t *testing.T) {
+		e := encrypt.NewFakeEncryptService(false)
+		s := &service{encrypt: e, logger: aplog.NewNoopLogger()}
+		conn := newTestConnectionWithService(s)
+		conn.EncryptedConfiguration = &encfield.EncryptedField{ID: "ekv_wrong", Data: "some-data"}
+
+		_, err := conn.GetPredicateVars(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "get connection configuration")
+	})
+}

--- a/internal/core/connection_setup_flow.go
+++ b/internal/core/connection_setup_flow.go
@@ -9,7 +9,6 @@ import (
 
 	apauthcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/aptmpl"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/core/setup_token"
@@ -175,29 +174,12 @@ func newSchemaStepEligibility(c iface.Connection, spec *cschema.SetupFlowStep) f
 		return nil
 	}
 	return func(ctx context.Context) (bool, error) {
-		cfg, err := c.GetConfiguration(ctx)
+		vars, err := c.GetPredicateVars(ctx)
 		if err != nil {
-			return false, fmt.Errorf("step %q: get connection configuration: %w", spec.Id, err)
-		}
-		if cfg == nil {
-			cfg = map[string]any{}
+			return false, fmt.Errorf("step %q: get predicate vars: %w", spec.Id, err)
 		}
 
-		labels := c.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
-		}
-
-		annotations := c.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-
-		ok, err := apjs.EvaluateBoolean(spec.If.Javascript, map[string]any{
-			"cfg":         cfg,
-			"labels":      labels,
-			"annotations": annotations,
-		})
+		ok, err := spec.If.GetValue(vars)
 		if err != nil {
 			return false, fmt.Errorf("step %q if.javascript: %w", spec.Id, err)
 		}

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -30,6 +30,7 @@ type Connection interface {
 	GetAnnotations() map[string]string
 	GetSetupStep() *cschema.SetupStep
 	GetSetupError() *string
+	GetPredicateVars(ctx context.Context) (map[string]any, error)
 
 	/*
 	 * Nested entities

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -144,6 +144,29 @@ func (m *Connection) SetConfiguration(ctx context.Context, data map[string]any) 
 	return nil
 }
 
+func (m *Connection) GetPredicateVars(ctx context.Context) (map[string]any, error) {
+	cfg := m.Configuration
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+
+	labels := m.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	annotations := m.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	return map[string]any{
+		"cfg":         cfg,
+		"labels":      labels,
+		"annotations": annotations,
+	}, nil
+}
+
 func (m *Connection) GetMustacheContext(ctx context.Context) (map[string]any, error) {
 	data := map[string]any{}
 

--- a/internal/schema/common/predicate.go
+++ b/internal/schema/common/predicate.go
@@ -28,3 +28,8 @@ func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
 	}
 	return result.ErrorOrNil()
 }
+
+// GetValue returns the boolean value by evaluating the predicate's javascript.
+func (p *Predicate) GetValue(vars map[string]any) (bool, error) {
+	return apjs.EvaluateBoolean(p.Javascript, vars)
+}

--- a/internal/schema/common/predicate_test.go
+++ b/internal/schema/common/predicate_test.go
@@ -8,13 +8,14 @@ import (
 
 func TestPredicateValidate(t *testing.T) {
 	vars := map[string]any{
-		"cfg":         map[string]any{},
-		"labels":      map[string]string{},
-		"annotations": map[string]string{},
+		"sounds": map[string]string{
+			"dog": "woof",
+			"cat": "meow",
+		},
 	}
 
 	t.Run("accepts boolean result", func(t *testing.T) {
-		p := &Predicate{Javascript: `cfg.enabled === true`}
+		p := &Predicate{Javascript: `sounds.dog === 'woof'`}
 		require.NoError(t, p.Validate(&ValidationContext{Path: "predicate"}, vars))
 	})
 
@@ -26,16 +27,57 @@ func TestPredicateValidate(t *testing.T) {
 	})
 
 	t.Run("rejects syntax errors", func(t *testing.T) {
-		p := &Predicate{Javascript: `cfg.enabled ===`}
+		p := &Predicate{Javascript: `sounds.dog ===`}
 		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must evaluate to a boolean")
 	})
 
 	t.Run("rejects non boolean results", func(t *testing.T) {
-		p := &Predicate{Javascript: `cfg.enabled`}
+		p := &Predicate{Javascript: `sounds.dog`}
 		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must evaluate to a boolean")
+	})
+}
+
+func TestPredicateGetValue(t *testing.T) {
+	vars := map[string]any{
+		"sounds": map[string]string{
+			"dog": "woof",
+			"cat": "meow",
+		},
+	}
+
+	t.Run("returns true", func(t *testing.T) {
+		p := &Predicate{Javascript: `sounds.dog === 'woof'`}
+		v, err := p.GetValue(vars)
+		require.NoError(t, err)
+		require.True(t, v)
+	})
+
+	t.Run("returns false", func(t *testing.T) {
+		p := &Predicate{Javascript: `sounds.dog === 'meow'`}
+		v, err := p.GetValue(vars)
+		require.NoError(t, err)
+		require.False(t, v)
+	})
+
+	t.Run("errors on blank javascript", func(t *testing.T) {
+		p := &Predicate{Javascript: " \n\t "}
+		_, err := p.GetValue(vars)
+		require.Error(t, err)
+	})
+
+	t.Run("errors on syntax errors", func(t *testing.T) {
+		p := &Predicate{Javascript: `sounds.dog ===`}
+		_, err := p.GetValue(vars)
+		require.Error(t, err)
+	})
+
+	t.Run("errors on non boolean results", func(t *testing.T) {
+		p := &Predicate{Javascript: `sounds.dog`}
+		_, err := p.GetValue(vars)
+		require.Error(t, err)
 	})
 }

--- a/internal/schema/resources/connectors/auth_oauth2_scope.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope.go
@@ -17,13 +17,14 @@ type Scope struct {
 	Reason   string            `json:"reason" yaml:"reason"`
 }
 
-func (s *Scope) IsRequired() bool {
+func (s *Scope) IsRequired(vars map[string]any) (bool, error) {
+	// If the attribute is not specified, scopes default to required.
 	if s == nil || s.Required == nil {
 		// If unspecified, assume required.
-		return true
+		return true, nil
 	}
 
-	return s.Required.IsRequired()
+	return s.Required.IsRequired(vars)
 }
 
 func (s *Scope) Validate(vc *common.ValidationContext) error {
@@ -53,7 +54,8 @@ func (s Scope) Clone() Scope {
 }
 
 // ScopeRequired preserves the existing `required: true|false` shape while
-// allowing a dynamic predicate object at the same YAML key.
+// allowing a dynamic predicate object at the same YAML key. It does this by
+// implementing custom JSON/YAML marshalling and unmarshalling.
 type ScopeRequired struct {
 	Bool      *bool             `json:"-" yaml:"-"`
 	Predicate *common.Predicate `json:"-" yaml:"-"`
@@ -67,13 +69,20 @@ func NewScopeRequiredPredicate(predicate *common.Predicate) *ScopeRequired {
 	return &ScopeRequired{Predicate: predicate}
 }
 
-func (r *ScopeRequired) IsRequired() bool {
-	if r == nil || r.Bool == nil {
-		// Runtime evaluates Predicate in the OAuth runtime work. Until then,
-		// preserve the historical required-by-default behavior.
-		return true
+func (r *ScopeRequired) IsRequired(vars map[string]any) (bool, error) {
+	if r == nil {
+		return true, nil
 	}
-	return *r.Bool
+
+	if r.Bool != nil {
+		return *r.Bool, nil
+	}
+
+	if r.Predicate == nil {
+		return false, fmt.Errorf("required must be a boolean or predicate object")
+	}
+
+	return r.Predicate.GetValue(vars)
 }
 
 func (r *ScopeRequired) Clone() *ScopeRequired {
@@ -93,10 +102,24 @@ func (r *ScopeRequired) Clone() *ScopeRequired {
 }
 
 func (r *ScopeRequired) Validate(vc *common.ValidationContext) error {
-	if r == nil || r.Predicate == nil {
+	// The scope will default to required.
+	if r == nil {
 		return nil
 	}
-	return r.Predicate.Validate(vc, connectorPredicateValidationVars())
+
+	if r.Bool != nil && r.Predicate != nil {
+		return vc.NewError("required must be a boolean or predicate object; cannot be both")
+	}
+
+	if r.Bool == nil && r.Predicate == nil {
+		return vc.NewError("required must be a boolean or predicate object")
+	}
+
+	if r.Predicate != nil {
+		return r.Predicate.Validate(vc, connectorPredicateValidationVars())
+	}
+
+	return nil
 }
 
 func (r ScopeRequired) MarshalJSON() ([]byte, error) {

--- a/internal/schema/resources/connectors/auth_oauth2_scope_test.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope_test.go
@@ -23,7 +23,9 @@ reason: |
 			assert.NoError(err)
 			assert.Equal("https://www.googleapis.com/auth/drive.readonly", scope.Id)
 			assert.Equal("We need to be able to view the files\n", scope.Reason)
-			assert.True(scope.IsRequired())
+			required, err := scope.IsRequired(nil)
+			assert.NoError(err)
+			assert.True(required)
 		})
 		t.Run("allowed to be not required", func(t *testing.T) {
 			data := `id: https://www.googleapis.com/auth/drive.readonly
@@ -35,7 +37,9 @@ reason: We need to be able to view the files
 			assert.NoError(err)
 			assert.Equal("https://www.googleapis.com/auth/drive.readonly", scope.Id)
 			assert.Equal("We need to be able to view the files", scope.Reason)
-			assert.False(scope.IsRequired())
+			required, err := scope.IsRequired(nil)
+			assert.NoError(err)
+			assert.False(required)
 		})
 		t.Run("allowed to use dynamic required", func(t *testing.T) {
 			data := `id: https://www.googleapis.com/auth/drive.activity.readonly
@@ -49,7 +53,16 @@ reason: We need to be able to see what's been going on in drive
 			require.NotNil(t, scope.Required)
 			require.NotNil(t, scope.Required.Predicate)
 			assert.Equal("cfg.sync_activity === true", scope.Required.Predicate.Javascript)
-			assert.True(scope.IsRequired())
+			required, err := scope.IsRequired(map[string]any{
+				"cfg": map[string]any{"sync_activity": true},
+			})
+			assert.NoError(err)
+			assert.True(required)
+			required, err = scope.IsRequired(map[string]any{
+				"cfg": map[string]any{"sync_activity": false},
+			})
+			assert.NoError(err)
+			assert.False(required)
 		})
 		t.Run("allowed to use conditional inclusion", func(t *testing.T) {
 			data := `id: https://www.googleapis.com/auth/drive.readwrite
@@ -107,6 +120,24 @@ reason: We need to be able to see what's been going on in drive
 			err := scope.Validate(&common.ValidationContext{Path: "scope"})
 			assert.Error(err)
 			assert.Contains(err.Error(), "scope.required.javascript")
+		})
+		t.Run("rejects empty required object", func(t *testing.T) {
+			scope := &Scope{Required: &ScopeRequired{}}
+			err := scope.Validate(&common.ValidationContext{Path: "scope"})
+			assert.Error(err)
+			assert.Contains(err.Error(), "scope.required")
+		})
+		t.Run("rejects required object with bool and predicate", func(t *testing.T) {
+			required := false
+			scope := &Scope{
+				Required: &ScopeRequired{
+					Bool:      &required,
+					Predicate: &common.Predicate{Javascript: "true"},
+				},
+			}
+			err := scope.Validate(&common.ValidationContext{Path: "scope"})
+			assert.Error(err)
+			assert.Contains(err.Error(), "scope.required")
 		})
 	})
 }

--- a/internal/schema/resources/connectors/predicate.go
+++ b/internal/schema/resources/connectors/predicate.go
@@ -1,5 +1,8 @@
 package connectors
 
+// connectorPredicateValidationVars returns the variables that are needed to run the javascript that is
+// used in predicates for connector related values (setup steps, oauth scopes, etc). This just returns
+// empty variables for all the required variable names.
 func connectorPredicateValidationVars() map[string]any {
 	return map[string]any{
 		"cfg":         map[string]any{},


### PR DESCRIPTION
## Summary
- resolve OAuth scope if.javascript predicates from connection cfg, labels, and annotations
- use the effective scope set for authorization URLs, client-credentials grants, requested_scopes persistence, and mismatch detection
- resolve dynamic required.javascript to required vs optional before checking provider grants

## Tests
- go test ./internal/auth_methods/oauth2
- go test ./internal/auth_methods/oauth2 ./internal/core ./internal/schema/config ./internal/schema/resources/connectors
- go test ./internal/...
- (cd integration_tests && go test -tags integration -run '^$' ./...)
- ./scripts/preflight.sh

Closes #647