### PR TITLE
Add API key version migration scenarios

### DIFF
--- a/integration_tests/version_migration/README.md
+++ b/integration_tests/version_migration/README.md
@@ -8,8 +8,8 @@ state, auth/config behavior, probes, and notifications.
 
 Scenario files:
 
-- API-key configure migration: tracked by #739.
-- API-key preconnect migration: tracked by #739.
+- API-key configure migration: `api_key_configure_change_test.md`.
+- API-key preconnect migration: `api_key_preconnect_change_test.md`.
 - OAuth required-scope reauth migration: tracked by #740.
 - OAuth required-scope rollback migration: tracked by #740.
 - No-auth defaults and probe migration: tracked by #741.

--- a/integration_tests/version_migration/README.md
+++ b/integration_tests/version_migration/README.md
@@ -8,8 +8,8 @@ state, auth/config behavior, probes, and notifications.
 
 Scenario files:
 
-- API-key configure migration: `api_key_configure_change_test.md`.
-- API-key preconnect migration: `api_key_preconnect_change_test.md`.
+- API-key configure migration: [api_key_configure_change_test.md](api_key_configure_change_test.md).
+- API-key preconnect migration: [api_key_preconnect_change_test.md](api_key_preconnect_change_test.md).
 - OAuth required-scope reauth migration: tracked by #740.
 - OAuth required-scope rollback migration: tracked by #740.
 - No-auth defaults and probe migration: tracked by #741.

--- a/integration_tests/version_migration/api_key_configure_change_test.md
+++ b/integration_tests/version_migration/api_key_configure_change_test.md
@@ -1,0 +1,23 @@
+# API-key configure migration
+
+## Fixture
+
+- Create a draft bearer API-key connector through the connector API.
+- Promote version 1 to primary.
+- Create a connection through `_initiate`, submit the API key, and run verify against the stub upstream so the connection is configured and healthy.
+- Publish version 2 with one new required configure field, `workspace`.
+
+## Flow
+
+1. Start the core workflow worker in-process.
+2. Call `POST /connections/{id}/_migrate_version` targeting version 2.
+3. Wait for the durable task to complete.
+4. Submit the `configure-workspace` form with a workspace value.
+
+## Assertions
+
+- Migration switches the connection to connector version 2.
+- The connection remains configured and healthy, but records `setup_step=configure-workspace`.
+- Exactly one active high-level `setup_required` notification is visible for the actor.
+- The notification action points to connection configuration and does not use host-internal naming.
+- Submitting the configure step stores `workspace`, clears `setup_step`, leaves the connection healthy, and resolves the notification.

--- a/integration_tests/version_migration/api_key_preconnect_change_test.md
+++ b/integration_tests/version_migration/api_key_preconnect_change_test.md
@@ -1,0 +1,26 @@
+# API-key preconnect migration
+
+## Fixture
+
+- Create a draft bearer API-key connector through the connector API.
+- Promote version 1 to primary.
+- Create a connection through `_initiate`, submit the API key, and run verify against the stub upstream so the connection is configured and healthy.
+- Publish version 2 with one new required preconnect field, `region`.
+
+## Flow
+
+1. Start the core workflow worker in-process.
+2. Call `POST /connections/{id}/_migrate_version` targeting version 2.
+3. Wait for the durable task to complete.
+4. Rotate the stub upstream to require a new API key.
+5. Start reauth through `POST /connections/{id}/_reauth`.
+6. Submit the `select-region` preconnect form, then submit the API-key credential form.
+7. Run verify against the stub upstream.
+
+## Assertions
+
+- Migration switches the connection to connector version 2.
+- The connection remains configured but becomes unhealthy because required auth-time data is missing.
+- Exactly one active high-level `auth_required` notification is visible for the actor.
+- The notification action points to reauth and does not use host-internal naming.
+- Reauth stores `region`, replaces the active API key, returns the connection to healthy, clears setup state, and resolves the notification.

