### PR TITLE
Add load-test environment harness

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,144 @@
+# AuthProxy Load-Test Harness
+
+This directory contains the Kubernetes harness for the AuthProxy load-test
+project tracked by #711 and #717. It is intentionally split from product
+optimizations: this first slice gives us repeatable environment setup, smoke
+traffic, and artifact capture. The large-state seeder, proxy-QPS scenarios, and
+background-job suites build on this foundation in follow-up issues.
+
+## Prerequisites
+
+- `kubectl` pointed at the target cluster.
+- `helm` for installing AuthProxy from the local chart.
+- `openssl` for disposable JWT, actor, and AES keys.
+- Metrics Server in the cluster when validating HPA behavior.
+- k6 Operator installed when using `LOADTEST_K6_MODE=operator`; the default
+  smoke path runs k6 as a plain Kubernetes Job.
+- KEDA installed only for future queue/custom-metric scaling profiles.
+
+Local kind or minikube is suitable for the `smoke` profile. The `100k`, `250k`,
+and `500k` profiles are capacity targets for a real cluster with enough node
+capacity.
+
+## Quick Start
+
+```bash
+# Deploy dependencies, generated secrets, go-oauth2-server, and separate
+# AuthProxy admin/api/public/worker releases into authproxy-load.
+./loadtest/scripts/up smoke
+
+# No-op for now except for artifact metadata; #718 fills in real state seeding.
+./loadtest/scripts/seed smoke
+
+# Run a small k6 smoke test against AuthProxy health endpoints and provider
+# health. Uses a Kubernetes Job unless LOADTEST_K6_MODE=operator is set.
+./loadtest/scripts/run smoke
+
+# Capture pods, deployments, services, Helm values, logs, and k6 summary JSON.
+./loadtest/scripts/collect smoke
+
+# Remove Helm releases and load-test manifests. The namespace is kept by default.
+./loadtest/scripts/down smoke
+```
+
+Set `LOADTEST_RUN_DIR=/path/to/run` to force all scripts to write into the same
+artifact directory. Without it, each command creates a timestamped directory
+under `loadtest/runs/`.
+
+## Profiles
+
+Profiles live in `profiles/`:
+
+- `smoke.yaml` deploys the smallest environment and runs a low-rate k6 health
+  test.
+- `100k.yaml` targets 100,000 connections and 50,000-100,000 namespaces.
+- `250k.yaml` targets 250,000 connections and 100,000+ namespaces.
+- `500k.yaml` is the stretch profile.
+
+The current scripts use the profile for run metadata and namespace selection.
+Future seeding and k6 issues will consume the object-count and traffic sections
+directly.
+
+## Environment Variables
+
+- `LOADTEST_NAMESPACE`: overrides the namespace from the profile.
+- `LOADTEST_RUN_DIR`: writes artifacts to a fixed directory.
+- `AUTHPROXY_IMAGE_REPOSITORY`: defaults to `ghcr.io/rmorlok/authproxy`.
+- `AUTHPROXY_IMAGE_TAG`: defaults to `main`.
+- `GO_OAUTH2_SERVER_IMAGE`: defaults to the current demo provider image.
+- `K6_IMAGE`: defaults to `grafana/k6:0.54.0`.
+- `LOADTEST_K6_MODE`: `job` (default) or `operator`.
+- `LOADTEST_K6_TIMEOUT`: defaults to `5m`.
+- `LOADTEST_INSTALL_K6_OPERATOR=true`: install or upgrade the k6 Operator with
+  Helm during `up`.
+- `LOADTEST_INSTALL_KEDA=true`: install or upgrade KEDA with Helm during `up`.
+
+## What `up` Deploys
+
+The smoke environment installs:
+
+- Postgres for AuthProxy's main database.
+- Redis for Asynq, sessions, rate-limit state, and task queues.
+- ClickHouse as a placeholder app-metrics backend for future pressure tests.
+- Grafana's `otel-lgtm` image for local OTel, Prometheus, Grafana, Tempo, and
+  Loki endpoints.
+- `go-oauth2-server` in test mode.
+- Four separate AuthProxy Helm releases:
+  - `authproxy-admin-api`
+  - `authproxy-api`
+  - `authproxy-public`
+  - `authproxy-worker`
+
+The chart's current model is one Deployment per release. Installing separate
+releases lets later issues add independent autoscaling and per-service resource
+tuning without changing this harness.
+
+## Run Artifacts
+
+Each script writes or appends to a run directory containing:
+
+- `metadata.env`: command, timestamps, namespace, image references, and profile.
+- `profile.yaml`: exact profile used for the run.
+- `helm-values/`: the value overlays used by `up`.
+- `kubernetes/`: resource snapshots, events, and rollout summaries.
+- `helm/`: `helm list`, rendered values, and manifest snapshots.
+- `k6/`: k6 logs and summary JSON when available.
+
+These artifacts are the handoff point for follow-up optimization work such as DB
+indexes, keyset pagination, request-event buffering, or worker tuning.
+
+## Optional k6 Operator Mode
+
+Install the k6 Operator in the cluster, or let `up` install it:
+
+```bash
+LOADTEST_INSTALL_K6_OPERATOR=true ./loadtest/scripts/up smoke
+```
+
+Then run:
+
+```bash
+LOADTEST_K6_MODE=operator ./loadtest/scripts/run smoke
+```
+
+The script creates the k6 script ConfigMap and applies
+`k8s/k6/smoke-testrun.yaml`. The default Job mode is kept so smoke tests work on
+clusters where the operator CRDs are not installed.
+
+## Optional KEDA
+
+KEDA is not needed for the smoke profile, but future worker queue and custom
+metric scaling tests can install it during environment setup:
+
+```bash
+LOADTEST_INSTALL_KEDA=true ./loadtest/scripts/up smoke
+```
+
+## Cleanup
+
+`down` uninstalls the four AuthProxy Helm releases and deletes the load-test
+manifests. To remove the namespace as well:
+
+```bash
+./loadtest/scripts/down smoke --delete-namespace
+```

