### PR TITLE
Add Vault Transit support for unified keys

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -148,10 +148,10 @@ Notes:
 
 ## HashiCorp Vault Integration Test
 
-This test hits a running HashiCorp Vault server and is gated behind the `vault` build tag and an env flag. Unlike the AWS and GCP tests, Vault runs locally (in dev mode) both on developer machines and in CI — no external credentials required.
+These tests hit a running HashiCorp Vault server and are gated behind the `vault` build tag and an env flag. Unlike the AWS and GCP tests, Vault runs locally (in dev mode) both on developer machines and in CI — no external credentials required.
 
 Requirements:
-- A Vault server reachable at `VAULT_ADDR` with a token in `VAULT_TOKEN` that can read and write the `secret/` KV v2 mount.
+- A Vault server reachable at `VAULT_ADDR` with a token in `VAULT_TOKEN` that can read and write the `secret/` KV v2 mount, enable/read/write the `transit/` mount, and rotate Transit keys.
 - `AUTH_PROXY_VAULT_TEST=1` set to opt in.
 
 The `docker-compose.yml` in this directory already includes a Vault dev-mode service with the root token `dev-only-token`. Bring it up with `docker compose up -d` and point the test at it:
@@ -173,7 +173,8 @@ docker run -d --name vault -p 8200:8200 --cap-add=IPC_LOCK \
 ```
 
 Notes:
-- The test writes a short-lived KV v2 secret at a unique path and deletes its metadata on cleanup.
+- The KV test writes a short-lived KV v2 secret at a unique path and deletes its metadata on cleanup.
+- The Transit test creates a unique Transit key, generates a DEK through `datakey/plaintext`, rotates the Transit key, verifies DEK rewrap, and decrypts through a fresh encrypt service cache.
 - CI uses `.github/workflows/vault-integration.yml`, which runs Vault as a dev-mode container inside the workflow. The workflow runs on pushes to `main` and on `workflow_dispatch`.
 
 ## Teardown

--- a/integration_tests/encrypt/vault_test.go
+++ b/integration_tests/encrypt/vault_test.go
@@ -22,11 +22,12 @@ import (
 )
 
 const (
-	vaultTestEnv    = "AUTH_PROXY_VAULT_TEST"
-	vaultAddrEnv    = "VAULT_ADDR"
-	vaultTokenEnv   = "VAULT_TOKEN"
-	vaultKvMount    = "secret"
-	vaultValueField = "value"
+	vaultTestEnv      = "AUTH_PROXY_VAULT_TEST"
+	vaultAddrEnv      = "VAULT_ADDR"
+	vaultTokenEnv     = "VAULT_TOKEN"
+	vaultKvMount      = "secret"
+	vaultTransitMount = "transit"
+	vaultValueField   = "value"
 )
 
 func init() {
@@ -157,6 +158,117 @@ func TestVaultKeySyncAndReencrypt(t *testing.T) {
 	require.Equal(t, plaintext, decrypted)
 }
 
+func TestVaultTransitKeySyncAndReencrypt(t *testing.T) {
+	if os.Getenv(vaultTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", vaultTestEnv)
+	}
+
+	vaultAddr := os.Getenv(vaultAddrEnv)
+	if vaultAddr == "" {
+		t.Skipf("%s is not set", vaultAddrEnv)
+	}
+
+	vaultToken := os.Getenv(vaultTokenEnv)
+	if vaultToken == "" {
+		t.Skipf("%s is not set", vaultTokenEnv)
+	}
+
+	ctx := context.Background()
+	client := newVaultClient(t, vaultAddr, vaultToken)
+	ensureVaultTransitMount(t, ctx, client, vaultTransitMount)
+
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+
+	transitKeyName := fmt.Sprintf("authproxy-transit-test-%d", time.Now().UnixNano())
+	_, err := client.Logical().WriteWithContext(ctx, fmt.Sprintf("%s/keys/%s", vaultTransitMount, transitKeyName), map[string]interface{}{
+		"type": "aes256-gcm96",
+	})
+	require.NoError(t, err)
+
+	namespace := fmt.Sprintf("root.vault-transit-test-%d", time.Now().UnixNano())
+	keyID := apid.New(apid.PrefixKey)
+
+	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
+		Path:  namespace,
+		KeyId: &keyID,
+	}))
+
+	keyData := sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataVaultTransit{
+			VaultAddress:          vaultAddr,
+			VaultToken:            vaultToken,
+			VaultTransitMountPath: vaultTransitMount,
+			VaultTransitKeyName:   transitKeyName,
+		},
+	}
+	keyDataJSON, err := json.Marshal(&keyData)
+	require.NoError(t, err)
+
+	encKeyData, err := env.DM.GetEncryptService().EncryptGlobal(ctx, keyDataJSON)
+	require.NoError(t, err)
+
+	require.NoError(t, env.Db.CreateKey(ctx, &database.Key{
+		Id:               keyID,
+		Namespace:        namespace,
+		MaterialType:     database.KeyMaterialTypeExternal,
+		EncryptedKeyData: &encKeyData,
+		State:            database.KeyStateActive,
+	}))
+
+	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyID, &keyData)
+	require.Equal(t, string(sconfig.ProviderTypeHashicorpVaultTransit), currentV1.Provider)
+	require.Equal(t, fmt.Sprintf("%s/%s", vaultTransitMount, transitKeyName), currentV1.ProviderID)
+	require.Equal(t, "1", currentV1.ProviderVersion)
+	require.NotNil(t, currentV1.ProtectedData)
+	require.Equal(t, string(sconfig.ProviderTypeHashicorpVaultTransit), currentV1.ProtectedData.Type)
+	require.NotEmpty(t, currentV1.ProtectedData.WrappedData)
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	plaintext := "vault-transit-test"
+	encrypted, err := env.DM.GetEncryptService().EncryptStringForNamespace(ctx, namespace, plaintext)
+	require.NoError(t, err)
+	require.Equal(t, currentV1.Id, encrypted.ID)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, env.Db.CreateActor(ctx, &database.Actor{
+		Id:           actorID,
+		Namespace:    namespace,
+		ExternalId:   "vault-transit-test-actor",
+		EncryptedKey: &encrypted,
+	}))
+
+	_, err = client.Logical().WriteWithContext(ctx, fmt.Sprintf("%s/keys/%s/rotate", vaultTransitMount, transitKeyName), map[string]interface{}{})
+	require.NoError(t, err)
+
+	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
+	require.NoError(t, env.DM.GetEncryptService().SyncKeysFromDbToMemory(ctx))
+
+	currentV2, err := env.Db.GetCurrentDataEncryptionKeyForKey(ctx, keyID)
+	require.NoError(t, err)
+	require.Equal(t, currentV1.Id, currentV2.Id)
+	require.Equal(t, "2", currentV2.ProviderVersion)
+	require.NotEqual(t, currentV1.ProtectedData.WrappedData, currentV2.ProtectedData.WrappedData)
+
+	require.NoError(t, runReencryptAll(ctx, env))
+
+	updated, err := env.Db.GetActor(ctx, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.EncryptedKey)
+	require.Equal(t, currentV2.Id, updated.EncryptedKey.ID)
+	require.Equal(t, encrypted.Data, updated.EncryptedKey.Data)
+
+	freshEncryptService := encrypt.NewEncryptService(env.Cfg, env.Db, env.Logger)
+	defer freshEncryptService.Shutdown()
+	require.NoError(t, freshEncryptService.SyncKeysFromDbToMemory(ctx))
+
+	decrypted, err := freshEncryptService.DecryptString(ctx, *updated.EncryptedKey)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+}
+
 func newVaultClient(t *testing.T, addr, token string) *vault.Client {
 	t.Helper()
 
@@ -168,4 +280,18 @@ func newVaultClient(t *testing.T, addr, token string) *vault.Client {
 
 	client.SetToken(token)
 	return client
+}
+
+func ensureVaultTransitMount(t *testing.T, ctx context.Context, client *vault.Client, mount string) {
+	t.Helper()
+
+	mounts, err := client.Sys().ListMountsWithContext(ctx)
+	require.NoError(t, err)
+	if _, ok := mounts[mount+"/"]; ok {
+		return
+	}
+
+	require.NoError(t, client.Sys().MountWithContext(ctx, mount, &vault.MountInput{
+		Type: "transit",
+	}))
 }

--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -98,6 +98,7 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 | **GCP Secret Manager** | `gcp_secret_name`, `gcp_project` | Fetches from Google Cloud. Defaults to `latest` version. |
 | **GCP KMS** | `gcp_kms_key_name` or `gcp_project`, `gcp_location`, `gcp_key_ring`, `gcp_crypto_key` | Uses Google Cloud KMS to generate DEK bytes, wrap/unwrap DEKs with the configured CryptoKey, and track the CryptoKeyVersion used for wrapping. Supports ADC, `gcp_credentials_file`, `gcp_credentials_json`, `gcp_kms_endpoint`, and `cache_ttl`. |
 | **HashiCorp Vault** | `vault_address`, `vault_path` | KV v1/v2 auto-detection. Reads `VAULT_TOKEN` from env if not configured. Exponential backoff retry. |
+| **HashiCorp Vault Transit** | `vault_address`, `vault_transit_key_name` | Uses Transit datakey generation and encrypt/decrypt operations to generate, wrap, and unwrap DEKs. Supports `vault_token`, `vault_namespace`, `vault_transit_mount_path`, and `cache_ttl`. |
 | **Environment Variable** | `env_var` | Reads key bytes from an environment variable (also available as base64-encoded variant). |
 | **File** | `path` | Reads key bytes from a file. Supports `~` expansion. |
 | **Value** | `value` | Inline string value. Development/testing only. |

--- a/internal/schema/config/key_data_serialization_json.go
+++ b/internal/schema/config/key_data_serialization_json.go
@@ -36,6 +36,8 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 		t = &KeyDataFile{}
 	} else if _, ok := valueMap["random"]; ok {
 		t = &KeyDataRandomBytes{}
+	} else if _, ok := valueMap["vault_transit_key_name"]; ok {
+		t = &KeyDataVaultTransit{}
 	} else if _, ok := valueMap["vault_address"]; ok {
 		t = &KeyDataVault{}
 	} else if _, ok := valueMap["aws_kms_key_id"]; ok {
@@ -53,7 +55,7 @@ func (kd *KeyData) UnmarshalJSON(data []byte) error {
 	} else if _, ok := valueMap["mock_kms_id"]; ok {
 		t = &KeyDataMockKMS{}
 	} else {
-		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for value type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, vault_transit_key_name, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := json.Unmarshal(data, t); err != nil {

--- a/internal/schema/config/key_data_serialization_yaml.go
+++ b/internal/schema/config/key_data_serialization_yaml.go
@@ -23,56 +23,45 @@ func (kd *KeyData) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	var keyData KeyDataType
+	keys := map[string]bool{}
 
-fieldLoop:
 	for i := 0; i < len(value.Content); i += 2 {
-		keyNode := value.Content[i]
+		keys[value.Content[i].Value] = true
+	}
 
-		switch keyNode.Value {
-		case "value":
-			keyData = &KeyDataValue{}
-			break fieldLoop
-		case "base64":
-			keyData = &KeyDataBase64Val{}
-			break fieldLoop
-		case "env_var":
-			keyData = &KeyDataEnvVar{}
-			break fieldLoop
-		case "env_var_base64":
-			keyData = &KeyDataEnvBase64Var{}
-			break fieldLoop
-		case "path":
-			keyData = &KeyDataFile{}
-			break fieldLoop
-		case "random":
-			keyData = &KeyDataRandomBytes{}
-			break fieldLoop
-		case "vault_address":
-			keyData = &KeyDataVault{}
-			break fieldLoop
-		case "aws_kms_key_id":
-			keyData = &KeyDataAwsKMS{}
-			break fieldLoop
-		case "aws_secret_id":
-			keyData = &KeyDataAwsSecret{}
-			break fieldLoop
-		case "gcp_kms_key_name", "gcp_crypto_key":
-			keyData = &KeyDataGcpKMS{}
-			break fieldLoop
-		case "gcp_secret_name":
-			keyData = &KeyDataGcpSecret{}
-			break fieldLoop
-		case "mock_id":
-			keyData = &KeyDataMock{}
-			break fieldLoop
-		case "mock_kms_id":
-			keyData = &KeyDataMockKMS{}
-			break fieldLoop
-		}
+	switch {
+	case keys["value"]:
+		keyData = &KeyDataValue{}
+	case keys["base64"]:
+		keyData = &KeyDataBase64Val{}
+	case keys["env_var"]:
+		keyData = &KeyDataEnvVar{}
+	case keys["env_var_base64"]:
+		keyData = &KeyDataEnvBase64Var{}
+	case keys["path"]:
+		keyData = &KeyDataFile{}
+	case keys["random"]:
+		keyData = &KeyDataRandomBytes{}
+	case keys["vault_transit_key_name"]:
+		keyData = &KeyDataVaultTransit{}
+	case keys["vault_address"]:
+		keyData = &KeyDataVault{}
+	case keys["aws_kms_key_id"]:
+		keyData = &KeyDataAwsKMS{}
+	case keys["aws_secret_id"]:
+		keyData = &KeyDataAwsSecret{}
+	case keys["gcp_kms_key_name"] || keys["gcp_crypto_key"]:
+		keyData = &KeyDataGcpKMS{}
+	case keys["gcp_secret_name"]:
+		keyData = &KeyDataGcpSecret{}
+	case keys["mock_id"]:
+		keyData = &KeyDataMock{}
+	case keys["mock_kms_id"]:
+		keyData = &KeyDataMockKMS{}
 	}
 
 	if keyData == nil {
-		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
+		return fmt.Errorf("invalid structure for key data type; does not match value, base64, env_var, env_var_base64, path, random, vault_address, vault_transit_key_name, aws_kms_key_id, aws_secret_id, gcp_kms_key_name, gcp_secret_name, mock_id, mock_kms_id")
 	}
 
 	if err := value.Decode(keyData); err != nil {

--- a/internal/schema/config/key_data_vault_transit.go
+++ b/internal/schema/config/key_data_vault_transit.go
@@ -1,0 +1,474 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+const (
+	vaultTransitProtectedDataType = string(ProviderTypeHashicorpVaultTransit)
+
+	vaultTransitDefaultMountPath = "transit"
+
+	vaultTransitMetadataMountPath  = "vault_transit_mount_path"
+	vaultTransitMetadataKeyName    = "vault_transit_key_name"
+	vaultTransitMetadataKeyVersion = "vault_transit_key_version"
+	vaultTransitMetadataNamespace  = "vault_namespace"
+)
+
+type vaultTransitLogicalClient interface {
+	ReadWithContext(ctx context.Context, path string) (*vault.Secret, error)
+	WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*vault.Secret, error)
+}
+
+// KeyDataVaultTransit uses HashiCorp Vault Transit as a wrapping-key provider for DEKs.
+type KeyDataVaultTransit struct {
+	VaultAddress          string `json:"vault_address" yaml:"vault_address"`
+	VaultToken            string `json:"vault_token,omitempty" yaml:"vault_token,omitempty"`
+	VaultNamespace        string `json:"vault_namespace,omitempty" yaml:"vault_namespace,omitempty"`
+	VaultTransitMountPath string `json:"vault_transit_mount_path,omitempty" yaml:"vault_transit_mount_path,omitempty"`
+	VaultTransitKeyName   string `json:"vault_transit_key_name" yaml:"vault_transit_key_name"`
+	CacheTTL              string `json:"cache_ttl,omitempty" yaml:"cache_ttl,omitempty"`
+
+	cache keyDataCache
+
+	// clientFactory overrides the default Vault client creation for testing.
+	clientFactory func(ctx context.Context) (vaultTransitLogicalClient, error)
+}
+
+func (kv *KeyDataVaultTransit) initCache() error {
+	if kv.cache.fetchCurrent != nil {
+		return nil
+	}
+
+	if kv.CacheTTL != "" {
+		ttl, err := time.ParseDuration(kv.CacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid cache_ttl for vault transit key data: %w", err)
+		}
+		kv.cache.ttl = ttl
+	}
+
+	kv.cache.fetchCurrent = kv.fetchCurrentVersion
+	kv.cache.fetchVersion = kv.fetchVersion
+	kv.cache.fetchList = kv.fetchListVersions
+	return nil
+}
+
+func (kv *KeyDataVaultTransit) fetchCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	current, err := kv.CurrentWrappingKey(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+
+	return KeyVersionInfo{
+		Provider:        current.Provider,
+		ProviderID:      current.ProviderID,
+		ProviderVersion: current.ProviderVersion,
+		IsCurrent:       true,
+	}, nil
+}
+
+func (kv *KeyDataVaultTransit) fetchVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	current, err := kv.fetchCurrentVersion(ctx)
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+	if current.ProviderVersion == version {
+		return current, nil
+	}
+
+	providerID, err := kv.providerID()
+	if err != nil {
+		return KeyVersionInfo{}, err
+	}
+
+	return KeyVersionInfo{
+		Provider:        ProviderTypeHashicorpVaultTransit,
+		ProviderID:      providerID,
+		ProviderVersion: version,
+	}, nil
+}
+
+func (kv *KeyDataVaultTransit) fetchListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	current, err := kv.fetchCurrentVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []KeyVersionInfo{current}, nil
+}
+
+func (kv *KeyDataVaultTransit) GetCurrentVersion(ctx context.Context) (KeyVersionInfo, error) {
+	if err := kv.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return kv.cache.GetCurrentVersion(ctx)
+}
+
+func (kv *KeyDataVaultTransit) GetVersion(ctx context.Context, version string) (KeyVersionInfo, error) {
+	if err := kv.initCache(); err != nil {
+		return KeyVersionInfo{}, err
+	}
+	return kv.cache.GetVersion(ctx, version)
+}
+
+func (kv *KeyDataVaultTransit) ListVersions(ctx context.Context) ([]KeyVersionInfo, error) {
+	if err := kv.initCache(); err != nil {
+		return nil, err
+	}
+	return kv.cache.ListVersions(ctx)
+}
+
+func (kv *KeyDataVaultTransit) ListVersionsWithDataEncryptionKeys(ctx context.Context, deks []DataEncryptionKeyInfo) ([]KeyVersionInfo, error) {
+	var result []KeyVersionInfo
+	for _, dekInfo := range deks {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if dekInfo.Provider != ProviderTypeHashicorpVaultTransit {
+			continue
+		}
+
+		dekBytes, err := kv.UnwrapDataEncryptionKey(ctx, dekInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, KeyVersionInfo{
+			Provider:        ProviderTypeHashicorpVaultTransit,
+			ProviderID:      dekInfo.ID,
+			ProviderVersion: dekInfo.ProviderVersion,
+			Data:            dekBytes,
+			IsCurrent:       dekInfo.IsCurrent,
+		})
+	}
+
+	return result, nil
+}
+
+func (kv *KeyDataVaultTransit) CurrentWrappingKey(ctx context.Context) (KeyWrappingKeyInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	providerID, err := kv.providerID()
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	client, err := kv.getClient(ctx)
+	if err != nil {
+		return KeyWrappingKeyInfo{}, err
+	}
+
+	secret, err := client.ReadWithContext(ctx, kv.keyInfoPath())
+	if err != nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("failed to read Vault Transit key %s: %w", providerID, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("no data returned for Vault Transit key %s", providerID)
+	}
+
+	version := vaultVersionNumberString(secret.Data["latest_version"])
+	if version == "" {
+		return KeyWrappingKeyInfo{}, fmt.Errorf("Vault Transit key %s returned no latest_version", providerID)
+	}
+
+	metadata := kv.providerMetadata(version)
+	return KeyWrappingKeyInfo{
+		Provider:        ProviderTypeHashicorpVaultTransit,
+		ProviderID:      providerID,
+		ProviderVersion: version,
+		Metadata:        metadata,
+	}, nil
+}
+
+func (kv *KeyDataVaultTransit) GenerateDataEncryptionKey(ctx context.Context) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	providerID, err := kv.providerID()
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := kv.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	secret, err := client.WriteWithContext(ctx, kv.dataKeyPath(), map[string]interface{}{
+		"bits": DataEncryptionKeySize * 8,
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to generate data encryption key with Vault Transit key %s: %w", providerID, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("no data returned when generating data encryption key with Vault Transit key %s", providerID)
+	}
+
+	plaintextB64, err := vaultTransitString(secret.Data, "plaintext")
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	dek, err := base64.StdEncoding.DecodeString(plaintextB64)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to decode Vault Transit plaintext data key: %w", err)
+	}
+	if len(dek) != DataEncryptionKeySize {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("Vault Transit returned %d DEK bytes; expected %d", len(dek), DataEncryptionKeySize)
+	}
+
+	ciphertext, err := vaultTransitString(secret.Data, "ciphertext")
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	version := vaultVersionNumberString(secret.Data["key_version"])
+	if version == "" {
+		current, err := kv.CurrentWrappingKey(ctx)
+		if err != nil {
+			return GeneratedDataEncryptionKey{}, err
+		}
+		version = current.ProviderVersion
+	}
+
+	metadata := kv.providerMetadata(version)
+	return GeneratedDataEncryptionKey{
+		Provider:         ProviderTypeHashicorpVaultTransit,
+		ProviderID:       providerID,
+		ProviderVersion:  version,
+		ProviderMetadata: metadata,
+		ProtectedData:    vaultTransitProtectedData(ciphertext, metadata),
+		Data:             dek,
+	}, nil
+}
+
+func (kv *KeyDataVaultTransit) WrapDataEncryptionKey(ctx context.Context, dek []byte) (GeneratedDataEncryptionKey, error) {
+	if err := ctx.Err(); err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+	if len(dek) == 0 {
+		return GeneratedDataEncryptionKey{}, errors.New("data encryption key is empty")
+	}
+
+	current, err := kv.CurrentWrappingKey(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	client, err := kv.getClient(ctx)
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	secret, err := client.WriteWithContext(ctx, kv.encryptPath(), map[string]interface{}{
+		"plaintext": base64.StdEncoding.EncodeToString(dek),
+	})
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("failed to wrap data encryption key with Vault Transit key %s: %w", current.ProviderID, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return GeneratedDataEncryptionKey{}, fmt.Errorf("no data returned when wrapping data encryption key with Vault Transit key %s", current.ProviderID)
+	}
+
+	ciphertext, err := vaultTransitString(secret.Data, "ciphertext")
+	if err != nil {
+		return GeneratedDataEncryptionKey{}, err
+	}
+
+	version := vaultVersionNumberString(secret.Data["key_version"])
+	if version == "" {
+		version = current.ProviderVersion
+	}
+	metadata := kv.providerMetadata(version)
+
+	return GeneratedDataEncryptionKey{
+		Provider:         ProviderTypeHashicorpVaultTransit,
+		ProviderID:       current.ProviderID,
+		ProviderVersion:  version,
+		ProviderMetadata: metadata,
+		ProtectedData:    vaultTransitProtectedData(ciphertext, metadata),
+		Data:             append([]byte(nil), dek...),
+	}, nil
+}
+
+func (kv *KeyDataVaultTransit) UnwrapDataEncryptionKey(ctx context.Context, dekInfo DataEncryptionKeyInfo) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if dekInfo.Provider != ProviderTypeHashicorpVaultTransit {
+		return nil, fmt.Errorf("unsupported Vault Transit provider %q", dekInfo.Provider)
+	}
+	if dekInfo.ProtectedData == nil || dekInfo.ProtectedData.IsZero() {
+		return nil, errors.New("data encryption key protected data is empty")
+	}
+	if dekInfo.ProtectedData.Type != vaultTransitProtectedDataType {
+		return nil, fmt.Errorf("unsupported Vault Transit protected data type %q", dekInfo.ProtectedData.Type)
+	}
+
+	decryptPath, err := kv.decryptPathForMetadata(dekInfo.ProtectedData.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kv.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := client.WriteWithContext(ctx, decryptPath, map[string]interface{}{
+		"ciphertext": dekInfo.ProtectedData.WrappedData,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to unwrap data encryption key with Vault Transit path %s: %w", decryptPath, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, fmt.Errorf("no data returned when unwrapping data encryption key with Vault Transit path %s", decryptPath)
+	}
+
+	plaintextB64, err := vaultTransitString(secret.Data, "plaintext")
+	if err != nil {
+		return nil, err
+	}
+	dek, err := base64.StdEncoding.DecodeString(plaintextB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode Vault Transit decrypted data key: %w", err)
+	}
+	if len(dek) == 0 {
+		return nil, errors.New("Vault Transit decrypt returned empty plaintext")
+	}
+
+	return dek, nil
+}
+
+func (kv *KeyDataVaultTransit) GetProviderType() ProviderType {
+	return ProviderTypeHashicorpVaultTransit
+}
+
+func (kv *KeyDataVaultTransit) getClient(ctx context.Context) (vaultTransitLogicalClient, error) {
+	if kv.clientFactory != nil {
+		return kv.clientFactory(ctx)
+	}
+	return kv.newLogicalClient()
+}
+
+func (kv *KeyDataVaultTransit) newLogicalClient() (*vault.Logical, error) {
+	config := vault.DefaultConfig()
+	config.Address = kv.VaultAddress
+	config.HttpClient.Transport = &vaultRetryTransport{base: config.HttpClient.Transport}
+
+	client, err := vault.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vault client: %w", err)
+	}
+
+	token := kv.resolveToken()
+	if token != "" {
+		client.SetToken(token)
+	}
+	if kv.VaultNamespace != "" {
+		client.SetNamespace(kv.VaultNamespace)
+	}
+
+	return client.Logical(), nil
+}
+
+func (kv *KeyDataVaultTransit) resolveToken() string {
+	token := kv.VaultToken
+	if token == "" {
+		token = os.Getenv("VAULT_TOKEN")
+	}
+	return token
+}
+
+func (kv *KeyDataVaultTransit) providerID() (string, error) {
+	mount := kv.mountPath()
+	keyName := kv.keyName()
+	if keyName == "" {
+		return "", errors.New("vault transit key data requires vault_transit_key_name")
+	}
+	return mount + "/" + keyName, nil
+}
+
+func (kv *KeyDataVaultTransit) mountPath() string {
+	mount := strings.Trim(kv.VaultTransitMountPath, "/")
+	if mount == "" {
+		return vaultTransitDefaultMountPath
+	}
+	return mount
+}
+
+func (kv *KeyDataVaultTransit) keyName() string {
+	return strings.Trim(kv.VaultTransitKeyName, "/")
+}
+
+func (kv *KeyDataVaultTransit) keyInfoPath() string {
+	return kv.mountPath() + "/keys/" + kv.keyName()
+}
+
+func (kv *KeyDataVaultTransit) dataKeyPath() string {
+	return kv.mountPath() + "/datakey/plaintext/" + kv.keyName()
+}
+
+func (kv *KeyDataVaultTransit) encryptPath() string {
+	return kv.mountPath() + "/encrypt/" + kv.keyName()
+}
+
+func (kv *KeyDataVaultTransit) decryptPath() string {
+	return kv.mountPath() + "/decrypt/" + kv.keyName()
+}
+
+func (kv *KeyDataVaultTransit) decryptPathForMetadata(metadata map[string]string) (string, error) {
+	mount := metadata[vaultTransitMetadataMountPath]
+	keyName := metadata[vaultTransitMetadataKeyName]
+	if mount == "" || keyName == "" {
+		return kv.decryptPath(), nil
+	}
+	return strings.Trim(mount, "/") + "/decrypt/" + strings.Trim(keyName, "/"), nil
+}
+
+func (kv *KeyDataVaultTransit) providerMetadata(version string) map[string]string {
+	metadata := map[string]string{
+		vaultTransitMetadataMountPath:  kv.mountPath(),
+		vaultTransitMetadataKeyName:    kv.keyName(),
+		vaultTransitMetadataKeyVersion: version,
+	}
+	if kv.VaultNamespace != "" {
+		metadata[vaultTransitMetadataNamespace] = kv.VaultNamespace
+	}
+	return metadata
+}
+
+func vaultTransitString(data map[string]interface{}, key string) (string, error) {
+	val, ok := data[key]
+	if !ok {
+		return "", fmt.Errorf("Vault Transit response missing %q", key)
+	}
+	str, ok := val.(string)
+	if !ok || str == "" {
+		return "", fmt.Errorf("Vault Transit response %q is not a non-empty string", key)
+	}
+	return str, nil
+}
+
+func vaultTransitProtectedData(ciphertext string, metadata map[string]string) KeyVersionProtectedData {
+	return KeyVersionProtectedData{
+		Type:        vaultTransitProtectedDataType,
+		WrappedData: ciphertext,
+		Metadata:    copyStringMap(metadata),
+	}
+}
+
+var _ KeyDataType = (*KeyDataVaultTransit)(nil)
+var _ KeyDataRequiresDataEncryptionKeys = (*KeyDataVaultTransit)(nil)
+var _ KeyDataWrapsDataEncryptionKeys = (*KeyDataVaultTransit)(nil)
+var _ KeyDataGeneratesDataEncryptionKeys = (*KeyDataVaultTransit)(nil)

--- a/internal/schema/config/key_data_vault_transit_test.go
+++ b/internal/schema/config/key_data_vault_transit_test.go
@@ -1,0 +1,338 @@
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type mockVaultTransitLogical struct {
+	read  func(ctx context.Context, path string) (*vault.Secret, error)
+	write func(ctx context.Context, path string, data map[string]interface{}) (*vault.Secret, error)
+}
+
+func (m *mockVaultTransitLogical) ReadWithContext(ctx context.Context, path string) (*vault.Secret, error) {
+	if m.read == nil {
+		return nil, errors.New("unexpected ReadWithContext")
+	}
+	return m.read(ctx, path)
+}
+
+func (m *mockVaultTransitLogical) WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*vault.Secret, error) {
+	if m.write == nil {
+		return nil, errors.New("unexpected WriteWithContext")
+	}
+	return m.write(ctx, path, data)
+}
+
+func newTestVaultTransit(keyName string, mock *mockVaultTransitLogical) *KeyDataVaultTransit {
+	return &KeyDataVaultTransit{
+		VaultAddress:        "http://127.0.0.1:8200",
+		VaultToken:          "dev-only-token",
+		VaultTransitKeyName: keyName,
+		clientFactory: func(context.Context) (vaultTransitLogicalClient, error) {
+			return mock, nil
+		},
+	}
+}
+
+func TestKeyDataVaultTransit_CurrentWrappingKey(t *testing.T) {
+	mock := &mockVaultTransitLogical{
+		read: func(_ context.Context, path string) (*vault.Secret, error) {
+			require.Equal(t, "transit/keys/authproxy", path)
+			return &vault.Secret{Data: map[string]interface{}{
+				"latest_version": json.Number("7"),
+			}}, nil
+		},
+	}
+
+	kv := newTestVaultTransit("authproxy", mock)
+	current, err := kv.CurrentWrappingKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeHashicorpVaultTransit, current.Provider)
+	assert.Equal(t, "transit/authproxy", current.ProviderID)
+	assert.Equal(t, "7", current.ProviderVersion)
+	assert.Equal(t, "transit", current.Metadata[vaultTransitMetadataMountPath])
+	assert.Equal(t, "authproxy", current.Metadata[vaultTransitMetadataKeyName])
+	assert.Equal(t, "7", current.Metadata[vaultTransitMetadataKeyVersion])
+}
+
+func TestKeyDataVaultTransit_GenerateDataEncryptionKey(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	ciphertext := "vault:v5:wrapped"
+	mock := &mockVaultTransitLogical{
+		write: func(_ context.Context, path string, data map[string]interface{}) (*vault.Secret, error) {
+			require.Equal(t, "transit/datakey/plaintext/authproxy", path)
+			require.Equal(t, DataEncryptionKeySize*8, data["bits"])
+			return &vault.Secret{Data: map[string]interface{}{
+				"plaintext":   base64.StdEncoding.EncodeToString(plaintext),
+				"ciphertext":  ciphertext,
+				"key_version": json.Number("5"),
+			}}, nil
+		},
+	}
+
+	kv := newTestVaultTransit("authproxy", mock)
+	generated, err := kv.GenerateDataEncryptionKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeHashicorpVaultTransit, generated.Provider)
+	assert.Equal(t, "transit/authproxy", generated.ProviderID)
+	assert.Equal(t, "5", generated.ProviderVersion)
+	assert.Equal(t, plaintext, generated.Data)
+	assert.Equal(t, vaultTransitProtectedDataType, generated.ProtectedData.Type)
+	assert.Equal(t, ciphertext, generated.ProtectedData.WrappedData)
+	assert.Equal(t, "5", generated.ProviderMetadata[vaultTransitMetadataKeyVersion])
+}
+
+func TestKeyDataVaultTransit_WrapAndUnwrapDataEncryptionKey(t *testing.T) {
+	dek := []byte("01234567890123456789012345678901")
+	ciphertext := "vault:v4:ciphertext"
+	mock := &mockVaultTransitLogical{
+		read: func(_ context.Context, path string) (*vault.Secret, error) {
+			require.Equal(t, "transit/keys/authproxy", path)
+			return &vault.Secret{Data: map[string]interface{}{
+				"latest_version": json.Number("4"),
+			}}, nil
+		},
+		write: func(_ context.Context, path string, data map[string]interface{}) (*vault.Secret, error) {
+			switch path {
+			case "transit/encrypt/authproxy":
+				require.Equal(t, base64.StdEncoding.EncodeToString(dek), data["plaintext"])
+				return &vault.Secret{Data: map[string]interface{}{
+					"ciphertext":  ciphertext,
+					"key_version": json.Number("4"),
+				}}, nil
+			case "transit/decrypt/authproxy":
+				require.Equal(t, ciphertext, data["ciphertext"])
+				return &vault.Secret{Data: map[string]interface{}{
+					"plaintext": base64.StdEncoding.EncodeToString(dek),
+				}}, nil
+			default:
+				return nil, fmt.Errorf("unexpected path %s", path)
+			}
+		},
+	}
+
+	kv := newTestVaultTransit("authproxy", mock)
+	wrapped, err := kv.WrapDataEncryptionKey(context.Background(), dek)
+	require.NoError(t, err)
+	require.Equal(t, "4", wrapped.ProviderVersion)
+
+	unwrapper := newTestVaultTransit("new-authproxy", mock)
+	unwrapped, err := unwrapper.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+		ID:              "dek_test",
+		Provider:        ProviderTypeHashicorpVaultTransit,
+		ProviderID:      wrapped.ProviderID,
+		ProviderVersion: wrapped.ProviderVersion,
+		ProtectedData:   &wrapped.ProtectedData,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, dek, unwrapped)
+}
+
+func TestKeyDataVaultTransit_ListVersionsWithDataEncryptionKeys(t *testing.T) {
+	plaintext := []byte("01234567890123456789012345678901")
+	protected := vaultTransitProtectedData("vault:v3:ciphertext", map[string]string{
+		vaultTransitMetadataMountPath:  "transit",
+		vaultTransitMetadataKeyName:    "authproxy",
+		vaultTransitMetadataKeyVersion: "3",
+	})
+	mock := &mockVaultTransitLogical{
+		write: func(_ context.Context, path string, data map[string]interface{}) (*vault.Secret, error) {
+			require.Equal(t, "transit/decrypt/authproxy", path)
+			require.Equal(t, "vault:v3:ciphertext", data["ciphertext"])
+			return &vault.Secret{Data: map[string]interface{}{
+				"plaintext": base64.StdEncoding.EncodeToString(plaintext),
+			}}, nil
+		},
+	}
+
+	kv := newTestVaultTransit("authproxy", mock)
+	versions, err := kv.ListVersionsWithDataEncryptionKeys(context.Background(), []DataEncryptionKeyInfo{
+		{
+			ID:              "dek_vault_transit",
+			Provider:        ProviderTypeHashicorpVaultTransit,
+			ProviderID:      "transit/authproxy",
+			ProviderVersion: "3",
+			ProtectedData:   &protected,
+			IsCurrent:       true,
+		},
+		{
+			ID:       "dek_vault_kv",
+			Provider: ProviderTypeHashicorpVault,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "dek_vault_transit", versions[0].ProviderID)
+	assert.Equal(t, plaintext, versions[0].Data)
+	assert.True(t, versions[0].IsCurrent)
+}
+
+func TestKeyDataVaultTransit_Caching(t *testing.T) {
+	callCount := 0
+	mock := &mockVaultTransitLogical{
+		read: func(_ context.Context, _ string) (*vault.Secret, error) {
+			callCount++
+			return &vault.Secret{Data: map[string]interface{}{
+				"latest_version": json.Number("2"),
+			}}, nil
+		},
+	}
+
+	kv := newTestVaultTransit("authproxy", mock)
+	kv.CacheTTL = "1h"
+
+	ctx := context.Background()
+	_, err := kv.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+	_, err = kv.GetCurrentVersion(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount)
+}
+
+func TestKeyDataVaultTransit_RetryBehavior(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/transit/keys/authproxy", r.URL.Path)
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Retry-After", "0.1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"latest_version":9}}`))
+	}))
+	defer server.Close()
+
+	kv := &KeyDataVaultTransit{
+		VaultAddress:        server.URL,
+		VaultToken:          "test-token",
+		VaultTransitKeyName: "authproxy",
+	}
+	current, err := kv.CurrentWrappingKey(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "9", current.ProviderVersion)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestKeyDataVaultTransit_Errors(t *testing.T) {
+	t.Run("invalid cache ttl", func(t *testing.T) {
+		kv := newTestVaultTransit("authproxy", &mockVaultTransitLogical{})
+		kv.CacheTTL = "not-a-duration"
+		_, err := kv.GetCurrentVersion(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid cache_ttl")
+	})
+
+	t.Run("missing key name", func(t *testing.T) {
+		kv := &KeyDataVaultTransit{}
+		_, err := kv.CurrentWrappingKey(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vault_transit_key_name")
+	})
+
+	t.Run("unsupported provider", func(t *testing.T) {
+		kv := newTestVaultTransit("authproxy", &mockVaultTransitLogical{})
+		_, err := kv.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeHashicorpVault,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported Vault Transit provider")
+	})
+
+	t.Run("unsupported protected data type", func(t *testing.T) {
+		kv := newTestVaultTransit("authproxy", &mockVaultTransitLogical{})
+		_, err := kv.UnwrapDataEncryptionKey(context.Background(), DataEncryptionKeyInfo{
+			Provider: ProviderTypeHashicorpVaultTransit,
+			ProtectedData: &KeyVersionProtectedData{
+				Type:        "other",
+				WrappedData: "vault:v1:ciphertext",
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported Vault Transit protected data type")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		called := false
+		kv := &KeyDataVaultTransit{
+			VaultAddress:        "http://127.0.0.1:8200",
+			VaultTransitKeyName: "authproxy",
+			clientFactory: func(context.Context) (vaultTransitLogicalClient, error) {
+				called = true
+				return nil, fmt.Errorf("should not be called")
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := kv.GenerateDataEncryptionKey(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, called)
+	})
+}
+
+func TestKeyDataVaultTransit_GetProviderType(t *testing.T) {
+	kv := &KeyDataVaultTransit{}
+	assert.Equal(t, ProviderTypeHashicorpVaultTransit, kv.GetProviderType())
+}
+
+func TestKeyDataVaultTransit_KeyDataSerialization(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"vault_address": "http://127.0.0.1:8200",
+			"vault_token": "dev-only-token",
+			"vault_namespace": "admin",
+			"vault_transit_mount_path": "transit",
+			"vault_transit_key_name": "authproxy",
+			"cache_ttl": "5m"
+		}`), &kd))
+
+		transit, ok := kd.InnerVal.(*KeyDataVaultTransit)
+		require.True(t, ok)
+		assert.Equal(t, "http://127.0.0.1:8200", transit.VaultAddress)
+		assert.Equal(t, "dev-only-token", transit.VaultToken)
+		assert.Equal(t, "admin", transit.VaultNamespace)
+		assert.Equal(t, "transit", transit.VaultTransitMountPath)
+		assert.Equal(t, "authproxy", transit.VaultTransitKeyName)
+		assert.Equal(t, "5m", transit.CacheTTL)
+	})
+
+	t.Run("yaml vault address first", func(t *testing.T) {
+		var kd KeyData
+		require.NoError(t, yaml.Unmarshal([]byte(`
+vault_address: http://127.0.0.1:8200
+vault_token: dev-only-token
+vault_transit_mount_path: transit
+vault_transit_key_name: authproxy
+cache_ttl: 5m
+`), &kd))
+
+		transit, ok := kd.InnerVal.(*KeyDataVaultTransit)
+		require.True(t, ok)
+		assert.Equal(t, "http://127.0.0.1:8200", transit.VaultAddress)
+		assert.Equal(t, "dev-only-token", transit.VaultToken)
+		assert.Equal(t, "transit", transit.VaultTransitMountPath)
+		assert.Equal(t, "authproxy", transit.VaultTransitKeyName)
+		assert.Equal(t, "5m", transit.CacheTTL)
+	})
+}

--- a/internal/schema/config/key_version_info.go
+++ b/internal/schema/config/key_version_info.go
@@ -11,18 +11,19 @@ import (
 type ProviderType string
 
 const (
-	ProviderTypeValue             ProviderType = "value"
-	ProviderTypeBase64            ProviderType = "base64"
-	ProviderTypeEnvVar            ProviderType = "env_var"
-	ProviderTypeEnvVarBase64      ProviderType = "env_var_base64"
-	ProviderTypeFile              ProviderType = "file"
-	ProviderTypeRandom            ProviderType = "random"
-	ProviderTypeAwsSecretsManager ProviderType = "aws_secrets_manager"
-	ProviderTypeAwsKMS            ProviderType = "aws_kms"
-	ProviderTypeGcp               ProviderType = "gcp"
-	ProviderTypeGcpKMS            ProviderType = "gcp_kms"
-	ProviderTypeHashicorpVault    ProviderType = "hashicorpvault"
-	ProviderTypeRaw               ProviderType = "raw"
+	ProviderTypeValue                 ProviderType = "value"
+	ProviderTypeBase64                ProviderType = "base64"
+	ProviderTypeEnvVar                ProviderType = "env_var"
+	ProviderTypeEnvVarBase64          ProviderType = "env_var_base64"
+	ProviderTypeFile                  ProviderType = "file"
+	ProviderTypeRandom                ProviderType = "random"
+	ProviderTypeAwsSecretsManager     ProviderType = "aws_secrets_manager"
+	ProviderTypeAwsKMS                ProviderType = "aws_kms"
+	ProviderTypeGcp                   ProviderType = "gcp"
+	ProviderTypeGcpKMS                ProviderType = "gcp_kms"
+	ProviderTypeHashicorpVault        ProviderType = "hashicorpvault"
+	ProviderTypeHashicorpVaultTransit ProviderType = "hashicorpvault_transit"
+	ProviderTypeRaw                   ProviderType = "raw"
 )
 
 // KeyVersionProtectedData stores provider-specific wrapped key material for

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -909,6 +909,19 @@
             { "required": ["gcp_project", "gcp_location", "gcp_key_ring", "gcp_crypto_key"] }
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "vault_address": { "type": "string" },
+            "vault_token": { "type": "string" },
+            "vault_namespace": { "type": "string" },
+            "vault_transit_mount_path": { "type": "string" },
+            "vault_transit_key_name": { "type": "string" },
+            "cache_ttl": { "type": "string" }
+          },
+          "required": ["vault_address", "vault_transit_key_name"],
+          "additionalProperties": false
         }
       ]
     },

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -230,6 +230,16 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"gcp_project": "test-project", "gcp_location": "global", "gcp_crypto_key": "dek-wrapper"}}`,
 				},
 				{
+					Name:  "vault transit",
+					Valid: true,
+					Data:  `{"test": {"vault_address": "http://127.0.0.1:8200", "vault_token": "dev-only-token", "vault_namespace": "admin", "vault_transit_mount_path": "transit", "vault_transit_key_name": "authproxy", "cache_ttl": "5m"}}`,
+				},
+				{
+					Name:  "vault transit missing key name",
+					Valid: false,
+					Data:  `{"test": {"vault_address": "http://127.0.0.1:8200", "vault_transit_mount_path": "transit"}}`,
+				},
+				{
 					Name:  "empty object",
 					Valid: false,
 					Data:  `{"test": {}}`,


### PR DESCRIPTION
## Summary

- add Vault Transit KeyData provider for native datakey generation, DEK wrap/unwrap, and provider key-version metadata
- add config schema/serialization support, including YAML detection priority for Transit vs KV Vault configs
- add unit coverage, opt-in Vault Transit integration coverage, and docs/runbook updates

## Tests

- go test ./internal/schema/config -run 'TestKeyDataVaultTransit|TestSchemaDefinitions' -count=1\n- go test ./internal/schema/config -count=1\n- go test ./internal/encrypt -run 'TestGenerateDataEncryptionKeysToDatabase|TestSyncKeysToDatabase' -count=1\n- cd integration_tests && go test -tags "integration,vault" ./encrypt -run TestVaultTransitKeySyncAndReencrypt -count=1\n- ./scripts/preflight.sh\n\nCloses #618