--- a/integration_tests/version_migration/api_key_test.go
+++ b/integration_tests/version_migration/api_key_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+package version_migration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	apiKeyMigrationTimeout       = 20 * time.Second
+	configureWorkspaceStepID     = "configure-workspace"
+	preconnectRegionStepID       = "select-region"
+	apiKeyMigrationCredentialKey = "version-migration-api-key"
+)
+
+func TestApiKeyVersionMigrationConfigureChangeRequiresSetup(t *testing.T) {
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: apiKeyMigrationCredentialKey,
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+	helpers.StartCoreWorkflowWorker(t, env)
+
+	connectorID := createPrimaryAPIKeyConnector(t, env, "api-key-migration-configure-v1", stub, nil)
+	connectionID := createHealthyAPIKeyConnection(t, env, connectorID, apiKeyMigrationCredentialKey)
+
+	v2 := apiKeyMigrationConnectorDefinition("api-key-migration-configure-v2", stub, &connectors.SetupFlow{
+		Configure: &connectors.SetupFlowPhase{
+			Steps: []connectors.SetupFlowStep{requiredStringStep(configureWorkspaceStepID, "Workspace", "workspace")},
+		},
+	})
+	published := env.PublishConnectorVersion(t, connectorID, v2, nil, nil)
+	require.Equal(t, uint64(2), published.Version)
+
+	env.MigrateConnectionVersionAndWait(t, connectionID, 2, apiKeyMigrationTimeout)
+
+	migrated := env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), migrated.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, migrated.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, migrated.HealthState)
+	require.NotNil(t, migrated.SetupStep)
+	assert.Equal(t, configureWorkspaceStepID, migrated.SetupStep.Id())
+
+	notification := env.RequireSingleActiveConnectionNotification(
+		t,
+		connectionID,
+		helpers.NotificationKeySuffixSetupRequired,
+	)
+	assertNoAuthProxyCopy(t, notification)
+	assert.True(t, notification.CanAction)
+	assert.Contains(t, notification.ActionUrl, "action=configure")
+
+	w := env.SubmitSetupForm(t, connectionID, configureWorkspaceStepID, map[string]any{
+		"workspace": "north",
+	})
+	requireConnectionSetupComplete(t, w)
+
+	afterSetup := env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), afterSetup.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, afterSetup.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, afterSetup.HealthState)
+	require.Nil(t, afterSetup.SetupStep)
+	require.Nil(t, afterSetup.SetupError)
+
+	cfg := env.DecryptConnectionConfiguration(t, connectionID)
+	assert.Equal(t, "north", cfg["workspace"])
+
+	env.RequireNoActiveConnectionNotifications(t, connectionID)
+	env.RequireResolvedConnectionNotification(t, connectionID, helpers.NotificationKeySuffixSetupRequired)
+}
+
+func TestApiKeyVersionMigrationPreconnectChangeRequiresReauth(t *testing.T) {
+	const rotatedKey = "version-migration-api-key-reauth"
+
+	stub := helpers.NewApiKeyStubUpstream(t, helpers.ApiKeyStubOptions{
+		Placement:   connectors.ApiKeyPlacementBearer,
+		AcceptedKey: apiKeyMigrationCredentialKey,
+	})
+
+	env := helpers.Setup(t, helpers.SetupOptions{Service: helpers.ServiceTypeAPI})
+	defer env.Cleanup()
+	helpers.StartCoreWorkflowWorker(t, env)
+
+	connectorID := createPrimaryAPIKeyConnector(t, env, "api-key-migration-preconnect-v1", stub, nil)
+	connectionID := createHealthyAPIKeyConnection(t, env, connectorID, apiKeyMigrationCredentialKey)
+
+	v2 := apiKeyMigrationConnectorDefinition("api-key-migration-preconnect-v2", stub, &connectors.SetupFlow{
+		Preconnect: &connectors.SetupFlowPhase{
+			Steps: []connectors.SetupFlowStep{requiredStringStep(preconnectRegionStepID, "Region", "region")},
+		},
+	})
+	published := env.PublishConnectorVersion(t, connectorID, v2, nil, nil)
+	require.Equal(t, uint64(2), published.Version)
+
+	env.MigrateConnectionVersionAndWait(t, connectionID, 2, apiKeyMigrationTimeout)
+
+	migrated := env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), migrated.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, migrated.State)
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, migrated.HealthState)
+	require.Nil(t, migrated.SetupStep)
+
+	notification := env.RequireSingleActiveConnectionNotification(
+		t,
+		connectionID,
+		helpers.NotificationKeySuffixAuthRequired,
+	)
+	assertNoAuthProxyCopy(t, notification)
+	assert.True(t, notification.CanAction)
+	assert.Contains(t, notification.ActionUrl, "action=reauth")
+
+	stub.RotateAcceptedKey(rotatedKey)
+
+	w := env.ReauthConnection(t, connectionID)
+	form := requireConnectionSetupForm(t, w)
+	require.Equal(t, preconnectRegionStepID, form.StepId)
+
+	w = env.SubmitSetupForm(t, connectionID, preconnectRegionStepID, map[string]any{
+		"region": "us-east-1",
+	})
+	form = requireConnectionSetupForm(t, w)
+	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepId)
+
+	w = env.SubmitApiKeyCredentials(t, connectionID, helpers.ApiKeySubmitFormStepId(), map[string]any{
+		"api_key": rotatedKey,
+	})
+	requireConnectionSetupVerifying(t, w)
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	afterReauth := env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), afterReauth.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, afterReauth.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, afterReauth.HealthState)
+	require.Nil(t, afterReauth.SetupStep)
+	require.Nil(t, afterReauth.SetupError)
+
+	cfg := env.DecryptConnectionConfiguration(t, connectionID)
+	assert.Equal(t, "us-east-1", cfg["region"])
+	assert.Equal(t, rotatedKey, env.DecryptApiKeyCredential(t, connectionID).ApiKey)
+
+	env.RequireNoActiveConnectionNotifications(t, connectionID)
+	env.RequireResolvedConnectionNotification(t, connectionID, helpers.NotificationKeySuffixAuthRequired)
+}
+
+func createPrimaryAPIKeyConnector(
+	t *testing.T,
+	env *helpers.IntegrationTestEnv,
+	displayName string,
+	stub *helpers.ApiKeyStubUpstream,
+	setupFlow *connectors.SetupFlow,
+) apid.ID {
+	t.Helper()
+
+	created := env.CreateConnector(t, apiKeyMigrationConnectorDefinition(displayName, stub, setupFlow), nil, nil)
+	require.Equal(t, uint64(1), created.Version)
+	require.Equal(t, schemaapi.ConnectorVersionStateDraft, created.State)
+
+	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
+	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
+	return created.Id
+}
+
+func createHealthyAPIKeyConnection(
+	t *testing.T,
+	env *helpers.IntegrationTestEnv,
+	connectorID apid.ID,
+	apiKey string,
+) string {
+	t.Helper()
+
+	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
+	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepId)
+
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": apiKey})
+	requireConnectionSetupVerifying(t, w)
+	require.NoError(t, env.RunVerifyConnection(t, connectionID))
+
+	conn := env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(1), conn.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, conn.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState)
+	require.Nil(t, conn.SetupStep)
+	require.Nil(t, conn.SetupError)
+	return connectionID
+}
+
+func apiKeyMigrationConnectorDefinition(
+	displayName string,
+	stub *helpers.ApiKeyStubUpstream,
+	setupFlow *connectors.SetupFlow,
+) sconfig.Connector {
+	conn := helpers.NewApiKeyConnector(apid.New(apid.PrefixConnectorVersion), displayName, helpers.ApiKeyConnectorOptions{
+		Placement: connectors.ApiKeyPlacementBearer,
+		ProbeURL:  stub.BaseURL + "/probe",
+	})
+	conn.SetupFlow = setupFlow
+	return conn
+}
+
+func requiredStringStep(stepID, title, fieldName string) connectors.SetupFlowStep {
+	return connectors.SetupFlowStep{
+		Id:    stepID,
+		Title: title,
+		JsonSchema: common.RawJSON(`{
+			"type": "object",
+			"properties": {
+				"` + fieldName + `": {
+					"type": "string",
+					"minLength": 1
+				}
+			},
+			"required": ["` + fieldName + `"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+func requireConnectionSetupForm(t *testing.T, w *httptest.ResponseRecorder) schemaapi.ConnectionSetupForm {
+	t.Helper()
+	require.Equalf(t, http.StatusOK, w.Code, "setup request failed: %s", w.Body.String())
+	requireConnectionSetupResponseType(t, w, schemaapi.ConnectionSetupResponseTypeForm)
+
+	var form schemaapi.ConnectionSetupForm
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &form))
+	return form
+}
+
+func requireConnectionSetupVerifying(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	require.Equalf(t, http.StatusOK, w.Code, "setup request failed: %s", w.Body.String())
+	requireConnectionSetupResponseType(t, w, schemaapi.ConnectionSetupResponseTypeVerifying)
+}
+
+func requireConnectionSetupComplete(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	require.Equalf(t, http.StatusOK, w.Code, "setup request failed: %s", w.Body.String())
+	requireConnectionSetupResponseType(t, w, schemaapi.ConnectionSetupResponseTypeComplete)
+}
+
+func requireConnectionSetupResponseType(
+	t *testing.T,
+	w *httptest.ResponseRecorder,
+	expected schemaapi.ConnectionSetupResponseType,
+) {
+	t.Helper()
+
+	var generic struct {
+		Type schemaapi.ConnectionSetupResponseType `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &generic))
+	require.Equalf(t, expected, generic.Type, "unexpected setup response: %s", w.Body.String())
+}
+
+func assertNoAuthProxyCopy(t *testing.T, notification schemaapi.NotificationJson) {
+	t.Helper()
+	assert.NotContains(t, strings.ToLower(notification.Title), "authproxy")
+	assert.NotContains(t, strings.ToLower(notification.Message), "authproxy")
+}

