### PR TITLE
Enable Grafana login in demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -18,6 +18,9 @@ name: Deploy Demo
 #     and demo-minio-creds.
 #   - Repo secret AWS_ROLE_ARN.
 #   - Repo variables AWS_REGION, EKS_CLUSTER, and DEMO_HOSTNAME.
+#   - Optional: repo variable DEMO_GRAFANA_ADMIN_USER and repo secret
+#     DEMO_GRAFANA_ADMIN_PASSWORD. If unset, the workflow generates and
+#     preserves random Grafana admin credentials in the cluster.
 
 on:
   workflow_run:
@@ -237,6 +240,31 @@ jobs:
             --dry-run=client -o yaml \
             | kubectl apply -f -
 
+      - name: Provision Grafana admin credentials
+        env:
+          GRAFANA_ADMIN_USER: ${{ vars.DEMO_GRAFANA_ADMIN_USER || 'admin' }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.DEMO_GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          username="${GRAFANA_ADMIN_USER:-admin}"
+          password="${GRAFANA_ADMIN_PASSWORD:-}"
+
+          if [ -z "${password}" ] && kubectl -n "${RELEASE_NS}" get secret authproxy-grafana-admin >/dev/null 2>&1; then
+            echo "Reusing authproxy-grafana-admin"
+            exit 0
+          fi
+
+          if [ -z "${password}" ]; then
+            password="$(openssl rand -base64 32)"
+          fi
+
+          kubectl -n "${RELEASE_NS}" create secret generic authproxy-grafana-admin \
+            --from-literal=username="${username}" \
+            --from-literal=password="${password}" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
+
       - name: Render Kustomize overlay
         id: render
         env:
@@ -263,6 +291,10 @@ jobs:
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-grafana:${IMAGE_TAG}" "${manifest}"
           grep -Fq "host: ${DEMO_HOSTNAME}" "${manifest}"
           grep -Fq "value: https://${DEMO_HOSTNAME}/grafana" "${manifest}"
+          perl -0ne 'exit(/name: GF_AUTH_DISABLE_LOGIN_FORM\s*\n\s*value: "false"/ ? 0 : 1)' "${manifest}"
+          grep -Fq "name: GF_SECURITY_ADMIN_USER" "${manifest}"
+          grep -Fq "name: GF_SECURITY_ADMIN_PASSWORD" "${manifest}"
+          grep -Fq "name: authproxy-grafana-admin" "${manifest}"
 
       - name: Apply Kustomize manifest
         run: |
@@ -368,6 +400,20 @@ jobs:
           curl -fsS "${SMOKE_BASE_URL}/config.json" -o "${config_json}"
           grep -Fq "\"url\":\"${SMOKE_BASE_URL}/grafana\"" "${config_json}"
           curl -fsS "${SMOKE_BASE_URL}/grafana/api/health" -o /dev/null
+
+          grafana_user="$(kubectl -n "${RELEASE_NS}" get secret authproxy-grafana-admin -o jsonpath='{.data.username}' | base64 -d)"
+          grafana_password="$(kubectl -n "${RELEASE_NS}" get secret authproxy-grafana-admin -o jsonpath='{.data.password}' | base64 -d)"
+          jq -n \
+            --arg user "${grafana_user}" \
+            --arg password "${grafana_password}" \
+            '{user: $user, password: $password}' \
+            > "${RUNNER_TEMP}/grafana-login.json"
+          curl -fsS \
+            -c "${RUNNER_TEMP}/grafana.cookies" \
+            -H 'Content-Type: application/json' \
+            --data-binary @"${RUNNER_TEMP}/grafana-login.json" \
+            "${SMOKE_BASE_URL}/grafana/login" \
+            -o /dev/null
 
       - name: Smoke test (live service)
         id: smoke

--- a/deploy/docs/runbook.md
+++ b/deploy/docs/runbook.md
@@ -187,12 +187,17 @@ rollouts and catalog refreshes can be run independently. One-time setup:
    | `AWS_REGION`    | `us-east-1`      |
    | `EKS_CLUSTER`   | `authproxy-eks`  |
    | `DEMO_HOSTNAME` | `demo.authproxy.net` |
+   | `DEMO_GRAFANA_ADMIN_USER` | `admin` |
 
    (The Let's Encrypt email is configured on the bootstrap chart's
    ClusterIssuer at install time — see Section 1.8 — and isn't
    re-passed per deploy.)
 
    `AWS_ROLE_ARN` should already be set as a Secret from Section 1.6.
+   Set `DEMO_GRAFANA_ADMIN_PASSWORD` as an optional Secret when you want a
+   known Grafana admin password. If it is absent, `Deploy Demo` generates a
+   random password on the first deploy and reuses the resulting
+   `authproxy-grafana-admin` Kubernetes Secret.
 
 3. **Confirm the `gha-eks` environment** (from Section 1.6) exists.
    No required reviewers = fully automatic deploys; add reviewers in

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -41,6 +41,14 @@ that match the existing release convention after `namePrefix` is applied:
 - `<env>-demo-shell-key`
 - `<env>-db` and `<env>-redis-creds` for the demo overlay
 
+The demo Grafana deployment keeps anonymous viewer access enabled, but also
+allows username/password login for admin exploration. `Deploy Demo` creates or
+reuses the unprefixed `authproxy-grafana-admin` Secret in the demo namespace.
+Set the `DEMO_GRAFANA_ADMIN_USER` repo variable and
+`DEMO_GRAFANA_ADMIN_PASSWORD` repo secret to control those credentials; if the
+password is unset, the first deploy generates a random password and stores it
+in the cluster Secret.
+
 Seeding is intentionally not part of the Kustomize deployment apply. Run the
 `Seed Demo` GitHub Actions workflow to reseed the persistent demo environment
 on demand; it renders `overlays/demo/seed` and applies the resulting Job.

--- a/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
@@ -77,7 +77,17 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Viewer
             - name: GF_AUTH_DISABLE_LOGIN_FORM
-              value: "true"
+              value: "false"
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-grafana-admin
+                  key: username
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-grafana-admin
+                  key: password
             - name: AUTHPROXY_GRAFANA_JWT
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Keep anonymous Grafana viewer access enabled in the demo environment while re-enabling the login form.
- Source Grafana admin credentials from an operator-managed Kubernetes Secret.
- Teach Deploy Demo to create/reuse the admin Secret and smoke-test username/password login.
- Document the optional repo variable/secret used to control the credentials.

## Verification
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
- ./scripts/check-workflows.sh
- ./scripts/preflight.sh
- Live demo: /grafana/api/health returned 200
- Live demo: /grafana/login returned 200
- Live demo: Grafana login API returned 200 using authproxy-grafana-admin
- Live demo: anonymous /grafana/api/search returned 200

## Notes
- The live demo has already been patched and rolled out with authproxy-grafana-admin in the demo namespace.