### PR TITLE
Enable anonymous demo Grafana viewing

### DIFF
--- a/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
@@ -72,6 +72,12 @@ spec:
               value: "%(protocol)s://%(domain)s/grafana/"
             - name: GF_SERVER_SERVE_FROM_SUB_PATH
               value: "true"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
             - name: AUTHPROXY_GRAFANA_JWT
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- enable anonymous access for demo Grafana with Viewer permissions
- disable the login form so demo telemetry links open without username/password prompts

## Verification
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo | rg -n "GF_AUTH_ANONYMOUS|GF_AUTH_DISABLE_LOGIN_FORM" -C 2
- ./scripts/preflight.sh