--- a/internal/core/connection_notifications.go
+++ b/internal/core/connection_notifications.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+)
+
+func connectionRequiredActionNotificationKey(connectionID apid.ID, keyPart string) string {
+	return fmt.Sprintf("connection:%s:%s", connectionID, keyPart)
+}
+
+func (c *connection) resolveRequiredActionNotifications(ctx context.Context, keyParts ...string) error {
+	keys := make([]string, 0, len(keyParts))
+	for _, keyPart := range keyParts {
+		keys = append(keys, connectionRequiredActionNotificationKey(c.Id, keyPart))
+	}
+	return c.s.resolveNotificationsForResourceKeys(ctx, "connection", c.Id, keys)
+}

--- a/internal/core/connection_notifications_test.go
+++ b/internal/core/connection_notifications_test.go
@@ -1,0 +1,22 @@
+package core
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	mockDb "github.com/rmorlok/authproxy/internal/database/mock"
+)
+
+func expectResolveRequiredActionNotification(
+	db *mockDb.MockDB,
+	connectionID apid.ID,
+	keyPart string,
+) *gomock.Call {
+	return db.EXPECT().
+		ResolveNotificationsForResourceKeys(
+			gomock.Any(),
+			"connection",
+			connectionID,
+			[]string{connectionRequiredActionNotificationKey(connectionID, keyPart)},
+		).
+		Return(nil)
+}

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -33,6 +34,9 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 		if _, err := c.completeFlow(ctx); err != nil {
 			return iface.PostAuthOutcome{}, err
 		}
