### PR TITLE
Add AuthProxy load-test seeder

### DIFF
--- a/cmd/server/loadtest_seed.go
+++ b/cmd/server/loadtest_seed.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	encryptpkg "github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/loadtest/seeder"
+	"github.com/rmorlok/authproxy/internal/service"
+	"github.com/spf13/cobra"
+)
+
+func cmdLoadtestSeed() *cobra.Command {
+	var profilePath string
+	var runDir string
+	var providerBaseURL string
+	var migrate bool
+	var distributedMigrationLocks bool
+	var verifySamples int
+	var progressEvery int
+	var oauthExpiringPercent int
+	var periodicProbePercent int
+
+	cmd := &cobra.Command{
+		Use:   "loadtest-seed",
+		Short: "Seed AuthProxy resources for load-test profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if profilePath == "" {
+				return fmt.Errorf("--profile is required")
+			}
+
+			profile, err := seeder.LoadProfile(profilePath)
+			if err != nil {
+				return fmt.Errorf("failed to load profile: %w", err)
+			}
+
+			dm := service.NewDependencyManager("loadtest-seed", cfg)
+			defer dm.ShutdownTelemetry()
+			defer dm.ShutdownDatabase()
+
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			if migrate {
+				if distributedMigrationLocks {
+					dm.AutoMigrateDatabase()
+					dm.AutoMigrateGenerateDataEncryptionKeys()
+					dm.AutoMigrateSyncKeysToDatabase()
+				} else {
+					if err := dm.GetDatabase().Migrate(ctx); err != nil {
+						return fmt.Errorf("failed to migrate database: %w", err)
+					}
+					if err := encryptpkg.GenerateDataEncryptionKeysToDatabase(ctx, cfg, dm.GetDatabase(), dm.GetLogger(), nil); err != nil {
+						return fmt.Errorf("failed to generate data encryption keys: %w", err)
+					}
+					if err := encryptpkg.SyncKeysToDatabase(ctx, cfg, dm.GetDatabase(), dm.GetLogger(), nil); err != nil {
+						return fmt.Errorf("failed to sync keys to database: %w", err)
+					}
+				}
+			}
+
+			enc := dm.GetEncryptService()
+			defer enc.Shutdown()
+			if err := enc.SyncKeysFromDbToMemory(ctx); err != nil {
+				return fmt.Errorf("failed to sync encryption keys: %w", err)
+			}
+
+			var oauthOverride *int
+			if cmd.Flags().Changed("oauth-expiring-percent") {
+				oauthOverride = &oauthExpiringPercent
+			}
+			var probeOverride *int
+			if cmd.Flags().Changed("periodic-probe-percent") {
+				probeOverride = &periodicProbePercent
+			}
+
+			result, err := seeder.Seed(ctx, seeder.Options{
+				Profile:              profile,
+				DB:                   dm.GetDatabase(),
+				Encrypt:              enc,
+				ProviderBaseURL:      providerBaseURL,
+				OAuthExpiringPercent: oauthOverride,
+				PeriodicProbePercent: probeOverride,
+				VerifySamples:        verifySamples,
+				ProgressEvery:        progressEvery,
+				Now:                  time.Now().UTC(),
+				Logf: func(format string, args ...any) {
+					fmt.Printf("[loadtest-seed] "+format+"\n", args...)
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			if err := seeder.WriteArtifacts(runDir, result); err != nil {
+				return fmt.Errorf("failed to write seed artifacts: %w", err)
+			}
+
+			fmt.Printf(
+				"Seeded profile %s: namespaces=%d connections=%d oauth_tokens=%d verified=%d\n",
+				result.ProfileName,
+				result.CreatedNamespaces,
+				len(result.Connections),
+				result.UpsertedOAuthTokens,
+				len(result.VerifiedSamples),
+			)
+			if runDir != "" {
+				fmt.Printf("Run artifacts: %s\n", runDir)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&profilePath, "profile", "", "load-test profile YAML")
+	cmd.Flags().StringVar(&runDir, "run-dir", "", "artifact directory to populate")
+	cmd.Flags().StringVar(&providerBaseURL, "provider-base-url", "", "go-oauth2-server base URL used in seeded connector definitions")
+	cmd.Flags().BoolVar(&migrate, "migrate", true, "run database and encryption-key migrations before seeding")
+	cmd.Flags().BoolVar(&distributedMigrationLocks, "distributed-migration-locks", false, "use Redis-backed distributed migration locks")
+	cmd.Flags().IntVar(&verifySamples, "verify-samples", 3, "number of seeded connections to verify through AuthProxy internals")
+	cmd.Flags().IntVar(&progressEvery, "progress-every", 1000, "log progress every N connections")
+	cmd.Flags().IntVar(&oauthExpiringPercent, "oauth-expiring-percent", 0, "override percent of tokens expiring inside the refresh window")
+	cmd.Flags().IntVar(&periodicProbePercent, "periodic-probe-percent", 0, "override percent of connections marked for periodic probes")
+
+	return cmd
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -172,5 +172,6 @@ func main() {
 	rootCmd.AddCommand(cmdRoutes())
 	rootCmd.AddCommand(cmdServe())
 	rootCmd.AddCommand(cmdReencrypt())
+	rootCmd.AddCommand(cmdLoadtestSeed())
 	rootCmd.Execute()
 }

--- a/internal/loadtest/seeder/artifacts.go
+++ b/internal/loadtest/seeder/artifacts.go
@@ -1,0 +1,170 @@
+package seeder
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func WriteArtifacts(runDir string, result *Result) error {
+	if runDir == "" {
+		return nil
+	}
+	if result == nil {
+		return fmt.Errorf("seed result is required")
+	}
+
+	datasetsDir := filepath.Join(runDir, "datasets")
+	if err := os.MkdirAll(datasetsDir, 0o755); err != nil {
+		return err
+	}
+
+	if err := writeConnectionsCSV(filepath.Join(datasetsDir, "connections.csv"), result.Connections); err != nil {
+		return err
+	}
+	if err := writeNamespacesCSV(filepath.Join(datasetsDir, "namespaces.csv"), result.Namespaces); err != nil {
+		return err
+	}
+	if err := writeActorsCSV(filepath.Join(datasetsDir, "actors.csv"), result.Actors); err != nil {
+		return err
+	}
+
+	summary, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "seed-summary.json"), append(summary, '\n'), 0o644); err != nil {
+		return err
+	}
+
+	plan := fmt.Sprintf(`AuthProxy load-test seed summary
+
+Profile: %s
+Provider base URL: %s
+Base namespace: %s
+Connector: %s:%d
+
+Tenant namespaces requested: %d
+Connections requested: %d
+Connections created: %d
+Connections already present: %d
+OAuth2 tokens upserted: %d
+OAuth expiring percent: %d
+Periodic probe percent: %d
+Probe-enabled connections: %d
+Verified samples: %d
+
+Datasets:
+  datasets/connections.csv
+  datasets/namespaces.csv
+  datasets/actors.csv
+`,
+		result.ProfileName,
+		result.ProviderBaseURL,
+		result.BaseNamespace,
+		result.ConnectorID,
+		result.ConnectorVersion,
+		result.RequestedTenantNamespaces,
+		result.RequestedConnections,
+		result.CreatedConnections,
+		result.ExistingConnections,
+		result.UpsertedOAuthTokens,
+		result.OAuthExpiringPercent,
+		result.PeriodicProbePercent,
+		result.ProbeEnabledConnections,
+		len(result.VerifiedSamples),
+	)
+	return os.WriteFile(filepath.Join(runDir, "seed-plan.txt"), []byte(plan), 0o644)
+}
+
+func writeConnectionsCSV(path string, rows []ConnectionRecord) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err := writer.Write([]string{
+		"connection_id",
+		"namespace",
+		"actor_id",
+		"connector_id",
+		"connector_version",
+		"refresh_token",
+		"access_token",
+		"access_token_expires_at",
+		"probe_enabled",
+		"oauth_token_id",
+	}); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		tokenID := ""
+		if row.OAuthTokenID != nil {
+			tokenID = row.OAuthTokenID.String()
+		}
+		if err := writer.Write([]string{
+			row.ConnectionID.String(),
+			row.Namespace,
+			row.ActorID.String(),
+			row.ConnectorID.String(),
+			strconv.FormatUint(row.ConnectorVersion, 10),
+			row.RefreshToken,
+			row.AccessToken,
+			row.AccessTokenExpiresAt.Format("2006-01-02T15:04:05Z07:00"),
+			strconv.FormatBool(row.ProbeEnabled),
+			tokenID,
+		}); err != nil {
+			return err
+		}
+	}
+	return writer.Error()
+}
+
+func writeNamespacesCSV(path string, rows []NamespaceRecord) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err := writer.Write([]string{"namespace"}); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writer.Write([]string{row.Namespace}); err != nil {
+			return err
+		}
+	}
+	return writer.Error()
+}
+
+func writeActorsCSV(path string, rows []ActorRecord) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err := writer.Write([]string{"actor_id", "namespace", "external_id"}); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writer.Write([]string{row.ActorID.String(), row.Namespace, row.ExternalID}); err != nil {
+			return err
+		}
+	}
+	return writer.Error()
+}

