### PR TITLE
Add version migration integration harness

### DIFF
--- a/integration_tests/helpers/version_migration.go
+++ b/integration_tests/helpers/version_migration.go
@@ -1,0 +1,325 @@
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateConnector creates a connector through the API route and returns the
+// draft version response. It is useful when a scenario wants to exercise the
+// same management API shape a host application would use.
+func (env *IntegrationTestEnv) CreateConnector(
+	t *testing.T,
+	definition sconfig.Connector,
+	labels map[string]string,
+	annotations map[string]string,
+	opts ...OAuth2Option,
+) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	body, err := jsonMarshal(schemaapi.CreateConnectorRequestJson{
+		Namespace:   sconfig.RootNamespace,
+		Definition:  definition,
+		Labels:      labels,
+		Annotations: annotations,
+	})
+	require.NoError(t, err)
+
+	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connectors", body, env.resolveOAuth2Options(opts))
+	require.Equalf(t, http.StatusCreated, w.Code, "create connector failed: %s", w.Body.String())
+
+	var out schemaapi.ConnectorVersionJson
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
+	return out
+}
+
+// CreateDraftConnectorVersion creates the next draft version for connectorID.
+// The server owns the final id/version/state fields on the definition.
+func (env *IntegrationTestEnv) CreateDraftConnectorVersion(
+	t *testing.T,
+	connectorID apid.ID,
+	definition sconfig.Connector,
+	labels map[string]string,
+	annotations map[string]string,
+	opts ...OAuth2Option,
+) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	req := schemaapi.CreateConnectorVersionRequestJson{Definition: &definition}
+	if labels != nil {
+		req.Labels = &labels
+	}
+	if annotations != nil {
+		req.Annotations = &annotations
+	}
+
+	body, err := jsonMarshal(req)
+	require.NoError(t, err)
+
+	path := fmt.Sprintf("/api/v1/connectors/%s/versions", connectorID)
+	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveOAuth2Options(opts))
+	require.Equalf(t, http.StatusCreated, w.Code, "create connector version failed: %s", w.Body.String())
+
+	var out schemaapi.ConnectorVersionJson
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
+	return out
+}
+
+// ForceConnectorVersionState changes the lifecycle state for an existing
+// connector version through the API.
+func (env *IntegrationTestEnv) ForceConnectorVersionState(
+	t *testing.T,
+	connectorID apid.ID,
+	version uint64,
+	state schemaapi.ConnectorVersionState,
+	opts ...OAuth2Option,
+) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	body, err := jsonMarshal(schemaapi.ForceConnectorVersionStateRequestJson{State: string(state)})
+	require.NoError(t, err)
+
+	path := fmt.Sprintf("/api/v1/connectors/%s/versions/%d/_force_state", connectorID, version)
+	w := env.doSignedRequest(t, http.MethodPut, path, body, env.resolveOAuth2Options(opts))
+	require.Equalf(t, http.StatusOK, w.Code, "force connector version state failed: %s", w.Body.String())
+
+	var out schemaapi.ConnectorVersionJson
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
+	return out
+}
+
+// PublishConnectorVersion creates a draft connector version and promotes it to
+// primary. The previously-primary version becomes active and can be targeted
+// by rollback tests.
+func (env *IntegrationTestEnv) PublishConnectorVersion(
+	t *testing.T,
+	connectorID apid.ID,
+	definition sconfig.Connector,
+	labels map[string]string,
+	annotations map[string]string,
+	opts ...OAuth2Option,
+) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	draft := env.CreateDraftConnectorVersion(t, connectorID, definition, labels, annotations, opts...)
+	return env.ForceConnectorVersionState(t, connectorID, draft.Version, schemaapi.ConnectorVersionStatePrimary, opts...)
+}
+
+// MigrateConnectionVersion starts the durable connection-version migration
+// workflow and returns the task response.
+func (env *IntegrationTestEnv) MigrateConnectionVersion(
+	t *testing.T,
+	connectionID string,
+	targetVersion uint64,
+	timeoutSeconds int64,
+	opts ...OAuth2Option,
+) schemaapi.MigrateConnectionVersionResponseJson {
+	t.Helper()
+
+	req := schemaapi.MigrateConnectionVersionRequestJson{TargetVersion: targetVersion}
+	if timeoutSeconds > 0 {
+		req.TimeoutSeconds = &timeoutSeconds
+	}
+	body, err := jsonMarshal(req)
+	require.NoError(t, err)
+
+	path := "/api/v1/connections/" + connectionID + "/_migrate_version"
+	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveOAuth2Options(opts))
+	require.Equalf(t, http.StatusOK, w.Code, "migrate connection version failed: %s", w.Body.String())
+
+	var out schemaapi.MigrateConnectionVersionResponseJson
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
+	require.Equal(t, connectionID, out.ConnectionId.String())
+	require.Equal(t, targetVersion, out.TargetVersion)
+	require.NotEmpty(t, out.TaskId)
+	return out
+}
+
+// MigrateConnectionVersionAndWait starts a migration and waits for the
+// workflow-backed task to complete. Call StartCoreWorkflowWorker before using
+// this helper.
+func (env *IntegrationTestEnv) MigrateConnectionVersionAndWait(
+	t *testing.T,
+	connectionID string,
+	targetVersion uint64,
+	timeout time.Duration,
+	opts ...OAuth2Option,
+) schemaapi.MigrateConnectionVersionResponseJson {
+	t.Helper()
+
+	timeoutSeconds := int64(timeout.Seconds())
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 10
+	}
+	resp := env.MigrateConnectionVersion(t, connectionID, targetVersion, timeoutSeconds, opts...)
+	RequireWorkflowTaskCompleted(t, env, resp.TaskId, timeout, opts...)
+	return resp
+}
+
+// SubmitSetupForm submits any schema-defined form step. Auth-method-specific
+// helpers can still wrap this for credential forms.
+func (env *IntegrationTestEnv) SubmitSetupForm(
+	t *testing.T,
+	connectionID string,
+	stepID string,
+	data map[string]any,
+	opts ...OAuth2Option,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rawData, err := json.Marshal(data)
+	require.NoError(t, err)
+	body, err := jsonMarshal(iface.SubmitConnectionRequest{
+		StepId: stepID,
+		Data:   rawData,
+	})
+	require.NoError(t, err)
+
+	return env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/"+connectionID+"/_submit", body, env.resolveOAuth2Options(opts))
+}
+
+// DecryptConnectionConfiguration reads and decrypts a connection's current
+// configuration map. Missing configuration is returned as an empty map.
+func (env *IntegrationTestEnv) DecryptConnectionConfiguration(t *testing.T, connectionID string) map[string]any {
+	t.Helper()
+
+	conn := env.GetConnection(t, connectionID)
+	if conn.EncryptedConfiguration == nil || conn.EncryptedConfiguration.IsZero() {
+		return map[string]any{}
+	}
+
+	plaintext, err := env.DM.GetEncryptService().DecryptString(context.Background(), *conn.EncryptedConfiguration)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(plaintext), &out))
+	if out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+// ListNotifications lists actor-visible notifications through the API. State
+// defaults to active when an empty state is supplied.
+func (env *IntegrationTestEnv) ListNotifications(
+	t *testing.T,
+	state schemaapi.NotificationState,
+	includeViewed bool,
+	opts ...OAuth2Option,
+) []schemaapi.NotificationJson {
+	t.Helper()
+
+	q := url.Values{}
+	if state != "" {
+		q.Set("state", string(state))
+	}
+	if includeViewed {
+		q.Set("include_viewed", "true")
+	}
+	path := "/api/v1/notifications"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	w := env.doSignedRequest(t, http.MethodGet, path, nil, env.resolveOAuth2Options(opts))
+	require.Equalf(t, http.StatusOK, w.Code, "list notifications failed: %s", w.Body.String())
+
+	var out schemaapi.ListNotificationsResponseJson
+	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
+	return out.Items
+}
+
+// ListConnectionNotifications filters actor-visible notifications down to one
+// connection resource.
+func (env *IntegrationTestEnv) ListConnectionNotifications(
+	t *testing.T,
+	connectionID string,
+	state schemaapi.NotificationState,
+	includeViewed bool,
+	opts ...OAuth2Option,
+) []schemaapi.NotificationJson {
+	t.Helper()
+
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+
+	items := env.ListNotifications(t, state, includeViewed, opts...)
+	filtered := make([]schemaapi.NotificationJson, 0, len(items))
+	for _, n := range items {
+		if n.ResourceType == "connection" && n.ResourceId == id {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
+}
+
+// RequireSingleActiveConnectionNotification asserts that exactly one active
+// notification exists for a connection and that its key has the expected
+// high-level suffix, such as "auth_required" or "setup_required".
+func (env *IntegrationTestEnv) RequireSingleActiveConnectionNotification(
+	t *testing.T,
+	connectionID string,
+	keySuffix string,
+	opts ...OAuth2Option,
+) schemaapi.NotificationJson {
+	t.Helper()
+
+	items := env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateActive, false, opts...)
+	require.Len(t, items, 1, "expected one active connection notification")
+	require.Truef(t, strings.HasSuffix(items[0].Key, ":"+keySuffix),
+		"notification key %q should end with %q", items[0].Key, keySuffix)
+	return items[0]
+}
+
+// RequireNoActiveConnectionNotifications asserts that the connection has no
+// active actor-visible notifications.
+func (env *IntegrationTestEnv) RequireNoActiveConnectionNotifications(
+	t *testing.T,
+	connectionID string,
+	opts ...OAuth2Option,
+) {
+	t.Helper()
+	require.Empty(t, env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateActive, false, opts...))
+}
+
+// RequireResolvedConnectionNotification asserts that a previously-active
+// high-level notification was resolved.
+func (env *IntegrationTestEnv) RequireResolvedConnectionNotification(
+	t *testing.T,
+	connectionID string,
+	keySuffix string,
+	opts ...OAuth2Option,
+) schemaapi.NotificationJson {
+	t.Helper()
+
+	items := env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateResolved, true, opts...)
+	for _, n := range items {
+		if strings.HasSuffix(n.Key, ":"+keySuffix) {
+			require.NotNil(t, n.ResolvedAt, "resolved notification should include resolved_at")
+			return n
+		}
+	}
+	require.Failf(t, "resolved notification not found", "connection=%s key_suffix=%s items=%v", connectionID, keySuffix, items)
+	return schemaapi.NotificationJson{}
+}
+
+// Notification key suffixes used by connection-level required-action
+// notifications.
+const (
+	NotificationKeySuffixAuthRequired  = database.NotificationKeyAuthRequired
+	NotificationKeySuffixSetupRequired = database.NotificationKeySetupRequired
+)