--- a/loadtest/helm-values/admin-api.yaml
+++ b/loadtest/helm-values/admin-api.yaml
@@ -1,0 +1,21 @@
+replicaCount: 1
+
+services:
+  adminApi:
+    enabled: true
+
+database:
+  autoMigrate: true
+
+connectors:
+  autoMigrate: true
+
+appMetrics:
+  autoMigrate: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi

--- a/loadtest/helm-values/api.yaml
+++ b/loadtest/helm-values/api.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+
+services:
+  api:
+    enabled: true
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/loadtest/helm-values/common.yaml
+++ b/loadtest/helm-values/common.yaml
@@ -1,0 +1,101 @@
+image:
+  repository: ghcr.io/rmorlok/authproxy
+  tag: main
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+
+services:
+  api:
+    enabled: false
+  adminApi:
+    enabled: false
+    ui:
+      enabled: false
+    static:
+      enabled: false
+  public:
+    enabled: false
+    enableProxy: false
+    static:
+      enabled: false
+  worker:
+    enabled: false
+
+database:
+  provider: postgres
+  host: postgresql
+  port: 5432
+  database: authproxy
+  user: authproxy
+  sslmode: disable
+  autoMigrate: false
+  existingSecret: authproxy-load-db
+
+redis:
+  provider: redis
+  address: redis-master:6379
+  db: 0
+  existingSecret: authproxy-load-redis
+
+jwt:
+  existingSecret: authproxy-load-jwt
+
+encryptionKeys:
+  existingSecret: authproxy-load-encryption
+
+actors:
+  existingSecret: authproxy-load-actors
+  permissions:
+    - namespace: root.**
+      resources:
+        - "*"
+      verbs:
+        - "*"
+
+hostApplication:
+  initiateSessionUrl: http://authproxy-admin-api:8082/login
+
+blobStorage:
+  provider: filesystem
+  filesystem:
+    path: /tmp/authproxy-blobs
+    emptyDir: true
+
+connectors:
+  autoMigrate: false
+  loadFromList: []
+
+appMetrics:
+  shareMainDatabase: true
+  autoMigrate: false
+  fullRequestRecording: never
+
+config:
+  telemetry:
+    enabled: true
+    exporter:
+      protocol: grpc
+      endpoint: http://otel-lgtm:4317
+      insecure: true
+    resource:
+      service_name_prefix: authproxy-load
+      attributes:
+        deployment.environment: loadtest
+    sampling:
+      ratio: 1.0
+    signals:
+      traces: true
+      metrics: true
+      logs: true
+    http:
+      excluded_paths:
+        - /ping
+        - /healthz
+    proxy:
+      span_attribute_labels:
+        - loadtest
+      metric_dimension_labels:
+        - loadtest
+      metric_dimension_value_cap: 25

--- a/loadtest/helm-values/public.yaml
+++ b/loadtest/helm-values/public.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+
+services:
+  public:
+    enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi

--- a/loadtest/helm-values/worker.yaml
+++ b/loadtest/helm-values/worker.yaml
@@ -1,0 +1,18 @@
+replicaCount: 1
+
+services:
+  worker:
+    enabled: true
+
+worker:
+  workflowPollers: 8
+  activityPollers: 16
+  maxParallelWorkflowTasks: 32
+  maxParallelActivityTasks: 64
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/loadtest/k6/smoke.js
+++ b/loadtest/k6/smoke.js
@@ -1,0 +1,49 @@
+import http from 'k6/http';
+import { check, group } from 'k6';
+
+const rate = Number(__ENV.K6_RATE || 2);
+const preAllocatedVUs = Number(__ENV.K6_PRE_ALLOCATED_VUS || 4);
+const maxVUs = Number(__ENV.K6_MAX_VUS || 16);
+const duration = __ENV.K6_DURATION || '30s';
+
+const publicUrl = __ENV.AUTHPROXY_PUBLIC_URL || 'http://authproxy-public:8080';
+const apiUrl = __ENV.AUTHPROXY_API_URL || 'http://authproxy-api:8081';
+const adminApiUrl = __ENV.AUTHPROXY_ADMIN_API_URL || 'http://authproxy-admin-api:8082';
+const workerUrl = __ENV.AUTHPROXY_WORKER_URL || 'http://authproxy-worker:8083';
+const providerUrl = __ENV.GO_OAUTH2_SERVER_URL || 'http://go-oauth2-server';
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs,
+      maxVUs,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.001'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+function expectOK(name, response) {
+  check(response, {
+    [`${name} status is 200`]: (res) => res.status === 200,
+  });
+}
+
+export default function () {
+  group('authproxy', () => {
+    expectOK('public healthz', http.get(`${publicUrl}/healthz`, { tags: { target: 'authproxy-public' } }));
+    expectOK('api ping', http.get(`${apiUrl}/ping`, { tags: { target: 'authproxy-api' } }));
+    expectOK('admin-api ping', http.get(`${adminApiUrl}/ping`, { tags: { target: 'authproxy-admin-api' } }));
+    expectOK('worker ping', http.get(`${workerUrl}/ping`, { tags: { target: 'authproxy-worker' } }));
+  });
+
+  group('provider', () => {
+    expectOK('provider health', http.get(`${providerUrl}/test/health`, { tags: { target: 'go-oauth2-server' } }));
+  });
+}

