### PR TITLE
Read AWS access key ID from CI variables

### DIFF
--- a/.github/workflows/aws-integration.yml
+++ b/.github/workflows/aws-integration.yml
@@ -74,14 +74,14 @@ jobs:
     - name: Check AWS key provider configuration
       env:
         AWS_REGION: ${{ vars.AWS_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AUTH_PROXY_AWS_KMS_TEST: ${{ vars.AUTH_PROXY_AWS_KMS_TEST }}
         AUTH_PROXY_AWS_KMS_KEY_ID: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID }}
         AUTH_PROXY_AWS_KMS_KEY_ID_V2: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID_V2 }}
       run: |
         : "${AWS_REGION:?AWS_REGION environment variable is required}"
-        : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID environment secret is required}"
+        : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID environment variable is required}"
         : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY environment secret is required}"
         : "${AUTH_PROXY_AWS_KMS_TEST:?AUTH_PROXY_AWS_KMS_TEST environment variable is required}"
         : "${AUTH_PROXY_AWS_KMS_KEY_ID:?AUTH_PROXY_AWS_KMS_KEY_ID environment variable is required}"
@@ -104,7 +104,7 @@ jobs:
         AUTH_PROXY_AWS_KMS_KEY_ID_V2: ${{ vars.AUTH_PROXY_AWS_KMS_KEY_ID_V2 }}
         AUTH_PROXY_AWS_KMS_ENDPOINT: ${{ vars.AUTH_PROXY_AWS_KMS_ENDPOINT }}
         AWS_REGION: ${{ vars.AWS_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       run: go test -tags "integration,aws" -v -timeout 10m ./encrypt/...

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -55,7 +55,7 @@ AUTH_PROXY_AWS_SECRETS_TEST=1 AWS_REGION=us-east-1 \\
 
 Notes:
 - The test creates a short-lived secret and deletes it at the end.
-- For CI, provide `AWS_REGION` as an environment variable and `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` as environment secrets.
+- For CI, provide `AWS_REGION` and `AWS_ACCESS_KEY_ID` as environment variables. Provide `AWS_SECRET_ACCESS_KEY` and optional `AWS_SESSION_TOKEN` as environment secrets.
 
 ## AWS KMS Integration Test
 
@@ -85,7 +85,7 @@ Notes:
 - The test does not create or delete KMS keys because AWS KMS keys have delayed deletion windows.
 - AWS KMS DEK generation uses `GenerateDataKey`; rewrap uses `Encrypt` / `Decrypt` and keeps the same `dek_` id.
 - Set `AUTH_PROXY_AWS_KMS_KEY_ID_V2` to verify provider metadata advancement and DEK rewrap with a second key or alias.
-- For CI, provide `AWS_REGION`, `AUTH_PROXY_AWS_KMS_TEST`, `AUTH_PROXY_AWS_KMS_KEY_ID`, and `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as environment variables. Provide `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` as environment secrets. CI treats `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as required so the rewrap path is covered.
+- For CI, provide `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AUTH_PROXY_AWS_KMS_TEST`, `AUTH_PROXY_AWS_KMS_KEY_ID`, and `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as environment variables. Provide `AWS_SECRET_ACCESS_KEY` and optional `AWS_SESSION_TOKEN` as environment secrets. CI treats `AUTH_PROXY_AWS_KMS_KEY_ID_V2` as required so the rewrap path is covered.
 
 ## GCP Secret Manager Integration Test
 
@@ -130,7 +130,7 @@ Requirements:
 - GCP credentials available via Application Default Credentials.
 - `AUTH_PROXY_GCP_KMS_TEST=1` set to opt in.
 - `AUTH_PROXY_GCP_KMS_KEY_NAME` set to an existing symmetric encryption CryptoKey resource name, or `GCP_PROJECT_ID`, `AUTH_PROXY_GCP_KMS_LOCATION`, `AUTH_PROXY_GCP_KMS_KEY_RING`, and `AUTH_PROXY_GCP_KMS_CRYPTO_KEY` set to its components.
-- IAM permissions: `cloudkms.cryptoKeys.get`, `cloudkms.cryptoKeyVersions.useToEncrypt`, `cloudkms.cryptoKeyVersions.useToDecrypt`, and `cloudkms.locations.generateRandomBytes`.
+- IAM permissions: `cloudkms.cryptoKeys.get`, `cloudkms.cryptoKeyVersions.useToEncrypt`, `cloudkms.cryptoKeyVersions.useToDecrypt`, and `cloudkms.locations.generateRandomBytes`. The `cloudkms.locations.generateRandomBytes` permission must be granted on the KMS location used by `AUTH_PROXY_GCP_KMS_KEY_NAME` (for example, `projects/my-project/locations/global`).
 
 Optional:
 - `AUTH_PROXY_GCP_KMS_KEY_NAME_V2` set to a second accessible CryptoKey to exercise provider metadata advancement and DEK rewrap.


### PR DESCRIPTION
## Summary

- read `AWS_ACCESS_KEY_ID` from GitHub environment variables instead of environment secrets
- keep `AWS_SECRET_ACCESS_KEY` and optional `AWS_SESSION_TOKEN` in secrets
- update integration test docs to match the AWS environment variable/secret split
- document that GCP KMS CI needs `cloudkms.locations.generateRandomBytes` on the configured KMS location

## Investigation

- AWS run 27827945220 failed in the configuration check because `AWS_ACCESS_KEY_ID` was empty while it was read from `secrets.*`.
- GCP run 27827695207 reached the KMS test and failed because the service account lacks `cloudkms.locations.generateRandomBytes` on `projects/auth-proxy-446804/locations/global`.

## Tests

- `git diff --check`
- `go test -tags integration,aws ./encrypt -list 'TestAws(KMS|Secrets)' -run '^$'` from `integration_tests/`\n- `./scripts/preflight.sh`\n\nFollow-up to #605.