### PR TITLE
Fix Vault Transit cold reload after re-encryption

### DIFF
--- a/integration_tests/encrypt/aws_kms_test.go
+++ b/integration_tests/encrypt/aws_kms_test.go
@@ -48,8 +48,7 @@ func TestAwsKMSKeySyncAndReencrypt(t *testing.T) {
 	keyIDAuthProxy := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &keyIDAuthProxy,
+		Path: namespace,
 	}))
 
 	keyData := awsKMSKeyData(keyID, region)
@@ -66,6 +65,8 @@ func TestAwsKMSKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &keyIDAuthProxy)
+	require.NoError(t, err)
 
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyIDAuthProxy, &keyData)
 	require.Equal(t, awsKMSProviderString, currentV1.Provider)

--- a/integration_tests/encrypt/aws_kms_test.go
+++ b/integration_tests/encrypt/aws_kms_test.go
@@ -131,6 +131,28 @@ func TestAwsKMSKeySyncAndReencrypt(t *testing.T) {
 	require.Equal(t, plaintext, decrypted)
 }
 
+func TestAwsKMSGlobalAESKeyStartup(t *testing.T) {
+	if os.Getenv(awsKMSTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", awsKMSTestEnv)
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		t.Skip("AWS_REGION is not set")
+	}
+	keyID := os.Getenv(awsKMSKeyIDEnv)
+	if keyID == "" {
+		t.Skipf("%s is not set", awsKMSKeyIDEnv)
+	}
+
+	ctx := context.Background()
+	keyData := awsKMSKeyData(keyID, region)
+	env := setupWithGlobalKeyDataIntegrationTest(t, &keyData)
+	defer env.Cleanup()
+
+	requireGlobalKeyProviderRoundTrip(t, ctx, env, sconfig.ProviderTypeAwsKMS, keyID)
+}
+
 func awsKMSKeyData(keyID string, region string) sconfig.KeyData {
 	return sconfig.KeyData{
 		InnerVal: &sconfig.KeyDataAwsKMS{

--- a/integration_tests/encrypt/aws_secrets_test.go
+++ b/integration_tests/encrypt/aws_secrets_test.go
@@ -66,8 +66,7 @@ func TestAwsSecretsManagerKeySyncAndReencrypt(t *testing.T) {
 	ekID := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &ekID,
+		Path: namespace,
 	}))
 
 	keyData := sconfig.KeyData{
@@ -88,6 +87,8 @@ func TestAwsSecretsManagerKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &ekID)
+	require.NoError(t, err)
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, ekID, &keyData)
 
 	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))

--- a/integration_tests/encrypt/gcp_kms_test.go
+++ b/integration_tests/encrypt/gcp_kms_test.go
@@ -44,8 +44,7 @@ func TestGcpKMSKeySyncAndReencrypt(t *testing.T) {
 	keyID := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &keyID,
+		Path: namespace,
 	}))
 
 	keyData := gcpKMSKeyData(keyName)
@@ -62,6 +61,8 @@ func TestGcpKMSKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &keyID)
+	require.NoError(t, err)
 
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyID, &keyData)
 	require.Equal(t, gcpKMSProviderString, currentV1.Provider)

--- a/integration_tests/encrypt/gcp_kms_test.go
+++ b/integration_tests/encrypt/gcp_kms_test.go
@@ -127,6 +127,21 @@ func TestGcpKMSKeySyncAndReencrypt(t *testing.T) {
 	require.Equal(t, plaintext, decrypted)
 }
 
+func TestGcpKMSGlobalAESKeyStartup(t *testing.T) {
+	if os.Getenv(gcpKMSTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", gcpKMSTestEnv)
+	}
+
+	keyName := gcpKMSKeyNameFromEnv(t, "")
+
+	ctx := context.Background()
+	keyData := gcpKMSKeyData(keyName)
+	env := setupWithGlobalKeyDataIntegrationTest(t, &keyData)
+	defer env.Cleanup()
+
+	requireGlobalKeyProviderRoundTrip(t, ctx, env, sconfig.ProviderTypeGcpKMS, keyName)
+}
+
 func gcpKMSKeyData(keyName string) sconfig.KeyData {
 	return sconfig.KeyData{
 		InnerVal: &sconfig.KeyDataGcpKMS{

--- a/integration_tests/encrypt/gcp_secrets_test.go
+++ b/integration_tests/encrypt/gcp_secrets_test.go
@@ -84,8 +84,7 @@ func TestGcpSecretManagerKeySyncAndReencrypt(t *testing.T) {
 	ekID := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &ekID,
+		Path: namespace,
 	}))
 
 	keyData := sconfig.KeyData{
@@ -106,6 +105,8 @@ func TestGcpSecretManagerKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &ekID)
+	require.NoError(t, err)
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, ekID, &keyData)
 
 	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))

--- a/integration_tests/encrypt/helpers_test.go
+++ b/integration_tests/encrypt/helpers_test.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"crypto/rand"
 	"testing"
+	"time"
 
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 	"github.com/stretchr/testify/require"
@@ -51,6 +53,54 @@ func createDataEncryptionKeyForIntegrationTest(
 	require.NoError(t, db.CreateDataEncryptionKey(ctx, dek))
 
 	return dek
+}
+
+func setupWithGlobalKeyDataIntegrationTest(
+	t *testing.T,
+	globalKeyData *sconfig.KeyData,
+) *helpers.IntegrationTestEnv {
+	t.Helper()
+
+	return helpers.Setup(t, helpers.SetupOptions{
+		Service: helpers.ServiceTypeAPI,
+		ConfigureRoot: func(root *sconfig.Root) {
+			root.SystemAuth.GlobalAESKey = globalKeyData
+		},
+	})
+}
+
+func requireGlobalKeyProviderRoundTrip(
+	t *testing.T,
+	ctx context.Context,
+	env *helpers.IntegrationTestEnv,
+	provider sconfig.ProviderType,
+	providerID string,
+) {
+	t.Helper()
+
+	globalDEK, err := env.Db.GetCurrentDataEncryptionKeyForKey(ctx, database.GlobalKeyID)
+	require.NoError(t, err)
+	require.Equal(t, string(provider), globalDEK.Provider)
+	require.Equal(t, providerID, globalDEK.ProviderID)
+	require.NotEmpty(t, globalDEK.ProviderVersion)
+	require.NotNil(t, globalDEK.ProtectedData)
+	require.Equal(t, string(provider), globalDEK.ProtectedData.Type)
+	require.NotEmpty(t, globalDEK.ProtectedData.WrappedData)
+
+	encrypted, err := env.DM.GetEncryptService().EncryptStringGlobal(ctx, "global kms plaintext")
+	require.NoError(t, err)
+	require.Equal(t, globalDEK.Id, encrypted.ID)
+
+	freshEncryptService := encrypt.NewEncryptService(env.Cfg, env.Db, env.Logger)
+	freshEncryptService.Start()
+	defer freshEncryptService.Shutdown()
+
+	decryptCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	decrypted, err := freshEncryptService.DecryptString(decryptCtx, encrypted)
+	require.NoError(t, err)
+	require.Equal(t, "global kms plaintext", decrypted)
 }
 
 func runReencryptAll(ctx context.Context, env *helpers.IntegrationTestEnv) error {

--- a/integration_tests/encrypt/vault_test.go
+++ b/integration_tests/encrypt/vault_test.go
@@ -271,6 +271,51 @@ func TestVaultTransitKeySyncAndReencrypt(t *testing.T) {
 	require.Equal(t, plaintext, decrypted)
 }
 
+func TestVaultTransitGlobalAESKeyStartup(t *testing.T) {
+	if os.Getenv(vaultTestEnv) != "1" {
+		t.Skipf("%s is not set to 1", vaultTestEnv)
+	}
+
+	vaultAddr := os.Getenv(vaultAddrEnv)
+	if vaultAddr == "" {
+		t.Skipf("%s is not set", vaultAddrEnv)
+	}
+
+	vaultToken := os.Getenv(vaultTokenEnv)
+	if vaultToken == "" {
+		t.Skipf("%s is not set", vaultTokenEnv)
+	}
+
+	ctx := context.Background()
+	client := newVaultClient(t, vaultAddr, vaultToken)
+	ensureVaultTransitMount(t, ctx, client, vaultTransitMount)
+
+	transitKeyName := fmt.Sprintf("authproxy-global-transit-test-%d", time.Now().UnixNano())
+	_, err := client.Logical().WriteWithContext(ctx, fmt.Sprintf("%s/keys/%s", vaultTransitMount, transitKeyName), map[string]interface{}{
+		"type": "aes256-gcm96",
+	})
+	require.NoError(t, err)
+
+	keyData := sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataVaultTransit{
+			VaultAddress:          vaultAddr,
+			VaultToken:            vaultToken,
+			VaultTransitMountPath: vaultTransitMount,
+			VaultTransitKeyName:   transitKeyName,
+		},
+	}
+	env := setupWithGlobalKeyDataIntegrationTest(t, &keyData)
+	defer env.Cleanup()
+
+	requireGlobalKeyProviderRoundTrip(
+		t,
+		ctx,
+		env,
+		sconfig.ProviderTypeHashicorpVaultTransit,
+		fmt.Sprintf("%s/%s", vaultTransitMount, transitKeyName),
+	)
+}
+
 func newVaultClient(t *testing.T, addr, token string) *vault.Client {
 	t.Helper()
 

--- a/integration_tests/encrypt/vault_test.go
+++ b/integration_tests/encrypt/vault_test.go
@@ -84,8 +84,7 @@ func TestVaultKeySyncAndReencrypt(t *testing.T) {
 	ekID := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &ekID,
+		Path: namespace,
 	}))
 
 	keyData := sconfig.KeyData{
@@ -108,6 +107,8 @@ func TestVaultKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &ekID)
+	require.NoError(t, err)
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, ekID, &keyData)
 
 	require.NoError(t, encrypt.SyncKeysToDatabase(ctx, env.Cfg, env.Db, env.Logger, nil))
