### PR TITLE
Add connector-level JavaScript schema and runtime context

### DIFF
--- a/internal/auth_methods/oauth2/scope_mismatch.go
+++ b/internal/auth_methods/oauth2/scope_mismatch.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
@@ -37,9 +38,9 @@ func detectScopeMismatch(declaredEffectiveScopes []sconfig.Scope, granted string
 			continue
 		}
 
-		// We can use nil here because these are effective scopes that have
-		// had predicates resolved.
-		required, err := s.IsRequired(nil)
+		// These are effective scopes that have had predicates resolved, so an
+		// empty context is enough to read the concrete required value.
+		required, err := s.IsRequired(apjs.Context{})
 		if err != nil {
 			return scopeMismatchOutcome{}, fmt.Errorf("scope %q required: %w", s.Id, err)
 		}

--- a/internal/auth_methods/oauth2/scope_predicates.go
+++ b/internal/auth_methods/oauth2/scope_predicates.go
@@ -15,16 +15,16 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 		return nil, nil
 	}
 
-	vars, err := o.connection.GetPredicateVars(ctx)
+	jsctx, err := o.connection.GetJavascriptContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get predicate vars for effective scopes: %w", err)
+		return nil, fmt.Errorf("get javascript context for effective scopes: %w", err)
 	}
 
 	scopes := make([]sconfig.Scope, 0, len(o.auth.Scopes))
 	for _, declared := range o.auth.Scopes {
 		scope := declared.Clone()
 		if scope.If != nil {
-			ok, err := scope.If.GetValue(vars)
+			ok, err := scope.If.GetValue(jsctx)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q if.javascript: %w", scope.Id, err)
 			}
@@ -34,7 +34,7 @@ func (o *oAuth2Connection) effectiveScopes(ctx context.Context) ([]sconfig.Scope
 		}
 
 		if scope.Required != nil && scope.Required.Predicate != nil {
-			required, err := scope.IsRequired(vars)
+			required, err := scope.IsRequired(jsctx)
 			if err != nil {
 				return nil, fmt.Errorf("scope %q required.javascript: %w", scope.Id, err)
 			}

--- a/internal/auth_methods/oauth2/scope_predicates_test.go
+++ b/internal/auth_methods/oauth2/scope_predicates_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/apredis"
 	"github.com/rmorlok/authproxy/internal/config"
 	mockCore "github.com/rmorlok/authproxy/internal/core/mock"
@@ -60,15 +61,55 @@ func TestEffectiveScopes_UsesConnectionPredicateContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 	assert.Equal(t, []string{"read", "write", "activity"}, []string{got[0].Id, got[1].Id, got[2].Id})
-	required, err := got[0].IsRequired(nil)
+	required, err := got[0].IsRequired(apjs.Context{})
 	require.NoError(t, err)
 	assert.True(t, required)
-	required, err = got[1].IsRequired(nil)
+	required, err = got[1].IsRequired(apjs.Context{})
 	require.NoError(t, err)
 	assert.True(t, required)
-	required, err = got[2].IsRequired(nil)
+	required, err = got[2].IsRequired(apjs.Context{})
 	require.NoError(t, err)
 	assert.False(t, required)
+}
+
+func TestEffectiveScopes_UsesConnectionJavascriptLibrary(t *testing.T) {
+	library, err := apjs.CompileAndValidateLibrary(`
+		function includeWriteScope() {
+			return cfg.push_files === true && labels["env"] === "prod";
+		}
+
+		function requireActivityScope() {
+			return annotations["tier"] === "gold";
+		}
+	`)
+	require.NoError(t, err)
+
+	o := &oAuth2Connection{
+		connection: &mockCore.Connection{
+			Configuration:     map[string]any{"push_files": true},
+			Labels:            map[string]string{"env": "prod"},
+			Annotations:       map[string]string{"tier": "gold"},
+			JavascriptLibrary: library,
+		},
+		auth: &sconfig.AuthOAuth2{
+			Scopes: []sconfig.Scope{
+				{Id: "read"},
+				{Id: "write", If: &common.Predicate{Javascript: `includeWriteScope()`}},
+				{
+					Id:       "activity",
+					Required: sconfig.NewScopeRequiredPredicate(&common.Predicate{Javascript: `requireActivityScope()`}),
+				},
+			},
+		},
+	}
+
+	got, err := o.effectiveScopes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"read", "write", "activity"}, []string{got[0].Id, got[1].Id, got[2].Id})
+	required, err := got[2].IsRequired(apjs.Context{})
+	require.NoError(t, err)
+	assert.True(t, required)
 }
 
 func TestEffectiveScopes_PredicateErrorIncludesScopeContext(t *testing.T) {

--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -27,6 +27,10 @@ type connection struct {
 	cv     *ConnectorVersion
 	logger *slog.Logger
 
+	configMu     sync.Mutex
+	configLoaded bool
+	configCache  map[string]any
+
 	proxyImplOnce sync.Once
 	proxyImpl     iface.Proxy
 	proxyImplErr  error
@@ -160,7 +164,16 @@ func (c *connection) SetSetupError(ctx context.Context, setupError *string) erro
 }
 
 func (c *connection) GetConfiguration(ctx context.Context) (map[string]any, error) {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+
+	if c.configLoaded {
+		return cloneConfiguration(c.configCache), nil
+	}
+
 	if c.EncryptedConfiguration == nil || c.EncryptedConfiguration.IsZero() {
+		c.configLoaded = true
+		c.configCache = nil
 		return nil, nil
 	}
 
@@ -174,13 +187,24 @@ func (c *connection) GetConfiguration(ctx context.Context) (map[string]any, erro
 		return nil, fmt.Errorf("failed to unmarshal connection configuration: %w", err)
 	}
 
-	return result, nil
+	c.configLoaded = true
+	c.configCache = result
+
+	return cloneConfiguration(c.configCache), nil
 }
 
 func (c *connection) SetConfiguration(ctx context.Context, data map[string]any) error {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("failed to marshal connection configuration: %w", err)
+	}
+
+	var cached map[string]any
+	if err := json.Unmarshal(jsonBytes, &cached); err != nil {
+		return fmt.Errorf("failed to normalize connection configuration: %w", err)
 	}
 
 	ef, err := c.s.encrypt.EncryptStringForNamespace(ctx, c.Namespace, string(jsonBytes))
@@ -193,7 +217,36 @@ func (c *connection) SetConfiguration(ctx context.Context, data map[string]any) 
 	}
 
 	c.EncryptedConfiguration = &ef
+	c.configCache = cached
+	c.configLoaded = true
 	return nil