+		if err := c.resolveRequiredActionNotifications(ctx, database.NotificationKeyAuthRequired); err != nil {
+			return iface.PostAuthOutcome{}, fmt.Errorf("failed to resolve auth-required notification after credentials were established: %w", err)
+		}
 		return iface.PostAuthOutcome{SetupPending: false}, nil
 	}
 
@@ -44,6 +48,8 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 		if err := c.s.EnqueueVerifyConnection(ctx, c.GetId()); err != nil {
 			return iface.PostAuthOutcome{}, fmt.Errorf("failed to enqueue verify connection task: %w", err)
 		}
+	} else if err := c.resolveRequiredActionNotifications(ctx, database.NotificationKeyAuthRequired); err != nil {
+		return iface.PostAuthOutcome{}, fmt.Errorf("failed to resolve auth-required notification after credentials were established: %w", err)
 	}
 	return iface.PostAuthOutcome{SetupPending: true}, nil
 }

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -101,6 +101,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		current := cschema.MustNewSetupStep(oauth2.OAuth2AuthorizeStepId)
 		conn.SetupStep = &current
 
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
@@ -136,6 +137,7 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		current := cschema.MustNewSetupStep(oauth2.OAuth2AuthorizeStepId)
 		conn.SetupStep = &current
 
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 		// No EnqueueContext expectation — disabled probes must skip verify.
 
