### PR TITLE
Document unified key model operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ root.tenant-a.app1  →  root.tenant-a  →  root  →  global key
 
 The first namespace with an assigned key is used. Child namespaces inherit their parent's key unless they explicitly set their own. This enables **per-tenant key isolation**: a customer can bring their own key so that their data is cryptographically separated from other tenants, even within a shared database.
 
-Keys can be sourced from external secret managers including AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, environment variables, or the filesystem — allowing customers to retain control of their key material.
+Keys can be backed by external secret managers and KMS providers including AWS Secrets Manager, AWS KMS, GCP Secret Manager, Google Cloud KMS, HashiCorp Vault KV, Vault Transit, environment variables, or the filesystem — allowing customers to retain control of their key material.
 
 #### Automatic Key Rotation and Re-encryption
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 - **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
 - **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
 - **[Application metrics](app_metrics.md)** — configure the app metrics store, query request-event and resource metrics, and understand supported aggregations and dimensions.
-- **[Unified key model migration](key-model-migration.md)** — design contract for replacing encryption key versions with `keys` and `data_encryption_keys`.
+- **[Unified key model migration](key-model-migration.md)** — design and operations guide for replacing encryption key versions with `keys` and `data_encryption_keys`.
 
 ## Operational guides
 

--- a/docs/key-model-migration.md
+++ b/docs/key-model-migration.md
@@ -1,8 +1,8 @@
 # Unified Key Model Migration
 
