### PR TITLE
Add Prometheus Tempo and Loki to demo Grafana

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -289,12 +289,18 @@ jobs:
           grep -Fq "image: ghcr.io/rmorlok/authproxy:${IMAGE_TAG}" "${manifest}"
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-grafana:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "image: docker.io/grafana/otel-lgtm:0.8.6" "${manifest}"
           grep -Fq "host: ${DEMO_HOSTNAME}" "${manifest}"
           grep -Fq "value: https://${DEMO_HOSTNAME}/grafana" "${manifest}"
           perl -0ne 'exit(/name: GF_AUTH_DISABLE_LOGIN_FORM\s*\n\s*value: "false"/ ? 0 : 1)' "${manifest}"
           grep -Fq "name: GF_SECURITY_ADMIN_USER" "${manifest}"
           grep -Fq "name: GF_SECURITY_ADMIN_PASSWORD" "${manifest}"
           grep -Fq "name: authproxy-grafana-admin" "${manifest}"
+          grep -Fq "name: demo-otel-lgtm" "${manifest}"
+          grep -Fq "endpoint: http://demo-otel-lgtm:4317" "${manifest}"
+          grep -Fq "uid: prometheus" "${manifest}"
+          grep -Fq "uid: tempo" "${manifest}"
+          grep -Fq "uid: loki" "${manifest}"
 
       - name: Apply Kustomize manifest
         run: |
@@ -309,6 +315,7 @@ jobs:
             "${RELEASE_NAME}-authproxy"
             "${RELEASE_NAME}-demo-shell"
             "${RELEASE_NAME}-grafana"
+            "${RELEASE_NAME}-otel-lgtm"
           )
 
           for deployment in "${deployments[@]}"; do
@@ -333,12 +340,13 @@ jobs:
             "${RELEASE_NAME}-redis-master" \
             "${RELEASE_NAME}-minio" \
             "${RELEASE_NAME}-grafana" \
+            "${RELEASE_NAME}-otel-lgtm" \
           ; do
             kubectl -n "${RELEASE_NS}" describe "deployment/$d"
             echo
           done
           echo "## Recent pod logs"
-          for selector in authproxy demo-shell go-oauth2-server grafana; do
+          for selector in authproxy demo-shell go-oauth2-server grafana otel-lgtm; do
             kubectl -n "${RELEASE_NS}" logs \
               -l "app.kubernetes.io/name=${selector}" \
               --all-containers --tail=120
@@ -357,6 +365,7 @@ jobs:
             "${RELEASE_NAME}-postgresql" \
             "${RELEASE_NAME}-redis-master" \
             "${RELEASE_NAME}-minio" \
+            "${RELEASE_NAME}-otel-lgtm" \
             "${RELEASE_NAME}-authproxy" \
             "${RELEASE_NAME}-demo-shell" \
             "${RELEASE_NAME}-go-oauth2-server" \
@@ -396,10 +405,15 @@ jobs:
         run: |
           set -euo pipefail
           config_json="${RUNNER_TEMP}/demo-config.json"
+          datasources_json="${RUNNER_TEMP}/grafana-datasources.json"
 
           curl -fsS "${SMOKE_BASE_URL}/config.json" -o "${config_json}"
           grep -Fq "\"url\":\"${SMOKE_BASE_URL}/grafana\"" "${config_json}"
           curl -fsS "${SMOKE_BASE_URL}/grafana/api/health" -o /dev/null
+          curl -fsS "${SMOKE_BASE_URL}/grafana/api/datasources" -o "${datasources_json}"
+          jq -e 'any(.[]; .uid == "prometheus" and .type == "prometheus")' "${datasources_json}" >/dev/null
+          jq -e 'any(.[]; .uid == "tempo" and .type == "tempo")' "${datasources_json}" >/dev/null
+          jq -e 'any(.[]; .uid == "loki" and .type == "loki")' "${datasources_json}" >/dev/null
 
           grafana_user="$(kubectl -n "${RELEASE_NS}" get secret authproxy-grafana-admin -o jsonpath='{.data.username}' | base64 -d)"
           grafana_password="$(kubectl -n "${RELEASE_NS}" get secret authproxy-grafana-admin -o jsonpath='{.data.password}' | base64 -d)"

--- a/deploy/docs/runbook.md
+++ b/deploy/docs/runbook.md
@@ -179,6 +179,9 @@ rollouts and catalog refreshes can be run independently. One-time setup:
    `demo-actors` already exist in the `demo` namespace. Persistent
    backing-store Secrets (`demo-db`, `demo-redis-creds`, and
    `demo-minio-creds`) are also preserved across Kustomize applies.
+   The demo observability backend (`demo-otel-lgtm`) is created by the
+   Kustomize overlay and receives AuthProxy OTLP telemetry for Prometheus,
+   Tempo, and Loki.
 
 2. **Set repo Variables** (Settings → Variables → Actions):
 

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -22,8 +22,11 @@ kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
 `Deploy Demo` renders `overlays/demo`, rewrites the checked-out overlay with
 the selected image tag and configured hostname, and applies the resulting
 manifest with `kubectl apply`. The demo overlay includes Grafana at