--- a/loadtest/k8s/base/clickhouse.yaml
+++ b/loadtest/k8s/base/clickhouse.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: app-metrics
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/component: app-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: clickhouse
+        app.kubernetes.io/component: app-metrics
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: clickhouse
+          image: docker.io/clickhouse/clickhouse-server:24.8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8123
+            - name: native
+              containerPort: 9000
+          env:
+            - name: CLICKHOUSE_DB
+              value: authproxy_app_metrics
+            - name: CLICKHOUSE_USER
+              value: authproxy
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-load-clickhouse
+                  key: CLICKHOUSE_PASSWORD
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: app-metrics
+    loadtest.authproxy.io/component: dependency
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: app-metrics
+  ports:
+    - name: http
+      port: 8123
+      targetPort: http
+    - name: native
+      port: 9000
+      targetPort: native

--- a/loadtest/k8s/base/go-oauth2-server.yaml
+++ b/loadtest/k8s/base/go-oauth2-server.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-oauth2-server
+  labels:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: provider
+    loadtest.authproxy.io/component: provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: go-oauth2-server
+      app.kubernetes.io/component: provider
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: go-oauth2-server
+        app.kubernetes.io/component: provider
+        loadtest.authproxy.io/component: provider
+    spec:
+      containers:
+        - name: go-oauth2-server
+          image: ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3
+          imagePullPolicy: IfNotPresent
+          command:
+            - go-oauth2-server
+          args:
+            - runserver
+            - --test-mode
+            - --test-port
+            - "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /test/health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-oauth2-server
+  labels:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: provider
+    loadtest.authproxy.io/component: provider
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: go-oauth2-server
+    app.kubernetes.io/component: provider
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/loadtest/k8s/base/observability.yaml
+++ b/loadtest/k8s/base/observability.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-lgtm
+  labels:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-lgtm
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-lgtm
+        app.kubernetes.io/component: observability
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: otel-lgtm
+          image: docker.io/grafana/otel-lgtm:0.8.6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: grafana
+              containerPort: 3000
+            - name: loki
+              containerPort: 3100
+            - name: tempo
+              containerPort: 3200
+            - name: otel-grpc
+              containerPort: 4317
+            - name: otel-http
+              containerPort: 4318
+            - name: prometheus
+              containerPort: 9090
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: tempo-data
+              mountPath: /data/tempo
+            - name: grafana-data
+              mountPath: /data/grafana
+            - name: loki-data
+              mountPath: /data/loki
+            - name: loki-storage
+              mountPath: /loki
+            - name: prometheus-storage
+              mountPath: /data/prometheus
+            - name: pyroscope-storage
+              mountPath: /data/pyroscope
+      volumes:
+        - name: tempo-data
+          emptyDir: {}
+        - name: grafana-data
+          emptyDir: {}
+        - name: loki-data
+          emptyDir: {}
+        - name: loki-storage
+          emptyDir: {}
+        - name: prometheus-storage
+          emptyDir: {}
+        - name: pyroscope-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-lgtm
+  labels:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: otel-lgtm
+    app.kubernetes.io/component: observability
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: grafana
+    - name: loki
+      port: 3100
+      targetPort: loki
+    - name: tempo
+      port: 3200
+      targetPort: tempo
+    - name: otel-grpc
+      port: 4317
+      targetPort: otel-grpc
+    - name: otel-http
+      port: 4318
+      targetPort: otel-http
+    - name: prometheus
+      port: 9090
+      targetPort: prometheus

--- a/loadtest/k8s/base/postgres.yaml
+++ b/loadtest/k8s/base/postgres.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: database
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:17.2.0-debian-12-r6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRESQL_USERNAME
+              value: authproxy
+            - name: POSTGRESQL_DATABASE
+              value: authproxy
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-load-db
+                  key: AUTHPROXY_DB_PASSWORD
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+    loadtest.authproxy.io/component: dependency
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql

--- a/loadtest/k8s/base/redis.yaml
+++ b/loadtest/k8s/base/redis.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: redis
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: redis
+          image: docker.io/bitnamilegacy/redis:7.4.1-debian-12-r2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "no"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-load-redis
+                  key: AUTHPROXY_REDIS_PASSWORD
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+    loadtest.authproxy.io/component: dependency
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/loadtest/k8s/k6/smoke-job.yaml
+++ b/loadtest/k8s/k6/smoke-job.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authproxy-smoke-k6
+  labels:
+    app.kubernetes.io/name: k6
+    app.kubernetes.io/component: load-generator
+    loadtest.authproxy.io/scenario: smoke
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k6
+        app.kubernetes.io/component: load-generator
+        loadtest.authproxy.io/scenario: smoke
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: grafana/k6:0.54.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /scripts/smoke.js
+            - --summary-export
+            - /artifacts/summary.json
+          env:
+            - name: AUTHPROXY_PUBLIC_URL
+              value: http://authproxy-public:8080
+            - name: AUTHPROXY_API_URL
+              value: http://authproxy-api:8081
+            - name: AUTHPROXY_ADMIN_API_URL
+              value: http://authproxy-admin-api:8082
+            - name: AUTHPROXY_WORKER_URL
+              value: http://authproxy-worker:8083
+            - name: GO_OAUTH2_SERVER_URL
+              value: http://go-oauth2-server
+            - name: K6_RATE
+              value: "2"
+            - name: K6_DURATION
+              value: 30s
+            - name: K6_PRE_ALLOCATED_VUS
+              value: "4"
+            - name: K6_MAX_VUS
+              value: "16"
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: artifacts
+              mountPath: /artifacts
+      volumes:
+        - name: scripts
+          configMap:
+            name: authproxy-loadtest-k6
+        - name: artifacts
+          emptyDir: {}

--- a/loadtest/k8s/k6/smoke-testrun.yaml
+++ b/loadtest/k8s/k6/smoke-testrun.yaml
@@ -1,0 +1,35 @@
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: authproxy-smoke
+  labels:
+    app.kubernetes.io/name: k6
+    app.kubernetes.io/component: load-generator
+    loadtest.authproxy.io/scenario: smoke
+spec:
+  parallelism: 1
+  script:
+    configMap:
+      name: authproxy-loadtest-k6
+      file: smoke.js
+  runner:
+    image: grafana/k6:0.54.0
+    env:
+      - name: AUTHPROXY_PUBLIC_URL
+        value: http://authproxy-public:8080
+      - name: AUTHPROXY_API_URL
+        value: http://authproxy-api:8081
+      - name: AUTHPROXY_ADMIN_API_URL
+        value: http://authproxy-admin-api:8082
+      - name: AUTHPROXY_WORKER_URL
+        value: http://authproxy-worker:8083
+      - name: GO_OAUTH2_SERVER_URL
+        value: http://go-oauth2-server
+      - name: K6_RATE
+        value: "2"
+      - name: K6_DURATION
+        value: 30s
+      - name: K6_PRE_ALLOCATED_VUS
+        value: "4"
+      - name: K6_MAX_VUS
+        value: "16"

--- a/loadtest/profiles/100k.yaml
+++ b/loadtest/profiles/100k.yaml
@@ -1,0 +1,34 @@
+name: 100k
+namespace: authproxy-load
+description: Baseline high-cardinality target profile.
+cluster:
+  target: real-cluster
+objects:
+  namespaces_min: 50000
+  namespaces_max: 100000
+  connections: 100000
+  oauth_tokens_expiring_percent:
+    - 10
+    - 50
+    - 100
+  periodic_probe_percent:
+    - 1
+    - 10
+    - 100
+authproxy:
+  api_replicas: 2
+  worker_replicas: 2
+  public_replicas: 1
+  admin_api_replicas: 1
+k6:
+  mode: operator
+  scenario: proxy-raw
+  scale_replicas:
+    - 2
+    - 4
+    - 8
+    - 16
+acceptance:
+  max_5xx_rate: 0.001
+  p95_latency_target: profile-configured
+  refresh_sweep_must_drain_before_next_cron: true

--- a/loadtest/profiles/250k.yaml
+++ b/loadtest/profiles/250k.yaml
@@ -1,0 +1,32 @@
+name: 250k
+namespace: authproxy-load
+description: Larger cardinality target profile for database, scheduler, and worker pressure.
+cluster:
+  target: real-cluster
+objects:
+  namespaces_min: 100000
+  connections: 250000
+  oauth_tokens_expiring_percent:
+    - 10
+    - 50
+    - 100
+  periodic_probe_percent:
+    - 1
+    - 10
+    - 100
+authproxy:
+  api_replicas: 4
+  worker_replicas: 4
+  public_replicas: 1
+  admin_api_replicas: 1
+k6:
+  mode: operator
+  scenario: proxy-raw
+  scale_replicas:
+    - 4
+    - 8
+    - 16
+acceptance:
+  max_5xx_rate: 0.001
+  p95_latency_target: profile-configured
+  refresh_sweep_must_drain_before_next_cron: true

