### PR TITLE
Fix metrics query permission validation

### DIFF
--- a/internal/apauth/service/permission_validator.go
+++ b/internal/apauth/service/permission_validator.go
@@ -140,7 +140,7 @@ func (rpv *ResourcePermissionValidator) ValidateHttpStatusError(obj interface{})
 }
 
 // GetEffectiveNamespaceMatchers computes the namespace matchers that should be applied to a database query.
-// `queryMatcher` should be the namespace matcher received as a query param to an endpoint intented as filter.
+// `queryMatcher` should be the namespace matcher received as a query param to an endpoint intended as filter.
 //
 // It returns:
 // - the allowed namespaces for the resource/verb, optionally intersected with queryMatcher

--- a/internal/apauth/service/permission_validator_test.go
+++ b/internal/apauth/service/permission_validator_test.go
@@ -423,6 +423,7 @@ func TestGetEffectiveNamespaceMatchers(t *testing.T) {
 
 			result := validator.GetEffectiveNamespaceMatchers(tt.queryMatcher)
 			assert.Equal(t, tt.expected, result)
+			assert.False(t, validator.hasBeenValidated)
 		})
 	}
 }
@@ -500,6 +501,7 @@ func TestGetEffectiveNamespaceMatchers_MultiVerb(t *testing.T) {
 
 			result := validator.GetEffectiveNamespaceMatchers(tt.queryMatcher)
 			assert.ElementsMatch(t, tt.expected, result)
+			assert.False(t, validator.hasBeenValidated)
 		})
 	}
 }
@@ -833,6 +835,86 @@ func TestValidatorOnRoutes(t *testing.T) {
 
 			require.True(t, panicOccurred)
 		})
+	})
+
+	t.Run("namespace matcher alone is not validation", func(t *testing.T) {
+		fakeRouteThatConstrainsQuery := func(gctx *gin.Context) {
+			val := MustGetValidatorFromGinContext(gctx)
+			require.Equal(t, []string{"root.test.**"}, val.GetEffectiveNamespaceMatchers(nil))
+
+			gctx.PureJSON(200, gin.H{"status": "ok"})
+		}
+
+		register := func(g gin.IRouter, auth A) {
+			g.GET(
+				"/cats",
+				auth.NewRequiredBuilder().
+					ForResource("cats").
+					ForVerb("meow").
+					Build(),
+				fakeRouteThatConstrainsQuery,
+			)
+		}
+
+		tu := setup(t, register)
+
+		panicOccurred := false
+		defer func() {
+			if r := recover(); r != nil {
+				panicOccurred = true
+			}
+			require.True(t, panicOccurred)
+		}()
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/cats",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.test.**", "cats", "meow"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+	})
+
+	t.Run("explicit query validation mark", func(t *testing.T) {
+		fakeRouteThatConstrainsQuery := func(gctx *gin.Context) {
+			val := MustGetValidatorFromGinContext(gctx)
+			require.Equal(t, []string{"root.test.**"}, val.GetEffectiveNamespaceMatchers(nil))
+			val.MarkValidated()
+
+			gctx.PureJSON(200, gin.H{"status": "ok"})
+		}
+
+		register := func(g gin.IRouter, auth A) {
+			g.GET(
+				"/cats",
+				auth.NewRequiredBuilder().
+					ForResource("cats").
+					ForVerb("meow").
+					Build(),
+				fakeRouteThatConstrainsQuery,
+			)
+		}
+
+		tu := setup(t, register)
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/cats",
+			nil,
+			"root",
+			"some-actor",
+			aschema.PermissionsSingle("root.test.**", "cats", "meow"),
+		)
+		require.NoError(t, err)
+
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
 	})
 
 	t.Run("ForVerbs accepts any matching verb", func(t *testing.T) {

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -791,6 +791,9 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 		responseSeries = append(responseSeries, resourceMetricsResponseSeries(series)...)
 	}
 
+	// Metrics responses are aggregate series, not resource rows, so the request is validated once all query refs are
+	// accepted and their namespace matchers are constrained by the actor's permissions.
+	val.MarkValidated()
 	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
 }
 
@@ -804,6 +807,9 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/metrics/schema [get]
 func (r *RequestEventsRoutes) schema(gctx *gin.Context) {
+	val := auth.MustGetValidatorFromGinContext(gctx)
+	// The schema response is static metadata for the app-metrics API, so there are no resource rows to post-validate.
+	val.MarkValidated()
 	gctx.PureJSON(http.StatusOK, metricsSchemaResponse())
 }
 

--- a/internal/routes/request_events_test.go
+++ b/internal/routes/request_events_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rmorlok/authproxy/internal/apgin"
-
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
@@ -42,7 +40,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 		rlr := mock.NewMockLogRetriever(ctrl)
 		rl := NewRequestEventsRoutes(cfg, auth, rlr)
 
-		r := apgin.ForTest(nil)
+		r := gin.New()
 		rl.Register(r)
 
 		return &TestSetup{


### PR DESCRIPTION
## Summary
- keep GetEffectiveNamespaceMatchers as a non-mutating namespace constraint helper
- explicitly mark app-metrics query and schema endpoints validated after their endpoint-specific checks complete
- add regression coverage proving namespace matcher computation alone does not satisfy the route post-validation contract

## Tests
- go test ./internal/apauth/service ./internal/routes
- ./scripts/preflight.sh