### PR TITLE
Add distributed k6 proxy-QPS load scenarios

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -2,8 +2,8 @@
 
 This directory contains the Kubernetes harness for the AuthProxy load-test
 project tracked by #711. It is intentionally split from product
-optimizations: this first slice gives us repeatable environment setup, smoke
-traffic, state seeding, and artifact capture. The proxy-QPS scenarios and
+optimizations: the harness gives us repeatable environment setup, smoke
+traffic, state seeding, proxy-QPS scenarios, and artifact capture. The
 background-job suites build on this foundation in follow-up issues.
 
 ## Prerequisites
@@ -36,6 +36,14 @@ capacity.
 # health. Uses a Kubernetes Job unless LOADTEST_K6_MODE=operator is set.
 ./loadtest/scripts/run smoke
 
+# Run proxy-QPS scenarios against seeded connections. The high-cardinality
+# profiles default to k6 Operator mode for distributed runs.
+./loadtest/scripts/run 100k proxy-raw
+./loadtest/scripts/run 100k proxy-wrapped
+./loadtest/scripts/run 100k proxy-scale
+./loadtest/scripts/run 100k proxy-soak
+./loadtest/scripts/run 100k proxy-spike
+
 # Capture pods, deployments, services, Helm values, logs, and k6 summary JSON.
 ./loadtest/scripts/collect smoke
 
@@ -57,9 +65,50 @@ Profiles live in `profiles/`:
 - `250k.yaml` targets 250,000 connections and 100,000+ namespaces.
 - `500k.yaml` is the stretch profile.
 
-The seed script consumes the object-count section directly. The k6 and
-background-job scenario issues will consume the generated datasets and traffic
-sections.
+The seed script consumes the object-count section directly. Proxy-QPS scenarios
+consume the generated `datasets/connections.csv`, compact it to the columns k6
+needs, and reuse that same sampled dataset across raw, wrapped, spike, soak,
+and scale runs.
+
+## k6 Proxy Scenarios
+
+`./loadtest/scripts/run <profile> <scenario>` supports:
+
+- `smoke`: low-rate health checks for the deployed services.
+- `proxy-raw`: constant-arrival-rate traffic against
+  `/api/v1/connections/{id}/_proxy_raw`.
+- `proxy-wrapped`: constant-arrival-rate comparison traffic against
+  `/api/v1/connections/{id}/_proxy`.
+- `proxy-scale`: sequentially fixes `authproxy-api` replicas to the profile's
+  `k6.scale_replicas` entries and runs `LOADTEST_PROXY_SCALE_SCENARIO`
+  (`proxy-raw` by default) at each size.
+- `proxy-soak`: long constant-arrival-rate run using `k6.soak_duration`.
+- `proxy-spike`: ramping-arrival-rate run using the profile's spike knobs.
+
+The proxy script calls the go-oauth2-server load sink under
+`/test/load/resource/proxy/{connection_id}` and expects the provider to accept
+seeded bearer tokens with the `at_` prefix. Override the sink behavior with
+`K6_UPSTREAM_STATUS`, `K6_UPSTREAM_BYTES`, `K6_UPSTREAM_DELAY_MS`,
+`K6_UPSTREAM_JITTER_MS`, and `K6_UPSTREAM_BEARER_PREFIX`.
+
+The runner mints a scoped `connections:proxy` token from the generated
+`authproxy-load-actors` secret. Set `LOADTEST_AUTHPROXY_BEARER_TOKEN` or
+`AUTHPROXY_BEARER_TOKEN` to provide a token yourself.
+
+k6 thresholds fail runs when:
+
+- `http_req_duration` p95 exceeds `K6_P95_THRESHOLD_MS`.
+- `http_req_failed`, `proxy_5xx_rate`, or `proxy_upstream_5xx_rate` exceed the
+  configured rate.
+- k6 drops iterations or observes any unexpected upstream status.
+
+ConfigMap-backed k6 Operator scripts have a Kubernetes size ceiling, so the
+runner defaults to a compact sample of 10,000 seeded connections. Tune that with
+`LOADTEST_K6_CONNECTION_ROWS` or `k6.connection_rows`; use `all` only when the
+generated ConfigMap remains below `LOADTEST_K6_CONFIGMAP_MAX_BYTES`. Grafana's
+k6 Operator docs recommend a PVC or local-file based runner image for larger
+multi-file suites:
+https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/executing-k6-scripts-with-testrun-crd/
 
 ## Environment Variables
 
@@ -67,10 +116,21 @@ sections.
 - `LOADTEST_RUN_DIR`: writes artifacts to a fixed directory.
 - `AUTHPROXY_IMAGE_REPOSITORY`: defaults to `ghcr.io/rmorlok/authproxy`.
 - `AUTHPROXY_IMAGE_TAG`: defaults to `main`.
-- `GO_OAUTH2_SERVER_IMAGE`: defaults to the current demo provider image.
+- `GO_OAUTH2_SERVER_IMAGE`: defaults to `ghcr.io/rmorlok/go-oauth2-server:master`;
+  pin this to a digest for reproducible capacity runs.
 - `K6_IMAGE`: defaults to `grafana/k6:0.54.0`.
 - `LOADTEST_K6_MODE`: `job` (default) or `operator`.
 - `LOADTEST_K6_TIMEOUT`: defaults to `5m`.
+- `LOADTEST_K6_WAIT=true`: wait for k6 Operator `TestRun` completion. `proxy-scale`
+  enables this automatically so replica measurements run sequentially.
+- `LOADTEST_K6_CONNECTIONS_CSV`: explicit seeded `connections.csv` path for proxy
+  runs. Defaults to the latest seed artifacts for the profile.
+- `LOADTEST_K6_CONNECTION_ROWS`: number of seeded rows to compact into the k6
+  dataset, or `all`.
+- `LOADTEST_PROXY_MODE`: override proxy mode for soak/spike runs (`raw` or
+  `wrapped`).
+- `LOADTEST_PROXY_SCALE_SCENARIO`: scenario to run for each replica count in
+  `proxy-scale`; defaults to `proxy-raw`.
 - `LOADTEST_AUTHPROXY_CONFIG`: AuthProxy config used by `seed`. When unset,
   `seed` generates a local SQLite/miniredis config in the run directory.
 - `LOADTEST_PROVIDER_BASE_URL`: provider URL written into seeded connector
@@ -108,7 +168,8 @@ Each script writes or appends to a run directory containing:
 - `helm-values/`: the value overlays used by `up`.
 - `kubernetes/`: resource snapshots, events, and rollout summaries.
 - `helm/`: `helm list`, rendered values, and manifest snapshots.
-- `k6/`: k6 logs and summary JSON when available.
+- `k6/`: k6 logs, generated TestRun manifests, environment snapshots, summary
+  JSON when available, and `scale-results.tsv` for Job-backed replica sweeps.
 
 The `seed` step also writes:
 
@@ -134,11 +195,14 @@ Then run:
 
 ```bash
 LOADTEST_K6_MODE=operator ./loadtest/scripts/run smoke
+LOADTEST_K6_MODE=operator ./loadtest/scripts/run 100k proxy-raw
 ```
 
-The script creates the k6 script ConfigMap and applies
-`k8s/k6/smoke-testrun.yaml`. The default Job mode is kept so smoke tests work on
-clusters where the operator CRDs are not installed.
+The script creates the k6 script ConfigMap and applies a `TestRun`. Proxy
+scenarios set `parallelism` from the profile or `K6_PARALLELISM`, and `proxy-scale`
+waits for each distributed run to finish before moving to the next API replica
+count. The default Job mode is kept so smoke tests and smaller proxy checks work
+on clusters where the operator CRDs are not installed.
 
 ## Optional KEDA
 

