### PR TITLE
Evaluate conditional probes at runtime

### DIFF
--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,6 +102,42 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		conn.SetupStep = &current
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.True(t, outcome.SetupPending)
+		require.NotNil(t, conn.GetSetupStep())
+		assert.Equal(t, "workspace", conn.GetSetupStep().String())
+	})
+
+	t.Run("skips verify when all probes are disabled", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sf := &cschema.SetupFlow{
+			Configure: &cschema.SetupFlowPhase{
+				Steps: []cschema.SetupFlowStep{
+					{Id: "workspace", JsonSchema: workspaceSchema},
+				},
+			},
+		}
+		conn, db, _ := newTestConnectionWithSetupFlowAndAsynq(t, ctrl, sf)
+		conn.cv = NewTestConnectorVersion(cschema.Connector{
+			Auth:      &cschema.Auth{InnerVal: &cschema.AuthOAuth2{Type: cschema.AuthTypeOAuth2}},
+			SetupFlow: sf,
+			Probes: []cschema.Probe{{
+				Id: "ping",
+				If: &common.Predicate{Javascript: `cfg.run_probe === true`},
+			}},
+		})
+		conn.ConnectorId = conn.cv.GetId()
+		conn.ConnectorVersion = conn.cv.GetVersion()
+		setConnectionConfigFixture(t, conn, map[string]any{"run_probe": false})
+		current := cschema.MustNewSetupStep(oauth2.OAuth2AuthorizeStepId)
+		conn.SetupStep = &current
+
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
+		// No EnqueueContext expectation — disabled probes must skip verify.
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)

