### PR TITLE
Fix metrics route permission validation panic

### DIFF
--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -791,6 +791,7 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 		responseSeries = append(responseSeries, resourceMetricsResponseSeries(series)...)
 	}
 
+	val.MarkValidated()
 	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
 }
 
@@ -804,6 +805,7 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 // @Security		BearerAuth
 // @Router			/metrics/schema [get]
 func (r *RequestEventsRoutes) schema(gctx *gin.Context) {
+	auth.MustGetValidatorFromGinContext(gctx).MarkValidated()
 	gctx.PureJSON(http.StatusOK, metricsSchemaResponse())
 }
 

--- a/internal/routes/request_events_test.go
+++ b/internal/routes/request_events_test.go
@@ -32,6 +32,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 		Gin           *gin.Engine
 		AuthUtil      *auth2.AuthTestUtil
 		MockRetriever *mock.MockLogRetriever
+		RecoveryLog   *bytes.Buffer
 	}
 
 	setup := func(t *testing.T, cfg config.C) *TestSetup {
@@ -42,14 +43,34 @@ func TestRequestEventsRoutes(t *testing.T) {
 		rlr := mock.NewMockLogRetriever(ctrl)
 		rl := NewRequestEventsRoutes(cfg, auth, rlr)
 
-		r := apgin.ForTest(nil)
+		recoveryLog := &bytes.Buffer{}
+		var r *gin.Engine
+		func() {
+			previousRecoveryWriter := gin.DefaultErrorWriter
+			gin.DefaultErrorWriter = recoveryLog
+			defer func() {
+				gin.DefaultErrorWriter = previousRecoveryWriter
+			}()
+
+			r = apgin.ForTest(nil)
+		}()
 		rl.Register(r)
 
 		return &TestSetup{
 			Gin:           r,
 			MockRetriever: rlr,
 			AuthUtil:      authUtil,
+			RecoveryLog:   recoveryLog,
 		}
+	}
+
+	serveHTTPNoRecovery := func(t *testing.T, tu *TestSetup, w *httptest.ResponseRecorder, req *http.Request) {
+		t.Helper()
+		tu.RecoveryLog.Reset()
+
+		tu.Gin.ServeHTTP(w, req)
+
+		require.Empty(t, tu.RecoveryLog.String())
 	}
 
 	t.Run("list", func(t *testing.T) {
@@ -625,7 +646,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 					}, nil
 				})
 
-			tu.Gin.ServeHTTP(w, req)
+			serveHTTPNoRecovery(t, tu, w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
 			var resp sapi.MetricsQueryResponseJson
@@ -670,7 +691,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 					}, nil
 				})
 
-			tu.Gin.ServeHTTP(w, req)
+			serveHTTPNoRecovery(t, tu, w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
 			var resp sapi.MetricsQueryResponseJson
@@ -694,7 +715,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 					return nil, nil
 				})
 
-			tu.Gin.ServeHTTP(w, req)
+			serveHTTPNoRecovery(t, tu, w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 		})
 
@@ -776,7 +797,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newSchemaRequest(t, aschema.PermissionsSingle("root.**", "app-metrics", "schema"))
 
-			tu.Gin.ServeHTTP(w, req)
+			serveHTTPNoRecovery(t, tu, w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
 			var resp sapi.MetricsSchemaResponseJson


### PR DESCRIPTION
## Summary
- Mark aggregate metrics query responses as permission-validated after namespace-constrained query construction.
- Mark the static metrics schema response as validated to satisfy the permission post-validator.
- Add route-test coverage that fails if Gin recovery logs a post-response panic on metrics success paths.

## Tests
- AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite GOCACHE=/private/tmp/authproxy3-gocache go test ./internal/routes -run TestRequestEventsRoutes -count=1
- GOCACHE=/private/tmp/authproxy3-gocache ./scripts/preflight.sh
- git push hook reran ./scripts/preflight.sh