-This document is the design contract for the key model migration tracked by
-[#605](https://github.com/rmorlok/authproxy/issues/605). The feature branch for
-the full migration is `codex/key-model-migration`.
+This document is the design and operations contract for the key model migration
+tracked by [#605](https://github.com/rmorlok/authproxy/issues/605). The feature
+branch for the full migration is `codex/key-model-migration`.
 
 ## Branching
 
@@ -17,6 +17,18 @@ This migration is not backwards compatible. No production environment is running
 the current encryption model, so implementation PRs may use forward migrations to
 rename, drop, or recreate tables. Demo and development environments can be
 destroyed and recreated when this branch merges.
+
+For demo and development environments, the expected rollout is:
+
+1. Destroy the existing database and Redis state.
+2. Recreate the environment from the merged branch.
+3. Let startup migrations create `keys`, `data_encryption_keys`, and namespace
+   target DEK columns from scratch.
+4. Let startup key sync generate the first current DEK for each active
+   data-encryption key before serving encrypted-data paths.
+
+Do not attempt to preserve old `encryption_keys` or `encryption_key_versions`
+rows in those environments.
 
 ## Why The Model Changes
 
@@ -250,6 +262,103 @@ Cache entries should map:
 dek_id -> plaintext DEK bytes and metadata needed for encryption/decryption
 ```
 
+## Operating The Model
+
+There are two independent rotation workflows. Keeping them separate is the point
+of the unified model:
+
+- **Wrapping-key rotation** changes the provider-managed key encryption key
+  (KEK) or secret value that protects DEKs. The DEK ids stay the same.
+- **DEK rotation** creates a new `dek_...` row and makes it current for future
+  writes. Existing encrypted fields are moved to that DEK by re-encryption.
+
+### Rotating Wrapping Keys
+
+Use this workflow when rotating AWS KMS keys, Google Cloud KMS CryptoKeys,
+HashiCorp Vault Transit keys, secret-manager versions, environment-backed
+secrets, or file-backed wrapping material.
+
+1. Rotate or update the wrapping material in the provider.
+2. Keep old provider material available for decrypt or unwrap until AuthProxy has
+   rewrapped every retained DEK.
+3. Run or wait for `encrypt:sync_keys_to_database`.
+4. Confirm `data_encryption_keys.provider_version` and
+   `data_encryption_keys.provider_metadata` reflect the latest provider material.
+5. After all DEKs for the logical key are rewrapped, retire the old provider
+   material according to the provider's own recovery/deletion policy.
+
+Wrapping-key rotation should not change `data_encryption_keys.id` and should not
+trigger application-data re-encryption by itself. The sync task unwraps each
+stale DEK, wraps the same plaintext DEK with current provider material, and saves
+updated wrapping metadata on the same row.
+
+Provider notes:
+
+- AWS KMS uses `GenerateDataKey` for new DEKs and KMS `Encrypt` / `Decrypt` for
+  explicit wrap and unwrap. AWS KMS keys have delayed deletion windows; use a
+  new key or alias when testing key advancement.
+- Google Cloud KMS uses `GenerateRandomBytes` for provider-generated DEK bytes,
+  then wraps with `Encrypt`. The stored metadata includes the CryptoKeyVersion
+  used for wrapping.
+- Vault Transit uses `datakey/plaintext` for new DEKs and Transit
+  `encrypt` / `decrypt` for explicit wrap and unwrap. Rotate the Transit key
+  with `transit/keys/<name>/rotate`.
+- Secret-backed providers expose wrapping bytes to AuthProxy. Keep the old
+  secret version readable until sync has rewrapped retained DEKs.
+
+### Rotating DEKs
+
+Use this workflow when the actual data-encryption key should change, such as a
+routine cryptoperiod rotation or a tenant isolation change.
+
+Configure policy under `system_auth.data_encryption_keys`:
+
+```yaml
+system_auth:
+  data_encryption_keys:
+    ensure_current: true
+    rotation_interval: 2160h # 90 days
+```
+
+Operational steps:
+
+1. Set `ensure_current` to `true` so every active data-encryption key has a
+   current DEK.
+2. Set `rotation_interval` to the desired cryptoperiod. The default is 90 days;
+   `0` disables age-based rotation.
+3. Run or wait for `encrypt:generate_data_encryption_keys`.
+4. Run or wait for `encrypt:sync_keys_to_database` so namespace
+   `target_data_encryption_key_id` values advance by inheritance.
+5. Run or wait for `encrypt:reencrypt_all` to move stored application fields to
+   the namespace target DEK.
+6. Retain old DEKs until scans show no encrypted fields reference their `dek_`
+   ids. Removing retired DEKs before that point makes those fields
+   undecryptable.
+
+The normal worker schedule runs DEK generation and key sync every 15 minutes,
+and full re-encryption every 30 minutes.
+
+### Namespace Key Changes
+
+Changing a namespace's `key_id` changes which logical key owns future
+encryption. After sync resolves a new `target_data_encryption_key_id`, the
+re-encryption task decrypts fields that still reference an older DEK and writes
+them with the namespace target DEK. Child namespaces inherit the nearest
+ancestor `key_id` unless they set their own.
+
+### Operational Checks
+
+For a healthy deployment:
+
+- Every active data-encryption key has exactly one current DEK.
+- Every namespace resolves to a non-deleted `target_data_encryption_key_id`.
+- Encrypted fields store `{"id":"dek_...","d":"..."}` and no longer reference
+  `ekv_...` ids.
+- Provider-backed DEKs retain provider metadata sufficient for unwrap and stale
+  wrapping detection.
+- Old wrapping material and old DEKs remain available until rewrap and
+  re-encryption are complete.
+
 ## API And Generated Artifacts
 
 Public naming changes from encryption keys to keys:
@@ -291,6 +400,33 @@ CryptoKey. Google Cloud KMS does not expose an AWS-style `GenerateDataKey` API,
 so AuthProxy uses `GenerateRandomBytes` for provider-generated DEK bytes and
 then wraps the DEK with `Encrypt`; the DEK row stores the CryptoKeyVersion used
 for wrapping.
+
+HashiCorp Vault Transit integration tests run against a Vault server with a
+Transit mount. The test creates a unique Transit key, generates a DEK with
+`datakey/plaintext`, rotates the Transit key, verifies that sync rewraps the same
+DEK id, and verifies decrypt through a fresh encrypt-service cache.
+
+See [integration_tests/README.md](../integration_tests/README.md) for provider
+credentials, IAM/policy requirements, and focused run commands.
+
+## Superseded KMS Project
+
+The older `project:kms` issue set is closed and superseded by this migration:
+
+- [#100](https://github.com/rmorlok/authproxy/issues/100) - original KMS support
+  request
+- [#581](https://github.com/rmorlok/authproxy/issues/581) - generalized KMS key
+  protection
+- [#582](https://github.com/rmorlok/authproxy/issues/582) - AWS KMS support
+- [#583](https://github.com/rmorlok/authproxy/issues/583) - Google Cloud KMS
+  support
+- [#584](https://github.com/rmorlok/authproxy/issues/584) - Vault Transit support
+- [#585](https://github.com/rmorlok/authproxy/issues/585) - KMS operations docs
+- [#598](https://github.com/rmorlok/authproxy/issues/598) - DEK generation and
+  rotation policy
+
+Use [#605](https://github.com/rmorlok/authproxy/issues/605) and its child issues
+as the source of truth for the unified key model.
 
 ## Implementation Order
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -77,11 +77,13 @@ Run:
 cd integration_tests
 AUTH_PROXY_AWS_KMS_TEST=1 AWS_REGION=us-east-1 \\
   AUTH_PROXY_AWS_KMS_KEY_ID=alias/authproxy-test \\
-  go test -tags "integration,aws" -v ./encrypt/...
+  go test -tags "integration,aws" -v ./encrypt/... -run TestAwsKMSKeySyncAndReencrypt
 ```
 
 Notes:
 - The test does not create or delete KMS keys because AWS KMS keys have delayed deletion windows.
+- AWS KMS DEK generation uses `GenerateDataKey`; rewrap uses `Encrypt` / `Decrypt` and keeps the same `dek_` id.
+- Set `AUTH_PROXY_AWS_KMS_KEY_ID_V2` to verify provider metadata advancement and DEK rewrap with a second key or alias.
 - For CI, provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` via secrets.
 
 ## GCP Secret Manager Integration Test
@@ -139,12 +141,13 @@ cd integration_tests
 AUTH_PROXY_GCP_KMS_TEST=1 \
   AUTH_PROXY_GCP_KMS_KEY_NAME=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper \
   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
-  go test -tags "integration,gcp" -v ./encrypt/...
+  go test -tags "integration,gcp" -v ./encrypt/... -run TestGcpKMSKeySyncAndReencrypt
 ```
 
 Notes:
 - The test does not create or delete KMS keys because Google Cloud KMS keys are long-lived resources.
 - GCP KMS DEK generation uses `GenerateRandomBytes` and then wraps the generated DEK with the configured CryptoKey.
+- Set `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` to verify provider metadata advancement and DEK rewrap with a second CryptoKey.
 
 ## HashiCorp Vault Integration Test
 
@@ -161,7 +164,7 @@ cd integration_tests
 AUTH_PROXY_VAULT_TEST=1 \
   VAULT_ADDR=http://127.0.0.1:8200 \
   VAULT_TOKEN=dev-only-token \
-  go test -tags "integration,vault" -v ./encrypt/...
+  go test -tags "integration,vault" -v ./encrypt/... -run 'TestVault(KeySyncAndReencrypt|TransitKeySyncAndReencrypt)'
 ```
 
 Or start Vault ad hoc:
@@ -176,6 +179,29 @@ Notes:
 - The KV test writes a short-lived KV v2 secret at a unique path and deletes its metadata on cleanup.
 - The Transit test creates a unique Transit key, generates a DEK through `datakey/plaintext`, rotates the Transit key, verifies DEK rewrap, and decrypts through a fresh encrypt service cache.
 - CI uses `.github/workflows/vault-integration.yml`, which runs Vault as a dev-mode container inside the workflow. The workflow runs on pushes to `main` and on `workflow_dispatch`.
+
+Focused KMS provider commands:
+
+```bash
+cd integration_tests
+
+# AWS KMS
+AUTH_PROXY_AWS_KMS_TEST=1 AWS_REGION=us-east-1 \
+  AUTH_PROXY_AWS_KMS_KEY_ID=alias/authproxy-test \
+  go test -tags "integration,aws" -v ./encrypt/... -run TestAwsKMSKeySyncAndReencrypt
+
+# Google Cloud KMS
+AUTH_PROXY_GCP_KMS_TEST=1 \
+  AUTH_PROXY_GCP_KMS_KEY_NAME=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper \
+  GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
+  go test -tags "integration,gcp" -v ./encrypt/... -run TestGcpKMSKeySyncAndReencrypt
+
+# Vault Transit
+AUTH_PROXY_VAULT_TEST=1 \
+  VAULT_ADDR=http://127.0.0.1:8200 \
+  VAULT_TOKEN=dev-only-token \
+  go test -tags "integration,vault" -v ./encrypt/... -run TestVaultTransitKeySyncAndReencrypt
+```
 
 ## Teardown
 

--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -107,7 +107,7 @@ The `KeyData` wrapper supports multiple sources for key material. Each provider 
 
 Cloud providers (AWS, GCP, Vault) support caching via `cache_ttl` and report provider-version metadata when the underlying secret or KMS material has been rotated.
 
-KMS-backed providers are different from secret-backed providers. Secret-backed providers return AES key bytes directly to AuthProxy. KMS-backed providers generate or wrap data encryption keys (DEKs) and persist only the wrapped DEK in `data_encryption_keys`. Runtime encryption and re-encryption are driven by the current DEK for the namespace key.
+KMS-backed providers are different from secret-backed providers. Secret-backed providers return AES key bytes directly to AuthProxy, and AuthProxy uses those bytes to wrap generated DEKs. KMS-backed providers keep wrapping material outside AuthProxy, generate or wrap DEKs through provider APIs, and persist only wrapped DEKs plus provider metadata in `data_encryption_keys`. Runtime encryption and re-encryption are driven by the current DEK for the namespace key.
 
 ## Key Sync and Rotation
 
@@ -161,6 +161,33 @@ The DEK generation task walks keys in dependency order, decrypts each key's `Key
 A background goroutine loads keys and DEKs from the database into in-memory caches. Caches are rebuilt atomically and swapped under a write lock.
 
 On startup, the service blocks until the global key is available (up to 5 minutes with exponential backoff), then signals readiness.
+
+## Operational Runbook
+
+There are two separate rotations:
+
+- **Wrapping-key rotation** changes the provider material that protects existing DEKs. Run or wait for `encrypt:sync_keys_to_database`; it keeps each `dek_` id stable while updating `protected_data`, `provider_version`, and `provider_metadata`.
+- **DEK rotation** creates a new current DEK for a key. Run or wait for `encrypt:generate_data_encryption_keys`, then `encrypt:sync_keys_to_database` to advance namespace targets, then `encrypt:reencrypt_all` to move stored fields to the target DEK.
+
+DEK policy lives under `system_auth.data_encryption_keys`:
+
+```yaml
+system_auth:
+  data_encryption_keys:
+    ensure_current: true
+    rotation_interval: 2160h # 90 days
+```
+
+Defaults are `ensure_current: true` and a 90-day `rotation_interval`. A `rotation_interval` of `0` disables age-based DEK rotation, but `ensure_current` can still create the first DEK for a key.
+
+Operational guardrails:
+
+- Keep old provider wrapping material available until sync has rewrapped every retained DEK.
+- Keep old DEK rows available until re-encryption has moved all encrypted fields off their `dek_` ids.
+- Rotating wrapping material alone should not change encrypted field ids.
+- Rotating DEKs should change namespace targets first, then encrypted field ids as the re-encryption task processes rows.
+
+The full migration and operator guide lives in [docs/key-model-migration.md](../../docs/key-model-migration.md).
 
 ## Automatic Re-encryption
 


### PR DESCRIPTION
## Summary

- expand the unified key model migration guide into an operator runbook covering demo/dev recreation, wrapping-key rotation, DEK rotation, namespace key changes, health checks, and superseded KMS project issues
- add engineering-facing rotation guidance to the encrypt package README
- document focused AWS KMS, GCP KMS, and Vault Transit integration test requirements and commands
- update README/docs index language for KMS-backed providers and operations guidance

## Tests

- git diff --check
- ./scripts/preflight.sh

Closes #619