### PR TITLE
Enqueue DEK generation when creating keys

### DIFF
--- a/internal/core/service_key.go
+++ b/internal/core/service_key.go
@@ -54,8 +54,10 @@ func (s *service) CreateKey(ctx context.Context, namespace string, keyData *cfgs
 		return nil, err
 	}
 
-	// Enqueue an immediate key sync task so the new key's versions are available
-	// in the database without waiting for the next cron cycle.
+	// Enqueue immediate DEK generation so the new key can be used for
+	// encryption without waiting for the next cron cycle. The follow-up sync
+	// keeps wrapping metadata and namespace targets reconciled.
+	encrypt.EnqueueGenerateDataEncryptionKeysToDatabase(ctx, s.ac, s.logger)
 	encrypt.EnqueueForceSyncKeysToDatabase(ctx, s.r, s.ac, s.logger)
 
 	return wrapKey(*ek, s), nil

--- a/internal/core/service_key_test.go
+++ b/internal/core/service_key_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+type asynqTaskTypeMatcher struct {
+	taskType string
+}
+
+func (m asynqTaskTypeMatcher) Matches(x any) bool {
+	task, ok := x.(*asynq.Task)
+	return ok && task.Type() == m.taskType
+}
+
+func (m asynqTaskTypeMatcher) String() string {
+	return fmt.Sprintf("asynq task type %q", m.taskType)
+}
+
+func TestCreateKeyEnqueuesDEKGeneration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s, db, redisClient, _, asynqClient, enc := FullMockService(t, ctrl)
+	ctx := context.Background()
+
+	keyData := &sconfig.KeyData{
+		InnerVal: &sconfig.KeyDataRawVal{Raw: []byte("01234567890123456789012345678901")},
+	}
+
+	enc.EXPECT().
+		EncryptKeyForNamespace(gomock.Any(), "root.dev", gomock.Any()).
+		Return(encfield.EncryptedField{ID: "dek_parent", Data: "encrypted-key-data"}, nil)
+
+	db.EXPECT().
+		CreateKey(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, key *database.Key) error {
+			require.True(t, key.Id.HasPrefix(apid.PrefixKey))
+			require.Equal(t, "root.dev", key.Namespace)
+			require.Equal(t, database.KeyStateActive, key.State)
+			require.Equal(t, database.Labels{"purpose": "test"}, key.Labels)
+			require.Equal(t, encfield.EncryptedField{ID: "dek_parent", Data: "encrypted-key-data"}, *key.EncryptedKeyData)
+			return nil
+		})
+
+	gomock.InOrder(
+		asynqClient.EXPECT().
+			EnqueueContext(gomock.Any(), asynqTaskTypeMatcher{taskType: encrypt.TaskTypeGenerateDataEncryptionKeys}).
+			Return(nil, nil),
+		redisClient.EXPECT().
+			Del(gomock.Any(), gomock.Any()).
+			Return(redis.NewIntCmd(ctx)),
+		asynqClient.EXPECT().
+			EnqueueContext(gomock.Any(), asynqTaskTypeMatcher{taskType: encrypt.TaskTypeSyncKeysToDatabase}).
+			Return(nil, nil),
+	)
+
+	created, err := s.CreateKey(ctx, "root.dev", keyData, map[string]string{"purpose": "test"})
+
+	require.NoError(t, err)
+	require.Equal(t, "root.dev", created.GetNamespace())
+	require.Equal(t, database.KeyStateActive, created.GetState())
+}

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/apasynq"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
@@ -26,6 +27,15 @@ const (
 
 func NewGenerateDataEncryptionKeysTask() *asynq.Task {
 	return asynq.NewTask(TaskTypeGenerateDataEncryptionKeys, nil)
+}
+
+// EnqueueGenerateDataEncryptionKeysToDatabase schedules immediate DEK
+// reconciliation. This is used after creating new key material so the key gets
+// a current DEK without waiting for the periodic task.
+func EnqueueGenerateDataEncryptionKeysToDatabase(ctx context.Context, ac apasynq.Client, logger *slog.Logger) {
+	if _, err := ac.EnqueueContext(ctx, NewGenerateDataEncryptionKeysTask()); err != nil {
+		logger.Warn("failed to enqueue data encryption key generation task", "error", err)
+	}
 }
 
 func createDataEncryptionKey(


### PR DESCRIPTION
## Summary
- enqueue immediate DEK generation after creating new key material
- keep the existing wrapping sync enqueue so namespace targets still reconcile promptly
- add a core regression test covering generation-before-sync task ordering

## Tests
- go test ./internal/core -run TestCreateKeyEnqueuesDEKGeneration -count=1
- go test ./internal/routes -run TestKeys/create_key -count=1
- go test ./internal/core ./internal/routes ./internal/encrypt
- ./scripts/preflight.sh