### PR TITLE
Treat non-global key sync errors as nonfatal

### DIFF
--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -275,9 +275,11 @@ func syncKeysToDatabase(
 	db database.DB,
 	logger *slog.Logger,
 	redis apredis.Client,
+	opts ...SyncKeysOption,
 ) error {
 	logger.Info("syncing data encryption key wrapping to database")
 	defer logger.Info("syncing data encryption key wrapping to database complete")
+	options := newSyncKeysOptions(opts)
 
 	if err := ensureRootNamespaceHasKeySet(ctx, db); err != nil {
 		return errors.Wrap(err, "failed to ensure root namespace uses global key")
@@ -318,14 +320,22 @@ func syncKeysToDatabase(
 
 	// key material id -> plaintext DEK for decrypting child key data.
 	keyMaterialDataCache := make(map[apid.ID]config.KeyVersionInfo)
+	globalKey := &database.Key{
+		Id:           globalEncryptionKeyID,
+		Usage:        database.KeyUsageDataEncryption,
+		MaterialType: database.KeyMaterialTypeSymmetric,
+		State:        database.KeyStateActive,
+	}
 
 	// Manually sync the global key first because other keys depend on it.
 	err := rewrapDataEncryptionKeysForKey(ctx, db, globalEncryptionKeyID, sa.GlobalAESKey)
 	if err != nil {
+		options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonGlobalRewrap, globalKey, sa.GlobalAESKey.GetProviderType())
 		return errors.Wrap(err, "failed to rewrap global data encryption keys")
 	}
 	err = cacheDataEncryptionKeysForKey(ctx, db, keyMaterialDataCache, globalEncryptionKeyID, sa.GlobalAESKey)
 	if err != nil {
+		options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonGlobalCache, globalKey, sa.GlobalAESKey.GetProviderType())
 		return errors.Wrap(err, "failed to cache global data encryption keys")
 	}
 
@@ -341,38 +351,69 @@ func syncKeysToDatabase(
 			ef := key.EncryptedKeyData
 			kvi, ok := keyMaterialDataCache[ef.ID]
 			if !ok {
-				result = multierror.Append(result, fmt.Errorf("key material info not found for key ID %s key material %s", key.Id, ef.ID))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonMissingWrapping, key, "")
+				logger.Warn("key wrapping material not found, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"data_encryption_key_id", ef.ID,
+				)
 				continue
 			}
 
 			decodedData, err := base64.StdEncoding.DecodeString(ef.Data)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to decode base64 string for key id %s", key.Id))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonDecodeEncryptedKey, key, "")
+				logger.Warn("failed to decode encrypted key data, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 
 			decryptedData, err := decryptWithKey(kvi.Data, decodedData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to decrypt key id %s with key data from %s", key.Id, ef.ID))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonDecryptKeyData, key, "")
+				logger.Warn("failed to decrypt key data, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"data_encryption_key_id", ef.ID,
+					"error", err,
+				)
 				continue
 			}
 
 			var keyData config.KeyData
 			err = json.Unmarshal(decryptedData, &keyData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to unmarshal key data for key ID %s", key.Id))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonUnmarshalKeyData, key, "")
+				logger.Warn("failed to unmarshal key data, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 
 			err = rewrapDataEncryptionKeysForKey(ctx, db, key.Id, &keyData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to rewrap data encryption keys for key ID %s", key.Id))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonRewrap, key, keyData.GetProviderType())
+				logger.Warn("failed to rewrap data encryption keys for key, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 
 			err = cacheDataEncryptionKeysForKey(ctx, db, keyMaterialDataCache, key.Id, &keyData)
 			if err != nil {
-				result = multierror.Append(result, errors.Wrapf(err, "failed to cache data encryption keys for key ID %s", key.Id))
+				options.telemetry.recordKeySyncFailure(ctx, keySyncFailureReasonCache, key, keyData.GetProviderType())
+				logger.Warn("failed to cache data encryption keys for key, skipping key sync",
+					"key_id", key.Id,
+					"namespace", key.Namespace,
+					"error", err,
+				)
 				continue
 			}
 		}
@@ -407,8 +448,9 @@ func SyncKeysToDatabase(
 	db database.DB,
 	logger *slog.Logger,
 	redis apredis.Client,
+	opts ...SyncKeysOption,
 ) error {
-	return syncKeysToDatabase(ctx, cfg, db, logger, redis)
+	return syncKeysToDatabase(ctx, cfg, db, logger, redis, opts...)
 }
 
 func (h *EncryptServiceTaskHandler) handleSyncKeysToDatabase(ctx context.Context, task *asynq.Task) error {
@@ -417,7 +459,14 @@ func (h *EncryptServiceTaskHandler) handleSyncKeysToDatabase(ctx context.Context
 
 // doSyncKeysToDatabase delegates to the standalone function with the redis sentinel.
 func (h *EncryptServiceTaskHandler) doSyncKeysToDatabase(ctx context.Context) error {
-	return syncKeysToDatabase(ctx, h.cfg, h.db, h.logger, h.redis)
+	return syncKeysToDatabase(
+		ctx,
+		h.cfg,
+		h.db,
+		h.logger,
+		h.redis,
+		WithSyncKeysTelemetry(h.dataEncryptionKeyTelemetry),
+	)
 }
 
 // EnqueueForceSyncKeysToDatabase clears the sync sentinel and enqueues a sync task immediately.

--- a/internal/encrypt/task_sync_keys_to_database_test.go
+++ b/internal/encrypt/task_sync_keys_to_database_test.go
@@ -9,8 +9,12 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aptelemetry"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encfield"
@@ -428,6 +432,74 @@ func TestSyncKeysToDatabase(t *testing.T) {
 		require.Equal(t, rootKeyID, *root.KeyId)
 	})
 
+	t.Run("returns global rewrap errors", func(t *testing.T) {
+		sconfig.ResetKeyDataMockKMSRegistry()
+		t.Cleanup(sconfig.ResetKeyDataMockKMSRegistry)
+
+		ctx := context.Background()
+		globalKD := sconfig.NewKeyDataMockKMS("global-sync-error")
+		cfg := config.FromRoot(&sconfig.Root{
+			SystemAuth: sconfig.SystemAuth{
+				GlobalAESKey: globalKD,
+			},
+		})
+		cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+
+		err := syncKeysToDatabase(ctx, cfg, db, slog.Default(), nil)
+		require.ErrorContains(t, err, "failed to rewrap global data encryption keys")
+		require.ErrorContains(t, err, "no current version")
+	})
+
+	t.Run("logs non-global rewrap errors without failing startup", func(t *testing.T) {
+		env := setupMockKMSKeySyncTest(t)
+		before, err := env.db.GetDataEncryptionKey(env.ctx, env.dekV1ID)
+		require.NoError(t, err)
+
+		sconfig.ResetKeyDataMockKMSRegistry()
+
+		require.NoError(t, syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
+
+		after, err := env.db.GetDataEncryptionKey(env.ctx, env.dekV1ID)
+		require.NoError(t, err)
+		require.Equal(t, before.ProviderVersion, after.ProviderVersion)
+		require.Equal(t, before.ProtectedData, after.ProtectedData)
+	})
+
+	t.Run("records non-global rewrap errors as metrics", func(t *testing.T) {
+		env := setupMockKMSKeySyncTest(t)
+		reader := sdkmetric.NewManualReader()
+		providers := &aptelemetry.Providers{
+			Enabled:       true,
+			MeterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		}
+		tel, err := NewDataEncryptionKeyTelemetry(providers, telemetryMetricsEnabledConfig())
+		require.NoError(t, err)
+
+		sconfig.ResetKeyDataMockKMSRegistry()
+
+		err = syncKeysToDatabase(
+			env.ctx,
+			env.cfg,
+			env.db,
+			env.logger,
+			nil,
+			WithSyncKeysTelemetry(tel),
+		)
+		require.NoError(t, err)
+
+		rm := metricdata.ResourceMetrics{}
+		require.NoError(t, reader.Collect(env.ctx, &rm))
+		dp := requireInt64SumDataPoint(t, rm, metricKeySyncFailures)
+		require.Equal(t, int64(1), dp.Value)
+		attrs := metricAttrMap(dp.Attributes.ToSlice())
+		require.Equal(t, keySyncFailureReasonRewrap, attrs[attrDEKGenerationFailureReason])
+		require.Equal(t, dekGenerationKeyScopeNonGlobal, attrs[attrDEKGenerationKeyScope])
+		require.Equal(t, string(database.KeyUsageDataEncryption), attrs[attrKeyUsage])
+		require.Equal(t, string(database.KeyMaterialTypeSymmetric), attrs[attrKeyMaterialType])
+		require.Equal(t, string(database.KeyStateActive), attrs[attrKeyState])
+		require.Equal(t, string(sconfig.ProviderTypeMockKMS), attrs[attrKeyProviderType])
+	})
+
 	t.Run("does not create or duplicate deks", func(t *testing.T) {
 		env := setupRewrapSyncTest(t)
 
@@ -532,8 +604,7 @@ func TestSyncKeysToDatabase(t *testing.T) {
 		sconfig.KeyDataMockAddVersion("namespace-secret", "mock-secret-key", "v2", util.MustGenerateSecureRandomKey(32))
 		sconfig.KeyDataMockRemoveVersion("namespace-secret", "v1")
 
-		err = syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
-		require.ErrorContains(t, err, "failed to unwrap data encryption key")
+		require.NoError(t, syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
 
 		after, getErr := env.db.GetDataEncryptionKey(env.ctx, env.dekID)
 		require.NoError(t, getErr)
@@ -548,8 +619,7 @@ func TestSyncKeysToDatabase(t *testing.T) {
 
 		sconfig.KeyDataMockAddVersion("namespace-secret", "mock-secret-key", "v2", []byte("bad"))
 
-		err = syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil)
-		require.ErrorContains(t, err, "failed to rewrap data encryption key")
+		require.NoError(t, syncKeysToDatabase(env.ctx, env.cfg, env.db, env.logger, nil))
 
 		after, getErr := env.db.GetDataEncryptionKey(env.ctx, env.dekID)
 		require.NoError(t, getErr)

--- a/internal/encrypt/telemetry.go
+++ b/internal/encrypt/telemetry.go
@@ -16,6 +16,7 @@ const (
 	encryptTelemetryInstrumentationName = "github.com/rmorlok/authproxy/internal/encrypt"
 
 	metricDataEncryptionKeyGenerationFailures = "authproxy.encrypt.dek_generation.failures"
+	metricKeySyncFailures                     = "authproxy.encrypt.key_sync.failures"
 
 	attrDEKGenerationFailureReason = "authproxy.encrypt.failure_reason"
 	attrDEKGenerationKeyScope      = "authproxy.encrypt.key_scope"
@@ -37,6 +38,15 @@ const (
 	dekGenerationFailureReasonUnmarshalKeyData   = "unmarshal_key_data_failed"
 	dekGenerationFailureReasonReconcile          = "reconcile_dek_failed"
 	dekGenerationFailureReasonCache              = "cache_dek_failed"
+
+	keySyncFailureReasonGlobalRewrap       = "global_rewrap_failed"
+	keySyncFailureReasonGlobalCache        = "global_cache_failed"
+	keySyncFailureReasonMissingWrapping    = "missing_wrapping_material"
+	keySyncFailureReasonDecodeEncryptedKey = "decode_encrypted_key_data_failed"
+	keySyncFailureReasonDecryptKeyData     = "decrypt_key_data_failed"
+	keySyncFailureReasonUnmarshalKeyData   = "unmarshal_key_data_failed"
+	keySyncFailureReasonRewrap             = "rewrap_dek_failed"
+	keySyncFailureReasonCache              = "cache_dek_failed"
 )
 
 // DataEncryptionKeyTelemetry owns OTel metrics emitted by the encrypt package.
@@ -45,6 +55,7 @@ type DataEncryptionKeyTelemetry struct {
 	metricsEnabled bool
 
 	dekGenerationFailures metric.Int64Counter
+	keySyncFailures       metric.Int64Counter
 }
 
 func NewDataEncryptionKeyTelemetry(
@@ -68,6 +79,16 @@ func NewDataEncryptionKeyTelemetry(
 
 	t.metricsEnabled = true
 	t.dekGenerationFailures = failures
+
+	t.keySyncFailures, err = meter.Int64Counter(
+		metricKeySyncFailures,
+		metric.WithUnit("{failure}"),
+		metric.WithDescription("Number of data encryption key wrapping sync failures encountered while walking keys."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt: create key sync failures counter: %w", err)
+	}
+
 	return t, nil
 }
 
@@ -81,7 +102,30 @@ func (t *DataEncryptionKeyTelemetry) recordDEKGenerationFailure(
 		return
 	}
 
-	t.dekGenerationFailures.Add(ctx, 1, metric.WithAttributes(
+	t.recordFailure(ctx, t.dekGenerationFailures, reason, key, provider)
+}
+
+func (t *DataEncryptionKeyTelemetry) recordKeySyncFailure(
+	ctx context.Context,
+	reason string,
+	key *database.Key,
+	provider sconfig.ProviderType,
+) {
+	if t == nil || !t.metricsEnabled {
+		return
+	}
+
+	t.recordFailure(ctx, t.keySyncFailures, reason, key, provider)
+}
+
+func (t *DataEncryptionKeyTelemetry) recordFailure(
+	ctx context.Context,
+	counter metric.Int64Counter,
+	reason string,
+	key *database.Key,
+	provider sconfig.ProviderType,
+) {
+	counter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String(attrDEKGenerationFailureReason, reason),
 		attribute.String(attrDEKGenerationKeyScope, dekGenerationKeyScope(key)),
 		attribute.String(attrKeyUsage, boundedString(stringFromKey(key, func(k *database.Key) string { return string(k.Usage) }))),
@@ -133,6 +177,28 @@ func WithGenerateDataEncryptionKeysTelemetry(tel *DataEncryptionKeyTelemetry) Ge
 
 func newGenerateDataEncryptionKeysOptions(opts []GenerateDataEncryptionKeysOption) generateDataEncryptionKeysOptions {
 	var out generateDataEncryptionKeysOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&out)
+		}
+	}
+	return out
+}
+
+type syncKeysOptions struct {
+	telemetry *DataEncryptionKeyTelemetry
+}
+
+type SyncKeysOption func(*syncKeysOptions)
+
+func WithSyncKeysTelemetry(tel *DataEncryptionKeyTelemetry) SyncKeysOption {
+	return func(opts *syncKeysOptions) {
+		opts.telemetry = tel
+	}
+}
+
+func newSyncKeysOptions(opts []SyncKeysOption) syncKeysOptions {
+	var out syncKeysOptions
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&out)

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -779,6 +779,7 @@ func (dm *DependencyManager) AutoMigrateSyncKeysToDatabase() {
 		dm.GetDatabase(),
 		dm.GetLogger(),
 		dm.GetRedisClient(),
+		encrypt.WithSyncKeysTelemetry(dm.GetDataEncryptionKeyTelemetry()),
 	); err != nil {
 		panic(fmt.Errorf("failed to sync keys to database: %w", err))
 	}


### PR DESCRIPTION
## Summary
- make non-global key sync/DEK rewrap failures warning-only so bad unused keys do not block startup
- keep global key sync failures fatal because the app depends on key_global being usable
- add `authproxy.encrypt.key_sync.failures` with bounded attributes for skipped/bad key sync failures
- add regression coverage for global fatal behavior, non-global startup tolerance, and key sync failure metrics

## Tests
- go test ./internal/encrypt -run TestSyncKeysToDatabase -count=1
- go test ./internal/encrypt ./internal/service/...
- ./scripts/preflight.sh
- go run ./cmd/server serve all --config=./dev_config/default.yaml against local dev database with bad root.dev AWS-backed key; startup completed and recurring worker jobs ran, with bad key logged as warnings instead of panicking

## Notes
- Stopping the local dev server with Ctrl-C exposed an unrelated Asynq subscriber nil-pointer during shutdown; the startup panic from key sync was resolved.