@@ -190,8 +191,7 @@ func TestVaultTransitKeySyncAndReencrypt(t *testing.T) {
 	keyID := apid.New(apid.PrefixKey)
 
 	require.NoError(t, env.Db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &keyID,
+		Path: namespace,
 	}))
 
 	keyData := sconfig.KeyData{
@@ -215,6 +215,8 @@ func TestVaultTransitKeySyncAndReencrypt(t *testing.T) {
 		EncryptedKeyData: &encKeyData,
 		State:            database.KeyStateActive,
 	}))
+	_, err = env.Db.SetNamespaceKeyId(ctx, namespace, &keyID)
+	require.NoError(t, err)
 
 	currentV1 := createDataEncryptionKeyForIntegrationTest(t, ctx, env.Db, keyID, &keyData)
 	require.Equal(t, string(sconfig.ProviderTypeHashicorpVaultTransit), currentV1.Provider)

--- a/integration_tests/encrypt/vault_test.go
+++ b/integration_tests/encrypt/vault_test.go
@@ -261,8 +261,8 @@ func TestVaultTransitKeySyncAndReencrypt(t *testing.T) {
 	require.Equal(t, encrypted.Data, updated.EncryptedKey.Data)
 
 	freshEncryptService := encrypt.NewEncryptService(env.Cfg, env.Db, env.Logger)
+	freshEncryptService.Start()
 	defer freshEncryptService.Shutdown()
-	require.NoError(t, freshEncryptService.SyncKeysFromDbToMemory(ctx))
 
 	decrypted, err := freshEncryptService.DecryptString(ctx, *updated.EncryptedKey)
 	require.NoError(t, err)

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -105,6 +105,12 @@ type SetupOptions struct {
 	// Defaults to integration_tests/config/integration.yaml.
 	ConfigPath string
 
+	// ConfigureRoot, when non-nil, can mutate the loaded config before the
+	// dependency manager is built and before encryption DEK seeding runs. It is
+	// called after test database isolation is applied, so callers should leave
+	// the database block intact unless they intentionally need a custom DB.
+	ConfigureRoot func(root *sconfig.Root)
+
 	// Service specifies which service to start. Defaults to ServiceTypeAPI.
 	Service ServiceType
 
@@ -227,6 +233,10 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 			cfgRoot.Connectors = &sconfig.Connectors{}
 		}
 		cfgRoot.Connectors.LoadFromList = append(cfgRoot.Connectors.LoadFromList, opts.Connectors...)
+	}
+
+	if opts.ConfigureRoot != nil {
+		opts.ConfigureRoot(cfg.GetRoot())
 	}
 
 	// Hook the log capture before the dependency manager builds its cached

--- a/internal/core/service_key.go
+++ b/internal/core/service_key.go
@@ -43,7 +43,7 @@ func (s *service) CreateKey(ctx context.Context, namespace string, keyData *cfgs
 		return nil, fmt.Errorf("failed to marshal key data to JSON: %w", err)
 	}
 