-`https://<hostname>/grafana` with the bundled AuthProxy datasource plugin and
-sample app metrics dashboard provisioned from Kustomize ConfigMaps.
+`https://<hostname>/grafana` with the bundled AuthProxy datasource plugin,
+Prometheus, Tempo, and Loki datasources, and sample app metrics dashboard
+provisioned from Kustomize ConfigMaps. Prometheus, Tempo, Loki, and the OTel
+Collector are provided by the internal `otel-lgtm` workload; AuthProxy exports
+OTLP/gRPC telemetry to `demo-otel-lgtm:4317`.
 
 During the Helm-to-Kustomize cutover, `Deploy Demo` preserves the operator
 Secrets listed below, uninstalls any legacy `demo` / `authproxy-demo` Helm

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -42,6 +42,34 @@ app_metrics:
     path: /tmp/authproxy-app-metrics.db
   request_events:
     full_request_recording: never
+telemetry:
+  enabled: true
+  exporter:
+    protocol: grpc
+    endpoint: http://demo-otel-lgtm:4317
+    insecure: true
+  resource:
+    service_name_prefix: authproxy-demo
+    attributes:
+      deployment.environment: demo
+  sampling:
+    ratio: 1.0
+  signals:
+    traces: true
+    metrics: true
+    logs: true
+  http:
+    excluded_paths:
+      - /ping
+      - /healthz
+  proxy:
+    span_attribute_labels:
+      - type
+      - demo
+    metric_dimension_labels:
+      - type
+      - demo
+    metric_dimension_value_cap: 50
 system_auth:
   jwt_signing_key:
     public_key:

--- a/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/grafana.yaml
@@ -18,6 +18,34 @@ data:
           baseUrl: http://demo-authproxy:8081
         secureJsonData:
           jwt: ${AUTHPROXY_GRAFANA_JWT}
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        editable: true
+        url: http://demo-otel-lgtm:9090
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        editable: true
+        url: http://demo-otel-lgtm:3200
+        jsonData:
+          nodeGraph:
+            enabled: true
+          serviceMap:
+            datasourceUid: prometheus
+          tracesToLogsV2:
+            datasourceUid: loki
+            filterByTraceID: true
+          tracesToMetrics:
+            datasourceUid: prometheus
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        editable: true
+        url: http://demo-otel-lgtm:3100
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - grafana.yaml
   - ingress.yaml
   - minio.yaml
+  - otel-lgtm.yaml
   - postgres.yaml
   - redis.yaml
 

--- a/deploy/kustomize/authproxy-demo/overlays/demo/otel-lgtm.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/otel-lgtm.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-lgtm
+  labels:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-lgtm
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-lgtm
+        app.kubernetes.io/component: observability
+    spec:
+      containers:
+        - name: otel-lgtm
+          image: docker.io/grafana/otel-lgtm:0.8.6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: grafana
+              containerPort: 3000
+            - name: loki
+              containerPort: 3100
+            - name: tempo
+              containerPort: 3200
+            - name: otel-grpc
+              containerPort: 4317
+            - name: otel-http
+              containerPort: 4318
+            - name: prometheus
+              containerPort: 9090
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          volumeMounts:
+            - name: tempo-data
+              mountPath: /data/tempo
+            - name: grafana-data
+              mountPath: /data/grafana
+            - name: loki-data
+              mountPath: /data/loki
+            - name: loki-storage
+              mountPath: /loki
+            - name: prometheus-storage
+              mountPath: /data/prometheus
+            - name: pyroscope-storage
+              mountPath: /data/pyroscope
+      volumes:
+        - name: tempo-data
+          emptyDir: {}
+        - name: grafana-data
+          emptyDir: {}
+        - name: loki-data
+          emptyDir: {}
+        - name: loki-storage
+          emptyDir: {}
+        - name: prometheus-storage
+          emptyDir: {}
+        - name: pyroscope-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-lgtm
+  labels:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: grafana
+    - name: loki
+      port: 3100
+      targetPort: loki
+    - name: tempo
+      port: 3200
+      targetPort: tempo
+    - name: otel-grpc
+      port: 4317
+      targetPort: otel-grpc
+    - name: otel-http
+      port: 4318
+      targetPort: otel-http
+    - name: prometheus
+      port: 9090
+      targetPort: prometheus


### PR DESCRIPTION
## Summary
- Add a demo-only `otel-lgtm` workload that bundles Prometheus, Tempo, Loki, and an OTel Collector.
- Enable AuthProxy demo telemetry export to `demo-otel-lgtm:4317`.
- Provision Prometheus, Tempo, and Loki datasources in the existing demo Grafana alongside the AuthProxy datasource.
- Update Deploy Demo to wait for the observability backend and smoke-check the new Grafana datasources.
- Document the hosted demo observability backend in the demo manifests README and runbook.

## Verification
- Applied the rendered overlay to the live `demo` namespace while preserving the current `sha-3d17abe` app image tags.
- `kubectl -n demo rollout status deployment/demo-otel-lgtm --timeout=10m`
- `kubectl -n demo rollout status deployment/demo-authproxy --timeout=10m`
- `kubectl -n demo rollout status deployment/demo-grafana --timeout=10m`
- Public Grafana API lists datasources: `authproxy-app-metrics,loki,prometheus,tempo`
- Prometheus datasource proxy query returned `status=success`
- Loki datasource labels proxy returned `status=success`
- Tempo datasource tags proxy returned `metrics,tagNames`
- `kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo`
- `./scripts/check-workflows.sh`
- `go test ./internal/schema/config ./internal/aptelemetry`
- `./scripts/preflight.sh`

## Notes
- The stack uses `docker.io/grafana/otel-lgtm:0.8.6`, matching the local dev observability stack and intended for demo/test use.
- The live demo has already been updated and verified.