### PR TITLE
Add connector JavaScript context primitives

### DIFF
--- a/internal/apjs/condition.go
+++ b/internal/apjs/condition.go
@@ -1,36 +1,9 @@
 package apjs
 
-import (
-	"fmt"
-
-	"github.com/dop251/goja"
-)
-
 // EvaluateBoolean runs a JavaScript expression with the supplied variables in
 // scope and returns its boolean result. The expression must evaluate to a
 // boolean; undefined, null, and other result types are rejected so callers can
 // fail closed instead of guessing intent.
 func EvaluateBoolean(expression string, vars map[string]any) (bool, error) {
-	vm := goja.New()
-
-	for name, value := range vars {
-		if err := vm.Set(name, value); err != nil {
-			return false, fmt.Errorf("failed to set %q in JS runtime: %w", name, err)
-		}
-	}
-
-	result, err := vm.RunString(expression)
-	if err != nil {
-		return false, fmt.Errorf("JS expression error: %w", err)
-	}
-	if goja.IsUndefined(result) || goja.IsNull(result) {
-		return false, fmt.Errorf("JS expression returned %s", result)
-	}
-
-	exported := result.Export()
-	b, ok := exported.(bool)
-	if !ok {
-		return false, fmt.Errorf("JS expression must return a boolean, got %T", exported)
-	}
-	return b, nil
+	return NewContext(nil, vars).EvaluateBoolean(expression)
 }

--- a/internal/apjs/context.go
+++ b/internal/apjs/context.go
@@ -1,0 +1,94 @@
+package apjs
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// Context evaluates JavaScript expressions against a connector library and a
+// caller-provided runtime variable set.
+type Context struct {
+	library *Library
+	vars    map[string]any
+}
+
+// NewContext builds a JavaScript evaluation context with an optional library.
+func NewContext(library *Library, vars map[string]any) Context {
+	return Context{
+		library: library,
+		vars:    vars,
+	}
+}
+
+// WithVar returns a copy of the context with one additional runtime variable.
+func (c Context) WithVar(name string, value any) Context {
+	vars := make(map[string]any, len(c.vars)+1)
+	for k, v := range c.vars {
+		vars[k] = v
+	}
+	vars[name] = value
+	c.vars = vars
+	return c
+}
+
+// EvaluateBoolean runs a JavaScript expression and requires a boolean result.
+// Undefined, null, and other result types are rejected so callers can fail
+// closed instead of guessing intent.
+func (c Context) EvaluateBoolean(expression string) (bool, error) {
+	result, err := c.runExpression(expression)
+	if err != nil {
+		return false, err
+	}
+	if goja.IsUndefined(result) || goja.IsNull(result) {
+		return false, fmt.Errorf("JS expression returned %s", result)
+	}
+
+	exported := result.Export()
+	b, ok := exported.(bool)
+	if !ok {
+		return false, fmt.Errorf("JS expression must return a boolean, got %T", exported)
+	}
+	return b, nil
+}
+
+// TransformOptions runs a JavaScript expression and converts its result into
+// data-source dropdown/select options.
+func (c Context) TransformOptions(expression string) ([]DataSourceOption, error) {
+	result, err := c.runExpression(expression)
+	if err != nil {
+		return nil, err
+	}
+	return dataSourceOptionsFromValue(result)
+}
+
+// TransformJSON runs a transform expression with data exposed as the runtime
+// variable "data".
+func (c Context) TransformJSON(expression string, data any) ([]DataSourceOption, error) {
+	return c.WithVar("data", data).TransformOptions(expression)
+}
+
+func (c Context) runExpression(expression string) (goja.Value, error) {
+	vm := goja.New()
+
+	if c.library != nil {
+		if err := c.library.run(vm); err != nil {
+			return nil, err
+		}
+		if err := validateReservedRuntimeVars(vm); err != nil {
+			return nil, err
+		}
+	}
+
+	for name, value := range c.vars {
+		if err := vm.Set(name, value); err != nil {
+			return nil, fmt.Errorf("failed to set %q in JS runtime: %w", name, err)
+		}
+	}
+
+	result, err := vm.RunString(expression)
+	if err != nil {
+		return nil, fmt.Errorf("JS expression error: %w", err)
+	}
+	return result, nil
+}

