### PR TITLE
Add notification service cache

### DIFF
--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
+	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
@@ -34,6 +35,12 @@ type ConnectionMigrationTask struct {
 	ConnectionID  apid.ID
 	SourceVersion uint64
 	TargetVersion uint64
+}
+
+type ActorNotification struct {
+	Notification database.Notification
+	Viewed       bool
+	CanAction    bool
 }
 
 // C is the interface for the core service that implements primary business logic and binds the system together.
@@ -173,6 +180,28 @@ type C interface {
 	// defined, otherwise re-initiates the OAuth redirect. The connection's State remains Ready
 	// throughout; only setup_step is reset and re-driven.
 	ReauthConnection(ctx context.Context, id apid.ID, returnToUrl string) (ConnectionSetupResponse, error)
+
+	/*
+	 *
+	 * Notifications
+	 *
+	 */
+
+	// ListActorNotifications returns actor-visible notifications with actor-specific
+	// viewed/action state. Results are cached by actor and permission fingerprint.
+	ListActorNotifications(
+		ctx context.Context,
+		ra *authcore.RequestAuth,
+		opts database.ListNotificationsOptions,
+	) ([]ActorNotification, error)
+
+	// MarkActorNotificationViewed records viewed state for the authenticated
+	// actor after checking that the actor can see the notification.
+	MarkActorNotificationViewed(ctx context.Context, ra *authcore.RequestAuth, id apid.ID) error
+
+	// MarkActorNotificationsViewed records viewed state for multiple
+	// authenticated-actor-visible notifications.
+	MarkActorNotificationsViewed(ctx context.Context, ra *authcore.RequestAuth, ids []apid.ID) error
 
 	/*
 	 *

--- a/internal/core/service_notifications.go
+++ b/internal/core/service_notifications.go
@@ -1,0 +1,348 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+)
+
+const (
+	notificationCacheTTL        = 30 * time.Second
+	notificationCacheVersionKey = "notifications:version"
+)
+
+type notificationAuthCacheFingerprint struct {
+	ActorID            apid.ID              `json:"actor_id"`
+	ExternalID         string               `json:"external_id"`
+	Namespace          string               `json:"namespace"`
+	Labels             map[string]string    `json:"labels,omitempty"`
+	Annotations        map[string]string    `json:"annotations,omitempty"`
+	ActorPermissions   []aschema.Permission `json:"actor_permissions,omitempty"`
+	RequestPermissions []aschema.Permission `json:"request_permissions,omitempty"`
+}
+
+// ListActorNotifications returns actor-visible notifications with the actor's
+// viewed/action state. The result is cached because the list is read often, but
+// the cache key includes the actor permission fingerprint and global
+// notification version so permission or notification changes cannot share a
+// stale entry.
+func (s *service) ListActorNotifications(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	opts database.ListNotificationsOptions,
+) ([]iface.ActorNotification, error) {
+	if ra == nil || !ra.IsAuthenticated() {
+		return nil, httperr.Forbidden("permission denied")
+	}
+
+	actor := ra.MustGetActor()
+	opts.ActorId = actor.GetId()
+
+	if cacheKey, ok := s.notificationListCacheKey(ctx, ra, opts); ok {
+		if cached, hit := s.notificationListCacheGet(ctx, cacheKey); hit {
+			return cached, nil
+		}
+
+		result, err := s.listActorNotificationsFromDB(ctx, ra, opts)
+		if err != nil {
+			return nil, err
+		}
+		s.notificationListCacheSet(ctx, cacheKey, result)
+		return result, nil
+	}
+
+	return s.listActorNotificationsFromDB(ctx, ra, opts)
+}
+
+func (s *service) listActorNotificationsFromDB(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	opts database.ListNotificationsOptions,
+) ([]iface.ActorNotification, error) {
+	notifications, err := s.db.ListNotifications(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]apid.ID, 0, len(notifications))
+	for _, n := range notifications {
+		ids = append(ids, n.Id)
+	}
+	viewed, err := s.db.NotificationViewedMap(ctx, ra.MustGetActor().GetId(), ids)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]iface.ActorNotification, 0, len(notifications))
+	for _, n := range notifications {
+		if !notificationPermissionsAllow(ra, n.ViewPermissions, n) {
+			continue
+		}
+		_, isViewed := viewed[n.Id]
+		result = append(result, iface.ActorNotification{
+			Notification: n,
+			Viewed:       isViewed,
+			CanAction:    notificationPermissionsAllow(ra, n.ActionPermissions, n),
+		})
+	}
+
+	return result, nil
+}
+
+// MarkActorNotificationViewed records viewed state for a visible notification
+// and bumps the global notification cache version.
+func (s *service) MarkActorNotificationViewed(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	id apid.ID,
+) error {
+	return s.MarkActorNotificationsViewed(ctx, ra, []apid.ID{id})
+}
+
+func (s *service) MarkActorNotificationsViewed(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	ids []apid.ID,
+) error {
+	if ra == nil || !ra.IsAuthenticated() {
+		return httperr.Forbidden("permission denied")
+	}
+
+	notificationIDs, err := normalizeActorNotificationIDs(ids)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range notificationIDs {
+		notification, err := s.db.GetNotification(ctx, id)
+		if err != nil {
+			if errors.Is(err, database.ErrNotFound) {
+				return httperr.NotFound("notification not found", httperr.WithInternalErr(err))
+			}
+			return err
+		}
+		if !notificationPermissionsAllow(ra, notification.ViewPermissions, *notification) {
+			return httperr.Forbidden("permission denied")
+		}
+	}
+
+	if err := s.db.MarkNotificationsViewed(ctx, notificationIDs, ra.MustGetActor().GetId()); err != nil {
+		return err
+	}
+	s.bumpNotificationCacheVersion(ctx)
+	return nil
+}
+
+func (s *service) upsertNotification(
+	ctx context.Context,
+	upsert database.NotificationUpsert,
+) (*database.Notification, error) {
+	notification, err := s.db.UpsertNotification(ctx, upsert)
+	if err != nil {
+		return nil, err
+	}
+	s.bumpNotificationCacheVersion(ctx)
+	return notification, nil
+}
+
+func (s *service) resolveNotificationsForResourceKeys(
+	ctx context.Context,
+	resourceType string,
+	resourceID apid.ID,
+	keys []string,
+) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if err := s.db.ResolveNotificationsForResourceKeys(ctx, resourceType, resourceID, keys); err != nil {
+		return err
+	}
+	s.bumpNotificationCacheVersion(ctx)
+	return nil
+}
+
+func normalizeActorNotificationIDs(ids []apid.ID) ([]apid.ID, error) {
+	if len(ids) == 0 {
+		return nil, httperr.BadRequest("ids are required")
+	}
+	result := make([]apid.ID, 0, len(ids))
+	seen := make(map[apid.ID]struct{}, len(ids))
+	for _, id := range ids {
+		if id == apid.Nil {
+			return nil, httperr.BadRequest("notification id is required")
+		}
+		if err := id.ValidatePrefix(apid.PrefixNotification); err != nil {
+			return nil, httperr.BadRequest("invalid notification id", httperr.WithInternalErr(err))
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+func (s *service) notificationListCacheKey(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	opts database.ListNotificationsOptions,
+) (string, bool) {
+	if s.r == nil {
+		return "", false
+	}
+
+	version, err := s.notificationCacheVersion(ctx)
+	if err != nil {
+		s.warnNotificationCache("notification cache disabled after version lookup failed", err)
+		return "", false
+	}
+
+	permissionFingerprint, err := notificationPermissionFingerprint(ra)
+	if err != nil {
+		s.warnNotificationCache("notification cache disabled after permission fingerprint failed", err)
+		return "", false
+	}
+
+	queryFingerprint, err := json.Marshal(opts)
+	if err != nil {
+		s.warnNotificationCache("notification cache disabled after query fingerprint failed", err)
+		return "", false
+	}
+
+	return fmt.Sprintf(
+		"notifications:list:v1:%s:%s:%s:%s",
+		ra.MustGetActor().GetId(),
+		version,
+		sha256Hex(permissionFingerprint),
+		sha256Hex(queryFingerprint),
+	), true
+}
+
+func notificationPermissionFingerprint(ra *authcore.RequestAuth) ([]byte, error) {
+	actor := ra.MustGetActor()
+	return json.Marshal(notificationAuthCacheFingerprint{
+		ActorID:            actor.GetId(),
+		ExternalID:         actor.GetExternalId(),
+		Namespace:          actor.GetNamespace(),
+		Labels:             actor.GetLabels(),
+		Annotations:        actor.GetAnnotations(),
+		ActorPermissions:   actor.GetPermissions(),
+		RequestPermissions: ra.GetPermissions(),
+	})
+}
+
+func (s *service) notificationCacheVersion(ctx context.Context) (string, error) {
+	value, err := s.r.Get(ctx, notificationCacheVersionKey).Result()
+	if errors.Is(err, redis.Nil) {
+		return "0", nil
+	}
+	return value, err
+}
+
+func (s *service) notificationListCacheGet(
+	ctx context.Context,
+	cacheKey string,
+) ([]iface.ActorNotification, bool) {
+	raw, err := s.r.Get(ctx, cacheKey).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, false
+	}
+	if err != nil {
+		s.warnNotificationCache("notification cache read failed", err)
+		return nil, false
+	}
+
+	var result []iface.ActorNotification
+	if err := json.Unmarshal(raw, &result); err != nil {
+		s.warnNotificationCache("notification cache payload was invalid", err)
+		_ = s.r.Del(ctx, cacheKey).Err()
+		return nil, false
+	}
+
+	return result, true
+}
+
+func (s *service) notificationListCacheSet(
+	ctx context.Context,
+	cacheKey string,
+	result []iface.ActorNotification,
+) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		s.warnNotificationCache("notification cache payload marshal failed", err)
+		return
+	}
+	if err := s.r.Set(ctx, cacheKey, raw, notificationCacheTTL).Err(); err != nil {
+		s.warnNotificationCache("notification cache write failed", err)
+	}
+}
+
+func (s *service) bumpNotificationCacheVersion(ctx context.Context) {
+	if s.r == nil {
+		return
+	}
+	if err := s.r.Incr(ctx, notificationCacheVersionKey).Err(); err != nil {
+		s.warnNotificationCache("notification cache version bump failed", err)
+	}
+}
+
+func notificationPermissionsAllow(
+	ra *authcore.RequestAuth,
+	permissions []aschema.Permission,
+	n database.Notification,
+) bool {
+	if ra == nil || !ra.IsAuthenticated() || len(permissions) == 0 {
+		return false
+	}
+	for _, p := range permissions {
+		resources := p.Resources
+		if len(resources) == 0 {
+			resources = []string{n.ResourceType}
+		}
+		verbs := p.Verbs
+		if len(verbs) == 0 {
+			verbs = []string{"get"}
+		}
+		resourceIds := p.ResourceIds
+		if len(resourceIds) == 0 {
+			resourceIds = []string{n.ResourceId.String()}
+		}
+		for _, resource := range resources {
+			for _, verb := range verbs {
+				for _, resourceId := range resourceIds {
+					if ra.Allows(n.Namespace, resource, verb, resourceId) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func sha256Hex(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *service) warnNotificationCache(msg string, err error) {
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Warn(msg, "error", err)
+}

--- a/internal/core/service_notifications_test.go
+++ b/internal/core/service_notifications_test.go
@@ -1,0 +1,271 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/aplog"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/database"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListActorNotificationsCachesActorFilteredResult(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	s := newNotificationTestService(t, db)
+
+	actorID := apid.New(apid.PrefixActor)
+	connectionID := apid.New(apid.PrefixConnection)
+	notification := notificationTestNotification(connectionID)
+	ra := notificationTestAuth(actorID, connectionID)
+	viewedAt := time.Unix(100, 0).UTC()
+
+	db.EXPECT().
+		ListNotifications(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, opts database.ListNotificationsOptions) ([]database.Notification, error) {
+			require.Equal(t, actorID, opts.ActorId)
+			return []database.Notification{notification}, nil
+		}).
+		Times(1)
+	db.EXPECT().
+		NotificationViewedMap(gomock.Any(), actorID, []apid.ID{notification.Id}).
+		Return(map[apid.ID]time.Time{notification.Id: viewedAt}, nil).
+		Times(1)
+
+	first, err := s.ListActorNotifications(ctx, ra, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.True(t, first[0].Viewed)
+	require.True(t, first[0].CanAction)
+
+	second, err := s.ListActorNotifications(ctx, ra, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestListActorNotificationsCacheKeyIncludesRequestPermissions(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	s := newNotificationTestService(t, db)
+
+	actorID := apid.New(apid.PrefixActor)
+	connectionID := apid.New(apid.PrefixConnection)
+	notification := notificationTestNotification(connectionID)
+	actor := notificationTestActor(actorID, connectionID)
+	fullAuth := authcore.NewAuthenticatedRequestAuth(actor)
+	getOnlyAuth := authcore.NewAuthenticatedRequestAuthWithPermissions(
+		actor,
+		aschema.PermissionsSingleWithResourceIds("root", "connections", "get", connectionID.String()),
+	)
+
+	db.EXPECT().
+		ListNotifications(gomock.Any(), gomock.Any()).
+		Return([]database.Notification{notification}, nil).
+		Times(2)
+	db.EXPECT().
+		NotificationViewedMap(gomock.Any(), actorID, []apid.ID{notification.Id}).
+		Return(map[apid.ID]time.Time{}, nil).
+		Times(2)
+
+	fullResult, err := s.ListActorNotifications(ctx, fullAuth, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Len(t, fullResult, 1)
+	require.True(t, fullResult[0].CanAction)
+
+	restrictedResult, err := s.ListActorNotifications(ctx, getOnlyAuth, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Len(t, restrictedResult, 1)
+	require.False(t, restrictedResult[0].CanAction)
+}
+
+func TestNotificationCacheInvalidatesOnMarkViewed(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	s := newNotificationTestService(t, db)
+
+	actorID := apid.New(apid.PrefixActor)
+	connectionID := apid.New(apid.PrefixConnection)
+	notification := notificationTestNotification(connectionID)
+	ra := notificationTestAuth(actorID, connectionID)
+	viewedAt := time.Unix(200, 0).UTC()
+
+	gomock.InOrder(
+		db.EXPECT().
+			ListNotifications(gomock.Any(), gomock.Any()).
+			Return([]database.Notification{notification}, nil),
+		db.EXPECT().
+			NotificationViewedMap(gomock.Any(), actorID, []apid.ID{notification.Id}).
+			Return(map[apid.ID]time.Time{}, nil),
+		db.EXPECT().
+			GetNotification(gomock.Any(), notification.Id).
+			Return(&notification, nil),
+		db.EXPECT().
+			MarkNotificationsViewed(gomock.Any(), []apid.ID{notification.Id}, actorID).
+			Return(nil),
+		db.EXPECT().
+			ListNotifications(gomock.Any(), gomock.Any()).
+			Return([]database.Notification{notification}, nil),
+		db.EXPECT().
+			NotificationViewedMap(gomock.Any(), actorID, []apid.ID{notification.Id}).
+			Return(map[apid.ID]time.Time{notification.Id: viewedAt}, nil),
+	)
+
+	before, err := s.ListActorNotifications(ctx, ra, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	require.False(t, before[0].Viewed)
+
+	require.NoError(t, s.MarkActorNotificationViewed(ctx, ra, notification.Id))
+
+	after, err := s.ListActorNotifications(ctx, ra, notificationListTestOptions())
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.True(t, after[0].Viewed)
+}
+
+func TestNotificationCacheInvalidatesOnMarkNotificationsViewed(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	s := newNotificationTestService(t, db)
+
+	actorID := apid.New(apid.PrefixActor)
+	connectionID := apid.New(apid.PrefixConnection)
+	first := notificationTestNotification(connectionID)
+	second := notificationTestNotification(connectionID)
+	second.Key = "connection:" + connectionID.String() + ":setup_required"
+	ra := notificationTestAuth(actorID, connectionID)
+
+	gomock.InOrder(
+		db.EXPECT().
+			GetNotification(gomock.Any(), first.Id).
+			Return(&first, nil),
+		db.EXPECT().
+			GetNotification(gomock.Any(), second.Id).
+			Return(&second, nil),
+		db.EXPECT().
+			MarkNotificationsViewed(gomock.Any(), []apid.ID{first.Id, second.Id}, actorID).
+			Return(nil),
+	)
+
+	require.NoError(t, s.MarkActorNotificationsViewed(ctx, ra, []apid.ID{first.Id, second.Id, first.Id}))
+	require.Equal(t, "1", s.r.Get(ctx, notificationCacheVersionKey).Val())
+}
+
+func TestNotificationWriteHelpersBumpCacheVersion(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := mockDb.NewMockDB(ctrl)
+	s := newNotificationTestService(t, db)
+
+	connectionID := apid.New(apid.PrefixConnection)
+	notification := notificationTestNotification(connectionID)
+	upsert := database.NotificationUpsert{
+		Key:               notification.Key,
+		Level:             notification.Level,
+		ResourceType:      notification.ResourceType,
+		ResourceId:        notification.ResourceId,
+		Namespace:         notification.Namespace,
+		Labels:            notification.Labels,
+		Title:             notification.Title,
+		Message:           notification.Message,
+		ActionUrl:         notification.ActionUrl,
+		ViewPermissions:   notification.ViewPermissions,
+		ActionPermissions: notification.ActionPermissions,
+		Metadata:          notification.Metadata,
+	}
+
+	db.EXPECT().
+		UpsertNotification(gomock.Any(), upsert).
+		Return(&notification, nil)
+	db.EXPECT().
+		ResolveNotificationsForResourceKeys(gomock.Any(), "connection", connectionID, []string{notification.Key}).
+		Return(nil)
+
+	_, err := s.upsertNotification(ctx, upsert)
+	require.NoError(t, err)
+	require.Equal(t, "1", s.r.Get(ctx, notificationCacheVersionKey).Val())
+
+	require.NoError(t, s.resolveNotificationsForResourceKeys(ctx, "connection", connectionID, []string{notification.Key}))
+	require.Equal(t, "2", s.r.Get(ctx, notificationCacheVersionKey).Val())
+}
+
+func newNotificationTestService(t *testing.T, db *mockDb.MockDB) *service {
+	t.Helper()
+
+	_, r := apredis.MustApplyTestConfig(nil)
+	require.NoError(t, r.FlushDB(context.Background()).Err())
+	return &service{
+		db:     db,
+		r:      r,
+		logger: aplog.NewNoopLogger(),
+	}
+}
+
+func notificationListTestOptions() database.ListNotificationsOptions {
+	return database.ListNotificationsOptions{
+		States: []database.NotificationState{database.NotificationStateActive},
+		Limit:  100,
+	}
+}
+
+func notificationTestAuth(actorID apid.ID, connectionID apid.ID) *authcore.RequestAuth {
+	return authcore.NewAuthenticatedRequestAuth(notificationTestActor(actorID, connectionID))
+}
+
+func notificationTestActor(actorID apid.ID, connectionID apid.ID) *authcore.Actor {
+	return &authcore.Actor{
+		Id:         actorID,
+		ExternalId: "actor",
+		Namespace:  "root",
+		Permissions: []aschema.Permission{{
+			Namespace:   "root",
+			Resources:   []string{"connections"},
+			ResourceIds: []string{connectionID.String()},
+			Verbs:       []string{"get", "update"},
+		}},
+	}
+}
+
+func notificationTestNotification(connectionID apid.ID) database.Notification {
+	now := time.Unix(50, 0).UTC()
+	actionURL := "/connections/" + connectionID.String() + "?action=reauth"
+	return database.Notification{
+		Id:           apid.New(apid.PrefixNotification),
+		Key:          "connection:" + connectionID.String() + ":auth_required",
+		Level:        database.NotificationLevelWarning,
+		State:        database.NotificationStateActive,
+		ResourceType: "connection",
+		ResourceId:   connectionID,
+		Namespace:    "root",
+		Labels:       database.Labels{"env": "test"},
+		Title:        "Authentication required",
+		Message:      "Reconnect this connection.",
+		ActionUrl:    &actionURL,
+		ViewPermissions: aschema.PermissionsSingleWithResourceIds(
+			"root",
+			"connections",
+			"get",
+			connectionID.String(),
+		),
+		ActionPermissions: aschema.PermissionsSingleWithResourceIds(
+			"root",
+			"connections",
+			"update",
+			connectionID.String(),
+		),
+		Metadata:  database.NotificationMetadata{"reason": "test"},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}

--- a/internal/core/workflow_migrate_connection_version_activity.go
+++ b/internal/core/workflow_migrate_connection_version_activity.go
@@ -115,7 +115,7 @@ func (s *service) applyMigrateConnectionVersionV1(
 	}
 
 	// Resolve any notifications that are no longer applicable.
-	if err := s.db.ResolveNotificationsForResourceKeys(
+	if err := s.resolveNotificationsForResourceKeys(
 		ctx,
 		"connection", // resource type
 		connectionID,
@@ -127,7 +127,7 @@ func (s *service) applyMigrateConnectionVersionV1(
 	// Add newly generated notifications
 	for _, notification := range candidate.Notifications {
 		notification.Labels = updated.Labels
-		if _, err := s.db.UpsertNotification(ctx, notification); err != nil {
+		if _, err := s.upsertNotification(ctx, notification); err != nil {
 			return err
 		}
 	}

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -137,6 +137,7 @@ type DB interface {
 	GetNotification(ctx context.Context, id apid.ID) (*Notification, error)
 	ListNotifications(ctx context.Context, opts ListNotificationsOptions) ([]Notification, error)
 	MarkNotificationViewed(ctx context.Context, notificationID apid.ID, actorID apid.ID) error
+	MarkNotificationsViewed(ctx context.Context, notificationIDs []apid.ID, actorID apid.ID) error
 	NotificationViewedMap(ctx context.Context, actorID apid.ID, ids []apid.ID) (map[apid.ID]time.Time, error)
 	ResolveNotificationsForResourceKeys(ctx context.Context, resourceType string, resourceID apid.ID, keys []string) error
 

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -1380,6 +1380,20 @@ func (mr *MockDBMockRecorder) MarkNotificationViewed(ctx, notificationID, actorI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkNotificationViewed", reflect.TypeOf((*MockDB)(nil).MarkNotificationViewed), ctx, notificationID, actorID)
 }
 
+// MarkNotificationsViewed mocks base method.
+func (m *MockDB) MarkNotificationsViewed(ctx context.Context, notificationIDs []apid.ID, actorID apid.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkNotificationsViewed", ctx, notificationIDs, actorID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkNotificationsViewed indicates an expected call of MarkNotificationsViewed.
+func (mr *MockDBMockRecorder) MarkNotificationsViewed(ctx, notificationIDs, actorID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkNotificationsViewed", reflect.TypeOf((*MockDB)(nil).MarkNotificationsViewed), ctx, notificationIDs, actorID)
+}
+
 // Migrate mocks base method.
 func (m *MockDB) Migrate(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -580,12 +580,14 @@ func (s *service) MarkNotificationViewed(
 	notificationID apid.ID,
 	actorID apid.ID,
 ) error {
-	if notificationID == apid.Nil {
-		return errors.New("notification id is required")
-	}
-	if err := notificationID.ValidatePrefix(apid.PrefixNotification); err != nil {
-		return err
-	}
+	return s.MarkNotificationsViewed(ctx, []apid.ID{notificationID}, actorID)
+}
+
+func (s *service) MarkNotificationsViewed(
+	ctx context.Context,
+	notificationIDs []apid.ID,
+	actorID apid.ID,
+) error {
 	if actorID == apid.Nil {
 		return errors.New("actor id is required")
 	}
@@ -593,22 +595,80 @@ func (s *service) MarkNotificationViewed(
 		return err
 	}
 
-	// Check that the notification exists
-	_, err := s.GetNotification(ctx, notificationID)
+	ids, err := normalizeNotificationIDs(notificationIDs)
 	if err != nil {
 		return err
 	}
 
-	// Insert a viewed record or update the viewed at time if already exists
+	existing, err := s.existingNotificationIDs(ctx, ids)
+	if err != nil {
+		return err
+	}
+	if len(existing) != len(ids) {
+		return ErrNotFound
+	}
+
+	// Insert viewed records or update viewed_at when already present.
 	now := apctx.GetClock(ctx).Now()
-	_, err = s.sq.
+	query := s.sq.
 		Insert(NotificationViewsTable).
-		Columns("notification_id", "actor_id", "viewed_at", "created_at", "updated_at").
-		Values(notificationID, actorID, now, now, now).
+		Columns("notification_id", "actor_id", "viewed_at", "created_at", "updated_at")
+	for _, id := range ids {
+		query = query.Values(id, actorID, now, now, now)
+	}
+	_, err = query.
 		Suffix("ON CONFLICT(notification_id, actor_id) DO UPDATE SET viewed_at = ?, updated_at = ?", now, now).
 		RunWith(s.db).
 		ExecContext(ctx)
 	return err
+}
+
+func normalizeNotificationIDs(ids []apid.ID) ([]apid.ID, error) {
+	if len(ids) == 0 {
+		return nil, errors.New("notification ids are required")
+	}
+	result := make([]apid.ID, 0, len(ids))
+	seen := make(map[apid.ID]struct{}, len(ids))
+	for _, id := range ids {
+		if id == apid.Nil {
+			return nil, errors.New("notification id is required")
+		}
+		if err := id.ValidatePrefix(apid.PrefixNotification); err != nil {
+			return nil, err
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+func (s *service) existingNotificationIDs(
+	ctx context.Context,
+	ids []apid.ID,
+) (map[apid.ID]struct{}, error) {
+	rows, err := s.sq.
+		Select("id").
+		From(NotificationsTable).
+		Where(sq.Eq{"id": ids, "deleted_at": nil}).
+		RunWith(s.db).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[apid.ID]struct{}, len(ids))
+	for rows.Next() {
+		var id apid.ID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		result[id] = struct{}{}
+	}
+	return result, rows.Err()
 }
 
 // NotificationViewedMap returns a map of notification IDs to

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -126,6 +126,45 @@ func TestResolveNotificationsForResourceKeys(t *testing.T) {
 	require.Equal(t, NotificationStateActive, active.State)
 }
 
+func TestMarkNotificationsViewedBatch(t *testing.T) {
+	_, db := MustApplyBlankTestDbConfig(t, nil)
+	ctx := apctx.NewBuilderBackground().
+		WithClock(clock.NewFakeClock(time.Date(2026, time.July, 3, 12, 0, 0, 0, time.UTC))).
+		Build()
+
+	connID := apid.New(apid.PrefixConnection)
+	first, err := db.UpsertNotification(ctx, NotificationUpsert{
+		Key:          "connection:" + connID.String() + ":auth_required",
+		Level:        NotificationLevelWarning,
+		ResourceType: "connection",
+		ResourceId:   connID,
+		Namespace:    "root",
+		Title:        "Auth required",
+		Message:      "Please reconnect.",
+	})
+	require.NoError(t, err)
+	second, err := db.UpsertNotification(ctx, NotificationUpsert{
+		Key:          "connection:" + connID.String() + ":setup_required",
+		Level:        NotificationLevelWarning,
+		ResourceType: "connection",
+		ResourceId:   connID,
+		Namespace:    "root",
+		Title:        "Setup required",
+		Message:      "Please finish setup.",
+	})
+	require.NoError(t, err)
+
+	actorID := apid.New(apid.PrefixActor)
+	require.NoError(t, db.MarkNotificationsViewed(ctx, []apid.ID{first.Id, second.Id, first.Id}, actorID))
+
+	viewed, err := db.NotificationViewedMap(ctx, actorID, []apid.ID{first.Id, second.Id})
+	require.NoError(t, err)
+	require.Contains(t, viewed, first.Id)
+	require.Contains(t, viewed, second.Id)
+
+	require.ErrorIs(t, db.MarkNotificationsViewed(ctx, []apid.ID{apid.New(apid.PrefixNotification)}, actorID), ErrNotFound)
+}
+
 func TestListNotificationsFiltersNamespaceAndLabels(t *testing.T) {
 	_, db := MustApplyBlankTestDbConfig(t, nil)
 	ctx := apctx.NewBuilderBackground().

--- a/internal/routes/notifications.go
+++ b/internal/routes/notifications.go
@@ -1,30 +1,28 @@
 package routes
 
 import (
-	"errors"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
+	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
-	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 type NotificationsRoutes struct {
 	auth auth.A
-	db   database.DB
+	core coreIface.C
 }
 
 type NotificationJson = schemaapi.NotificationJson
 type ListNotificationsResponseJson = schemaapi.ListNotificationsResponseJson
+type MarkNotificationsViewedRequestJson = schemaapi.MarkNotificationsViewedRequestJson
 type OpenAPIListNotificationsResponseJson = schemaapiopenapi.ListNotificationsResponseJson
 
 type ListNotificationsRequestQuery struct {
@@ -98,13 +96,11 @@ func (r *NotificationsRoutes) list(gctx *gin.Context) {
 		}
 	}
 
-	actor := ra.MustGetActor()
-	notifications, err := r.db.ListNotifications(ctx, database.ListNotificationsOptions{
+	notifications, err := r.core.ListActorNotifications(ctx, ra, database.ListNotificationsOptions{
 		States:            []database.NotificationState{state},
 		NamespaceMatchers: namespaceMatchers,
 		LabelSelector:     req.LabelSelector,
 		Limit:             limit,
-		ActorId:           actor.GetId(),
 		IncludeViewed:     includeViewed,
 	})
 	if err != nil {
@@ -112,26 +108,43 @@ func (r *NotificationsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	ids := make([]apid.ID, 0, len(notifications))
-	for _, n := range notifications {
-		ids = append(ids, n.Id)
-	}
-	viewed, err := r.db.NotificationViewedMap(ctx, actor.GetId(), ids)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		return
-	}
-
 	items := make([]NotificationJson, 0, len(notifications))
 	for _, n := range notifications {
-		if !notificationPermissionsAllow(ra, n.ViewPermissions, n) {
-			continue
-		}
-		item := notificationToJSON(ra, n, viewed)
-		items = append(items, item)
+		items = append(items, notificationToJSON(n))
 	}
 
 	apgin.APIJSON(gctx, http.StatusOK, ListNotificationsResponseJson{Items: items})
+}
+
+// @Summary		Mark notifications viewed
+// @Description	Mark multiple notifications viewed for the authenticated actor
+// @Tags			notifications
+// @Accept			json
+// @Produce		json
+// @Param			request	body	MarkNotificationsViewedRequestJson	true	"Notification IDs"
+// @Success		204
+// @Failure		400	{object}	ErrorResponse
+// @Failure		401	{object}	ErrorResponse
+// @Failure		403	{object}	ErrorResponse
+// @Failure		404	{object}	ErrorResponse
+// @Failure		500	{object}	ErrorResponse
+// @Security		BearerAuth
+// @Router			/notifications/_viewed [post]
+func (r *NotificationsRoutes) markViewedBatch(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+	ra := auth.MustGetAuthFromGinContext(gctx)
+
+	var req MarkNotificationsViewedRequestJson
+	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+		return
+	}
+
+	if err := r.core.MarkActorNotificationsViewed(ctx, ra, req.Ids); err != nil {
+		apgin.WriteErr(gctx, nil, err)
+		return
+	}
+	gctx.Status(http.StatusNoContent)
 }
 
 // @Summary		Mark notification viewed
@@ -165,38 +178,23 @@ func (r *NotificationsRoutes) markViewed(gctx *gin.Context) {
 		return
 	}
 
-	notification, err := r.db.GetNotification(ctx, id)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFound("notification not found"))
-		} else {
-			apgin.WriteErr(gctx, nil, err)
-		}
-		return
-	}
-	if !notificationPermissionsAllow(ra, notification.ViewPermissions, *notification) {
-		apgin.WriteError(gctx, nil, httperr.Forbidden("permission denied"))
-		return
-	}
-
-	if err := r.db.MarkNotificationViewed(ctx, id, ra.MustGetActor().GetId()); err != nil {
+	if err := r.core.MarkActorNotificationViewed(ctx, ra, id); err != nil {
 		apgin.WriteErr(gctx, nil, err)
 		return
 	}
 	gctx.Status(http.StatusNoContent)
 }
 
-func notificationToJSON(ra *authcore.RequestAuth, n database.Notification, viewed map[apid.ID]time.Time) NotificationJson {
-	canAction := notificationPermissionsAllow(ra, n.ActionPermissions, n)
+func notificationToJSON(actorNotification coreIface.ActorNotification) NotificationJson {
+	n := actorNotification.Notification
 	actionURL := ""
-	if canAction && n.ActionUrl != nil {
+	if actorNotification.CanAction && n.ActionUrl != nil {
 		actionURL = *n.ActionUrl
 	}
 	metadata := map[string]any(n.Metadata)
 	if len(metadata) == 0 {
 		metadata = nil
 	}
-	_, isViewed := viewed[n.Id]
 	return NotificationJson{
 		Id:           n.Id,
 		Key:          n.Key,
@@ -208,8 +206,8 @@ func notificationToJSON(ra *authcore.RequestAuth, n database.Notification, viewe
 		Title:        n.Title,
 		Message:      n.Message,
 		ActionUrl:    actionURL,
-		CanAction:    canAction,
-		Viewed:       isViewed,
+		CanAction:    actorNotification.CanAction,
+		Viewed:       actorNotification.Viewed,
 		Metadata:     metadata,
 		CreatedAt:    n.CreatedAt,
 		UpdatedAt:    n.UpdatedAt,
@@ -217,44 +215,15 @@ func notificationToJSON(ra *authcore.RequestAuth, n database.Notification, viewe
 	}
 }
 
-func notificationPermissionsAllow(ra *authcore.RequestAuth, permissions []aschema.Permission, n database.Notification) bool {
-	if ra == nil || !ra.IsAuthenticated() || len(permissions) == 0 {
-		return false
-	}
-	for _, p := range permissions {
-		resources := p.Resources
-		if len(resources) == 0 {
-			resources = []string{n.ResourceType}
-		}
-		verbs := p.Verbs
-		if len(verbs) == 0 {
-			verbs = []string{"get"}
-		}
-		resourceIds := p.ResourceIds
-		if len(resourceIds) == 0 {
-			resourceIds = []string{n.ResourceId.String()}
-		}
-		for _, resource := range resources {
-			for _, verb := range verbs {
-				for _, resourceId := range resourceIds {
-					if ra.Allows(n.Namespace, resource, verb, resourceId) {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
 func (r *NotificationsRoutes) Register(g gin.IRouter) {
 	g.GET("/notifications", r.auth.Required(), r.list)
+	g.POST("/notifications/_viewed", r.auth.Required(), r.markViewedBatch)
 	g.POST("/notifications/:id/_viewed", r.auth.Required(), r.markViewed)
 }
 
-func NewNotificationsRoutes(authService auth.A, db database.DB) *NotificationsRoutes {
+func NewNotificationsRoutes(authService auth.A, core coreIface.C) *NotificationsRoutes {
 	return &NotificationsRoutes{
 		auth: authService,
-		db:   db,
+		core: core,
 	}
 }

--- a/internal/schema/api/notifications.go
+++ b/internal/schema/api/notifications.go
@@ -49,6 +49,10 @@ type ListNotificationsResponseJson struct {
 	Cursor string             `json:"cursor,omitempty" yaml:"cursor,omitempty"`
 }
 
+type MarkNotificationsViewedRequestJson struct {
+	Ids []apid.ID `json:"ids" yaml:"ids" swaggertype:"array,string" example:"ntf_test550e8400abcde"`
+}
+
 // NotificationUpsertJson is an internal service shape used by migration hooks
 // and core code when creating deterministic notifications.
 type NotificationUpsertJson struct {

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -192,7 +192,7 @@ func GetGinServer(
 	)
 	routesNotifications := common_routes.NewNotificationsRoutes(
 		authService,
-		dm.GetDatabase(),
+		dm.GetCoreService(),
 	)
 
 	api := server.Group("/api/v1")

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -6801,6 +6801,72 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "/notifications/_viewed": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mark multiple notifications viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Mark notifications viewed",
+                "parameters": [
+                    {
+                        "description": "Notification IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/{id}/_viewed": {
             "post": {
                 "security": [
@@ -8438,6 +8504,20 @@ const docTemplateadmin_api = `{
                 "value": {
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.MarkNotificationsViewedRequestJson": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ntf_test550e8400abcde"
+                    ]
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -6795,6 +6795,72 @@
                 }
             }
         },
+        "/notifications/_viewed": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mark multiple notifications viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Mark notifications viewed",
+                "parameters": [
+                    {
+                        "description": "Notification IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/{id}/_viewed": {
             "post": {
                 "security": [
@@ -8432,6 +8498,20 @@
                 "value": {
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.MarkNotificationsViewedRequestJson": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ntf_test550e8400abcde"
+                    ]
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -374,6 +374,15 @@ definitions:
         example: production
         type: string
     type: object
+  routes.MarkNotificationsViewedRequestJson:
+    properties:
+      ids:
+        example:
+        - ntf_test550e8400abcde
+        items:
+          type: string
+        type: array
+    type: object
   routes.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -5425,6 +5434,48 @@ paths:
       security:
       - BearerAuth: []
       summary: List notifications
+      tags:
+      - notifications
+  /notifications/_viewed:
+    post:
+      consumes:
+      - application/json
+      description: Mark multiple notifications viewed for the authenticated actor
+      parameters:
+      - description: Notification IDs
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.MarkNotificationsViewedRequestJson'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Mark notifications viewed
       tags:
       - notifications
   /notifications/{id}/_viewed:

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -150,7 +150,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 	)
 	routesNotifications := common_routes.NewNotificationsRoutes(
 		authService,
-		dm.GetDatabase(),
+		dm.GetCoreService(),
 	)
 
 	api := server.Group("/api/v1")

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -6801,6 +6801,72 @@ const docTemplateApi = `{
                 }
             }
         },
+        "/notifications/_viewed": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mark multiple notifications viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Mark notifications viewed",
+                "parameters": [
+                    {
+                        "description": "Notification IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/{id}/_viewed": {
             "post": {
                 "security": [
@@ -8438,6 +8504,20 @@ const docTemplateApi = `{
                 "value": {
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.MarkNotificationsViewedRequestJson": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ntf_test550e8400abcde"
+                    ]
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -6795,6 +6795,72 @@
                 }
             }
         },
+        "/notifications/_viewed": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mark multiple notifications viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Mark notifications viewed",
+                "parameters": [
+                    {
+                        "description": "Notification IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/{id}/_viewed": {
             "post": {
                 "security": [
@@ -8432,6 +8498,20 @@
                 "value": {
                     "type": "string",
                     "example": "production"
+                }
+            }
+        },
+        "routes.MarkNotificationsViewedRequestJson": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ntf_test550e8400abcde"
+                    ]
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -374,6 +374,15 @@ definitions:
         example: production
         type: string
     type: object
+  routes.MarkNotificationsViewedRequestJson:
+    properties:
+      ids:
+        example:
+        - ntf_test550e8400abcde
+        items:
+          type: string
+        type: array
+    type: object
   routes.NamespaceJson:
     description: Namespace for organizing resources
     properties:
@@ -5425,6 +5434,48 @@ paths:
       security:
       - BearerAuth: []
       summary: List notifications
+      tags:
+      - notifications
+  /notifications/_viewed:
+    post:
+      consumes:
+      - application/json
+      description: Mark multiple notifications viewed for the authenticated actor
+      parameters:
+      - description: Notification IDs
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.MarkNotificationsViewedRequestJson'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Mark notifications viewed
       tags:
       - notifications
   /notifications/{id}/_viewed:

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -191,7 +191,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 
 		routesNotifications := common_routes.NewNotificationsRoutes(
 			authService,
-			dm.GetDatabase(),
+			dm.GetCoreService(),
 		)
 		routesNotifications.Register(api)
 


### PR DESCRIPTION
## Summary
- move notification listing/viewed handling into core with actor-filtered Redis list caching
- include actor permission fingerprints and a global notification version in cache keys, bumped on viewed/upsert/resolve changes
- wire API, admin API, and public marketplace notification routes through the core service
- add focused tests for cache hits, permission separation, viewed invalidation, and workflow write invalidation

## Tests
- go test ./internal/core -run 'Test(ListActorNotifications|NotificationCache|NotificationWrite|ApplyRequiredActionNotification|SetCandidateNotification|NotificationKeys)' -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/routes ./internal/service/api ./internal/service/admin_api ./internal/service/public -count=1
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -count=1
- ./scripts/preflight.sh

Closes #707