--- a/internal/core/connection_probe.go
+++ b/internal/core/connection_probe.go
@@ -1,19 +1,23 @@
 package core
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	"github.com/rmorlok/authproxy/internal/core/iface"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 var ErrProbeNotFound = errors.New("probe not found")
+var ErrProbeDisabled = errors.New("probe disabled")
 
 func (c *connection) GetProbe(probeId string) (iface.Probe, error) {
 	def := c.cv.GetDefinition()
 
-	for _, probe := range def.Probes {
-		if probe.Id == probeId {
-			return NewProbe(&probe, c.s, c.cv, c), nil
+	for i := range def.Probes {
+		if def.Probes[i].Id == probeId {
+			return NewProbe(&def.Probes[i], c.s, c.cv, c), nil
 		}
 	}
 
@@ -24,9 +28,86 @@ func (c *connection) GetProbes() []iface.Probe {
 	def := c.cv.GetDefinition()
 	probes := make([]iface.Probe, 0, len(def.Probes))
 
-	for _, probe := range def.Probes {
-		probes = append(probes, NewProbe(&probe, c.s, c.cv, c))
+	for i := range def.Probes {
+		probes = append(probes, NewProbe(&def.Probes[i], c.s, c.cv, c))
 	}
 
 	return probes
+}
+
+func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface.Probe, error) {
+	def := c.cv.GetDefinition()
+	getVars := c.lazyProbePredicateVars(ctx)
+
+	for i := range def.Probes {
+		probe := &def.Probes[i]
+		if probe.Id != probeId {
+			continue
+		}
+
+		enabled, err := c.isProbeEnabled(probe, getVars)
+		if err != nil {
+			return nil, err
+		}
+		if !enabled {
+			return nil, fmt.Errorf("probe %q: %w", probeId, ErrProbeDisabled)
+		}
+		return NewProbe(probe, c.s, c.cv, c), nil
+	}
+
+	return nil, ErrProbeNotFound
+}
+
+func (c *connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error) {
+	def := c.cv.GetDefinition()
+	probes := make([]iface.Probe, 0, len(def.Probes))
+	getVars := c.lazyProbePredicateVars(ctx)
+
+	for i := range def.Probes {
+		probe := &def.Probes[i]
+		enabled, err := c.isProbeEnabled(probe, getVars)
+		if err != nil {
+			return nil, err
+		}
+		if !enabled {
+			continue
+		}
+		probes = append(probes, NewProbe(probe, c.s, c.cv, c))
+	}
+
+	return probes, nil
+}
+
+type probePredicateVarsLoader func() (map[string]any, error)
+
+func (c *connection) lazyProbePredicateVars(ctx context.Context) probePredicateVarsLoader {
+	var (
+		loaded bool
+		vars   map[string]any
+		err    error
+	)
+	return func() (map[string]any, error) {
+		if !loaded {
+			vars, err = c.GetPredicateVars(ctx)
+			loaded = true
+		}
+		return vars, err
+	}
+}
+
+func (c *connection) isProbeEnabled(probe *cschema.Probe, getVars probePredicateVarsLoader) (bool, error) {
+	if probe == nil || probe.If == nil {
+		return true, nil
+	}
+
+	vars, err := getVars()
+	if err != nil {
+		return false, fmt.Errorf("probe %q: get predicate vars: %w", probe.Id, err)
+	}
+
+	ok, err := probe.If.GetValue(vars)
+	if err != nil {
+		return false, fmt.Errorf("probe %q if.javascript: %w", probe.Id, err)
+	}
+	return ok, nil
 }

--- a/internal/core/connection_probe_health.go
+++ b/internal/core/connection_probe_health.go
@@ -88,23 +88,24 @@ func (c *connection) maybeRecoverHealth(ctx context.Context, probe iface.Probe) 
 		return nil
 	}
 
-	// Recovery requires every OTHER probe to be within its failure threshold.
-	// A recovery on probe A doesn't restore health while probe B is still
-	// over-failing.
-	def := c.cv.GetDefinition()
-	if def != nil {
-		for _, p := range def.Probes {
-			if p.Id == probe.GetId() {
-				continue
-			}
-			otherFailureThreshold := p.EffectiveFailureThreshold()
-			otherStreak, err := c.consecutiveOutcomeStreak(ctx, p.Id, database.ProbeOutcomeStatusFailure, otherFailureThreshold)
-			if err != nil {
-				return err
-			}
-			if otherStreak >= otherFailureThreshold {
-				return nil // another probe is still failing
-			}
+	// Recovery requires every OTHER enabled probe to be within its failure
+	// threshold. A recovery on probe A doesn't restore health while enabled
+	// probe B is still over-failing, but disabled peers are ignored.
+	enabledProbes, err := c.GetEnabledProbes(ctx)
+	if err != nil {
+		return err
+	}
+	for _, otherProbe := range enabledProbes {
+		if otherProbe.GetId() == probe.GetId() {
+			continue
+		}
+		otherFailureThreshold := otherProbe.EffectiveFailureThreshold()
+		otherStreak, err := c.consecutiveOutcomeStreak(ctx, otherProbe.GetId(), database.ProbeOutcomeStatusFailure, otherFailureThreshold)
+		if err != nil {
+			return err
+		}
+		if otherStreak >= otherFailureThreshold {
+			return nil // another probe is still failing
 		}
 	}
 

--- a/internal/core/connection_probe_health_test.go
+++ b/internal/core/connection_probe_health_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -277,6 +278,36 @@ func TestRecordPeriodicProbeOutcome_AnotherProbeOverThresholdBlocksRecovery(t *t
 	for _, rec := range decodeJSONLines(t, buf) {
 		assert.NotEqual(t, connectionHealthStateChangedMessage, rec["msg"])
 	}
+}
+
+func TestRecordPeriodicProbeOutcome_DisabledPeerDoesNotBlockRecovery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	probes := []cschema.Probe{
+		{Id: "ping", FailureThreshold: intPtr(3), RecoveryThreshold: intPtr(1)},
+		{
+			Id:                "pong",
+			If:                &common.Predicate{Javascript: `cfg.enable_pong === true`},
+			FailureThreshold:  intPtr(1),
+			RecoveryThreshold: intPtr(1),
+		},
+	}
+	conn, db, _ := newProbeHealthTestConn(t, ctrl, probes, database.ConnectionHealthStateUnhealthy)
+
+	probe := &stubProbe{id: "ping", failureThresh: 3, recoveryThresh: 1}
+	db.EXPECT().
+		InsertProbeOutcome(gomock.Any(), conn.Id, "ping", database.ProbeOutcomeStatusSuccess, "").
+		Return(&database.ConnectionProbeOutcome{}, nil)
+	db.EXPECT().
+		GetRecentProbeOutcomes(gomock.Any(), conn.Id, "ping", 1).
+		Return(outcomes("s"), nil)
+	db.EXPECT().
+		SetConnectionHealthState(gomock.Any(), conn.Id, database.ConnectionHealthStateHealthy).
+		Return(nil)
+	// No pong outcome lookup — disabled peer probes do not block recovery.
+
+	require.NoError(t, conn.recordPeriodicProbeOutcome(context.Background(), probe, true, nil))
+	assert.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState)
 }
 
 func TestRecordPeriodicProbeOutcome_AnotherProbeRecoveredAllowsRecovery(t *testing.T) {

--- a/internal/core/connection_probe_test.go
+++ b/internal/core/connection_probe_test.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"context"
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,4 +46,68 @@ func TestConnection_Probe(t *testing.T) {
 		require.Equal(t, "probe-1", probes[0].GetId())
 		require.Equal(t, "probe-2", probes[1].GetId())
 	})
+}
+
+func TestConnection_EnabledProbePredicates(t *testing.T) {
+	conn := newTestConnection(cschema.Connector{
+		Probes: []cschema.Probe{
+			{
+				Id: "cfg_true",
+				If: &common.Predicate{Javascript: `cfg.region === "eu"`},
+			},
+			{
+				Id: "cfg_false",
+				If: &common.Predicate{Javascript: `cfg.region === "us"`},
+			},
+			{
+				Id: "label_true",
+				If: &common.Predicate{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
+			},
+			{
+				Id: "annotation_true",
+				If: &common.Predicate{Javascript: `annotations["setup-mode"] === "advanced"`},
+			},
+			{
+				Id: "always",
+			},
+		},
+	})
+	setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
+	conn.Labels = map[string]string{"apxy/cxr/type": "salesforce"}
+	conn.Annotations = map[string]string{"setup-mode": "advanced"}
+
+	probes, err := conn.GetEnabledProbes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, probes, 4)
+	assert.Equal(t, "cfg_true", probes[0].GetId())
+	assert.Equal(t, "label_true", probes[1].GetId())
+	assert.Equal(t, "annotation_true", probes[2].GetId())
+	assert.Equal(t, "always", probes[3].GetId())
+
+	p, err := conn.GetEnabledProbe(context.Background(), "cfg_true")
+	require.NoError(t, err)
+	assert.Equal(t, "cfg_true", p.GetId())
+
+	p, err = conn.GetEnabledProbe(context.Background(), "cfg_false")
+	require.ErrorIs(t, err, ErrProbeDisabled)
+	require.Nil(t, p)
+
+	p, err = conn.GetEnabledProbe(context.Background(), "missing")
+	require.ErrorIs(t, err, ErrProbeNotFound)
+	require.Nil(t, p)
+}
+
+func TestConnection_EnabledProbePredicateError(t *testing.T) {
+	conn := newTestConnection(cschema.Connector{
+		Probes: []cschema.Probe{
+			{
+				Id: "broken",
+				If: &common.Predicate{Javascript: `cfg.region ===`},
+			},
+		},
+	})
+
+	_, err := conn.GetEnabledProbes(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `probe "broken" if.javascript`)
 }

--- a/internal/core/connection_probe_test.go
+++ b/internal/core/connection_probe_test.go
@@ -48,7 +48,9 @@ func TestConnection_Probe(t *testing.T) {
 	})
 }
 