+}
+
+func cloneConfiguration(cfg map[string]any) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+
+	cloned := make(map[string]any, len(cfg))
+	for key, value := range cfg {
+		cloned[key] = cloneConfigurationValue(value)
+	}
+	return cloned
+}
+
+func cloneConfigurationValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneConfiguration(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneConfigurationValue(item)
+		}
+		return cloned
+	default:
+		return typed
+	}
 }
 
 func (c *connection) GetMustacheContext(ctx context.Context) (map[string]any, error) {

--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -100,10 +101,15 @@ func (c *connection) GetConnectorVersionEntity() iface.ConnectorVersion {
 	return c.cv
 }
 
-func (c *connection) GetPredicateVars(ctx context.Context) (map[string]any, error) {
+func (c *connection) GetJavascriptContext(ctx context.Context) (apjs.Context, error) {
+	jsLib, err := c.cv.getJavascriptLibrary()
+	if err != nil {
+		return apjs.Context{}, err
+	}
+
 	cfg, err := c.GetConfiguration(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get connection configuration: %w", err)
+		return apjs.Context{}, fmt.Errorf("get connection configuration: %w", err)
 	}
 	if cfg == nil {
 		cfg = map[string]any{}
@@ -119,11 +125,14 @@ func (c *connection) GetPredicateVars(ctx context.Context) (map[string]any, erro
 		annotations = map[string]string{}
 	}
 
-	return map[string]any{
-		"cfg":         cfg,
-		"labels":      labels,
-		"annotations": annotations,
-	}, nil
+	return apjs.NewContext(
+		jsLib,
+		map[string]any{
+			"cfg":         cfg,
+			"labels":      labels,
+			"annotations": annotations,
+		},
+	), nil
 }
 
 func (c *connection) Logger() *slog.Logger {

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -370,7 +370,7 @@ func TestConnectionGetMustacheContext(t *testing.T) {
 	})
 }
 
-func TestConnectionGetPredicateVars(t *testing.T) {
+func TestConnectionGetJavascriptContext(t *testing.T) {
 	t.Run("returns cfg labels and annotations", func(t *testing.T) {
 		e := encrypt.NewFakeEncryptService(false)
 		s := &service{encrypt: e, logger: aplog.NewNoopLogger()}
@@ -382,39 +382,44 @@ func TestConnectionGetPredicateVars(t *testing.T) {
 		conn.Labels = map[string]string{"env": "prod"}
 		conn.Annotations = map[string]string{"region": "us-east"}
 
-		data, err := conn.GetPredicateVars(context.Background())
+		jsctx, err := conn.GetJavascriptContext(context.Background())
 		require.NoError(t, err)
 
-		cfg, ok := data["cfg"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "acme", cfg["tenant"])
-
-		labels, ok := data["labels"].(map[string]string)
-		require.True(t, ok)
-		assert.Equal(t, "prod", labels["env"])
-
-		annotations, ok := data["annotations"].(map[string]string)
-		require.True(t, ok)
-		assert.Equal(t, "us-east", annotations["region"])
+		ok, err := jsctx.EvaluateBoolean(`cfg.tenant === "acme" && labels.env === "prod" && annotations.region === "us-east"`)
+		require.NoError(t, err)
+		assert.True(t, ok)
 	})
 
 	t.Run("returns empty maps when values are absent", func(t *testing.T) {
 		conn := newTestConnection(cschema.Connector{})
 
-		data, err := conn.GetPredicateVars(context.Background())
+		jsctx, err := conn.GetJavascriptContext(context.Background())
 		require.NoError(t, err)
 
-		cfg, ok := data["cfg"].(map[string]any)
-		require.True(t, ok)
-		assert.Empty(t, cfg)
+		ok, err := jsctx.EvaluateBoolean(`Object.keys(cfg).length === 0 && Object.keys(labels).length === 0 && Object.keys(annotations).length === 0`)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
 
-		labels, ok := data["labels"].(map[string]string)
-		require.True(t, ok)
-		assert.Empty(t, labels)
+	t.Run("includes connector javascript helpers", func(t *testing.T) {
+		conn := newTestConnection(cschema.Connector{
+			Javascript: `
+				function isProdTenant() {
+					return cfg.tenant === "acme" &&
+						labels.env === "prod" &&
+						annotations.region === "us-east";
+				}
+			`,
+		})
+		setConnectionConfigFixture(t, conn, map[string]any{"tenant": "acme"})
+		conn.Labels = map[string]string{"env": "prod"}
+		conn.Annotations = map[string]string{"region": "us-east"}
 
-		annotations, ok := data["annotations"].(map[string]string)
-		require.True(t, ok)
-		assert.Empty(t, annotations)
+		jsctx, err := conn.GetJavascriptContext(context.Background())
+		require.NoError(t, err)
+		ok, err := jsctx.EvaluateBoolean(`isProdTenant()`)
+		require.NoError(t, err)
+		assert.True(t, ok)
 	})
 
 	t.Run("returns error on decrypt failure", func(t *testing.T) {
@@ -423,8 +428,16 @@ func TestConnectionGetPredicateVars(t *testing.T) {
 		conn := newTestConnectionWithService(s)
 		conn.EncryptedConfiguration = &encfield.EncryptedField{ID: "ekv_wrong", Data: "some-data"}
 
-		_, err := conn.GetPredicateVars(context.Background())
+		_, err := conn.GetJavascriptContext(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "get connection configuration")
+	})
+
+	t.Run("returns error for invalid connector javascript", func(t *testing.T) {
+		conn := newTestConnection(cschema.Connector{Javascript: `function broken(`})
+
+		_, err := conn.GetJavascriptContext(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compile connector JavaScript library")
 	})
 }

--- a/internal/core/connection_configuration_test.go
+++ b/internal/core/connection_configuration_test.go
@@ -131,6 +131,33 @@ func TestConnectionGetConfiguration(t *testing.T) {
 		assert.Equal(t, "https://acme.example.com", result["base_url"])
 	})
 
+	t.Run("caches decrypted configuration and returns copies", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		s, _, _, _, _, enc := FullMockService(t, ctrl)
+		conn := newTestConnectionWithService(s)
+		ef := encfield.EncryptedField{ID: "ekv_test", Data: "encrypted-data"}
+		conn.EncryptedConfiguration = &ef
+
+		enc.EXPECT().
+			DecryptString(gomock.Any(), ef).
+			Return(`{"tenant":"acme","nested":{"flag":true},"items":[{"id":"one"}]}`, nil).
+			Times(1)
+
+		first, err := conn.GetConfiguration(context.Background())
+		require.NoError(t, err)
+		first["tenant"] = "mutated"
+		first["nested"].(map[string]any)["flag"] = false
+		first["items"].([]any)[0].(map[string]any)["id"] = "mutated"
+
+		second, err := conn.GetConfiguration(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "acme", second["tenant"])
+		assert.Equal(t, true, second["nested"].(map[string]any)["flag"])
+		assert.Equal(t, "one", second["items"].([]any)[0].(map[string]any)["id"])
+	})
+
 	t.Run("returns error on decrypt failure", func(t *testing.T) {
 		e := encrypt.NewFakeEncryptService(false)
 		s := &service{encrypt: e, logger: aplog.NewNoopLogger()}
@@ -258,6 +285,34 @@ func TestConnectionSetConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "newcorp", result["tenant"])
 		assert.Equal(t, "field", result["extra"])
+	})
+
+	t.Run("updates decrypted configuration cache", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		s, db, _, _, _, enc := FullMockService(t, ctrl)
+		conn := newTestConnectionWithService(s)
+		ef := encfield.EncryptedField{ID: "ekv_test", Data: "encrypted-data"}
+
+		enc.EXPECT().
+			EncryptStringForNamespace(gomock.Any(), "root", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, namespace string, data string) (encfield.EncryptedField, error) {
+				assert.JSONEq(t, `{"tenant":"acme","count":2}`, data)
+				return ef, nil
+			})
+		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, &ef).Return(nil)
+
+		err := conn.SetConfiguration(context.Background(), map[string]any{
+			"tenant": "acme",
+			"count":  2,
+		})
+		require.NoError(t, err)
+
+		result, err := conn.GetConfiguration(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "acme", result["tenant"])
+		assert.Equal(t, float64(2), result["count"])
 	})
 }
 

--- a/internal/core/connection_data_source.go
+++ b/internal/core/connection_data_source.go
@@ -97,7 +97,12 @@ func (c *connection) GetDataSource(ctx context.Context, sourceId string) ([]apjs
 	}
 
 	// Run JavaScript transform
-	options, err := apjs.TransformJSON(ds.Transform, responseData)
+	jsctx, err := c.GetJavascriptContext(ctx)
+	if err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to get javascript context: %w", err))
+	}
+
+	options, err := jsctx.TransformJSON(ds.Transform, responseData)
 	if err != nil {
 		return nil, httperr.InternalServerErrorMsg("failed to transform data source response", httperr.WithInternalErrorf("data source transform failed: %w", err))
 	}