@@ -161,6 +163,8 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 
 		outcome, err := conn.HandleCredentialsEstablished(context.Background())
 		require.NoError(t, err)

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -82,6 +82,9 @@ func (c *connection) completeFlow(ctx context.Context) (iface.ConnectionSetupRes
 			return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to set connection state to configured: %w", err))
 		}
 	}
+	if err := c.resolveRequiredActionNotifications(ctx, database.NotificationKeySetupRequired); err != nil {
+		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to resolve setup-required notification: %w", err))
+	}
 	return &iface.ConnectionSetupComplete{
 		Id:   c.GetId(),
 		Type: iface.ConnectionSetupResponseTypeComplete,
@@ -193,4 +196,30 @@ func ensureStepMatches(setupStep *cschema.SetupStep, reqStepId string) error {
 		return httperr.BadRequest(fmt.Sprintf("step_id %q does not match current step %q", reqStepId, setupStep.Id()))
 	}
 	return nil
+}
+
+func (c *connection) resolveAuthRequiredIfCredentialsEstablished(
+	ctx context.Context,
+	current iface.ManifestSetupStep,
+	next iface.ManifestSetupStep,
+) error {
+	if current == nil || !c.isAuthMethodSetupStep(current.Id()) {
+		return nil
+	}
+	if next != nil && next.Type() == iface.ManifestStepTypeVerify {
+		return nil
+	}
+	if err := c.resolveRequiredActionNotifications(ctx, database.NotificationKeyAuthRequired); err != nil {
+		return httperr.InternalServerError(httperr.WithInternalErrorf("failed to resolve auth-required notification: %w", err))
+	}
+	return nil
+}
+
+func (c *connection) isAuthMethodSetupStep(stepID string) bool {
+	connector := c.cv.GetDefinition()
+	if connector == nil || connector.SetupFlow == nil {
+		return true
+	}
+	_, found := connector.SetupFlow.FindStepById(stepID)
+	return !found
 }

--- a/internal/core/connection_setup_dispatch.go
+++ b/internal/core/connection_setup_dispatch.go
@@ -198,6 +198,12 @@ func ensureStepMatches(setupStep *cschema.SetupStep, reqStepId string) error {
 	return nil
 }
 