-func TestConnection_EnabledProbePredicates(t *testing.T) {
+func newConditionalProbeTestConnection(t *testing.T) *connection {
+	t.Helper()
+
 	conn := newTestConnection(cschema.Connector{
 		Probes: []cschema.Probe{
 			{
@@ -75,6 +77,11 @@ func TestConnection_EnabledProbePredicates(t *testing.T) {
 	setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
 	conn.Labels = map[string]string{"apxy/cxr/type": "salesforce"}
 	conn.Annotations = map[string]string{"setup-mode": "advanced"}
+	return conn
+}
+
+func TestConnection_GetEnabledProbes(t *testing.T) {
+	conn := newConditionalProbeTestConnection(t)
 
 	probes, err := conn.GetEnabledProbes(context.Background())
 	require.NoError(t, err)
@@ -83,6 +90,10 @@ func TestConnection_EnabledProbePredicates(t *testing.T) {
 	assert.Equal(t, "label_true", probes[1].GetId())
 	assert.Equal(t, "annotation_true", probes[2].GetId())
 	assert.Equal(t, "always", probes[3].GetId())
+}
+
+func TestConnection_GetEnabledProbe(t *testing.T) {
+	conn := newConditionalProbeTestConnection(t)
 
 	p, err := conn.GetEnabledProbe(context.Background(), "cfg_true")
 	require.NoError(t, err)
@@ -97,7 +108,23 @@ func TestConnection_EnabledProbePredicates(t *testing.T) {
 	require.Nil(t, p)
 }
 
-func TestConnection_EnabledProbePredicateError(t *testing.T) {
+func TestConnection_GetEnabledProbePredicateError(t *testing.T) {
+	conn := newTestConnection(cschema.Connector{
+		Probes: []cschema.Probe{
+			{
+				Id: "broken",
+				If: &common.Predicate{Javascript: `cfg.region ===`},
+			},
+		},
+	})
+
+	p, err := conn.GetEnabledProbe(context.Background(), "broken")
+	require.Error(t, err)
+	require.Nil(t, p)
+	assert.Contains(t, err.Error(), `probe "broken" if.javascript`)
+}
+
+func TestConnection_GetEnabledProbesPredicateError(t *testing.T) {
 	conn := newTestConnection(cschema.Connector{
 		Probes: []cschema.Probe{
 			{

--- a/internal/core/connection_setup_flow.go
+++ b/internal/core/connection_setup_flow.go
@@ -72,9 +72,20 @@ func (s *service) buildManifestSetupFlow(c iface.Connection) iface.ManifestSetup
 	}
 
 	return &manifestFlow{
-		steps:        steps,
-		hasProbes:    connector.HasProbes(),
-		authBoundary: authBoundary,
+		steps:            steps,
+		hasProbes:        connector.HasProbes(),
+		hasEnabledProbes: cHasEnabledProbes(c),
+		authBoundary:     authBoundary,
+	}
+}
+
+func cHasEnabledProbes(c iface.Connection) func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		probes, err := c.GetEnabledProbes(ctx)
+		if err != nil {
+			return false, err
+		}
+		return len(probes) > 0, nil
 	}
 }
 
@@ -220,9 +231,10 @@ func (s *service) mintReturnURL(ctx context.Context, connectionId apid.ID, stepI
 // manifestFlow is the materialized setup flow for a single connection.
 // Exposed as iface.ManifestSetupFlow.
 type manifestFlow struct {
-	steps        []iface.ManifestSetupStep
-	hasProbes    bool
-	authBoundary int // index in steps after which verify slots in when hasProbes
+	steps            []iface.ManifestSetupStep
+	hasProbes        bool
+	hasEnabledProbes func(context.Context) (bool, error)
+	authBoundary     int // index in steps after which verify slots in when probes are enabled
 }
 
 func (f *manifestFlow) Steps(ctx context.Context) ([]iface.ManifestSetupStep, error) {
@@ -244,6 +256,13 @@ func (f *manifestFlow) StepById(ctx context.Context, id string) (iface.ManifestS
 		return nil, false, nil
 	}
 	if id == iface.NewVerifyStep().Id() && f.hasProbes {
+		ok, err := f.verifyEnabled(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			return nil, false, nil
+		}
 		return iface.NewVerifyStep(), true, nil
 	}
 	for i, s := range f.steps {
@@ -280,7 +299,13 @@ func (f *manifestFlow) FirstStep(ctx context.Context) (iface.ManifestSetupStep, 
 		if err != nil || ok {
 			return step, err
 		}
-		return iface.NewVerifyStep(), nil
+		verify, err := f.verifyEnabled(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if verify {
+			return iface.NewVerifyStep(), nil
+		}
 	}
 	step, _, err := f.nextEligibleStep(ctx, 0, len(f.steps)-1)
 	return step, err
@@ -307,11 +332,28 @@ func (f *manifestFlow) NextStep(ctx context.Context, currentId string) (iface.Ma
 			if err != nil || ok {
 				return next, ok, err
 			}
-			return iface.NewVerifyStep(), true, nil
+			verify, err := f.verifyEnabled(ctx)
+			if err != nil {
+				return nil, false, err
+			}
+			if verify {
+				return iface.NewVerifyStep(), true, nil
+			}
+			return f.nextEligibleStep(ctx, f.authBoundary+1, len(f.steps)-1)
 		}
 		return f.nextEligibleStep(ctx, i+1, len(f.steps)-1)
 	}
 	return nil, false, nil
+}
+
+func (f *manifestFlow) verifyEnabled(ctx context.Context) (bool, error) {
+	if !f.hasProbes {
+		return false, nil
+	}
+	if f.hasEnabledProbes == nil {
+		return true, nil
+	}
+	return f.hasEnabledProbes(ctx)
 }
 
 func (f *manifestFlow) nextEligibleStep(ctx context.Context, start int, end int) (iface.ManifestSetupStep, bool, error) {

--- a/internal/core/connection_setup_flow_test.go
+++ b/internal/core/connection_setup_flow_test.go
@@ -89,6 +89,36 @@ func TestManifestSetupFlowIfJavascriptVerifyBoundary(t *testing.T) {
 	assert.Equal(t, "apxy:verify", first.Id())
 }
 
+func TestManifestSetupFlowSkipsVerifyWhenAllProbesDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+		Configure: &cschema.SetupFlowPhase{
+			Steps: []cschema.SetupFlowStep{
+				{Id: "workspace", JsonSchema: workspaceSchema},
+			},
+		},
+	})
+	setConnectionConfigFixture(t, conn, map[string]any{"run_probe": false})
+	conn.cv.GetDefinition().Probes = []cschema.Probe{{
+		Id: "ping",
+		If: &common.Predicate{Javascript: `cfg.run_probe === true`},
+	}}
+
+	flow := conn.s.buildManifestSetupFlow(conn)
+	first, err := flow.FirstStep(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "workspace", first.Id())
+	assert.True(t, flow.ContainsStep("apxy:verify"))
+
+	verify, ok, err := flow.StepById(context.Background(), "apxy:verify")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, verify)
+}
+
 func TestManifestSetupFlowIfJavascriptError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -57,6 +57,8 @@ type Connection interface {
 	GetMustacheContext(ctx context.Context) (map[string]any, error)
 	GetProbe(probeId string) (Probe, error)
 	GetProbes() []Probe
+	GetEnabledProbe(ctx context.Context, probeId string) (Probe, error)
+	GetEnabledProbes(ctx context.Context) ([]Probe, error)
 	ProxyRequest(
 		ctx context.Context,
 		reqType httpf.RequestType,

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -96,6 +96,14 @@ func (m *Connection) GetProbes() []iface.Probe {
 	return nil
 }
 
+func (m *Connection) GetEnabledProbe(ctx context.Context, probeId string) (iface.Probe, error) {
+	return m.GetProbe(probeId)
+}
+
+func (m *Connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error) {
+	return m.GetProbes(), nil
+}
+
 func (m *Connection) GetAnnotations() map[string]string {
 	return m.Annotations
 }

--- a/internal/core/service_probe_now.go
+++ b/internal/core/service_probe_now.go
@@ -48,7 +48,11 @@ func (s *service) EnqueueProbeNow(ctx context.Context, connectionId apid.ID) err
 		return err
 	}
 
-	probes := conn.GetProbes()
+	probes, err := conn.GetEnabledProbes(ctx)
+	if err != nil {
+		logger.Warn("probe-now: failed to resolve enabled probes", "error", err)
+		return err
+	}
 	if len(probes) == 0 {
 		return nil
 	}

--- a/internal/core/service_probe_now_test.go
+++ b/internal/core/service_probe_now_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	mockRedisPkg "github.com/rmorlok/authproxy/internal/apredis/mock"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,39 @@ func TestEnqueueProbeNow_EnqueuesEachProbeWhenThrottleAllows(t *testing.T) {
 	defer ctrl.Finish()
 	svc.r = mockRedisAllowingSetNX(ctrl, connectionId, []string{"p1", "p2"}, true)
 	svc.ac = mockAsynqExpectingEnqueues(ctrl, 2)
+
+	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
+}
+
+func TestEnqueueProbeNow_EnqueuesOnlyEnabledProbes(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "probe-now-conditional",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{Id: "enabled", Http: &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"}},
+			{
+				Id:   "disabled",
+				If:   &common.Predicate{Javascript: `cfg.run_disabled === true`},
+				Http: &cschema.ProbeHttp{Method: "GET", URL: "https://y.example/health"},
+			},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateConfigured,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+	svc.r = mockRedisAllowingSetNX(ctrl, connectionId, []string{"enabled"}, true)
+	svc.ac = mockAsynqExpectingEnqueues(ctrl, 1)
 
 	require.NoError(t, svc.EnqueueProbeNow(context.Background(), connectionId))
 }

--- a/internal/core/service_tasks.go
+++ b/internal/core/service_tasks.go
@@ -44,7 +44,13 @@ func (s *service) GetCronTasks() []*asynq.PeriodicTaskConfig {
 						continue
 					}
 
-					for _, probe := range c.GetProbes() {
+					probes, err := c.GetEnabledProbes(context.Background())
+					if err != nil {
+						logger.Error("failed to resolve enabled probes for periodic tasks", "error", err)
+						continue
+					}
+
+					for _, probe := range probes {
 						if probe.IsPeriodic() {
 							logger.Debug("adding periodic probe task", "probe_id", probe.GetId())
 							t, err := newProbeTask(c.Id, probe.GetId())

--- a/internal/core/service_tasks_test.go
+++ b/internal/core/service_tasks_test.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCronTasks_SchedulesOnlyEnabledPeriodicProbes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	svc, db, _, _, _, encrypt := FullMockService(t, ctrl)
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "periodic-conditional",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{
+				Id:     "enabled",
+				Period: common.HumanDurationFor("1m"),
+				Http:   &cschema.ProbeHttp{Method: "GET", URL: "https://x.example/health"},
+			},
+			{
+				Id:     "disabled",
+				Period: common.HumanDurationFor("2m"),
+				If:     &common.Predicate{Javascript: `cfg.run_disabled === true`},
+				Http:   &cschema.ProbeHttp{Method: "GET", URL: "https://y.example/health"},
+			},
+			{
+				Id:   "manual",
+				Http: &cschema.ProbeHttp{Method: "GET", URL: "https://z.example/health"},
+			},
+		},
+	}
+	conn := database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateConfigured,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+	encryptedDef := encfield.EncryptedField{ID: "ekv_mock", Data: "encrypted-def"}
+	connJSON, err := json.Marshal(connector)
+	require.NoError(t, err)
+
+	db.EXPECT().
+		ListConnectionsBuilder().
+		Return(&staticListConnectionsBuilder{connections: []database.Connection{conn}})
+	db.EXPECT().
+		GetConnectorVersion(gomock.Any(), connector.Id, connector.Version).
+		Return(&database.ConnectorVersion{
+			Id:                  connector.Id,
+			Version:             connector.Version,
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                "hash",
+			EncryptedDefinition: encryptedDef,
+		}, nil)
+	encrypt.EXPECT().
+		DecryptString(gomock.Any(), encryptedDef).
+		Return(string(connJSON), nil)
+
+	tasks := svc.GetCronTasks()
+	require.Len(t, tasks, 2)
+	assert.Equal(t, taskTypeProbe, tasks[0].Task.Type())
+	assert.Equal(t, "@every 1m0s", tasks[0].Cronspec)
+	assert.Equal(t, taskTypeProbeOutcomeCleanup, tasks[1].Task.Type())
+}
+
+type staticListConnectionsBuilder struct {
+	connections []database.Connection
+}
+
+func (b *staticListConnectionsBuilder) FetchPage(ctx context.Context) pagination.PageResult[database.Connection] {
+	return pagination.PageResult[database.Connection]{Results: b.connections}
+}
+
+func (b *staticListConnectionsBuilder) Enumerate(ctx context.Context, callback pagination.EnumerateCallback[database.Connection]) error {
+	_, err := callback(b.FetchPage(ctx))
+	return err
+}
+
+func (b *staticListConnectionsBuilder) Limit(int32) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForState(database.ConnectionState) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForStates([]database.ConnectionState) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForConnectorId(apid.ID) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForNamespaceMatcher(string) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForNamespaceMatchers([]string) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) OrderBy(database.ConnectionOrderByField, pagination.OrderBy) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) IncludeDeleted() database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) WithDeletedHandling(database.DeletedHandling) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) ForLabelSelector(string) database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) WithSetupStepNotNull() database.ListConnectionsBuilder {
+	return b
+}
+
+func (b *staticListConnectionsBuilder) UpdatedBefore(time.Time) database.ListConnectionsBuilder {
+	return b
+}

--- a/internal/core/task_probe.go
+++ b/internal/core/task_probe.go
@@ -92,11 +92,15 @@ func (s *service) runProbeInternal(ctx context.Context, logger *slog.Logger, con
 		return nil, err
 	}
 
-	probe, err := conn.GetProbe(probeId)
+	probe, err := conn.GetEnabledProbe(ctx, probeId)
 	if err != nil {
 		if errors.Is(err, ErrProbeNotFound) {
 			logger.Error("probe not found", "error", err)
 			return nil, fmt.Errorf("%s probe not found: %w", taskTypeProbe, asynq.SkipRetry)
+		}
+		if errors.Is(err, ErrProbeDisabled) {
+			logger.Info("probe disabled; skipping", "error", err)
+			return nil, fmt.Errorf("%s probe disabled: %w", taskTypeProbe, asynq.SkipRetry)
 		}
 
 		return probe, err

--- a/internal/core/task_probe_outcome_cleanup.go
+++ b/internal/core/task_probe_outcome_cleanup.go
@@ -43,14 +43,14 @@ func newProbeOutcomeCleanupTask(retention time.Duration) (*asynq.Task, error) {
 // runProbeOutcomeCleanup walks every non-deleted connection and prunes its
 // probe outcome events. For each (connection, probe):
 //
-//   - Reads the probe's effective failure_threshold and recovery_threshold
-//     from the connector definition; keeps at least max(those) most-recent
-//     rows so the runtime always has enough history to compute transitions.
+//   - Reads each enabled probe's effective failure_threshold and
+//     recovery_threshold; keeps at least max(those) most-recent rows so the
+//     runtime always has enough history to compute transitions.
 //   - Deletes rows older than the retention window beyond that minimum.
 //
-// Probe ids that have outcomes but no longer appear in the connector
-// definition (e.g. probe was removed from YAML) still get pruned using
-// default thresholds — keeps stale outcomes from accumulating forever.
+// Probe ids that have outcomes but no longer appear in the enabled probe set
+// (e.g. probe was removed from YAML or is now disabled) still get pruned
+// using default thresholds — keeps stale outcomes from accumulating forever.
 //
 // Errors on individual connections are logged and skipped — one bad connection
 // shouldn't poison the whole sweep.
@@ -109,7 +109,7 @@ func (s *service) cleanupProbeOutcomesForConnection(ctx context.Context, connect
 	// thresholds. A connection without a resolvable definition still gets
 	// outcomes pruned using default thresholds — stale outcomes for a
 	// missing definition would otherwise grow unbounded.
-	probesByID, err := s.probeConfigsForConnection(ctx, connectionId)
+	probesByID, err := s.enabledProbeThresholdsForConnection(ctx, connectionId)
 	if err != nil {
 		// Don't bail — fall through to default thresholds.
 		probesByID = nil
@@ -150,7 +150,12 @@ var defaultKeepMinimum = func() int {
 // probeKeepMinimum returns the number of recent outcomes that must be kept for
 // transition correctness: enough history to satisfy whichever threshold is
 // larger.
-func probeKeepMinimum(p *cschema.Probe) int {
+type probeThresholds interface {
+	EffectiveFailureThreshold() int
+	EffectiveRecoveryThreshold() int
+}
+
+func probeKeepMinimum(p probeThresholds) int {
 	a := p.EffectiveFailureThreshold()
 	b := p.EffectiveRecoveryThreshold()
 	if a > b {
@@ -159,22 +164,22 @@ func probeKeepMinimum(p *cschema.Probe) int {
 	return b
 }
 
-// probeConfigsForConnection returns the connection's connector-defined probes
+// enabledProbeThresholdsForConnection returns the connection's enabled probes
 // keyed by id, for threshold lookup during cleanup. Returns nil + error if the
-// connection or definition can't be resolved; caller falls back to defaults.
-func (s *service) probeConfigsForConnection(ctx context.Context, connectionId apid.ID) (map[string]*cschema.Probe, error) {
+// connection, definition, or predicate context can't be resolved; caller falls
+// back to defaults.
+func (s *service) enabledProbeThresholdsForConnection(ctx context.Context, connectionId apid.ID) (map[string]probeThresholds, error) {
 	conn, err := s.getConnection(ctx, connectionId)
 	if err != nil {
 		return nil, err
 	}
-	def := conn.cv.GetDefinition()
-	if def == nil {
-		return nil, fmt.Errorf("nil connector definition")
+	probes, err := conn.GetEnabledProbes(ctx)
+	if err != nil {
+		return nil, err
 	}
-	out := make(map[string]*cschema.Probe, len(def.Probes))
-	for i := range def.Probes {
-		p := &def.Probes[i]
-		out[p.Id] = p
+	out := make(map[string]probeThresholds, len(probes))
+	for _, p := range probes {
+		out[p.GetId()] = p
 	}
 	return out, nil
 }

--- a/internal/core/task_probe_outcome_cleanup_test.go
+++ b/internal/core/task_probe_outcome_cleanup_test.go
@@ -1,10 +1,15 @@
 package core
 
 import (
+	"context"
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProbeKeepMinimum_UsesLargerThreshold(t *testing.T) {
@@ -28,4 +33,42 @@ func TestProbeKeepMinimum_UsesDefaultsWhenUnset(t *testing.T) {
 		want = cschema.DefaultProbeRecoveryThreshold
 	}
 	assert.Equal(t, want, probeKeepMinimum(p))
+}
+
+func TestEnabledProbeThresholdsForConnection_ExcludesDisabledProbes(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "cleanup-conditional",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{
+				Id:               "enabled",
+				FailureThreshold: intPtr(5),
+			},
+			{
+				Id:               "disabled",
+				If:               &common.Predicate{Javascript: `cfg.keep_disabled === true`},
+				FailureThreshold: intPtr(10),
+			},
+		},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateConfigured,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	thresholds, err := svc.enabledProbeThresholdsForConnection(context.Background(), connectionId)
+	require.NoError(t, err)
+	require.Contains(t, thresholds, "enabled")
+	assert.NotContains(t, thresholds, "disabled")
+	assert.Equal(t, 5, probeKeepMinimum(thresholds["enabled"]))
 }

--- a/internal/core/task_probe_test.go
+++ b/internal/core/task_probe_test.go
@@ -12,6 +12,7 @@ import (
 	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
 	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -200,6 +201,40 @@ func TestRunProbe_ProbeNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, asynq.SkipRetry,
 		"missing probe id should be SkipRetry — retrying won't bring it back")
+}
+
+func TestRunProbe_DisabledProbeSkipsRetry(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "disabled-probe-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "ping",
+			If: &common.Predicate{Javascript: `cfg.run_probe === true`},
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/health",
+			},
+		}},
+	}
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateConfigured,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+	}
+
+	svc, _, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	err := svc.RunProbe(context.Background(), connectionId, "ping")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry,
+		"disabled probe task should be SkipRetry — retrying will not enable it")
 }
 
 // TestRunProbe_ConnectionNotFound returns SkipRetry so the asynq retry loop

--- a/internal/core/task_verify_connection.go
+++ b/internal/core/task_verify_connection.go
@@ -93,7 +93,10 @@ func (s *service) runVerifyConnection(ctx context.Context, connectionId apid.ID)
 		return nil
 	}
 
-	probes := conn.GetProbes()
+	probes, err := conn.GetEnabledProbes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve enabled probes for verify: %w", err)
+	}
 	for _, probe := range probes {
 		outcome, invokeErr := probe.Invoke(ctx)
 		if invokeErr == nil {

--- a/internal/core/task_verify_connection_test.go
+++ b/internal/core/task_verify_connection_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	mockEncrypt "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	mockH "github.com/rmorlok/authproxy/internal/httpf/mock"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,6 +99,98 @@ func TestRunVerifyConnection_NoProbes_AdvancesToReady(t *testing.T) {
 
 	// onVerifyPassed: no configure step → next is zero → clear setup_step
 	// + advance to Ready.
+	db.EXPECT().
+		SetConnectionSetupStep(gomock.Any(), connectionId, (*cschema.SetupStep)(nil)).
+		Return(nil)
+	db.EXPECT().
+		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
+		Return(nil)
+
+	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
+}
+
+func TestRunVerifyConnection_AllProbesDisabled_AdvancesToReady(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "verify-disabled-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{{
+			Id: "disabled",
+			If: &common.Predicate{Javascript: `cfg.run_probe === true`},
+			Http: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    "https://upstream.example.invalid/disabled",
+			},
+		}},
+	}
+	verifyStep := cschema.SetupStepVerify
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateSetup,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+		SetupStep:        &verifyStep,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	db.EXPECT().
+		SetConnectionSetupStep(gomock.Any(), connectionId, (*cschema.SetupStep)(nil)).
+		Return(nil)
+	db.EXPECT().
+		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
+		Return(nil)
+
+	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
+}
+
+func TestRunVerifyConnection_MixedProbePredicates_RunOnlyEnabled(t *testing.T) {
+	connectionId := apid.New(apid.PrefixConnection)
+	connector := &cschema.Connector{
+		Id:          apid.New(apid.PrefixConnectorVersion),
+		Version:     1,
+		DisplayName: "verify-mixed-test",
+		Auth:        &cschema.Auth{InnerVal: &cschema.AuthApiKey{Type: cschema.AuthTypeAPIKey}},
+		Probes: []cschema.Probe{
+			{
+				Id: "enabled",
+				Http: &cschema.ProbeHttp{
+					Method: "GET",
+					URL:    "https://upstream.example.invalid/enabled",
+				},
+			},
+			{
+				Id: "disabled",
+				If: &common.Predicate{Javascript: `cfg.run_disabled === true`},
+				Http: &cschema.ProbeHttp{
+					Method: "GET",
+					URL:    "https://upstream.example.invalid/disabled",
+				},
+			},
+		},
+	}
+	verifyStep := cschema.SetupStepVerify
+	conn := &database.Connection{
+		Id:               connectionId,
+		Namespace:        "root",
+		State:            database.ConnectionStateSetup,
+		HealthState:      database.ConnectionHealthStateHealthy,
+		ConnectorId:      connector.Id,
+		ConnectorVersion: connector.Version,
+		SetupStep:        &verifyStep,
+	}
+
+	svc, db, _, ctrl := setupVerifyTest(t, connectionId, conn, connector)
+	defer ctrl.Finish()
+
+	svc.httpf = mockH.NewFactoryWithMockingClient(ctrl)
+	genmock.New("https://upstream.example.invalid").Get("/enabled").Reply(200)
+
 	db.EXPECT().
 		SetConnectionSetupStep(gomock.Any(), connectionId, (*cschema.SetupStep)(nil)).
 		Return(nil)


### PR DESCRIPTION
## Summary
- add context-aware enabled-probe resolution for probe if.javascript predicates
- use enabled probes for verify, periodic scheduling, probe-now, manual probe runs, cleanup thresholds, and health recovery
- skip now-disabled probe tasks without retrying and skip setup verify when no probes are enabled

Closes #648

## Tests
- go test ./internal/core
- go test ./internal/...
- ./scripts/preflight.sh