### PR TITLE
Document connector predicates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 - **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
 - **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
 - **[Connector setup flow](connector-setup-flow.md)** — author preconnect/configure steps, conditional `if.javascript` steps, redirect steps, and configure-time data sources.
+- **[Connector predicates](connector-predicates.md)** — condition setup steps, OAuth scopes, dynamic required OAuth scopes, and probes with JavaScript predicates over `cfg`, `labels`, and `annotations`.
 - **[Application metrics](app_metrics.md)** — configure the app metrics store, query request-event and resource metrics, and understand supported aggregations and dimensions.
 
 ## Operational guides

--- a/docs/connector-predicates.md
+++ b/docs/connector-predicates.md
@@ -1,0 +1,123 @@
+# Connector Predicates
+
+Connector predicates let a connector definition enable or require parts of a connection dynamically. They are authored in YAML and evaluated server-side for the specific connection.
+
+Predicates currently support JavaScript only:
+
+```yaml
+if:
+  javascript: |
+    cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"
+```
+
+The JavaScript must evaluate to a boolean. Syntax errors, thrown errors, `null`, `undefined`, and non-boolean results fail the operation instead of guessing the connector author's intent.
+
+## Runtime Context
+
+Every connector predicate receives the same variables:
+
+| Variable | Shape | Description |
+|---|---|---|
+| `cfg` | object | The connection configuration collected by submitted setup steps so far. It is `{}` when no configuration has been saved yet. |
+| `labels` | object | The connection labels available to the runtime, including carried-forward system labels such as `apxy/cxr/type`. |
+| `annotations` | object | The connection annotations available to the runtime. It is `{}` when none are present. |
+
+There is no `attributes` alias. Use `cfg`, `labels`, and `annotations` directly.
+
+## Setup Steps
+
+Connector-authored setup-flow form and redirect steps support `if.javascript`. Clients only see eligible steps. See [Connector setup flow](connector-setup-flow.md#conditional-steps) for setup-step examples and behavior.
+
+Auth-method steps and AuthProxy pseudo-steps cannot be gated directly. For example, OAuth redirect steps always run when the OAuth auth method needs them. Verification is controlled indirectly by probe predicates: `apxy:verify` is inserted only when at least one probe is enabled for the connection.
+
+## OAuth Scopes
+
+OAuth2 scopes support two predicate-related fields:
+
+- `if.javascript`: include or omit the scope from the effective requested scope set.
+- `required.javascript`: decide whether the scope is required when AuthProxy compares requested scopes to provider-granted scopes.
+
+```yaml
+auth:
+  type: OAuth2
+  client_id:
+    env_var: GOOGLE_CLIENT_ID
+  client_secret:
+    env_var: GOOGLE_CLIENT_SECRET
+  authorization:
+    endpoint: https://accounts.google.com/o/oauth2/v2/auth
+  token:
+    endpoint: https://oauth2.googleapis.com/token
+  scopes:
+    - id: https://www.googleapis.com/auth/drive.readonly
+      reason: We need to be able to view files.
+
+    - id: https://www.googleapis.com/auth/drive.file
+      if:
+        javascript: cfg.push_files === true
+      reason: We need to be able to write files when file push is enabled.
+
+    - id: https://www.googleapis.com/auth/drive.activity.readonly
+      required:
+        javascript: cfg.sync_activity === true
+      reason: We need activity access when activity sync is enabled.
+```
+
+Scope behavior:
+
+- A scope with no `if` is included.
+- A scope whose `if.javascript` evaluates to `false` is not requested and is not part of scope-mismatch detection.
+- If `if.javascript` evaluates to `false`, `required` is not evaluated for that scope.
+- A scope with omitted `required` defaults to required.
+- `required: false` means the scope is still requested, but AuthProxy does not fail setup if the provider omits it.
+- `required.javascript` has the same semantics: when it evaluates to `false`, the scope is still requested but optional.
+
+AuthProxy uses the same effective scope set when building the OAuth authorization URL, requesting client-credentials tokens, persisting `requested_scopes`, and checking provider-granted scopes. If a provider omits a required effective scope, AuthProxy records an OAuth scope mismatch and fails setup or token handling according to the existing OAuth error path. If a provider omits an optional effective scope, setup can continue.
+
+### OAuth Timing
+
+OAuth scope predicates are evaluated before OAuth authorization for authorization-code connectors. Any `cfg` values they read must already exist before OAuth begins, usually from `setup_flow.preconnect` steps. Values collected in `setup_flow.configure` happen after OAuth and are too late to affect the initial authorization URL.
+
+For client-credentials connectors, scope predicates are evaluated before the token request. Any `cfg` values they read must be collected before that request is made.
+
+Labels and annotations can also drive scope predicates because they are available before OAuth. Use them when the scope decision is known from connector metadata, namespace policy, or operator-provided connection annotations.
+
+## Probes
+
+Probes support `if.javascript` to decide whether the probe is enabled for a connection:
+
+```yaml
+probes:
+  - id: drive-health
+    period: 1m
+    proxy_http:
+      method: GET
+      url: https://www.googleapis.com/drive/v3/about
+
+  - id: calendar-list
+    period: 30s
+    if:
+      javascript: cfg.has_calendar === true
+    proxy_http:
+      method: GET
+      url: https://www.googleapis.com/calendar/v3/users/me/calendarList
+```
+
+Probe behavior:
+
+- A probe with no `if` is enabled.
+- A probe whose `if.javascript` evaluates to `false` is disabled for that connection.
+- Disabled probes are not run during setup verification.
+- Disabled periodic probes are not scheduled.
+- `probe-now` enqueueing only queues enabled probes.
+- Manual or stale queued tasks for a now-disabled probe skip without retry.
+- Disabled probes do not block health recovery for enabled probes.
+- Existing outcome rows for a now-disabled probe are still cleaned up by the outcome cleanup task using default retention thresholds.
+
+`apxy:verify` is inserted during setup only when at least one probe is enabled for the connection. If all probes are disabled, setup advances to the next eligible configure step or completes immediately when no configure step is left.
+
+## Versioning Notes
+
+Adding, removing, or changing predicates changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path.
+
+Existing in-flight connections are evaluated against the connector version they are using. If a predicate changes in a new version, only connections migrated to that version use the new predicate behavior.

--- a/docs/connector-setup-flow.md
+++ b/docs/connector-setup-flow.md
@@ -19,7 +19,7 @@ setup_flow:
 Auth-method steps and AuthProxy pseudo-steps are inserted by the runtime. Connector YAML cannot conditionally hide or override them. In particular:
 
 - Auth-method steps, such as OAuth redirect or API-key credential collection, are always eligible.
-- `apxy:verify` is always eligible when verification is needed.
+- `apxy:verify` is inserted when verification is needed, which means at least one probe is enabled for the connection.
 - Connector-authored step ids must not start with `apxy:`.
 
 ## Form Steps
@@ -71,6 +71,8 @@ Redirect steps cannot define `json_schema`, `ui_schema`, or `data_sources`.
 ## Conditional Steps
 
 Connector-authored form and redirect steps can include an `if.javascript` condition. AuthProxy evaluates the condition server-side each time it resolves the current or next setup step. Clients only receive steps whose condition is true.
+
+Setup-step predicates share the same shape and runtime context as OAuth scope and probe predicates. See [Connector predicates](connector-predicates.md) for the shared predicate contract and non-setup examples.
 
 ```yaml
 setup_flow:

--- a/internal/schema/resources/connectors/README.md
+++ b/internal/schema/resources/connectors/README.md
@@ -4,4 +4,4 @@ This package defines connector resource configuration: auth methods, setup flow,
 
 Use this package for connector shapes that are shared between config, core logic, and future API DTOs. API-specific request/response wrappers belong in `internal/schema/api`.
 
-Connector-author setup-flow guidance lives in [`docs/connector-setup-flow.md`](../../../../docs/connector-setup-flow.md).
+Connector-author setup-flow guidance lives in [`docs/connector-setup-flow.md`](../../../../docs/connector-setup-flow.md). Shared predicate behavior for setup steps, OAuth scopes, and probes lives in [`docs/connector-predicates.md`](../../../../docs/connector-predicates.md).


### PR DESCRIPTION
## Summary
- add a connector predicate guide covering shared javascript context
- document OAuth scope if.javascript and required.javascript behavior
- document probe if.javascript disabled semantics and setup verify behavior
- link the new guide from setup-flow and schema docs

Closes #649

## Tests
- ./scripts/preflight.sh