+// resolveAuthRequiredIfCredentialsEstablished resolves the high-level
+// auth_required notification after a credential-establishing auth-method step
+// has been successfully submitted and the flow is not handing off to verify.
+// It applies to auth methods such as API key forms that can finish credential
+// establishment from SubmitForm; OAuth callbacks and verify success resolve the
+// same notification through their own completion paths.
 func (c *connection) resolveAuthRequiredIfCredentialsEstablished(
 	ctx context.Context,
 	current iface.ManifestSetupStep,
@@ -215,6 +221,11 @@ func (c *connection) resolveAuthRequiredIfCredentialsEstablished(
 	return nil
 }
 
+// isAuthMethodSetupStep returns true when a manifest step came from the auth
+// method rather than the connector YAML setup_flow. The connector SetupFlow only
+// contains user-authored preconnect and configure steps; auth methods inject
+// their own runtime steps between those phases, and apxy:* pseudo-steps are
+// handled by the caller before this helper resolves notifications.
 func (c *connection) isAuthMethodSetupStep(stepID string) bool {
 	connector := c.cv.GetDefinition()
 	if connector == nil || connector.SetupFlow == nil {

--- a/internal/core/connection_verify.go
+++ b/internal/core/connection_verify.go
@@ -20,6 +20,9 @@ func (c *connection) onVerifyPassed(ctx context.Context) error {
 	if err := c.MarkHealthState(ctx, database.ConnectionHealthStateHealthy, "verify_passed"); err != nil {
 		return fmt.Errorf("failed to mark connection healthy after verify: %w", err)
 	}
+	if err := c.resolveRequiredActionNotifications(ctx, database.NotificationKeyAuthRequired); err != nil {
+		return fmt.Errorf("failed to resolve auth-required notification after verify: %w", err)
+	}
 
 	flow := c.s.buildManifestSetupFlow(c)
 	next, hasNext, err := flow.NextStep(ctx, cschema.SetupStepVerify.Id())

--- a/internal/core/connection_verify_test.go
+++ b/internal/core/connection_verify_test.go
@@ -27,6 +27,7 @@ func TestOnVerifyPassed(t *testing.T) {
 		verify := cschema.SetupStepVerify
 		conn.SetupStep = &verify
 
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, ptrStep(cschema.MustNewSetupStep("workspace"))).Return(nil)
 
 		err := conn.onVerifyPassed(context.Background())
@@ -45,8 +46,10 @@ func TestOnVerifyPassed(t *testing.T) {
 		verify := cschema.SetupStepVerify
 		conn.SetupStep = &verify
 
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)
@@ -64,8 +67,10 @@ func TestOnVerifyPassed(t *testing.T) {
 		conn.SetupStep = &verify
 
 		db.EXPECT().SetConnectionHealthState(gomock.Any(), conn.Id, database.ConnectionHealthStateHealthy).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
 
 		err := conn.onVerifyPassed(context.Background())
 		require.NoError(t, err)

--- a/internal/core/service_connection_submit.go
+++ b/internal/core/service_connection_submit.go
@@ -43,7 +43,17 @@ func (c *connection) SubmitForm(ctx context.Context, req iface.SubmitConnectionR
 		return nil, httperr.InternalServerError(httperr.WithInternalErrorf("failed to evaluate setup flow: %w", err))
 	}
 	if !hasNext {
-		return c.completeFlow(ctx)
+		resp, err := c.completeFlow(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.resolveAuthRequiredIfCredentialsEstablished(ctx, current, nil); err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}
+	if err := c.resolveAuthRequiredIfCredentialsEstablished(ctx, current, next); err != nil {
+		return nil, err
 	}
 	return c.advanceToStep(ctx, next, flow, req.ReturnToUrl)
 }

--- a/internal/core/service_connection_submit_api_key_test.go
+++ b/internal/core/service_connection_submit_api_key_test.go
@@ -39,6 +39,7 @@ func newTestApiKeyConnection(
 	// plaintext JSON (rather than the production-style ciphertext that the
 	// mock encrypt service in FullMockService would produce).
 	s.encrypt = e
+	s.r = nil
 	s.authMethodFactories[cschema.AuthTypeAPIKey] = api_key.NewFactory(db, e, s.httpf, s.logger)
 
 	connector := cschema.Connector{
@@ -113,6 +114,8 @@ func TestApiKeySubmit_BearerPersistsCredentialAndAdvancesToReady(t *testing.T) {
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 
 	resp, err := conn.SubmitForm(ctx, iface.SubmitConnectionRequest{
 		StepId: api_key.SynthesizedApiKeyCredentialsStepId,
@@ -148,6 +151,8 @@ func TestApiKeySubmit_BasicPersistsBothCredentialFields(t *testing.T) {
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 
 	resp, err := conn.SubmitForm(ctx, iface.SubmitConnectionRequest{
 		StepId: api_key.SynthesizedApiKeyCredentialsStepId,
@@ -208,6 +213,8 @@ func TestApiKeySubmit_NoReplay_PriorCredentialNeverDecryptedIntoForm(t *testing.
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 	db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 
 	// CRITICAL: GetActiveApiKeyCredential must NOT be called during submit.
 	// gomock fails ctrl.Finish() if submit reads the prior credential.
@@ -246,6 +253,7 @@ func TestApiKeySubmit_PreconnectFieldNamedApiKeyIsNotTreatedAsCredential(t *test
 	e := encrypt.NewFakeEncryptService(false)
 	s, db, _, _, _, _ := FullMockService(t, ctrl)
 	s.encrypt = e
+	s.r = nil
 	s.authMethodFactories[cschema.AuthTypeAPIKey] = api_key.NewFactory(db, e, s.httpf, s.logger)
 
 	connector := cschema.Connector{
@@ -314,6 +322,7 @@ func TestApiKeySubmit_TransitionsToConfigureWhenNoProbes(t *testing.T) {
 	e := encrypt.NewFakeEncryptService(false)
 	s, db, _, _, _, _ := FullMockService(t, ctrl)
 	s.encrypt = e
+	s.r = nil
 	s.authMethodFactories[cschema.AuthTypeAPIKey] = api_key.NewFactory(db, e, s.httpf, s.logger)
 
 	configureStep := cschema.SetupFlowStep{
@@ -353,6 +362,7 @@ func TestApiKeySubmit_TransitionsToConfigureWhenNoProbes(t *testing.T) {
 		Return(&database.ApiKeyCredential{Id: apid.New(apid.PrefixApiKeyCredential)}, nil)
 	// Single transition: dispatcher advances to the first configure step after
 	// PersistCredentials returns. The render-form path is read-only.
+	expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
 	db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, &configureFirst).Return(nil)
 
 	resp, err := conn.SubmitForm(ctx, iface.SubmitConnectionRequest{

--- a/internal/core/service_connection_submit_test.go
+++ b/internal/core/service_connection_submit_test.go
@@ -51,6 +51,7 @@ func newTestConnectionWithSetupFlowAndAsynq(t *testing.T, ctrl *gomock.Controlle
 	e := encrypt.NewFakeEncryptService(false)
 	s, db, _, _, ac, _ := FullMockService(t, ctrl)
 	s.encrypt = e
+	s.r = nil
 
 	connector := cschema.Connector{
 		SetupFlow: sf,
@@ -202,6 +203,7 @@ func TestSubmitForm(t *testing.T) {
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
 
 		resp, err := conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
 			StepId: "workspace",
@@ -292,6 +294,7 @@ func TestSubmitForm(t *testing.T) {
 		db.EXPECT().SetConnectionEncryptedConfiguration(gomock.Any(), conn.Id, gomock.Any()).Return(nil)
 		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
 		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
 
 		resp, err = conn.SubmitForm(context.Background(), iface.SubmitConnectionRequest{
 			StepId: "step2",

--- a/internal/core/task_verify_connection_test.go
+++ b/internal/core/task_verify_connection_test.go
@@ -105,6 +105,8 @@ func TestRunVerifyConnection_NoProbes_AdvancesToReady(t *testing.T) {
 	db.EXPECT().
 		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
 		Return(nil)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeyAuthRequired)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeySetupRequired)
 
 	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
 }
@@ -145,6 +147,8 @@ func TestRunVerifyConnection_AllProbesDisabled_AdvancesToReady(t *testing.T) {
 	db.EXPECT().
 		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
 		Return(nil)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeyAuthRequired)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeySetupRequired)
 
 	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
 }
@@ -197,6 +201,8 @@ func TestRunVerifyConnection_MixedProbePredicates_RunOnlyEnabled(t *testing.T) {
 	db.EXPECT().
 		SetConnectionState(gomock.Any(), connectionId, database.ConnectionStateConfigured).
 		Return(nil)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeyAuthRequired)
+	expectResolveRequiredActionNotification(db, connectionId, database.NotificationKeySetupRequired)
 
 	require.NoError(t, svc.RunVerifyConnection(context.Background(), connectionId))
 }

--- a/internal/core/workflow_migrate_connection_version_analysis.go
+++ b/internal/core/workflow_migrate_connection_version_analysis.go
@@ -335,7 +335,7 @@ func connectionNotificationKey(
 	candidate *connectionMigrationCandidate,
 	keyPart string,
 ) string {
-	return fmt.Sprintf("connection:%s:%s", candidate.Connection.Id, keyPart)
+	return connectionRequiredActionNotificationKey(candidate.Connection.Id, keyPart)
 }
 
 // migrationNotificationMetadata constructs standard notification metadata for

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 type NotificationLevel string
@@ -513,19 +514,19 @@ func (s *service) ListNotifications(
 		limit = 100
 	}
 	query := s.sq.
-		Select((&Notification{}).cols()...).
-		From(NotificationsTable).
-		Where(sq.Eq{"deleted_at": nil}).
-		OrderBy("created_at desc", "id desc").
+		Select(util.PrependAll("n.", (&Notification{}).cols())...).
+		From(NotificationsTable+" AS n").
+		Where(sq.Eq{"n.deleted_at": nil}).
+		OrderBy("n.created_at desc", "n.id desc").
 		Limit(limit)
 	if len(opts.States) > 0 {
-		query = query.Where(sq.Eq{"state": opts.States})
+		query = query.Where(sq.Eq{"n.state": opts.States})
 	}
 	if opts.ResourceType != "" {
-		query = query.Where(sq.Eq{"resource_type": opts.ResourceType})
+		query = query.Where(sq.Eq{"n.resource_type": opts.ResourceType})
 	}
 	if opts.ResourceId != apid.Nil {
-		query = query.Where(sq.Eq{"resource_id": opts.ResourceId})
+		query = query.Where(sq.Eq{"n.resource_id": opts.ResourceId})
 	}
 	if len(opts.NamespaceMatchers) > 0 {
 		for _, matcher := range opts.NamespaceMatchers {
@@ -533,22 +534,21 @@ func (s *service) ListNotifications(
 				return nil, err
 			}
 		}
-		query = restrictToNamespaceMatchers(query, "namespace", opts.NamespaceMatchers)
+		query = restrictToNamespaceMatchers(query, "n.namespace", opts.NamespaceMatchers)
 	}
 	if opts.LabelSelector != nil {
 		selector, err := ParseLabelSelector(*opts.LabelSelector)
 		if err != nil {
 			return nil, err
 		}
-		query = selector.ApplyToSqlBuilderWithProvider(query, "labels", s.cfg.GetProvider())
+		query = selector.ApplyToSqlBuilderWithProvider(query, "n.labels", s.cfg.GetProvider())
 	}
 	if opts.ActorId != apid.Nil && !opts.IncludeViewed {
 		query = query.
 			LeftJoin(
 				fmt.Sprintf(
-					"%s nv ON nv.notification_id = %s.id AND nv.actor_id = ?",
+					"%s nv ON nv.notification_id = n.id AND nv.actor_id = ?",
 					NotificationViewsTable,
-					NotificationsTable,
 				),
 				opts.ActorId,
 			).

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -75,6 +75,23 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, viewed, updated.Id)
 
+	unviewedItems, err := db.ListNotifications(ctx, ListNotificationsOptions{
+		States:  []NotificationState{NotificationStateActive},
+		Limit:   10,
+		ActorId: actorID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, unviewedItems)
+
+	unviewedForOtherActor, err := db.ListNotifications(ctx, ListNotificationsOptions{
+		States:  []NotificationState{NotificationStateActive},
+		Limit:   10,
+		ActorId: apid.New(apid.PrefixActor),
+	})
+	require.NoError(t, err)
+	require.Len(t, unviewedForOtherActor, 1)
+	require.Equal(t, updated.Id, unviewedForOtherActor[0].Id)
+
 	require.NoError(t, db.ResolveNotificationsForResourceKeys(ctx, "connection", connID, []string{updated.Key}))
 	resolved, err := db.GetNotification(ctx, updated.Id)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- add API-key connector version migration integration scenarios for required configure and preconnect changes
- document each scenario with fixture, flow, and assertions markdown
- resolve high-level setup/auth required notifications when setup completes, auth credentials are established without verify, or verify succeeds

Closes #739

## Tests
- go test ./internal/core -run 'Test.*Notification|Test.*Verify|Test.*Setup|Test.*MigrateConnectionVersion|TestSubmitForm|TestApiKeySubmit|TestHandleCredentialsEstablished|TestNotificationKeysToResolve'
- go test ./internal/core -run 'TestGetCurrentSetupStepResponse|TestCancelSetup|TestReconfigure|TestReauthConnection|TestRetryConnectionSetup'
- cd integration_tests && go test -tags integration -run '^$' ./version_migration/... ./api_key/...
- ./scripts/preflight.sh

## Not run
- cd integration_tests && go test -tags integration -v ./version_migration/... (blocked: Docker daemon is not running, so the compose-backed Postgres/Redis test services could not be started)
- go test ./internal/core (blocked: local Postgres test dependency is not running at 127.0.0.1:5432)