-	ef, err := s.encrypt.EncryptStringGlobal(ctx, string(keyDataBytes))
+	ef, err := s.encrypt.EncryptKeyForNamespace(ctx, namespace, keyDataBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt key data: %w", err)
 	}

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -17,15 +17,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
-func init() {
-	RegisterEncryptedField(EncryptedFieldRegistration{
-		Table:          KeysTable,
-		PrimaryKeyCols: []string{"id"},
-		EncryptedCols:  []string{"encrypted_key_data"},
-		NamespaceCol:   "namespace",
-	})
-}
-
 const KeysTable = "keys"
 
 // GlobalKeyID is the ID of the global key created by migration. It is the root

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -96,10 +96,13 @@ func IsValidKeyOrderByField[T string | KeyOrderByField](field T) bool {
 
 // Key represents a user-managed key configuration.
 type Key struct {
-	Id               apid.ID
-	Namespace        string
-	Usage            KeyUsage
-	MaterialType     KeyMaterialType
+	Id           apid.ID
+	Namespace    string
+	Usage        KeyUsage
+	MaterialType KeyMaterialType
+	// Key provider configuration is encrypted at rest, but it is not registered
+	// with namespace re-encryption. It defines the key hierarchy, so rewrapping
+	// it based on namespace targets can make a key depend on its own DEK.
 	EncryptedKeyData *encfield.EncryptedField
 	State            KeyState
 	Labels           Labels

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -235,6 +235,12 @@ func (s *service) getNamespaceByPath(ctx context.Context, tx sq.BaseRunner, path
 	return &result, nil
 }
 
+// validateNamespaceKeyScope enforces that a namespace can only target a key
+// scoped to the namespace itself or one of its ancestors. This keeps a
+// namespace from depending on key material owned by a child or sibling
+// namespace, which could be deleted independently while the namespace still
+// references it. The seeded root key (key_global) naturally satisfies this
+// rule for root and its descendants.
 func (s *service) validateNamespaceKeyScope(ctx context.Context, runner sq.BaseRunner, path string, keyID apid.ID) error {
 	var keyNamespace string
 	err := s.sq.

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -235,6 +235,32 @@ func (s *service) getNamespaceByPath(ctx context.Context, tx sq.BaseRunner, path
 	return &result, nil
 }
 
+func (s *service) validateNamespaceKeyScope(ctx context.Context, runner sq.BaseRunner, path string, keyID apid.ID) error {
+	var keyNamespace string
+	err := s.sq.
+		Select("namespace").
+		From(KeysTable).
+		Where(sq.Eq{
+			"id":         keyID,
+			"deleted_at": nil,
+		}).
+		RunWith(runner).
+		QueryRow().
+		Scan(&keyNamespace)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to look up encryption key: %w", ErrNotFound)
+		}
+		return fmt.Errorf("failed to look up encryption key: %w", err)
+	}
+
+	if !namespace.NamespaceIsSameOrChild(keyNamespace, path) {
+		return httperr.BadRequestf("encryption key belongs to namespace '%s' which is not the same as or an ancestor of '%s'", keyNamespace, path)
+	}
+
+	return nil
+}
+
 func (s *service) createNamespace(ctx context.Context, tx *sql.Tx, ns *Namespace) error {
 	prefixes := namespace.SplitNamespacePathToPrefixes(ns.Path)
 	state := ns.State
@@ -261,6 +287,12 @@ func (s *service) createNamespace(ctx context.Context, tx *sql.Tx, ns *Namespace
 
 	// Update the state so that we are always bound by the parent namespace state
 	ns.State = state
+
+	if ns.KeyId != nil {
+		if err := s.validateNamespaceKeyScope(ctx, tx, ns.Path, *ns.KeyId); err != nil {
+			return err
+		}
+	}
 
 	// Materialize parent-namespace carry-forward. Each ancestor namespace
 	// already stored its own ancestor chain at create time, so it suffices
@@ -393,54 +425,40 @@ func (s *service) DeleteNamespace(ctx context.Context, path string) error {
 }
 
 func (s *service) SetNamespaceKeyId(ctx context.Context, path string, ekId *apid.ID) (*Namespace, error) {
-	if ekId != nil {
-		ek, err := s.GetKey(ctx, *ekId)
-		if err != nil {
-			return nil, fmt.Errorf("failed to look up encryption key: %w", err)
-		}
-
-		prefixes := namespace.SplitNamespacePathToPrefixes(path)
-		// Strict ancestors: all prefixes except the last (self)
-		var strictAncestors []string
-		if len(prefixes) > 1 {
-			strictAncestors = prefixes[:len(prefixes)-1]
-		}
-
-		found := false
-		for _, ancestor := range strictAncestors {
-			if ek.Namespace == ancestor {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			if len(strictAncestors) == 0 {
-				return nil, httperr.BadRequestf("cannot assign encryption key to root namespace; encryption keys must belong to a strict ancestor namespace")
-			}
-			return nil, httperr.BadRequestf("encryption key belongs to namespace '%s' which is not a strict ancestor of '%s'", ek.Namespace, path)
-		}
-	}
-
 	now := apctx.GetClock(ctx).Now()
-	dbResult, err := s.sq.
-		Update(NamespacesTable).
-		Set("updated_at", now).
-		Set("key_id", ekId).
-		Where(sq.Eq{"path": path, "deleted_at": nil}).
-		RunWith(s.db).
-		Exec()
-	if err != nil {
-		return nil, fmt.Errorf("failed to set namespace encryption key: %w", err)
-	}
 
-	affected, err := dbResult.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to set namespace encryption key: %w", err)
-	}
+	err := s.transaction(func(tx *sql.Tx) error {
+		if ekId != nil {
+			if err := s.validateNamespaceKeyScope(ctx, tx, path, *ekId); err != nil {
+				return err
+			}
+		}
 
-	if affected == 0 {
-		return nil, ErrNotFound
+		dbResult, err := s.sq.
+			Update(NamespacesTable).
+			Set("updated_at", now).
+			Set("key_id", ekId).
+			Where(sq.Eq{"path": path, "deleted_at": nil}).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return fmt.Errorf("failed to set namespace encryption key: %w", err)
+		}
+
+		affected, err := dbResult.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to set namespace encryption key: %w", err)
+		}
+
+		if affected == 0 {
+			return ErrNotFound
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
 	return s.GetNamespace(ctx, path)

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -2054,6 +2054,121 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 	})
 }
 
+func TestValidateNamespaceKeyScope(t *testing.T) {
+	_, db := MustApplyBlankTestDbConfig(t, nil)
+	svc := db.(*service)
+	now := time.Date(2024, time.January, 10, 12, 0, 0, 0, time.UTC)
+	ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+
+	for _, path := range []string{"root.parent", "root.parent.child", "root.parent.child.grandchild", "root.sibling"} {
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:  path,
+			State: NamespaceStateActive,
+		}))
+	}
+
+	rootKey := &Key{
+		Id:        apid.New(apid.PrefixKey),
+		Namespace: "root",
+		State:     KeyStateActive,
+	}
+	parentKey := &Key{
+		Id:        apid.New(apid.PrefixKey),
+		Namespace: "root.parent",
+		State:     KeyStateActive,
+	}
+	childKey := &Key{
+		Id:        apid.New(apid.PrefixKey),
+		Namespace: "root.parent.child",
+		State:     KeyStateActive,
+	}
+	grandchildKey := &Key{
+		Id:        apid.New(apid.PrefixKey),
+		Namespace: "root.parent.child.grandchild",
+		State:     KeyStateActive,
+	}
+	siblingKey := &Key{
+		Id:        apid.New(apid.PrefixKey),
+		Namespace: "root.sibling",
+		State:     KeyStateActive,
+	}
+
+	for _, key := range []*Key{rootKey, parentKey, childKey, grandchildKey, siblingKey} {
+		require.NoError(t, db.CreateKey(ctx, key))
+	}
+
+	tests := []struct {
+		name           string
+		targetPath     string
+		keyID          apid.ID
+		wantBadRequest bool
+		wantNotFound   bool
+	}{
+		{
+			name:       "root key can scope descendant",
+			targetPath: "root.parent.child",
+			keyID:      rootKey.Id,
+		},
+		{
+			name:       "parent key can scope child",
+			targetPath: "root.parent.child",
+			keyID:      parentKey.Id,
+		},
+		{
+			name:       "same namespace key can scope namespace",
+			targetPath: "root.parent.child",
+			keyID:      childKey.Id,
+		},
+		{
+			name:       "global key can scope root",
+			targetPath: "root",
+			keyID:      GlobalKeyID,
+		},
+		{
+			name:       "global key can scope descendant",
+			targetPath: "root.parent.child",
+			keyID:      GlobalKeyID,
+		},
+		{
+			name:           "descendant key cannot scope ancestor",
+			targetPath:     "root.parent.child",
+			keyID:          grandchildKey.Id,
+			wantBadRequest: true,
+		},
+		{
+			name:           "sibling key cannot scope namespace",
+			targetPath:     "root.parent.child",
+			keyID:          siblingKey.Id,
+			wantBadRequest: true,
+		},
+		{
+			name:         "missing key returns not found",
+			targetPath:   "root.parent.child",
+			keyID:        apid.New(apid.PrefixKey),
+			wantNotFound: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := svc.validateNamespaceKeyScope(ctx, svc.db, test.targetPath, test.keyID)
+			if test.wantNotFound {
+				require.ErrorIs(t, err, ErrNotFound)
+				return
+			}
+			if test.wantBadRequest {
+				require.Error(t, err)
+				var httpErr *httperr.Error
+				require.True(t, errors.As(err, &httpErr))
+				require.Equal(t, http.StatusBadRequest, httpErr.Status)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestNamespaceLabelChangePropagation(t *testing.T) {
 	// These tests exercise RefreshNamespaceLabelsCarryForward directly. In
 	// production the asynq task scheduled by the core layer invokes it; we

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1576,6 +1576,12 @@ INSERT INTO namespaces
 			ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
 
 			ekId := apid.New(apid.PrefixKey)
+			require.NoError(t, db.CreateKey(ctx, &Key{
+				Id:        ekId,
+				Namespace: "root",
+				State:     KeyStateActive,
+			}))
+
 			err := db.CreateNamespace(ctx, &Namespace{
 				Path:  "root.roundtrip",
 				State: NamespaceStateActive,
@@ -1966,12 +1972,12 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, ekParent.Id, *ns.KeyId)
 	})
 
-	t.Run("rejected: key in same namespace", func(t *testing.T) {
-		_, err := db.SetNamespaceKeyId(ctx, "root.parent.child", &ekChild.Id)
-		require.Error(t, err)
-		var httpErr *httperr.Error
-		require.True(t, errors.As(err, &httpErr))
-		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+	t.Run("valid: key in same namespace", func(t *testing.T) {
+		ns, err := db.SetNamespaceKeyId(ctx, "root.parent.child", &ekChild.Id)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, ekChild.Id, *ns.KeyId)
 	})
 
 	t.Run("rejected: key in descendant namespace", func(t *testing.T) {
@@ -1990,13 +1996,49 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, httpErr.Status)
 	})
 
-	t.Run("rejected: key on root namespace", func(t *testing.T) {
-		_, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
+	t.Run("valid: key in root namespace", func(t *testing.T) {
+		ns, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, ekRoot.Id, *ns.KeyId)
+	})
+
+	t.Run("valid: global key in root and descendant namespace", func(t *testing.T) {
+		ns, err := db.SetNamespaceKeyId(ctx, "root", &GlobalKeyID)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, GlobalKeyID, *ns.KeyId)
+
+		ns, err = db.SetNamespaceKeyId(ctx, "root.parent.child", &GlobalKeyID)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, GlobalKeyID, *ns.KeyId)
+	})
+
+	t.Run("create validates key namespace", func(t *testing.T) {
+		require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+			Path:  "root.parent.created",
+			State: NamespaceStateActive,
+			KeyId: &ekParent.Id,
+		}))
+
+		created, err := db.GetNamespace(ctx, "root.parent.created")
+		require.NoError(t, err)
+		require.NotNil(t, created.KeyId)
+		require.Equal(t, ekParent.Id, *created.KeyId)
+
+		err = db.CreateNamespace(ctx, &Namespace{
+			Path:  "root.parent.rejected",
+			State: NamespaceStateActive,
+			KeyId: &ekSibling.Id,
+		})
 		require.Error(t, err)
 		var httpErr *httperr.Error
 		require.True(t, errors.As(err, &httpErr))
 		require.Equal(t, http.StatusBadRequest, httpErr.Status)
-		require.Contains(t, httpErr.ResponseMsg, "root namespace")
 	})
 
 	t.Run("clear encryption key succeeds", func(t *testing.T) {

--- a/internal/database/reencrypt_registry_test.go
+++ b/internal/database/reencrypt_registry_test.go
@@ -18,15 +18,18 @@ func TestReEncryptRegistry(t *testing.T) {
 		regs := GetEncryptedFieldRegistrations()
 		require.GreaterOrEqual(t, len(regs), 4, "expected at least 4 registrations from init()")
 
-		// Verify the four expected registrations exist
+		// Key provider configuration is intentionally not registered here:
+		// namespace re-encryption can otherwise make a key depend on its own DEK.
 		tableNames := make(map[string]bool)
 		for _, r := range regs {
 			tableNames[r.Table] = true
 		}
 		require.True(t, tableNames[ActorTable])
+		require.True(t, tableNames[ConnectionsTable])
 		require.True(t, tableNames[ConnectorVersionsTable])
+		require.True(t, tableNames[ConnectionCredentialsTable])
 		require.True(t, tableNames[OAuth2TokensTable])
-		require.True(t, tableNames[KeysTable])
+		require.False(t, tableNames[KeysTable])
 	})
 
 	t.Run("enumerate finds actor needing re-encryption", func(t *testing.T) {

--- a/internal/encrypt/README.md
+++ b/internal/encrypt/README.md
@@ -227,9 +227,6 @@ type E interface {
     // Encrypt with the global key
     EncryptGlobal(ctx, data) (EncryptedField, error)
 
-    // Encrypt with a specific key
-    EncryptForKey(ctx, keyId, data) (EncryptedField, error)
-
     // Encrypt using the key resolved for a namespace
     EncryptForNamespace(ctx, namespacePath, data) (EncryptedField, error)
 

--- a/internal/encrypt/fake_service.go
+++ b/internal/encrypt/fake_service.go
@@ -28,11 +28,6 @@ func (s *fakeService) encryptForKey(ctx context.Context, ekId apid.ID, data []by
 	}, nil
 }
 
-// EncryptStringForKey encrypts a string with the current DEK of the specified key.
-func (s *fakeService) EncryptStringForKey(ctx context.Context, ekId apid.ID, data string) (encfield.EncryptedField, error) {
-	return s.encryptForKey(ctx, ekId, []byte(data))
-}
-
 // EncryptGlobal encrypts raw bytes with the current global key.
 func (s *fakeService) EncryptGlobal(ctx context.Context, data []byte) (encfield.EncryptedField, error) {
 	return s.encryptForKey(ctx, globalEncryptionKeyID, data)
@@ -49,6 +44,10 @@ func (s *fakeService) EncryptForNamespace(ctx context.Context, _ string, data []
 
 func (s *fakeService) EncryptStringForNamespace(ctx context.Context, namespacePath string, data string) (encfield.EncryptedField, error) {
 	return s.EncryptForNamespace(ctx, namespacePath, []byte(data))
+}
+
+func (s *fakeService) EncryptKeyForNamespace(ctx context.Context, namespacePath string, keyData []byte) (encfield.EncryptedField, error) {
+	return s.EncryptForNamespace(ctx, namespacePath, keyData)
 }
 
 func (s *fakeService) EncryptForEntity(ctx context.Context, entity NamespacedEntity, data []byte) (encfield.EncryptedField, error) {

--- a/internal/encrypt/fake_service.go
+++ b/internal/encrypt/fake_service.go
@@ -21,8 +21,7 @@ func NewFakeEncryptService(doBase64Encode bool) E {
 	}
 }
 
-// EncryptForKey encrypts data with the current DEK of the specified key.
-func (s *fakeService) EncryptForKey(ctx context.Context, ekId apid.ID, data []byte) (encfield.EncryptedField, error) {
+func (s *fakeService) encryptForKey(ctx context.Context, ekId apid.ID, data []byte) (encfield.EncryptedField, error) {
 	return encfield.EncryptedField{
 		ID:   fakeDataEncryptionKeyId,
 		Data: string(data),
@@ -31,12 +30,12 @@ func (s *fakeService) EncryptForKey(ctx context.Context, ekId apid.ID, data []by
 
 // EncryptStringForKey encrypts a string with the current DEK of the specified key.
 func (s *fakeService) EncryptStringForKey(ctx context.Context, ekId apid.ID, data string) (encfield.EncryptedField, error) {
-	return s.EncryptForKey(ctx, ekId, []byte(data))
+	return s.encryptForKey(ctx, ekId, []byte(data))
 }
 
 // EncryptGlobal encrypts raw bytes with the current global key.
 func (s *fakeService) EncryptGlobal(ctx context.Context, data []byte) (encfield.EncryptedField, error) {
-	return s.EncryptForKey(ctx, globalEncryptionKeyID, data)
+	return s.encryptForKey(ctx, globalEncryptionKeyID, data)
 }
 
 // EncryptStringGlobal encrypts a string with the current global key.

--- a/internal/encrypt/interface.go
+++ b/internal/encrypt/interface.go
@@ -13,15 +13,34 @@ type NamespacedEntity interface {
 
 //go:generate mockgen -source=./interface.go -destination=./mock/encrypt.go -package=mock
 type E interface {
+	// EncryptGlobal encrypts the given data using the global encryption key.
 	EncryptGlobal(ctx context.Context, data []byte) (encfield.EncryptedField, error)
+
+	// EncryptStringGlobal encrypts the given data using the global encryption key.
 	EncryptStringGlobal(ctx context.Context, data string) (encfield.EncryptedField, error)
-	EncryptForKey(ctx context.Context, keyId apid.ID, data []byte) (encfield.EncryptedField, error)
-	EncryptStringForKey(ctx context.Context, keyId apid.ID, data string) (encfield.EncryptedField, error)
+
+	// EncryptForNamespace encrypts the given data using the namespace encryption key.
 	EncryptForNamespace(ctx context.Context, namespacePath string, data []byte) (encfield.EncryptedField, error)
+
+	// EncryptStringForNamespace encrypts the given data using the namespace encryption key.
 	EncryptStringForNamespace(ctx context.Context, namespacePath string, data string) (encfield.EncryptedField, error)
+
+	// EncryptKeyForNamespace is a special variant for key entities only. It follows special
+	// rules about which encryption key to use to avoid cycles in the graph.
+	EncryptKeyForNamespace(ctx context.Context, namespacePath string, keyData []byte) (encfield.EncryptedField, error)
+
+	// EncryptForEntity encrypts the given data using the key for namespace of the entity
 	EncryptForEntity(ctx context.Context, entity NamespacedEntity, data []byte) (encfield.EncryptedField, error)
+
+	// EncryptStringForEntity encrypts the given data using the key for namespace of the entity
 	EncryptStringForEntity(ctx context.Context, enity NamespacedEntity, data string) (encfield.EncryptedField, error)
+
+	// Decrypt decrypts the given encrypted field. It uses the metadata in the encrypted field to identify the
+	// appropriate DEK to use for decryption.
 	Decrypt(ctx context.Context, ef encfield.EncryptedField) ([]byte, error)
+
+	// DecryptString decrypts the given encrypted field to a string. It uses the metadata in the encrypted
+	// to identify the appropriate DEK to use for decryption.
 	DecryptString(ctx context.Context, ef encfield.EncryptedField) (string, error)
 
 	// ReEncryptField decrypts the given encrypted field and re-encrypts it with the specified

--- a/internal/encrypt/mock/encrypt.go
+++ b/internal/encrypt/mock/encrypt.go
@@ -164,19 +164,19 @@ func (mr *MockEMockRecorder) EncryptStringForEntity(ctx, enity, data interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptStringForEntity", reflect.TypeOf((*MockE)(nil).EncryptStringForEntity), ctx, enity, data)
 }
 
-// EncryptStringForKey mocks base method.
-func (m *MockE) EncryptStringForKey(ctx context.Context, keyId apid.ID, data string) (encfield.EncryptedField, error) {
+// EncryptKeyForNamespace mocks base method.
+func (m *MockE) EncryptKeyForNamespace(ctx context.Context, namespacePath string, keyData []byte) (encfield.EncryptedField, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EncryptStringForKey", ctx, keyId, data)
+	ret := m.ctrl.Call(m, "EncryptKeyForNamespace", ctx, namespacePath, keyData)
 	ret0, _ := ret[0].(encfield.EncryptedField)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EncryptStringForKey indicates an expected call of EncryptStringForKey.
-func (mr *MockEMockRecorder) EncryptStringForKey(ctx, keyId, data interface{}) *gomock.Call {
+// EncryptKeyForNamespace indicates an expected call of EncryptKeyForNamespace.
+func (mr *MockEMockRecorder) EncryptKeyForNamespace(ctx, namespacePath, keyData interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptStringForKey", reflect.TypeOf((*MockE)(nil).EncryptStringForKey), ctx, keyId, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptKeyForNamespace", reflect.TypeOf((*MockE)(nil).EncryptKeyForNamespace), ctx, namespacePath, keyData)
 }
 
 // EncryptStringForNamespace mocks base method.

--- a/internal/encrypt/mock/encrypt.go
+++ b/internal/encrypt/mock/encrypt.go
@@ -119,21 +119,6 @@ func (mr *MockEMockRecorder) EncryptForEntity(ctx, entity, data interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptForEntity", reflect.TypeOf((*MockE)(nil).EncryptForEntity), ctx, entity, data)
 }
 
-// EncryptForKey mocks base method.
-func (m *MockE) EncryptForKey(ctx context.Context, keyId apid.ID, data []byte) (encfield.EncryptedField, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EncryptForKey", ctx, keyId, data)
-	ret0, _ := ret[0].(encfield.EncryptedField)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EncryptForKey indicates an expected call of EncryptForKey.
-func (mr *MockEMockRecorder) EncryptForKey(ctx, keyId, data interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptForKey", reflect.TypeOf((*MockE)(nil).EncryptForKey), ctx, keyId, data)
-}
-
 // EncryptForNamespace mocks base method.
 func (m *MockE) EncryptForNamespace(ctx context.Context, namespacePath string, data []byte) (encfield.EncryptedField, error) {
 	m.ctrl.T.Helper()

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -44,6 +44,8 @@ type service struct {
 	stopCh    chan struct{} // signal goroutine to stop
 	doneCh    chan struct{} // closed when goroutine exits
 	syncReady chan struct{} // closed after first successful sync
+
+	syncReadyOnce sync.Once
 }
 
 func NewTestEncryptService(
@@ -249,6 +251,25 @@ func (s *service) ensureSynced(ctx context.Context) error {
 	}
 }
 
+func (s *service) markSyncReady() {
+	s.syncReadyOnce.Do(func() {
+		close(s.syncReady)
+	})
+}
+
+func (s *service) hasGlobalDataEncryptionKey() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dekID, hasGlobal := s.keyToCurrentDEKCache[globalEncryptionKeyID]
+	if !hasGlobal {
+		return false
+	}
+
+	_, hasGlobalBytes := s.dekToBytesCache[dekID]
+	return hasGlobalBytes
+}
+
 // Start launches the background key sync goroutine.
 func (s *service) Start() {
 	go s.syncLoop()
@@ -289,7 +310,7 @@ func (s *service) startForTest() {
 		s.logger.Warn("test encrypt service: failed to sync keys from db to memory", "error", err)
 	}
 
-	close(s.syncReady)
+	s.markSyncReady()
 	close(s.doneCh) // No goroutine to wait for
 }
 
@@ -304,21 +325,13 @@ func (s *service) syncLoop() {
 	maxBackoff := 30 * time.Second
 
 	for {
-		if err := s.syncKeysFromDbToMemory(ctx); err != nil {
+		err := s.syncKeysFromDbToMemory(ctx)
+		if err != nil {
 			s.logger.Warn("encrypt service: initial key sync failed", "error", err)
 		}
 
-		hasGlobalVersion := false
-
-		// Check if global AES key is available
-		s.mu.RLock()
-		if dekID, hasGlobal := s.keyToCurrentDEKCache[globalEncryptionKeyID]; hasGlobal {
-			_, hasGlobalVersion = s.dekToBytesCache[dekID]
-		}
-		s.mu.RUnlock()
-
-		if hasGlobalVersion {
-			close(s.syncReady)
+		if err == nil && s.hasGlobalDataEncryptionKey() {
+			s.markSyncReady()
 			break
 		}
 
@@ -612,7 +625,15 @@ func (s *service) ReEncryptField(ctx context.Context, ef encfield.EncryptedField
 
 // SyncKeysFromDbToMemory forces a refresh of the in-memory key caches from the database.
 func (s *service) SyncKeysFromDbToMemory(ctx context.Context) error {
-	return s.syncKeysFromDbToMemory(ctx)
+	if err := s.syncKeysFromDbToMemory(ctx); err != nil {
+		return err
+	}
+
+	if s.hasGlobalDataEncryptionKey() {
+		s.markSyncReady()
+	}
+
+	return nil
 }
 
 // DecryptString decrypts an EncryptedField using the key ID embedded in the field.

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -539,7 +539,7 @@ func (s *service) EncryptKeyForNamespace(ctx context.Context, namespacePath stri
 
 	// Keys are always encrypted with the parent namespace key to avoid creating a dependency cycle.
 	parentNamespace := namespace.NamespaceParentPath(namespacePath)
-	return s.EncryptKeyForNamespace(ctx, parentNamespace, keyData)
+	return s.EncryptForNamespace(ctx, parentNamespace, keyData)
 }
 
 func decryptFieldWithBytes(keyBytes []byte, ef encfield.EncryptedField) ([]byte, error) {

--- a/internal/encrypt/service.go
+++ b/internal/encrypt/service.go
@@ -469,20 +469,7 @@ func decryptWithKey(key []byte, data []byte) ([]byte, error) {
 	return decryptedData, nil
 }
 
-// decryptWithAnyKey tries to decrypt data with each key in order, returning the first success.
-func decryptWithAnyKey(keys [][]byte, data []byte) ([]byte, error) {
-	var lastErr error
-	for _, key := range keys {
-		result, err := decryptWithKey(key, data)
-		if err == nil {
-			return result, nil
-		}
-		lastErr = err
-	}
-	return nil, fmt.Errorf("decryption failed with all keys: %w", lastErr)
-}
-
-// EncryptForKey encrypts data with the current DEK of the specified key. The caller is assumed to
+// encryptForKey encrypts data with the current DEK of the specified key. The caller is assumed to
 // have validated that the cache sync has completed.
 func (s *service) encryptForKey(keyId apid.ID, data []byte) (encfield.EncryptedField, error) {
 	dekId, err := s.getCurrentDataEncryptionKeyId(keyId)
@@ -504,22 +491,12 @@ func (s *service) encryptForKey(keyId apid.ID, data []byte) (encfield.EncryptedF
 	return encfield.EncryptedField{ID: dekId, Data: encodedData}, nil
 }
 
-// EncryptForKey encrypts data with the current version of the specified key.
-func (s *service) EncryptForKey(ctx context.Context, ekId apid.ID, data []byte) (encfield.EncryptedField, error) {
+// EncryptGlobal encrypts raw bytes with the current global key.
+func (s *service) EncryptGlobal(ctx context.Context, data []byte) (encfield.EncryptedField, error) {
 	if err := s.ensureSynced(ctx); err != nil {
 		return encfield.EncryptedField{}, err
 	}
-	return s.encryptForKey(ekId, data)
-}
-
-// EncryptStringForKey encrypts a string with the current version of the specified key.
-func (s *service) EncryptStringForKey(ctx context.Context, ekId apid.ID, data string) (encfield.EncryptedField, error) {
-	return s.EncryptForKey(ctx, ekId, []byte(data))
-}
-
-// EncryptGlobal encrypts raw bytes with the current global key.
-func (s *service) EncryptGlobal(ctx context.Context, data []byte) (encfield.EncryptedField, error) {
-	return s.EncryptForKey(ctx, globalEncryptionKeyID, data)
+	return s.encryptForKey(globalEncryptionKeyID, data)
 }
 
 // EncryptStringGlobal encrypts a string with the current global key.
@@ -553,6 +530,16 @@ func (s *service) EncryptForEntity(ctx context.Context, entity NamespacedEntity,
 
 func (s *service) EncryptStringForEntity(ctx context.Context, entity NamespacedEntity, data string) (encfield.EncryptedField, error) {
 	return s.EncryptForEntity(ctx, entity, []byte(data))
+}
+
+func (s *service) EncryptKeyForNamespace(ctx context.Context, namespacePath string, keyData []byte) (encfield.EncryptedField, error) {
+	if namespacePath == namespace.RootNamespace {
+		return s.EncryptGlobal(ctx, keyData)
+	}
+
+	// Keys are always encrypted with the parent namespace key to avoid creating a dependency cycle.
+	parentNamespace := namespace.NamespaceParentPath(namespacePath)
+	return s.EncryptKeyForNamespace(ctx, parentNamespace, keyData)
 }
 
 func decryptFieldWithBytes(keyBytes []byte, ef encfield.EncryptedField) ([]byte, error) {

--- a/internal/encrypt/service_test.go
+++ b/internal/encrypt/service_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,6 +113,16 @@ func TestService(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, someString, decrypted)
 		})
+		t.Run("roundtrip namespace", func(t *testing.T) {
+			encrypted, err := s.EncryptStringForNamespace(context.Background(), connection.Namespace, someString)
+			require.NoError(t, err)
+			require.False(t, encrypted.IsZero())
+			require.True(t, encrypted.ID.HasPrefix(apid.PrefixDataEncryptionKey))
+
+			decrypted, err := s.DecryptString(context.Background(), encrypted)
+			require.NoError(t, err)
+			require.Equal(t, someString, decrypted)
+		})
 	})
 
 	t.Run("bytes", func(t *testing.T) {
@@ -144,5 +156,308 @@ func TestService(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, someBytes, decrypted)
 		})
+		t.Run("roundtrip namespace", func(t *testing.T) {
+			encryptedBytes, err := s.EncryptForNamespace(context.Background(), connection.Namespace, someBytes)
+			require.NoError(t, err)
+			require.NotEmpty(t, encryptedBytes)
+			require.NotEqual(t, someBytes, encryptedBytes)
+
+			decrypted, err := s.Decrypt(context.Background(), encryptedBytes)
+			require.NoError(t, err)
+			require.Equal(t, someBytes, decrypted)
+		})
+		t.Run("zero field decrypts to zero values", func(t *testing.T) {
+			decryptedBytes, err := s.Decrypt(context.Background(), encfield.EncryptedField{})
+			require.NoError(t, err)
+			require.Nil(t, decryptedBytes)
+
+			decryptedString, err := s.DecryptString(context.Background(), encfield.EncryptedField{})
+			require.NoError(t, err)
+			require.Empty(t, decryptedString)
+		})
 	})
+}
+
+func TestNewTestEncryptServiceDefaultsGlobalKey(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("existing config", func(t *testing.T) {
+		cfg := config.FromRoot(&sconfig.Root{})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+		cfg, s := NewTestEncryptService(cfg, db)
+		require.NotNil(t, cfg.GetRoot().SystemAuth.GlobalAESKey)
+
+		encrypted, err := s.EncryptStringGlobal(ctx, "generated default")
+		require.NoError(t, err)
+		require.False(t, encrypted.IsZero())
+
+		decrypted, err := s.DecryptString(ctx, encrypted)
+		require.NoError(t, err)
+		require.Equal(t, "generated default", decrypted)
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		cfg := config.FromRoot(&sconfig.Root{})
+		_, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+		cfg, s := NewTestEncryptService(nil, db)
+		require.NotNil(t, cfg.GetRoot().SystemAuth.GlobalAESKey)
+
+		encrypted, err := s.EncryptStringGlobal(ctx, "generated from nil config")
+		require.NoError(t, err)
+		require.False(t, encrypted.IsZero())
+
+		decrypted, err := s.DecryptString(ctx, encrypted)
+		require.NoError(t, err)
+		require.Equal(t, "generated from nil config", decrypted)
+	})
+}
+
+func TestServiceStartSyncLoop(t *testing.T) {
+	sconfig.ResetKeyDataMockRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+	ctx := context.Background()
+	globalKD := sconfig.NewKeyDataMock("service-start-global")
+	sconfig.KeyDataMockAddVersion("service-start-global", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	createDataEncryptionKeyForTest(t, ctx, db, globalEncryptionKeyID, globalKD)
+
+	s := NewEncryptService(cfg, db, slog.Default())
+	s.Start()
+	t.Cleanup(s.Shutdown)
+
+	syncCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	encrypted, err := s.EncryptStringGlobal(syncCtx, "from background sync")
+	require.NoError(t, err)
+
+	decrypted, err := s.DecryptString(syncCtx, encrypted)
+	require.NoError(t, err)
+	require.Equal(t, "from background sync", decrypted)
+}
+
+func TestServiceSyncKeysFromDbToMemoryRefreshesNamespaceKey(t *testing.T) {
+	sconfig.ResetKeyDataMockRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+	ctx := context.Background()
+	globalKD := sconfig.NewKeyDataMock("service-sync-global")
+	sconfig.KeyDataMockAddVersion("service-sync-global", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	cfg, s := NewTestEncryptService(cfg, db)
+
+	globalDEK, err := db.GetCurrentDataEncryptionKeyForKey(ctx, globalEncryptionKeyID)
+	require.NoError(t, err)
+	globalDEKBytes, err := globalKD.UnwrapDataEncryptionKey(ctx, dataEncryptionKeyInfos([]*database.DataEncryptionKey{globalDEK})[0])
+	require.NoError(t, err)
+
+	namespacePath := "root.service-sync"
+	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{Path: namespacePath}))
+
+	keyData := sconfig.NewKeyDataMock("service-sync-namespace")
+	sconfig.KeyDataMockAddVersion("service-sync-namespace", "namespace-key", "v1", util.MustGenerateSecureRandomKey(32))
+	keyID := apid.New(apid.PrefixKey)
+	require.NoError(t, db.CreateKey(ctx, &database.Key{
+		Id:               keyID,
+		Namespace:        namespacePath,
+		EncryptedKeyData: encryptKeyDataForTest(t, globalDEK.Id, globalDEKBytes, keyData),
+	}))
+	_, err = db.SetNamespaceKeyId(ctx, namespacePath, &keyID)
+	require.NoError(t, err)
+	namespaceDEK, _ := createDataEncryptionKeyForTest(t, ctx, db, keyID, keyData)
+
+	beforeRefresh, err := s.EncryptStringForNamespace(ctx, namespacePath, "namespace data")
+	require.NoError(t, err)
+	require.Equal(t, globalDEK.Id, beforeRefresh.ID)
+
+	require.NoError(t, s.SyncKeysFromDbToMemory(ctx))
+
+	afterRefresh, err := s.EncryptStringForNamespace(ctx, namespacePath, "namespace data")
+	require.NoError(t, err)
+	require.Equal(t, namespaceDEK.Id, afterRefresh.ID)
+
+	decrypted, err := s.DecryptString(ctx, afterRefresh)
+	require.NoError(t, err)
+	require.Equal(t, "namespace data", decrypted)
+}
+
+func TestServiceEncryptKeyForNamespace(t *testing.T) {
+	env := setupServiceKeyNamespaceTest(t)
+
+	rootKeyMaterial, err := env.enc.EncryptKeyForNamespace(env.ctx, "root", []byte("root key data"))
+	require.NoError(t, err)
+	require.Equal(t, env.globalDEKID, rootKeyMaterial.ID)
+
+	childData, err := env.enc.EncryptStringForNamespace(env.ctx, env.childNamespace, "child namespace data")
+	require.NoError(t, err)
+	require.Equal(t, env.childDEKID, childData.ID)
+
+	childKeyMaterial, err := env.enc.EncryptKeyForNamespace(env.ctx, env.childNamespace, []byte("child key data"))
+	require.NoError(t, err)
+	require.Equal(t, env.parentDEKID, childKeyMaterial.ID)
+
+	decrypted, err := env.enc.Decrypt(env.ctx, childKeyMaterial)
+	require.NoError(t, err)
+	require.Equal(t, []byte("child key data"), decrypted)
+}
+
+func TestServiceReEncryptField(t *testing.T) {
+	sconfig.ResetKeyDataMockRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+	ctx := context.Background()
+	globalKD := sconfig.NewKeyDataMock("service-reencrypt-global")
+	sconfig.KeyDataMockAddVersion("service-reencrypt-global", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	cfg, s := NewTestEncryptService(cfg, db)
+
+	encryptedV1, err := s.EncryptStringGlobal(ctx, "rotated data")
+	require.NoError(t, err)
+
+	same, err := s.ReEncryptField(ctx, encryptedV1, encryptedV1.ID)
+	require.NoError(t, err)
+	require.Equal(t, encryptedV1, same)
+
+	sconfig.KeyDataMockAddVersion("service-reencrypt-global", "global-key", "v2", util.MustGenerateSecureRandomKey(32))
+	dekV2, _ := createDataEncryptionKeyForTest(t, ctx, db, globalEncryptionKeyID, cfg.GetRoot().SystemAuth.GlobalAESKey)
+	require.NoError(t, s.SyncKeysFromDbToMemory(ctx))
+
+	encryptedV2, err := s.ReEncryptField(ctx, encryptedV1, dekV2.Id)
+	require.NoError(t, err)
+	require.Equal(t, dekV2.Id, encryptedV2.ID)
+	require.NotEqual(t, encryptedV1.Data, encryptedV2.Data)
+
+	decrypted, err := s.DecryptString(ctx, encryptedV2)
+	require.NoError(t, err)
+	require.Equal(t, "rotated data", decrypted)
+}
+
+func TestServiceCachedKeyBytesAreCopied(t *testing.T) {
+	sconfig.ResetKeyDataMockRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+	ctx := context.Background()
+	globalKD := sconfig.NewKeyDataMock("service-cache-global")
+	sconfig.KeyDataMockAddVersion("service-cache-global", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	_, enc := NewTestEncryptService(cfg, db)
+	svc := enc.(*service)
+
+	globalDEK, err := db.GetCurrentDataEncryptionKeyForKey(ctx, globalEncryptionKeyID)
+	require.NoError(t, err)
+
+	keyBytes, err := svc.getDataEncryptionKeyBytes(globalDEK.Id)
+	require.NoError(t, err)
+	require.NotEmpty(t, keyBytes)
+	original := append([]byte(nil), keyBytes...)
+
+	keyBytes[0] ^= 0xff
+	keyBytesAgain, err := svc.getDataEncryptionKeyBytes(globalDEK.Id)
+	require.NoError(t, err)
+	require.Equal(t, original, keyBytesAgain)
+
+	allKeyBytes := svc.getAllKeyBytes()
+	require.NotEmpty(t, allKeyBytes)
+	allKeyBytes[0][0] ^= 0xff
+
+	keyBytesAfterAll, err := svc.getDataEncryptionKeyBytes(globalDEK.Id)
+	require.NoError(t, err)
+	require.Equal(t, original, keyBytesAfterAll)
+}
+
+type serviceKeyNamespaceTestEnv struct {
+	ctx             context.Context
+	enc             E
+	globalDEKID     apid.ID
+	parentNamespace string
+	parentDEKID     apid.ID
+	childNamespace  string
+	childDEKID      apid.ID
+}
+
+func setupServiceKeyNamespaceTest(t *testing.T) serviceKeyNamespaceTestEnv {
+	t.Helper()
+
+	sconfig.ResetKeyDataMockRegistry()
+	t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+	ctx := context.Background()
+	globalKD := sconfig.NewKeyDataMock("service-key-global")
+	sconfig.KeyDataMockAddVersion("service-key-global", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+
+	cfg := config.FromRoot(&sconfig.Root{
+		SystemAuth: sconfig.SystemAuth{
+			GlobalAESKey: globalKD,
+		},
+	})
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	globalDEK, globalDEKBytes := createDataEncryptionKeyForTest(t, ctx, db, globalEncryptionKeyID, globalKD)
+
+	parentNamespace := "root.service-key-parent"
+	childNamespace := parentNamespace + ".child"
+	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{Path: parentNamespace}))
+	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{Path: childNamespace}))
+
+	parentKeyData := sconfig.NewKeyDataMock("service-key-parent")
+	sconfig.KeyDataMockAddVersion("service-key-parent", "parent-key", "v1", util.MustGenerateSecureRandomKey(32))
+	parentKeyID := apid.New(apid.PrefixKey)
+	require.NoError(t, db.CreateKey(ctx, &database.Key{
+		Id:               parentKeyID,
+		Namespace:        parentNamespace,
+		EncryptedKeyData: encryptKeyDataForTest(t, globalDEK.Id, globalDEKBytes, parentKeyData),
+	}))
+	_, err := db.SetNamespaceKeyId(ctx, parentNamespace, &parentKeyID)
+	require.NoError(t, err)
+	parentDEK, parentDEKBytes := createDataEncryptionKeyForTest(t, ctx, db, parentKeyID, parentKeyData)
+
+	childKeyData := sconfig.NewKeyDataMock("service-key-child")
+	sconfig.KeyDataMockAddVersion("service-key-child", "child-key", "v1", util.MustGenerateSecureRandomKey(32))
+	childKeyID := apid.New(apid.PrefixKey)
+	require.NoError(t, db.CreateKey(ctx, &database.Key{
+		Id:               childKeyID,
+		Namespace:        childNamespace,
+		EncryptedKeyData: encryptKeyDataForTest(t, parentDEK.Id, parentDEKBytes, childKeyData),
+	}))
+	_, err = db.SetNamespaceKeyId(ctx, childNamespace, &childKeyID)
+	require.NoError(t, err)
+	childDEK, _ := createDataEncryptionKeyForTest(t, ctx, db, childKeyID, childKeyData)
+
+	_, enc := NewTestEncryptService(cfg, db)
+
+	return serviceKeyNamespaceTestEnv{
+		ctx:             ctx,
+		enc:             enc,
+		globalDEKID:     globalDEK.Id,
+		parentNamespace: parentNamespace,
+		parentDEKID:     parentDEK.Id,
+		childNamespace:  childNamespace,
+		childDEKID:      childDEK.Id,
+	}
 }

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -59,8 +59,7 @@ func setupGenerateTest(t *testing.T, keyDataFactory func() *sconfig.KeyData) moc
 	ekID := apid.New(apid.PrefixKey)
 	namespace := "root.kms"
 	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &ekID,
+		Path: namespace,
 	}))
 
 	require.NoError(t, db.CreateKey(ctx, &database.Key{
@@ -69,6 +68,8 @@ func setupGenerateTest(t *testing.T, keyDataFactory func() *sconfig.KeyData) moc
 		State:            database.KeyStateActive,
 		EncryptedKeyData: encryptKeyDataForTest(t, globalDEK.Id, globalDEKBytes, keyData),
 	}))
+	_, err := db.SetNamespaceKeyId(ctx, namespace, &ekID)
+	require.NoError(t, err)
 
 	return mockKMSGenerateTestEnv{
 		ctx:       ctx,

--- a/internal/encrypt/task_reencrypt.go
+++ b/internal/encrypt/task_reencrypt.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apctx"
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -72,6 +75,10 @@ func (h *EncryptServiceTaskHandler) handleReencryptAll(ctx context.Context, task
 		return fmt.Errorf("re-encryption enumeration failed: %w", err)
 	}
 
+	if err := h.reencryptKeys(ctx, &totalProcessed, &totalSkipped, &totalErrors); err != nil {
+		return fmt.Errorf("key re-encryption failed: %w", err)
+	}
+
 	h.logger.Info("re-encryption complete",
 		"total_processed", totalProcessed,
 		"total_skipped", totalSkipped,
@@ -83,4 +90,91 @@ func (h *EncryptServiceTaskHandler) handleReencryptAll(ctx context.Context, task
 	}
 
 	return nil
+}
+
+func (h *EncryptServiceTaskHandler) reencryptKeys(ctx context.Context, totalProcessed, totalSkipped, totalErrors *int) error {
+	now := apctx.GetClock(ctx).Now()
+
+	return h.db.ListKeysBuilder().
+		OrderBy(database.KeyOrderByCreatedAt, pagination.OrderByAsc).
+		Enumerate(ctx, func(page pagination.PageResult[database.Key]) (pagination.KeepGoing, error) {
+			if page.Error != nil {
+				return pagination.Stop, page.Error
+			}
+
+			for _, key := range page.Results {
+				if key.EncryptedKeyData == nil || key.EncryptedKeyData.IsZero() {
+					(*totalSkipped)++
+					continue
+				}
+
+				targetDEKID, ok, err := h.keyTargetDataEncryptionKeyID(ctx, key)
+				if err != nil {
+					h.logger.Warn("failed to resolve key re-encryption target, skipping",
+						"key_id", key.Id,
+						"namespace", key.Namespace,
+						"error", err,
+					)
+					(*totalErrors)++
+					continue
+				}
+				if !ok {
+					h.logger.Warn("key parent namespace has no target data encryption key, skipping",
+						"key_id", key.Id,
+						"namespace", key.Namespace,
+					)
+					(*totalSkipped)++
+					continue
+				}
+
+				if key.EncryptedKeyData.ID == targetDEKID {
+					(*totalSkipped)++
+					continue
+				}
+
+				newEF, err := h.enc.ReEncryptField(ctx, *key.EncryptedKeyData, targetDEKID)
+				if err != nil {
+					h.logger.Warn("failed to re-encrypt key data, skipping",
+						"key_id", key.Id,
+						"namespace", key.Namespace,
+						"target_dek", targetDEKID,
+						"error", err,
+					)
+					(*totalErrors)++
+					continue
+				}
+
+				_, err = h.db.UpdateKey(ctx, key.Id, map[string]interface{}{
+					"encrypted_key_data": newEF,
+					"encrypted_at":       now,
+				})
+				if err != nil {
+					h.logger.Warn("failed to update re-encrypted key data, skipping",
+						"key_id", key.Id,
+						"namespace", key.Namespace,
+						"target_dek", targetDEKID,
+						"error", err,
+					)
+					(*totalErrors)++
+					continue
+				}
+
+				(*totalProcessed)++
+			}
+
+			return pagination.Continue, nil
+		})
+}
+
+func (h *EncryptServiceTaskHandler) keyTargetDataEncryptionKeyID(ctx context.Context, key database.Key) (apid.ID, bool, error) {
+	parentNamespace := namespace.NamespaceParentPath(key.Namespace)
+	ns, err := h.db.GetNamespace(ctx, parentNamespace)
+	if err != nil {
+		return "", false, err
+	}
+	if ns.TargetDataEncryptionKeyId == nil {
+		return "", false, nil
+	}
+
+	return *ns.TargetDataEncryptionKeyId, true, nil
 }

--- a/internal/encrypt/task_reencrypt_test.go
+++ b/internal/encrypt/task_reencrypt_test.go
@@ -172,7 +172,7 @@ func TestHandleReencryptAll(t *testing.T) {
 
 		// Create actor encrypted with current (only) version
 		actorId := apid.New(apid.PrefixActor)
-		ef, err := env.enc.EncryptStringForKey(env.ctx, globalEncryptionKeyID, "my-key")
+		ef, err := env.enc.EncryptStringGlobal(env.ctx, "my-key")
 		require.NoError(t, err)
 		require.Equal(t, env.globalDEKID, ef.ID)
 
@@ -223,6 +223,74 @@ func TestHandleReencryptAll(t *testing.T) {
 		refreshPlain, err := env.enc.DecryptString(env.ctx, updatedToken.EncryptedRefreshToken)
 		require.NoError(t, err)
 		require.Equal(t, "refresh-token", refreshPlain)
+	})
+
+	t.Run("re-encrypts root namespace key with global target", func(t *testing.T) {
+		env := setupReencryptTest(t)
+		v2DEKID, _ := env.addGlobalV2(t)
+
+		keyData := []byte(`{"mock_id":"root-key"}`)
+		ef := env.encryptWithV1(t, keyData)
+		keyID := apid.New(apid.PrefixKey)
+		require.NoError(t, env.db.CreateKey(env.ctx, &database.Key{
+			Id:               keyID,
+			Namespace:        "root",
+			EncryptedKeyData: &ef,
+			State:            database.KeyStateActive,
+		}))
+
+		env.setNamespaceTarget(t, "root", v2DEKID)
+
+		err := env.runReencrypt(t)
+		require.NoError(t, err)
+
+		key, err := env.db.GetKey(env.ctx, keyID)
+		require.NoError(t, err)
+		require.NotNil(t, key.EncryptedKeyData)
+		require.Equal(t, v2DEKID, key.EncryptedKeyData.ID)
+
+		decrypted, err := env.enc.Decrypt(env.ctx, *key.EncryptedKeyData)
+		require.NoError(t, err)
+		require.Equal(t, keyData, decrypted)
+	})
+
+	t.Run("re-encrypts child namespace key with parent namespace target", func(t *testing.T) {
+		env := setupReencryptTest(t)
+		rootTargetDEKID, rootTargetBytes := env.addGlobalV2(t)
+
+		require.NoError(t, env.db.CreateNamespace(env.ctx, &database.Namespace{Path: "root.parent"}))
+		require.NoError(t, env.db.CreateNamespace(env.ctx, &database.Namespace{Path: "root.parent.child"}))
+
+		keyData := []byte(`{"mock_id":"child-key"}`)
+		encrypted, err := encryptWithKey(rootTargetBytes, keyData)
+		require.NoError(t, err)
+		ef := encfield.EncryptedField{
+			ID:   rootTargetDEKID,
+			Data: base64.StdEncoding.EncodeToString(encrypted),
+		}
+		keyID := apid.New(apid.PrefixKey)
+		require.NoError(t, env.db.CreateKey(env.ctx, &database.Key{
+			Id:               keyID,
+			Namespace:        "root.parent.child",
+			EncryptedKeyData: &ef,
+			State:            database.KeyStateActive,
+		}))
+
+		env.setNamespaceTarget(t, "root", rootTargetDEKID)
+		env.setNamespaceTarget(t, "root.parent", env.globalDEKID)
+		env.setNamespaceTarget(t, "root.parent.child", rootTargetDEKID)
+
+		err = env.runReencrypt(t)
+		require.NoError(t, err)
+
+		key, err := env.db.GetKey(env.ctx, keyID)
+		require.NoError(t, err)
+		require.NotNil(t, key.EncryptedKeyData)
+		require.Equal(t, env.globalDEKID, key.EncryptedKeyData.ID)
+
+		decrypted, err := env.enc.Decrypt(env.ctx, *key.EncryptedKeyData)
+		require.NoError(t, err)
+		require.Equal(t, keyData, decrypted)
 	})
 
 	t.Run("empty no rows need re-encryption", func(t *testing.T) {

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -110,8 +110,7 @@ func setupMockKMSKeySyncTest(t *testing.T) mockKMSSyncTestEnv {
 	ekID := apid.New(apid.PrefixKey)
 	namespace := "root.kms"
 	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &ekID,
+		Path: namespace,
 	}))
 
 	require.NoError(t, db.CreateKey(ctx, &database.Key{
@@ -120,6 +119,8 @@ func setupMockKMSKeySyncTest(t *testing.T) mockKMSSyncTestEnv {
 		State:            database.KeyStateActive,
 		EncryptedKeyData: encryptKeyDataForTest(t, globalDEK.Id, globalDEKBytes, kmsKeyData),
 	}))
+	_, err := db.SetNamespaceKeyId(ctx, namespace, &ekID)
+	require.NoError(t, err)
 
 	dekV1ID := createMockKMSDataEncryptionKey(t, ctx, db, ekID, "v1", true)
 	require.NoError(t, syncKeysToDatabase(ctx, cfg, db, logger, nil))
@@ -197,8 +198,7 @@ func TestMockKMSKeySync(t *testing.T) {
 		ekID := apid.New(apid.PrefixKey)
 		namespace := "root.kms.nodek"
 		require.NoError(t, env.db.CreateNamespace(env.ctx, &database.Namespace{
-			Path:  namespace,
-			KeyId: &ekID,
+			Path: namespace,
 		}))
 
 		keyData := sconfig.NewKeyDataMockKMS("namespace-kms")
@@ -212,6 +212,8 @@ func TestMockKMSKeySync(t *testing.T) {
 			State:            database.KeyStateActive,
 			EncryptedKeyData: &encKeyData,
 		}))
+		_, err = env.db.SetNamespaceKeyId(env.ctx, namespace, &ekID)
+		require.NoError(t, err)
 
 		require.NoError(t, syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
 		deks, err := env.db.ListDataEncryptionKeysForKey(env.ctx, ekID)
@@ -306,8 +308,7 @@ func setupRewrapSyncTest(t *testing.T) rewrapSyncTestEnv {
 	keyID := apid.New(apid.PrefixKey)
 	namespace := "root.secret"
 	require.NoError(t, db.CreateNamespace(ctx, &database.Namespace{
-		Path:  namespace,
-		KeyId: &keyID,
+		Path: namespace,
 	}))
 
 	require.NoError(t, db.CreateKey(ctx, &database.Key{
@@ -316,6 +317,8 @@ func setupRewrapSyncTest(t *testing.T) rewrapSyncTestEnv {
 		State:            database.KeyStateActive,
 		EncryptedKeyData: encryptKeyDataForTest(t, globalDEK.Id, globalDEKBytes, keyData),
 	}))
+	_, err := db.SetNamespaceKeyId(ctx, namespace, &keyID)
+	require.NoError(t, err)
 
 	dek, dekBytes := createDataEncryptionKeyForTest(t, ctx, db, keyID, keyData)
 	require.NoError(t, syncKeysToDatabase(ctx, cfg, db, logger, nil))

--- a/internal/schema/resources/namespace/namespace.go
+++ b/internal/schema/resources/namespace/namespace.go
@@ -148,6 +148,17 @@ func NamespacePathFromRoot(parts ...string) string {
 	return strings.Join(allPaths, NamespacePathSeparator)
 }
 
+// NamespaceParentPath returns the parent namespace path for a valid namespace path.
+// The parent of root is root.
+func NamespaceParentPath(path string) string {
+	i := strings.LastIndex(path, NamespacePathSeparator)
+	if i < 0 {
+		return RootNamespace
+	}
+
+	return path[:i]
+}
+
 // NamespaceIsChild returns true if the child path is a child of the parent path.
 func NamespaceIsChild(parentPath, childPath string) bool {
 	return strings.HasPrefix(childPath, parentPath+NamespacePathSeparator)

--- a/internal/schema/resources/namespace/namespace_test.go
+++ b/internal/schema/resources/namespace/namespace_test.go
@@ -411,6 +411,40 @@ func TestNamespaces(t *testing.T) {
 			require.Equal(t, NamespacePathFromRoot("some-namespace"), RootNamespace+".some-namespace")
 			require.Equal(t, NamespacePathFromRoot("some-namespace", "other-namespace"), RootNamespace+".some-namespace.other-namespace")
 		})
+		t.Run("NamespaceParentPath", func(t *testing.T) {
+			tests := []struct {
+				name   string
+				path   string
+				parent string
+			}{
+				{
+					name:   "root",
+					path:   RootNamespace,
+					parent: RootNamespace,
+				},
+				{
+					name:   "single child",
+					path:   "root.child",
+					parent: RootNamespace,
+				},
+				{
+					name:   "grandchild",
+					path:   "root.child.grandchild",
+					parent: "root.child",
+				},
+				{
+					name:   "allows namespace characters",
+					path:   "root.child_1.grand-child2",
+					parent: "root.child_1",
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					require.Equal(t, tt.parent, NamespaceParentPath(tt.path))
+				})
+			}
+		})
 		t.Run("NamespaceIsChild", func(t *testing.T) {
 			tests := []struct {
 				name   string


### PR DESCRIPTION
## Summary
- keep key provider metadata out of namespace-driven re-encryption so keys do not become self-wrapped by their own DEKs
- make encrypt service readiness close race-safe and require a clean initial sync before startup readiness
- update the Vault Transit integration to verify cold-service reload via the normal service lifecycle

## Testing
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=authproxy_integration POSTGRES_TEST_OPTIONS=sslmode=disable AUTH_PROXY_VAULT_TEST=1 VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=dev-only-token go test -tags "integration,vault" -v -timeout 90s ./encrypt/... -run TestVaultTransitKeySyncAndReencrypt -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=authproxy_integration POSTGRES_TEST_OPTIONS=sslmode=disable AUTH_PROXY_VAULT_TEST=1 VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=dev-only-token go test -tags "integration,vault" -v -timeout 10m ./encrypt/...
- go test ./internal/database -run TestReEncryptRegistry -count=1
- go test ./internal/encrypt -count=1
- ./scripts/preflight.sh