### PR TITLE
Document connector-level JavaScript contract

### DIFF
--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -264,6 +264,16 @@ connectors:
         - id: https://www.googleapis.com/auth/calendar.readonly
           reason: |
             We need to be able to read the calendar
+    javascript: |
+      function isPrimaryCalendar(cfg) {
+        return cfg.calendar_id === "primary";
+      }
+
+      function transformCalendarItems(items) {
+        return items.map(function(c) {
+          return { value: c.id, label: c.summary || c.id };
+        });
+      }
     setup_flow:
       configure:
         steps:
@@ -289,7 +299,23 @@ connectors:
                 proxy_request:
                   method: GET
                   url: https://www.googleapis.com/calendar/v3/users/me/calendarList
-                transform: "data.items.map(function(c) { return { value: c.id, label: c.summary || c.id }; })"
+                transform: transformCalendarItems(data.items)
+          - id: primary-calendar-options
+            title: Primary Calendar Options
+            description: Configure behavior that only applies to the primary calendar.
+            if:
+              javascript: isPrimaryCalendar(cfg)
+            json_schema:
+              type: object
+              properties:
+                include_declined:
+                  type: boolean
+                  title: Include declined events
+            ui_schema:
+              type: VerticalLayout
+              elements:
+                - type: Control
+                  scope: "#/properties/include_declined"
     probes:
       - id: example
         period: 1m

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory holds long-form documentation that supplements the [main repo REA
 - **[Rate limits](rate-limits.md)** — define rate-limit resources, configure connector-level reactive 429 handling, understand the request log attribution fields.
 - **[Labels and annotations](labels.md)** — the Kubernetes-style label system, system labels under `apxy/`, carry-forward through the namespace → connector → connection hierarchy, label selectors, per-request label snapshots.
 - **[Connector setup flow](connector-setup-flow.md)** — author preconnect/configure steps, conditional `if.javascript` steps, redirect steps, and configure-time data sources.
-- **[Connector predicates](connector-predicates.md)** — condition setup steps, OAuth scopes, dynamic required OAuth scopes, and probes with JavaScript predicates over `cfg`, `labels`, and `annotations`.
+- **[Connector predicates](connector-predicates.md)** — condition setup steps, OAuth scopes, dynamic required OAuth scopes, and probes with JavaScript predicates over `cfg`, `labels`, and `annotations`, including connector-level shared JavaScript helpers.
 - **[Application metrics](app_metrics.md)** — configure the app metrics store, query request-event and resource metrics, and understand supported aggregations and dimensions.
 
 ## Operational guides

--- a/docs/connector-predicates.md
+++ b/docs/connector-predicates.md
@@ -24,6 +24,35 @@ Every connector predicate receives the same variables:
 
 There is no `attributes` alias. Use `cfg`, `labels`, and `annotations` directly.
 
+## Connector JavaScript Library
+
+A connector can define top-level shared JavaScript with the `javascript` field. Use it for helper functions and constants that are reused by predicates and configure-step data-source transforms:
+
+```yaml
+javascript: |
+  function isProductionConnection() {
+    return labels.env === "prod";
+  }
+
+  function shouldRequestDriveActivity() {
+    return cfg.sync_activity === true && isProductionConnection();
+  }
+
+auth:
+  type: OAuth2
+  scopes:
+    - id: https://www.googleapis.com/auth/drive.activity.readonly
+      if:
+        javascript: shouldRequestDriveActivity()
+      reason: We need activity access when activity sync is enabled.
+```
+
+AuthProxy compiles connector-level JavaScript once for the connector version, validates it by running top-level initialization without runtime variables, and then runs it in a fresh JavaScript VM for each predicate or transform evaluation. This means helpers can share code, but mutable globals do not carry state between evaluations.
+
+Connector-level JavaScript cannot declare the reserved runtime variables `cfg`, `labels`, `annotations`, or `data`. AuthProxy injects those names for each evaluation. Syntax errors, top-level thrown errors, and reserved-name declarations fail connector validation.
+
+The same connector-level helpers are available to setup-step predicates, OAuth scope predicates, probe predicates, and configure-step data-source transforms. Data-source transforms also receive `data`, which contains the proxied JSON response. See [Connector setup flow](connector-setup-flow.md#data-sources) for transform examples.
+
 ## Setup Steps
 
 Connector-authored setup-flow form and redirect steps support `if.javascript`. Clients only see eligible steps. See [Connector setup flow](connector-setup-flow.md#conditional-steps) for setup-step examples and behavior.
@@ -118,6 +147,6 @@ Probe behavior:
 
 ## Versioning Notes
 
-Adding, removing, or changing predicates changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path.
+Adding, removing, or changing predicates or connector-level JavaScript changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path.
 
 Existing in-flight connections are evaluated against the connector version they are using. If a predicate changes in a new version, only connections migrated to that version use the new predicate behavior.

--- a/docs/connector-setup-flow.md
+++ b/docs/connector-setup-flow.md
@@ -163,8 +163,41 @@ AuthProxy applies step conditions consistently across setup APIs:
 
 If all connector-authored steps in a phase are ineligible, the runtime skips that phase. Auth-method and verification steps still run according to the connector's auth method and probe configuration.
 
+## Data Sources
+
+Configure form steps can define `data_sources` for controls that need upstream options. AuthProxy calls the `proxy_request` through the authenticated connection, exposes the JSON response as `data`, and evaluates `transform` JavaScript to produce options:
+
+```yaml
+javascript: |
+  function workspaceOptions(items) {
+    return items.map(function(w) {
+      return { value: w.id, label: w.name || w.id };
+    });
+  }
+
+setup_flow:
+  configure:
+    steps:
+      - id: workspace
+        title: Workspace
+        json_schema:
+          type: object
+          properties:
+            workspace_id:
+              type: string
+              x-data-source: workspaces
+        data_sources:
+          workspaces:
+            proxy_request:
+              method: GET
+              url: https://api.example.com/workspaces
+            transform: workspaceOptions(data.items)
+```
+
+Transforms must return an array of objects with `value` and `label` fields. They run in the same connector JavaScript context as predicates, so top-level connector helpers can read `cfg`, `labels`, and `annotations`; transforms additionally receive `data`. See [Connector predicates](connector-predicates.md#connector-javascript-library) for the shared JavaScript library contract.
+
 ## Migration Notes
 
-Adding, removing, or changing `if.javascript` changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path for configuration changes.
+Adding, removing, or changing `if.javascript`, data-source transforms, or connector-level JavaScript changes the connector definition. For published connectors, publish a new connector version or rely on the normal connector-version migration path for configuration changes.
 
 Existing in-flight connections are evaluated against the connector version they are using. If a connection resumes while its stored step is now ineligible, AuthProxy advances it to the next eligible step rather than returning the ineligible step to the client.


### PR DESCRIPTION
Closes #669

## Summary
- Document the connector-level `javascript` library contract, validation behavior, reserved runtime variables, and fresh-VM evaluation model.
- Add setup-flow data-source transform docs that share the same JavaScript context and explain the `data` variable.
- Update the Google Calendar dev connector example to use shared helpers for a data-source transform and a conditional setup step.

## Tests
- `go test ./dev_config ./internal/schema/resources/connectors`
- `./scripts/preflight.sh`