--- a/loadtest/k6/proxy.js
+++ b/loadtest/k6/proxy.js
@@ -1,0 +1,287 @@
+import exec from 'k6/execution';
+import http from 'k6/http';
+import { check, group } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+import { SharedArray } from 'k6/data';
+
+const apiUrl = trimTrailingSlash(__ENV.AUTHPROXY_API_URL || 'http://authproxy-api:8081');
+const providerUrl = trimTrailingSlash(__ENV.GO_OAUTH2_SERVER_URL || 'http://go-oauth2-server');
+const bearerToken = __ENV.AUTHPROXY_BEARER_TOKEN || '';
+const proxyMode = (__ENV.K6_PROXY_MODE || 'raw').toLowerCase();
+const scenarioName = __ENV.K6_SCENARIO_NAME || `proxy-${proxyMode}`;
+const scenarioShape = (__ENV.K6_SCENARIO_SHAPE || 'constant').toLowerCase();
+const apiReplicas = __ENV.K6_API_REPLICAS || 'unspecified';
+const connectionsFile = __ENV.K6_CONNECTIONS_FILE || './connections.csv';
+
+const rate = numberEnv('K6_RATE', 100);
+const timeUnit = __ENV.K6_TIME_UNIT || '1s';
+const duration = __ENV.K6_DURATION || '5m';
+const preAllocatedVUs = numberEnv('K6_PRE_ALLOCATED_VUS', 100);
+const maxVUs = numberEnv('K6_MAX_VUS', 1000);
+const requestTimeout = __ENV.K6_REQUEST_TIMEOUT || '30s';
+
+const p95ThresholdMs = numberEnv('K6_P95_THRESHOLD_MS', 1000);
+const maxFailedRate = numberEnv('K6_MAX_FAILED_RATE', 0.001);
+const max5xxRate = numberEnv('K6_MAX_5XX_RATE', 0.001);
+
+const upstreamStatus = numberEnv('K6_UPSTREAM_STATUS', 200);
+const upstreamBytes = numberEnv('K6_UPSTREAM_BYTES', 256);
+const upstreamDelayMs = numberEnv('K6_UPSTREAM_DELAY_MS', 0);
+const upstreamJitterMs = numberEnv('K6_UPSTREAM_JITTER_MS', 0);
+const upstreamBearerPrefix = __ENV.K6_UPSTREAM_BEARER_PREFIX || 'at_';
+const upstreamPathPrefix = trimSlashes(__ENV.K6_UPSTREAM_PATH_PREFIX || '/test/load/resource/proxy');
+const proxyMethod = (__ENV.K6_PROXY_METHOD || 'GET').toUpperCase();
+
+const proxyRequests = new Counter('proxy_requests');
+const proxyUnexpectedStatus = new Counter('proxy_unexpected_status');
+const proxy5xxRate = new Rate('proxy_5xx_rate');
+const proxyUpstream5xxRate = new Rate('proxy_upstream_5xx_rate');
+
+const connections = new SharedArray('connections', () => parseConnections(open(connectionsFile)));
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  scenarios: {
+    proxy: buildScenario(),
+  },
+  thresholds: {
+    http_req_duration: [`p(95)<${p95ThresholdMs}`],
+    http_req_failed: [`rate<${maxFailedRate}`],
+    dropped_iterations: ['count==0'],
+    proxy_5xx_rate: [`rate<${max5xxRate}`],
+    proxy_upstream_5xx_rate: [`rate<${max5xxRate}`],
+    proxy_unexpected_status: ['count==0'],
+  },
+};
+
+export function setup() {
+  if (!bearerToken) {
+    throw new Error('AUTHPROXY_BEARER_TOKEN is required');
+  }
+  if (proxyMode !== 'raw' && proxyMode !== 'wrapped') {
+    throw new Error(`K6_PROXY_MODE must be raw or wrapped, got ${proxyMode}`);
+  }
+  console.log(JSON.stringify({
+    scenario: scenarioName,
+    shape: scenarioShape,
+    proxy_mode: proxyMode,
+    api_replicas: apiReplicas,
+    connection_rows: connections.length,
+    rate,
+    time_unit: timeUnit,
+    duration,
+  }));
+}
+
+export default function () {
+  const connection = selectConnection();
+  const upstreamUrl = buildUpstreamUrl(connection);
+
+  group(proxyMode, () => {
+    const result = proxyMode === 'wrapped'
+      ? wrappedProxy(connection, upstreamUrl)
+      : { response: rawProxy(connection, upstreamUrl), upstreamStatus: null };
+    recordResponse(result.response, result.upstreamStatus);
+  });
+}
+
+function rawProxy(connection, upstreamUrl) {
+  const url = `${apiUrl}/api/v1/connections/${encodeURIComponent(connection.connection_id)}/_proxy_raw`;
+  return http.request(proxyMethod, url, null, {
+    timeout: requestTimeout,
+    headers: {
+      Authorization: `Bearer ${bearerToken}`,
+      Accept: 'application/octet-stream',
+      'X-AuthProxy-Upstream-URL': upstreamUrl,
+      'X-AuthProxy-Label': 'loadtest=true',
+    },
+    tags: requestTags(connection, 'raw'),
+  });
+}
+
+function wrappedProxy(connection, upstreamUrl) {
+  const url = `${apiUrl}/api/v1/connections/${encodeURIComponent(connection.connection_id)}/_proxy`;
+  const payload = JSON.stringify({
+    url: upstreamUrl,
+    method: proxyMethod,
+    labels: {
+      loadtest: 'true',
+      'loadtest.authproxy.io/scenario': scenarioName,
+      'loadtest.authproxy.io/mode': 'wrapped',
+    },
+  });
+  const response = http.post(url, payload, {
+    timeout: requestTimeout,
+    headers: {
+      Authorization: `Bearer ${bearerToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    tags: requestTags(connection, 'wrapped'),
+  });
+  return {
+    response,
+    upstreamStatus: wrappedUpstreamStatus(response),
+  };
+}
+
+function recordResponse(response, wrappedStatus) {
+  const upstreamObservedStatus = proxyMode === 'wrapped' ? wrappedStatus : response.status;
+  const api5xx = response.status >= 500 && response.status < 600;
+  const upstream5xx = upstreamObservedStatus >= 500 && upstreamObservedStatus < 600;
+  const expectedStatus = proxyMode === 'wrapped'
+    ? response.status === 200 && upstreamObservedStatus === upstreamStatus
+    : response.status === upstreamStatus;
+
+  proxyRequests.add(1);
+  proxy5xxRate.add(api5xx);
+  proxyUpstream5xxRate.add(upstream5xx);
+  proxyUnexpectedStatus.add(expectedStatus ? 0 : 1);
+
+  check(response, {
+    'authproxy did not return 5xx': (res) => res.status < 500,
+    'upstream status matched': () => upstreamObservedStatus === upstreamStatus,
+    'wrapped envelope succeeded': (res) => proxyMode !== 'wrapped' || res.status === 200,
+  });
+}
+
+function wrappedUpstreamStatus(response) {
+  if (response.status !== 200) {
+    return 0;
+  }
+  try {
+    const body = response.json();
+    return Number(body && body.status_code ? body.status_code : 0);
+  } catch (err) {
+    return 0;
+  }
+}
+
+function buildScenario() {
+  if (scenarioShape === 'spike') {
+    return {
+      executor: 'ramping-arrival-rate',
+      startRate: numberEnv('K6_SPIKE_BASE_RATE', rate),
+      timeUnit,
+      preAllocatedVUs,
+      maxVUs,
+      stages: [
+        { target: numberEnv('K6_SPIKE_BASE_RATE', rate), duration: __ENV.K6_SPIKE_RAMP_UP || '1m' },
+        { target: numberEnv('K6_SPIKE_RATE', rate * 3), duration: __ENV.K6_SPIKE_HOLD || '3m' },
+        { target: numberEnv('K6_SPIKE_BASE_RATE', rate), duration: __ENV.K6_SPIKE_RAMP_DOWN || '1m' },
+        { target: numberEnv('K6_SPIKE_BASE_RATE', rate), duration: __ENV.K6_SPIKE_RECOVERY || '3m' },
+      ],
+    };
+  }
+
+  return {
+    executor: 'constant-arrival-rate',
+    rate,
+    timeUnit,
+    duration,
+    preAllocatedVUs,
+    maxVUs,
+  };
+}
+
+function selectConnection() {
+  const iteration = exec.scenario.iterationInTest || exec.scenario.iterationInInstance || 0;
+  return connections[iteration % connections.length];
+}
+
+function buildUpstreamUrl(connection) {
+  const path = `${providerUrl}/${upstreamPathPrefix}/${encodeURIComponent(connection.connection_id)}`;
+  const params = [
+    ['status', String(upstreamStatus)],
+    ['bytes', String(upstreamBytes)],
+    ['bearer_prefix', upstreamBearerPrefix],
+  ];
+  if (upstreamDelayMs > 0) {
+    params.push(['delay', `${upstreamDelayMs}ms`]);
+  }
+  if (upstreamJitterMs > 0) {
+    params.push(['jitter', `${upstreamJitterMs}ms`]);
+  }
+  return `${path}?${params.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join('&')}`;
+}
+
+function requestTags(connection, mode) {
+  return {
+    scenario: scenarioName,
+    proxy_mode: mode,
+    api_replicas: apiReplicas,
+    connector_id: connection.connector_id || 'unknown',
+  };
+}
+
+function parseConnections(raw) {
+  const lines = String(raw).trim().split(/\r?\n/).filter((line) => line.trim() !== '');
+  if (lines.length < 2) {
+    throw new Error(`${connectionsFile} must contain a header and at least one connection row`);
+  }
+
+  const headers = splitCSVLine(lines[0]).map((header) => header.trim());
+  if (headers.indexOf('connection_id') === -1) {
+    throw new Error(`${connectionsFile} must include a connection_id column`);
+  }
+
+  const rows = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const values = splitCSVLine(lines[i]);
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || '';
+    });
+    if (!row.connection_id) {
+      throw new Error(`${connectionsFile} row ${i + 1} is missing connection_id`);
+    }
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function splitCSVLine(line) {
+  const fields = [];
+  let field = '';
+  let quoted = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (quoted && line[i + 1] === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (ch === ',' && !quoted) {
+      fields.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
+function numberEnv(name, fallback) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name} must be numeric, got ${raw}`);
+  }
+  return value;
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function trimSlashes(value) {
+  return value.replace(/^\/+/, '').replace(/\/+$/, '');
+}

--- a/loadtest/k8s/base/go-oauth2-server.yaml
+++ b/loadtest/k8s/base/go-oauth2-server.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: go-oauth2-server
-          image: ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3
+          image: ghcr.io/rmorlok/go-oauth2-server:master
           imagePullPolicy: IfNotPresent
           command:
             - go-oauth2-server

--- a/loadtest/k8s/k6/proxy-job.yaml
+++ b/loadtest/k8s/k6/proxy-job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authproxy-proxy-k6
+  labels:
+    app.kubernetes.io/name: k6
+    app.kubernetes.io/component: load-generator
+    loadtest.authproxy.io/scenario: proxy
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k6
+        app.kubernetes.io/component: load-generator
+        loadtest.authproxy.io/scenario: proxy
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: grafana/k6:0.54.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /scripts/proxy.js
+            - --summary-export
+            - /artifacts/summary.json
+          env:
+            - name: AUTHPROXY_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-loadtest-k6-auth
+                  key: AUTHPROXY_BEARER_TOKEN
+            - name: K6_CONNECTIONS_FILE
+              value: /scripts/connections.csv
+          envFrom:
+            - configMapRef:
+                name: authproxy-loadtest-k6-env
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: artifacts
+              mountPath: /artifacts
+      volumes:
+        - name: scripts
+          configMap:
+            name: authproxy-loadtest-k6
+        - name: artifacts
+          emptyDir: {}

--- a/loadtest/k8s/k6/proxy-testrun.yaml
+++ b/loadtest/k8s/k6/proxy-testrun.yaml
@@ -1,0 +1,33 @@
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: authproxy-proxy
+  labels:
+    app.kubernetes.io/name: k6
+    app.kubernetes.io/component: load-generator
+    loadtest.authproxy.io/scenario: proxy
+spec:
+  parallelism: 1
+  arguments: --summary-export /tmp/summary.json
+  script:
+    configMap:
+      name: authproxy-loadtest-k6
+      file: proxy.js
+  runner:
+    image: grafana/k6:0.54.0
+    metadata:
+      labels:
+        app.kubernetes.io/name: k6
+        app.kubernetes.io/component: load-generator
+        loadtest.authproxy.io/scenario: proxy
+    env:
+      - name: AUTHPROXY_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: authproxy-loadtest-k6-auth
+            key: AUTHPROXY_BEARER_TOKEN
+      - name: K6_CONNECTIONS_FILE
+        value: ./connections.csv
+    envFrom:
+      - configMapRef:
+          name: authproxy-loadtest-k6-env

--- a/loadtest/profiles/100k.yaml
+++ b/loadtest/profiles/100k.yaml
@@ -23,6 +23,29 @@ authproxy:
 k6:
   mode: operator
   scenario: proxy-raw
+  rate: 500
+  duration: 10m
+  time_unit: 1s
+  connection_rows: 10000
+  parallelism: 4
+  pre_allocated_vus: 250
+  max_vus: 2000
+  request_timeout: 30s
+  p95_latency_ms: 1000
+  max_failed_rate: 0.001
+  upstream_status: 200
+  upstream_bytes: 256
+  upstream_delay_ms: 0
+  upstream_jitter_ms: 0
+  upstream_bearer_prefix: at_
+  upstream_path_prefix: /test/load/resource/proxy
+  soak_duration: 2h
+  spike_base_rate: 500
+  spike_rate: 1500
+  spike_ramp_up: 2m
+  spike_hold: 5m
+  spike_ramp_down: 2m
+  spike_recovery: 5m
   scale_replicas:
     - 2
     - 4

--- a/loadtest/profiles/250k.yaml
+++ b/loadtest/profiles/250k.yaml
@@ -22,6 +22,29 @@ authproxy:
 k6:
   mode: operator
   scenario: proxy-raw
+  rate: 1000
+  duration: 10m
+  time_unit: 1s
+  connection_rows: 10000
+  parallelism: 8
+  pre_allocated_vus: 500
+  max_vus: 4000
+  request_timeout: 30s
+  p95_latency_ms: 1000
+  max_failed_rate: 0.001
+  upstream_status: 200
+  upstream_bytes: 256
+  upstream_delay_ms: 0
+  upstream_jitter_ms: 0
+  upstream_bearer_prefix: at_
+  upstream_path_prefix: /test/load/resource/proxy
+  soak_duration: 2h
+  spike_base_rate: 1000
+  spike_rate: 3000
+  spike_ramp_up: 2m
+  spike_hold: 5m
+  spike_ramp_down: 2m
+  spike_recovery: 5m
   scale_replicas:
     - 4
     - 8

--- a/loadtest/profiles/500k.yaml
+++ b/loadtest/profiles/500k.yaml
@@ -22,6 +22,29 @@ authproxy:
 k6:
   mode: operator
   scenario: proxy-raw
+  rate: 1500
+  duration: 10m
+  time_unit: 1s
+  connection_rows: 10000
+  parallelism: 12
+  pre_allocated_vus: 750
+  max_vus: 6000
+  request_timeout: 30s
+  p95_latency_ms: 1000
+  max_failed_rate: 0.001
+  upstream_status: 200
+  upstream_bytes: 256
+  upstream_delay_ms: 0
+  upstream_jitter_ms: 0
+  upstream_bearer_prefix: at_
+  upstream_path_prefix: /test/load/resource/proxy
+  soak_duration: 2h
+  spike_base_rate: 1500
+  spike_rate: 4500
+  spike_ramp_up: 2m
+  spike_hold: 5m
+  spike_ramp_down: 2m
+  spike_recovery: 5m
   scale_replicas:
     - 8
     - 16

--- a/loadtest/profiles/smoke.yaml
+++ b/loadtest/profiles/smoke.yaml
@@ -18,6 +18,7 @@ k6:
   scenario: smoke
   rate: 2
   duration: 30s
+  connection_rows: 10
   pre_allocated_vus: 4
   max_vus: 16
 acceptance:

--- a/loadtest/scripts/collect
+++ b/loadtest/scripts/collect
@@ -17,15 +17,24 @@ loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 loadtest_capture_helm_snapshot "$namespace" "$run_dir"
 
 kubectl -n "$namespace" get jobs -o wide > "$run_dir/kubernetes/jobs.txt" 2>&1 || true
+kubectl -n "$namespace" get jobs -l app.kubernetes.io/name=k6 -o yaml > "$run_dir/k6/jobs.yaml" 2>&1 || true
+kubectl -n "$namespace" get pods -l app.kubernetes.io/name=k6 -o yaml > "$run_dir/k6/pods.yaml" 2>&1 || true
 kubectl -n "$namespace" get configmaps -o wide > "$run_dir/kubernetes/configmaps.txt" 2>&1 || true
+kubectl -n "$namespace" get configmaps -l app.kubernetes.io/name=k6 -o yaml > "$run_dir/k6/configmaps.yaml" 2>&1 || true
 kubectl -n "$namespace" get secrets -o name > "$run_dir/kubernetes/secrets.txt" 2>&1 || true
 kubectl -n "$namespace" get testruns.k6.io -o yaml > "$run_dir/k6/testruns.yaml" 2>&1 || true
-kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
 
-pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-smoke-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-if [[ -n "$pod" ]]; then
-  kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/summary.json" >/dev/null 2>&1 || true
-fi
+while IFS= read -r job; do
+  [[ -n "$job" ]] || continue
+  kubectl -n "$namespace" logs "job/$job" > "$run_dir/k6/${job}.log" 2>&1 || true
+done < <(kubectl -n "$namespace" get jobs -l app.kubernetes.io/name=k6 -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+while IFS= read -r pod; do
+  [[ -n "$pod" ]] || continue
+  kubectl -n "$namespace" logs "$pod" > "$run_dir/k6/${pod}.log" 2>&1 || true
+  kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/${pod}-summary.json" >/dev/null 2>&1 || true
+  kubectl -n "$namespace" cp "$pod:/tmp/summary.json" "$run_dir/k6/${pod}-summary.json" >/dev/null 2>&1 || true
+done < <(kubectl -n "$namespace" get pods -l app.kubernetes.io/name=k6 -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
 
 loadtest_log "collected artifacts for profile $profile_name"
 loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/down
+++ b/loadtest/scripts/down
@@ -23,9 +23,12 @@ for release in "${LOADTEST_AUTH_PROXY_RELEASES[@]}"; do
   helm -n "$namespace" uninstall "$release" >/dev/null 2>&1 || true
 done
 
-kubectl -n "$namespace" delete job authproxy-smoke-k6 --ignore-not-found=true >/dev/null 2>&1 || true
-kubectl -n "$namespace" delete configmap authproxy-loadtest-k6 --ignore-not-found=true >/dev/null 2>&1 || true
-kubectl -n "$namespace" delete testrun authproxy-smoke --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete jobs -l app.kubernetes.io/name=k6 --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete configmaps -l app.kubernetes.io/name=k6 --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete configmap authproxy-loadtest-k6 authproxy-loadtest-k6-env --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete secret authproxy-loadtest-k6-auth --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete testruns.k6.io -l app.kubernetes.io/name=k6 --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete testrun authproxy-smoke authproxy-proxy --ignore-not-found=true >/dev/null 2>&1 || true
 
 for manifest in "$LOADTEST_ROOT"/k8s/base/*.yaml; do
   kubectl -n "$namespace" delete -f "$manifest" --ignore-not-found=true >/dev/null 2>&1 || true

--- a/loadtest/scripts/lib/loadtest.sh
+++ b/loadtest/scripts/lib/loadtest.sh
@@ -52,6 +52,99 @@ loadtest_yaml_top_value() {
   ' "$file"
 }
 
+loadtest_yaml_section_value() {
+  local file=$1
+  local section=$2
+  local key=$3
+  awk -v section="$section" -v key="$key" '
+    function indent(line, copy) {
+      copy = line
+      sub(/[^ ].*$/, "", copy)
+      return length(copy)
+    }
+    function clean_value(value) {
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]+#.*$/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["\047]|["\047]$/, "", value)
+      return value
+    }
+    /^[[:space:]]*($|#)/ { next }
+    indent($0) == 0 && $0 ~ "^" section ":[[:space:]]*($|#)" {
+      in_section = 1
+      section_indent = indent($0)
+      next
+    }
+    in_section {
+      current_indent = indent($0)
+      if (current_indent <= section_indent) {
+        exit
+      }
+      if (current_indent == section_indent + 2 && $0 ~ "^[[:space:]]*" key ":") {
+        print clean_value($0)
+        exit
+      }
+    }
+  ' "$file"
+}
+
+loadtest_yaml_section_list() {
+  local file=$1
+  local section=$2
+  local key=$3
+  awk -v section="$section" -v key="$key" '
+    function indent(line, copy) {
+      copy = line
+      sub(/[^ ].*$/, "", copy)
+      return length(copy)
+    }
+    function trim(value) {
+      sub(/[[:space:]]+#.*$/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["\047]|["\047]$/, "", value)
+      return value
+    }
+    /^[[:space:]]*($|#)/ { next }
+    indent($0) == 0 && $0 ~ "^" section ":[[:space:]]*($|#)" {
+      in_section = 1
+      section_indent = indent($0)
+      next
+    }
+    in_section {
+      current_indent = indent($0)
+      if (current_indent <= section_indent) {
+        exit
+      }
+      if (in_list) {
+        if (current_indent <= key_indent) {
+          exit
+        }
+        if ($0 ~ "^[[:space:]]*-[[:space:]]*") {
+          value = $0
+          sub(/^[[:space:]]*-[[:space:]]*/, "", value)
+          print trim(value)
+        }
+        next
+      }
+      if (current_indent == section_indent + 2 && $0 ~ "^[[:space:]]*" key ":") {
+        value = $0
+        sub(/^[^:]*:[[:space:]]*/, "", value)
+        value = trim(value)
+        if (value ~ /^\[/) {
+          gsub(/^\[|\]$/, "", value)
+          n = split(value, parts, ",")
+          for (idx = 1; idx <= n; idx++) {
+            print trim(parts[idx])
+          }
+          exit
+        }
+        in_list = 1
+        key_indent = current_indent
+      }
+    }
+  ' "$file"
+}
+
 loadtest_profile_name() {
   local profile_file=$1
   local name
@@ -68,6 +161,34 @@ loadtest_namespace() {
 
 loadtest_timestamp() {
   date -u "+%Y%m%dT%H%M%SZ"
+}
+
+loadtest_sanitize_k8s_name() {
+  printf "%s\n" "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' | cut -c 1-50 | sed -E 's/-+$//'
+}
+
+loadtest_latest_seed_dataset() {
+  local profile_name=$1
+  local latest=""
+  local candidate
+
+  shopt -s nullglob
+  for candidate in "$LOADTEST_ROOT"/runs/*-"$profile_name"-seed/datasets/connections.csv; do
+    latest=$candidate
+  done
+  shopt -u nullglob
+
+  if [[ -n "$latest" ]]; then
+    printf "%s\n" "$latest"
+  fi
+}
+
+loadtest_base64_decode() {
+  if base64 --help 2>&1 | grep -q -- "--decode"; then
+    base64 --decode
+  else
+    base64 -D
+  fi
 }
 
 loadtest_init_run_dir() {
@@ -91,7 +212,7 @@ loadtest_init_run_dir() {
     printf "namespace=%s\n" "$namespace"
     printf "authproxy_image_repository=%s\n" "${AUTHPROXY_IMAGE_REPOSITORY:-ghcr.io/rmorlok/authproxy}"
     printf "authproxy_image_tag=%s\n" "${AUTHPROXY_IMAGE_TAG:-main}"
-    printf "go_oauth2_server_image=%s\n" "${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3}"
+    printf "go_oauth2_server_image=%s\n" "${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server:master}"
     printf "k6_image=%s\n" "${K6_IMAGE:-grafana/k6:0.54.0}"
     printf "install_k6_operator=%s\n" "${LOADTEST_INSTALL_K6_OPERATOR:-false}"
     printf "install_keda=%s\n" "${LOADTEST_INSTALL_KEDA:-false}"

--- a/loadtest/scripts/run
+++ b/loadtest/scripts/run
@@ -5,50 +5,526 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$SCRIPT_DIR/lib/loadtest.sh"
 
 profile=${1:-${LOADTEST_PROFILE:-smoke}}
-scenario=${2:-smoke}
 profile_file=$(loadtest_profile_path "$profile")
 profile_name=$(loadtest_profile_name "$profile_file")
 namespace=$(loadtest_namespace "$profile_file")
+default_scenario=$(loadtest_yaml_section_value "$profile_file" k6 scenario)
+scenario=${2:-${LOADTEST_SCENARIO:-${default_scenario:-smoke}}}
 run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" run)
 
 loadtest_require_cmd kubectl
 
-[[ "$scenario" == "smoke" ]] || loadtest_die "unsupported scenario in this slice: $scenario"
-
-k6_mode=${LOADTEST_K6_MODE:-job}
-k6_timeout=${LOADTEST_K6_TIMEOUT:-5m}
+profile_k6_mode=$(loadtest_yaml_section_value "$profile_file" k6 mode)
+k6_mode=${LOADTEST_K6_MODE:-${profile_k6_mode:-job}}
+k6_timeout=${LOADTEST_K6_TIMEOUT:-10m}
 k6_image=${K6_IMAGE:-grafana/k6:0.54.0}
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-kubectl -n "$namespace" create configmap authproxy-loadtest-k6 \
-  --from-file=smoke.js="$LOADTEST_ROOT/k6/smoke.js" \
-  --dry-run=client -o yaml > "$tmp/k6-configmap.yaml"
-kubectl -n "$namespace" apply -f "$tmp/k6-configmap.yaml"
+k6_profile_value() {
+  local key=$1
+  local default_value=$2
+  local value
+  value=$(loadtest_yaml_section_value "$profile_file" k6 "$key")
+  printf "%s\n" "${value:-$default_value}"
+}
 
-if [[ "$k6_mode" == "operator" ]]; then
-  if ! kubectl get crd testruns.k6.io >/dev/null 2>&1; then
-    loadtest_die "LOADTEST_K6_MODE=operator requested, but testruns.k6.io is not installed"
+k6_env_or_profile() {
+  local env_name=$1
+  local key=$2
+  local default_value=$3
+  local value=${!env_name:-}
+  if [[ -z "$value" ]]; then
+    value=$(k6_profile_value "$key" "$default_value")
+  fi
+  printf "%s\n" "$value"
+}
+
+k6_p95_threshold_ms() {
+  local value=${K6_P95_THRESHOLD_MS:-}
+  if [[ -z "$value" ]]; then
+    value=$(loadtest_yaml_section_value "$profile_file" k6 p95_latency_ms)
+  fi
+  if [[ -z "$value" ]]; then
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95_latency_target)
   fi
 
-  loadtest_log "applying k6 TestRun"
-  kubectl -n "$namespace" delete testrun authproxy-smoke --ignore-not-found=true >/dev/null 2>&1 || true
-  kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-testrun.yaml"
-  loadtest_log "TestRun submitted; use collect to capture status and runner logs"
-else
-  loadtest_log "running k6 smoke Job"
-  kubectl -n "$namespace" delete job authproxy-smoke-k6 --ignore-not-found=true >/dev/null 2>&1 || true
-  kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-job.yaml"
-  kubectl -n "$namespace" set image job/authproxy-smoke-k6 "k6=$k6_image"
-  kubectl -n "$namespace" wait --for=condition=complete job/authproxy-smoke-k6 "--timeout=$k6_timeout"
-  kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
+  case "$value" in
+    "")
+      printf "1000\n"
+      ;;
+    profile-configured)
+      printf "1000\n"
+      ;;
+    *ms)
+      printf "%s\n" "${value%ms}"
+      ;;
+    *s)
+      printf "%s\n" "$(( ${value%s} * 1000 ))"
+      ;;
+    *)
+      printf "%s\n" "$value"
+      ;;
+  esac
+}
 
-  pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-smoke-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-  if [[ -n "$pod" ]]; then
-    kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/summary.json" >/dev/null 2>&1 || true
+proxy_mode_for_scenario() {
+  if [[ -n "${LOADTEST_PROXY_MODE:-}" ]]; then
+    printf "%s\n" "$LOADTEST_PROXY_MODE"
+    return
   fi
-fi
+
+  case "$1" in
+    proxy-wrapped)
+      printf "wrapped\n"
+      ;;
+    *)
+      printf "raw\n"
+      ;;
+  esac
+}
+
+shape_for_scenario() {
+  case "$1" in
+    proxy-spike)
+      printf "spike\n"
+      ;;
+    *)
+      printf "constant\n"
+      ;;
+  esac
+}
+
+duration_for_scenario() {
+  case "$1" in
+    proxy-soak)
+      k6_env_or_profile LOADTEST_K6_SOAK_DURATION soak_duration 2h
+      ;;
+    *)
+      k6_env_or_profile K6_DURATION duration 5m
+      ;;
+  esac
+}
+
+max_5xx_rate() {
+  local value=${K6_MAX_5XX_RATE:-}
+  if [[ -z "$value" ]]; then
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance max_5xx_rate)
+  fi
+  printf "%s\n" "${value:-0.001}"
+}
+
+prepare_connections_dataset() {
+  local source=${LOADTEST_K6_CONNECTIONS_CSV:-${LOADTEST_CONNECTIONS_CSV:-}}
+  if [[ -z "$source" ]]; then
+    source=$(loadtest_latest_seed_dataset "$profile_name")
+  fi
+  [[ -n "$source" ]] || loadtest_die "no seeded connections.csv found for profile $profile_name; run seed first or set LOADTEST_K6_CONNECTIONS_CSV"
+  [[ -f "$source" ]] || loadtest_die "connections dataset does not exist: $source"
+
+  local rows
+  rows=$(k6_env_or_profile LOADTEST_K6_CONNECTION_ROWS connection_rows 10000)
+  if [[ "$rows" != "all" && ! "$rows" =~ ^[0-9]+$ ]]; then
+    loadtest_die "LOADTEST_K6_CONNECTION_ROWS must be numeric or all"
+  fi
+
+  local target="$tmp/connections.csv"
+  awk -v limit="$rows" -F, '
+    BEGIN { OFS = "," }
+    NR == 1 {
+      for (idx = 1; idx <= NF; idx++) {
+        if ($idx == "connection_id") {
+          connection_col = idx
+        }
+        if ($idx == "connector_id") {
+          connector_col = idx
+        }
+      }
+      if (connection_col == 0) {
+        exit 2
+      }
+      print "connection_id", "connector_id"
+      next
+    }
+    limit != "all" && written >= limit {
+      exit
+    }
+    {
+      connector = connector_col == 0 ? "" : $connector_col
+      print $connection_col, connector
+      written++
+    }
+  ' "$source" > "$target" || loadtest_die "failed to build compact k6 dataset from $source"
+
+  local row_count
+  row_count=$(awk 'NR > 1 { count++ } END { print count + 0 }' "$target")
+  [[ "$row_count" -gt 0 ]] || loadtest_die "compact k6 dataset is empty: $source"
+  loadtest_log "using $row_count k6 connection rows from $source" >&2
+  printf "%s\n" "$target"
+}
+
+apply_k6_script_configmap() {
+  local connections_csv=$1
+  local bundle_bytes
+  bundle_bytes=$(
+    (
+      wc -c < "$LOADTEST_ROOT/k6/smoke.js"
+      wc -c < "$LOADTEST_ROOT/k6/proxy.js"
+      wc -c < "$connections_csv"
+    ) | awk '{ total += $1 } END { print total + 0 }'
+  )
+
+  local max_bytes=${LOADTEST_K6_CONFIGMAP_MAX_BYTES:-900000}
+  if [[ "${LOADTEST_K6_ALLOW_LARGE_CONFIGMAP:-false}" != "true" && "$bundle_bytes" -gt "$max_bytes" ]]; then
+    loadtest_die "k6 ConfigMap bundle is ${bundle_bytes} bytes, above ${max_bytes}; lower LOADTEST_K6_CONNECTION_ROWS or set LOADTEST_K6_ALLOW_LARGE_CONFIGMAP=true"
+  fi
+
+  kubectl -n "$namespace" create configmap authproxy-loadtest-k6 \
+    --from-file=smoke.js="$LOADTEST_ROOT/k6/smoke.js" \
+    --from-file=proxy.js="$LOADTEST_ROOT/k6/proxy.js" \
+    --from-file=connections.csv="$connections_csv" \
+    --dry-run=client -o yaml > "$tmp/k6-configmap.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/k6-configmap.yaml"
+}
+
+mint_proxy_token() {
+  local token=${LOADTEST_AUTHPROXY_BEARER_TOKEN:-${AUTHPROXY_BEARER_TOKEN:-}}
+  if [[ -n "$token" ]]; then
+    printf "%s\n" "$token"
+    return
+  fi
+
+  loadtest_require_cmd go
+
+  local key_path="$tmp/loadtest-admin"
+  kubectl -n "$namespace" get secret authproxy-load-actors \
+    -o go-template='{{ index .data "loadtest-admin" }}' | loadtest_base64_decode > "$key_path"
+  chmod 600 "$key_path"
+
+  cat > "$tmp/proxy-permissions.yaml" <<'YAML'
+- namespace: root.**
+  resources:
+    - connections
+  verbs:
+    - proxy
+YAML
+
+  (
+    cd "$REPO_ROOT"
+    go run ./cmd/cli sign-jwt \
+      --actorId loadtest-admin \
+      --privateKeyPath "$key_path" \
+      --apis api \
+      --expires-in "${LOADTEST_K6_TOKEN_EXPIRES_IN:-4h}" \
+      --permissions-file "$tmp/proxy-permissions.yaml"
+  )
+}
+
+apply_k6_auth_secret() {
+  local token=$1
+  kubectl -n "$namespace" create secret generic authproxy-loadtest-k6-auth \
+    --from-literal=AUTHPROXY_BEARER_TOKEN="$token" \
+    --dry-run=client -o yaml > "$tmp/k6-auth.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/k6-auth.yaml"
+}
+
+apply_k6_env_configmap() {
+  local scenario_name=$1
+  local proxy_mode=$2
+  local shape=$3
+  local api_replicas=$4
+  local configmap_name=${5:-authproxy-loadtest-k6-env}
+
+  local env_file="$run_dir/k6/${scenario_name}.env"
+  {
+    printf "AUTHPROXY_API_URL=%s\n" "${AUTHPROXY_API_URL:-http://authproxy-api:8081}"
+    printf "GO_OAUTH2_SERVER_URL=%s\n" "${GO_OAUTH2_SERVER_URL:-http://go-oauth2-server}"
+    printf "K6_PROXY_MODE=%s\n" "$proxy_mode"
+    printf "K6_SCENARIO_NAME=%s\n" "$scenario_name"
+    printf "K6_SCENARIO_SHAPE=%s\n" "$shape"
+    printf "K6_API_REPLICAS=%s\n" "$api_replicas"
+    printf "K6_RATE=%s\n" "$(k6_env_or_profile K6_RATE rate 100)"
+    printf "K6_DURATION=%s\n" "$(duration_for_scenario "$scenario_name")"
+    printf "K6_TIME_UNIT=%s\n" "$(k6_env_or_profile K6_TIME_UNIT time_unit 1s)"
+    printf "K6_PRE_ALLOCATED_VUS=%s\n" "$(k6_env_or_profile K6_PRE_ALLOCATED_VUS pre_allocated_vus 100)"
+    printf "K6_MAX_VUS=%s\n" "$(k6_env_or_profile K6_MAX_VUS max_vus 1000)"
+    printf "K6_REQUEST_TIMEOUT=%s\n" "$(k6_env_or_profile K6_REQUEST_TIMEOUT request_timeout 30s)"
+    printf "K6_P95_THRESHOLD_MS=%s\n" "$(k6_p95_threshold_ms)"
+    printf "K6_MAX_FAILED_RATE=%s\n" "$(k6_env_or_profile K6_MAX_FAILED_RATE max_failed_rate "$(max_5xx_rate)")"
+    printf "K6_MAX_5XX_RATE=%s\n" "$(max_5xx_rate)"
+    printf "K6_UPSTREAM_STATUS=%s\n" "$(k6_env_or_profile K6_UPSTREAM_STATUS upstream_status 200)"
+    printf "K6_UPSTREAM_BYTES=%s\n" "$(k6_env_or_profile K6_UPSTREAM_BYTES upstream_bytes 256)"
+    printf "K6_UPSTREAM_DELAY_MS=%s\n" "$(k6_env_or_profile K6_UPSTREAM_DELAY_MS upstream_delay_ms 0)"
+    printf "K6_UPSTREAM_JITTER_MS=%s\n" "$(k6_env_or_profile K6_UPSTREAM_JITTER_MS upstream_jitter_ms 0)"
+    printf "K6_UPSTREAM_BEARER_PREFIX=%s\n" "$(k6_env_or_profile K6_UPSTREAM_BEARER_PREFIX upstream_bearer_prefix at_)"
+    printf "K6_UPSTREAM_PATH_PREFIX=%s\n" "$(k6_env_or_profile K6_UPSTREAM_PATH_PREFIX upstream_path_prefix /test/load/resource/proxy)"
+    printf "K6_PROXY_METHOD=%s\n" "$(k6_env_or_profile K6_PROXY_METHOD proxy_method GET)"
+    printf "K6_SPIKE_BASE_RATE=%s\n" "$(k6_env_or_profile K6_SPIKE_BASE_RATE spike_base_rate "$(k6_env_or_profile K6_RATE rate 100)")"
+    printf "K6_SPIKE_RATE=%s\n" "$(k6_env_or_profile K6_SPIKE_RATE spike_rate 300)"
+    printf "K6_SPIKE_RAMP_UP=%s\n" "$(k6_env_or_profile K6_SPIKE_RAMP_UP spike_ramp_up 1m)"
+    printf "K6_SPIKE_HOLD=%s\n" "$(k6_env_or_profile K6_SPIKE_HOLD spike_hold 3m)"
+    printf "K6_SPIKE_RAMP_DOWN=%s\n" "$(k6_env_or_profile K6_SPIKE_RAMP_DOWN spike_ramp_down 1m)"
+    printf "K6_SPIKE_RECOVERY=%s\n" "$(k6_env_or_profile K6_SPIKE_RECOVERY spike_recovery 3m)"
+  } > "$env_file"
+
+  kubectl -n "$namespace" create configmap "$configmap_name" \
+    --from-env-file="$env_file" \
+    --dry-run=client -o yaml > "$tmp/k6-env.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/k6-env.yaml"
+  kubectl -n "$namespace" label configmap "$configmap_name" \
+    app.kubernetes.io/name=k6 \
+    app.kubernetes.io/component=load-generator \
+    --overwrite >/dev/null
+}
+
+render_proxy_testrun() {
+  local name=$1
+  local parallelism=$2
+  local env_configmap=$3
+  cat > "$tmp/${name}.yaml" <<YAML
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: $name
+  labels:
+    app.kubernetes.io/name: k6
+    app.kubernetes.io/component: load-generator
+    loadtest.authproxy.io/scenario: proxy
+spec:
+  parallelism: $parallelism
+  arguments: --summary-export /tmp/summary.json
+  script:
+    configMap:
+      name: authproxy-loadtest-k6
+      file: proxy.js
+  runner:
+    image: $k6_image
+    metadata:
+      labels:
+        app.kubernetes.io/name: k6
+        app.kubernetes.io/component: load-generator
+        loadtest.authproxy.io/scenario: proxy
+    env:
+      - name: AUTHPROXY_BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: authproxy-loadtest-k6-auth
+            key: AUTHPROXY_BEARER_TOKEN
+      - name: K6_CONNECTIONS_FILE
+        value: ./connections.csv
+    envFrom:
+      - configMapRef:
+          name: $env_configmap
+YAML
+  printf "%s\n" "$tmp/${name}.yaml"
+}
+
+run_smoke() {
+  local connections_csv="$tmp/connections.csv"
+  printf "connection_id,connector_id\nsmoke,smoke\n" > "$connections_csv"
+  apply_k6_script_configmap "$connections_csv"
+
+  if [[ "$k6_mode" == "operator" ]]; then
+    if ! kubectl get crd testruns.k6.io >/dev/null 2>&1; then
+      loadtest_die "LOADTEST_K6_MODE=operator requested, but testruns.k6.io is not installed"
+    fi
+
+    loadtest_log "applying k6 smoke TestRun"
+    kubectl -n "$namespace" delete testrun authproxy-smoke --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-testrun.yaml"
+    loadtest_log "TestRun submitted; use collect to capture status and runner logs"
+  else
+    loadtest_log "running k6 smoke Job"
+    kubectl -n "$namespace" delete job authproxy-smoke-k6 --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/smoke-job.yaml"
+    kubectl -n "$namespace" set image job/authproxy-smoke-k6 "k6=$k6_image"
+    if ! kubectl -n "$namespace" wait --for=condition=complete job/authproxy-smoke-k6 "--timeout=$k6_timeout"; then
+      kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
+      loadtest_die "k6 smoke Job did not complete within $k6_timeout"
+    fi
+    kubectl -n "$namespace" logs job/authproxy-smoke-k6 > "$run_dir/k6/smoke.log" 2>&1 || true
+
+    local pod
+    pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-smoke-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "$pod" ]]; then
+      kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/summary.json" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+wait_for_testrun() {
+  local name=$1
+  local timeout_seconds=${LOADTEST_K6_OPERATOR_WAIT_SECONDS:-3600}
+  local deadline=$((SECONDS + timeout_seconds))
+  local stage=""
+
+  loadtest_log "waiting for TestRun $name to finish"
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    stage=$(kubectl -n "$namespace" get testrun "$name" -o jsonpath='{.status.stage}' 2>/dev/null || true)
+    case "$stage" in
+      finished)
+        kubectl -n "$namespace" get testrun "$name" -o yaml > "$run_dir/k6/${name}-status.yaml" 2>&1 || true
+        return
+        ;;
+      error)
+        kubectl -n "$namespace" get testrun "$name" -o yaml > "$run_dir/k6/${name}-status.yaml" 2>&1 || true
+        loadtest_die "TestRun $name entered error stage"
+        ;;
+    esac
+    sleep 10
+  done
+
+  kubectl -n "$namespace" get testrun "$name" -o yaml > "$run_dir/k6/${name}-status.yaml" 2>&1 || true
+  loadtest_die "TestRun $name did not finish within ${timeout_seconds}s; last stage: ${stage:-unknown}"
+}
+
+run_proxy_once() {
+  local scenario_name=$1
+  local api_replicas=${2:-configured}
+  local proxy_mode
+  local shape
+  local run_name
+
+  proxy_mode=$(proxy_mode_for_scenario "$scenario_name")
+  shape=$(shape_for_scenario "$scenario_name")
+  run_name=$(loadtest_sanitize_k8s_name "authproxy-${scenario_name}-${api_replicas}")
+
+  if [[ "$k6_mode" == "operator" ]]; then
+    if ! kubectl get crd testruns.k6.io >/dev/null 2>&1; then
+      loadtest_die "LOADTEST_K6_MODE=operator requested, but testruns.k6.io is not installed"
+    fi
+
+    local parallelism
+    local env_configmap
+    parallelism=$(k6_env_or_profile K6_PARALLELISM parallelism 1)
+    env_configmap=$(loadtest_sanitize_k8s_name "authproxy-loadtest-k6-env-${run_name}")
+    apply_k6_env_configmap "$scenario_name" "$proxy_mode" "$shape" "$api_replicas" "$env_configmap"
+    local testrun_manifest
+    testrun_manifest=$(render_proxy_testrun "$run_name" "$parallelism" "$env_configmap")
+    loadtest_log "submitting k6 TestRun $run_name with parallelism=$parallelism"
+    kubectl -n "$namespace" delete testrun "$run_name" --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "$namespace" apply -f "$testrun_manifest"
+    cp "$testrun_manifest" "$run_dir/k6/${run_name}.yaml"
+    if [[ "${LOADTEST_K6_WAIT:-false}" == "true" ]]; then
+      wait_for_testrun "$run_name"
+    fi
+    loadtest_log "TestRun submitted; use collect to capture status and runner logs"
+  else
+    apply_k6_env_configmap "$scenario_name" "$proxy_mode" "$shape" "$api_replicas"
+    loadtest_log "running k6 proxy Job for $scenario_name"
+    kubectl -n "$namespace" delete job authproxy-proxy-k6 --ignore-not-found=true >/dev/null 2>&1 || true
+    kubectl -n "$namespace" apply -f "$LOADTEST_ROOT/k8s/k6/proxy-job.yaml"
+    kubectl -n "$namespace" set image job/authproxy-proxy-k6 "k6=$k6_image"
+    if ! kubectl -n "$namespace" wait --for=condition=complete job/authproxy-proxy-k6 "--timeout=$k6_timeout"; then
+      kubectl -n "$namespace" logs job/authproxy-proxy-k6 > "$run_dir/k6/${run_name}.log" 2>&1 || true
+      loadtest_die "k6 proxy Job did not complete within $k6_timeout"
+    fi
+    kubectl -n "$namespace" logs job/authproxy-proxy-k6 > "$run_dir/k6/${run_name}.log" 2>&1 || true
+
+    local pod
+    pod=$(kubectl -n "$namespace" get pod -l job-name=authproxy-proxy-k6 -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "$pod" ]]; then
+      kubectl -n "$namespace" cp "$pod:/artifacts/summary.json" "$run_dir/k6/${run_name}-summary.json" >/dev/null 2>&1 || true
+      record_scale_result "$api_replicas" "$scenario_name" "$run_dir/k6/${run_name}-summary.json" "$run_dir/k6/${run_name}.log"
+    fi
+  fi
+}
+
+record_scale_result() {
+  local replicas=$1
+  local scenario_name=$2
+  local summary_file=$3
+  local log_file=$4
+  local results_file="$run_dir/k6/scale-results.tsv"
+
+  if [[ ! -f "$results_file" ]]; then
+    printf "api_replicas\tscenario\titerations_per_second\thttp_req_duration_p95_ms\thttp_req_failed_rate\tdropped_iterations\tmax_vus\tlog_file\tsummary_file\n" > "$results_file"
+  fi
+
+  if command -v jq >/dev/null 2>&1 && [[ -f "$summary_file" ]]; then
+    jq -r \
+      --arg replicas "$replicas" \
+      --arg scenario "$scenario_name" \
+      --arg log "$log_file" \
+      --arg summary "$summary_file" '
+        [
+          $replicas,
+          $scenario,
+          (.metrics.iterations.rate // .metrics.iterations.values.rate // ""),
+          (.metrics.http_req_duration.values["p(95)"] // .metrics.http_req_duration["p(95)"] // ""),
+          (.metrics.http_req_failed.rate // .metrics.http_req_failed.values.rate // ""),
+          (.metrics.dropped_iterations.count // .metrics.dropped_iterations.values.count // 0),
+          (.metrics.vus_max.max // .metrics.vus_max.values.max // ""),
+          $log,
+          $summary
+        ] | @tsv
+      ' "$summary_file" >> "$results_file" || printf "%s\t%s\t\t\t\t\t\t%s\t%s\n" "$replicas" "$scenario_name" "$log_file" "$summary_file" >> "$results_file"
+  else
+    printf "%s\t%s\t\t\t\t\t\t%s\t%s\n" "$replicas" "$scenario_name" "$log_file" "$summary_file" >> "$results_file"
+  fi
+}
+
+set_api_replicas() {
+  local replicas=$1
+  local timeout=${LOADTEST_SCALE_TIMEOUT:-5m}
+
+  loadtest_log "setting authproxy-api replicas to $replicas"
+  if kubectl -n "$namespace" get hpa authproxy-api >/dev/null 2>&1; then
+    kubectl -n "$namespace" patch hpa authproxy-api --type merge -p "{\"spec\":{\"minReplicas\":$replicas,\"maxReplicas\":$replicas}}"
+  else
+    kubectl -n "$namespace" scale deployment/authproxy-api "--replicas=$replicas"
+  fi
+  kubectl -n "$namespace" rollout status deployment/authproxy-api "--timeout=$timeout"
+}
+
+run_proxy_suite() {
+  local connections_csv
+  local token
+  connections_csv=$(prepare_connections_dataset)
+  apply_k6_script_configmap "$connections_csv"
+  token=$(mint_proxy_token)
+  apply_k6_auth_secret "$token"
+
+  case "$scenario" in
+    proxy-raw|proxy-wrapped|proxy-soak|proxy-spike)
+      run_proxy_once "$scenario"
+      ;;
+    proxy-scale)
+      local scale_scenario=${LOADTEST_PROXY_SCALE_SCENARIO:-proxy-raw}
+      local -a replicas=()
+      local replica_count
+      while IFS= read -r replica_count; do
+        [[ -n "$replica_count" ]] && replicas+=("$replica_count")
+      done < <(loadtest_yaml_section_list "$profile_file" k6 scale_replicas)
+      if [[ "${#replicas[@]}" -eq 0 ]]; then
+        loadtest_die "profile $profile_name has no k6.scale_replicas entries"
+      fi
+      if [[ "$k6_mode" == "operator" && -z "${LOADTEST_K6_WAIT:-}" ]]; then
+        export LOADTEST_K6_WAIT=true
+      fi
+      for replica_count in "${replicas[@]}"; do
+        set_api_replicas "$replica_count"
+        run_proxy_once "$scale_scenario" "$replica_count"
+      done
+      ;;
+    *)
+      loadtest_die "unsupported proxy scenario: $scenario"
+      ;;
+  esac
+}
+
+case "$scenario" in
+  smoke)
+    run_smoke
+    ;;
+  proxy-raw|proxy-wrapped|proxy-scale|proxy-soak|proxy-spike)
+    run_proxy_suite
+    ;;
+  *)
+    loadtest_die "unsupported scenario: $scenario"
+    ;;
+esac
 
 loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 loadtest_capture_helm_snapshot "$namespace" "$run_dir"

--- a/loadtest/scripts/up
+++ b/loadtest/scripts/up
@@ -16,7 +16,7 @@ loadtest_require_cmd openssl
 
 authproxy_repo=${AUTHPROXY_IMAGE_REPOSITORY:-ghcr.io/rmorlok/authproxy}
 authproxy_tag=${AUTHPROXY_IMAGE_TAG:-main}
-provider_image=${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3}
+provider_image=${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server:master}
 helm_timeout=${LOADTEST_HELM_TIMEOUT:-5m}
 
 loadtest_log "profile: $profile_name"


### PR DESCRIPTION
## Summary
- Add a reusable k6 proxy scenario for raw and wrapped AuthProxy calls, seeded connection datasets, constant/spike arrival shapes, and p95/5xx/dropped-iteration thresholds.
- Extend the load-test runner for proxy-raw, proxy-wrapped, proxy-scale, proxy-soak, and proxy-spike in Job or k6 Operator mode.
- Update profiles, collection/cleanup, provider image defaults, and README guidance for proxy-QPS runs.

## Verification
- bash -n loadtest/scripts/lib/loadtest.sh loadtest/scripts/run loadtest/scripts/collect loadtest/scripts/down loadtest/scripts/up loadtest/scripts/seed
- node --check loadtest/k6/proxy.js
- git diff --check
- ./scripts/preflight.sh

Closes #712