### PR TITLE
Bundle Grafana plugin JSX runtime

### DIFF
--- a/plugins/grafana/authproxy-datasource/webpack.config.cjs
+++ b/plugins/grafana/authproxy-datasource/webpack.config.cjs
@@ -14,7 +14,6 @@ module.exports = {
     '@grafana/ui',
     'react',
     'react-dom',
-    'react/jsx-runtime',
   ],
   module: {
     rules: [


### PR DESCRIPTION
## Summary
- stop externalizing react/jsx-runtime from the AuthProxy Grafana datasource plugin bundle
- let webpack include the JSX runtime helper so Grafana no longer requests /react/jsx-runtime from the demo instance

## Investigation
- the demo dashboard showed AuthProxy plugin failed errors and no data
- live Grafana logs showed repeated 404s for /react/jsx-runtime
- live plugin module declared AMD deps: @grafana/data, react/jsx-runtime, react, @grafana/ui, @grafana/runtime
- Grafana tried to resolve that dependency as https://demo.authproxy.net/grafana/react/jsx-runtime, which does not exist

## Verification
- npm run validate (plugins/grafana/authproxy-datasource)
- built dist/module.js now declares AMD deps: @grafana/data, react, @grafana/ui, @grafana/runtime
- rg -n "react/jsx-runtime" plugins/grafana/authproxy-datasource/dist/module.js plugins/grafana/authproxy-datasource/webpack.config.cjs returned no matches
- ./scripts/preflight.sh