--- a/loadtest/profiles/500k.yaml
+++ b/loadtest/profiles/500k.yaml
@@ -1,0 +1,31 @@
+name: 500k
+namespace: authproxy-load
+description: Stretch target profile for upper-bound capacity exploration.
+cluster:
+  target: real-cluster
+objects:
+  namespaces_min: 200000
+  connections: 500000
+  oauth_tokens_expiring_percent:
+    - 10
+    - 50
+    - 100
+  periodic_probe_percent:
+    - 1
+    - 10
+    - 100
+authproxy:
+  api_replicas: 8
+  worker_replicas: 8
+  public_replicas: 1
+  admin_api_replicas: 1
+k6:
+  mode: operator
+  scenario: proxy-raw
+  scale_replicas:
+    - 8
+    - 16
+acceptance:
+  max_5xx_rate: 0.001
+  p95_latency_target: profile-configured
+  refresh_sweep_must_drain_before_next_cron: true

--- a/loadtest/profiles/smoke.yaml
+++ b/loadtest/profiles/smoke.yaml
@@ -1,0 +1,25 @@
+name: smoke
+namespace: authproxy-load
+description: Minimal Kubernetes smoke test for the load-test harness.
+cluster:
+  target: local-or-small-cluster
+objects:
+  namespaces: 10
+  connections: 10
+  oauth_tokens_expiring_percent: 0
+  periodic_probe_percent: 0
+authproxy:
+  api_replicas: 1
+  worker_replicas: 1
+  public_replicas: 1
+  admin_api_replicas: 1
+k6:
+  mode: job
+  scenario: smoke
+  rate: 2
+  duration: 30s
+  pre_allocated_vus: 4
+  max_vus: 16
+acceptance:
+  max_5xx_rate: 0.001
+  p95_latency_target: 500ms

