### PR TITLE
Add API secret redaction serialization

### DIFF
--- a/internal/apauth/service/gin.go
+++ b/internal/apauth/service/gin.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apserde"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 // GetAuthFromGinContext returns auth info from a request. This auth info can be authenticated or unauthenticated.
@@ -33,6 +35,12 @@ func applyAuthToGinContext(c *gin.Context, ra *core.RequestAuth) {
 
 	ctx := c.Request.Context()
 	ctx = ra.ContextWith(ctx)
+	ctx = apserde.WithSecretReplay(ctx, ra.Allows(
+		namespace.NamespaceSkipNamespacePermissionChecks,
+		apserde.SecretResource,
+		apserde.SecretReplayVerb,
+		"",
+	))
 	c.Request = c.Request.WithContext(ctx)
 }
 

--- a/internal/apgin/api_json.go
+++ b/internal/apgin/api_json.go
@@ -1,0 +1,45 @@
+package apgin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rmorlok/authproxy/internal/apserde"
+)
+
+var apiJSONContentType = []string{"application/json; charset=utf-8"}
+
+// APIJSON serializes obj as an API JSON response, applying apiredact tags unless
+// the request context is authorized for secret replay.
+func APIJSON(gctx *gin.Context, code int, obj any) {
+	gctx.Render(code, apiJSONRender{
+		ctx:  gctx.Request.Context(),
+		data: obj,
+	})
+}
+
+type apiJSONRender struct {
+	ctx  context.Context
+	data any
+}
+
+func (r apiJSONRender) Render(w http.ResponseWriter) error {
+	r.WriteContentType(w)
+	data, report, err := apserde.MarshalJSONForAPI(r.ctx, r.data)
+	if err != nil {
+		return err
+	}
+	if report.Redacted {
+		w.Header().Set(apserde.RedactedHeader, "true")
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func (r apiJSONRender) WriteContentType(w http.ResponseWriter) {
+	header := w.Header()
+	if len(header["Content-Type"]) == 0 {
+		header["Content-Type"] = apiJSONContentType
+	}
+}

--- a/internal/apgin/api_json_test.go
+++ b/internal/apgin/api_json_test.go
@@ -1,0 +1,81 @@
+package apgin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rmorlok/authproxy/internal/apserde"
+	"github.com/stretchr/testify/require"
+)
+
+type apiJSONSecretPayload struct {
+	Public string `json:"public"`
+	HTML   string `json:"html"`
+	Secret string `json:"secret" apiredact:"secret"`
+}
+
+func TestAPIJSON_RedactsAndSetsHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		APIJSON(c, http.StatusOK, apiJSONSecretPayload{
+			Public: "shown",
+			HTML:   "<b>",
+			Secret: "secret",
+		})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "true", w.Header().Get(apserde.RedactedHeader))
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"public":"shown","html":"<b>","secret":"******"}`, w.Body.String())
+	require.Contains(t, w.Body.String(), "<b>")
+}
+
+func TestAPIJSON_ReplayLeavesHeaderUnset(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		c.Request = c.Request.WithContext(apserde.WithSecretReplay(c.Request.Context(), true))
+		APIJSON(c, http.StatusOK, apiJSONSecretPayload{Secret: "secret"})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Empty(t, w.Header().Get(apserde.RedactedHeader))
+	require.JSONEq(t, `{"public":"","html":"","secret":"secret"}`, w.Body.String())
+}
+
+func TestAPIJSON_NoBodyStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		APIJSON(c, http.StatusNoContent, apiJSONSecretPayload{Secret: "secret"})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Empty(t, w.Body.String())
+}
+
+func TestAPIJSON_RenderError(t *testing.T) {
+	err := apiJSONRender{
+		ctx:  context.Background(),
+		data: make(chan int),
+	}.Render(httptest.NewRecorder())
+
+	require.Error(t, err)
+}

--- a/internal/apserde/api.go
+++ b/internal/apserde/api.go
@@ -1,0 +1,576 @@
+package apserde
+
+import (
+	"bytes"
+	"context"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	RedactTagName           = "apiredact"
+	RedactTagSecret         = "secret"
+	SecretResource          = "secrets"
+	SecretReplayVerb        = "replay"
+	RedactedHeader          = "X-AuthProxy-Data-Redacted"
+	redactionRune           = "*"
+	secretReplayKey         = contextKey("secretReplay")
+	formatJSON       format = iota
+	formatYAML
+)
+
+type contextKey string
+
+type format int
+
+// Report describes what happened during API sanitization.
+type Report struct {
+	Redacted bool
+}
+
+// WithSecretReplay records whether the current request may replay secret values.
+func WithSecretReplay(ctx context.Context, allowed bool) context.Context {
+	return context.WithValue(ctx, secretReplayKey, allowed)
+}
+
+// SecretReplayAllowed returns true when API serializers should emit original secret values.
+func SecretReplayAllowed(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	allowed, _ := ctx.Value(secretReplayKey).(bool)
+	return allowed
+}
+
+// SanitizeJSONForAPI converts v into JSON-ready data with API redaction applied.
+func SanitizeJSONForAPI(ctx context.Context, v any) (any, Report, error) {
+	return sanitizeForAPI(ctx, v, formatJSON)
+}
+
+// SanitizeYAMLForAPI converts v into YAML-ready data with API redaction applied.
+func SanitizeYAMLForAPI(ctx context.Context, v any) (any, Report, error) {
+	return sanitizeForAPI(ctx, v, formatYAML)
+}
+
+// MarshalJSONForAPI renders v as JSON with API redaction applied and HTML escaping disabled.
+func MarshalJSONForAPI(ctx context.Context, v any) ([]byte, Report, error) {
+	sanitized, report, err := SanitizeJSONForAPI(ctx, v)
+	if err != nil {
+		return nil, report, err
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(sanitized); err != nil {
+		return nil, report, err
+	}
+	return buf.Bytes(), report, nil
+}
+
+// MarshalYAMLForAPI renders v as YAML with API redaction applied.
+func MarshalYAMLForAPI(ctx context.Context, v any) ([]byte, Report, error) {
+	sanitized, report, err := SanitizeYAMLForAPI(ctx, v)
+	if err != nil {
+		return nil, report, err
+	}
+	out, err := yaml.Marshal(sanitized)
+	return out, report, err
+}
+
+func sanitizeForAPI(ctx context.Context, v any, fmtType format) (any, Report, error) {
+	if SecretReplayAllowed(ctx) || !valueHasRedactionTag(reflect.ValueOf(v), map[visit]bool{}) {
+		plain, err := toPlain(fmtType, v)
+		return plain, Report{}, err
+	}
+
+	report := Report{}
+	sanitized, err := sanitizeValue(fmtType, reflect.ValueOf(v), &report)
+	return sanitized, report, err
+}
+
+func sanitizeValue(fmtType format, v reflect.Value, report *Report) (any, error) {
+	if !v.IsValid() {
+		return nil, nil
+	}
+
+	v = unwrapInterface(v)
+	if !v.IsValid() {
+		return nil, nil
+	}
+	if isNil(v) {
+		return nil, nil
+	}
+
+	if !valueHasRedactionTag(v, map[visit]bool{}) {
+		return toPlain(fmtType, v.Interface())
+	}
+
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil, nil
+		}
+		v = unwrapInterface(v.Elem())
+	}
+
+	if inner, ok := innerValue(v); ok && valueHasRedactionTag(inner, map[visit]bool{}) {
+		return sanitizeValue(fmtType, inner, report)
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		return sanitizeStruct(fmtType, v, report)
+	case reflect.Slice, reflect.Array:
+		items := make([]any, 0, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			item, err := sanitizeValue(fmtType, v.Index(i), report)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+		}
+		return items, nil
+	case reflect.Map:
+		result := make(map[string]any, v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			key, err := mapKeyToString(iter.Key())
+			if err != nil {
+				return nil, err
+			}
+			value, err := sanitizeValue(fmtType, iter.Value(), report)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = value
+		}
+		return result, nil
+	default:
+		return toPlain(fmtType, v.Interface())
+	}
+}
+
+func sanitizeStruct(fmtType format, v reflect.Value, report *Report) (map[string]any, error) {
+	result := map[string]any{}
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+
+		name, opts, ok := fieldName(fmtType, field)
+		if !ok {
+			continue
+		}
+
+		fv := v.Field(i)
+		if opts.Contains("omitempty") && isEmptyValue(fv) {
+			continue
+		}
+
+		if isSecretField(field) {
+			redacted, didRedact, err := redactValue(fmtType, fv)
+			if err != nil {
+				return nil, err
+			}
+			if didRedact {
+				report.Redacted = true
+			}
+			result[name] = redacted
+			continue
+		}
+
+		sanitized, err := sanitizeValue(fmtType, fv, report)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = sanitized
+	}
+
+	return result, nil
+}
+
+func redactValue(fmtType format, v reflect.Value) (any, bool, error) {
+	if !v.IsValid() || isNil(v) {
+		return nil, false, nil
+	}
+
+	plain, err := toPlain(fmtType, v.Interface())
+	if err != nil {
+		return nil, false, err
+	}
+	return maskPlain(plain)
+}
+
+func maskPlain(v any) (any, bool, error) {
+	switch typed := v.(type) {
+	case nil:
+		return nil, false, nil
+	case string:
+		if typed == "" {
+			return typed, false, nil
+		}
+		return strings.Repeat(redactionRune, utf8.RuneCountInString(typed)), true, nil
+	case []any:
+		redacted := false
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			masked, didMask, err := maskPlain(item)
+			if err != nil {
+				return nil, false, err
+			}
+			out[i] = masked
+			redacted = redacted || didMask
+		}
+		return out, redacted, nil
+	case map[string]any:
+		redacted := false
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			masked, didMask, err := maskPlain(item)
+			if err != nil {
+				return nil, false, err
+			}
+			out[key] = masked
+			redacted = redacted || didMask
+		}
+		return out, redacted, nil
+	default:
+		text := fmt.Sprint(typed)
+		if text == "" {
+			return typed, false, nil
+		}
+		return strings.Repeat(redactionRune, utf8.RuneCountInString(text)), true, nil
+	}
+}
+
+// ValidateNoRedactedPlaceholders rejects mask-only values supplied for annotated secret fields.
+func ValidateNoRedactedPlaceholders(v any) error {
+	paths := []string{}
+	if err := collectRedactedPlaceholders(reflect.ValueOf(v), "$", &paths); err != nil {
+		return err
+	}
+	if len(paths) > 0 {
+		return fmt.Errorf("redacted placeholder values are not accepted for secret fields: %s", strings.Join(paths, ", "))
+	}
+	return nil
+}
+
+func collectRedactedPlaceholders(v reflect.Value, path string, paths *[]string) error {
+	if !v.IsValid() || isNil(v) {
+		return nil
+	}
+
+	v = unwrapInterface(v)
+	for v.IsValid() && v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
+		v = unwrapInterface(v.Elem())
+	}
+	if !v.IsValid() {
+		return nil
+	}
+
+	if inner, ok := innerValue(v); ok {
+		return collectRedactedPlaceholders(inner, path, paths)
+	}
+
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+		name, _, ok := fieldName(formatJSON, field)
+		if !ok {
+			continue
+		}
+		fv := v.Field(i)
+		fieldPath := path + "." + name
+		if isSecretField(field) {
+			plain, err := toPlain(formatJSON, fv.Interface())
+			if err != nil {
+				return err
+			}
+			if containsMaskOnlyString(plain) {
+				*paths = append(*paths, fieldPath)
+			}
+			continue
+		}
+		if err := collectRedactedPlaceholders(fv, fieldPath, paths); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func containsMaskOnlyString(v any) bool {
+	switch typed := v.(type) {
+	case string:
+		if typed == "" {
+			return false
+		}
+		for _, r := range typed {
+			if r != '*' {
+				return false
+			}
+		}
+		return true
+	case []any:
+		return slices.ContainsFunc(typed, containsMaskOnlyString)
+	case map[string]any:
+		for _, item := range typed {
+			if containsMaskOnlyString(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type tagOptions []string
+
+func (o tagOptions) Contains(option string) bool {
+	return slices.Contains(o, option)
+}
+
+func fieldName(fmtType format, field reflect.StructField) (string, tagOptions, bool) {
+	tagName := "json"
+	if fmtType == formatYAML {
+		tagName = "yaml"
+	}
+
+	tag := field.Tag.Get(tagName)
+	if tag == "-" {
+		return "", nil, false
+	}
+
+	name, opts, _ := strings.Cut(tag, ",")
+	if name == "" {
+		if fmtType == formatYAML {
+			name = strings.ToLower(field.Name)
+		} else {
+			name = field.Name
+		}
+	}
+	if opts == "" {
+		return name, nil, true
+	}
+	return name, strings.Split(opts, ","), true
+}
+
+func isSecretField(field reflect.StructField) bool {
+	for _, tag := range strings.Split(field.Tag.Get(RedactTagName), ",") {
+		if strings.TrimSpace(tag) == RedactTagSecret {
+			return true
+		}
+	}
+	return false
+}
+
+func toPlain(fmtType format, v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	var data []byte
+	var err error
+	if fmtType == formatYAML {
+		data, err = yaml.Marshal(v)
+	} else {
+		data, err = json.Marshal(v)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var plain any
+	if fmtType == formatYAML {
+		if err := yaml.Unmarshal(data, &plain); err != nil {
+			return nil, err
+		}
+		return normalizeYAML(plain), nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&plain); err != nil {
+		return nil, err
+	}
+	return plain, nil
+}
+
+func normalizeYAML(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[key] = normalizeYAML(value)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[fmt.Sprint(key)] = normalizeYAML(value)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, value := range typed {
+			out[i] = normalizeYAML(value)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+type visit struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+func valueHasRedactionTag(v reflect.Value, seen map[visit]bool) bool {
+	if !v.IsValid() {
+		return false
+	}
+
+	v = unwrapInterface(v)
+	if !v.IsValid() || isNil(v) {
+		return false
+	}
+
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return false
+		}
+		id := visit{typ: v.Type(), ptr: v.Pointer()}
+		if seen[id] {
+			return false
+		}
+		seen[id] = true
+		v = unwrapInterface(v.Elem())
+	}
+
+	if inner, ok := innerValue(v); ok {
+		return valueHasRedactionTag(inner, seen)
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if field.PkgPath != "" && !field.Anonymous {
+				continue
+			}
+			if isSecretField(field) {
+				return true
+			}
+			if valueHasRedactionTag(v.Field(i), seen) {
+				return true
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if valueHasRedactionTag(v.Index(i), seen) {
+				return true
+			}
+		}
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			if valueHasRedactionTag(iter.Value(), seen) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func innerValue(v reflect.Value) (reflect.Value, bool) {
+	if v.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+	field := v.FieldByName("InnerVal")
+	if !field.IsValid() || !canBeNil(field) || field.IsNil() {
+		return reflect.Value{}, false
+	}
+	return unwrapInterface(field), true
+}
+
+func unwrapInterface(v reflect.Value) reflect.Value {
+	for v.IsValid() && v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+	return v
+}
+
+func isNil(v reflect.Value) bool {
+	if !canBeNil(v) {
+		return false
+	}
+	return v.IsNil()
+}
+
+func canBeNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return true
+	default:
+		return false
+	}
+}
+
+func mapKeyToString(v reflect.Value) (string, error) {
+	if v.Kind() == reflect.String {
+		return v.String(), nil
+	}
+	if v.CanInterface() {
+		if tm, ok := v.Interface().(encoding.TextMarshaler); ok {
+			text, err := tm.MarshalText()
+			return string(text), err
+		}
+	}
+	return fmt.Sprint(v.Interface()), nil
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	}
+	return false
+}

--- a/internal/apserde/api_test.go
+++ b/internal/apserde/api_test.go
@@ -1,0 +1,138 @@
+package apserde
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type apiSecretPayload struct {
+	Public string `json:"public" yaml:"public"`
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty" apiredact:"secret"`
+	Empty  string `json:"empty,omitempty" yaml:"empty,omitempty" apiredact:"secret"`
+}
+
+type apiNestedPayload struct {
+	Items []apiSecretPayload          `json:"items" yaml:"items"`
+	Map   map[string]apiSecretPayload `json:"map" yaml:"map"`
+}
+
+type apiInnerSecret struct {
+	Type   string `json:"type" yaml:"type"`
+	Secret string `json:"client_secret" yaml:"client_secret" apiredact:"secret"`
+}
+
+type apiWrapper struct {
+	InnerVal any `json:"-" yaml:"-"`
+}
+
+func (w apiWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(w.InnerVal)
+}
+
+func (w apiWrapper) MarshalYAML() (any, error) {
+	return w.InnerVal, nil
+}
+
+func TestMarshalJSONForAPI_RedactsSecretFields(t *testing.T) {
+	payload := apiNestedPayload{
+		Items: []apiSecretPayload{{Public: "shown", Secret: "secret"}},
+		Map:   map[string]apiSecretPayload{"one": {Public: "visible", Secret: "sëcret"}},
+	}
+
+	data, report, err := MarshalJSONForAPI(context.Background(), payload)
+	require.NoError(t, err)
+	require.True(t, report.Redacted)
+	require.JSONEq(t, `{
+		"items": [{"public": "shown", "secret": "******"}],
+		"map": {"one": {"public": "visible", "secret": "******"}}
+	}`, string(data))
+
+	require.Equal(t, "secret", payload.Items[0].Secret)
+	require.Equal(t, "sëcret", payload.Map["one"].Secret)
+}
+
+func TestStandardJSONMarshalIgnoresRedactionTags(t *testing.T) {
+	data, err := json.Marshal(apiSecretPayload{Public: "shown", Secret: "secret"})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"public":"shown","secret":"secret"}`, string(data))
+}
+
+func TestMarshalJSONForAPI_ReplayLeavesSecretsUnchanged(t *testing.T) {
+	ctx := WithSecretReplay(context.Background(), true)
+	payload := apiSecretPayload{Public: "shown", Secret: "secret"}
+
+	data, report, err := MarshalJSONForAPI(ctx, payload)
+	require.NoError(t, err)
+	require.False(t, report.Redacted)
+	require.JSONEq(t, `{"public":"shown","secret":"secret"}`, string(data))
+}
+
+func TestMarshalJSONForAPI_RedactsStringValueShapes(t *testing.T) {
+	type payload struct {
+		Inline *common.StringValue `json:"inline,omitempty" yaml:"inline,omitempty" apiredact:"secret"`
+		Object *common.StringValue `json:"object,omitempty" yaml:"object,omitempty" apiredact:"secret"`
+	}
+
+	data, report, err := MarshalJSONForAPI(context.Background(), payload{
+		Inline: common.NewStringValueDirectInline("token"),
+		Object: common.NewStringValueDirect("secret"),
+	})
+	require.NoError(t, err)
+	require.True(t, report.Redacted)
+	require.JSONEq(t, `{
+		"inline": "*****",
+		"object": {"value": "******"}
+	}`, string(data))
+}
+
+func TestMarshalJSONForAPI_UnwrapsPolymorphicStructsWithRedaction(t *testing.T) {
+	type payload struct {
+		Auth apiWrapper `json:"auth" yaml:"auth"`
+	}
+
+	data, report, err := MarshalJSONForAPI(context.Background(), payload{
+		Auth: apiWrapper{InnerVal: apiInnerSecret{Type: "OAuth2", Secret: "client-secret"}},
+	})
+	require.NoError(t, err)
+	require.True(t, report.Redacted)
+	require.JSONEq(t, `{"auth":{"type":"OAuth2","client_secret":"*************"}}`, string(data))
+}
+
+func TestMarshalYAMLForAPI_RedactsSecretFields(t *testing.T) {
+	data, report, err := MarshalYAMLForAPI(context.Background(), apiSecretPayload{
+		Public: "shown",
+		Secret: "secret",
+	})
+	require.NoError(t, err)
+	require.True(t, report.Redacted)
+
+	var decoded map[string]string
+	require.NoError(t, yaml.Unmarshal(data, &decoded))
+	require.Equal(t, map[string]string{
+		"public": "shown",
+		"secret": "******",
+	}, decoded)
+}
+
+func TestValidateNoRedactedPlaceholders(t *testing.T) {
+	type payload struct {
+		Secret *common.StringValue `json:"secret,omitempty" yaml:"secret,omitempty" apiredact:"secret"`
+		Public string              `json:"public" yaml:"public"`
+	}
+
+	require.NoError(t, ValidateNoRedactedPlaceholders(payload{
+		Secret: common.NewStringValueDirectInline("real-secret"),
+		Public: "***",
+	}))
+
+	err := ValidateNoRedactedPlaceholders(payload{
+		Secret: common.NewStringValueDirectInline("***"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "$.secret")
+}

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -149,7 +149,7 @@ func (r *ActorsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListActorsResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListActorsResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), DatabaseActorToJson),
 		Cursor: result.Cursor,
 	})
@@ -209,7 +209,7 @@ func (r *ActorsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(a))
+	apgin.APIJSON(gctx, http.StatusOK, DatabaseActorToJson(a))
 }
 
 // @Summary		Get actor by external ID
@@ -267,7 +267,7 @@ func (r *ActorsRoutes) getByExternalId(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(a))
+	apgin.APIJSON(gctx, http.StatusOK, DatabaseActorToJson(a))
 }
 
 // @Summary		Delete actor by UUID
@@ -521,7 +521,7 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusCreated, DatabaseActorToJson(createdActor))
+	apgin.APIJSON(gctx, http.StatusCreated, DatabaseActorToJson(createdActor))
 }
 
 // @Summary		Update actor by UUID
@@ -622,7 +622,7 @@ func (r *ActorsRoutes) update(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(updatedActor))
+	apgin.APIJSON(gctx, http.StatusOK, DatabaseActorToJson(updatedActor))
 }
 
 // @Summary		Update actor by external ID
@@ -724,7 +724,7 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, DatabaseActorToJson(updatedActor))
+	apgin.APIJSON(gctx, http.StatusOK, DatabaseActorToJson(updatedActor))
 }
 
 // Label and annotation handlers for actors delegate to a shared

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -95,7 +95,7 @@ func (r *ConnectionsRoutes) initiate(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 // @Summary		Submit connection form
@@ -154,7 +154,7 @@ func (r *ConnectionsRoutes) submit(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 // @Summary		Get setup step
@@ -209,7 +209,7 @@ func (r *ConnectionsRoutes) getSetupStep(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 // @Summary		Get data source options
@@ -271,7 +271,7 @@ func (r *ConnectionsRoutes) getDataSource(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, options)
+	apgin.APIJSON(gctx, http.StatusOK, options)
 }
 
 func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
@@ -402,7 +402,7 @@ func (r *ConnectionsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListConnectionResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListConnectionResponseJson{
 		Items: util.Map(auth.FilterForValidatedResources(val, result.Results), func(c coreIface.Connection) ConnectionJson {
 			return ConnectionToJson(c)
 		}),
@@ -464,7 +464,7 @@ func (r *ConnectionsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectionToJson(c))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectionToJson(c))
 }
 
 // @Summary		Disconnect connection
@@ -542,7 +542,7 @@ func (r *ConnectionsRoutes) disconnect(gctx *gin.Context) {
 		Connection: connJson,
 	}
 
-	gctx.PureJSON(http.StatusOK, response)
+	apgin.APIJSON(gctx, http.StatusOK, response)
 }
 
 func (r *ConnectionsRoutes) parseConnectionDisconnectRequest(gctx *gin.Context) (coreIface.ConnectionDisconnectOptions, bool) {
@@ -675,7 +675,7 @@ func (r *ConnectionsRoutes) reconfigure(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 // @Summary		Cancel in-flight setup
@@ -792,7 +792,7 @@ func (r *ConnectionsRoutes) retry(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 type ReauthConnectionRequest struct {
@@ -856,7 +856,7 @@ func (r *ConnectionsRoutes) reauth(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, resp)
+	apgin.APIJSON(gctx, http.StatusOK, resp)
 }
 
 // @Summary		Force connection state
@@ -925,7 +925,7 @@ func (r *ConnectionsRoutes) forceState(gctx *gin.Context) {
 
 	state := database.ConnectionState(req.State)
 	if c.GetState() == state {
-		gctx.PureJSON(http.StatusOK, ConnectionToJson(c))
+		apgin.APIJSON(gctx, http.StatusOK, ConnectionToJson(c))
 		return
 	}
 
@@ -936,7 +936,7 @@ func (r *ConnectionsRoutes) forceState(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectionToJson(c))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectionToJson(c))
 }
 
 // @Summary		Update connection
@@ -1021,7 +1021,7 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectionToJson(c))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectionToJson(c))
 }
 
 // Label and annotation handlers for connections delegate to a shared
@@ -1227,7 +1227,7 @@ func (r *ConnectionsRoutes) getScopes(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectionScopesJson{
+	apgin.APIJSON(gctx, http.StatusOK, ConnectionScopesJson{
 		Requested: oauth2.SplitScopes(token.RequestedScopes),
 		Granted:   oauth2.SplitScopes(token.Scopes),
 	})

--- a/internal/routes/connections_proxy.go
+++ b/internal/routes/connections_proxy.go
@@ -98,7 +98,7 @@ func (r *ConnectionsProxyRoutes) proxy(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(200, resp)
+	apgin.APIJSON(gctx, 200, resp)
 }
 
 func (r *ConnectionsProxyRoutes) Register(g gin.IRouter) {

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -11,6 +11,7 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apserde"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
@@ -218,7 +219,7 @@ func (r *ConnectorsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorToJson(c))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorToJson(c))
 }
 
 // @Summary		List connectors
@@ -304,7 +305,7 @@ func (r *ConnectorsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListConnectorsResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListConnectorsResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), ConnectorToJson),
 		Cursor: result.Cursor,
 	})
@@ -366,7 +367,7 @@ func (r *ConnectorsRoutes) getVersion(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(cv))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(cv))
 }
 
 // @Summary		List connector versions
@@ -413,7 +414,7 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 	if effectiveMatchers != nil && len(effectiveMatchers) == 0 {
 		// No access to any namespaces for this resource/verb
 		val.MarkValidated()
-		gctx.PureJSON(http.StatusOK, ListConnectorVersionsResponseJson{Items: []ConnectorVersionJson{}})
+		apgin.APIJSON(gctx, http.StatusOK, ListConnectorVersionsResponseJson{Items: []ConnectorVersionJson{}})
 		return
 	}
 
@@ -476,7 +477,7 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListConnectorVersionsResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListConnectorVersionsResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), ConnectorVersionToJson),
 		Cursor: result.Cursor,
 	})
@@ -501,6 +502,11 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 
 	var req CreateConnectorRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
@@ -542,7 +548,7 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusCreated, ConnectorVersionToJson(result))
+	apgin.APIJSON(gctx, http.StatusCreated, ConnectorVersionToJson(result))
 }
 
 // @Summary		Update connector
@@ -573,6 +579,11 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 
 	var req UpdateConnectorRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
@@ -645,7 +656,7 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(result))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(result))
 }
 
 // @Summary		Create connector version
@@ -700,6 +711,11 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 			val.MarkErrorReturn()
 			return
 		}
+		if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
 	}
 
 	if req.Definition != nil {
@@ -747,7 +763,7 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusCreated, ConnectorVersionToJson(result))
+	apgin.APIJSON(gctx, http.StatusCreated, ConnectorVersionToJson(result))
 }
 
 // @Summary		Update connector version
@@ -782,6 +798,11 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 
 	var req UpdateConnectorRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
 		return
@@ -865,7 +886,7 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(result))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(result))
 }
 
 // @Summary		Get all labels for a connector
@@ -1076,7 +1097,7 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 	}
 
 	if cv.GetState() == state {
-		gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(cv))
+		apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(cv))
 		return
 	}
 
@@ -1087,7 +1108,7 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorVersionToJson(cv))
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(cv))
 }
 
 func (r *ConnectorsRoutes) loadConnectorByID(ctx context.Context, connectorId apid.ID) (connIface.Connector, error) {
@@ -1154,7 +1175,7 @@ func (r *ConnectorsRoutes) writeLifecycleTaskResponse(
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ConnectorLifecycleResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ConnectorLifecycleResponseJson{
 		TaskId:      taskId,
 		ConnectorId: connectorID,
 	})

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -28,6 +28,7 @@ import (
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/tasks"
@@ -117,6 +118,32 @@ func assertWorkflowTaskPolls(
 	require.NotNil(t, tu.Workflow.requestedInstance)
 	require.Equal(t, workflowInstanceID, tu.Workflow.requestedInstance.InstanceID)
 	require.Equal(t, workflowExecutionID, tu.Workflow.requestedInstance.ExecutionID)
+}
+
+func redactionTestConnector() sconfig.Connector {
+	return redactionTestConnectorWithSecret("client-secret")
+}
+
+func redactionTestConnectorWithSecret(secret string) sconfig.Connector {
+	return sconfig.Connector{
+		Id:          apid.MustParse("cxr_test0000000000001"),
+		Version:     1,
+		Namespace:   util.ToPtr("root"),
+		DisplayName: "Secret Connector",
+		Description: "Connector with a client secret",
+		Auth: &cschema.Auth{InnerVal: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			ClientId:     common.NewStringValueDirectInline("client-id"),
+			ClientSecret: common.NewStringValueDirectInline(secret),
+			Scopes:       []cschema.Scope{},
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: "https://auth.example.com/authorize",
+			},
+			Token: cschema.AuthOauth2Token{
+				Endpoint: "https://auth.example.com/token",
+			},
+		}},
+	}
 }
 
 func TestParseConnectorID(t *testing.T) {
@@ -829,6 +856,79 @@ func TestConnectors(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Id)
 			})
+
+			t.Run("redacts connector secrets by default", func(t *testing.T) {
+				tu := setup(t, config.FromRoot(&sconfig.Root{
+					Connectors: &sconfig.Connectors{
+						LoadFromList: []sconfig.Connector{
+							redactionTestConnector(),
+						},
+					},
+				}))
+
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodGet,
+					"/connectors/cxr_test0000000000001/versions/1",
+					nil,
+					"root",
+					"some-actor",
+					aschema.PermissionsSingle("root.**", "connectors", "list/versions"),
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Equal(t, "true", w.Header().Get("X-AuthProxy-Data-Redacted"))
+
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+				definition := raw["definition"].(map[string]any)
+				auth := definition["auth"].(map[string]any)
+				require.Equal(t, "*************", auth["client_secret"])
+			})
+
+			t.Run("replays connector secrets with secret replay permission", func(t *testing.T) {
+				tu := setup(t, config.FromRoot(&sconfig.Root{
+					Connectors: &sconfig.Connectors{
+						LoadFromList: []sconfig.Connector{
+							redactionTestConnector(),
+						},
+					},
+				}))
+
+				w := httptest.NewRecorder()
+				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+					http.MethodGet,
+					"/connectors/cxr_test0000000000001/versions/1",
+					nil,
+					"root",
+					"some-actor",
+					[]aschema.Permission{
+						{
+							Namespace: "root.**",
+							Resources: []string{"connectors"},
+							Verbs:     []string{"list/versions"},
+						},
+						{
+							Namespace: "root.**",
+							Resources: []string{"secrets"},
+							Verbs:     []string{"replay"},
+						},
+					},
+				)
+				require.NoError(t, err)
+
+				tu.Gin.ServeHTTP(w, req)
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Empty(t, w.Header().Get("X-AuthProxy-Data-Redacted"))
+
+				var raw map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+				definition := raw["definition"].(map[string]any)
+				auth := definition["auth"].(map[string]any)
+				require.Equal(t, "client-secret", auth["client_secret"])
+			})
 		})
 
 		t.Run("list", func(t *testing.T) {
@@ -976,6 +1076,34 @@ func TestConnectors(t *testing.T) {
 
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("rejects redacted placeholders in secret fields", func(t *testing.T) {
+			tu := setup(t, nil)
+			def := redactionTestConnectorWithSecret("***")
+			def.Id = apid.Nil
+			def.Version = 0
+			def.Namespace = nil
+			body := CreateConnectorRequestJson{
+				Namespace:  "root",
+				Definition: def,
+			}
+			jsonBody, _ := json.Marshal(body)
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors",
+				bytes.NewReader(jsonBody),
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "redacted placeholder values")
 		})
 
 		t.Run("valid", func(t *testing.T) {

--- a/internal/routes/key_value/adapter.go
+++ b/internal/routes/key_value/adapter.go
@@ -143,7 +143,7 @@ func (a Adapter[ID]) HandleList(gctx *gin.Context) {
 	if values == nil {
 		values = make(map[string]string)
 	}
-	gctx.PureJSON(http.StatusOK, values)
+	apgin.APIJSON(gctx, http.StatusOK, values)
 }
 
 // HandleGet serves GET /<resource>/<id>/<segment>/<key> — returns the
@@ -177,7 +177,7 @@ func (a Adapter[ID]) HandleGet(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, KeyValueJson{Key: key, Value: value})
+	apgin.APIJSON(gctx, http.StatusOK, KeyValueJson{Key: key, Value: value})
 }
 
 // HandlePut serves PUT /<resource>/<id>/<segment>/<key> — adds or
@@ -235,7 +235,7 @@ func (a Adapter[ID]) HandlePut(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, KeyValueJson{
+	apgin.APIJSON(gctx, http.StatusOK, KeyValueJson{
 		Key:   key,
 		Value: a.Kind.Get(updated)[key],
 	})

--- a/internal/routes/key_value/adapter_test.go
+++ b/internal/routes/key_value/adapter_test.go
@@ -32,9 +32,9 @@ type fakeResource struct {
 	annotations map[string]string
 }
 
-func (f *fakeResource) GetId() apid.ID                   { return f.id }
-func (f *fakeResource) GetNamespace() string             { return f.namespace }
-func (f *fakeResource) GetLabels() map[string]string     { return f.labels }
+func (f *fakeResource) GetId() apid.ID               { return f.id }
+func (f *fakeResource) GetNamespace() string         { return f.namespace }
+func (f *fakeResource) GetLabels() map[string]string { return f.labels }
 func (f *fakeResource) GetAnnotations() map[string]string {
 	return f.annotations
 }

--- a/internal/routes/keys.go
+++ b/internal/routes/keys.go
@@ -102,7 +102,7 @@ func (r *KeysRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, KeyToJson(ek))
+	apgin.APIJSON(gctx, http.StatusOK, KeyToJson(ek))
 }
 
 // @Summary		Create key
@@ -171,7 +171,7 @@ func (r *KeysRoutes) create(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, KeyToJson(ek))
+	apgin.APIJSON(gctx, http.StatusOK, KeyToJson(ek))
 }
 
 // @Summary		List keys
@@ -257,7 +257,7 @@ func (r *KeysRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListKeysResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListKeysResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), KeyToJson),
 		Cursor: result.Cursor,
 	})
@@ -395,7 +395,7 @@ func (r *KeysRoutes) update(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, KeyToJson(ek))
+	apgin.APIJSON(gctx, http.StatusOK, KeyToJson(ek))
 }
 
 // @Summary		Delete key

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -111,7 +111,7 @@ func (r *NamespacesRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, NamespaceToJson(ns))
+	apgin.APIJSON(gctx, http.StatusOK, NamespaceToJson(ns))
 }
 
 // @Summary		Create namespace
@@ -195,7 +195,7 @@ func (r *NamespacesRoutes) create(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, NamespaceToJson(ns))
+	apgin.APIJSON(gctx, http.StatusOK, NamespaceToJson(ns))
 }
 
 // @Summary		List namespaces
@@ -300,7 +300,7 @@ func (r *NamespacesRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListNamespacesResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListNamespacesResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), NamespaceToJson),
 		Cursor: result.Cursor,
 	})
@@ -408,7 +408,7 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, NamespaceToJson(ns))
+	apgin.APIJSON(gctx, http.StatusOK, NamespaceToJson(ns))
 }
 
 // Label and annotation handlers for namespaces delegate to a shared
@@ -574,7 +574,7 @@ func (r *NamespacesRoutes) getKey(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, NamespaceKeyJson{
+	apgin.APIJSON(gctx, http.StatusOK, NamespaceKeyJson{
 		KeyId: string(*ekId),
 	})
 }
@@ -643,7 +643,7 @@ func (r *NamespacesRoutes) setKey(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, NamespaceToJson(ns))
+	apgin.APIJSON(gctx, http.StatusOK, NamespaceToJson(ns))
 }
 
 func (r *NamespacesRoutes) clearKey(gctx *gin.Context) {

--- a/internal/routes/rate_limits.go
+++ b/internal/routes/rate_limits.go
@@ -159,7 +159,7 @@ func (r *RateLimitsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+	apgin.APIJSON(gctx, http.StatusOK, RateLimitToJson(rl))
 }
 
 // @Summary		Create rate limit
@@ -226,7 +226,7 @@ func (r *RateLimitsRoutes) create(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+	apgin.APIJSON(gctx, http.StatusOK, RateLimitToJson(rl))
 }
 
 // @Summary		List rate limits
@@ -306,7 +306,7 @@ func (r *RateLimitsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListRateLimitsResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListRateLimitsResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), RateLimitToJson),
 		Cursor: result.Cursor,
 	})
@@ -418,7 +418,7 @@ func (r *RateLimitsRoutes) update(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, RateLimitToJson(rl))
+	apgin.APIJSON(gctx, http.StatusOK, RateLimitToJson(rl))
 }
 
 func (r *RateLimitsRoutes) handleMutateError(gctx *gin.Context, val *auth.ResourcePermissionValidator, id apid.ID, err error) {
@@ -532,7 +532,7 @@ func (r *RateLimitsRoutes) dryRun(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, dryRunResponseFromCore(result))
+	apgin.APIJSON(gctx, http.StatusOK, dryRunResponseFromCore(result))
 }
 
 // Label and annotation handlers delegate to the shared key_value adapter.

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -572,7 +572,7 @@ func (r *RequestEventsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, entry)
+	apgin.APIJSON(gctx, http.StatusOK, entry)
 }
 
 // @Summary		List request events entries
@@ -668,7 +668,7 @@ func (r *RequestEventsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(200, &ListRequestEventsResponseJson{
+	apgin.APIJSON(gctx, 200, &ListRequestEventsResponseJson{
 		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), requestEventToJson),
 		Cursor: result.Cursor,
 		Total:  result.Total,
@@ -794,7 +794,7 @@ func (r *RequestEventsRoutes) queryMetrics(gctx *gin.Context) {
 	// Metrics responses are aggregate series, not resource rows, so the request is validated once all query refs are
 	// accepted and their namespace matchers are constrained by the actor's permissions.
 	val.MarkValidated()
-	gctx.PureJSON(http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
+	apgin.APIJSON(gctx, http.StatusOK, metricsResponseFromAPIRequest(req, responseSeries))
 }
 
 // @Summary		Get application metrics schema
@@ -810,7 +810,7 @@ func (r *RequestEventsRoutes) schema(gctx *gin.Context) {
 	val := auth.MustGetValidatorFromGinContext(gctx)
 	// The schema response is static metadata for the app-metrics API, so there are no resource rows to post-validate.
 	val.MarkValidated()
-	gctx.PureJSON(http.StatusOK, metricsSchemaResponse())
+	apgin.APIJSON(gctx, http.StatusOK, metricsSchemaResponse())
 }
 
 func (r *RequestEventsRoutes) Register(g gin.IRouter) {

--- a/internal/routes/session.go
+++ b/internal/routes/session.go
@@ -81,7 +81,7 @@ func (r *SessionRoutes) initiate(gctx *gin.Context) {
 	if !ra.IsAuthenticated() {
 		logger.Debug("request was not authenticated, returning redirect url")
 		apgin.AddDebugHeader(gctx, "auth not present on context")
-		gctx.PureJSON(http.StatusUnauthorized, SessionInitiateFailureResponse{
+		apgin.APIJSON(gctx, http.StatusUnauthorized, SessionInitiateFailureResponse{
 			RedirectUrl: r.sessionInitiateUrlGenerator.GetInitiateSessionUrl(req.ReturnToUrl),
 		})
 		return
@@ -100,7 +100,7 @@ func (r *SessionRoutes) initiate(gctx *gin.Context) {
 
 	a := ra.MustGetActor()
 
-	gctx.PureJSON(http.StatusOK, SessionInitiateSuccessResponse{
+	apgin.APIJSON(gctx, http.StatusOK, SessionInitiateSuccessResponse{
 		ActorId: a.Id,
 	})
 }
@@ -128,7 +128,7 @@ func (r *SessionRoutes) terminate(gctx *gin.Context) {
 	if !ra.IsAuthenticated() {
 		logger.Debug("request was already unauthenticated; ignoring")
 		apgin.AddDebugHeader(gctx, "auth not present on context")
-		gctx.PureJSON(http.StatusOK, gin.H{})
+		apgin.APIJSON(gctx, http.StatusOK, gin.H{})
 		return
 	}
 
@@ -140,7 +140,7 @@ func (r *SessionRoutes) terminate(gctx *gin.Context) {
 	}
 
 	logger.Debug("successfully terminated session")
-	gctx.PureJSON(http.StatusOK, gin.H{})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{})
 }
 
 func (r *SessionRoutes) Register(g gin.IRouter) {

--- a/internal/routes/task_monitoring.go
+++ b/internal/routes/task_monitoring.go
@@ -221,7 +221,7 @@ func (r *TaskMonitoringRoutes) listQueues(gctx *gin.Context) {
 		items = append(items, queueInfoToJson(qi))
 	}
 
-	gctx.PureJSON(http.StatusOK, ListQueuesResponseJson{Items: items})
+	apgin.APIJSON(gctx, http.StatusOK, ListQueuesResponseJson{Items: items})
 }
 
 func (r *TaskMonitoringRoutes) getQueueInfo(gctx *gin.Context) {
@@ -240,7 +240,7 @@ func (r *TaskMonitoringRoutes) getQueueInfo(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, queueInfoToJson(qi))
+	apgin.APIJSON(gctx, http.StatusOK, queueInfoToJson(qi))
 }
 
 func (r *TaskMonitoringRoutes) getQueueHistory(gctx *gin.Context) {
@@ -274,7 +274,7 @@ func (r *TaskMonitoringRoutes) getQueueHistory(gctx *gin.Context) {
 		result = append(result, dailyStatsToJson(s))
 	}
 
-	gctx.PureJSON(http.StatusOK, ListQueueHistoryResponseJson{Items: result})
+	apgin.APIJSON(gctx, http.StatusOK, ListQueueHistoryResponseJson{Items: result})
 }
 
 func (r *TaskMonitoringRoutes) listTasksByState(gctx *gin.Context) {
@@ -366,7 +366,7 @@ func (r *TaskMonitoringRoutes) listTasksByState(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, ListMonitoringTasksResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListMonitoringTasksResponseJson{
 		Items:  items,
 		Cursor: cursor,
 	})
@@ -390,7 +390,7 @@ func (r *TaskMonitoringRoutes) getTask(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, taskInfoToJson(ti))
+	apgin.APIJSON(gctx, http.StatusOK, taskInfoToJson(ti))
 }
 
 func (r *TaskMonitoringRoutes) listServers(gctx *gin.Context) {
@@ -408,7 +408,7 @@ func (r *TaskMonitoringRoutes) listServers(gctx *gin.Context) {
 		items = append(items, serverInfoToJson(s))
 	}
 
-	gctx.PureJSON(http.StatusOK, ListServersResponseJson{Items: items})
+	apgin.APIJSON(gctx, http.StatusOK, ListServersResponseJson{Items: items})
 }
 
 func (r *TaskMonitoringRoutes) listSchedulerEntries(gctx *gin.Context) {
@@ -426,7 +426,7 @@ func (r *TaskMonitoringRoutes) listSchedulerEntries(gctx *gin.Context) {
 		items = append(items, schedulerEntryToJson(e))
 	}
 
-	gctx.PureJSON(http.StatusOK, ListSchedulerEntriesResponseJson{Items: items})
+	apgin.APIJSON(gctx, http.StatusOK, ListSchedulerEntriesResponseJson{Items: items})
 }
 
 func (r *TaskMonitoringRoutes) runTask(gctx *gin.Context) {
@@ -441,7 +441,7 @@ func (r *TaskMonitoringRoutes) runTask(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) archiveTask(gctx *gin.Context) {
@@ -456,7 +456,7 @@ func (r *TaskMonitoringRoutes) archiveTask(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) cancelTask(gctx *gin.Context) {
@@ -470,7 +470,7 @@ func (r *TaskMonitoringRoutes) cancelTask(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) deleteTask(gctx *gin.Context) {
@@ -485,7 +485,7 @@ func (r *TaskMonitoringRoutes) deleteTask(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) pauseQueue(gctx *gin.Context) {
@@ -499,7 +499,7 @@ func (r *TaskMonitoringRoutes) pauseQueue(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) unpauseQueue(gctx *gin.Context) {
@@ -513,7 +513,7 @@ func (r *TaskMonitoringRoutes) unpauseQueue(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *TaskMonitoringRoutes) runAllArchivedTasks(gctx *gin.Context) {
@@ -528,7 +528,7 @@ func (r *TaskMonitoringRoutes) runAllArchivedTasks(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
+	apgin.APIJSON(gctx, http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
 }
 
 func (r *TaskMonitoringRoutes) runAllRetryTasks(gctx *gin.Context) {
@@ -543,7 +543,7 @@ func (r *TaskMonitoringRoutes) runAllRetryTasks(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
+	apgin.APIJSON(gctx, http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
 }
 
 func (r *TaskMonitoringRoutes) deleteAllArchivedTasks(gctx *gin.Context) {
@@ -558,7 +558,7 @@ func (r *TaskMonitoringRoutes) deleteAllArchivedTasks(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
+	apgin.APIJSON(gctx, http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
 }
 
 func (r *TaskMonitoringRoutes) deleteAllCompletedTasks(gctx *gin.Context) {
@@ -573,7 +573,7 @@ func (r *TaskMonitoringRoutes) deleteAllCompletedTasks(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
+	apgin.APIJSON(gctx, http.StatusOK, &BulkActionResponseJson{AffectedCount: count})
 }
 
 // Register registers all task monitoring routes

--- a/internal/routes/tasks.go
+++ b/internal/routes/tasks.go
@@ -235,7 +235,7 @@ func (r *TaskRoutes) get(gctx *gin.Context) {
 
 		resp := WorkflowTaskInfoToJson(encryptedTaskInfo, ti, state)
 		resp.State = WorkflowTaskInfoStateFromHistory(state, historyEvents)
-		gctx.PureJSON(http.StatusOK, resp)
+		apgin.APIJSON(gctx, http.StatusOK, resp)
 		return
 	}
 
@@ -260,7 +260,7 @@ func (r *TaskRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, TaskInfoToJson(encryptedTaskInfo, ati))
+	apgin.APIJSON(gctx, http.StatusOK, TaskInfoToJson(encryptedTaskInfo, ati))
 }
 
 func (r *TaskRoutes) Register(g gin.IRouter) {

--- a/internal/routes/workflow_monitoring.go
+++ b/internal/routes/workflow_monitoring.go
@@ -203,7 +203,7 @@ func (r *WorkflowMonitoringRoutes) listInstances(gctx *gin.Context) {
 		}
 	}
 
-	gctx.PureJSON(http.StatusOK, ListWorkflowInstancesResponseJson{
+	apgin.APIJSON(gctx, http.StatusOK, ListWorkflowInstancesResponseJson{
 		Items:  workflowInstanceRefsToJson(items),
 		Cursor: cursor,
 	})
@@ -235,7 +235,7 @@ func (r *WorkflowMonitoringRoutes) getInstance(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, &WorkflowInstanceInfoJson{
+	apgin.APIJSON(gctx, http.StatusOK, &WorkflowInstanceInfoJson{
 		WorkflowInstanceRefJson: workflowInstanceRefToJson(instanceRef),
 		History:                 workflowHistoryEventsToJson(historyEvents),
 	})
@@ -267,7 +267,7 @@ func (r *WorkflowMonitoringRoutes) getHistory(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, ListWorkflowHistoryResponseJson{Items: workflowHistoryEventsToJson(historyEvents)})
+	apgin.APIJSON(gctx, http.StatusOK, ListWorkflowHistoryResponseJson{Items: workflowHistoryEventsToJson(historyEvents)})
 }
 
 func (r *WorkflowMonitoringRoutes) getTree(gctx *gin.Context) {
@@ -290,7 +290,7 @@ func (r *WorkflowMonitoringRoutes) getTree(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, workflowInstanceTreeToJson(tree))
+	apgin.APIJSON(gctx, http.StatusOK, workflowInstanceTreeToJson(tree))
 }
 
 func (r *WorkflowMonitoringRoutes) cancelInstance(gctx *gin.Context) {
@@ -308,7 +308,7 @@ func (r *WorkflowMonitoringRoutes) cancelInstance(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *WorkflowMonitoringRoutes) removeInstance(gctx *gin.Context) {
@@ -326,7 +326,7 @@ func (r *WorkflowMonitoringRoutes) removeInstance(gctx *gin.Context) {
 		return
 	}
 
-	gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
+	apgin.APIJSON(gctx, http.StatusOK, gin.H{"ok": true})
 }
 
 func (r *WorkflowMonitoringRoutes) Register(g gin.IRouter) {

--- a/internal/schema/resources/connectors/auth_oauth2.go
+++ b/internal/schema/resources/connectors/auth_oauth2.go
@@ -52,7 +52,7 @@ type AuthOAuth2 struct {
 	// default.
 	TokenEndpointAuthMethod *TokenEndpointAuthMethod `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
 	ClientId                *common.StringValue      `json:"client_id,omitempty" yaml:"client_id,omitempty"`
-	ClientSecret            *common.StringValue      `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	ClientSecret            *common.StringValue      `json:"client_secret,omitempty" yaml:"client_secret,omitempty" apiredact:"secret"`
 	Scopes                  []Scope                  `json:"scopes" yaml:"scopes"`
 	Authorization           AuthOauth2Authorization  `json:"authorization" yaml:"authorization"`
 	Token                   AuthOauth2Token          `json:"token" yaml:"token"`


### PR DESCRIPTION
## Summary
- add `internal/apserde` for API-only JSON/YAML redaction via `apiredact:"secret"`
- add `apgin.APIJSON` and migrate API route JSON responses to use it
- wire `secrets/replay` authorization into request context and annotate OAuth client secrets
- reject mask-only placeholders on connector write paths

## Test Plan
- `go test ./internal/apgin ./internal/apauth/service ./internal/apserde ./internal/schema/resources/connectors ./internal/routes`
- `./scripts/preflight.sh`

Part of #687.
Closes #688.
Closes #689.
Closes #690.
Closes #691.
Closes #692.