--- a/integration_tests/helpers/workflow.go
+++ b/integration_tests/helpers/workflow.go
@@ -1,0 +1,143 @@
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	workflowworker "github.com/cschleiden/go-workflows/worker"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
+	"github.com/stretchr/testify/require"
+)
+
+// StartCoreWorkflowWorker starts an in-test workflow worker registered with
+// the core workflows. Tests call this before invoking API operations that
+// return workflow-backed task ids, then poll the task endpoint.
+func StartCoreWorkflowWorker(t *testing.T, env *IntegrationTestEnv) {
+	t.Helper()
+
+	workflowRuntime := env.DM.GetWorkflowRuntime()
+	workflowWorker, err := apworkflows.NewWorker(workflowRuntime, &workflowworker.Options{
+		WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
+			WorkflowPollers:          2,
+			MaxParallelWorkflowTasks: 1,
+		},
+		ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
+			ActivityPollers:          2,
+			MaxParallelActivityTasks: 1,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, env.Core.RegisterWorkflows(workflowWorker))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+
+	go func() {
+		if err := workflowWorker.Start(ctx); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- workflowWorker.WaitForCompletion()
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("workflow worker did not stop")
+		}
+	})
+}
+
+// RequireWorkflowTaskCompleted polls /tasks/{taskID} until the workflow task
+// completes. It fails immediately if the task reaches the failed state.
+func RequireWorkflowTaskCompleted(
+	t *testing.T,
+	env *IntegrationTestEnv,
+	taskID string,
+	timeout time.Duration,
+	opts ...OAuth2Option,
+) schemaapi.TaskInfoJson {
+	t.Helper()
+
+	cfg := env.resolveOAuth2Options(opts)
+	var lastStatus int
+	var lastBody string
+	var lastState schemaapi.TaskState
+	var result schemaapi.TaskInfoJson
+
+	require.Eventually(t, func() bool {
+		req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet,
+			"/api/v1/tasks/"+taskID,
+			nil,
+			cfg.actorNamespace,
+			cfg.actorExternalID,
+			aschema.NoPermissions(),
+		)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		if env.ApiGin != nil {
+			env.ApiGin.ServeHTTP(w, req)
+		} else {
+			abs, err := url.Parse(env.ServerURL + "/api/v1/tasks/" + taskID)
+			require.NoError(t, err)
+			req.URL = abs
+			req.Host = abs.Host
+			req.RequestURI = ""
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			w.Code = resp.StatusCode
+			for k, vs := range resp.Header {
+				for _, v := range vs {
+					w.Header().Add(k, v)
+				}
+			}
+			if _, err := w.Body.ReadFrom(resp.Body); err != nil {
+				require.NoError(t, err)
+			}
+		}
+
+		lastStatus = w.Code
+		lastBody = w.Body.String()
+		if w.Code != http.StatusOK {
+			return false
+		}
+
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		lastState = result.State
+		require.Equal(t, taskID, result.Id)
+
+		switch result.State {
+		case schemaapi.TaskStateCompleted:
+			return true
+		case schemaapi.TaskStateFailed:
+			t.Fatalf("workflow task failed: %s", w.Body.String())
+		}
+		return false
+	}, timeout, 100*time.Millisecond,
+		"workflow task should complete; last status=%d state=%s body=%s",
+		lastStatus,
+		lastState,
+		lastBody,
+	)
+
+	return result
+}
+
+// RootActor returns helper options for the default integration-test actor.
+func RootActor() OAuth2Option {
+	return WithActor("test-actor", sconfig.RootNamespace)
+}