--- a/internal/apjs/library.go
+++ b/internal/apjs/library.go
@@ -1,0 +1,106 @@
+package apjs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+var reservedRuntimeVars = map[string]struct{}{
+	"cfg":         {},
+	"labels":      {},
+	"annotations": {},
+	"data":        {},
+}
+
+// Library is connector-level JavaScript that can define shared constants and
+// functions for later predicate and transform expressions. The source is
+// compiled once, but each evaluation gets its own goja runtime.
+type Library struct {
+	source  string
+	program *goja.Program
+}
+
+// CompileLibrary parses connector-level JavaScript into a reusable program.
+// It does not run the library; call Validate to check top-level execution.
+func CompileLibrary(source string) (*Library, error) {
+	if strings.TrimSpace(source) == "" {
+		return &Library{}, nil
+	}
+
+	program, err := goja.Compile("connector.js", source, false)
+	if err != nil {
+		return nil, fmt.Errorf("compile connector JavaScript library: %w", err)
+	}
+
+	return &Library{
+		source:  source,
+		program: program,
+	}, nil
+}
+
+// CompileAndValidateLibrary compiles connector-level JavaScript and verifies
+// that its top-level initialization runs without runtime variables.
+func CompileAndValidateLibrary(source string) (*Library, error) {
+	library, err := CompileLibrary(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := library.Validate(); err != nil {
+		return nil, err
+	}
+	return library, nil
+}
+
+// Source returns the source JavaScript used to compile the library.
+func (l *Library) Source() string {
+	if l == nil {
+		return ""
+	}
+	return l.source
+}
+
+// Validate runs the connector library without any injected runtime variables.
+// This catches top-level initialization errors and prevents connector code from
+// claiming names that AuthProxy injects during predicate and transform calls.
+func (l *Library) Validate() error {
+	if l == nil {
+		return nil
+	}
+
+	vm := goja.New()
+	if err := l.run(vm); err != nil {
+		return err
+	}
+	return validateReservedRuntimeVars(vm)
+}
+
+// NewContext builds a JavaScript evaluation context using this library and
+// the supplied runtime variables.
+func (l *Library) NewContext(vars map[string]any) Context {
+	return Context{
+		library: l,
+		vars:    vars,
+	}
+}
+
+func (l *Library) run(vm *goja.Runtime) error {
+	if l == nil || l.program == nil {
+		return nil
+	}
+	if _, err := vm.RunProgram(l.program); err != nil {
+		return fmt.Errorf("JS library error: %w", err)
+	}
+	return nil
+}
+
+func validateReservedRuntimeVars(vm *goja.Runtime) error {
+	for name := range reservedRuntimeVars {
+		value := vm.Get(name)
+		if value != nil && !goja.IsUndefined(value) {
+			return fmt.Errorf("JS library defines reserved runtime variable %q", name)
+		}
+	}
+	return nil
+}

--- a/internal/apjs/library_test.go
+++ b/internal/apjs/library_test.go
@@ -1,0 +1,137 @@
+package apjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLibraryContextEvaluateBoolean(t *testing.T) {
+	library, err := CompileAndValidateLibrary(`
+		const PERSONAL_CALENDAR = "yes";
+
+		function isPersonalCalendar(cfg) {
+			return cfg.calendar_id === PERSONAL_CALENDAR;
+		}
+	`)
+	require.NoError(t, err)
+
+	ctx := library.NewContext(map[string]any{
+		"cfg": map[string]any{
+			"calendar_id": "yes",
+		},
+		"labels":      map[string]string{"env": "prod"},
+		"annotations": map[string]string{},
+	})
+
+	result, err := ctx.EvaluateBoolean(`isPersonalCalendar(cfg) && labels.env === "prod"`)
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestLibraryContextTransformOptions(t *testing.T) {
+	library, err := CompileAndValidateLibrary(`
+		function transformCalendarItems(items, prefix) {
+			return items.map(function(c) {
+				return { value: prefix + c.id, label: c.summary || c.id };
+			});
+		}
+	`)
+	require.NoError(t, err)
+
+	ctx := library.NewContext(map[string]any{
+		"cfg": map[string]any{
+			"value_prefix": "cal:",
+		},
+		"labels":      map[string]string{},
+		"annotations": map[string]string{},
+		"data": map[string]any{
+			"items": []any{
+				map[string]any{"id": "primary", "summary": "Primary"},
+				map[string]any{"id": "team"},
+			},
+		},
+	})
+
+	options, err := ctx.TransformOptions(`transformCalendarItems(data.items, cfg.value_prefix)`)
+	require.NoError(t, err)
+	require.Len(t, options, 2)
+	assert.Equal(t, DataSourceOption{Value: "cal:primary", Label: "Primary"}, options[0])
+	assert.Equal(t, DataSourceOption{Value: "cal:team", Label: "team"}, options[1])
+}
+
+func TestLibraryContextTransformJSON(t *testing.T) {
+	library, err := CompileAndValidateLibrary(`
+		function toOptions(items) {
+			return items.map(function(item) {
+				return { value: item.id, label: item.name };
+			});
+		}
+	`)
+	require.NoError(t, err)
+
+	options, err := library.NewContext(map[string]any{
+		"cfg":         map[string]any{},
+		"labels":      map[string]string{},
+		"annotations": map[string]string{},
+	}).TransformJSON(`toOptions(data)`, []any{
+		map[string]any{"id": "a", "name": "Alpha"},
+	})
+	require.NoError(t, err)
+	require.Len(t, options, 1)
+	assert.Equal(t, DataSourceOption{Value: "a", Label: "Alpha"}, options[0])
+}
+
+func TestCompileLibraryRejectsSyntaxError(t *testing.T) {
+	_, err := CompileLibrary(`function broken(`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compile connector JavaScript library")
+}
+
+func TestCompileAndValidateLibraryRejectsTopLevelRuntimeError(t *testing.T) {
+	_, err := CompileAndValidateLibrary(`throw new Error("boom")`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JS library error")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestCompileAndValidateLibraryRunsWithoutRuntimeVars(t *testing.T) {
+	_, err := CompileAndValidateLibrary(`var selected = cfg.calendar_id`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JS library error")
+}
+
+func TestLibraryRejectsReservedRuntimeVars(t *testing.T) {
+	_, err := CompileAndValidateLibrary(`const cfg = { calendar_id: "yes" }`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reserved runtime variable "cfg"`)
+
+	library, err := CompileLibrary(`const data = []`)
+	require.NoError(t, err)
+
+	_, err = library.NewContext(map[string]any{"data": []any{}}).TransformOptions(`data`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reserved runtime variable "data"`)
+}
+
+func TestLibraryEvaluationUsesFreshRuntime(t *testing.T) {
+	library, err := CompileAndValidateLibrary(`
+		var count = 0;
+		function firstCallOnly() {
+			count++;
+			return count === 1;
+		}
+	`)
+	require.NoError(t, err)
+
+	ctx := library.NewContext(nil)
+
+	first, err := ctx.EvaluateBoolean(`firstCallOnly()`)
+	require.NoError(t, err)
+	assert.True(t, first)
+
+	second, err := ctx.EvaluateBoolean(`firstCallOnly()`)
+	require.NoError(t, err)
+	assert.True(t, second)
+}

--- a/internal/apjs/transform.go
+++ b/internal/apjs/transform.go
@@ -17,17 +17,10 @@ type DataSourceOption struct {
 // in the JS expression. The expression should return an array of objects with "value"
 // and "label" string fields.
 func TransformJSON(expression string, data any) ([]DataSourceOption, error) {
-	vm := goja.New()
+	return NewContext(nil, nil).TransformJSON(expression, data)
+}
 
-	if err := vm.Set("data", data); err != nil {
-		return nil, fmt.Errorf("failed to set data in JS runtime: %w", err)
-	}
-
-	result, err := vm.RunString(expression)
-	if err != nil {
-		return nil, fmt.Errorf("JS expression error: %w", err)
-	}
-
+func dataSourceOptionsFromValue(result goja.Value) ([]DataSourceOption, error) {
 	if goja.IsUndefined(result) || goja.IsNull(result) {
 		return nil, fmt.Errorf("JS expression returned %s", result)
 	}


### PR DESCRIPTION
Closes #668

## Summary
- Add reusable `apjs.Library` and `apjs.Context` primitives for connector-level JavaScript helpers.
- Compile connector JavaScript once, validate top-level initialization without runtime vars, and run a fresh goja VM for each evaluation.
- Preserve existing `EvaluateBoolean` and `TransformJSON` package helpers by delegating through the new context path.

## Tests
- `go test ./internal/apjs`
- `./scripts/preflight.sh`