### PR TITLE
Guard routes against raw Gin JSON rendering

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,9 @@ jobs:
       with:
         version: latest
 
+    - name: Check route JSON rendering guardrails
+      run: go run ./tools/check-gin-json-rendering
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/time v0.12.0
+	golang.org/x/tools v0.40.0
 	google.golang.org/api v0.247.0
 	gopkg.in/h2non/gentleman-mock.v2 v2.0.0
 	gopkg.in/h2non/gentleman.v2 v2.0.5
@@ -203,7 +204,6 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250929231259-57b25ae835d4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 // indirect

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -41,6 +41,9 @@ say "Checking integration_tests module (go list -mod=readonly)"
 say "Checking workflow guardrails"
 "$ROOT_DIR/scripts/check-workflows.sh" >/dev/null
 
+say "Checking route JSON rendering guardrails"
+go run ./tools/check-gin-json-rendering >/dev/null
+
 say "Checking schema package layout"
 "$ROOT_DIR/scripts/check-schema-layout.sh" >/dev/null
 

--- a/tools/check-gin-json-rendering/main.go
+++ b/tools/check-gin-json-rendering/main.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	defaultPattern = "./internal/routes/..."
+	ginPackage     = "github.com/gin-gonic/gin"
+	allowMarker    = "apiredact:allow-gin-json"
+)
+
+var forbiddenMethods = map[string]struct{}{
+	"JSON":         {},
+	"PureJSON":     {},
+	"IndentedJSON": {},
+	"SecureJSON":   {},
+	"AsciiJSON":    {},
+}
+
+type violation struct {
+	Filename string
+	Line     int
+	Column   int
+	Method   string
+	Message  string
+}
+
+type allowDirective struct {
+	valid bool
+}
+
+type allowStatus struct {
+	allowed bool
+	present bool
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	patterns := args
+	if len(patterns) == 0 {
+		patterns = []string{defaultPattern}
+	}
+
+	violations, err := check(".", patterns)
+	if err != nil {
+		fmt.Fprintf(stderr, "check-gin-json-rendering: %v\n", err)
+		return 2
+	}
+
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "route JSON rendering guard passed")
+		return 0
+	}
+
+	for _, v := range violations {
+		fmt.Fprintf(stderr, "%s:%d:%d: %s\n", v.Filename, v.Line, v.Column, v.Message)
+	}
+	return 1
+}
+
+func check(dir string, patterns []string) ([]violation, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	fset := token.NewFileSet()
+	cfg := &packages.Config{
+		Dir:   absDir,
+		Fset:  fset,
+		Mode:  packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo,
+		Tests: false,
+	}
+
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("load packages: %w", err)
+	}
+	if loadErr := packageLoadError(pkgs); loadErr != nil {
+		return nil, loadErr
+	}
+
+	var violations []violation
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Syntax {
+			filename := fset.Position(file.Pos()).Filename
+			if !shouldCheckFile(absDir, filename) {
+				continue
+			}
+
+			allows := collectAllowDirectives(fset, file)
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if _, found := forbiddenMethods[sel.Sel.Name]; !found {
+					return true
+				}
+				if !isGinRenderSelection(pkg, sel) {
+					return true
+				}
+
+				pos := fset.Position(sel.Sel.Pos())
+				status := allowForLine(allows, pos.Line)
+				if status.allowed {
+					return true
+				}
+
+				message := fmt.Sprintf("direct Gin %s rendering is forbidden in internal/routes; use apgin.APIJSON so apiredact tags are honored, or add // %s: <reason>", sel.Sel.Name, allowMarker)
+				if status.present {
+					message = fmt.Sprintf("%s escape hatch comment must include a reason for the direct Gin %s rendering call", allowMarker, sel.Sel.Name)
+				}
+				violations = append(violations, violation{
+					Filename: displayPath(absDir, pos.Filename),
+					Line:     pos.Line,
+					Column:   pos.Column,
+					Method:   sel.Sel.Name,
+					Message:  message,
+				})
+				return true
+			})
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].Filename != violations[j].Filename {
+			return violations[i].Filename < violations[j].Filename
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Column < violations[j].Column
+	})
+
+	return violations, nil
+}
+
+func packageLoadError(pkgs []*packages.Package) error {
+	var messages []string
+	packages.Visit(pkgs, nil, func(pkg *packages.Package) {
+		for _, err := range pkg.Errors {
+			messages = append(messages, err.Error())
+		}
+	})
+	if len(messages) == 0 {
+		return nil
+	}
+	sort.Strings(messages)
+	return fmt.Errorf("load packages:\n%s", strings.Join(messages, "\n"))
+}
+
+func shouldCheckFile(rootDir string, filename string) bool {
+	if strings.HasSuffix(filename, "_test.go") {
+		return false
+	}
+
+	rel, err := filepath.Rel(rootDir, filename)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	return rel == "internal/routes" || strings.HasPrefix(rel, "internal/routes/")
+}
+
+func isGinRenderSelection(pkg *packages.Package, sel *ast.SelectorExpr) bool {
+	selection := pkg.TypesInfo.Selections[sel]
+	if selection == nil {
+		return false
+	}
+
+	obj := selection.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	if obj.Pkg().Path() != ginPackage {
+		return false
+	}
+	_, forbidden := forbiddenMethods[obj.Name()]
+	return forbidden
+}
+
+func collectAllowDirectives(fset *token.FileSet, file *ast.File) map[int][]allowDirective {
+	allows := make(map[int][]allowDirective)
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			if !strings.Contains(comment.Text, allowMarker) {
+				continue
+			}
+
+			directive := allowDirective{valid: allowCommentHasReason(comment.Text)}
+			start := fset.Position(comment.Pos()).Line
+			end := fset.Position(comment.End()).Line
+			for line := start; line <= end; line++ {
+				allows[line] = append(allows[line], directive)
+			}
+		}
+	}
+	return allows
+}
+
+func allowCommentHasReason(text string) bool {
+	idx := strings.Index(text, allowMarker)
+	if idx == -1 {
+		return false
+	}
+
+	reason := strings.TrimSpace(text[idx+len(allowMarker):])
+	reason = strings.TrimPrefix(reason, ":")
+	reason = strings.TrimPrefix(reason, "-")
+	reason = strings.TrimSpace(reason)
+	reason = strings.TrimSuffix(reason, "*/")
+	reason = strings.TrimSpace(reason)
+	return reason != ""
+}
+
+func allowForLine(allows map[int][]allowDirective, line int) allowStatus {
+	var status allowStatus
+	for _, checkLine := range []int{line, line - 1} {
+		for _, directive := range allows[checkLine] {
+			status.present = true
+			if directive.valid {
+				status.allowed = true
+				return status
+			}
+		}
+	}
+	return status
+}
+
+func displayPath(rootDir string, filename string) string {
+	rel, err := filepath.Rel(rootDir, filename)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return filename
+	}
+	return filepath.ToSlash(rel)
+}