--- a/loadtest/runs/.gitignore
+++ b/loadtest/runs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/loadtest/scripts/collect
+++ b/loadtest/scripts/collect
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" collect)
+
+loadtest_require_cmd kubectl
+loadtest_require_cmd helm
+
+loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
+loadtest_capture_helm_snapshot "$namespace" "$run_dir"
+
+kubectl -n "$namespace" get jobs -o wide > "$run_dir/kubernetes/jobs.txt" 2>&1 || true
+kubectl -n "$namespace" get configmaps -o wide > "$run_dir/kubernetes/configmaps.txt" 2>&1 || true
+kubectl -n "$namespace" get secrets -o name > "$run_dir/kubernetes/secrets.txt" 2>&1 || true
+kubectl -n "$namespace" get testruns.k6.io -o yaml > "$run_dir/k6/testruns.yaml" 2>&1 || true
+kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
+
+pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-smoke-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [[ -n "$pod" ]]; then
+  kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/summary.json" >/dev/null 2>&1 || true
+fi
+
+loadtest_log "collected artifacts for profile $profile_name"
+loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/down
+++ b/loadtest/scripts/down
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+delete_namespace=false
+if [[ "${2:-}" == "--delete-namespace" ]]; then
+  delete_namespace=true
+fi
+
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" down)
+
+loadtest_require_cmd kubectl
+loadtest_require_cmd helm
+
+for release in "${LOADTEST_AUTH_PROXY_RELEASES[@]}"; do
+  loadtest_log "uninstalling $release"
+  helm -n "$namespace" uninstall "$release" >/dev/null 2>&1 || true
+done
+
+kubectl -n "$namespace" delete job authproxy-smoke-k6 --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete configmap authproxy-loadtest-k6 --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete testrun authproxy-smoke --ignore-not-found=true >/dev/null 2>&1 || true
+
+for manifest in "$LOADTEST_ROOT"/k8s/base/*.yaml; do
+  kubectl -n "$namespace" delete -f "$manifest" --ignore-not-found=true >/dev/null 2>&1 || true
+done
+
+kubectl -n "$namespace" delete secret \
+  authproxy-load-db \
+  authproxy-load-redis \
+  authproxy-load-clickhouse \
+  authproxy-load-jwt \
+  authproxy-load-actors \
+  authproxy-load-encryption \
+  --ignore-not-found=true >/dev/null 2>&1 || true
+
+if [[ "$delete_namespace" == "true" ]]; then
+  loadtest_log "deleting namespace $namespace"
+  kubectl delete namespace "$namespace" --ignore-not-found=true
+fi
+
+loadtest_log "environment removed for profile $profile_name"
+loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/lib/loadtest.sh
+++ b/loadtest/scripts/lib/loadtest.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOADTEST_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LOADTEST_ROOT=$(cd "$LOADTEST_SCRIPT_DIR/../.." && pwd)
+REPO_ROOT=$(cd "$LOADTEST_ROOT/.." && pwd)
+
+LOADTEST_DEFAULT_NAMESPACE=authproxy-load
+LOADTEST_AUTH_PROXY_RELEASES=(
+  authproxy-admin-api
+  authproxy-api
+  authproxy-public
+  authproxy-worker
+)
+
+loadtest_log() {
+  printf "[loadtest] %s\n" "$*"
+}
+
+loadtest_die() {
+  printf "[loadtest] ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+loadtest_require_cmd() {
+  local cmd=$1
+  command -v "$cmd" >/dev/null 2>&1 || loadtest_die "required command not found: $cmd"
+}
+
+loadtest_profile_path() {
+  local profile=$1
+  if [[ -f "$profile" ]]; then
+    printf "%s\n" "$profile"
+    return
+  fi
+
+  local candidate="$LOADTEST_ROOT/profiles/${profile}.yaml"
+  [[ -f "$candidate" ]] || loadtest_die "unknown profile: $profile"
+  printf "%s\n" "$candidate"
+}
+
+loadtest_yaml_top_value() {
+  local file=$1
+  local key=$2
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*" key ":" {
+      sub("^[^:]*:[[:space:]]*", "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+loadtest_profile_name() {
+  local profile_file=$1
+  local name
+  name=$(loadtest_yaml_top_value "$profile_file" name)
+  printf "%s\n" "${name:-$(basename "$profile_file" .yaml)}"
+}
+
+loadtest_namespace() {
+  local profile_file=$1
+  local namespace
+  namespace=$(loadtest_yaml_top_value "$profile_file" namespace)
+  printf "%s\n" "${LOADTEST_NAMESPACE:-${namespace:-$LOADTEST_DEFAULT_NAMESPACE}}"
+}
+
+loadtest_timestamp() {
+  date -u "+%Y%m%dT%H%M%SZ"
+}
+
+loadtest_init_run_dir() {
+  local profile_name=$1
+  local profile_file=$2
+  local namespace=$3
+  local command_name=$4
+  local now
+  now=$(loadtest_timestamp)
+
+  local run_dir="${LOADTEST_RUN_DIR:-$LOADTEST_ROOT/runs/${now}-${profile_name}-${command_name}}"
+  mkdir -p "$run_dir/helm-values" "$run_dir/kubernetes" "$run_dir/helm" "$run_dir/k6"
+  cp "$profile_file" "$run_dir/profile.yaml"
+  cp "$LOADTEST_ROOT"/helm-values/*.yaml "$run_dir/helm-values/"
+
+  {
+    printf "command=%s\n" "$command_name"
+    printf "started_at=%s\n" "$now"
+    printf "profile=%s\n" "$profile_name"
+    printf "profile_file=%s\n" "$profile_file"
+    printf "namespace=%s\n" "$namespace"
+    printf "authproxy_image_repository=%s\n" "${AUTHPROXY_IMAGE_REPOSITORY:-ghcr.io/rmorlok/authproxy}"
+    printf "authproxy_image_tag=%s\n" "${AUTHPROXY_IMAGE_TAG:-main}"
+    printf "go_oauth2_server_image=%s\n" "${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3}"
+    printf "k6_image=%s\n" "${K6_IMAGE:-grafana/k6:0.54.0}"
+    printf "install_k6_operator=%s\n" "${LOADTEST_INSTALL_K6_OPERATOR:-false}"
+    printf "install_keda=%s\n" "${LOADTEST_INSTALL_KEDA:-false}"
+  } > "$run_dir/metadata.env"
+
+  printf "%s\n" "$run_dir"
+}
+
+loadtest_ensure_namespace() {
+  local namespace=$1
+  if kubectl get namespace "$namespace" >/dev/null 2>&1; then
+    loadtest_log "namespace exists: $namespace"
+  else
+    loadtest_log "creating namespace: $namespace"
+    kubectl create namespace "$namespace"
+  fi
+}
+
+loadtest_apply_manifest_dir() {
+  local namespace=$1
+  local dir=$2
+  local manifest
+
+  for manifest in "$dir"/*.yaml; do
+    loadtest_log "applying $(basename "$manifest")"
+    kubectl -n "$namespace" apply -f "$manifest"
+  done
+}
+
+loadtest_wait_for_deployment() {
+  local namespace=$1
+  local deployment=$2
+  local timeout=${3:-5m}
+
+  loadtest_log "waiting for deployment/$deployment"
+  kubectl -n "$namespace" rollout status "deployment/$deployment" "--timeout=$timeout"
+}
+
+loadtest_ensure_generated_secrets() {
+  local namespace=$1
+  local tmp
+  tmp=$(mktemp -d)
+
+  local db_password=${LOADTEST_DB_PASSWORD:-authproxy-load}
+  local redis_password=${LOADTEST_REDIS_PASSWORD:-authproxy-load}
+  local clickhouse_password=${LOADTEST_CLICKHOUSE_PASSWORD:-authproxy-load}
+
+  kubectl -n "$namespace" create secret generic authproxy-load-db \
+    --from-literal=AUTHPROXY_DB_PASSWORD="$db_password" \
+    --dry-run=client -o yaml > "$tmp/db.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/db.yaml"
+
+  kubectl -n "$namespace" create secret generic authproxy-load-redis \
+    --from-literal=AUTHPROXY_REDIS_PASSWORD="$redis_password" \
+    --dry-run=client -o yaml > "$tmp/redis.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/redis.yaml"
+
+  kubectl -n "$namespace" create secret generic authproxy-load-clickhouse \
+    --from-literal=CLICKHOUSE_PASSWORD="$clickhouse_password" \
+    --dry-run=client -o yaml > "$tmp/clickhouse.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/clickhouse.yaml"
+
+  openssl genrsa -out "$tmp/system" 2048 >/dev/null 2>&1
+  openssl rsa -in "$tmp/system" -pubout -out "$tmp/system.pub" >/dev/null 2>&1
+  kubectl -n "$namespace" create secret generic authproxy-load-jwt \
+    --from-file=system="$tmp/system" \
+    --from-file=system.pub="$tmp/system.pub" \
+    --dry-run=client -o yaml > "$tmp/jwt.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/jwt.yaml"
+
+  openssl genrsa -out "$tmp/loadtest-admin" 2048 >/dev/null 2>&1
+  openssl rsa -in "$tmp/loadtest-admin" -pubout -out "$tmp/loadtest-admin.pub" >/dev/null 2>&1
+  kubectl -n "$namespace" create secret generic authproxy-load-actors \
+    --from-file=loadtest-admin="$tmp/loadtest-admin" \
+    --from-file=loadtest-admin.pub="$tmp/loadtest-admin.pub" \
+    --dry-run=client -o yaml > "$tmp/actors.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/actors.yaml"
+
+  openssl rand -out "$tmp/global_aes.key" 32
+  kubectl -n "$namespace" create secret generic authproxy-load-encryption \
+    --from-file=global_aes.key="$tmp/global_aes.key" \
+    --dry-run=client -o yaml > "$tmp/encryption.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/encryption.yaml"
+
+  rm -rf "$tmp"
+}
+
+loadtest_capture_cluster_snapshot() {
+  local namespace=$1
+  local run_dir=$2
+
+  kubectl -n "$namespace" get pods -o wide > "$run_dir/kubernetes/pods.txt" 2>&1 || true
+  kubectl -n "$namespace" get deployments -o wide > "$run_dir/kubernetes/deployments.txt" 2>&1 || true
+  kubectl -n "$namespace" get services -o wide > "$run_dir/kubernetes/services.txt" 2>&1 || true
+  kubectl -n "$namespace" get hpa -o yaml > "$run_dir/kubernetes/hpa.yaml" 2>&1 || true
+  kubectl -n "$namespace" get events --sort-by=.lastTimestamp > "$run_dir/kubernetes/events.txt" 2>&1 || true
+}
+
+loadtest_capture_helm_snapshot() {
+  local namespace=$1
+  local run_dir=$2
+  local release
+
+  helm -n "$namespace" list > "$run_dir/helm/list.txt" 2>&1 || true
+  for release in "${LOADTEST_AUTH_PROXY_RELEASES[@]}"; do
+    helm -n "$namespace" get values "$release" --all > "$run_dir/helm/${release}-values.yaml" 2>&1 || true
+    helm -n "$namespace" get manifest "$release" > "$run_dir/helm/${release}-manifest.yaml" 2>&1 || true
+  done
+}

--- a/loadtest/scripts/run
+++ b/loadtest/scripts/run
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+scenario=${2:-smoke}
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" run)
+
+loadtest_require_cmd kubectl
+
+[[ "$scenario" == "smoke" ]] || loadtest_die "unsupported scenario in this slice: $scenario"
+
+k6_mode=${LOADTEST_K6_MODE:-job}
+k6_timeout=${LOADTEST_K6_TIMEOUT:-5m}
+k6_image=${K6_IMAGE:-grafana/k6:0.54.0}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+kubectl -n "$namespace" create configmap authproxy-loadtest-k6 \
+  --from-file=smoke.js="$LOADTEST_ROOT/k6/smoke.js" \
+  --dry-run=client -o yaml > "$tmp/k6-configmap.yaml"
+kubectl -n "$namespace" apply -f "$tmp/k6-configmap.yaml"
+
+if [[ "$k6_mode" == "operator" ]]; then
+  if ! kubectl get crd testruns.k6.io >/dev/null 2>&1; then
+    loadtest_die "LOADTEST_K6_MODE=operator requested, but testruns.k6.io is not installed"
+  fi
+
+  loadtest_log "applying k6 TestRun"
+  kubectl -n "$namespace" delete testrun authproxy-smoke --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-testrun.yaml"
+  loadtest_log "TestRun submitted; use collect to capture status and runner logs"
+else
+  loadtest_log "running k6 smoke Job"
+  kubectl -n "$namespace" delete job authproxy-smoke-k6 --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-job.yaml"
+  kubectl -n "$namespace" set image job/authproxy-smoke-k6 "k6=$k6_image"
+  kubectl -n "$namespace" wait --for=condition=complete job/authproxy-smoke-k6 "--timeout=$k6_timeout"
+  kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
+
+  pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-smoke-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [[ -n "$pod" ]]; then
+    kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/summary.json" >/dev/null 2>&1 || true
+  fi
+fi
+
+loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
+loadtest_capture_helm_snapshot "$namespace" "$run_dir"
+
+loadtest_log "scenario complete: $scenario"
+loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/seed
+++ b/loadtest/scripts/seed
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" seed)
+
+mkdir -p "$run_dir/datasets"
+
+cat > "$run_dir/seed-plan.txt" <<'EOF'
+The environment harness is ready, but large-state seeding is implemented in
+the next workstream (#718).
+
+This command exists now so the end-to-end load-test flow is stable:
+
+  up -> seed -> run -> collect -> down
+
+For the smoke profile, no AuthProxy resources are required because the k6
+scenario only checks service health and provider reachability.
+EOF
+
+printf "connection_id\n" > "$run_dir/datasets/connections.csv"
+
+loadtest_log "seed step recorded for profile $profile_name"
+loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/up
+++ b/loadtest/scripts/up
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" up)
+
+loadtest_require_cmd kubectl
+loadtest_require_cmd helm
+loadtest_require_cmd openssl
+
+authproxy_repo=${AUTHPROXY_IMAGE_REPOSITORY:-ghcr.io/rmorlok/authproxy}
+authproxy_tag=${AUTHPROXY_IMAGE_TAG:-main}
+provider_image=${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3}
+helm_timeout=${LOADTEST_HELM_TIMEOUT:-5m}
+
+loadtest_log "profile: $profile_name"
+loadtest_log "namespace: $namespace"
+loadtest_log "artifacts: $run_dir"
+
+loadtest_ensure_namespace "$namespace"
+loadtest_ensure_generated_secrets "$namespace"
+
+if [[ "${LOADTEST_INSTALL_K6_OPERATOR:-false}" == "true" ]]; then
+  loadtest_log "installing k6 Operator"
+  helm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+  helm repo update grafana >/dev/null
+  helm upgrade --install k6-operator grafana/k6-operator \
+    --namespace "$namespace" \
+    --wait \
+    "--timeout=$helm_timeout"
+fi
+
+if [[ "${LOADTEST_INSTALL_KEDA:-false}" == "true" ]]; then
+  loadtest_log "installing KEDA"
+  helm repo add kedacore https://kedacore.github.io/charts >/dev/null
+  helm repo update kedacore >/dev/null
+  helm upgrade --install keda kedacore/keda \
+    --namespace "$namespace" \
+    --wait \
+    "--timeout=$helm_timeout"
+fi
+
+loadtest_apply_manifest_dir "$namespace" "$LOADTEST_ROOT/k8s/base"
+
+kubectl -n "$namespace" set image deployment/go-oauth2-server "go-oauth2-server=$provider_image"
+
+loadtest_wait_for_deployment "$namespace" postgresql "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" redis-master "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" clickhouse "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" otel-lgtm "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" go-oauth2-server "$helm_timeout"
+
+chart="$REPO_ROOT/deploy/charts/authproxy"
+common_values="$LOADTEST_ROOT/helm-values/common.yaml"
+
+install_release() {
+  local release=$1
+  local values_file=$2
+
+  loadtest_log "installing $release"
+  helm upgrade --install "$release" "$chart" \
+    --namespace "$namespace" \
+    --wait \
+    "--timeout=$helm_timeout" \
+    -f "$common_values" \
+    -f "$values_file" \
+    --set "image.repository=$authproxy_repo" \
+    --set "image.tag=$authproxy_tag"
+}
+
+install_release authproxy-admin-api "$LOADTEST_ROOT/helm-values/admin-api.yaml"
+install_release authproxy-api "$LOADTEST_ROOT/helm-values/api.yaml"
+install_release authproxy-public "$LOADTEST_ROOT/helm-values/public.yaml"
+install_release authproxy-worker "$LOADTEST_ROOT/helm-values/worker.yaml"
+
+loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
+loadtest_capture_helm_snapshot "$namespace" "$run_dir"
+
+loadtest_log "environment ready"
+loadtest_log "run artifacts: $run_dir"


### PR DESCRIPTION
## Summary

- Add `loadtest/` profiles for smoke, 100k, 250k, and 500k load-test targets.
- Add Kubernetes smoke dependencies for Postgres, Redis, ClickHouse, otel-lgtm, and go-oauth2-server.
- Add per-service AuthProxy Helm values for separate `admin-api`, `api`, `public`, and `worker` releases.
- Add `up`, `seed`, `run`, `collect`, and `down` scripts with generated secrets, run metadata, k6 smoke execution, optional k6 Operator/KEDA installation, and artifact collection.

Closes #717.

## Validation

- `bash -n loadtest/scripts/lib/loadtest.sh`
- `bash -n loadtest/scripts/{up,seed,run,collect,down}`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_stream(File.read(file)); puts file }' ...`
- `helm lint deploy/charts/authproxy -f loadtest/helm-values/common.yaml -f loadtest/helm-values/{admin-api,api,public,worker}.yaml`
- `helm template` for all four load-test AuthProxy releases
- `./loadtest/scripts/seed smoke`
- `env GOCACHE=/private/tmp/authproxy-go-cache GOMODCACHE=/private/tmp/authproxy-go-modcache ./scripts/preflight.sh`

`kubectl apply --dry-run=client --validate=false` could not complete against the configured EKS context because the local AWS SSO token is expired; the manifests were syntax-checked locally and the Helm values render successfully.
