### PR TITLE
Fix demo Grafana actor token signing

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -220,16 +220,16 @@ jobs:
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
 
-          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-jwt" \
-            -o jsonpath='{.data.system}' \
-            | base64 -d > "${workdir}/system.key"
-          chmod 600 "${workdir}/system.key"
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-demo-shell-key" \
+            -o jsonpath='{.data.private}' \
+            | base64 -d > "${workdir}/grafana-actor.key"
+          chmod 600 "${workdir}/grafana-actor.key"
 
           go run ./cmd/cli sign-jwt \
             --actorId grafana \
             --apis api,admin-api \
             --grafana-preset logs \
-            --privateKeyPath "${workdir}/system.key" \
+            --privateKeyPath "${workdir}/grafana-actor.key" \
             > "${workdir}/grafana.jwt"
 
           kubectl -n "${RELEASE_NS}" create secret generic authproxy-grafana-jwt \

--- a/cmd/cli/config/resolver_test.go
+++ b/cmd/cli/config/resolver_test.go
@@ -157,6 +157,8 @@ func TestResolveBuilderWithGrafanaPreset(t *testing.T) {
 		Resources: []string{"request-events"},
 		Verbs:     []string{"list"},
 	})
+	require.True(t, claims.ActorSigned)
+	require.False(t, claims.SystemSigned)
 }
 
 func TestResolveBuilderNoExpiryOverridesGrafanaDefault(t *testing.T) {


### PR DESCRIPTION
## Summary
- sign the demo Grafana datasource JWT with the Grafana actor private key instead of the system JWT key
- keep the Grafana preset explicitly covered as an actor-signed token in CLI resolver tests

## Why
The live `grafana` actor has a synced public key from `-actors`, so AuthProxy verifies actor-signed tokens against that actor key. The deploy workflow was minting an actor-signed token with `-jwt`'s system private key, which produced `invalid token` from the datasource.

## Verification
- `go test ./cmd/cli/config`
- `./scripts/preflight.sh`
- patched the live `demo/authproxy-grafana-jwt` secret with a token signed by `demo-demo-shell-key.private`
- verified live token with `demo-actors.grafana.pub`
- verified AuthProxy accepted the live token through localhost port-forward: `GET /api/v1/namespaces?limit=1` returned `200 OK`
- checked fresh Grafana/AuthProxy logs: no new `invalid token` entries after restart