### PR TITLE
Fix Admin UI namespace creation action

### DIFF
--- a/ui/admin/src/components/NamespaceSelector.test.tsx
+++ b/ui/admin/src/components/NamespaceSelector.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {cleanup, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Provider} from 'react-redux';
+import {configureStore} from '@reduxjs/toolkit';
+import namespaceReducer from '../store/namespacesSlice';
+import NamespaceSelector, {
+    childNamespacePath,
+    validateNamespaceLeafName,
+} from './NamespaceSelector';
+import {NamespaceState, namespaces, ROOT_NAMESPACE_PATH} from '@authproxy/api';
+
+vi.mock('@authproxy/api', () => {
+    const apiNamespaces = {
+        create: vi.fn(),
+        getByPath: vi.fn(),
+        list: vi.fn(),
+    };
+
+    return {
+        NAMESPACE_PATH_SEPARATOR: '.',
+        ROOT_NAMESPACE_PATH: 'root',
+        NamespaceState: {
+            ACTIVE: 'active',
+            DISCONNECTING: 'disconnecting',
+            DISCONNECTED: 'disconnected',
+        },
+        namespaces: apiNamespaces,
+    };
+});
+
+const rootNamespace = {
+    path: ROOT_NAMESPACE_PATH,
+    state: NamespaceState.ACTIVE,
+    created_at: '2026-06-20T00:00:00.000Z',
+    updated_at: '2026-06-20T00:00:00.000Z',
+};
+
+function renderSelector() {
+    const store = configureStore({
+        reducer: {
+            namespaces: namespaceReducer,
+        },
+        preloadedState: {
+            namespaces: {
+                currentPath: ROOT_NAMESPACE_PATH,
+                hasInitialized: true,
+                current: rootNamespace,
+                status: 'succeeded' as const,
+                error: null,
+                children: [],
+                childrenStatus: 'succeeded' as const,
+                childrenError: null,
+            },
+        },
+    });
+
+    render(
+        <Provider store={store}>
+            <NamespaceSelector />
+        </Provider>,
+    );
+
+    return store;
+}
+
+describe('NamespaceSelector', () => {
+    beforeEach(() => {
+        vi.mocked(namespaces.getByPath).mockResolvedValue({status: 200, data: rootNamespace} as any);
+        vi.mocked(namespaces.list).mockResolvedValue({status: 200, data: {items: []}} as any);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('creates a child namespace from the add namespace action', async () => {
+        const user = userEvent.setup();
+        const store = renderSelector();
+        const createdNamespace = {
+            ...rootNamespace,
+            path: 'root.team-a',
+        };
+        vi.mocked(namespaces.create).mockResolvedValue({status: 200, data: createdNamespace} as any);
+        vi.mocked(namespaces.getByPath).mockResolvedValue({status: 200, data: createdNamespace} as any);
+
+        await user.click(screen.getByRole('combobox', {name: 'Select namespace'}));
+        await user.click(await screen.findByText('Add namespace'));
+        expect(screen.getByRole('dialog', {name: 'Add namespace'})).toBeTruthy();
+
+        await user.type(screen.getByLabelText('Name'), 'team-a');
+        await user.click(screen.getByRole('button', {name: 'Create'}));
+
+        await waitFor(() => {
+            expect(namespaces.create).toHaveBeenCalledWith({path: 'root.team-a'});
+        });
+        expect(store.getState().namespaces.currentPath).toBe('root.team-a');
+    });
+
+    it('builds and validates child namespace names', () => {
+        expect(childNamespacePath('root.platform', 'team-a')).toBe('root.platform.team-a');
+        expect(validateNamespaceLeafName('team-a')).toBeNull();
+        expect(validateNamespaceLeafName('')).toBe('Name is required');
+        expect(validateNamespaceLeafName('team.alpha')).toBe('Enter only the child namespace name');
+        expect(validateNamespaceLeafName('-team')).toBe('Use letters, numbers, underscores, and hyphens');
+    });
+});

--- a/ui/admin/src/components/NamespaceSelector.tsx
+++ b/ui/admin/src/components/NamespaceSelector.tsx
@@ -8,6 +8,13 @@ import ListSubheader from '@mui/material/ListSubheader';
 import Select, {SelectChangeEvent, selectClasses} from '@mui/material/Select';
 import Divider from '@mui/material/Divider';
 import {styled} from '@mui/material/styles';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -24,7 +31,16 @@ import {
 import CircularProgress from "@mui/material/CircularProgress";
 import {AppDispatch} from "../store";
 import {useEffect} from "react";
-import {NAMESPACE_PATH_SEPARATOR, ROOT_NAMESPACE_PATH} from "@authproxy/api";
+import {NAMESPACE_PATH_SEPARATOR, namespaces, ROOT_NAMESPACE_PATH} from "@authproxy/api";
+
+const ACTION_ADD = "...action.add";
+const ACTION_CHILDREN = "...action.children";
+const ACTION_LOADING_NAMESPACE = "...action.loading-ns";
+const ACTION_NAVIGATE_PARENT = "...action.navigate-parent";
+const ACTION_NAVIGATE_ROOT = "...action.navigate-root";
+const ACTION_REFRESH = "...action.refresh";
+const ACTION_PREFIX = "...action.";
+const NAMESPACE_LEAF_REGEX = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
 
 const Avatar = styled(MuiAvatar)(({theme}) => ({
     width: 28,
@@ -73,6 +89,27 @@ function leafNamespace(path: string | null | undefined): string {
     }
 }
 
+export function childNamespacePath(parentPath: string | null | undefined, leafName: string): string {
+    const parent = parentPath || ROOT_NAMESPACE_PATH;
+    return `${parent}${NAMESPACE_PATH_SEPARATOR}${leafName}`;
+}
+
+export function validateNamespaceLeafName(leafName: string): string | null {
+    if (!leafName) {
+        return "Name is required";
+    }
+
+    if (leafName.includes(NAMESPACE_PATH_SEPARATOR)) {
+        return "Enter only the child namespace name";
+    }
+
+    if (!NAMESPACE_LEAF_REGEX.test(leafName)) {
+        return "Use letters, numbers, underscores, and hyphens";
+    }
+
+    return null;
+}
+
 export default function NamespaceSelector() {
     const dispatch = useDispatch<AppDispatch>();
     const loadingStatus = useSelector(selectNamespaceStatus);
@@ -80,29 +117,14 @@ export default function NamespaceSelector() {
     const ns = useSelector(selectCurrentNamespace);
     const children = useSelector(selectCurrentNamespaceChildren);
     const [val, setVal] = React.useState("");
+    const [createOpen, setCreateOpen] = React.useState(false);
+    const [createName, setCreateName] = React.useState("");
+    const [createError, setCreateError] = React.useState<string | null>(null);
+    const [createLoading, setCreateLoading] = React.useState(false);
 
     useEffect(() => {
         setVal(ns?.path || "");
     }, [ns]);
-
-    const handleChange = (event: SelectChangeEvent) => {
-        let path = event.target.value as string;
-
-        if (path === "...action.navigate-root") {
-            path = ROOT_NAMESPACE_PATH;
-        }
-
-        if (path === "...action.navigate-parent") {
-            path = parentNamespace(ns?.path);
-        }
-
-        if (path.startsWith("...action.")) {
-            return;
-        }
-
-        dispatch(setCurrentNamespace(path));
-        setVal(path);
-    };
 
     const refreshList = () => {
         if(ns?.path) {
@@ -110,8 +132,79 @@ export default function NamespaceSelector() {
         }
     }
 
+    const openCreateDialog = () => {
+        setCreateName("");
+        setCreateError(null);
+        setCreateOpen(true);
+    };
+
+    const closeCreateDialog = () => {
+        if (!createLoading) {
+            setCreateOpen(false);
+            setCreateError(null);
+        }
+    };
+
+    const handleChange = (event: SelectChangeEvent) => {
+        let path = event.target.value as string;
+
+        if (path === ACTION_ADD) {
+            openCreateDialog();
+            return;
+        }
+
+        if (path === ACTION_REFRESH) {
+            refreshList();
+            return;
+        }
+
+        if (path === ACTION_NAVIGATE_ROOT) {
+            path = ROOT_NAMESPACE_PATH;
+        }
+
+        if (path === ACTION_NAVIGATE_PARENT) {
+            path = parentNamespace(ns?.path);
+        }
+
+        if (path.startsWith(ACTION_PREFIX)) {
+            return;
+        }
+
+        dispatch(setCurrentNamespace(path));
+        setVal(path);
+    };
+
+    const createNamespacePath = childNamespacePath(ns?.path, createName.trim());
+
+    const submitCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const leafName = createName.trim();
+        const validationError = validateNamespaceLeafName(leafName);
+        if (validationError) {
+            setCreateError(validationError);
+            return;
+        }
+
+        const path = childNamespacePath(ns?.path, leafName);
+        setCreateError(null);
+        setCreateLoading(true);
+        try {
+            const res = await namespaces.create({path});
+            setCreateOpen(false);
+            setCreateName("");
+            dispatch(setCurrentNamespace(res.data.path));
+            setVal(res.data.path);
+        } catch (err: any) {
+            const msg = err?.response?.data?.error || err.message || 'Failed to create namespace';
+            setCreateError(msg);
+        } finally {
+            setCreateLoading(false);
+        }
+    };
+
     let currentNamespaceItem = (
-        <MenuItem value="...action.loading-ns">
+        <MenuItem value={val || ACTION_LOADING_NAMESPACE}>
             <ListItemIcon>
                 <RefreshIcon />
             </ListItemIcon>
@@ -147,7 +240,7 @@ export default function NamespaceSelector() {
     }
 
     let childNamespaceItems = [(
-        <MenuItem key="...action.children" value="...action.children">
+        <MenuItem key={ACTION_CHILDREN} value={ACTION_CHILDREN}>
             <ListItemIcon>
                 <RefreshIcon />
             </ListItemIcon>
@@ -188,75 +281,112 @@ export default function NamespaceSelector() {
     }
 
     return (
-        <Select
-            labelId="namespace-select"
-            id="namespace-simple-select"
-            value={val}
-            onChange={handleChange}
-            displayEmpty
-            inputProps={{'aria-label': 'Select namespace'}}
-            fullWidth
-            sx={{
-                maxHeight: 56,
-                width: 215,
-                '&.MuiList-root': {
-                    p: '8px',
-                },
-                [`& .${selectClasses.select}`]: {
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '2px',
-                    pl: 1,
-                },
-            }}
-        >
-            <ListSubheader sx={{pt: 0}}>Current Namespace</ListSubheader>
-            {currentNamespaceItem}
+        <>
+            <Select
+                labelId="namespace-select"
+                id="namespace-simple-select"
+                value={val}
+                onChange={handleChange}
+                displayEmpty
+                inputProps={{'aria-label': 'Select namespace'}}
+                fullWidth
+                sx={{
+                    maxHeight: 56,
+                    width: 215,
+                    '&.MuiList-root': {
+                        p: '8px',
+                    },
+                    [`& .${selectClasses.select}`]: {
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '2px',
+                        pl: 1,
+                    },
+                }}
+            >
+                <ListSubheader sx={{pt: 0}}>Current Namespace</ListSubheader>
+                {currentNamespaceItem}
 
-            {childNamespaceItems.length == 0 ?
-                null :
-                ([
-                    <ListSubheader key="children-header">Children</ListSubheader>,
-                    ...childNamespaceItems
-                ])
-            }
+                {childNamespaceItems.length == 0 ?
+                    null :
+                    ([
+                        <ListSubheader key="children-header">Children</ListSubheader>,
+                        ...childNamespaceItems
+                    ])
+                }
 
-            {depth(ns?.path) > 0 ?
-                ([
-                    <ListSubheader key="navigate-header" sx={{pt: 0}}>Navigate</ListSubheader>,
-                    <MenuItem key="...action.navigate-parent" value="...action.navigate-parent">
-                        <ListItemIcon>
-                            <ArrowBackIcon />
-                        </ListItemIcon>
-                        <ListItemText primary="Go to parent" secondary={`Return to ${parentNamespace(ns?.path)}`} />
-                    </MenuItem>
-                ]) : []
-            }
+                {depth(ns?.path) > 0 ?
+                    ([
+                        <ListSubheader key="navigate-header" sx={{pt: 0}}>Navigate</ListSubheader>,
+                        <MenuItem key={ACTION_NAVIGATE_PARENT} value={ACTION_NAVIGATE_PARENT}>
+                            <ListItemIcon>
+                                <ArrowBackIcon />
+                            </ListItemIcon>
+                            <ListItemText primary="Go to parent" secondary={`Return to ${parentNamespace(ns?.path)}`} />
+                        </MenuItem>
+                    ]) : []
+                }
 
-            {depth(ns?.path) > 1 ?
-                (
-                    <MenuItem value="...action.navigate-root">
-                        <ListItemIcon>
-                            <AccountTreeIcon sx={{fontSize: '1rem'}}/>
-                        </ListItemIcon>
-                        <ListItemText primary={`Go to ${ROOT_NAMESPACE_PATH}`} />
-                    </MenuItem>
-                ) : null
-            }
+                {depth(ns?.path) > 1 ?
+                    (
+                        <MenuItem value={ACTION_NAVIGATE_ROOT}>
+                            <ListItemIcon>
+                                <AccountTreeIcon sx={{fontSize: '1rem'}}/>
+                            </ListItemIcon>
+                            <ListItemText primary={`Go to ${ROOT_NAMESPACE_PATH}`} />
+                        </MenuItem>
+                    ) : null
+                }
 
-            <ListSubheader sx={{pt: 0}}>Actions</ListSubheader>
-            <MenuItem value="///action/refresh" onClick={refreshList}>
-                <ListItemIcon>
-                    <RefreshIcon />
-                </ListItemIcon>
-                <ListItemText primary="Refresh" secondary="Refresh namespace list" />
-            </MenuItem>
-            <MenuItem value="...action.add">
-                <ListItemIcon>
-                    <AddRoundedIcon />
-                </ListItemIcon>
-                <ListItemText primary="Add namespace" secondary={`Add a new namespace under ${ns?.path || 'root'}.`} />
-            </MenuItem>
-        </Select>
+                <ListSubheader sx={{pt: 0}}>Actions</ListSubheader>
+                <MenuItem value={ACTION_REFRESH}>
+                    <ListItemIcon>
+                        <RefreshIcon />
+                    </ListItemIcon>
+                    <ListItemText primary="Refresh" secondary="Refresh namespace list" />
+                </MenuItem>
+                <MenuItem value={ACTION_ADD}>
+                    <ListItemIcon>
+                        <AddRoundedIcon />
+                    </ListItemIcon>
+                    <ListItemText primary="Add namespace" secondary={`Add a new namespace under ${ns?.path || 'root'}.`} />
+                </MenuItem>
+            </Select>
+            <Dialog
+                open={createOpen}
+                onClose={closeCreateDialog}
+                fullWidth
+                maxWidth="xs"
+                PaperProps={{
+                    component: 'form',
+                    onSubmit: submitCreate,
+                }}
+            >
+                <DialogTitle>Add namespace</DialogTitle>
+                <DialogContent>
+                    {createError && <Alert severity="error" sx={{mb: 2}}>{createError}</Alert>}
+                    <TextField
+                        autoFocus
+                        fullWidth
+                        margin="dense"
+                        label="Name"
+                        value={createName}
+                        onChange={(event) => {
+                            setCreateName(event.target.value);
+                            setCreateError(null);
+                        }}
+                        disabled={createLoading}
+                        error={Boolean(validateNamespaceLeafName(createName.trim())) && createName.trim().length > 0}
+                        helperText={createName.trim() ? createNamespacePath : ' '}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeCreateDialog} disabled={createLoading}>Cancel</Button>
+                    <Button type="submit" variant="contained" disabled={createLoading}>
+                        {createLoading ? <CircularProgress size={18} /> : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- Wire the namespace selector's Add namespace action to a creation dialog that posts a child namespace path and selects the created namespace.
- Normalize selector action values so refresh/navigate actions are not treated as namespace paths, and keep the selected value valid while namespace transitions load.
- Add a mounted jsdom regression test for the Add namespace flow.

## Screenshots
- Not attached: the in-app browser refused DOM access to the localhost Admin UI under its URL policy, so I could not safely capture the requested UI screenshot in this environment.

## Testing
- yarn workspace @authproxy/admin test NamespaceSelector.test.tsx
- yarn workspace @authproxy/admin test
- yarn workspace @authproxy/admin typecheck
- yarn workspace @authproxy/admin build (passes with existing large chunk warning)
- yarn workspace @authproxy/admin lint (passes with an existing ConnectorDetail unused eslint-disable warning)
- ./scripts/preflight.sh