### PR TITLE
Fix demo Grafana datasource JWT signing

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -220,16 +220,16 @@ jobs:
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
 
-          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-encryption" \
-            -o jsonpath='{.data.global_aes\.key}' \
-            | base64 -d > "${workdir}/global_aes.key"
-          chmod 600 "${workdir}/global_aes.key"
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-jwt" \
+            -o jsonpath='{.data.system}' \
+            | base64 -d > "${workdir}/system.key"
+          chmod 600 "${workdir}/system.key"
 
           go run ./cmd/cli sign-jwt \
             --actorId grafana \
             --apis api,admin-api \
             --grafana-preset logs \
-            --secretKeyPath "${workdir}/global_aes.key" \
+            --privateKeyPath "${workdir}/system.key" \
             > "${workdir}/grafana.jwt"
 
           kubectl -n "${RELEASE_NS}" create secret generic authproxy-grafana-jwt \


### PR DESCRIPTION
## Summary
- mint the demo Grafana datasource JWT from the demo JWT private key instead of the AES encryption key
- switch the CLI call from HS256 `--secretKeyPath` to RSA `--privateKeyPath`

## Evidence
- live Grafana datasource queries were failing with `authproxy returned 401: {\"error\":\"invalid token\"}`
- the current workflow minted `authproxy-grafana-jwt` from `demo-encryption.global_aes.key`, while AuthProxy validates API tokens against `demo-jwt.system.pub`
- locally minted token using `demo-jwt.system` + `--privateKeyPath` verifies with `demo-jwt.system.pub`

## Verification
- `./scripts/preflight.sh`