### PR TITLE
Add docs.authproxy.net DNS record

### DIFF
--- a/deploy/terraform/eks/main.tf
+++ b/deploy/terraform/eks/main.tf
@@ -20,6 +20,9 @@ data "aws_caller_identity" "current" {}
 locals {
   azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
 
+  github_owner        = split("/", var.github_repository)[0]
+  github_pages_domain = "${local.github_owner}.github.io"
+
   # Subnets carved out of the VPC CIDR. /16 split into:
   #   - private: 10.0.0.0/19, 10.0.32.0/19, 10.0.64.0/19    (nodes)
   #   - public:  10.0.96.0/20, 10.0.112.0/20, 10.0.128.0/20 (LB, NAT)

--- a/deploy/terraform/eks/route53.tf
+++ b/deploy/terraform/eks/route53.tf
@@ -3,3 +3,11 @@ resource "aws_route53_zone" "primary" {
 
   comment = "Public hosted zone for ${var.domain_name}. Delegate the registrar's NS records to the four NS entries on this zone after first apply."
 }
+
+resource "aws_route53_record" "docs" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "docs.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = [local.github_pages_domain]
+}


### PR DESCRIPTION
## Summary
- add a Terraform-managed Route53 CNAME for docs.authproxy.net
- derive the GitHub Pages target from the repo owner in var.github_repository
- keep docs hosting on GitHub Pages rather than adding a docs container to the EKS deployment

## Validation
- terraform -chdir=deploy/terraform/eks fmt -check
- TF_DATA_DIR=/tmp/authproxy-docs-dns-tfdata terraform -chdir=deploy/terraform/eks init -backend=false -input=false
- TF_DATA_DIR=/tmp/authproxy-docs-dns-tfdata terraform -chdir=deploy/terraform/eks validate
- ./scripts/preflight.sh
- git diff --check

## Live checks
- GitHub Pages is already configured with cname=docs.authproxy.net and source branch github-pages
- authproxy.net NS records resolve to the Terraform-managed AWS Route53 nameservers
- docs.authproxy.net currently has no CNAME record

## Apply note
AWS SSO was expired locally, so I could not run terraform plan/apply against the remote S3 state in this session. After refreshing SSO, apply from deploy/terraform/eks should create a single aws_route53_record.docs CNAME to rmorlok.github.io.