### PR TITLE
Treat non-global DEK generation errors as nonfatal

### DIFF
--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -127,9 +127,11 @@ func generateDataEncryptionKeysToDatabase(
 	db database.DB,
 	logger *slog.Logger,
 	redis apredis.Client,
+	opts ...GenerateDataEncryptionKeysOption,
 ) error {
 	logger.Info("generating data encryption keys")
 	defer logger.Info("generating data encryption keys complete")
+	options := newGenerateDataEncryptionKeysOptions(opts)
 
 	if redis != nil {
 		m := apredis.NewMutex(
@@ -164,9 +166,16 @@ func generateDataEncryptionKeysToDatabase(
 	policy := sa.DataEncryptionKeys
 	// key material id -> plaintext DEK for decrypting child key data.
 	keyMaterialDataCache := make(map[apid.ID]config.KeyVersionInfo)
+	globalKey := &database.Key{
+		Id:           globalEncryptionKeyID,
+		Usage:        database.KeyUsageDataEncryption,
+		MaterialType: database.KeyMaterialTypeSymmetric,
+		State:        database.KeyStateActive,
+	}
 
 	generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, globalEncryptionKeyID, sa.GlobalAESKey)
 	if err != nil {
+		options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonGlobalReconcile, globalKey, sa.GlobalAESKey.GetProviderType())
 		result = multierror.Append(result, errors.Wrap(err, "failed to reconcile data encryption key for global key"))
 	} else {
 		if generated {
@@ -175,6 +184,7 @@ func generateDataEncryptionKeysToDatabase(
 	}
 	err = cacheDataEncryptionKeysForKey(ctx, db, keyMaterialDataCache, globalEncryptionKeyID, sa.GlobalAESKey)
 	if err != nil {
+		options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonGlobalCache, globalKey, sa.GlobalAESKey.GetProviderType())
 		result = multierror.Append(result, errors.Wrap(err, "failed to cache global data encryption keys"))
 	}
 
@@ -190,6 +200,7 @@ func generateDataEncryptionKeysToDatabase(
 			ef := key.EncryptedKeyData
 			kvi, ok := keyMaterialDataCache[ef.ID]
 			if !ok {
+				options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonMissingWrapping, key, "")
 				logger.Warn("key wrapping material not found, skipping data encryption key reconciliation",
 					"key_id", key.Id,
 					"namespace", key.Namespace,
@@ -200,6 +211,7 @@ func generateDataEncryptionKeysToDatabase(
 
 			decodedData, err := base64.StdEncoding.DecodeString(ef.Data)
 			if err != nil {
+				options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonDecodeEncryptedKey, key, "")
 				logger.Warn("failed to decode encrypted key data, skipping data encryption key reconciliation",
 					"key_id", key.Id,
 					"namespace", key.Namespace,
@@ -210,6 +222,7 @@ func generateDataEncryptionKeysToDatabase(
 
 			decryptedData, err := decryptWithKey(kvi.Data, decodedData)
 			if err != nil {
+				options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonDecryptKeyData, key, "")
 				logger.Warn("failed to decrypt key data, skipping data encryption key reconciliation",
 					"key_id", key.Id,
 					"namespace", key.Namespace,
@@ -222,6 +235,7 @@ func generateDataEncryptionKeysToDatabase(
 			var keyData config.KeyData
 			err = json.Unmarshal(decryptedData, &keyData)
 			if err != nil {
+				options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonUnmarshalKeyData, key, "")
 				logger.Warn("failed to unmarshal key data, skipping data encryption key reconciliation",
 					"key_id", key.Id,
 					"namespace", key.Namespace,
@@ -233,6 +247,7 @@ func generateDataEncryptionKeysToDatabase(
 			if shouldManageDataEncryptionKeysForKey(key) {
 				generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, key.Id, &keyData)
 				if err != nil {
+					options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonReconcile, key, keyData.GetProviderType())
 					logger.Warn("failed to reconcile data encryption key for key",
 						"key_id", key.Id,
 						"namespace", key.Namespace,
@@ -245,6 +260,7 @@ func generateDataEncryptionKeysToDatabase(
 
 			err = cacheDataEncryptionKeysForKey(ctx, db, keyMaterialDataCache, key.Id, &keyData)
 			if err != nil {
+				options.telemetry.recordDEKGenerationFailure(ctx, dekGenerationFailureReasonCache, key, keyData.GetProviderType())
 				logger.Warn("failed to cache data encryption keys for key",
 					"key_id", key.Id,
 					"namespace", key.Namespace,
@@ -269,7 +285,14 @@ func generateDataEncryptionKeysToDatabase(
 }
 
 func (h *EncryptServiceTaskHandler) handleGenerateDataEncryptionKeys(ctx context.Context, _ *asynq.Task) error {
-	return generateDataEncryptionKeysToDatabase(ctx, h.cfg, h.db, h.logger, h.redis)
+	return generateDataEncryptionKeysToDatabase(
+		ctx,
+		h.cfg,
+		h.db,
+		h.logger,
+		h.redis,
+		WithGenerateDataEncryptionKeysTelemetry(h.dataEncryptionKeyTelemetry),
+	)
 }
 
 // GenerateDataEncryptionKeysToDatabase reconciles current DEKs for configured
@@ -280,6 +303,7 @@ func GenerateDataEncryptionKeysToDatabase(
 	db database.DB,
 	logger *slog.Logger,
 	redis apredis.Client,
+	opts ...GenerateDataEncryptionKeysOption,
 ) error {
-	return generateDataEncryptionKeysToDatabase(ctx, cfg, db, logger, redis)
+	return generateDataEncryptionKeysToDatabase(ctx, cfg, db, logger, redis, opts...)
 }

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -191,43 +190,66 @@ func generateDataEncryptionKeysToDatabase(
 			ef := key.EncryptedKeyData
 			kvi, ok := keyMaterialDataCache[ef.ID]
 			if !ok {
-				result = multierror.Append(result, fmt.Errorf("key material info not found for key ID %s key material %s", key.Id, ef.ID))
+				logger.Warn("key wrapping material not found, skipping data encryption key reconciliation",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"data_encryption_key_id", ef.ID,
+				)
 				continue
 			}
 
 			decodedData, err := base64.StdEncoding.DecodeString(ef.Data)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to decode base64 string for key id %s", key.Id))
+				logger.Warn("failed to decode encrypted key data, skipping data encryption key reconciliation",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 
 			decryptedData, err := decryptWithKey(kvi.Data, decodedData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to decrypt key id %s with key data from %s", key.Id, ef.ID))
+				logger.Warn("failed to decrypt key data, skipping data encryption key reconciliation",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"data_encryption_key_id", ef.ID,
+					"error", err,
+				)
 				continue
 			}
 
 			var keyData config.KeyData
 			err = json.Unmarshal(decryptedData, &keyData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to unmarshal key data for key ID %s", key.Id))
+				logger.Warn("failed to unmarshal key data, skipping data encryption key reconciliation",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 
 			if shouldManageDataEncryptionKeysForKey(key) {
 				generated, err := ensureDataEncryptionKeyForKey(ctx, db, policy, key.Id, &keyData)
 				if err != nil {
-					result = multierror.Append(result, errors.Wrapf(err, "failed to reconcile data encryption key for key ID %s", key.Id))
-					continue
-				}
-				if generated {
+					logger.Warn("failed to reconcile data encryption key for key",
+						"key_id", key.Id,
+						"namespace", key.Namespace,
+						"error", err,
+					)
+				} else if generated {
 					logger.Info("generated data encryption key", "key_id", key.Id)
 				}
 			}
 
 			err = cacheDataEncryptionKeysForKey(ctx, db, keyMaterialDataCache, key.Id, &keyData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to cache data encryption keys for key ID %s", key.Id))
+				logger.Warn("failed to cache data encryption keys for key",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 		}

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -164,6 +164,28 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Equal(t, rootKeyID, *root.KeyId)
 	})
 
+	t.Run("returns global provider errors without creating partial dek", func(t *testing.T) {
+		sconfig.ResetKeyDataMockKMSRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockKMSRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMockKMS("global-kms-error")
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+		err := generateDataEncryptionKeysToDatabase(ctx, cfg, db, slog.Default(), nil)
+		require.ErrorContains(t, err, "failed to reconcile data encryption key for global key")
+		require.ErrorContains(t, err, "no current version")
+
+		globalDEKs, listErr := db.ListDataEncryptionKeysForKey(ctx, globalEncryptionKeyID)
+		require.NoError(t, listErr)
+		require.Empty(t, globalDEKs)
+	})
+
 	t.Run("creates first dek without changing wrapping sync state", func(t *testing.T) {
 		env := setupMockKMSGenerateTest(t, true)
 
@@ -276,11 +298,11 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Len(t, deks, 1)
 	})
 
-	t.Run("returns provider errors without creating partial dek", func(t *testing.T) {
+	t.Run("logs provider errors without creating partial dek", func(t *testing.T) {
 		env := setupMockKMSGenerateTest(t, false)
 
 		err := generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
-		require.ErrorContains(t, err, "no current version")
+		require.NoError(t, err)
 
 		deks, listErr := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
 		require.NoError(t, listErr)
@@ -291,11 +313,11 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Len(t, globalDEKs, 1)
 	})
 
-	t.Run("returns fallback provider errors without creating partial dek", func(t *testing.T) {
+	t.Run("logs fallback provider errors without creating partial dek", func(t *testing.T) {
 		env := setupMockSecretGenerateTest(t, []byte("bad"))
 
 		err := generateDataEncryptionKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
-		require.ErrorContains(t, err, "failed to create DEK wrapping cipher")
+		require.NoError(t, err)
 
 		deks, listErr := env.db.ListDataEncryptionKeysForKey(env.ctx, env.ekID)
 		require.NoError(t, listErr)

--- a/internal/encrypt/task_generate_data_encryption_keys_test.go
+++ b/internal/encrypt/task_generate_data_encryption_keys_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -313,6 +318,39 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.Len(t, globalDEKs, 1)
 	})
 
+	t.Run("records non-global provider errors as metrics", func(t *testing.T) {
+		env := setupMockKMSGenerateTest(t, false)
+		reader := sdkmetric.NewManualReader()
+		providers := &aptelemetry.Providers{
+			Enabled:       true,
+			MeterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		}
+		tel, err := NewDataEncryptionKeyTelemetry(providers, telemetryMetricsEnabledConfig())
+		require.NoError(t, err)
+
+		err = generateDataEncryptionKeysToDatabase(
+			env.ctx,
+			env.cfg,
+			env.db,
+			env.logger,
+			nil,
+			WithGenerateDataEncryptionKeysTelemetry(tel),
+		)
+		require.NoError(t, err)
+
+		rm := metricdata.ResourceMetrics{}
+		require.NoError(t, reader.Collect(env.ctx, &rm))
+		dp := requireInt64SumDataPoint(t, rm, metricDataEncryptionKeyGenerationFailures)
+		require.Equal(t, int64(1), dp.Value)
+		attrs := metricAttrMap(dp.Attributes.ToSlice())
+		require.Equal(t, dekGenerationFailureReasonReconcile, attrs[attrDEKGenerationFailureReason])
+		require.Equal(t, dekGenerationKeyScopeNonGlobal, attrs[attrDEKGenerationKeyScope])
+		require.Equal(t, string(database.KeyUsageDataEncryption), attrs[attrKeyUsage])
+		require.Equal(t, string(database.KeyMaterialTypeSymmetric), attrs[attrKeyMaterialType])
+		require.Equal(t, string(database.KeyStateActive), attrs[attrKeyState])
+		require.Equal(t, string(sconfig.ProviderTypeMockKMS), attrs[attrKeyProviderType])
+	})
+
 	t.Run("logs fallback provider errors without creating partial dek", func(t *testing.T) {
 		env := setupMockSecretGenerateTest(t, []byte("bad"))
 
@@ -323,4 +361,50 @@ func TestGenerateDataEncryptionKeysToDatabase(t *testing.T) {
 		require.NoError(t, listErr)
 		require.Empty(t, deks)
 	})
+}
+
+func telemetryMetricsEnabledConfig() *sconfig.Telemetry {
+	enabled := true
+	return &sconfig.Telemetry{
+		Enabled: &enabled,
+		Signals: &sconfig.TelemetrySignals{
+			Metrics: &enabled,
+		},
+	}
+}
+
+func requireInt64SumDataPoint(
+	t *testing.T,
+	rm metricdata.ResourceMetrics,
+	name string,
+) metricdata.DataPoint[int64] {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %q should be int64 sum, got %T", name, m.Data)
+			require.Len(t, sum.DataPoints, 1)
+			return sum.DataPoints[0]
+		}
+	}
+
+	var names []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names = append(names, m.Name)
+		}
+	}
+	t.Fatalf("metric %q not emitted; got: %v", name, names)
+	return metricdata.DataPoint[int64]{}
+}
+
+func metricAttrMap(kvs []attribute.KeyValue) map[string]any {
+	out := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		out[string(kv.Key)] = kv.Value.AsInterface()
+	}
+	return out
 }

--- a/internal/encrypt/tasks.go
+++ b/internal/encrypt/tasks.go
@@ -10,11 +10,12 @@ import (
 )
 
 type EncryptServiceTaskHandler struct {
-	cfg    config.C
-	db     database.DB
-	enc    E
-	redis  apredis.Client
-	logger *slog.Logger
+	cfg                        config.C
+	db                         database.DB
+	enc                        E
+	redis                      apredis.Client
+	logger                     *slog.Logger
+	dataEncryptionKeyTelemetry *DataEncryptionKeyTelemetry
 }
 
 func (h *EncryptServiceTaskHandler) RegisterTasks(mux *asynq.ServeMux) {
@@ -46,12 +47,27 @@ func NewEncryptServiceTaskHandler(
 	enc E,
 	redis apredis.Client,
 	logger *slog.Logger,
+	opts ...EncryptServiceTaskHandlerOption,
 ) *EncryptServiceTaskHandler {
-	return &EncryptServiceTaskHandler{
+	h := &EncryptServiceTaskHandler{
 		cfg:    cfg,
 		db:     db,
 		enc:    enc,
 		redis:  redis,
 		logger: logger,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(h)
+		}
+	}
+	return h
+}
+
+type EncryptServiceTaskHandlerOption func(*EncryptServiceTaskHandler)
+
+func WithDataEncryptionKeyTelemetry(tel *DataEncryptionKeyTelemetry) EncryptServiceTaskHandlerOption {
+	return func(h *EncryptServiceTaskHandler) {
+		h.dataEncryptionKeyTelemetry = tel
 	}
 }

--- a/internal/encrypt/telemetry.go
+++ b/internal/encrypt/telemetry.go
@@ -1,0 +1,142 @@
+package encrypt
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	"github.com/rmorlok/authproxy/internal/database"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+const (
+	encryptTelemetryInstrumentationName = "github.com/rmorlok/authproxy/internal/encrypt"
+
+	metricDataEncryptionKeyGenerationFailures = "authproxy.encrypt.dek_generation.failures"
+
+	attrDEKGenerationFailureReason = "authproxy.encrypt.failure_reason"
+	attrDEKGenerationKeyScope      = "authproxy.encrypt.key_scope"
+	attrKeyUsage                   = "authproxy.key.usage"
+	attrKeyMaterialType            = "authproxy.key.material_type"
+	attrKeyState                   = "authproxy.key.state"
+	attrKeyProviderType            = "authproxy.key.provider_type"
+
+	dekGenerationKeyScopeGlobal    = "global"
+	dekGenerationKeyScopeNonGlobal = "non_global"
+
+	dekGenerationProviderUnknown = "unknown"
+
+	dekGenerationFailureReasonGlobalReconcile    = "global_reconcile_failed"
+	dekGenerationFailureReasonGlobalCache        = "global_cache_failed"
+	dekGenerationFailureReasonMissingWrapping    = "missing_wrapping_material"
+	dekGenerationFailureReasonDecodeEncryptedKey = "decode_encrypted_key_data_failed"
+	dekGenerationFailureReasonDecryptKeyData     = "decrypt_key_data_failed"
+	dekGenerationFailureReasonUnmarshalKeyData   = "unmarshal_key_data_failed"
+	dekGenerationFailureReasonReconcile          = "reconcile_dek_failed"
+	dekGenerationFailureReasonCache              = "cache_dek_failed"
+)
+
+// DataEncryptionKeyTelemetry owns OTel metrics emitted by the encrypt package.
+// A zero-value or nil instance is safe and emits nothing.
+type DataEncryptionKeyTelemetry struct {
+	metricsEnabled bool
+
+	dekGenerationFailures metric.Int64Counter
+}
+
+func NewDataEncryptionKeyTelemetry(
+	providers *aptelemetry.Providers,
+	cfg *sconfig.Telemetry,
+) (*DataEncryptionKeyTelemetry, error) {
+	t := &DataEncryptionKeyTelemetry{}
+	if providers == nil || !providers.Enabled || !cfg.MetricsEnabled() || providers.MeterProvider == nil {
+		return t, nil
+	}
+
+	meter := providers.MeterProvider.Meter(encryptTelemetryInstrumentationName)
+	failures, err := meter.Int64Counter(
+		metricDataEncryptionKeyGenerationFailures,
+		metric.WithUnit("{failure}"),
+		metric.WithDescription("Number of data encryption key generation or reconciliation failures encountered while walking keys."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt: create DEK generation failures counter: %w", err)
+	}
+
+	t.metricsEnabled = true
+	t.dekGenerationFailures = failures
+	return t, nil
+}
+
+func (t *DataEncryptionKeyTelemetry) recordDEKGenerationFailure(
+	ctx context.Context,
+	reason string,
+	key *database.Key,
+	provider sconfig.ProviderType,
+) {
+	if t == nil || !t.metricsEnabled {
+		return
+	}
+
+	t.dekGenerationFailures.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(attrDEKGenerationFailureReason, reason),
+		attribute.String(attrDEKGenerationKeyScope, dekGenerationKeyScope(key)),
+		attribute.String(attrKeyUsage, boundedString(stringFromKey(key, func(k *database.Key) string { return string(k.Usage) }))),
+		attribute.String(attrKeyMaterialType, boundedString(stringFromKey(key, func(k *database.Key) string { return string(k.MaterialType) }))),
+		attribute.String(attrKeyState, boundedString(stringFromKey(key, func(k *database.Key) string { return string(k.State) }))),
+		attribute.String(attrKeyProviderType, boundedProvider(provider)),
+	))
+}
+
+func dekGenerationKeyScope(key *database.Key) string {
+	if key != nil && key.Id == globalEncryptionKeyID {
+		return dekGenerationKeyScopeGlobal
+	}
+	return dekGenerationKeyScopeNonGlobal
+}
+
+func boundedProvider(provider sconfig.ProviderType) string {
+	if provider == "" {
+		return dekGenerationProviderUnknown
+	}
+	return string(provider)
+}
+
+func boundedString(value string) string {
+	if value == "" {
+		return dekGenerationProviderUnknown
+	}
+	return value
+}
+
+func stringFromKey(key *database.Key, f func(*database.Key) string) string {
+	if key == nil {
+		return ""
+	}
+	return f(key)
+}
+
+type generateDataEncryptionKeysOptions struct {
+	telemetry *DataEncryptionKeyTelemetry
+}
+
+type GenerateDataEncryptionKeysOption func(*generateDataEncryptionKeysOptions)
+
+func WithGenerateDataEncryptionKeysTelemetry(tel *DataEncryptionKeyTelemetry) GenerateDataEncryptionKeysOption {
+	return func(opts *generateDataEncryptionKeysOptions) {
+		opts.telemetry = tel
+	}
+}
+
+func newGenerateDataEncryptionKeysOptions(opts []GenerateDataEncryptionKeysOption) generateDataEncryptionKeysOptions {
+	var out generateDataEncryptionKeysOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&out)
+		}
+	}
+	return out
+}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -60,6 +60,10 @@ type DependencyManager struct {
 	telemetryOnce sync.Once
 	telemetryErr  error
 
+	dataEncryptionKeyTelemetry     *encrypt.DataEncryptionKeyTelemetry
+	dataEncryptionKeyTelemetryOnce sync.Once
+	dataEncryptionKeyTelemetryErr  error
+
 	rootLogger     *slog.Logger
 	rootLoggerOnce sync.Once
 
@@ -590,6 +594,26 @@ func (dm *DependencyManager) GetTelemetry() *aptelemetry.Providers {
 	return dm.telemetry
 }
 
+func (dm *DependencyManager) GetDataEncryptionKeyTelemetry() *encrypt.DataEncryptionKeyTelemetry {
+	dm.dataEncryptionKeyTelemetryOnce.Do(func() {
+		tel, err := encrypt.NewDataEncryptionKeyTelemetry(
+			dm.GetTelemetry(),
+			dm.GetConfigRoot().Telemetry,
+		)
+		if err != nil {
+			dm.dataEncryptionKeyTelemetryErr = err
+			return
+		}
+		dm.dataEncryptionKeyTelemetry = tel
+	})
+
+	if dm.dataEncryptionKeyTelemetryErr != nil {
+		panic(fmt.Errorf("failed to initialise data encryption key telemetry: %w", dm.dataEncryptionKeyTelemetryErr))
+	}
+
+	return dm.dataEncryptionKeyTelemetry
+}
+
 // ShutdownTelemetry flushes and tears down OTel providers if they were
 // initialised. Safe to call multiple times. Bounded by aptelemetry.ShutdownTimeout.
 func (dm *DependencyManager) ShutdownTelemetry() {
@@ -740,6 +764,7 @@ func (dm *DependencyManager) AutoMigrateGenerateDataEncryptionKeys() {
 		dm.GetDatabase(),
 		dm.GetLogger(),
 		dm.GetRedisClient(),
+		encrypt.WithGenerateDataEncryptionKeysTelemetry(dm.GetDataEncryptionKeyTelemetry()),
 	); err != nil {
 		panic(fmt.Errorf("failed to generate data encryption keys: %w", err))
 	}

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -185,6 +185,7 @@ func Serve(cfg config.C) {
 		dm.GetEncryptService(),
 		dm.GetRedisClient(),
 		logger,
+		encrypt.WithDataEncryptionKeyTelemetry(dm.GetDataEncryptionKeyTelemetry()),
 	)
 	encryptTaskHandler.RegisterTasks(mux)
 


### PR DESCRIPTION
## Summary
- log non-global key material/provider failures during DEK generation instead of returning them as startup-fatal errors
- keep global key DEK generation failures fatal so startup still fails when the root encryption key is broken
- emit `authproxy.encrypt.dek_generation.failures` with bounded attributes for bad-key/failure tracking
- add regression coverage for global failure, non-global provider failure, and the emitted metric

## Tests
- go test ./internal/encrypt -run TestGenerateDataEncryptionKeysToDatabase/records_non-global_provider_errors_as_metrics -count=1
- go test ./internal/encrypt -run TestGenerateDataEncryptionKeysToDatabase -count=1
- go test ./internal/encrypt
- go test ./internal/service/...
- ./scripts/preflight.sh