--- a/tools/check-gin-json-rendering/main_test.go
+++ b/tools/check-gin-json-rendering/main_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCheckDetectsGinJSONRenderingMethods(t *testing.T) {
+	root := testModule(t, map[string]string{
+		"internal/routes/handlers.go": `
+package routes
+
+import "github.com/gin-gonic/gin"
+
+func handler(c *gin.Context) {
+	c.JSON(200, gin.H{"ok": true})
+	c.PureJSON(200, gin.H{"ok": true})
+	c.IndentedJSON(200, gin.H{"ok": true})
+	c.SecureJSON(200, gin.H{"ok": true})
+	c.AsciiJSON(200, gin.H{"ok": true})
+}
+`,
+	})
+
+	violations, err := check(root, []string{"./internal/routes/..."})
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+
+	got := violationMethods(violations)
+	want := []string{"AsciiJSON", "IndentedJSON", "JSON", "PureJSON", "SecureJSON"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("methods = %v, want %v", got, want)
+	}
+}
+
+func TestCheckIgnoresAllowedAndNonGinJSONCalls(t *testing.T) {
+	root := testModule(t, map[string]string{
+		"internal/routes/handlers.go": `
+package routes
+
+import "github.com/gin-gonic/gin"
+
+type localRenderer struct{}
+
+func (localRenderer) JSON(code int, obj any) {}
+
+func handler(c *gin.Context, local localRenderer) {
+	local.JSON(200, nil)
+
+	// apiredact:allow-gin-json: this endpoint intentionally returns a fixed health payload with no route data
+	c.JSON(200, gin.H{"ok": true})
+	c.PureJSON(200, gin.H{"ok": true}) // apiredact:allow-gin-json: this endpoint intentionally bypasses API serialization
+}
+`,
+	})
+
+	violations, err := check(root, []string{"./internal/routes/..."})
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("violations = %#v, want none", violations)
+	}
+}
+
+func TestCheckRequiresEscapeHatchReason(t *testing.T) {
+	root := testModule(t, map[string]string{
+		"internal/routes/handlers.go": `
+package routes
+
+import "github.com/gin-gonic/gin"
+
+func handler(c *gin.Context) {
+	// apiredact:allow-gin-json
+	c.JSON(200, gin.H{"ok": true})
+}
+`,
+	})
+
+	violations, err := check(root, []string{"./internal/routes/..."})
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("violations = %d, want 1", len(violations))
+	}
+	if !strings.Contains(violations[0].Message, "must include a reason") {
+		t.Fatalf("message = %q, want missing reason guidance", violations[0].Message)
+	}
+}
+
+func TestCheckSkipsTestsAndFilesOutsideRoutes(t *testing.T) {
+	root := testModule(t, map[string]string{
+		"internal/routes/handlers.go": `
+package routes
+
+func handler() {}
+`,
+		"internal/routes/handlers_test.go": `
+package routes
+
+import "github.com/gin-gonic/gin"
+
+func testHandler(c *gin.Context) {
+	c.JSON(200, gin.H{"ok": true})
+}
+`,
+		"internal/notroutes/handlers.go": `
+package notroutes
+
+import "github.com/gin-gonic/gin"
+
+func handler(c *gin.Context) {
+	c.JSON(200, gin.H{"ok": true})
+}
+`,
+	})
+
+	violations, err := check(root, []string{"./..."})
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("violations = %#v, want none", violations)
+	}
+}
+
+func violationMethods(violations []violation) []string {
+	methods := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		methods = append(methods, violation.Method)
+	}
+	slices.Sort(methods)
+	return methods
+}
+
+func testModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	baseFiles := map[string]string{
+		"go.mod": `
+module example.com/app
+
+go 1.24
+
+require github.com/gin-gonic/gin v0.0.0
+
+replace github.com/gin-gonic/gin => ./testgin
+`,
+		"testgin/go.mod": `
+module github.com/gin-gonic/gin
+
+go 1.24
+`,
+		"testgin/context.go": `
+package gin
+
+type H map[string]any
+
+type Context struct{}
+
+func (*Context) JSON(code int, obj any) {}
+func (*Context) PureJSON(code int, obj any) {}
+func (*Context) IndentedJSON(code int, obj any) {}
+func (*Context) SecureJSON(code int, obj any) {}
+func (*Context) AsciiJSON(code int, obj any) {}
+`,
+	}
+	for path, contents := range files {
+		baseFiles[path] = contents
+	}
+
+	for path, contents := range baseFiles {
+		fullPath := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(strings.TrimSpace(contents)+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	return root
+}


### PR DESCRIPTION
## Summary
- add a repo-local checker that rejects direct Gin JSON render methods in production files under internal/routes
- support a narrow // apiredact:allow-gin-json: <reason> escape hatch
- run the checker from ./scripts/preflight.sh and the Go lint workflow

Closes #695

## Tests
- go test ./tools/check-gin-json-rendering
- go run ./tools/check-gin-json-rendering
- ./scripts/preflight.sh
- push hook reran ./scripts/preflight.sh