### PR TITLE
Fix demo deployment image resolution

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,6 +20,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
+  DOCKER_METADATA_SHORT_SHA_LENGTH: 8
 
 jobs:
   build-authproxy:

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -80,9 +80,9 @@ jobs:
           if [ -n "${{ inputs.image_tag }}" ]; then
             tag="${{ inputs.image_tag }}"
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-            tag="sha-$(printf '%s' "${DEPLOY_SHA}" | cut -c1-7)"
+            tag="sha-$(printf '%s' "${DEPLOY_SHA}" | cut -c1-8)"
           else
-            tag="sha-$(git rev-parse --short HEAD)"
+            tag="sha-$(git rev-parse --short=8 HEAD)"
           fi
 
           echo "sha=${DEPLOY_SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -62,7 +62,7 @@ jobs:
           if [ -n "${{ inputs.image_tag }}" ]; then
             tag="${{ inputs.image_tag }}"
           else
-            tag="sha-$(git rev-parse --short HEAD)"
+            tag="sha-$(git rev-parse --short=8 HEAD)"
           fi
 
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"

--- a/demos/shell/Dockerfile
+++ b/demos/shell/Dockerfile
@@ -22,6 +22,7 @@ RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
 # All declared workspaces must exist on disk for `yarn install --immutable`
 # to succeed — copy them all even though we only build one here.
+COPY docs/package.json docs/package.json
 COPY ui ui
 COPY sdks sdks
 COPY demos demos


### PR DESCRIPTION
## Summary

- materialize the `docs` Yarn workspace in the demo-shell Docker dependency stage so `yarn install --immutable` no longer attempts to rewrite the lockfile
- configure Docker Metadata to publish eight-character SHA tags
- make automatic and manual demo deploys, plus manual demo seeding, resolve the same explicit eight-character SHA tags

## Failure analysis

The demo-shell image had failed on every `main` image build since `docs` became a root Yarn workspace because its Dockerfile copied the root workspace manifest and lockfile without copying `docs/package.json`. That caused the overall Build Image workflow to fail and automatic Deploy Demo runs to skip.

The manual Deploy Demo run independently used Git's repository-dependent `--short` abbreviation (currently eight characters), while Docker Metadata published its seven-character default, so it could not find any images.

## Validation

- reproduced the demo-shell Docker dependency stage in a clean temporary directory; `yarn install --immutable` passes
- `./scripts/preflight.sh`
- `git diff --check`

Docker Desktop was not running locally, so the full image build is left to CI.