--- a/internal/loadtest/seeder/profile.go
+++ b/internal/loadtest/seeder/profile.go
@@ -1,0 +1,103 @@
+package seeder
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Profile struct {
+	Name        string         `yaml:"name" json:"name"`
+	Namespace   string         `yaml:"namespace" json:"namespace"`
+	Description string         `yaml:"description" json:"description"`
+	Objects     ProfileObjects `yaml:"objects" json:"objects"`
+}
+
+type ProfileObjects struct {
+	Namespaces             int         `yaml:"namespaces" json:"namespaces,omitempty"`
+	NamespacesMin          int         `yaml:"namespaces_min" json:"namespaces_min,omitempty"`
+	NamespacesMax          int         `yaml:"namespaces_max" json:"namespaces_max,omitempty"`
+	Connections            int         `yaml:"connections" json:"connections"`
+	OAuthTokensExpiringPct PercentList `yaml:"oauth_tokens_expiring_percent" json:"oauth_tokens_expiring_percent,omitempty"`
+	PeriodicProbePct       PercentList `yaml:"periodic_probe_percent" json:"periodic_probe_percent,omitempty"`
+}
+
+type PercentList []int
+
+func (p *PercentList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var single int
+		if err := value.Decode(&single); err != nil {
+			return err
+		}
+		*p = []int{single}
+		return nil
+	case yaml.SequenceNode:
+		var values []int
+		if err := value.Decode(&values); err != nil {
+			return err
+		}
+		*p = values
+		return nil
+	default:
+		return fmt.Errorf("percent list must be a scalar or sequence")
+	}
+}
+
+func LoadProfile(path string) (Profile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Profile{}, err
+	}
+
+	var profile Profile
+	if err := yaml.Unmarshal(content, &profile); err != nil {
+		return Profile{}, err
+	}
+	if profile.Name == "" {
+		return Profile{}, fmt.Errorf("profile name is required")
+	}
+	if profile.Objects.Connections < 0 {
+		return Profile{}, fmt.Errorf("profile connections must be non-negative")
+	}
+	if profile.Namespace == "" {
+		profile.Namespace = "authproxy-load"
+	}
+	return profile, nil
+}
+
+func (p Profile) TenantNamespaceCount() int {
+	if p.Objects.Namespaces > 0 {
+		return p.Objects.Namespaces
+	}
+	if p.Objects.NamespacesMin > 0 {
+		return p.Objects.NamespacesMin
+	}
+	if p.Objects.Connections > 0 {
+		return p.Objects.Connections
+	}
+	return 0
+}
+
+func (p Profile) DefaultOAuthExpiringPercent() int {
+	return firstPercentOrZero(p.Objects.OAuthTokensExpiringPct)
+}
+
+func (p Profile) DefaultPeriodicProbePercent() int {
+	return firstPercentOrZero(p.Objects.PeriodicProbePct)
+}
+
+func firstPercentOrZero(values []int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	if values[0] < 0 {
+		return 0
+	}
+	if values[0] > 100 {
+		return 100
+	}
+	return values[0]
+}

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -1,0 +1,497 @@
+package seeder
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+)
+
+const (
+	defaultProviderBaseURL = "http://go-oauth2-server:8080"
+	defaultProgressEvery   = 1000
+)
+
+type Options struct {
+	Profile              Profile
+	DB                   database.DB
+	Encrypt              encrypt.E
+	ProviderBaseURL      string
+	OAuthExpiringPercent *int
+	PeriodicProbePercent *int
+	VerifySamples        int
+	ProgressEvery        int
+	Now                  time.Time
+	Logf                 func(format string, args ...any)
+}
+
+type Result struct {
+	ProfileName               string             `json:"profile_name"`
+	ProviderBaseURL           string             `json:"provider_base_url"`
+	BaseNamespace             string             `json:"base_namespace"`
+	ConnectorID               apid.ID            `json:"connector_id"`
+	ConnectorVersion          uint64             `json:"connector_version"`
+	RequestedTenantNamespaces int                `json:"requested_tenant_namespaces"`
+	RequestedConnections      int                `json:"requested_connections"`
+	OAuthExpiringPercent      int                `json:"oauth_expiring_percent"`
+	PeriodicProbePercent      int                `json:"periodic_probe_percent"`
+	StartedAt                 time.Time          `json:"started_at"`
+	FinishedAt                time.Time          `json:"finished_at"`
+	CreatedNamespaces         int                `json:"created_namespaces"`
+	UpsertedActors            int                `json:"upserted_actors"`
+	CreatedConnections        int                `json:"created_connections"`
+	ExistingConnections       int                `json:"existing_connections"`
+	UpsertedOAuthTokens       int                `json:"upserted_oauth_tokens"`
+	ProbeEnabledConnections   int                `json:"probe_enabled_connections"`
+	VerifiedSamples           []VerifiedSample   `json:"verified_samples"`
+	Namespaces                []NamespaceRecord  `json:"namespaces"`
+	Actors                    []ActorRecord      `json:"actors"`
+	Connections               []ConnectionRecord `json:"connections"`
+}
+
+type NamespaceRecord struct {
+	Namespace string `json:"namespace"`
+}
+
+type ActorRecord struct {
+	ActorID    apid.ID `json:"actor_id"`
+	Namespace  string  `json:"namespace"`
+	ExternalID string  `json:"external_id"`
+}
+
+type ConnectionRecord struct {
+	ConnectionID         apid.ID   `json:"connection_id"`
+	Namespace            string    `json:"namespace"`
+	ActorID              apid.ID   `json:"actor_id"`
+	ConnectorID          apid.ID   `json:"connector_id"`
+	ConnectorVersion     uint64    `json:"connector_version"`
+	RefreshToken         string    `json:"refresh_token"`
+	AccessToken          string    `json:"access_token"`
+	AccessTokenExpiresAt time.Time `json:"access_token_expires_at"`
+	ProbeEnabled         bool      `json:"probe_enabled"`
+	OAuthTokenID         *apid.ID  `json:"oauth_token_id,omitempty"`
+}
+
+type VerifiedSample struct {
+	ConnectionID apid.ID `json:"connection_id"`
+	Namespace    string  `json:"namespace"`
+	ActorID      apid.ID `json:"actor_id"`
+	OAuthTokenID apid.ID `json:"oauth_token_id"`
+}
+
+func Seed(ctx context.Context, opts Options) (*Result, error) {
+	if opts.DB == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	if opts.Encrypt == nil {
+		return nil, fmt.Errorf("encrypt service is required")
+	}
+	if opts.Profile.Name == "" {
+		return nil, fmt.Errorf("profile is required")
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	providerBaseURL := strings.TrimRight(opts.ProviderBaseURL, "/")
+	if providerBaseURL == "" {
+		providerBaseURL = defaultProviderBaseURL
+	}
+	oauthExpiringPercent := opts.Profile.DefaultOAuthExpiringPercent()
+	if opts.OAuthExpiringPercent != nil {
+		oauthExpiringPercent = *opts.OAuthExpiringPercent
+	}
+	oauthExpiringPercent = clampPercent(oauthExpiringPercent)
+	periodicProbePercent := opts.Profile.DefaultPeriodicProbePercent()
+	if opts.PeriodicProbePercent != nil {
+		periodicProbePercent = *opts.PeriodicProbePercent
+	}
+	periodicProbePercent = clampPercent(periodicProbePercent)
+	verifySamples := opts.VerifySamples
+	if verifySamples < 0 {
+		verifySamples = 0
+	}
+	progressEvery := opts.ProgressEvery
+	if progressEvery <= 0 {
+		progressEvery = defaultProgressEvery
+	}
+
+	slug := slugForID(opts.Profile.Name)
+	baseNamespace := nschema.PathFromRoot("loadtest", slugForNamespace(opts.Profile.Name))
+	connectorID := apid.ID(fmt.Sprintf("%slt_%s_oauth2", apid.PrefixConnectorVersion, slug))
+	connectorVersion := uint64(1)
+	tenantCount := opts.Profile.TenantNamespaceCount()
+	connectionCount := opts.Profile.Objects.Connections
+	probeEnabledCount := percentCount(connectionCount, periodicProbePercent)
+	expiringCount := percentCount(connectionCount, oauthExpiringPercent)
+
+	result := &Result{
+		ProfileName:               opts.Profile.Name,
+		ProviderBaseURL:           providerBaseURL,
+		BaseNamespace:             baseNamespace,
+		ConnectorID:               connectorID,
+		ConnectorVersion:          connectorVersion,
+		RequestedTenantNamespaces: tenantCount,
+		RequestedConnections:      connectionCount,
+		OAuthExpiringPercent:      oauthExpiringPercent,
+		PeriodicProbePercent:      periodicProbePercent,
+		StartedAt:                 now,
+	}
+
+	logf := opts.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+
+	logf("ensuring namespace tree under %s", baseNamespace)
+	if err := opts.DB.EnsureNamespaceByPath(ctx, baseNamespace); err != nil {
+		return nil, fmt.Errorf("ensure base namespace: %w", err)
+	}
+
+	tenantNamespaces := make([]string, 0, tenantCount)
+	for i := 1; i <= tenantCount; i++ {
+		ns := fmt.Sprintf("%s.tenant%06d", baseNamespace, i)
+		if err := opts.DB.EnsureNamespaceByPath(ctx, ns); err != nil {
+			return nil, fmt.Errorf("ensure tenant namespace %s: %w", ns, err)
+		}
+		tenantNamespaces = append(tenantNamespaces, ns)
+		result.Namespaces = append(result.Namespaces, NamespaceRecord{Namespace: ns})
+	}
+	result.CreatedNamespaces = len(tenantNamespaces)
+
+	logf("upserting %d actors", len(tenantNamespaces))
+	actors := make([]ActorRecord, 0, len(tenantNamespaces))
+	for i, ns := range tenantNamespaces {
+		actor := &database.Actor{
+			Id:         apid.ID(fmt.Sprintf("%slt_%s_%06d", apid.PrefixActor, slug, i+1)),
+			Namespace:  ns,
+			ExternalId: fmt.Sprintf("loadtest-%s-%06d", slug, i+1),
+			Permissions: database.Permissions{
+				{
+					Namespace: ns,
+					Resources: []string{aschema.PermissionWildcard},
+					Verbs:     []string{aschema.PermissionWildcard},
+				},
+			},
+			Labels: baseLabels(opts.Profile.Name),
+			Annotations: database.Annotations{
+				"loadtest.authproxy.io/generated-by": "loadtest-seeder",
+			},
+		}
+		upserted, err := opts.DB.UpsertActor(ctx, actor)
+		if err != nil {
+			return nil, fmt.Errorf("upsert actor %s: %w", actor.Id, err)
+		}
+		record := ActorRecord{ActorID: upserted.Id, Namespace: upserted.Namespace, ExternalID: upserted.ExternalId}
+		actors = append(actors, record)
+		result.Actors = append(result.Actors, record)
+	}
+	result.UpsertedActors = len(actors)
+
+	logf("upserting load-test OAuth2 connector %s", connectorID)
+	connectorDef := connectorDefinition(connectorID, connectorVersion, baseNamespace, opts.Profile.Name, providerBaseURL, periodicProbePercent > 0)
+	connectorJSON, err := json.Marshal(connectorDef)
+	if err != nil {
+		return nil, fmt.Errorf("marshal connector definition: %w", err)
+	}
+	encryptedDefinition, err := opts.Encrypt.EncryptStringGlobal(ctx, string(connectorJSON))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt connector definition: %w", err)
+	}
+	connectorHash := connectorDef.Hash()
+	existingConnector, err := opts.DB.GetConnectorVersion(ctx, connectorID, connectorVersion)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return nil, fmt.Errorf("get connector version: %w", err)
+	}
+	if existingConnector != nil && existingConnector.Hash != connectorHash {
+		return nil, fmt.Errorf("connector %s:%d already exists with a different hash", connectorID, connectorVersion)
+	}
+	if existingConnector == nil {
+		err = opts.DB.UpsertConnectorVersion(ctx, &database.ConnectorVersion{
+			Id:                  connectorID,
+			Version:             connectorVersion,
+			Namespace:           baseNamespace,
+			State:               database.ConnectorVersionStatePrimary,
+			Hash:                connectorHash,
+			EncryptedDefinition: encryptedDefinition,
+			Labels:              baseLabels(opts.Profile.Name),
+			Annotations: database.Annotations{
+				"loadtest.authproxy.io/provider-base-url": providerBaseURL,
+			},
+		})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("upsert connector version: %w", err)
+	}
+
+	if connectionCount > 0 && len(tenantNamespaces) == 0 {
+		return nil, fmt.Errorf("profile requests connections but no namespaces")
+	}
+
+	logf("seeding %d connections", connectionCount)
+	for i := 1; i <= connectionCount; i++ {
+		ns := tenantNamespaces[(i-1)%len(tenantNamespaces)]
+		actor := actors[(i-1)%len(actors)]
+		connectionID := apid.ID(fmt.Sprintf("%slt_%s_%09d", apid.PrefixConnection, slug, i))
+		probeEnabled := i <= probeEnabledCount
+		expiresAt := now.Add(24 * time.Hour)
+		if i <= expiringCount {
+			expiresAt = now.Add(1 * time.Minute)
+		}
+
+		connection := &database.Connection{
+			Id:               connectionID,
+			Namespace:        ns,
+			State:            database.ConnectionStateConfigured,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      connectorID,
+			ConnectorVersion: connectorVersion,
+			Labels:           connectionLabels(opts.Profile.Name, i, probeEnabled),
+			Annotations: database.Annotations{
+				"loadtest.authproxy.io/generated-by": "loadtest-seeder",
+			},
+		}
+		existing, err := opts.DB.GetConnection(ctx, connectionID)
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return nil, fmt.Errorf("get connection %s: %w", connectionID, err)
+		}
+		if existing == nil {
+			if err := opts.DB.CreateConnection(ctx, connection); err != nil {
+				return nil, fmt.Errorf("create connection %s: %w", connectionID, err)
+			}
+			result.CreatedConnections++
+		} else {
+			result.ExistingConnections++
+		}
+
+		refreshToken := fmt.Sprintf("rt_%s", connectionID)
+		accessToken := fmt.Sprintf("at_%s", connectionID)
+		encryptedRefreshToken, err := opts.Encrypt.EncryptStringForNamespace(ctx, ns, refreshToken)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt refresh token for %s: %w", connectionID, err)
+		}
+		encryptedAccessToken, err := opts.Encrypt.EncryptStringForNamespace(ctx, ns, accessToken)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt access token for %s: %w", connectionID, err)
+		}
+		token, err := opts.DB.InsertOAuth2Token(
+			ctx,
+			connectionID,
+			nil,
+			encryptedRefreshToken,
+			encryptedAccessToken,
+			&expiresAt,
+			"loadtest.read",
+			"loadtest.read",
+			&actor.ActorID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert OAuth2 token for %s: %w", connectionID, err)
+		}
+		result.UpsertedOAuthTokens++
+		if probeEnabled {
+			result.ProbeEnabledConnections++
+		}
+		tokenID := token.Id
+		result.Connections = append(result.Connections, ConnectionRecord{
+			ConnectionID:         connectionID,
+			Namespace:            ns,
+			ActorID:              actor.ActorID,
+			ConnectorID:          connectorID,
+			ConnectorVersion:     connectorVersion,
+			RefreshToken:         refreshToken,
+			AccessToken:          accessToken,
+			AccessTokenExpiresAt: expiresAt,
+			ProbeEnabled:         probeEnabled,
+			OAuthTokenID:         &tokenID,
+		})
+
+		if i%progressEvery == 0 {
+			logf("seeded %d/%d connections", i, connectionCount)
+		}
+	}
+
+	if verifySamples > 0 {
+		samples, err := verifySeededSamples(ctx, opts.DB, result.Connections, verifySamples)
+		if err != nil {
+			return nil, err
+		}
+		result.VerifiedSamples = samples
+	}
+
+	result.FinishedAt = time.Now().UTC()
+	logf("seeded %d connections (%d new, %d existing)", connectionCount, result.CreatedConnections, result.ExistingConnections)
+	return result, nil
+}
+
+func verifySeededSamples(ctx context.Context, db database.DB, connections []ConnectionRecord, sampleCount int) ([]VerifiedSample, error) {
+	if len(connections) == 0 || sampleCount == 0 {
+		return nil, nil
+	}
+	indexes := sampleIndexes(len(connections), sampleCount)
+	samples := make([]VerifiedSample, 0, len(indexes))
+	for _, idx := range indexes {
+		record := connections[idx]
+		conn, err := db.GetConnection(ctx, record.ConnectionID)
+		if err != nil {
+			return nil, fmt.Errorf("verify connection %s: %w", record.ConnectionID, err)
+		}
+		token, err := db.GetOAuth2Token(ctx, record.ConnectionID)
+		if err != nil {
+			return nil, fmt.Errorf("verify OAuth2 token for %s: %w", record.ConnectionID, err)
+		}
+		samples = append(samples, VerifiedSample{
+			ConnectionID: conn.Id,
+			Namespace:    conn.Namespace,
+			ActorID:      record.ActorID,
+			OAuthTokenID: token.Id,
+		})
+	}
+	return samples, nil
+}
+
+func sampleIndexes(length, requested int) []int {
+	if requested >= length {
+		indexes := make([]int, length)
+		for i := range indexes {
+			indexes[i] = i
+		}
+		return indexes
+	}
+	seen := make(map[int]struct{}, requested)
+	indexes := make([]int, 0, requested)
+	for i := 0; i < requested; i++ {
+		idx := 0
+		if requested > 1 {
+			idx = i * (length - 1) / (requested - 1)
+		}
+		if _, ok := seen[idx]; ok {
+			continue
+		}
+		seen[idx] = struct{}{}
+		indexes = append(indexes, idx)
+	}
+	return indexes
+}
+
+func connectorDefinition(id apid.ID, version uint64, namespace, profileName, providerBaseURL string, includeProbe bool) *cschema.Connector {
+	refreshInBackground := true
+	def := &cschema.Connector{
+		Id:          id,
+		Version:     version,
+		Namespace:   &namespace,
+		State:       string(database.ConnectorVersionStatePrimary),
+		DisplayName: fmt.Sprintf("Load Test OAuth2 (%s)", profileName),
+		Highlight:   "Synthetic OAuth2 connector for AuthProxy load tests.",
+		Description: "Generated by the AuthProxy load-test seeder.",
+		Auth: &cschema.Auth{InnerVal: &cschema.AuthOAuth2{
+			Type:         cschema.AuthTypeOAuth2,
+			ClientId:     common.NewStringValueDirectInline("loadtest-client"),
+			ClientSecret: common.NewStringValueDirectInline("loadtest-secret"),
+			Scopes: []cschema.Scope{
+				{Id: "loadtest.read", Reason: "Exercise AuthProxy load-test proxy and refresh paths."},
+			},
+			Authorization: cschema.AuthOauth2Authorization{
+				Endpoint: providerBaseURL + "/oauth/authorize",
+			},
+			Token: cschema.AuthOauth2Token{
+				Endpoint:                providerBaseURL + "/oauth/token",
+				RefreshInBackground:     &refreshInBackground,
+				RefreshTimeBeforeExpiry: &common.HumanDuration{Duration: 15 * time.Minute},
+			},
+		}},
+		Labels: baseLabels(profileName),
+	}
+	if includeProbe {
+		def.Probes = []cschema.Probe{
+			{
+				Id:     "load-sink",
+				Period: &common.HumanDuration{Duration: 5 * time.Minute},
+				ProxyHttp: &cschema.ProbeHttp{
+					Method: "GET",
+					URL:    providerBaseURL + "/test/load/resource/probe",
+				},
+			},
+		}
+	}
+	return def
+}
+
+func baseLabels(profileName string) database.Labels {
+	return database.Labels{
+		"loadtest.authproxy.io/profile": slugForLabelValue(profileName),
+		"loadtest.authproxy.io/suite":   "authproxy-load",
+		"loadtest":                      "true",
+	}
+}
+
+func connectionLabels(profileName string, index int, probeEnabled bool) database.Labels {
+	labels := baseLabels(profileName)
+	labels["loadtest.authproxy.io/connection-index"] = fmt.Sprintf("%d", index)
+	if probeEnabled {
+		labels["loadtest.authproxy.io/probe"] = "true"
+	} else {
+		labels["loadtest.authproxy.io/probe"] = "false"
+	}
+	return labels
+}
+
+func percentCount(total, pct int) int {
+	if total <= 0 || pct <= 0 {
+		return 0
+	}
+	if pct >= 100 {
+		return total
+	}
+	return total * pct / 100
+}
+
+func clampPercent(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+var nonIDChar = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slugForID(value string) string {
+	slug := strings.ToLower(value)
+	slug = nonIDChar.ReplaceAllString(slug, "_")
+	slug = strings.Trim(slug, "_")
+	if slug == "" {
+		return "profile"
+	}
+	return slug
+}
+
+func slugForNamespace(value string) string {
+	slug := slugForID(value)
+	if slug[0] >= '0' && slug[0] <= '9' {
+		return "p" + slug
+	}
+	return slug
+}
+
+func slugForLabelValue(value string) string {
+	slug := slugForID(value)
+	if len(slug) > database.LabelValueMaxLength {
+		return slug[:database.LabelValueMaxLength]
+	}
+	return slug
+}

--- a/internal/loadtest/seeder/seed_test.go
+++ b/internal/loadtest/seeder/seed_test.go
@@ -1,0 +1,127 @@
+package seeder
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProfileSmoke(t *testing.T) {
+	profile, err := LoadProfile(filepath.Join("..", "..", "..", "loadtest", "profiles", "smoke.yaml"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "smoke", profile.Name)
+	assert.Equal(t, 10, profile.TenantNamespaceCount())
+	assert.Equal(t, 10, profile.Objects.Connections)
+	assert.Equal(t, 0, profile.DefaultOAuthExpiringPercent())
+	assert.Equal(t, 0, profile.DefaultPeriodicProbePercent())
+}
+
+func TestSeedSmokeProfile(t *testing.T) {
+	_, db := database.MustApplyBlankTestDbConfig(t, nil)
+	enc := encrypt.NewFakeEncryptService(false)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	oauthExpiringPercent := 40
+	periodicProbePercent := 20
+
+	result, err := Seed(context.Background(), Options{
+		Profile: Profile{
+			Name: "smoke",
+			Objects: ProfileObjects{
+				Namespaces:  3,
+				Connections: 5,
+			},
+		},
+		DB:                   db,
+		Encrypt:              enc,
+		ProviderBaseURL:      "http://provider.test",
+		OAuthExpiringPercent: &oauthExpiringPercent,
+		PeriodicProbePercent: &periodicProbePercent,
+		VerifySamples:        3,
+		Now:                  now,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "root.loadtest.smoke", result.BaseNamespace)
+	assert.Equal(t, 3, result.CreatedNamespaces)
+	assert.Equal(t, 3, result.UpsertedActors)
+	assert.Equal(t, 5, result.CreatedConnections)
+	assert.Equal(t, 0, result.ExistingConnections)
+	assert.Equal(t, 5, result.UpsertedOAuthTokens)
+	assert.Equal(t, 1, result.ProbeEnabledConnections)
+	require.Len(t, result.VerifiedSamples, 3)
+	require.Len(t, result.Connections, 5)
+
+	first := result.Connections[0]
+	assert.Equal(t, "rt_"+first.ConnectionID.String(), first.RefreshToken)
+	assert.True(t, first.ProbeEnabled)
+	assert.Equal(t, now.Add(time.Minute), first.AccessTokenExpiresAt)
+
+	last := result.Connections[4]
+	assert.False(t, last.ProbeEnabled)
+	assert.Equal(t, now.Add(24*time.Hour), last.AccessTokenExpiresAt)
+
+	gotConnection, err := db.GetConnection(context.Background(), first.ConnectionID)
+	require.NoError(t, err)
+	assert.Equal(t, first.Namespace, gotConnection.Namespace)
+
+	gotToken, err := db.GetOAuth2Token(context.Background(), first.ConnectionID)
+	require.NoError(t, err)
+	assert.Equal(t, first.ConnectionID, gotToken.ConnectionId)
+}
+
+func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
+	_, db := database.MustApplyBlankTestDbConfig(t, nil)
+	enc := encrypt.NewFakeEncryptService(false)
+	profile := Profile{
+		Name: "smoke",
+		Objects: ProfileObjects{
+			Namespaces:  2,
+			Connections: 2,
+		},
+	}
+
+	first, err := Seed(context.Background(), Options{
+		Profile:       profile,
+		DB:            db,
+		Encrypt:       enc,
+		VerifySamples: 2,
+		Now:           time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, first.CreatedConnections)
+
+	second, err := Seed(context.Background(), Options{
+		Profile:       profile,
+		DB:            db,
+		Encrypt:       enc,
+		VerifySamples: 2,
+		Now:           time.Date(2026, 7, 13, 12, 30, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, second.CreatedConnections)
+	assert.Equal(t, 2, second.ExistingConnections)
+
+	runDir := t.TempDir()
+	require.NoError(t, WriteArtifacts(runDir, second))
+
+	connectionsCSV, err := os.ReadFile(filepath.Join(runDir, "datasets", "connections.csv"))
+	require.NoError(t, err)
+	assert.Contains(t, string(connectionsCSV), "connection_id,namespace,actor_id")
+	assert.Contains(t, string(connectionsCSV), "cxn_lt_smoke_000000001")
+
+	summary, err := os.ReadFile(filepath.Join(runDir, "seed-summary.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(summary), `"existing_connections": 2`)
+
+	plan, err := os.ReadFile(filepath.Join(runDir, "seed-plan.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(plan), "AuthProxy load-test seed summary")
+}

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,9 +1,9 @@
 # AuthProxy Load-Test Harness
 
 This directory contains the Kubernetes harness for the AuthProxy load-test
-project tracked by #711 and #717. It is intentionally split from product
+project tracked by #711. It is intentionally split from product
 optimizations: this first slice gives us repeatable environment setup, smoke
-traffic, and artifact capture. The large-state seeder, proxy-QPS scenarios, and
+traffic, state seeding, and artifact capture. The proxy-QPS scenarios and
 background-job suites build on this foundation in follow-up issues.
 
 ## Prerequisites
@@ -27,7 +27,9 @@ capacity.
 # AuthProxy admin/api/public/worker releases into authproxy-load.
 ./loadtest/scripts/up smoke
 
-# No-op for now except for artifact metadata; #718 fills in real state seeding.
+# Seed namespaces, actors, a synthetic OAuth2 connector, connections, OAuth2
+# tokens, and k6-ready datasets. With no config override this uses an
+# ephemeral SQLite/miniredis AuthProxy config under the run directory.
 ./loadtest/scripts/seed smoke
 
 # Run a small k6 smoke test against AuthProxy health endpoints and provider
@@ -55,9 +57,9 @@ Profiles live in `profiles/`:
 - `250k.yaml` targets 250,000 connections and 100,000+ namespaces.
 - `500k.yaml` is the stretch profile.
 
-The current scripts use the profile for run metadata and namespace selection.
-Future seeding and k6 issues will consume the object-count and traffic sections
-directly.
+The seed script consumes the object-count section directly. The k6 and
+background-job scenario issues will consume the generated datasets and traffic
+sections.
 
 ## Environment Variables
 
@@ -69,6 +71,10 @@ directly.
 - `K6_IMAGE`: defaults to `grafana/k6:0.54.0`.
 - `LOADTEST_K6_MODE`: `job` (default) or `operator`.
 - `LOADTEST_K6_TIMEOUT`: defaults to `5m`.
+- `LOADTEST_AUTHPROXY_CONFIG`: AuthProxy config used by `seed`. When unset,
+  `seed` generates a local SQLite/miniredis config in the run directory.
+- `LOADTEST_PROVIDER_BASE_URL`: provider URL written into seeded connector
+  definitions; defaults to `http://go-oauth2-server:8080`.
 - `LOADTEST_INSTALL_K6_OPERATOR=true`: install or upgrade the k6 Operator with
   Helm during `up`.
 - `LOADTEST_INSTALL_KEDA=true`: install or upgrade KEDA with Helm during `up`.
@@ -103,6 +109,15 @@ Each script writes or appends to a run directory containing:
 - `kubernetes/`: resource snapshots, events, and rollout summaries.
 - `helm/`: `helm list`, rendered values, and manifest snapshots.
 - `k6/`: k6 logs and summary JSON when available.
+
+The `seed` step also writes:
+
+- `datasets/connections.csv`: connection IDs and metadata for k6 scenarios.
+- `datasets/namespaces.csv`: generated tenant namespaces.
+- `datasets/actors.csv`: generated tenant actors.
+- `seed-summary.json`: machine-readable counts, selected percentages, and
+  verified samples.
+- `seed-plan.txt`: human-readable seed summary.
 
 These artifacts are the handoff point for follow-up optimization work such as DB
 indexes, keyset pagination, request-event buffering, or worker tuning.

--- a/loadtest/scripts/seed
+++ b/loadtest/scripts/seed
@@ -5,26 +5,75 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$SCRIPT_DIR/lib/loadtest.sh"
 
 profile=${1:-${LOADTEST_PROFILE:-smoke}}
+if [[ $# -gt 0 ]]; then
+  shift
+fi
 profile_file=$(loadtest_profile_path "$profile")
 profile_name=$(loadtest_profile_name "$profile_file")
 namespace=$(loadtest_namespace "$profile_file")
 run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" seed)
 
-mkdir -p "$run_dir/datasets"
+config_file=${LOADTEST_AUTHPROXY_CONFIG:-${AUTHPROXY_CONFIG:-}}
+if [[ -z "$config_file" ]]; then
+  config_file="$run_dir/authproxy-seed.yaml"
+  sqlite_path="$run_dir/authproxy-seed.sqlite3"
+  loadtest_log "generating local SQLite/miniredis seed config: $config_file"
+  cat > "$config_file" <<EOF
+host_application:
+  initiate_session_url: http://placeholder.invalid/login
 
-cat > "$run_dir/seed-plan.txt" <<'EOF'
-The environment harness is ready, but large-state seeding is implemented in
-the next workstream (#718).
+database:
+  provider: sqlite
+  auto_migrate: true
+  path: $sqlite_path
 
-This command exists now so the end-to-end load-test flow is stable:
+redis:
+  provider: miniredis
 
-  up -> seed -> run -> collect -> down
+system_auth:
+  jwt_signing_key:
+    public_key:
+      path: $REPO_ROOT/dev_config/system.pub
+    private_key:
+      path: $REPO_ROOT/dev_config/system
+  actors:
+    keys_path: $REPO_ROOT/dev_config/keys/admin
+    permissions:
+      - namespace: root.**
+        resources:
+          - "*"
+        verbs:
+          - "*"
+  global_aes_key:
+    path: $REPO_ROOT/dev_config/keys/global_aes.key
 
-For the smoke profile, no AuthProxy resources are required because the k6
-scenario only checks service health and provider reachability.
+connectors:
+  auto_migrate: false
+  load_from_list: []
+
+app_metrics:
+  auto_migrate: false
+  database:
+    provider: sqlite
+    path: $sqlite_path
+
+logging:
+  type: none
 EOF
+fi
 
-printf "connection_id\n" > "$run_dir/datasets/connections.csv"
+provider_base_url=${LOADTEST_PROVIDER_BASE_URL:-http://go-oauth2-server:8080}
+
+(
+  cd "$REPO_ROOT"
+  go run ./cmd/server \
+    --config "$config_file" \
+    loadtest-seed \
+    --profile "$profile_file" \
+    --run-dir "$run_dir" \
+    --provider-base-url "$provider_base_url" \
+    "$@"
+)
 
 loadtest_log "seed step recorded for profile $profile_name"
 loadtest_log "run artifacts: $run_dir"


### PR DESCRIPTION
## Summary
- add a loadtest-seed server command backed by AuthProxy database/encryption services
- seed profile-driven namespaces, actors, a synthetic OAuth2 connector, configured connections, OAuth2 tokens, and k6-ready CSV artifacts
- update loadtest/scripts/seed and docs so smoke seeding works with a generated local SQLite/miniredis config

## Verification
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./cmd/server ./internal/loadtest/seeder
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite ./loadtest/scripts/seed smoke
- ./scripts/preflight.sh

Closes #718