--- a/internal/core/connection_data_source_test.go
+++ b/internal/core/connection_data_source_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +14,65 @@ import (
 )
 
 func TestGetDataSource(t *testing.T) {
+	t.Run("transforms response with connector javascript context", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, proxy := newProbeTestConnection(t, ctrl, cschema.Connector{
+			Javascript: `
+				function workspaceOptions(items) {
+					return items.map(function(item) {
+						return {
+							value: labels.env + ":" + item.id,
+							label: cfg.region + "/" + annotations.prefix + "/" + item.summary
+						};
+					});
+				}
+			`,
+			SetupFlow: &cschema.SetupFlow{
+				Configure: &cschema.SetupFlowPhase{
+					Steps: []cschema.SetupFlowStep{
+						{
+							Id:         "workspace",
+							JsonSchema: workspaceSchema,
+							DataSources: map[string]cschema.DataSourceDef{
+								"workspaces": {
+									ProxyRequest: &cschema.DataSourceProxyRequest{
+										Method: "GET",
+										Url:    "https://api.example.com/workspaces",
+									},
+									Transform: "workspaceOptions(data.items)",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		step := cschema.MustNewSetupStep("workspace")
+		conn.SetupStep = &step
+		conn.s.encrypt = encrypt.NewFakeEncryptService(false)
+		setConnectionConfigFixture(t, conn, map[string]any{"region": "us-east"})
+		conn.Labels = map[string]string{"env": "prod"}
+		conn.Annotations = map[string]string{"prefix": "team"}
+		proxy.resp = &iface.ProxyResponse{
+			StatusCode: 200,
+			BodyJson: map[string]any{
+				"items": []any{
+					map[string]any{"id": "primary", "summary": "Primary"},
+				},
+			},
+		}
+
+		options, err := conn.GetDataSource(context.Background(), "workspaces")
+		require.NoError(t, err)
+		require.Len(t, options, 1)
+		assert.Equal(t, "prod:primary", options[0].Value)
+		assert.Equal(t, "us-east/team/Primary", options[0].Label)
+		require.Len(t, proxy.calls, 1)
+		assert.Equal(t, "https://api.example.com/workspaces", proxy.calls[0].URL)
+	})
+
 	t.Run("returns error when no setup step", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/internal/core/connection_probe.go
+++ b/internal/core/connection_probe.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
@@ -38,7 +37,6 @@ func (c *connection) GetProbes() []iface.Probe {
 
 func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface.Probe, error) {
 	def := c.cv.GetDefinition()
-	getJSContext := c.lazyProbeJavascriptContext(ctx)
 
 	for i := range def.Probes {
 		probe := &def.Probes[i]
@@ -46,7 +44,7 @@ func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface
 			continue
 		}
 
-		enabled, err := c.isProbeEnabled(probe, getJSContext)
+		enabled, err := c.isProbeEnabled(ctx, probe)
 		if err != nil {
 			return nil, err
 		}
@@ -62,11 +60,10 @@ func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface
 func (c *connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error) {
 	def := c.cv.GetDefinition()
 	probes := make([]iface.Probe, 0, len(def.Probes))
-	getJSContext := c.lazyProbeJavascriptContext(ctx)
 
 	for i := range def.Probes {
 		probe := &def.Probes[i]
-		enabled, err := c.isProbeEnabled(probe, getJSContext)
+		enabled, err := c.isProbeEnabled(ctx, probe)
 		if err != nil {
 			return nil, err
 		}
@@ -79,29 +76,12 @@ func (c *connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error
 	return probes, nil
 }
 
-type probeJavascriptContextLoader func() (apjs.Context, error)
-
-func (c *connection) lazyProbeJavascriptContext(ctx context.Context) probeJavascriptContextLoader {
-	var (
-		loaded bool
-		jsctx  apjs.Context
-		err    error
-	)
-	return func() (apjs.Context, error) {
-		if !loaded {
-			jsctx, err = c.GetJavascriptContext(ctx)
-			loaded = true
-		}
-		return jsctx, err
-	}
-}
-
-func (c *connection) isProbeEnabled(probe *cschema.Probe, getJSContext probeJavascriptContextLoader) (bool, error) {
+func (c *connection) isProbeEnabled(ctx context.Context, probe *cschema.Probe) (bool, error) {
 	if probe == nil || probe.If == nil {
 		return true, nil
 	}
 
-	jsctx, err := getJSContext()
+	jsctx, err := c.GetJavascriptContext(ctx)
 	if err != nil {
 		return false, fmt.Errorf("probe %q: get javascript context: %w", probe.Id, err)
 	}

--- a/internal/core/connection_probe.go
+++ b/internal/core/connection_probe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
@@ -37,7 +38,7 @@ func (c *connection) GetProbes() []iface.Probe {
 
 func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface.Probe, error) {
 	def := c.cv.GetDefinition()
-	getVars := c.lazyProbePredicateVars(ctx)
+	getJSContext := c.lazyProbeJavascriptContext(ctx)
 
 	for i := range def.Probes {
 		probe := &def.Probes[i]
@@ -45,7 +46,7 @@ func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface
 			continue
 		}
 
-		enabled, err := c.isProbeEnabled(probe, getVars)
+		enabled, err := c.isProbeEnabled(probe, getJSContext)
 		if err != nil {
 			return nil, err
 		}
@@ -61,11 +62,11 @@ func (c *connection) GetEnabledProbe(ctx context.Context, probeId string) (iface
 func (c *connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error) {
 	def := c.cv.GetDefinition()
 	probes := make([]iface.Probe, 0, len(def.Probes))
-	getVars := c.lazyProbePredicateVars(ctx)
+	getJSContext := c.lazyProbeJavascriptContext(ctx)
 
 	for i := range def.Probes {
 		probe := &def.Probes[i]
-		enabled, err := c.isProbeEnabled(probe, getVars)
+		enabled, err := c.isProbeEnabled(probe, getJSContext)
 		if err != nil {
 			return nil, err
 		}
@@ -78,34 +79,34 @@ func (c *connection) GetEnabledProbes(ctx context.Context) ([]iface.Probe, error
 	return probes, nil
 }
 
-type probePredicateVarsLoader func() (map[string]any, error)
+type probeJavascriptContextLoader func() (apjs.Context, error)
 
-func (c *connection) lazyProbePredicateVars(ctx context.Context) probePredicateVarsLoader {
+func (c *connection) lazyProbeJavascriptContext(ctx context.Context) probeJavascriptContextLoader {
 	var (
 		loaded bool
-		vars   map[string]any
+		jsctx  apjs.Context
 		err    error
 	)
-	return func() (map[string]any, error) {
+	return func() (apjs.Context, error) {
 		if !loaded {
-			vars, err = c.GetPredicateVars(ctx)
+			jsctx, err = c.GetJavascriptContext(ctx)
 			loaded = true
 		}
-		return vars, err
+		return jsctx, err
 	}
 }
 
-func (c *connection) isProbeEnabled(probe *cschema.Probe, getVars probePredicateVarsLoader) (bool, error) {
+func (c *connection) isProbeEnabled(probe *cschema.Probe, getJSContext probeJavascriptContextLoader) (bool, error) {
 	if probe == nil || probe.If == nil {
 		return true, nil
 	}
 
-	vars, err := getVars()
+	jsctx, err := getJSContext()
 	if err != nil {
-		return false, fmt.Errorf("probe %q: get predicate vars: %w", probe.Id, err)
+		return false, fmt.Errorf("probe %q: get javascript context: %w", probe.Id, err)
 	}
 
-	ok, err := probe.If.GetValue(vars)
+	ok, err := probe.If.GetValue(jsctx)
 	if err != nil {
 		return false, fmt.Errorf("probe %q if.javascript: %w", probe.Id, err)
 	}

--- a/internal/core/connection_probe_test.go
+++ b/internal/core/connection_probe_test.go
@@ -52,10 +52,19 @@ func newConditionalProbeTestConnection(t *testing.T) *connection {
 	t.Helper()
 
 	conn := newTestConnection(cschema.Connector{
+		Javascript: `
+			function isEuRegion() {
+				return cfg.region === "eu";
+			}
+
+			function isSalesforceConnection() {
+				return labels["apxy/cxr/type"] === "salesforce";
+			}
+		`,
 		Probes: []cschema.Probe{
 			{
 				Id: "cfg_true",
-				If: &common.Predicate{Javascript: `cfg.region === "eu"`},
+				If: &common.Predicate{Javascript: `isEuRegion()`},
 			},
 			{
 				Id: "cfg_false",
@@ -63,7 +72,7 @@ func newConditionalProbeTestConnection(t *testing.T) *connection {
 			},
 			{
 				Id: "label_true",
-				If: &common.Predicate{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
+				If: &common.Predicate{Javascript: `isSalesforceConnection()`},
 			},
 			{
 				Id: "annotation_true",

--- a/internal/core/connection_setup_flow.go
+++ b/internal/core/connection_setup_flow.go
@@ -185,12 +185,12 @@ func newSchemaStepEligibility(c iface.Connection, spec *cschema.SetupFlowStep) f
 		return nil
 	}
 	return func(ctx context.Context) (bool, error) {
-		vars, err := c.GetPredicateVars(ctx)
+		jsCtx, err := c.GetJavascriptContext(ctx)
 		if err != nil {
-			return false, fmt.Errorf("step %q: get predicate vars: %w", spec.Id, err)
+			return false, fmt.Errorf("step %q: get javascript context: %w", spec.Id, err)
 		}
 
-		ok, err := spec.If.GetValue(vars)
+		ok, err := spec.If.GetValue(jsCtx)
 		if err != nil {
 			return false, fmt.Errorf("step %q if.javascript: %w", spec.Id, err)
 		}

--- a/internal/core/connection_setup_flow_test.go
+++ b/internal/core/connection_setup_flow_test.go
@@ -16,7 +16,7 @@ func TestManifestSetupFlowIfJavascript(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{
+	sf := &cschema.SetupFlow{
 		Configure: &cschema.SetupFlowPhase{
 			Steps: []cschema.SetupFlowStep{
 				{
@@ -27,7 +27,7 @@ func TestManifestSetupFlowIfJavascript(t *testing.T) {
 				{
 					Id:         "label_true",
 					JsonSchema: workspaceSchema,
-					If:         &common.Predicate{Javascript: `labels["apxy/cxr/type"] === "salesforce"`},
+					If:         &common.Predicate{Javascript: `isSalesforceConnection()`},
 				},
 				{
 					Id:         "annotation_true",
@@ -36,6 +36,15 @@ func TestManifestSetupFlowIfJavascript(t *testing.T) {
 				},
 			},
 		},
+	}
+	conn, _ := newTestConnectionWithSetupFlow(t, ctrl, sf)
+	conn.cv = NewTestConnectorVersion(cschema.Connector{
+		Javascript: `
+			function isSalesforceConnection() {
+				return labels["apxy/cxr/type"] === "salesforce";
+			}
+		`,
+		SetupFlow: sf,
 	})
 	setConnectionConfigFixture(t, conn, map[string]any{"region": "eu"})
 	conn.Labels = map[string]string{"apxy/cxr/type": "salesforce"}

--- a/internal/core/connector_version.go
+++ b/internal/core/connector_version.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -23,7 +24,13 @@ type ConnectorVersion struct {
 	s     *service
 	defMu sync.RWMutex
 	def   *cschema.Connector
-	l     *slog.Logger
+
+	jsMu     sync.RWMutex
+	jsLib    *apjs.Library
+	jsLibErr error
+	jsLoaded bool
+
+	l *slog.Logger
 }
 
 func wrapConnectorVersion(cv database.ConnectorVersion, s *service) *ConnectorVersion {
@@ -80,7 +87,14 @@ func (cv *ConnectorVersion) GetAnnotations() map[string]string {
 
 func (cv *ConnectorVersion) getDefinition() (*cschema.Connector, error) {
 	cv.defMu.RLock()
-	defer cv.defMu.RUnlock()
+	if cv.def != nil {
+		defer cv.defMu.RUnlock()
+		return cv.def, nil
+	}
+	cv.defMu.RUnlock()
+
+	cv.defMu.Lock()
+	defer cv.defMu.Unlock()
 	if cv.def == nil {
 		decrypted, err := cv.s.encrypt.DecryptString(context.Background(), cv.ConnectorVersion.EncryptedDefinition)
 		if err != nil {
@@ -100,22 +114,59 @@ func (cv *ConnectorVersion) getDefinition() (*cschema.Connector, error) {
 
 func (cv *ConnectorVersion) setDefinition(def *cschema.Connector) error {
 	cv.defMu.Lock()
-	defer cv.defMu.Unlock()
 
 	jsonBytes, err := json.Marshal(def)
 	if err != nil {
+		cv.defMu.Unlock()
 		return err
 	}
 
 	encrypted, err := cv.s.encrypt.EncryptStringForEntity(context.Background(), cv, string(jsonBytes))
 	if err != nil {
+		cv.defMu.Unlock()
 		return err
 	}
 	cv.Hash = def.Hash()
 	cv.ConnectorVersion.EncryptedDefinition = encrypted
 	cv.def = def
+	cv.defMu.Unlock()
+
+	cv.resetJavascriptLibrary()
 
 	return nil
+}
+
+func (c *ConnectorVersion) getJavascriptLibrary() (*apjs.Library, error) {
+	c.jsMu.RLock()
+	if c.jsLoaded {
+		defer c.jsMu.RUnlock()
+		return c.jsLib, c.jsLibErr
+	}
+	c.jsMu.RUnlock()
+
+	def, err := c.getDefinition()
+	if err != nil {
+		return nil, err
+	}
+	jsLib, jsLibErr := apjs.CompileLibrary(def.Javascript)
+
+	c.jsMu.Lock()
+	defer c.jsMu.Unlock()
+	if !c.jsLoaded {
+		c.jsLib = jsLib
+		c.jsLibErr = jsLibErr
+		c.jsLoaded = true
+	}
+
+	return c.jsLib, c.jsLibErr
+}
+
+func (c *ConnectorVersion) resetJavascriptLibrary() {
+	c.jsMu.Lock()
+	defer c.jsMu.Unlock()
+	c.jsLib = nil
+	c.jsLibErr = nil
+	c.jsLoaded = false
 }
 
 func (cv *ConnectorVersion) Logger() *slog.Logger {

--- a/internal/core/connector_version_test.go
+++ b/internal/core/connector_version_test.go
@@ -15,6 +15,7 @@ import (
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type namespaceHolder struct {
@@ -153,6 +154,29 @@ func TestConnectorVersion_SetDefinition(t *testing.T) {
 	assert.Equal(t, expectedHash, cv.Hash)
 	assert.Equal(t, newEncryptedDef, cv.EncryptedDefinition)
 	assert.Equal(t, def, cv.def)
+}
+
+func TestConnectorVersion_SetDefinitionResetsJavascriptLibrary(t *testing.T) {
+	cv := NewTestConnectorVersion(cschema.Connector{
+		Javascript: `function isUpdated() { return false; }`,
+	})
+
+	library, err := cv.getJavascriptLibrary()
+	require.NoError(t, err)
+	ok, err := library.NewContext(nil).EvaluateBoolean(`isUpdated()`)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	err = cv.setDefinition(&cschema.Connector{
+		Javascript: `function isUpdated() { return true; }`,
+	})
+	require.NoError(t, err)
+
+	library, err = cv.getJavascriptLibrary()
+	require.NoError(t, err)
+	ok, err = library.NewContext(nil).EvaluateBoolean(`isUpdated()`)
+	require.NoError(t, err)
+	assert.True(t, ok)
 }
 
 // NewTestConnectorVersion creates a new test connector version using provided connector configuration data.

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -30,7 +30,7 @@ type Connection interface {
 	GetAnnotations() map[string]string
 	GetSetupStep() *cschema.SetupStep
 	GetSetupError() *string
-	GetPredicateVars(ctx context.Context) (map[string]any, error)
+	GetJavascriptContext(ctx context.Context) (apjs.Context, error)
 
 	/*
 	 * Nested entities

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -15,20 +15,21 @@ import (
 )
 
 type Connection struct {
-	Id               apid.ID
-	Namespace        string
-	State            database.ConnectionState
-	HealthState      database.ConnectionHealthState
-	ConnectorId      apid.ID
-	ConnectorVersion uint64
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	DeletedAt        *time.Time
-	Labels           map[string]string
-	Annotations      map[string]string
-	SetupStep        *cschema.SetupStep
-	SetupError       *string
-	Configuration    map[string]any
+	Id                apid.ID
+	Namespace         string
+	State             database.ConnectionState
+	HealthState       database.ConnectionHealthState
+	ConnectorId       apid.ID
+	ConnectorVersion  uint64
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         *time.Time
+	Labels            map[string]string
+	Annotations       map[string]string
+	SetupStep         *cschema.SetupStep
+	SetupError        *string
+	Configuration     map[string]any
+	JavascriptLibrary *apjs.Library
 }
 
 func (m *Connection) GetId() apid.ID {
@@ -152,7 +153,7 @@ func (m *Connection) SetConfiguration(ctx context.Context, data map[string]any) 
 	return nil
 }
 
-func (m *Connection) GetPredicateVars(ctx context.Context) (map[string]any, error) {
+func (m *Connection) GetJavascriptContext(ctx context.Context) (apjs.Context, error) {
 	cfg := m.Configuration
 	if cfg == nil {
 		cfg = map[string]any{}
@@ -168,11 +169,14 @@ func (m *Connection) GetPredicateVars(ctx context.Context) (map[string]any, erro
 		annotations = map[string]string{}
 	}
 
-	return map[string]any{
-		"cfg":         cfg,
-		"labels":      labels,
-		"annotations": annotations,
-	}, nil
+	return apjs.NewContext(
+		m.JavascriptLibrary,
+		map[string]any{
+			"cfg":         cfg,
+			"labels":      labels,
+			"annotations": annotations,
+		},
+	), nil
 }
 
 func (m *Connection) GetMustacheContext(ctx context.Context) (map[string]any, error) {

--- a/internal/schema/common/predicate.go
+++ b/internal/schema/common/predicate.go
@@ -15,6 +15,10 @@ type Predicate struct {
 }
 
 func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
+	return p.ValidateWithContext(vc, apjs.NewContext(nil, vars))
+}
+
+func (p *Predicate) ValidateWithContext(vc *ValidationContext, jsctx apjs.Context) error {
 	if p == nil {
 		return nil
 	}
@@ -23,7 +27,7 @@ func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
 		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript is required"))
 		return result.ErrorOrNil()
 	}
-	if _, err := apjs.EvaluateBoolean(p.Javascript, vars); err != nil {
+	if _, err := jsctx.EvaluateBoolean(p.Javascript); err != nil {
 		result = multierror.Append(result, vc.NewErrorfForField("javascript", "javascript must evaluate to a boolean: %v", err))
 	}
 	return result.ErrorOrNil()
@@ -31,5 +35,11 @@ func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
 
 // GetValue returns the boolean value by evaluating the predicate's javascript.
 func (p *Predicate) GetValue(vars map[string]any) (bool, error) {
-	return apjs.EvaluateBoolean(p.Javascript, vars)
+	return p.GetValueWithContext(apjs.NewContext(nil, vars))
+}
+
+// GetValueWithContext returns the boolean value by evaluating the predicate's
+// javascript with a prebuilt JavaScript context.
+func (p *Predicate) GetValueWithContext(jsctx apjs.Context) (bool, error) {
+	return jsctx.EvaluateBoolean(p.Javascript)
 }

--- a/internal/schema/common/predicate.go
+++ b/internal/schema/common/predicate.go
@@ -29,13 +29,8 @@ func (p *Predicate) Validate(vc *ValidationContext, jsctx apjs.Context) error {
 	return result.ErrorOrNil()
 }
 
-// GetValue returns the boolean value by evaluating the predicate's javascript.
-func (p *Predicate) GetValue(vars map[string]any) (bool, error) {
-	return p.GetValueWithContext(apjs.NewContext(nil, vars))
-}
-
-// GetValueWithContext returns the boolean value by evaluating the predicate's
+// GetValue returns the boolean value by evaluating the predicate's
 // javascript with a prebuilt JavaScript context.
-func (p *Predicate) GetValueWithContext(jsctx apjs.Context) (bool, error) {
+func (p *Predicate) GetValue(jsctx apjs.Context) (bool, error) {
 	return jsctx.EvaluateBoolean(p.Javascript)
 }

--- a/internal/schema/common/predicate.go
+++ b/internal/schema/common/predicate.go
@@ -14,11 +14,7 @@ type Predicate struct {
 	Javascript string `json:"javascript" yaml:"javascript"`
 }
 
-func (p *Predicate) Validate(vc *ValidationContext, vars map[string]any) error {
-	return p.ValidateWithContext(vc, apjs.NewContext(nil, vars))
-}
-
-func (p *Predicate) ValidateWithContext(vc *ValidationContext, jsctx apjs.Context) error {
+func (p *Predicate) Validate(vc *ValidationContext, jsctx apjs.Context) error {
 	if p == nil {
 		return nil
 	}

--- a/internal/schema/common/predicate_test.go
+++ b/internal/schema/common/predicate_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,29 +14,38 @@ func TestPredicateValidate(t *testing.T) {
 			"cat": "meow",
 		},
 	}
+	jsctx := apjs.NewContext(nil, vars)
 
 	t.Run("accepts boolean result", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog === 'woof'`}
-		require.NoError(t, p.Validate(&ValidationContext{Path: "predicate"}, vars))
+		require.NoError(t, p.Validate(&ValidationContext{Path: "predicate"}, jsctx))
+	})
+
+	t.Run("accepts helper from context library", func(t *testing.T) {
+		library, err := apjs.CompileAndValidateLibrary(`function soundsLikeDog() { return sounds.dog === "woof"; }`)
+		require.NoError(t, err)
+
+		p := &Predicate{Javascript: `soundsLikeDog()`}
+		require.NoError(t, p.Validate(&ValidationContext{Path: "predicate"}, apjs.NewContext(library, vars)))
 	})
 
 	t.Run("rejects blank javascript", func(t *testing.T) {
 		p := &Predicate{Javascript: " \n\t "}
-		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		err := p.Validate(&ValidationContext{Path: "predicate"}, jsctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "predicate.javascript")
 	})
 
 	t.Run("rejects syntax errors", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog ===`}
-		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		err := p.Validate(&ValidationContext{Path: "predicate"}, jsctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must evaluate to a boolean")
 	})
 
 	t.Run("rejects non boolean results", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog`}
-		err := p.Validate(&ValidationContext{Path: "predicate"}, vars)
+		err := p.Validate(&ValidationContext{Path: "predicate"}, jsctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must evaluate to a boolean")
 	})

--- a/internal/schema/common/predicate_test.go
+++ b/internal/schema/common/predicate_test.go
@@ -58,36 +58,37 @@ func TestPredicateGetValue(t *testing.T) {
 			"cat": "meow",
 		},
 	}
+	jsctx := apjs.NewContext(nil, vars)
 
 	t.Run("returns true", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog === 'woof'`}
-		v, err := p.GetValue(vars)
+		v, err := p.GetValue(jsctx)
 		require.NoError(t, err)
 		require.True(t, v)
 	})
 
 	t.Run("returns false", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog === 'meow'`}
-		v, err := p.GetValue(vars)
+		v, err := p.GetValue(jsctx)
 		require.NoError(t, err)
 		require.False(t, v)
 	})
 
 	t.Run("errors on blank javascript", func(t *testing.T) {
 		p := &Predicate{Javascript: " \n\t "}
-		_, err := p.GetValue(vars)
+		_, err := p.GetValue(jsctx)
 		require.Error(t, err)
 	})
 
 	t.Run("errors on syntax errors", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog ===`}
-		_, err := p.GetValue(vars)
+		_, err := p.GetValue(jsctx)
 		require.Error(t, err)
 	})
 
 	t.Run("errors on non boolean results", func(t *testing.T) {
 		p := &Predicate{Javascript: `sounds.dog`}
-		_, err := p.GetValue(vars)
+		_, err := p.GetValue(jsctx)
 		require.Error(t, err)
 	})
 }

--- a/internal/schema/resources/connectors/auth_oauth2.go
+++ b/internal/schema/resources/connectors/auth_oauth2.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
@@ -170,6 +171,10 @@ func (a *AuthOAuth2) Clone() AuthImpl {
 // block, and the optional token_endpoint_auth_method selector and its
 // cross-field requirements on client_secret / PKCE.
 func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
+	return a.ValidateWithJavascript(vc, nil)
+}
+
+func (a *AuthOAuth2) ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error {
 	if a == nil {
 		return nil
 	}
@@ -250,7 +255,7 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 	}
 
 	for i := range a.Scopes {
-		if err := a.Scopes[i].Validate(vc.PushField("scopes").PushIndex(i)); err != nil {
+		if err := a.Scopes[i].ValidateWithJavascript(vc.PushField("scopes").PushIndex(i), library); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -289,3 +294,4 @@ func (a *AuthOAuth2) Validate(vc *common.ValidationContext) error {
 
 var _ AuthImpl = (*AuthOAuth2)(nil)
 var _ AuthValidator = (*AuthOAuth2)(nil)
+var _ AuthJavascriptValidator = (*AuthOAuth2)(nil)

--- a/internal/schema/resources/connectors/auth_oauth2_scope.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope.go
@@ -38,7 +38,7 @@ func (s *Scope) ValidateWithJavascript(vc *common.ValidationContext, library *ap
 	}
 	result := &multierror.Error{}
 	jsctx := connectorPredicateValidationContext(library)
-	if err := s.If.ValidateWithContext(vc.PushField("if"), jsctx); err != nil {
+	if err := s.If.Validate(vc.PushField("if"), jsctx); err != nil {
 		result = multierror.Append(result, err)
 	}
 	if err := s.Required.ValidateWithJavascript(vc.PushField("required"), library); err != nil {
@@ -126,7 +126,7 @@ func (r *ScopeRequired) ValidateWithJavascript(vc *common.ValidationContext, lib
 	}
 
 	if r.Predicate != nil {
-		return r.Predicate.ValidateWithContext(vc, connectorPredicateValidationContext(library))
+		return r.Predicate.Validate(vc, connectorPredicateValidationContext(library))
 	}
 
 	return nil

--- a/internal/schema/resources/connectors/auth_oauth2_scope.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope.go
@@ -18,14 +18,14 @@ type Scope struct {
 	Reason   string            `json:"reason" yaml:"reason"`
 }
 
-func (s *Scope) IsRequired(vars map[string]any) (bool, error) {
+func (s *Scope) IsRequired(jsctx apjs.Context) (bool, error) {
 	// If the attribute is not specified, scopes default to required.
 	if s == nil || s.Required == nil {
 		// If unspecified, assume required.
 		return true, nil
 	}
 
-	return s.Required.IsRequired(vars)
+	return s.Required.IsRequired(jsctx)
 }
 
 func (s *Scope) Validate(vc *common.ValidationContext) error {
@@ -75,7 +75,7 @@ func NewScopeRequiredPredicate(predicate *common.Predicate) *ScopeRequired {
 	return &ScopeRequired{Predicate: predicate}
 }
 
-func (r *ScopeRequired) IsRequired(vars map[string]any) (bool, error) {
+func (r *ScopeRequired) IsRequired(jsctx apjs.Context) (bool, error) {
 	if r == nil {
 		return true, nil
 	}
@@ -88,7 +88,7 @@ func (r *ScopeRequired) IsRequired(vars map[string]any) (bool, error) {
 		return false, fmt.Errorf("required must be a boolean or predicate object")
 	}
 
-	return r.Predicate.GetValue(vars)
+	return r.Predicate.GetValue(jsctx)
 }
 
 func (r *ScopeRequired) Clone() *ScopeRequired {

--- a/internal/schema/resources/connectors/auth_oauth2_scope.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"gopkg.in/yaml.v3"
 )
@@ -28,14 +29,19 @@ func (s *Scope) IsRequired(vars map[string]any) (bool, error) {
 }
 
 func (s *Scope) Validate(vc *common.ValidationContext) error {
+	return s.ValidateWithJavascript(vc, nil)
+}
+
+func (s *Scope) ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error {
 	if s == nil {
 		return nil
 	}
 	result := &multierror.Error{}
-	if err := s.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
+	jsctx := connectorPredicateValidationContext(library)
+	if err := s.If.ValidateWithContext(vc.PushField("if"), jsctx); err != nil {
 		result = multierror.Append(result, err)
 	}
-	if err := s.Required.Validate(vc.PushField("required")); err != nil {
+	if err := s.Required.ValidateWithJavascript(vc.PushField("required"), library); err != nil {
 		result = multierror.Append(result, err)
 	}
 	return result.ErrorOrNil()
@@ -102,6 +108,10 @@ func (r *ScopeRequired) Clone() *ScopeRequired {
 }
 
 func (r *ScopeRequired) Validate(vc *common.ValidationContext) error {
+	return r.ValidateWithJavascript(vc, nil)
+}
+
+func (r *ScopeRequired) ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error {
 	// The scope will default to required.
 	if r == nil {
 		return nil
@@ -116,7 +126,7 @@ func (r *ScopeRequired) Validate(vc *common.ValidationContext) error {
 	}
 
 	if r.Predicate != nil {
-		return r.Predicate.Validate(vc, connectorPredicateValidationVars())
+		return r.Predicate.ValidateWithContext(vc, connectorPredicateValidationContext(library))
 	}
 
 	return nil

--- a/internal/schema/resources/connectors/auth_oauth2_scope_test.go
+++ b/internal/schema/resources/connectors/auth_oauth2_scope_test.go
@@ -1,6 +1,7 @@
 package connectors
 
 import (
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -23,7 +24,7 @@ reason: |
 			assert.NoError(err)
 			assert.Equal("https://www.googleapis.com/auth/drive.readonly", scope.Id)
 			assert.Equal("We need to be able to view the files\n", scope.Reason)
-			required, err := scope.IsRequired(nil)
+			required, err := scope.IsRequired(apjs.Context{})
 			assert.NoError(err)
 			assert.True(required)
 		})
@@ -37,7 +38,7 @@ reason: We need to be able to view the files
 			assert.NoError(err)
 			assert.Equal("https://www.googleapis.com/auth/drive.readonly", scope.Id)
 			assert.Equal("We need to be able to view the files", scope.Reason)
-			required, err := scope.IsRequired(nil)
+			required, err := scope.IsRequired(apjs.Context{})
 			assert.NoError(err)
 			assert.False(required)
 		})
@@ -53,14 +54,14 @@ reason: We need to be able to see what's been going on in drive
 			require.NotNil(t, scope.Required)
 			require.NotNil(t, scope.Required.Predicate)
 			assert.Equal("cfg.sync_activity === true", scope.Required.Predicate.Javascript)
-			required, err := scope.IsRequired(map[string]any{
+			required, err := scope.IsRequired(apjs.NewContext(nil, map[string]any{
 				"cfg": map[string]any{"sync_activity": true},
-			})
+			}))
 			assert.NoError(err)
 			assert.True(required)
-			required, err = scope.IsRequired(map[string]any{
+			required, err = scope.IsRequired(apjs.NewContext(nil, map[string]any{
 				"cfg": map[string]any{"sync_activity": false},
-			})
+			}))
 			assert.NoError(err)
 			assert.False(required)
 		})

--- a/internal/schema/resources/connectors/auth_validator.go
+++ b/internal/schema/resources/connectors/auth_validator.go
@@ -1,10 +1,19 @@
 package connectors
 
-import "github.com/rmorlok/authproxy/internal/schema/common"
+import (
+	"github.com/rmorlok/authproxy/internal/apjs"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
 
 // AuthValidator is implemented by Auth concrete types that have schema invariants
 // to enforce. Connector.Validate type-asserts on this interface so an auth type
 // without invariants (e.g. NoAuth) doesn't need to declare an empty Validate.
 type AuthValidator interface {
 	Validate(vc *common.ValidationContext) error
+}
+
+// AuthJavascriptValidator is implemented by auth concrete types whose
+// validation evaluates connector-authored JavaScript predicates.
+type AuthJavascriptValidator interface {
+	ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error
 }

--- a/internal/schema/resources/connectors/connector.go
+++ b/internal/schema/resources/connectors/connector.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
@@ -67,6 +68,10 @@ type Connector struct {
 	// documentation for each struct for more details.
 	Auth *Auth `json:"auth" yaml:"auth"`
 
+	// Javascript is connector-level JavaScript that defines shared constants
+	// and functions available to connector-authored predicates and transforms.
+	Javascript string `json:"javascript,omitempty" yaml:"javascript,omitempty"`
+
 	// RateLimiting configures how 429 rate limiting responses from the 3rd party are handled.
 	// If unset, default behavior is enabled (parse Retry-After header, 60s default backoff).
 	RateLimiting *RateLimiting `json:"rate_limiting,omitempty" yaml:"rate_limiting,omitempty"`
@@ -119,6 +124,11 @@ func (c *Connector) Clone() *Connector {
 
 func (c *Connector) Validate(vc *common.ValidationContext) error {
 	result := &multierror.Error{}
+	javascript, err := apjs.CompileAndValidateLibrary(c.Javascript)
+	if err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("javascript", "invalid connector javascript: %v", err))
+		javascript = nil
+	}
 
 	if c.State != "" {
 		if c.State != "draft" && c.State != "primary" {
@@ -139,7 +149,11 @@ func (c *Connector) Validate(vc *common.ValidationContext) error {
 	}
 
 	if c.Auth != nil {
-		if av, ok := c.Auth.Inner().(AuthValidator); ok {
+		if av, ok := c.Auth.Inner().(AuthJavascriptValidator); ok {
+			if err := av.ValidateWithJavascript(vc.PushField("auth"), javascript); err != nil {
+				result = multierror.Append(result, err)
+			}
+		} else if av, ok := c.Auth.Inner().(AuthValidator); ok {
 			if err := av.Validate(vc.PushField("auth")); err != nil {
 				result = multierror.Append(result, err)
 			}
@@ -147,13 +161,13 @@ func (c *Connector) Validate(vc *common.ValidationContext) error {
 	}
 
 	for i, probe := range c.Probes {
-		if err := probe.Validate(vc.PushField("probes").PushIndex(i)); err != nil {
+		if err := probe.ValidateWithJavascript(vc.PushField("probes").PushIndex(i), javascript); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
 
 	if c.SetupFlow != nil {
-		if err := c.SetupFlow.Validate(vc.PushField("setup_flow")); err != nil {
+		if err := c.SetupFlow.ValidateWithJavascript(vc.PushField("setup_flow"), javascript); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/internal/schema/resources/connectors/connector_javascript_test.go
+++ b/internal/schema/resources/connectors/connector_javascript_test.go
@@ -1,0 +1,123 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectorJavascriptValidation(t *testing.T) {
+	t.Run("helpers are available to connector predicates", func(t *testing.T) {
+		connector := Connector{
+			Javascript: `
+				function isEnabled(cfg) {
+					return cfg.enabled === true;
+				}
+
+				function isProd(labels) {
+					return labels.env === "prod";
+				}
+
+				function hasAdvancedSetup(annotations) {
+					return annotations["setup-mode"] === "advanced";
+				}
+			`,
+			Auth: testOAuth2AuthWithScopes([]Scope{
+				{
+					Id:       "read",
+					If:       &common.Predicate{Javascript: `isEnabled(cfg)`},
+					Required: NewScopeRequiredPredicate(&common.Predicate{Javascript: `isProd(labels)`}),
+					Reason:   "Read access",
+				},
+			}),
+			SetupFlow: &SetupFlow{
+				Configure: &SetupFlowPhase{
+					Steps: []SetupFlowStep{
+						{
+							Id:         "advanced",
+							If:         &common.Predicate{Javascript: `hasAdvancedSetup(annotations)`},
+							JsonSchema: common.RawJSON(`{"type":"object","properties":{"enabled":{"type":"boolean"}}}`),
+						},
+					},
+				},
+			},
+			Probes: []Probe{
+				{
+					Id:   "enabled",
+					If:   &common.Predicate{Javascript: `isEnabled(cfg)`},
+					Http: &ProbeHttp{Method: "GET", URL: "https://example.com/health"},
+				},
+			},
+		}
+
+		require.NoError(t, connector.Validate(&common.ValidationContext{}))
+	})
+
+	t.Run("top level javascript must compile and run", func(t *testing.T) {
+		connector := Connector{
+			Javascript: `throw new Error("boom")`,
+			Auth:       &Auth{InnerVal: &AuthNoAuth{Type: AuthTypeNoAuth}},
+		}
+
+		err := connector.Validate(&common.ValidationContext{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "javascript: invalid connector javascript")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("helpers are unavailable when connector javascript is absent", func(t *testing.T) {
+		connector := Connector{
+			Auth: &Auth{InnerVal: &AuthNoAuth{Type: AuthTypeNoAuth}},
+			SetupFlow: &SetupFlow{
+				Configure: &SetupFlowPhase{
+					Steps: []SetupFlowStep{
+						{
+							Id:         "advanced",
+							If:         &common.Predicate{Javascript: `isEnabled(cfg)`},
+							JsonSchema: common.RawJSON(`{"type":"object","properties":{"enabled":{"type":"boolean"}}}`),
+						},
+					},
+				},
+			},
+		}
+
+		err := connector.Validate(&common.ValidationContext{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "setup_flow.configure.steps[0].if.javascript")
+		assert.Contains(t, err.Error(), "isEnabled is not defined")
+	})
+
+	t.Run("reserved runtime variable declarations are rejected", func(t *testing.T) {
+		connector := Connector{
+			Javascript: `const cfg = {}`,
+			Auth:       &Auth{InnerVal: &AuthNoAuth{Type: AuthTypeNoAuth}},
+		}
+
+		err := connector.Validate(&common.ValidationContext{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `reserved runtime variable "cfg"`)
+	})
+}
+
+func testOAuth2AuthWithScopes(scopes []Scope) *Auth {
+	return &Auth{
+		InnerVal: &AuthOAuth2{
+			Type: AuthTypeOAuth2,
+			ClientId: &common.StringValue{InnerVal: &common.StringValueDirect{
+				Value: "client-id",
+			}},
+			ClientSecret: &common.StringValue{InnerVal: &common.StringValueDirect{
+				Value: "client-secret",
+			}},
+			Authorization: AuthOauth2Authorization{
+				Endpoint: "https://example.com/oauth/authorize",
+			},
+			Token: AuthOauth2Token{
+				Endpoint: "https://example.com/oauth/token",
+			},
+			Scopes: scopes,
+		},
+	}
+}

--- a/internal/schema/resources/connectors/predicate.go
+++ b/internal/schema/resources/connectors/predicate.go
@@ -1,5 +1,7 @@
 package connectors
 
+import "github.com/rmorlok/authproxy/internal/apjs"
+
 // connectorPredicateValidationVars returns the variables that are needed to run the javascript that is
 // used in predicates for connector related values (setup steps, oauth scopes, etc). This just returns
 // empty variables for all the required variable names.
@@ -9,4 +11,8 @@ func connectorPredicateValidationVars() map[string]any {
 		"labels":      map[string]string{},
 		"annotations": map[string]string{},
 	}
+}
+
+func connectorPredicateValidationContext(library *apjs.Library) apjs.Context {
+	return apjs.NewContext(library, connectorPredicateValidationVars())
 }

--- a/internal/schema/resources/connectors/probe.go
+++ b/internal/schema/resources/connectors/probe.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/robfig/cron/v3"
 )
@@ -78,6 +79,10 @@ func (p *Probe) EffectiveRecoveryThreshold() int {
 }
 
 func (p *Probe) Validate(vc *common.ValidationContext) error {
+	return p.ValidateWithJavascript(vc, nil)
+}
+
+func (p *Probe) ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error {
 	result := &multierror.Error{}
 
 	typeCount := 0
@@ -92,7 +97,7 @@ func (p *Probe) Validate(vc *common.ValidationContext) error {
 		result = multierror.Append(result, vc.NewErrorf("exactly one of proxy_http or http must be defined"))
 	}
 
-	if err := p.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
+	if err := p.If.ValidateWithContext(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/schema/resources/connectors/probe.go
+++ b/internal/schema/resources/connectors/probe.go
@@ -97,7 +97,7 @@ func (p *Probe) ValidateWithJavascript(vc *common.ValidationContext, library *ap
 		result = multierror.Append(result, vc.NewErrorf("exactly one of proxy_http or http must be defined"))
 	}
 
-	if err := p.If.ValidateWithContext(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
+	if err := p.If.Validate(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -283,6 +283,9 @@
         { "$ref": "#/$defs/AuthNoAuth" }
       ]
     },
+    "javascript": {
+      "type": "string"
+    },
     "probes": {
       "type": "array",
       "items": {

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -11,6 +11,7 @@ import (
 	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
 	"gopkg.in/yaml.v3"
 
+	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -32,6 +33,10 @@ type SetupFlow struct {
 }
 
 func (sf *SetupFlow) Validate(vc *common.ValidationContext) error {
+	return sf.ValidateWithJavascript(vc, nil)
+}
+
+func (sf *SetupFlow) ValidateWithJavascript(vc *common.ValidationContext, library *apjs.Library) error {
 	if sf == nil {
 		return nil
 	}
@@ -42,13 +47,13 @@ func (sf *SetupFlow) Validate(vc *common.ValidationContext) error {
 	seenIds := make(map[string]bool)
 
 	if sf.Preconnect != nil {
-		if err := sf.Preconnect.Validate(vc.PushField("preconnect"), seenIds, false); err != nil {
+		if err := sf.Preconnect.validate(vc.PushField("preconnect"), seenIds, false, library); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
 
 	if sf.Configure != nil {
-		if err := sf.Configure.Validate(vc.PushField("configure"), seenIds, true); err != nil {
+		if err := sf.Configure.validate(vc.PushField("configure"), seenIds, true, library); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -299,6 +304,10 @@ type SetupFlowPhase struct {
 }
 
 func (p *SetupFlowPhase) Validate(vc *common.ValidationContext, seenIds map[string]bool, allowDataSources bool) error {
+	return p.validate(vc, seenIds, allowDataSources, nil)
+}
+
+func (p *SetupFlowPhase) validate(vc *common.ValidationContext, seenIds map[string]bool, allowDataSources bool, library *apjs.Library) error {
 	if p == nil {
 		return nil
 	}
@@ -311,7 +320,7 @@ func (p *SetupFlowPhase) Validate(vc *common.ValidationContext, seenIds map[stri
 
 	for i := range p.Steps {
 		step := &p.Steps[i]
-		if err := step.Validate(vc.PushField("steps").PushIndex(i), seenIds, allowDataSources); err != nil {
+		if err := step.validate(vc.PushField("steps").PushIndex(i), seenIds, allowDataSources, library); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -421,6 +430,10 @@ func (r *SetupFlowStepRedirect) Validate(vc *common.ValidationContext) error {
 }
 
 func (s *SetupFlowStep) Validate(vc *common.ValidationContext, seenIds map[string]bool, allowDataSources bool) error {
+	return s.validate(vc, seenIds, allowDataSources, nil)
+}
+
+func (s *SetupFlowStep) validate(vc *common.ValidationContext, seenIds map[string]bool, allowDataSources bool, library *apjs.Library) error {
 	result := &multierror.Error{}
 
 	if s.Id == "" {
@@ -437,7 +450,7 @@ func (s *SetupFlowStep) Validate(vc *common.ValidationContext, seenIds map[strin
 		result = multierror.Append(result, vc.NewErrorfForField("type", "type must be %q or %q (got %q)", SetupFlowStepTypeForm, SetupFlowStepTypeRedirect, s.Type))
 	}
 
-	if err := s.If.Validate(vc.PushField("if"), connectorPredicateValidationVars()); err != nil {
+	if err := s.If.ValidateWithContext(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -450,7 +450,7 @@ func (s *SetupFlowStep) validate(vc *common.ValidationContext, seenIds map[strin
 		result = multierror.Append(result, vc.NewErrorfForField("type", "type must be %q or %q (got %q)", SetupFlowStepTypeForm, SetupFlowStepTypeRedirect, s.Type))
 	}
 
-	if err := s.If.ValidateWithContext(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
+	if err := s.If.Validate(vc.PushField("if"), connectorPredicateValidationContext(library)); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-javascript.yaml
+++ b/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-javascript.yaml
@@ -1,0 +1,38 @@
+# $schema: ./schema.json
+
+labels:
+  type: calendar-js
+display_name: Calendar JS
+logo:
+  public_url: https://example.com/calendar-logo.png
+description: |
+  OAuth2 connector fixture with connector-level JavaScript helpers.
+auth:
+  type: OAuth2
+  client_id:
+    env_var: CALENDAR_CLIENT_ID
+  client_secret:
+    env_var: CALENDAR_CLIENT_SECRET
+  authorization:
+    endpoint: https://example.com/oauth/authorize
+  token:
+    endpoint: https://example.com/oauth/token
+  scopes:
+    - id: calendar.read
+      reason: Read calendars
+javascript: |
+  function isPersonalCalendar(cfg) {
+    return cfg.calendar_id === "personal";
+  }
+setup_flow:
+  configure:
+    steps:
+      - id: select_calendar
+        title: Select Calendar
+        json_schema:
+          type: object
+          properties:
+            calendar_id:
+              type: string
+        if:
+          javascript: isPersonalCalendar(cfg)


### PR DESCRIPTION
Closes #670
Closes #671
Closes #672

## Summary
- Add top-level connector `javascript` field and JSON schema support.
- Validate connector JavaScript at definition validation time and pass the compiled library into connector predicate validation.
- Replace connection predicate vars with `GetJavascriptContext`, backed by a cached connector-version JS library.
- Evaluate setup-step, probe, OAuth scope, and data-source transform JavaScript through the shared context with `cfg`, `labels`, `annotations`, and `data` where applicable.

## Tests
- `go test ./internal/schema/common ./internal/schema/resources/connectors ./internal/core ./internal/auth_methods/oauth2`
- `./scripts/preflight.sh`