### PR TITLE
Map client cancellations to 499

### DIFF
--- a/internal/apgin/error.go
+++ b/internal/apgin/error.go
@@ -10,9 +10,9 @@ import (
 // WriteError writes an *httperr.Error to the gin context with logging,
 // debug headers, and error attachment.
 func WriteError(gctx *gin.Context, logger *slog.Logger, err *httperr.Error) {
-	err.LogError(logger)
-
 	ctx := gctx.Request.Context()
+	err = err.ForContext(ctx)
+	err.LogError(logger)
 
 	if err.InternalErr != nil {
 		AddDebugHeaderError(gctx, err.InternalErr)

--- a/internal/apgin/error_test.go
+++ b/internal/apgin/error_test.go
@@ -70,6 +70,20 @@ func TestWriteErr_PlainError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+func TestWriteErr_ClientClosedRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gctx, _ := gin.CreateTestContext(rec)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	gctx.Request = httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+
+	WriteErr(gctx, nil, errors.Join(errors.New("redis write failed"), context.Canceled))
+
+	require.Equal(t, httperr.StatusClientClosedRequest, rec.Code)
+	require.Equal(t, `{"error":"Client Closed Request"}`, strings.TrimSpace(rec.Body.String()))
+}
+
 func TestWriteErr_HttpError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/internal/httperr/error.go
+++ b/internal/httperr/error.go
@@ -3,6 +3,7 @@ package httperr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -17,6 +18,8 @@ type Error struct {
 	ResponseMsg string
 	InternalErr error
 }
+
+const StatusClientClosedRequest = 499
 
 func (e *Error) Error() string {
 	if e.InternalErr != nil {
@@ -42,6 +45,31 @@ func (e *Error) ResponseMsgOrDefault() string {
 		return e.ResponseMsg
 	}
 	return StatusText(e.Status)
+}
+
+// ForContext returns an HTTP error adjusted for request-context state.
+// A canceled client request commonly surfaces as context.Canceled from
+// downstream dependencies; classify those as 499 rather than a server 5xx.
+func (e *Error) ForContext(ctx context.Context) *Error {
+	if e == nil {
+		return nil
+	}
+
+	if e.Status >= http.StatusInternalServerError && IsClientClosedRequest(ctx, e) {
+		clone := *e
+		clone.Status = StatusClientClosedRequest
+		clone.ResponseMsg = ""
+		return &clone
+	}
+
+	return e
+}
+
+func IsClientClosedRequest(ctx context.Context, err error) bool {
+	if ctx == nil || err == nil {
+		return false
+	}
+	return errors.Is(ctx.Err(), context.Canceled) && errors.Is(err, context.Canceled)
 }
 
 // ErrorResponse is the standardized JSON error response format.
@@ -70,7 +98,11 @@ func (e *Error) LogError(logger *slog.Logger) {
 	}
 
 	responseMsg := e.ResponseMsgOrDefault()
-	if e.Status >= http.StatusInternalServerError {
+	if e.Status == StatusClientClosedRequest {
+		// The client already left; this is useful as a status code but not an
+		// application error worth surfacing in the error log.
+		return
+	} else if e.Status >= http.StatusInternalServerError {
 		logger.Error("api error", "status", e.Status, "response_msg", responseMsg, "error", e.InternalErr)
 	} else if e.Status == http.StatusUnauthorized {
 		// No logging for unauthorized
@@ -81,6 +113,7 @@ func (e *Error) LogError(logger *slog.Logger) {
 
 // WriteResponse writes the error as a JSON response to an http.ResponseWriter.
 func (e *Error) WriteResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter) {
+	e = e.ForContext(ctx)
 	e.LogError(logger)
 
 	if e.InternalErr != nil {
@@ -113,6 +146,8 @@ func StatusText(status int) string {
 		return "Conflict"
 	case 422:
 		return "Unprocessable Entity"
+	case StatusClientClosedRequest:
+		return "Client Closed Request"
 	case 500:
 		return "Internal Server Error"
 	case 501:

--- a/internal/httperr/error_test.go
+++ b/internal/httperr/error_test.go
@@ -56,6 +56,53 @@ func TestError_ResponseMsgOrDefault(t *testing.T) {
 	}
 }
 
+func TestError_ForContext_ClientClosedRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := InternalServerError(WithInternalErrorf("failed to write session to redis: %w", context.Canceled))
+
+	mapped := err.ForContext(ctx)
+
+	require.Equal(t, StatusClientClosedRequest, mapped.Status)
+	require.Equal(t, "Client Closed Request", mapped.ResponseMsgOrDefault())
+	require.Equal(t, http.StatusInternalServerError, err.Status, "must not mutate original error")
+	require.Empty(t, err.ResponseMsg, "must not mutate original response message")
+}
+
+func TestError_ForContext_DoesNotMapUnrelatedCancellation(t *testing.T) {
+	t.Run("request context still active", func(t *testing.T) {
+		err := InternalServerError(WithInternalErrorf("failed to write session to redis: %w", context.Canceled))
+
+		mapped := err.ForContext(context.Background())
+
+		require.Equal(t, http.StatusInternalServerError, mapped.Status)
+	})
+
+	t.Run("error is not context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := InternalServerError(WithInternalErr(errors.New("redis unavailable")))
+
+		mapped := err.ForContext(ctx)
+
+		require.Equal(t, http.StatusInternalServerError, mapped.Status)
+	})
+
+	t.Run("explicit client error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := BadRequest("invalid request", WithInternalErr(context.Canceled))
+
+		mapped := err.ForContext(ctx)
+
+		require.Equal(t, http.StatusBadRequest, mapped.Status)
+		require.Equal(t, "invalid request", mapped.ResponseMsgOrDefault())
+	})
+}
+
 func TestError_WriteResponse(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -95,4 +142,17 @@ func TestError_WriteResponse(t *testing.T) {
 			require.True(t, matched, "expected body to match regex %q, but got %q", tt.expectedBodyRegex, trimmedBody)
 		})
 	}
+}
+
+func TestError_WriteResponse_ClientClosedRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rec := httptest.NewRecorder()
+
+	err := InternalServerError(WithInternalErrorf("failed to write session to redis: %w", context.Canceled))
+
+	err.WriteResponse(ctx, nil, rec)
+
+	require.Equal(t, StatusClientClosedRequest, rec.Code)
+	require.Equal(t, `{"error":"Client Closed Request"}`, strings.TrimSpace(rec.Body.String()))
 }


### PR DESCRIPTION
## Summary
- classify request-context cancellations that wrap `context.Canceled` as HTTP 499 Client Closed Request
- apply the mapping in both direct `httperr` responses and Gin `apgin` error writes
- avoid API error logging for 499 client-abort responses

## Tests
- `go test ./internal/httperr ./internal/apgin`
- `go test ./internal/apauth/service`
- `./scripts/preflight.sh`