--- a/integration_tests/oauth2/connector_archive_test.go
+++ b/integration_tests/oauth2/connector_archive_test.go
@@ -49,7 +49,7 @@ func (r *connectorDisconnectAllRig) archive(t *testing.T, connectorID apid.ID, t
 	require.Equal(t, connectorID, body.ConnectorId)
 	require.NotEmpty(t, body.TaskId)
 
-	requireWorkflowTaskCompleted(t, r.env, body.TaskId, "test-actor", time.Duration(timeoutSeconds+5)*time.Second)
+	helpers.RequireWorkflowTaskCompleted(t, r.env, body.TaskId, time.Duration(timeoutSeconds+5)*time.Second)
 }
 
 func createArchiveVersionShape(t *testing.T, rig *connectorDisconnectAllRig, connector connectorDisconnectAllConnector) []uint64 {
@@ -106,7 +106,7 @@ func TestConnectorArchive_ArchivesVersionsAndDisconnectsConnections(t *testing.T
 	requireConnectionAvailable(t, rig, connectionID)
 	versions := createArchiveVersionShape(t, rig, rig.connectors[0])
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.archive(t, rig.connectors[0].id, 20)
 
 	requireConnectorVersionsArchived(t, rig.env.Db, rig.connectors[0].id, versions)
@@ -133,7 +133,7 @@ func TestConnectorArchive_RevocationFailureStillArchives(t *testing.T) {
 		FailCount: 10,
 	})
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.archive(t, rig.connectors[0].id, 20)
 
 	requireConnectorVersionsArchived(t, rig.env.Db, rig.connectors[0].id, versions)

--- a/integration_tests/oauth2/connector_disconnect_all_test.go
+++ b/integration_tests/oauth2/connector_disconnect_all_test.go
@@ -164,7 +164,7 @@ func (r *connectorDisconnectAllRig) disconnectAll(t *testing.T, connectorID apid
 	require.Equal(t, connectorID, body.ConnectorId)
 	require.NotEmpty(t, body.TaskId)
 
-	requireWorkflowTaskCompleted(t, r.env, body.TaskId, "test-actor", time.Duration(timeoutSeconds+5)*time.Second)
+	helpers.RequireWorkflowTaskCompleted(t, r.env, body.TaskId, time.Duration(timeoutSeconds+5)*time.Second)
 }
 
 func requireConnectionDeletedByID(t *testing.T, env *helpers.IntegrationTestEnv, connectionID string) {
@@ -205,7 +205,7 @@ func TestConnectorDisconnectAll_DisconnectsTargetConnectionsOnly(t *testing.T) {
 	requireConnectionAvailable(t, rig, targetConnection2)
 	requireConnectionAvailable(t, rig, otherConnection)
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.disconnectAll(t, rig.connectors[0].id, 20)
 
 	requireConnectionDeletedByID(t, rig.env, targetConnection1)
@@ -238,7 +238,7 @@ func TestConnectorDisconnectAll_RevocationFailureStillCompletes(t *testing.T) {
 		FailCount: 10,
 	})
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.disconnectAll(t, rig.connectors[0].id, 20)
 
 	requireConnectionDeletedByID(t, rig.env, connectionID)

--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	workflowworker "github.com/cschleiden/go-workflows/worker"
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -21,7 +20,6 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
-	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -155,101 +153,11 @@ func (r *disconnectRevocationRig) disconnect(t *testing.T, connectionID string) 
 	assert.Equal(t, string(database.ConnectionStateDisconnecting), body.Connection.State)
 	assert.NotEmpty(t, body.TaskID)
 
-	requireWorkflowTaskCompleted(t, r.env, body.TaskID, "test-actor", 15*time.Second)
-}
-
-func requireWorkflowTaskCompleted(
-	t *testing.T,
-	env *helpers.IntegrationTestEnv,
-	taskID string,
-	actorExternalID string,
-	timeout time.Duration,
-) {
-	t.Helper()
-
-	var lastStatus int
-	var lastBody string
-	var lastState schemaapi.TaskState
-	require.Eventually(t, func() bool {
-		req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(
-			http.MethodGet,
-			"/api/v1/tasks/"+taskID,
-			nil,
-			sconfig.RootNamespace,
-			actorExternalID,
-			aschema.NoPermissions(),
-		)
-		require.NoError(t, err)
-
-		w := httptest.NewRecorder()
-		env.ApiGin.ServeHTTP(w, req)
-		lastStatus = w.Code
-		lastBody = w.Body.String()
-		if w.Code != http.StatusOK {
-			return false
-		}
-
-		var body schemaapi.TaskInfoJson
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-		lastState = body.State
-		require.Equal(t, taskID, body.Id)
-
-		switch body.State {
-		case schemaapi.TaskStateCompleted:
-			return true
-		case schemaapi.TaskStateFailed:
-			t.Fatalf("disconnect workflow task failed: %s", w.Body.String())
-		}
-		return false
-	}, timeout, 100*time.Millisecond,
-		"disconnect workflow task should complete; last status=%d state=%s body=%s",
-		lastStatus,
-		lastState,
-		lastBody,
-	)
+	helpers.RequireWorkflowTaskCompleted(t, r.env, body.TaskID, 15*time.Second)
 }
 
 func int64Ptr(v int64) *int64 {
 	return &v
-}
-
-func startCoreWorkflowWorker(t *testing.T, env *helpers.IntegrationTestEnv) {
-	t.Helper()
-
-	workflowRuntime := env.DM.GetWorkflowRuntime()
-	workflowWorker, err := apworkflows.NewWorker(workflowRuntime, &workflowworker.Options{
-		WorkflowWorkerOptions: workflowworker.WorkflowWorkerOptions{
-			WorkflowPollers:          2,
-			MaxParallelWorkflowTasks: 1,
-		},
-		ActivityWorkerOptions: workflowworker.ActivityWorkerOptions{
-			ActivityPollers:          2,
-			MaxParallelActivityTasks: 1,
-		},
-	})
-	require.NoError(t, err)
-	require.NoError(t, env.Core.RegisterWorkflows(workflowWorker))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
-
-	go func() {
-		if err := workflowWorker.Start(ctx); err != nil {
-			errCh <- err
-			return
-		}
-		errCh <- workflowWorker.WaitForCompletion()
-	}()
-
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case err := <-errCh:
-			require.NoError(t, err)
-		case <-time.After(5 * time.Second):
-			t.Fatal("workflow worker did not stop")
-		}
-	})
 }
 
 func requireConnectionDeleted(t *testing.T, rig *disconnectRevocationRig, connectionID string) {
@@ -295,7 +203,7 @@ func TestDisconnectRevocation_RevokesProviderTokensAndBlocksFutureProxy(t *testi
 	w := rig.env.DoProxyRequest(t, connID, rig.provider.ResourceURL("/echo"), http.MethodGet)
 	require.Equal(t, http.StatusOK, parseRevocationProxyResponse(t, w).StatusCode)
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.disconnect(t, connID)
 	requireConnectionDeleted(t, rig, connID)
 
@@ -324,7 +232,7 @@ func TestDisconnectRevocation_RevocationFailureStillCompletesDisconnect(t *testi
 		FailCount: 10,
 	})
 
-	startCoreWorkflowWorker(t, rig.env)
+	helpers.StartCoreWorkflowWorker(t, rig.env)
 	rig.disconnect(t, connID)
 	requireConnectionDeleted(t, rig, connID)
 	requireProxyBlockedAfterDisconnect(t, rig, connID)

--- a/integration_tests/version_migration/README.md
+++ b/integration_tests/version_migration/README.md
@@ -1,0 +1,17 @@
+# Connector version migration integration tests
+
+This package contains end-to-end scenarios for single-connection connector
+version migration. The tests define connectors, create real connections,
+publish newer connector versions, migrate those connections through
+`POST /connections/{id}/_migrate_version`, and assert resulting connection
+state, auth/config behavior, probes, and notifications.
+
+Scenario files:
+
+- API-key configure migration: tracked by #739.
+- API-key preconnect migration: tracked by #739.
+- OAuth required-scope reauth migration: tracked by #740.
+- OAuth required-scope rollback migration: tracked by #740.
+- No-auth defaults and probe migration: tracked by #741.
+
+Shared harness work is tracked by #738.

--- a/integration_tests/version_migration/harness_test.go
+++ b/integration_tests/version_migration/harness_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package version_migration
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+)
+
+func TestVersionMigrationHarnessScaffold(t *testing.T) {
+	// Scenario tests live in the follow-up issues. Keep this package compiling
+	// with the shared helpers while those scenarios land.
+	_ = helpers.StartCoreWorkflowWorker
+	_ = helpers.RequireWorkflowTaskCompleted
+}


### PR DESCRIPTION
## Summary
- add shared integration helpers for workflow-backed tasks, connector version publishing, migration requests, notifications, setup submits, and config decrypts
- move existing OAuth lifecycle workflow worker/task polling tests to the shared helpers
- add the version_migration package scaffold for follow-up scenarios

Closes #738

## Tests
- cd integration_tests && go test -tags integration -v ./version_migration/...
- cd integration_tests && go test -tags integration -run '^$' ./oauth2/... ./helpers
- ./scripts/preflight.sh

## Not run
- cd integration_tests && go test -tags integration -v ./oauth2/... -run TestDisconnectRevocation (blocked: OAuth2 test provider not running at 127.0.0.1:8086)