### PR TITLE
Wire KMS provider CI variables

### DIFF
--- a/.github/workflows/aws-integration.yml
+++ b/.github/workflows/aws-integration.yml
@@ -1,5 +1,5 @@
 # schema: https://json.schemastore.org/github-workflow.json
-name: AWS Secrets Manager Integration Tests
+name: AWS Key Provider Integration Tests
 
 on:
   push:
@@ -71,7 +71,24 @@ jobs:
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
           minio/mc mb --ignore-existing minio/authproxy-request-logs
 
-    - name: AWS Secrets Manager Integration Tests
+    - name: Check AWS key provider configuration
+      env:
+        AWS_REGION: ${{ vars.AWS_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AUTH_PROXY_AWS_KMS_TEST: ${{ vars.AUTH_PROXY_AWS_KMS_TEST }}
+        AUTH_PROXY_AWS_KMS_KEY_ID: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID }}
+        AUTH_PROXY_AWS_KMS_KEY_ID_V2: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID_V2 }}
+      run: |
+        : "${AWS_REGION:?AWS_REGION environment variable is required}"
+        : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID environment secret is required}"
+        : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY environment secret is required}"
+        : "${AUTH_PROXY_AWS_KMS_TEST:?AUTH_PROXY_AWS_KMS_TEST environment variable is required}"
+        : "${AUTH_PROXY_AWS_KMS_KEY_ID:?AUTH_PROXY_AWS_KMS_KEY_ID environment variable is required}"
+        : "${AUTH_PROXY_AWS_KMS_KEY_ID_V2:?AUTH_PROXY_AWS_KMS_KEY_ID_V2 environment variable is required}"
+        test "$AUTH_PROXY_AWS_KMS_TEST" = "1"
+
+    - name: AWS Key Provider Integration Tests
       working-directory: integration_tests
       env:
         AUTH_PROXY_TEST_DATABASE_PROVIDER: postgres
@@ -82,7 +99,11 @@ jobs:
         POSTGRES_TEST_DATABASE: authproxy_integration
         POSTGRES_TEST_OPTIONS: sslmode=disable
         AUTH_PROXY_AWS_SECRETS_TEST: "1"
