### PR TITLE
Ensure root namespace uses global key

### DIFF
--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -89,6 +89,27 @@ func (ns *Namespace) normalize() {
 	}
 
 	ns.depth = namespace.DepthOfNamespacePath(ns.Path)
+
+	if ns.Path == namespace.RootNamespace {
+		ns.KeyId = rootNamespaceKeyID()
+	}
+}
+
+func rootNamespaceKeyID() *apid.ID {
+	id := GlobalKeyID
+	return &id
+}
+
+func normalizeNamespaceKeyID(path string, keyID *apid.ID) (*apid.ID, error) {
+	if path != namespace.RootNamespace {
+		return keyID, nil
+	}
+
+	if keyID != nil && *keyID != GlobalKeyID {
+		return nil, httperr.BadRequestf("root namespace must use the global key '%s'", GlobalKeyID)
+	}
+
+	return rootNamespaceKeyID(), nil
 }
 
 func (ns *Namespace) Validate() error {
@@ -268,6 +289,7 @@ func (s *service) validateNamespaceKeyScope(ctx context.Context, runner sq.BaseR
 }
 
 func (s *service) createNamespace(ctx context.Context, tx *sql.Tx, ns *Namespace) error {
+	ns.normalize()
 	prefixes := namespace.SplitNamespacePathToPrefixes(ns.Path)
 	state := ns.State
 
@@ -433,9 +455,14 @@ func (s *service) DeleteNamespace(ctx context.Context, path string) error {
 func (s *service) SetNamespaceKeyId(ctx context.Context, path string, ekId *apid.ID) (*Namespace, error) {
 	now := apctx.GetClock(ctx).Now()
 
-	err := s.transaction(func(tx *sql.Tx) error {
-		if ekId != nil {
-			if err := s.validateNamespaceKeyScope(ctx, tx, path, *ekId); err != nil {
+	normalizedKeyID, err := normalizeNamespaceKeyID(path, ekId)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.transaction(func(tx *sql.Tx) error {
+		if normalizedKeyID != nil {
+			if err := s.validateNamespaceKeyScope(ctx, tx, path, *normalizedKeyID); err != nil {
 				return err
 			}
 		}
@@ -443,7 +470,7 @@ func (s *service) SetNamespaceKeyId(ctx context.Context, path string, ekId *apid
 		dbResult, err := s.sq.
 			Update(NamespacesTable).
 			Set("updated_at", now).
-			Set("key_id", ekId).
+			Set("key_id", normalizedKeyID).
 			Where(sq.Eq{"path": path, "deleted_at": nil}).
 			RunWith(tx).
 			Exec()

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -90,7 +90,7 @@ func (ns *Namespace) normalize() {
 
 	ns.depth = namespace.DepthOfNamespacePath(ns.Path)
 
-	if ns.Path == namespace.RootNamespace {
+	if ns.Path == namespace.RootNamespace && ns.KeyId == nil {
 		ns.KeyId = rootNamespaceKeyID()
 	}
 }
@@ -98,18 +98,6 @@ func (ns *Namespace) normalize() {
 func rootNamespaceKeyID() *apid.ID {
 	id := GlobalKeyID
 	return &id
-}
-
-func normalizeNamespaceKeyID(path string, keyID *apid.ID) (*apid.ID, error) {
-	if path != namespace.RootNamespace {
-		return keyID, nil
-	}
-
-	if keyID != nil && *keyID != GlobalKeyID {
-		return nil, httperr.BadRequestf("root namespace must use the global key '%s'", GlobalKeyID)
-	}
-
-	return rootNamespaceKeyID(), nil
 }
 
 func (ns *Namespace) Validate() error {
@@ -455,14 +443,9 @@ func (s *service) DeleteNamespace(ctx context.Context, path string) error {
 func (s *service) SetNamespaceKeyId(ctx context.Context, path string, ekId *apid.ID) (*Namespace, error) {
 	now := apctx.GetClock(ctx).Now()
 
-	normalizedKeyID, err := normalizeNamespaceKeyID(path, ekId)
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.transaction(func(tx *sql.Tx) error {
-		if normalizedKeyID != nil {
-			if err := s.validateNamespaceKeyScope(ctx, tx, path, *normalizedKeyID); err != nil {
+	err := s.transaction(func(tx *sql.Tx) error {
+		if ekId != nil {
+			if err := s.validateNamespaceKeyScope(ctx, tx, path, *ekId); err != nil {
 				return err
 			}
 		}
@@ -470,7 +453,7 @@ func (s *service) SetNamespaceKeyId(ctx context.Context, path string, ekId *apid
 		dbResult, err := s.sq.
 			Update(NamespacesTable).
 			Set("updated_at", now).
-			Set("key_id", normalizedKeyID).
+			Set("key_id", ekId).
 			Where(sq.Eq{"path": path, "deleted_at": nil}).
 			RunWith(tx).
 			Exec()

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1996,12 +1996,12 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, httpErr.Status)
 	})
 
-	t.Run("rejected: root namespace only uses global key", func(t *testing.T) {
-		_, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
-		require.Error(t, err)
-		var httpErr *httperr.Error
-		require.True(t, errors.As(err, &httpErr))
-		require.Equal(t, http.StatusBadRequest, httpErr.Status)
+	t.Run("valid: key in root namespace", func(t *testing.T) {
+		ns, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, ekRoot.Id, *ns.KeyId)
 	})
 
 	t.Run("valid: global key in root and descendant namespace", func(t *testing.T) {
@@ -2018,12 +2018,11 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, GlobalKeyID, *ns.KeyId)
 	})
 
-	t.Run("clearing root namespace resets it to global key", func(t *testing.T) {
+	t.Run("clearing root namespace succeeds", func(t *testing.T) {
 		ns, err := db.SetNamespaceKeyId(ctx, "root", nil)
 		require.NoError(t, err)
 		require.NotNil(t, ns)
-		require.NotNil(t, ns.KeyId)
-		require.Equal(t, GlobalKeyID, *ns.KeyId)
+		require.Nil(t, ns.KeyId)
 	})
 
 	t.Run("create validates key namespace", func(t *testing.T) {

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1996,12 +1996,12 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, httpErr.Status)
 	})
 
-	t.Run("valid: key in root namespace", func(t *testing.T) {
-		ns, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
-		require.NoError(t, err)
-		require.NotNil(t, ns)
-		require.NotNil(t, ns.KeyId)
-		require.Equal(t, ekRoot.Id, *ns.KeyId)
+	t.Run("rejected: root namespace only uses global key", func(t *testing.T) {
+		_, err := db.SetNamespaceKeyId(ctx, "root", &ekRoot.Id)
+		require.Error(t, err)
+		var httpErr *httperr.Error
+		require.True(t, errors.As(err, &httpErr))
+		require.Equal(t, http.StatusBadRequest, httpErr.Status)
 	})
 
 	t.Run("valid: global key in root and descendant namespace", func(t *testing.T) {
@@ -2012,6 +2012,14 @@ func TestSetNamespaceEncryptionKeyIdAncestorValidation(t *testing.T) {
 		require.Equal(t, GlobalKeyID, *ns.KeyId)
 
 		ns, err = db.SetNamespaceKeyId(ctx, "root.parent.child", &GlobalKeyID)
+		require.NoError(t, err)
+		require.NotNil(t, ns)
+		require.NotNil(t, ns.KeyId)
+		require.Equal(t, GlobalKeyID, *ns.KeyId)
+	})
+
+	t.Run("clearing root namespace resets it to global key", func(t *testing.T) {
+		ns, err := db.SetNamespaceKeyId(ctx, "root", nil)
 		require.NoError(t, err)
 		require.NotNil(t, ns)
 		require.NotNil(t, ns.KeyId)

--- a/internal/database/schema_test.go
+++ b/internal/database/schema_test.go
@@ -32,6 +32,13 @@ func TestKeyModelSchema(t *testing.T) {
 		requireQueryable(t, rawDb, "SELECT key_id, target_data_encryption_key_id, target_data_encryption_key_updated_at FROM namespaces LIMIT 0")
 	})
 
+	t.Run("root namespace uses global key", func(t *testing.T) {
+		var keyID string
+		err := rawDb.QueryRow("SELECT key_id FROM namespaces WHERE path = 'root'").Scan(&keyID)
+		require.NoError(t, err)
+		require.Equal(t, string(GlobalKeyID), keyID)
+	})
+
 	t.Run("data encryption keys reference keys", func(t *testing.T) {
 		requireQueryable(t, rawDb, "SELECT key_id, provider_metadata, protected_data FROM data_encryption_keys LIMIT 0")
 	})

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -148,7 +148,7 @@ func generateDataEncryptionKeysToDatabase(
 	}
 
 	var result *multierror.Error
-	if err := ensureRootNamespaceUsesGlobalKey(ctx, db); err != nil {
+	if err := ensureRootNamespaceHasKeySet(ctx, db); err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to ensure root namespace uses global key"))
 	}
 

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -147,11 +147,15 @@ func generateDataEncryptionKeysToDatabase(
 		return errors.New("no global AES key configured")
 	}
 
+	var result *multierror.Error
+	if err := ensureRootNamespaceUsesGlobalKey(ctx, db); err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to ensure root namespace uses global key"))
+	}
+
 	policy := sa.DataEncryptionKeys
 	// key material id -> plaintext DEK for decrypting child key data.
 	keyMaterialDataCache := make(map[apid.ID]config.KeyVersionInfo)
 
-	var result *multierror.Error
 	generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, globalEncryptionKeyID, sa.GlobalAESKey)
 	if err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to reconcile data encryption key for global key"))

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -105,6 +105,35 @@ func setupMockSecretGenerateTest(t *testing.T, keyBytes []byte) mockKMSGenerateT
 }
 
 func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
+	t.Run("repairs root namespace key", func(t *testing.T) {
+		sconfig.ResetKeyDataMockRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMock("global-root-repair")
+		sconfig.KeyDataMockAddVersion("global-root-repair", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db, rawDb := database.MustApplyBlankTestDbConfigRaw(t, cfg)
+
+		_, err := rawDb.Exec("UPDATE namespaces SET key_id = NULL WHERE path = 'root'")
+		require.NoError(t, err)
+
+		root, err := db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.Nil(t, root.KeyId)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(ctx, cfg, db, slog.Default(), nil))
+
+		root, err = db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.NotNil(t, root.KeyId)
+		require.Equal(t, database.GlobalKeyID, *root.KeyId)
+	})
+
 	t.Run("creates first dek without changing wrapping sync state", func(t *testing.T) {
 		env := setupMockKMSGenerateTest(t, true)
 

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -134,6 +134,36 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Equal(t, database.GlobalKeyID, *root.KeyId)
 	})
 
+	t.Run("preserves existing root namespace key", func(t *testing.T) {
+		sconfig.ResetKeyDataMockRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMock("global-root-preserve")
+		sconfig.KeyDataMockAddVersion("global-root-preserve", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+		rootKeyID := apid.New(apid.PrefixKey)
+		require.NoError(t, db.CreateKey(ctx, &database.Key{
+			Id:        rootKeyID,
+			Namespace: sconfig.RootNamespace,
+		}))
+		_, err := db.SetNamespaceKeyId(ctx, sconfig.RootNamespace, &rootKeyID)
+		require.NoError(t, err)
+
+		require.NoError(t, generateDataEncryptionKeysToDatabase(ctx, cfg, db, slog.Default(), nil))
+
+		root, err := db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.NotNil(t, root.KeyId)
+		require.Equal(t, rootKeyID, *root.KeyId)
+	})
+
 	t.Run("creates first dek without changing wrapping sync state", func(t *testing.T) {
 		env := setupMockKMSGenerateTest(t, true)
 

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -32,6 +32,14 @@ func NewSyncKeysToDatabaseTask() *asynq.Task {
 	return asynq.NewTask(TaskTypeSyncKeysToDatabase, nil)
 }
 
+func ensureRootNamespaceUsesGlobalKey(ctx context.Context, db database.DB) error {
+	_, err := db.SetNamespaceKeyId(ctx, namespace.RootNamespace, &globalEncryptionKeyID)
+	if errors.Is(err, database.ErrNotFound) {
+		return nil
+	}
+	return err
+}
+
 // dataEncryptionKeyInfos converts a set of the database version of the DEK to the schema version.
 func dataEncryptionKeyInfos(deks []*database.DataEncryptionKey) []config.DataEncryptionKeyInfo {
 	infos := make([]config.DataEncryptionKeyInfo, 0, len(deks))
@@ -260,6 +268,10 @@ func syncKeysToDatabase(
 ) error {
 	logger.Info("syncing data encryption key wrapping to database")
 	defer logger.Info("syncing data encryption key wrapping to database complete")
+
+	if err := ensureRootNamespaceUsesGlobalKey(ctx, db); err != nil {
+		return errors.Wrap(err, "failed to ensure root namespace uses global key")
+	}
 
 	if redis != nil {
 		// Redis can be skipped in test cases

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -33,10 +33,18 @@ func NewSyncKeysToDatabaseTask() *asynq.Task {
 }
 
 func ensureRootNamespaceUsesGlobalKey(ctx context.Context, db database.DB) error {
-	_, err := db.SetNamespaceKeyId(ctx, namespace.RootNamespace, &globalEncryptionKeyID)
+	rootNamespace, err := db.GetNamespace(ctx, namespace.RootNamespace)
 	if errors.Is(err, database.ErrNotFound) {
 		return nil
 	}
+	if err != nil {
+		return err
+	}
+	if rootNamespace.KeyId != nil {
+		return nil
+	}
+
+	_, err = db.SetNamespaceKeyId(ctx, namespace.RootNamespace, &globalEncryptionKeyID)
 	return err
 }
 

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -32,7 +32,9 @@ func NewSyncKeysToDatabaseTask() *asynq.Task {
 	return asynq.NewTask(TaskTypeSyncKeysToDatabase, nil)
 }
 
-func ensureRootNamespaceUsesGlobalKey(ctx context.Context, db database.DB) error {
+// ensureRootNamespaceHasKeySet makes sure the root namespace has a key set. If it does not, it sets
+// it to the global key. If it has a key, it leaves it unchanged.
+func ensureRootNamespaceHasKeySet(ctx context.Context, db database.DB) error {
 	rootNamespace, err := db.GetNamespace(ctx, namespace.RootNamespace)
 	if errors.Is(err, database.ErrNotFound) {
 		return nil
@@ -277,7 +279,7 @@ func syncKeysToDatabase(
 	logger.Info("syncing data encryption key wrapping to database")
 	defer logger.Info("syncing data encryption key wrapping to database complete")
 
-	if err := ensureRootNamespaceUsesGlobalKey(ctx, db); err != nil {
+	if err := ensureRootNamespaceHasKeySet(ctx, db); err != nil {
 		return errors.Wrap(err, "failed to ensure root namespace uses global key")
 	}
 

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -367,6 +367,36 @@ func requireNamespaceTarget(
 }
 
 func TestSyncKeysToDatabase(t *testing.T) {
+	t.Run("repairs root namespace key before wrapping sync", func(t *testing.T) {
+		sconfig.ResetKeyDataMockRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMock("global-root-sync-repair")
+		sconfig.KeyDataMockAddVersion("global-root-sync-repair", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db, rawDb := database.MustApplyBlankTestDbConfigRaw(t, cfg)
+		createDataEncryptionKeyForTest(t, ctx, db, globalEncryptionKeyID, globalKD)
+
+		_, err := rawDb.Exec("UPDATE namespaces SET key_id = NULL WHERE path = 'root'")
+		require.NoError(t, err)
+
+		root, err := db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.Nil(t, root.KeyId)
+
+		require.NoError(t, syncKeysToDatabase(ctx, cfg, db, slog.Default(), nil))
+
+		root, err = db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.NotNil(t, root.KeyId)
+		require.Equal(t, database.GlobalKeyID, *root.KeyId)
+	})
+
 	t.Run("does not create or duplicate deks", func(t *testing.T) {
 		env := setupRewrapSyncTest(t)
 

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -397,6 +397,37 @@ func TestSyncKeysToDatabase(t *testing.T) {
 		require.Equal(t, database.GlobalKeyID, *root.KeyId)
 	})
 
+	t.Run("preserves existing root namespace key before wrapping sync", func(t *testing.T) {
+		sconfig.ResetKeyDataMockRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMock("global-root-sync-preserve")
+		sconfig.KeyDataMockAddVersion("global-root-sync-preserve", "global-key", "v1", util.MustGenerateSecureRandomKey(32))
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+		createDataEncryptionKeyForTest(t, ctx, db, globalEncryptionKeyID, globalKD)
+
+		rootKeyID := apid.New(apid.PrefixKey)
+		require.NoError(t, db.CreateKey(ctx, &database.Key{
+			Id:        rootKeyID,
+			Namespace: sconfig.RootNamespace,
+		}))
+		_, err := db.SetNamespaceKeyId(ctx, sconfig.RootNamespace, &rootKeyID)
+		require.NoError(t, err)
+
+		require.NoError(t, syncKeysToDatabase(ctx, cfg, db, slog.Default(), nil))
+
+		root, err := db.GetNamespace(ctx, sconfig.RootNamespace)
+		require.NoError(t, err)
+		require.NotNil(t, root.KeyId)
+		require.Equal(t, rootKeyID, *root.KeyId)
+	})
+
 	t.Run("does not create or duplicate deks", func(t *testing.T) {
 		env := setupRewrapSyncTest(t)
 


### PR DESCRIPTION
## Summary
- default the root namespace key_id to key_global when the root namespace is initially created
- repair existing root namespace rows only when key_id is missing, preserving valid root-scoped key overrides
- add regression coverage for root namespace defaults, repair, and preservation paths

## Tests
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/database ./internal/encrypt -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test ./internal/database ./internal/encrypt -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...
- ./scripts/preflight.sh