-        AWS_REGION: ${{ secrets.AWS_REGION }}
+        AUTH_PROXY_AWS_KMS_TEST: ${{ vars.AUTH_PROXY_AWS_KMS_TEST }}
+        AUTH_PROXY_AWS_KMS_KEY_ID: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID }}
+        AUTH_PROXY_AWS_KMS_KEY_ID_V2: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID_V2 }}
+        AUTH_PROXY_AWS_KMS_ENDPOINT: ${{ vars.AUTH_PROXY_AWS_KMS_ENDPOINT }}
+        AWS_REGION: ${{ vars.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}

--- a/.github/workflows/gcp-integration.yml
+++ b/.github/workflows/gcp-integration.yml
@@ -1,5 +1,5 @@
 # schema: https://json.schemastore.org/github-workflow.json
-name: GCP Secret Manager Integration Tests
+name: GCP Key Provider Integration Tests
 
 on:
   push:
@@ -78,7 +78,22 @@ jobs:
       env:
         GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
 
-    - name: GCP Secret Manager Integration Tests
+    - name: Check GCP key provider configuration
+      env:
+        GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        AUTH_PROXY_GCP_KMS_TEST: ${{ vars.AUTH_PROXY_GCP_KMS_TEST }}
+        AUTH_PROXY_GCP_KMS_KEY_NAME: ${{ vars.AUTH_PROXY_GCP_KMS_KEY_NAME }}
+        AUTH_PROXY_GCP_KMS_KEY_NAME_V2: ${{ vars.AUTH_PROXY_GCP_KMS_KEY_NAME_V2 }}
+      run: |
+        : "${GCP_PROJECT_ID:?GCP_PROJECT_ID environment variable is required}"
+        : "${GOOGLE_APPLICATION_CREDENTIALS:?GOOGLE_APPLICATION_CREDENTIALS must be written by the credentials step}"
+        test -s "$GOOGLE_APPLICATION_CREDENTIALS"
+        : "${AUTH_PROXY_GCP_KMS_TEST:?AUTH_PROXY_GCP_KMS_TEST environment variable is required}"
+        : "${AUTH_PROXY_GCP_KMS_KEY_NAME:?AUTH_PROXY_GCP_KMS_KEY_NAME environment variable is required}"
+        : "${AUTH_PROXY_GCP_KMS_KEY_NAME_V2:?AUTH_PROXY_GCP_KMS_KEY_NAME_V2 environment variable is required}"
+        test "$AUTH_PROXY_GCP_KMS_TEST" = "1"
+
+    - name: GCP Key Provider Integration Tests
       working-directory: integration_tests
       env:
         AUTH_PROXY_TEST_DATABASE_PROVIDER: postgres
@@ -89,5 +104,9 @@ jobs:
         POSTGRES_TEST_DATABASE: authproxy_integration
         POSTGRES_TEST_OPTIONS: sslmode=disable
         AUTH_PROXY_GCP_SECRETS_TEST: "1"
-        GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        AUTH_PROXY_GCP_KMS_TEST: ${{ vars.AUTH_PROXY_GCP_KMS_TEST }}
+        AUTH_PROXY_GCP_KMS_KEY_NAME: ${{ vars.AUTH_PROXY_GCP_KMS_KEY_NAME }}
+        AUTH_PROXY_GCP_KMS_KEY_NAME_V2: ${{ vars.AUTH_PROXY_GCP_KMS_KEY_NAME_V2 }}
+        AUTH_PROXY_GCP_KMS_ENDPOINT: ${{ vars.AUTH_PROXY_GCP_KMS_ENDPOINT }}
+        GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       run: go test -tags "integration,gcp" -v -timeout 10m ./encrypt/...

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -55,7 +55,7 @@ AUTH_PROXY_AWS_SECRETS_TEST=1 AWS_REGION=us-east-1 \\
 
 Notes:
 - The test creates a short-lived secret and deletes it at the end.
-- For CI, provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` via secrets.
+- For CI, provide `AWS_REGION` as an environment variable and `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` as environment secrets.
 
 ## AWS KMS Integration Test
 
@@ -77,6 +77,7 @@ Run:
 cd integration_tests
 AUTH_PROXY_AWS_KMS_TEST=1 AWS_REGION=us-east-1 \\
   AUTH_PROXY_AWS_KMS_KEY_ID=alias/authproxy-test \\
+  AUTH_PROXY_AWS_KMS_KEY_ID_V2=alias/authproxy-test-v2 \\
   go test -tags "integration,aws" -v ./encrypt/... -run TestAwsKMSKeySyncAndReencrypt
 ```
 
@@ -84,7 +85,7 @@ Notes:
 - The test does not create or delete KMS keys because AWS KMS keys have delayed deletion windows.
 - AWS KMS DEK generation uses `GenerateDataKey`; rewrap uses `Encrypt` / `Decrypt` and keeps the same `dek_` id.
 - Set `AUTH_PROXY_AWS_KMS_KEY_ID_V2` to verify provider metadata advancement and DEK rewrap with a second key or alias.
-- For CI, provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` via secrets.
+- For CI, provide `AWS_REGION`, `AUTH_PROXY_AWS_KMS_TEST`, `AUTH_PROXY_AWS_KMS_KEY_ID`, and `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as environment variables. Provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` as environment secrets. CI treats `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as required so the rewrap path is covered.
 
 ## GCP Secret Manager Integration Test
 
@@ -118,7 +119,7 @@ GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/sa.json
 
 Notes:
 - The test creates a short-lived secret and deletes it at the end.
-- For CI, provide `GCP_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS_JSON` (the full service account key JSON) as repository secrets. The GitHub Actions workflow writes the JSON to a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
+- For CI, provide `GCP_PROJECT_ID` as an environment variable and `GOOGLE_APPLICATION_CREDENTIALS_JSON` (the full service account key JSON) as an environment secret. The GitHub Actions workflow writes the JSON to a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
 - The workflow runs only on pushes to `main` (and manual `workflow_dispatch`) to avoid exposing the GCP secrets to PRs from forks.
 
 ## GCP KMS Integration Test
@@ -140,6 +141,7 @@ Run:
 cd integration_tests
 AUTH_PROXY_GCP_KMS_TEST=1 \
   AUTH_PROXY_GCP_KMS_KEY_NAME=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper \
+  AUTH_PROXY_GCP_KMS_KEY_NAME_V2=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper-v2 \
   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
   go test -tags "integration,gcp" -v ./encrypt/... -run TestGcpKMSKeySyncAndReencrypt
 ```
@@ -148,6 +150,7 @@ Notes:
 - The test does not create or delete KMS keys because Google Cloud KMS keys are long-lived resources.
 - GCP KMS DEK generation uses `GenerateRandomBytes` and then wraps the generated DEK with the configured CryptoKey.
 - Set `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` to verify provider metadata advancement and DEK rewrap with a second CryptoKey.
+- For CI, provide `GCP_PROJECT_ID`, `AUTH_PROXY_GCP_KMS_TEST`, `AUTH_PROXY_GCP_KMS_KEY_NAME`, and `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` as environment variables. Provide `GOOGLE_APPLICATION_CREDENTIALS_JSON` as an environment secret. CI treats `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` as required so the rewrap path is covered.
 
 ## HashiCorp Vault Integration Test
 
@@ -188,11 +191,13 @@ cd integration_tests
 # AWS KMS
 AUTH_PROXY_AWS_KMS_TEST=1 AWS_REGION=us-east-1 \
   AUTH_PROXY_AWS_KMS_KEY_ID=alias/authproxy-test \
+  AUTH_PROXY_AWS_KMS_KEY_ID_V2=alias/authproxy-test-v2 \
   go test -tags "integration,aws" -v ./encrypt/... -run TestAwsKMSKeySyncAndReencrypt
 
 # Google Cloud KMS
 AUTH_PROXY_GCP_KMS_TEST=1 \
   AUTH_PROXY_GCP_KMS_KEY_NAME=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper \
+  AUTH_PROXY_GCP_KMS_KEY_NAME_V2=projects/my-project/locations/global/keyRings/authproxy/cryptoKeys/dek-wrapper-v2 \
   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
   go test -tags "integration,gcp" -v ./encrypt/... -run TestGcpKMSKeySyncAndReencrypt
 


### PR DESCRIPTION
## Summary

- read non-sensitive AWS/GCP provider configuration from GitHub environment `vars.*` instead of `secrets.*`
- pass AWS/GCP KMS opt-in and key-name variables into the provider integration workflows
- add fail-fast configuration checks so AWS/GCP key-provider workflows cannot pass by skipping KMS tests
- update integration test docs to distinguish environment variables from environment secrets and require the second KMS key for CI rewrap coverage

## Tests

- `git diff --check`
- `go test -tags integration,aws ./encrypt -list 'TestAws(KMS|Secrets)' -run '^$'` from `integration_tests/`\n- `go test -tags integration,gcp ./encrypt -list 'TestGcp(KMS|Secret)' -run '^$'` from `integration_tests/`\n- `./scripts/preflight.sh`\n\nFollow-up to #605.