### PR TITLE
Add load-test background scenarios

### DIFF
--- a/cmd/server/loadtest_background.go
+++ b/cmd/server/loadtest_background.go
@@ -1,0 +1,558 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/loadtest/seeder"
+	"github.com/rmorlok/authproxy/internal/service"
+	"github.com/rmorlok/authproxy/internal/util/pagination"
+	"github.com/spf13/cobra"
+)
+
+const (
+	loadtestScenarioRefreshSweep        = "refresh-sweep"
+	loadtestScenarioSchedulerSync       = "scheduler-sync"
+	loadtestScenarioResourceSnapshot    = "resource-snapshot"
+	loadtestScenarioStaleSetupCleanup   = "stale-setup-cleanup"
+	loadtestScenarioProbeOutcomeCleanup = "probe-outcome-cleanup"
+
+	taskTypeRefreshExpiringOAuthTokens = "oauth2:refresh_expiring_oauth_tokens"
+	taskTypeResourceSnapshot           = "app_metrics:resource_snapshot"
+	taskTypeCleanupStaleConnections    = "database:cleanup_stale_connections"
+	taskTypeProbeOutcomeCleanup        = "core:probe_outcome_cleanup"
+
+	defaultLoadtestQueue = "default"
+)
+
+type loadtestBackgroundSummary struct {
+	ProfileName             string                 `json:"profile_name,omitempty"`
+	Scenario                string                 `json:"scenario"`
+	Queue                   string                 `json:"queue,omitempty"`
+	Percent                 *int                   `json:"percent,omitempty"`
+	TaskType                string                 `json:"task_type,omitempty"`
+	TaskID                  string                 `json:"task_id,omitempty"`
+	TaskQueue               string                 `json:"task_queue,omitempty"`
+	ExpectedExpiringTokens  int                    `json:"expected_expiring_tokens,omitempty"`
+	SchedulerTaskConfigs    int                    `json:"scheduler_task_configs,omitempty"`
+	SchedulerProbeTasks     int                    `json:"scheduler_probe_tasks,omitempty"`
+	StartedAt               time.Time              `json:"started_at"`
+	FinishedAt              time.Time              `json:"finished_at"`
+	DurationSeconds         float64                `json:"duration_seconds"`
+	EnqueueDurationSeconds  float64                `json:"enqueue_duration_seconds,omitempty"`
+	WaitDurationSeconds     float64                `json:"wait_duration_seconds,omitempty"`
+	ProcessedDelta          int                    `json:"processed_delta,omitempty"`
+	FailedDelta             int                    `json:"failed_delta,omitempty"`
+	ProcessedRatePerSecond  float64                `json:"processed_rate_per_second,omitempty"`
+	Before                  *loadtestQueueSnapshot `json:"before,omitempty"`
+	After                   *loadtestQueueSnapshot `json:"after,omitempty"`
+	MaxObserved             *loadtestQueueSnapshot `json:"max_observed,omitempty"`
+	MemoryBefore            loadtestMemorySnapshot `json:"memory_before"`
+	MemoryAfter             loadtestMemorySnapshot `json:"memory_after"`
+	MemoryDeltaAllocBytes   int64                  `json:"memory_delta_alloc_bytes"`
+	MemoryDeltaSysBytes     int64                  `json:"memory_delta_sys_bytes"`
+	SchedulerTaskTypeCounts map[string]int         `json:"scheduler_task_type_counts,omitempty"`
+	Artifacts               map[string]string      `json:"artifacts,omitempty"`
+}
+
+type loadtestQueueSnapshot struct {
+	CapturedAt       time.Time `json:"captured_at"`
+	Queue            string    `json:"queue"`
+	Size             int       `json:"size"`
+	Pending          int       `json:"pending"`
+	Active           int       `json:"active"`
+	Scheduled        int       `json:"scheduled"`
+	Retry            int       `json:"retry"`
+	Archived         int       `json:"archived"`
+	Completed        int       `json:"completed"`
+	Aggregating      int       `json:"aggregating"`
+	Processed        int       `json:"processed"`
+	Failed           int       `json:"failed"`
+	ProcessedTotal   int       `json:"processed_total"`
+	FailedTotal      int       `json:"failed_total"`
+	MemoryUsage      int64     `json:"memory_usage"`
+	LatencySeconds   float64   `json:"latency_seconds"`
+	InFlightAndRetry int       `json:"in_flight_and_retry"`
+}
+
+type loadtestMemorySnapshot struct {
+	AllocBytes      uint64 `json:"alloc_bytes"`
+	TotalAllocBytes uint64 `json:"total_alloc_bytes"`
+	SysBytes        uint64 `json:"sys_bytes"`
+	HeapAllocBytes  uint64 `json:"heap_alloc_bytes"`
+	HeapSysBytes    uint64 `json:"heap_sys_bytes"`
+	NumGC           uint32 `json:"num_gc"`
+}
+
+func cmdLoadtestBackground() *cobra.Command {
+	var profilePath string
+	var runDir string
+	var scenario string
+	var queue string
+	var percent int
+	var waitForDrain bool
+	var drainTimeout time.Duration
+	var pollInterval time.Duration
+	var taskRetention time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "loadtest-background",
+		Short: "Run AuthProxy load-test background job scenarios",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if scenario == "" {
+				return fmt.Errorf("--scenario is required")
+			}
+			if queue == "" {
+				queue = defaultLoadtestQueue
+			}
+
+			var profile seeder.Profile
+			if profilePath != "" {
+				loaded, err := seeder.LoadProfile(profilePath)
+				if err != nil {
+					return fmt.Errorf("failed to load profile: %w", err)
+				}
+				profile = loaded
+			}
+
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			dm := service.NewDependencyManager("loadtest-background", cfg)
+			defer dm.ShutdownTelemetry()
+			defer dm.ShutdownDatabase()
+
+			enc := dm.GetEncryptService()
+			defer enc.Shutdown()
+			if err := enc.SyncKeysFromDbToMemory(ctx); err != nil {
+				return fmt.Errorf("failed to sync encryption keys: %w", err)
+			}
+
+			runner := loadtestBackgroundRunner{
+				dm:            dm,
+				profile:       profile,
+				runDir:        runDir,
+				queue:         queue,
+				percent:       percent,
+				waitForDrain:  waitForDrain,
+				drainTimeout:  drainTimeout,
+				pollInterval:  pollInterval,
+				taskRetention: taskRetention,
+			}
+
+			summary, err := runner.run(ctx, scenario)
+			if err != nil {
+				return err
+			}
+
+			if err := runner.writeSummary(summary); err != nil {
+				return err
+			}
+
+			encoded, err := json.MarshalIndent(summary, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(encoded))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&profilePath, "profile", "", "load-test profile YAML")
+	cmd.Flags().StringVar(&runDir, "run-dir", "", "artifact directory to populate")
+	cmd.Flags().StringVar(&scenario, "scenario", "", "scenario: refresh-sweep, scheduler-sync, resource-snapshot, stale-setup-cleanup, probe-outcome-cleanup")
+	cmd.Flags().StringVar(&queue, "queue", defaultLoadtestQueue, "Asynq queue to inspect")
+	cmd.Flags().IntVar(&percent, "percent", 0, "profile percentage currently under test; used for artifact metadata")
+	cmd.Flags().BoolVar(&waitForDrain, "wait-drain", true, "wait for the queue to return to its baseline pending/active/retry counts")
+	cmd.Flags().DurationVar(&drainTimeout, "drain-timeout", 30*time.Minute, "maximum time to wait for worker drain")
+	cmd.Flags().DurationVar(&pollInterval, "poll-interval", 5*time.Second, "queue polling interval while waiting for drain")
+	cmd.Flags().DurationVar(&taskRetention, "task-retention", 24*time.Hour, "retention to apply to load-test trigger tasks")
+	return cmd
+}
+
+type loadtestBackgroundRunner struct {
+	dm            *service.DependencyManager
+	profile       seeder.Profile
+	runDir        string
+	queue         string
+	percent       int
+	waitForDrain  bool
+	drainTimeout  time.Duration
+	pollInterval  time.Duration
+	taskRetention time.Duration
+	queueSamples  []loadtestQueueSnapshot
+}
+
+func (r *loadtestBackgroundRunner) run(ctx context.Context, scenario string) (*loadtestBackgroundSummary, error) {
+	startedAt := time.Now().UTC()
+	memBefore := readLoadtestMemory()
+	summary := &loadtestBackgroundSummary{
+		ProfileName:  r.profile.Name,
+		Scenario:     scenario,
+		Queue:        r.queue,
+		StartedAt:    startedAt,
+		MemoryBefore: memBefore,
+		Artifacts:    map[string]string{},
+	}
+	if r.percent > 0 {
+		pct := r.percent
+		summary.Percent = &pct
+	}
+
+	var err error
+	switch scenario {
+	case loadtestScenarioRefreshSweep:
+		summary.ExpectedExpiringTokens, err = r.countExpiringOAuthTokens(ctx)
+		if err == nil {
+			err = r.runEnqueueScenario(ctx, summary, taskTypeRefreshExpiringOAuthTokens, nil)
+		}
+	case loadtestScenarioResourceSnapshot:
+		err = r.runEnqueueScenario(ctx, summary, taskTypeResourceSnapshot, nil)
+	case loadtestScenarioStaleSetupCleanup:
+		err = r.runEnqueueScenario(ctx, summary, taskTypeCleanupStaleConnections, nil)
+	case loadtestScenarioProbeOutcomeCleanup:
+		err = r.runEnqueueScenario(ctx, summary, taskTypeProbeOutcomeCleanup, []byte(`{"retention_seconds":0}`))
+	case loadtestScenarioSchedulerSync:
+		err = r.runSchedulerSync(ctx, summary)
+	default:
+		err = fmt.Errorf("unknown background load-test scenario: %s", scenario)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	finishedAt := time.Now().UTC()
+	memAfter := readLoadtestMemory()
+	summary.FinishedAt = finishedAt
+	summary.DurationSeconds = finishedAt.Sub(startedAt).Seconds()
+	summary.MemoryAfter = memAfter
+	summary.MemoryDeltaAllocBytes = int64(memAfter.AllocBytes) - int64(memBefore.AllocBytes)
+	summary.MemoryDeltaSysBytes = int64(memAfter.SysBytes) - int64(memBefore.SysBytes)
+	return summary, nil
+}
+
+func (r *loadtestBackgroundRunner) runEnqueueScenario(ctx context.Context, summary *loadtestBackgroundSummary, taskType string, payload []byte) error {
+	inspector := r.dm.GetAsyncInspector()
+	before, err := r.queueSnapshot(inspector, summary.Queue)
+	if err != nil {
+		return fmt.Errorf("capture queue before scenario: %w", err)
+	}
+	summary.Before = before
+	r.queueSamples = append(r.queueSamples, *before)
+
+	task := asynq.NewTask(taskType, payload)
+	enqueueOpts := []asynq.Option{asynq.Retention(r.taskRetention)}
+	if r.queue != "" {
+		enqueueOpts = append(enqueueOpts, asynq.Queue(r.queue))
+	}
+	enqueueStart := time.Now()
+	info, err := r.dm.GetAsyncClient().EnqueueContext(ctx, task, enqueueOpts...)
+	if err != nil {
+		return fmt.Errorf("enqueue %s: %w", taskType, err)
+	}
+	summary.EnqueueDurationSeconds = time.Since(enqueueStart).Seconds()
+	summary.TaskType = taskType
+	summary.TaskID = info.ID
+	summary.TaskQueue = info.Queue
+
+	if r.waitForDrain {
+		waitStart := time.Now()
+		maxObserved, err := r.waitForQueueDrain(ctx, inspector, before)
+		if err != nil {
+			return err
+		}
+		summary.WaitDurationSeconds = time.Since(waitStart).Seconds()
+		summary.MaxObserved = maxObserved
+	}
+
+	after, err := r.queueSnapshot(inspector, summary.Queue)
+	if err != nil {
+		return fmt.Errorf("capture queue after scenario: %w", err)
+	}
+	summary.After = after
+	r.queueSamples = append(r.queueSamples, *after)
+	summary.ProcessedDelta = after.ProcessedTotal - before.ProcessedTotal
+	summary.FailedDelta = after.FailedTotal - before.FailedTotal
+	if summary.WaitDurationSeconds > 0 {
+		summary.ProcessedRatePerSecond = float64(summary.ProcessedDelta) / summary.WaitDurationSeconds
+	}
+	return nil
+}
+
+func (r *loadtestBackgroundRunner) runSchedulerSync(ctx context.Context, summary *loadtestBackgroundSummary) error {
+	before, err := r.queueSnapshot(r.dm.GetAsyncInspector(), summary.Queue)
+	if err == nil {
+		summary.Before = before
+		r.queueSamples = append(r.queueSamples, *before)
+	}
+
+	start := time.Now()
+	configs := r.dm.GetCoreService().GetCronTasks()
+	summary.WaitDurationSeconds = time.Since(start).Seconds()
+	summary.SchedulerTaskConfigs = len(configs)
+	typeCounts := make(map[string]int)
+	cronspecCounts := make(map[string]map[string]int)
+	for _, cfg := range configs {
+		if cfg == nil || cfg.Task == nil {
+			continue
+		}
+		taskType := cfg.Task.Type()
+		typeCounts[taskType]++
+		if taskType == "core:probe" {
+			summary.SchedulerProbeTasks++
+		}
+		if _, ok := cronspecCounts[taskType]; !ok {
+			cronspecCounts[taskType] = make(map[string]int)
+		}
+		cronspecCounts[taskType][cfg.Cronspec]++
+	}
+	summary.SchedulerTaskTypeCounts = typeCounts
+	path, err := r.writeSchedulerTasks(cronspecCounts)
+	if err != nil {
+		return err
+	}
+	if path != "" {
+		summary.Artifacts["scheduler_task_configs"] = path
+	}
+
+	after, err := r.queueSnapshot(r.dm.GetAsyncInspector(), summary.Queue)
+	if err == nil {
+		summary.After = after
+		r.queueSamples = append(r.queueSamples, *after)
+	}
+	return ctx.Err()
+}
+
+func (r *loadtestBackgroundRunner) countExpiringOAuthTokens(ctx context.Context) (int, error) {
+	refreshWithin := r.dm.GetConfigRoot().Oauth.GetRefreshTokensTimeBeforeExpiryOrDefault()
+	total := 0
+	err := r.dm.GetDatabase().EnumerateOAuth2TokensExpiringWithin(
+		ctx,
+		refreshWithin,
+		func(tokens []*database.OAuth2TokenWithConnection, lastPage bool) (pagination.KeepGoing, error) {
+			total += len(tokens)
+			return pagination.Continue, nil
+		},
+	)
+	return total, err
+}
+
+func (r *loadtestBackgroundRunner) waitForQueueDrain(ctx context.Context, inspector *asynq.Inspector, baseline *loadtestQueueSnapshot) (*loadtestQueueSnapshot, error) {
+	deadline := time.Now().Add(r.drainTimeout)
+	maxObserved := *baseline
+	poll := r.pollInterval
+	if poll <= 0 {
+		poll = 5 * time.Second
+	}
+	for {
+		current, err := r.queueSnapshot(inspector, baseline.Queue)
+		if err != nil {
+			return nil, fmt.Errorf("capture queue while waiting for drain: %w", err)
+		}
+		r.queueSamples = append(r.queueSamples, *current)
+		maxObserved = maxQueueSnapshot(maxObserved, *current)
+
+		if queueAtOrBelowBaseline(current, baseline) && queueProgressed(current, baseline) {
+			return &maxObserved, nil
+		}
+		if time.Now().After(deadline) {
+			return &maxObserved, fmt.Errorf(
+				"queue %s did not drain within %s: pending=%d active=%d retry=%d baseline_pending=%d baseline_active=%d baseline_retry=%d",
+				baseline.Queue,
+				r.drainTimeout,
+				current.Pending,
+				current.Active,
+				current.Retry,
+				baseline.Pending,
+				baseline.Active,
+				baseline.Retry,
+			)
+		}
+
+		timer := time.NewTimer(poll)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return &maxObserved, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *loadtestBackgroundRunner) queueSnapshot(inspector *asynq.Inspector, queue string) (*loadtestQueueSnapshot, error) {
+	qi, err := inspector.GetQueueInfo(queue)
+	if err != nil {
+		return nil, err
+	}
+	return &loadtestQueueSnapshot{
+		CapturedAt:       time.Now().UTC(),
+		Queue:            qi.Queue,
+		Size:             qi.Size,
+		Pending:          qi.Pending,
+		Active:           qi.Active,
+		Scheduled:        qi.Scheduled,
+		Retry:            qi.Retry,
+		Archived:         qi.Archived,
+		Completed:        qi.Completed,
+		Aggregating:      qi.Aggregating,
+		Processed:        qi.Processed,
+		Failed:           qi.Failed,
+		ProcessedTotal:   qi.ProcessedTotal,
+		FailedTotal:      qi.FailedTotal,
+		MemoryUsage:      qi.MemoryUsage,
+		LatencySeconds:   qi.Latency.Seconds(),
+		InFlightAndRetry: qi.Pending + qi.Active + qi.Retry,
+	}, nil
+}
+
+func queueAtOrBelowBaseline(current, baseline *loadtestQueueSnapshot) bool {
+	return current.Pending <= baseline.Pending &&
+		current.Active <= baseline.Active &&
+		current.Retry <= baseline.Retry
+}
+
+func queueProgressed(current, baseline *loadtestQueueSnapshot) bool {
+	return current.ProcessedTotal > baseline.ProcessedTotal ||
+		current.FailedTotal > baseline.FailedTotal
+}
+
+func maxQueueSnapshot(a, b loadtestQueueSnapshot) loadtestQueueSnapshot {
+	result := a
+	if b.Size > result.Size {
+		result.Size = b.Size
+	}
+	if b.Pending > result.Pending {
+		result.Pending = b.Pending
+	}
+	if b.Active > result.Active {
+		result.Active = b.Active
+	}
+	if b.Scheduled > result.Scheduled {
+		result.Scheduled = b.Scheduled
+	}
+	if b.Retry > result.Retry {
+		result.Retry = b.Retry
+	}
+	if b.MemoryUsage > result.MemoryUsage {
+		result.MemoryUsage = b.MemoryUsage
+	}
+	if b.InFlightAndRetry > result.InFlightAndRetry {
+		result.InFlightAndRetry = b.InFlightAndRetry
+	}
+	result.CapturedAt = b.CapturedAt
+	return result
+}
+
+func readLoadtestMemory() loadtestMemorySnapshot {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return loadtestMemorySnapshot{
+		AllocBytes:      stats.Alloc,
+		TotalAllocBytes: stats.TotalAlloc,
+		SysBytes:        stats.Sys,
+		HeapAllocBytes:  stats.HeapAlloc,
+		HeapSysBytes:    stats.HeapSys,
+		NumGC:           stats.NumGC,
+	}
+}
+
+func (r *loadtestBackgroundRunner) writeSummary(summary *loadtestBackgroundSummary) error {
+	if r.runDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(r.runDir, 0o755); err != nil {
+		return err
+	}
+	if len(r.queueSamples) > 0 {
+		path := filepath.Join(r.runDir, "queue-samples.tsv")
+		if err := r.writeQueueSamples(path); err != nil {
+			return err
+		}
+		summary.Artifacts["queue_samples"] = path
+	}
+	path := filepath.Join(r.runDir, "background-summary.json")
+	summary.Artifacts["summary"] = path
+	encoded, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *loadtestBackgroundRunner) writeQueueSamples(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	fmt.Fprintln(file, "captured_at\tqueue\tsize\tpending\tactive\tscheduled\tretry\tarchived\tcompleted\taggregating\tprocessed\tfailed\tprocessed_total\tfailed_total\tmemory_usage\tlatency_seconds\tin_flight_and_retry")
+	for _, s := range r.queueSamples {
+		fmt.Fprintf(file, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.6f\t%d\n",
+			s.CapturedAt.Format(time.RFC3339Nano),
+			s.Queue,
+			s.Size,
+			s.Pending,
+			s.Active,
+			s.Scheduled,
+			s.Retry,
+			s.Archived,
+			s.Completed,
+			s.Aggregating,
+			s.Processed,
+			s.Failed,
+			s.ProcessedTotal,
+			s.FailedTotal,
+			s.MemoryUsage,
+			s.LatencySeconds,
+			s.InFlightAndRetry,
+		)
+	}
+	return nil
+}
+
+func (r *loadtestBackgroundRunner) writeSchedulerTasks(counts map[string]map[string]int) (string, error) {
+	if r.runDir == "" {
+		return "", nil
+	}
+	if err := os.MkdirAll(r.runDir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(r.runDir, "scheduler-task-configs.tsv")
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	fmt.Fprintln(file, "task_type\tcronspec\tcount")
+
+	taskTypes := make([]string, 0, len(counts))
+	for taskType := range counts {
+		taskTypes = append(taskTypes, taskType)
+	}
+	sort.Strings(taskTypes)
+	for _, taskType := range taskTypes {
+		cronspecs := make([]string, 0, len(counts[taskType]))
+		for cronspec := range counts[taskType] {
+			cronspecs = append(cronspecs, cronspec)
+		}
+		sort.Strings(cronspecs)
+		for _, cronspec := range cronspecs {
+			fmt.Fprintf(file, "%s\t%s\t%d\n", taskType, cronspec, counts[taskType][cronspec])
+		}
+	}
+	return path, nil
+}

--- a/cmd/server/loadtest_seed.go
+++ b/cmd/server/loadtest_seed.go
@@ -21,6 +21,7 @@ func cmdLoadtestSeed() *cobra.Command {
 	var progressEvery int
 	var oauthExpiringPercent int
 	var periodicProbePercent int
+	var staleSetupConnections int
 
 	cmd := &cobra.Command{
 		Use:   "loadtest-seed",
@@ -76,17 +77,22 @@ func cmdLoadtestSeed() *cobra.Command {
 			if cmd.Flags().Changed("periodic-probe-percent") {
 				probeOverride = &periodicProbePercent
 			}
+			var staleSetupOverride *int
+			if cmd.Flags().Changed("stale-setup-connections") {
+				staleSetupOverride = &staleSetupConnections
+			}
 
 			result, err := seeder.Seed(ctx, seeder.Options{
-				Profile:              profile,
-				DB:                   dm.GetDatabase(),
-				Encrypt:              enc,
-				ProviderBaseURL:      providerBaseURL,
-				OAuthExpiringPercent: oauthOverride,
-				PeriodicProbePercent: probeOverride,
-				VerifySamples:        verifySamples,
-				ProgressEvery:        progressEvery,
-				Now:                  time.Now().UTC(),
+				Profile:               profile,
+				DB:                    dm.GetDatabase(),
+				Encrypt:               enc,
+				ProviderBaseURL:       providerBaseURL,
+				OAuthExpiringPercent:  oauthOverride,
+				PeriodicProbePercent:  probeOverride,
+				StaleSetupConnections: staleSetupOverride,
+				VerifySamples:         verifySamples,
+				ProgressEvery:         progressEvery,
+				Now:                   time.Now().UTC(),
 				Logf: func(format string, args ...any) {
 					fmt.Printf("[loadtest-seed] "+format+"\n", args...)
 				},
@@ -123,6 +129,7 @@ func cmdLoadtestSeed() *cobra.Command {
 	cmd.Flags().IntVar(&progressEvery, "progress-every", 1000, "log progress every N connections")
 	cmd.Flags().IntVar(&oauthExpiringPercent, "oauth-expiring-percent", 0, "override percent of tokens expiring inside the refresh window")
 	cmd.Flags().IntVar(&periodicProbePercent, "periodic-probe-percent", 0, "override percent of connections marked for periodic probes")
+	cmd.Flags().IntVar(&staleSetupConnections, "stale-setup-connections", 0, "override number of setup-state connections to seed for stale cleanup runs")
 
 	return cmd
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -173,5 +173,6 @@ func main() {
 	rootCmd.AddCommand(cmdServe())
 	rootCmd.AddCommand(cmdReencrypt())
 	rootCmd.AddCommand(cmdLoadtestSeed())
+	rootCmd.AddCommand(cmdLoadtestBackground())
 	rootCmd.Execute()
 }

--- a/internal/loadtest/seeder/artifacts.go
+++ b/internal/loadtest/seeder/artifacts.go
@@ -25,6 +25,9 @@ func WriteArtifacts(runDir string, result *Result) error {
 	if err := writeConnectionsCSV(filepath.Join(datasetsDir, "connections.csv"), result.Connections); err != nil {
 		return err
 	}
+	if err := writeConnectionsCSV(filepath.Join(datasetsDir, "stale_setup_connections.csv"), result.StaleSetups); err != nil {
+		return err
+	}
 	if err := writeNamespacesCSV(filepath.Join(datasetsDir, "namespaces.csv"), result.Namespaces); err != nil {
 		return err
 	}
@@ -51,6 +54,9 @@ Tenant namespaces requested: %d
 Connections requested: %d
 Connections created: %d
 Connections already present: %d
+Stale setup connections requested: %d
+Stale setup connections created: %d
+Stale setup connections already present: %d
 OAuth2 tokens upserted: %d
 OAuth expiring percent: %d
 Periodic probe percent: %d
@@ -59,6 +65,7 @@ Verified samples: %d
 
 Datasets:
   datasets/connections.csv
+  datasets/stale_setup_connections.csv
   datasets/namespaces.csv
   datasets/actors.csv
 `,
@@ -71,6 +78,9 @@ Datasets:
 		result.RequestedConnections,
 		result.CreatedConnections,
 		result.ExistingConnections,
+		result.RequestedStaleSetups,
+		result.CreatedStaleSetups,
+		result.ExistingStaleSetups,
 		result.UpsertedOAuthTokens,
 		result.OAuthExpiringPercent,
 		result.PeriodicProbePercent,

--- a/internal/loadtest/seeder/profile.go
+++ b/internal/loadtest/seeder/profile.go
@@ -19,6 +19,7 @@ type ProfileObjects struct {
 	NamespacesMin          int         `yaml:"namespaces_min" json:"namespaces_min,omitempty"`
 	NamespacesMax          int         `yaml:"namespaces_max" json:"namespaces_max,omitempty"`
 	Connections            int         `yaml:"connections" json:"connections"`
+	StaleSetupConnections  int         `yaml:"stale_setup_connections" json:"stale_setup_connections,omitempty"`
 	OAuthTokensExpiringPct PercentList `yaml:"oauth_tokens_expiring_percent" json:"oauth_tokens_expiring_percent,omitempty"`
 	PeriodicProbePct       PercentList `yaml:"periodic_probe_percent" json:"periodic_probe_percent,omitempty"`
 }
@@ -61,6 +62,9 @@ func LoadProfile(path string) (Profile, error) {
 	}
 	if profile.Objects.Connections < 0 {
 		return Profile{}, fmt.Errorf("profile connections must be non-negative")
+	}
+	if profile.Objects.StaleSetupConnections < 0 {
+		return Profile{}, fmt.Errorf("profile stale setup connections must be non-negative")
 	}
 	if profile.Namespace == "" {
 		profile.Namespace = "authproxy-load"

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -24,16 +24,17 @@ const (
 )
 
 type Options struct {
-	Profile              Profile
-	DB                   database.DB
-	Encrypt              encrypt.E
-	ProviderBaseURL      string
-	OAuthExpiringPercent *int
-	PeriodicProbePercent *int
-	VerifySamples        int
-	ProgressEvery        int
-	Now                  time.Time
-	Logf                 func(format string, args ...any)
+	Profile               Profile
+	DB                    database.DB
+	Encrypt               encrypt.E
+	ProviderBaseURL       string
+	OAuthExpiringPercent  *int
+	PeriodicProbePercent  *int
+	StaleSetupConnections *int
+	VerifySamples         int
+	ProgressEvery         int
+	Now                   time.Time
+	Logf                  func(format string, args ...any)
 }
 
 type Result struct {
@@ -44,6 +45,7 @@ type Result struct {
 	ConnectorVersion          uint64             `json:"connector_version"`
 	RequestedTenantNamespaces int                `json:"requested_tenant_namespaces"`
 	RequestedConnections      int                `json:"requested_connections"`
+	RequestedStaleSetups      int                `json:"requested_stale_setup_connections"`
 	OAuthExpiringPercent      int                `json:"oauth_expiring_percent"`
 	PeriodicProbePercent      int                `json:"periodic_probe_percent"`
 	StartedAt                 time.Time          `json:"started_at"`
@@ -52,12 +54,15 @@ type Result struct {
 	UpsertedActors            int                `json:"upserted_actors"`
 	CreatedConnections        int                `json:"created_connections"`
 	ExistingConnections       int                `json:"existing_connections"`
+	CreatedStaleSetups        int                `json:"created_stale_setup_connections"`
+	ExistingStaleSetups       int                `json:"existing_stale_setup_connections"`
 	UpsertedOAuthTokens       int                `json:"upserted_oauth_tokens"`
 	ProbeEnabledConnections   int                `json:"probe_enabled_connections"`
 	VerifiedSamples           []VerifiedSample   `json:"verified_samples"`
 	Namespaces                []NamespaceRecord  `json:"namespaces"`
 	Actors                    []ActorRecord      `json:"actors"`
 	Connections               []ConnectionRecord `json:"connections"`
+	StaleSetups               []ConnectionRecord `json:"stale_setup_connections"`
 }
 
 type NamespaceRecord struct {
@@ -119,6 +124,13 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 		periodicProbePercent = *opts.PeriodicProbePercent
 	}
 	periodicProbePercent = clampPercent(periodicProbePercent)
+	staleSetupConnections := opts.Profile.Objects.StaleSetupConnections
+	if opts.StaleSetupConnections != nil {
+		staleSetupConnections = *opts.StaleSetupConnections
+	}
+	if staleSetupConnections < 0 {
+		staleSetupConnections = 0
+	}
 	verifySamples := opts.VerifySamples
 	if verifySamples < 0 {
 		verifySamples = 0
@@ -145,6 +157,7 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 		ConnectorVersion:          connectorVersion,
 		RequestedTenantNamespaces: tenantCount,
 		RequestedConnections:      connectionCount,
+		RequestedStaleSetups:      staleSetupConnections,
 		OAuthExpiringPercent:      oauthExpiringPercent,
 		PeriodicProbePercent:      periodicProbePercent,
 		StartedAt:                 now,
@@ -201,7 +214,7 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 	result.UpsertedActors = len(actors)
 
 	logf("upserting load-test OAuth2 connector %s", connectorID)
-	connectorDef := connectorDefinition(connectorID, connectorVersion, baseNamespace, opts.Profile.Name, providerBaseURL, periodicProbePercent > 0)
+	connectorDef := connectorDefinition(connectorID, connectorVersion, baseNamespace, opts.Profile.Name, providerBaseURL)
 	connectorJSON, err := json.Marshal(connectorDef)
 	if err != nil {
 		return nil, fmt.Errorf("marshal connector definition: %w", err)
@@ -239,6 +252,9 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 	if connectionCount > 0 && len(tenantNamespaces) == 0 {
 		return nil, fmt.Errorf("profile requests connections but no namespaces")
 	}
+	if staleSetupConnections > 0 && len(tenantNamespaces) == 0 {
+		return nil, fmt.Errorf("profile requests stale setup connections but no namespaces")
+	}
 
 	logf("seeding %d connections", connectionCount)
 	for i := 1; i <= connectionCount; i++ {
@@ -273,6 +289,9 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 			}
 			result.CreatedConnections++
 		} else {
+			if _, err := opts.DB.UpdateConnectionLabels(ctx, connectionID, connection.Labels); err != nil {
+				return nil, fmt.Errorf("update connection labels %s: %w", connectionID, err)
+			}
 			result.ExistingConnections++
 		}
 
@@ -320,6 +339,60 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 
 		if i%progressEvery == 0 {
 			logf("seeded %d/%d connections", i, connectionCount)
+		}
+	}
+
+	if staleSetupConnections > 0 {
+		logf("seeding %d stale setup connections", staleSetupConnections)
+	}
+	for i := 1; i <= staleSetupConnections; i++ {
+		ns := tenantNamespaces[(i-1)%len(tenantNamespaces)]
+		actor := actors[(i-1)%len(actors)]
+		connectionID := apid.ID(fmt.Sprintf("%slt_%s_stale_%09d", apid.PrefixConnection, slug, i))
+		setupStep := cschema.MustNewSetupStep("loadtest_stale_setup")
+		connection := &database.Connection{
+			Id:               connectionID,
+			Namespace:        ns,
+			State:            database.ConnectionStateSetup,
+			HealthState:      database.ConnectionHealthStateHealthy,
+			ConnectorId:      connectorID,
+			ConnectorVersion: connectorVersion,
+			SetupStep:        &setupStep,
+			Labels:           staleSetupConnectionLabels(opts.Profile.Name, i),
+			Annotations: database.Annotations{
+				"loadtest.authproxy.io/generated-by": "loadtest-seeder",
+				"loadtest.authproxy.io/scenario":     "stale-setup-cleanup",
+			},
+		}
+		existing, err := opts.DB.GetConnection(ctx, connectionID)
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return nil, fmt.Errorf("get stale setup connection %s: %w", connectionID, err)
+		}
+		if existing == nil {
+			if err := opts.DB.CreateConnection(ctx, connection); err != nil {
+				return nil, fmt.Errorf("create stale setup connection %s: %w", connectionID, err)
+			}
+			result.CreatedStaleSetups++
+		} else {
+			if _, err := opts.DB.UpdateConnectionLabels(ctx, connectionID, connection.Labels); err != nil {
+				return nil, fmt.Errorf("update stale setup connection labels %s: %w", connectionID, err)
+			}
+			if err := opts.DB.SetConnectionSetupStep(ctx, connectionID, &setupStep); err != nil {
+				return nil, fmt.Errorf("update stale setup step %s: %w", connectionID, err)
+			}
+			result.ExistingStaleSetups++
+		}
+		result.StaleSetups = append(result.StaleSetups, ConnectionRecord{
+			ConnectionID:     connectionID,
+			Namespace:        ns,
+			ActorID:          actor.ActorID,
+			ConnectorID:      connectorID,
+			ConnectorVersion: connectorVersion,
+			ProbeEnabled:     false,
+		})
+
+		if i%progressEvery == 0 {
+			logf("seeded %d/%d stale setup connections", i, staleSetupConnections)
 		}
 	}
 
@@ -386,7 +459,7 @@ func sampleIndexes(length, requested int) []int {
 	return indexes
 }
 
-func connectorDefinition(id apid.ID, version uint64, namespace, profileName, providerBaseURL string, includeProbe bool) *cschema.Connector {
+func connectorDefinition(id apid.ID, version uint64, namespace, profileName, providerBaseURL string) *cschema.Connector {
 	refreshInBackground := true
 	def := &cschema.Connector{
 		Id:          id,
@@ -414,17 +487,18 @@ func connectorDefinition(id apid.ID, version uint64, namespace, profileName, pro
 		}},
 		Labels: baseLabels(profileName),
 	}
-	if includeProbe {
-		def.Probes = []cschema.Probe{
-			{
-				Id:     "load-sink",
-				Period: &common.HumanDuration{Duration: 5 * time.Minute},
-				ProxyHttp: &cschema.ProbeHttp{
-					Method: "GET",
-					URL:    providerBaseURL + "/test/load/resource/probe",
-				},
+	def.Probes = []cschema.Probe{
+		{
+			Id:     "load-sink",
+			Period: &common.HumanDuration{Duration: 5 * time.Minute},
+			If: &common.Predicate{
+				Javascript: `labels["loadtest.authproxy.io/probe"] === "true"`,
 			},
-		}
+			ProxyHttp: &cschema.ProbeHttp{
+				Method: "GET",
+				URL:    providerBaseURL + "/test/load/resource/probe",
+			},
+		},
 	}
 	return def
 }
@@ -445,6 +519,14 @@ func connectionLabels(profileName string, index int, probeEnabled bool) database
 	} else {
 		labels["loadtest.authproxy.io/probe"] = "false"
 	}
+	return labels
+}
+
+func staleSetupConnectionLabels(profileName string, index int) database.Labels {
+	labels := baseLabels(profileName)
+	labels["loadtest.authproxy.io/connection-index"] = fmt.Sprintf("stale-%d", index)
+	labels["loadtest.authproxy.io/probe"] = "false"
+	labels["loadtest.authproxy.io/stale-setup"] = "true"
 	return labels
 }
 

--- a/internal/loadtest/seeder/seed_test.go
+++ b/internal/loadtest/seeder/seed_test.go
@@ -20,6 +20,7 @@ func TestLoadProfileSmoke(t *testing.T) {
 	assert.Equal(t, "smoke", profile.Name)
 	assert.Equal(t, 10, profile.TenantNamespaceCount())
 	assert.Equal(t, 10, profile.Objects.Connections)
+	assert.Equal(t, 2, profile.Objects.StaleSetupConnections)
 	assert.Equal(t, 0, profile.DefaultOAuthExpiringPercent())
 	assert.Equal(t, 0, profile.DefaultPeriodicProbePercent())
 }
@@ -30,6 +31,7 @@ func TestSeedSmokeProfile(t *testing.T) {
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
 	oauthExpiringPercent := 40
 	periodicProbePercent := 20
+	staleSetupConnections := 2
 
 	result, err := Seed(context.Background(), Options{
 		Profile: Profile{
@@ -39,13 +41,14 @@ func TestSeedSmokeProfile(t *testing.T) {
 				Connections: 5,
 			},
 		},
-		DB:                   db,
-		Encrypt:              enc,
-		ProviderBaseURL:      "http://provider.test",
-		OAuthExpiringPercent: &oauthExpiringPercent,
-		PeriodicProbePercent: &periodicProbePercent,
-		VerifySamples:        3,
-		Now:                  now,
+		DB:                    db,
+		Encrypt:               enc,
+		ProviderBaseURL:       "http://provider.test",
+		OAuthExpiringPercent:  &oauthExpiringPercent,
+		PeriodicProbePercent:  &periodicProbePercent,
+		StaleSetupConnections: &staleSetupConnections,
+		VerifySamples:         3,
+		Now:                   now,
 	})
 	require.NoError(t, err)
 
@@ -56,8 +59,11 @@ func TestSeedSmokeProfile(t *testing.T) {
 	assert.Equal(t, 0, result.ExistingConnections)
 	assert.Equal(t, 5, result.UpsertedOAuthTokens)
 	assert.Equal(t, 1, result.ProbeEnabledConnections)
+	assert.Equal(t, 2, result.CreatedStaleSetups)
+	assert.Equal(t, 0, result.ExistingStaleSetups)
 	require.Len(t, result.VerifiedSamples, 3)
 	require.Len(t, result.Connections, 5)
+	require.Len(t, result.StaleSetups, 2)
 
 	first := result.Connections[0]
 	assert.Equal(t, "rt_"+first.ConnectionID.String(), first.RefreshToken)
@@ -75,6 +81,13 @@ func TestSeedSmokeProfile(t *testing.T) {
 	gotToken, err := db.GetOAuth2Token(context.Background(), first.ConnectionID)
 	require.NoError(t, err)
 	assert.Equal(t, first.ConnectionID, gotToken.ConnectionId)
+
+	gotStaleSetup, err := db.GetConnection(context.Background(), result.StaleSetups[0].ConnectionID)
+	require.NoError(t, err)
+	assert.Equal(t, database.ConnectionStateSetup, gotStaleSetup.State)
+	require.NotNil(t, gotStaleSetup.SetupStep)
+	assert.Equal(t, "loadtest_stale_setup", gotStaleSetup.SetupStep.String())
+	assert.Equal(t, "true", gotStaleSetup.Labels["loadtest.authproxy.io/stale-setup"])
 }
 
 func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
@@ -83,8 +96,9 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 	profile := Profile{
 		Name: "smoke",
 		Objects: ProfileObjects{
-			Namespaces:  2,
-			Connections: 2,
+			Namespaces:            2,
+			Connections:           2,
+			StaleSetupConnections: 1,
 		},
 	}
 
@@ -97,6 +111,7 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 2, first.CreatedConnections)
+	assert.Equal(t, 1, first.CreatedStaleSetups)
 
 	second, err := Seed(context.Background(), Options{
 		Profile:       profile,
@@ -108,6 +123,8 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, second.CreatedConnections)
 	assert.Equal(t, 2, second.ExistingConnections)
+	assert.Equal(t, 0, second.CreatedStaleSetups)
+	assert.Equal(t, 1, second.ExistingStaleSetups)
 
 	runDir := t.TempDir()
 	require.NoError(t, WriteArtifacts(runDir, second))
@@ -117,11 +134,17 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 	assert.Contains(t, string(connectionsCSV), "connection_id,namespace,actor_id")
 	assert.Contains(t, string(connectionsCSV), "cxn_lt_smoke_000000001")
 
+	staleCSV, err := os.ReadFile(filepath.Join(runDir, "datasets", "stale_setup_connections.csv"))
+	require.NoError(t, err)
+	assert.Contains(t, string(staleCSV), "cxn_lt_smoke_stale_000000001")
+
 	summary, err := os.ReadFile(filepath.Join(runDir, "seed-summary.json"))
 	require.NoError(t, err)
 	assert.Contains(t, string(summary), `"existing_connections": 2`)
+	assert.Contains(t, string(summary), `"existing_stale_setup_connections": 1`)
 
 	plan, err := os.ReadFile(filepath.Join(runDir, "seed-plan.txt"))
 	require.NoError(t, err)
 	assert.Contains(t, string(plan), "AuthProxy load-test seed summary")
+	assert.Contains(t, string(plan), "datasets/stale_setup_connections.csv")
 }

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -61,6 +61,15 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "Connections": {
+      "properties": {
+        "setup_ttl": {
+          "$ref": "../common/schema.json#/$defs/HumanDuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "CookieConfig": {
       "properties": {
         "domain": {
@@ -903,6 +912,9 @@
     },
     "app_metrics": {
       "$ref": "#/$defs/AppMetrics"
+    },
+    "connections": {
+      "$ref": "#/$defs/Connections"
     },
     "tasks": {
       "$ref": "#/$defs/Tasks"

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -127,6 +127,15 @@ func Test_SchemaAppMetricsShape(t *testing.T) {
 			"full_request_recording": "always",
 		},
 	}))
+
+	require.NoError(t, schema.Validate(map[string]any{
+		"connections": map[string]any{
+			"setup_ttl": "1s",
+		},
+		"tasks": map[string]any{
+			"default_retention": "24h",
+		},
+	}))
 }
 
 type test struct {

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -4,7 +4,8 @@ This directory contains the Kubernetes harness for the AuthProxy load-test
 project tracked by #711. It is intentionally split from product
 optimizations: the harness gives us repeatable environment setup, smoke
 traffic, state seeding, proxy-QPS scenarios, and artifact capture. The
-background-job suites build on this foundation in follow-up issues.
+background-job suite adds repeatable refresh, scheduler, resource snapshot, and
+cleanup pressure runs against the same seeded profiles.
 
 ## Prerequisites
 
@@ -44,6 +45,10 @@ capacity.
 ./loadtest/scripts/run 100k proxy-soak
 ./loadtest/scripts/run 100k proxy-spike
 
+# Run background-job scenarios. Enqueue/drain scenarios need a config that
+# points at the same Postgres/Redis/app-metrics stores as running workers.
+LOADTEST_AUTHPROXY_CONFIG=/path/to/loadtest-authproxy.yaml ./loadtest/scripts/background 100k all
+
 # Capture pods, deployments, services, Helm values, logs, and k6 summary JSON.
 ./loadtest/scripts/collect smoke
 
@@ -69,6 +74,29 @@ The seed script consumes the object-count section directly. Proxy-QPS scenarios
 consume the generated `datasets/connections.csv`, compact it to the columns k6
 needs, and reuse that same sampled dataset across raw, wrapped, spike, soak,
 and scale runs.
+
+## Background Scenarios
+
+`./loadtest/scripts/background <profile> <scenario>` supports:
+
+- `all`: refresh sweeps, scheduler sync, resource snapshot, and stale setup
+  cleanup.
+- `refresh-sweep`: seeds each `objects.oauth_tokens_expiring_percent` value
+  and enqueues the OAuth refresh sweep task.
+- `scheduler-sync`: seeds each `objects.periodic_probe_percent` value and
+  measures the periodic scheduler's connection walk without needing a worker.
+- `resource-snapshot`: enqueues the app-metrics resource snapshot task.
+- `stale-setup-cleanup`: seeds `objects.stale_setup_connections`, waits for the
+  load-test setup TTL, then enqueues stale setup cleanup.
+- `probe-outcome-cleanup`: optional cleanup-task walk over probe-enabled
+  connections.
+
+Refresh, resource snapshot, stale setup cleanup, and probe outcome cleanup are
+queue-drain tests: they require `LOADTEST_AUTHPROXY_CONFIG` or
+`AUTHPROXY_CONFIG` to point at stores shared with a running worker. If no config
+is set, the script can still run `scheduler-sync` with a generated local
+SQLite config; set `LOADTEST_BACKGROUND_WAIT_DRAIN=false` only when you want to
+record enqueue/queue state without waiting for worker processing.
 
 ## k6 Proxy Scenarios
 
@@ -135,6 +163,20 @@ https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/executing-
   `seed` generates a local SQLite/miniredis config in the run directory.
 - `LOADTEST_PROVIDER_BASE_URL`: provider URL written into seeded connector
   definitions; defaults to `http://go-oauth2-server:8080`.
+- `LOADTEST_BACKGROUND_SCENARIO`: default background scenario for
+  `scripts/background`.
+- `LOADTEST_BACKGROUND_QUEUE`: Asynq queue to enqueue to and inspect; defaults
+  to `default`.
+- `LOADTEST_BACKGROUND_DRAIN_TIMEOUT`: maximum time to wait for queue drain;
+  defaults to `30m`.
+- `LOADTEST_BACKGROUND_POLL_INTERVAL`: queue sampling interval; defaults to
+  `5s`.
+- `LOADTEST_BACKGROUND_WAIT_DRAIN=false`: record enqueue/queue state without
+  waiting for workers.
+- `LOADTEST_BACKGROUND_SEED=false`: skip the per-scenario seed step when the
+  target DB is already prepared.
+- `LOADTEST_STALE_SETUP_CONNECTIONS`: override the profile's stale setup count
+  for `stale-setup-cleanup`.
 - `LOADTEST_INSTALL_K6_OPERATOR=true`: install or upgrade the k6 Operator with
   Helm during `up`.
 - `LOADTEST_INSTALL_KEDA=true`: install or upgrade KEDA with Helm during `up`.
@@ -174,11 +216,25 @@ Each script writes or appends to a run directory containing:
 The `seed` step also writes:
 
 - `datasets/connections.csv`: connection IDs and metadata for k6 scenarios.
+- `datasets/stale_setup_connections.csv`: setup-state rows used by stale
+  cleanup scenarios.
 - `datasets/namespaces.csv`: generated tenant namespaces.
 - `datasets/actors.csv`: generated tenant actors.
 - `seed-summary.json`: machine-readable counts, selected percentages, and
   verified samples.
 - `seed-plan.txt`: human-readable seed summary.
+
+The `background` step writes one directory per variant, plus
+`background-runs.tsv` at the top level. Each variant contains its seed artifacts
+and:
+
+- `background/background-summary.json`: timing, enqueue/drain deltas, expected
+  expiring-token counts, scheduler task counts, memory snapshots, and artifact
+  paths.
+- `background/queue-samples.tsv`: sampled queue size, pending/active/retry
+  counts, totals, latency, and Redis memory usage.
+- `background/scheduler-task-configs.tsv`: scheduler task counts by task type
+  and cronspec for `scheduler-sync`.
 
 These artifacts are the handoff point for follow-up optimization work such as DB
 indexes, keyset pagination, request-event buffering, or worker tuning.

--- a/loadtest/helm-values/common.yaml
+++ b/loadtest/helm-values/common.yaml
@@ -73,6 +73,10 @@ appMetrics:
   fullRequestRecording: never
 
 config:
+  connections:
+    setup_ttl: 1s
+  tasks:
+    default_retention: 24h
   telemetry:
     enabled: true
     exporter:

--- a/loadtest/profiles/100k.yaml
+++ b/loadtest/profiles/100k.yaml
@@ -7,6 +7,7 @@ objects:
   namespaces_min: 50000
   namespaces_max: 100000
   connections: 100000
+  stale_setup_connections: 1000
   oauth_tokens_expiring_percent:
     - 10
     - 50

--- a/loadtest/profiles/250k.yaml
+++ b/loadtest/profiles/250k.yaml
@@ -6,6 +6,7 @@ cluster:
 objects:
   namespaces_min: 100000
   connections: 250000
+  stale_setup_connections: 2500
   oauth_tokens_expiring_percent:
     - 10
     - 50

--- a/loadtest/profiles/500k.yaml
+++ b/loadtest/profiles/500k.yaml
@@ -6,6 +6,7 @@ cluster:
 objects:
   namespaces_min: 200000
   connections: 500000
+  stale_setup_connections: 5000
   oauth_tokens_expiring_percent:
     - 10
     - 50

--- a/loadtest/profiles/smoke.yaml
+++ b/loadtest/profiles/smoke.yaml
@@ -6,6 +6,7 @@ cluster:
 objects:
   namespaces: 10
   connections: 10
+  stale_setup_connections: 2
   oauth_tokens_expiring_percent: 0
   periodic_probe_percent: 0
 authproxy:

--- a/loadtest/scripts/background
+++ b/loadtest/scripts/background
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/lib/loadtest.sh"
+
+profile=${1:-${LOADTEST_PROFILE:-smoke}}
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+scenario=${1:-${LOADTEST_BACKGROUND_SCENARIO:-all}}
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+extra_background_args=("$@")
+
+profile_file=$(loadtest_profile_path "$profile")
+profile_name=$(loadtest_profile_name "$profile_file")
+namespace=$(loadtest_namespace "$profile_file")
+run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" background)
+index_file="$run_dir/background-runs.tsv"
+
+provider_base_url=${LOADTEST_PROVIDER_BASE_URL:-http://go-oauth2-server:8080}
+queue=${LOADTEST_BACKGROUND_QUEUE:-default}
+drain_timeout=${LOADTEST_BACKGROUND_DRAIN_TIMEOUT:-30m}
+poll_interval=${LOADTEST_BACKGROUND_POLL_INTERVAL:-5s}
+wait_drain=${LOADTEST_BACKGROUND_WAIT_DRAIN:-true}
+seed_enabled=${LOADTEST_BACKGROUND_SEED:-true}
+verify_samples=${LOADTEST_BACKGROUND_VERIFY_SAMPLES:-3}
+progress_every=${LOADTEST_BACKGROUND_PROGRESS_EVERY:-1000}
+stale_settle=${LOADTEST_BACKGROUND_STALE_SETTLE:-2s}
+
+config_file=${LOADTEST_AUTHPROXY_CONFIG:-${AUTHPROXY_CONFIG:-}}
+generated_local_config=false
+
+generate_local_config() {
+  local path=$1
+  local sqlite_path=$2
+
+  loadtest_log "generating local SQLite/miniredis background config: $path"
+  cat > "$path" <<EOF
+host_application:
+  initiate_session_url: http://placeholder.invalid/login
+
+connections:
+  setup_ttl: 1s
+
+tasks:
+  default_retention: 24h
+
+database:
+  provider: sqlite
+  auto_migrate: true
+  path: $sqlite_path
+
+redis:
+  provider: miniredis
+
+system_auth:
+  jwt_signing_key:
+    public_key:
+      path: $REPO_ROOT/dev_config/system.pub
+    private_key:
+      path: $REPO_ROOT/dev_config/system
+  actors:
+    keys_path: $REPO_ROOT/dev_config/keys/admin
+    permissions:
+      - namespace: root.**
+        resources:
+          - "*"
+        verbs:
+          - "*"
+  global_aes_key:
+    path: $REPO_ROOT/dev_config/keys/global_aes.key
+
+connectors:
+  auto_migrate: false
+  load_from_list: []
+
+app_metrics:
+  auto_migrate: false
+  database:
+    provider: sqlite
+    path: $sqlite_path
+
+logging:
+  type: none
+EOF
+}
+
+scenario_requires_worker() {
+  case "$1" in
+    all|refresh-sweep|resource-snapshot|stale-setup-cleanup|probe-outcome-cleanup)
+      return 0
+      ;;
+    scheduler-sync)
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ -z "$config_file" ]]; then
+  config_file="$run_dir/authproxy-background.yaml"
+  sqlite_path="$run_dir/authproxy-background.sqlite3"
+  generate_local_config "$config_file" "$sqlite_path"
+  generated_local_config=true
+fi
+
+if [[ "$generated_local_config" == "true" && "$wait_drain" != "false" ]] && scenario_requires_worker "$scenario"; then
+  loadtest_die "background enqueue scenarios need LOADTEST_AUTHPROXY_CONFIG/AUTHPROXY_CONFIG pointing at shared load-test stores with a running worker, or set LOADTEST_BACKGROUND_WAIT_DRAIN=false"
+fi
+
+printf "variant\tscenario\tpercent\tseed_dir\tbackground_dir\n" > "$index_file"
+
+run_authproxy() {
+  if [[ -n "${LOADTEST_AUTHPROXY_BIN:-}" ]]; then
+    "$LOADTEST_AUTHPROXY_BIN" --config "$config_file" "$@"
+    return
+  fi
+
+  (
+    cd "$REPO_ROOT"
+    go run ./cmd/server --config "$config_file" "$@"
+  )
+}
+
+append_index() {
+  local variant=$1
+  local scenario_name=$2
+  local percent=${3:-}
+  local seed_dir=$4
+  local background_dir=$5
+
+  printf "%s\t%s\t%s\t%s\t%s\n" "$variant" "$scenario_name" "$percent" "$seed_dir" "$background_dir" >> "$index_file"
+}
+
+seed_variant() {
+  local variant=$1
+  shift
+
+  local seed_dir="$run_dir/$variant/seed"
+  mkdir -p "$seed_dir"
+
+  if [[ "$seed_enabled" == "false" ]]; then
+    loadtest_log "skipping seed for $variant"
+    return
+  fi
+
+  loadtest_log "seeding $variant"
+  run_authproxy \
+    loadtest-seed \
+    --profile "$profile_file" \
+    --run-dir "$seed_dir" \
+    --provider-base-url "$provider_base_url" \
+    --verify-samples "$verify_samples" \
+    --progress-every "$progress_every" \
+    "$@"
+}
+
+run_background_scenario() {
+  local variant=$1
+  local scenario_name=$2
+  local percent=${3:-}
+
+  local seed_dir="$run_dir/$variant/seed"
+  local background_dir="$run_dir/$variant/background"
+  mkdir -p "$background_dir"
+
+  local args=(
+    loadtest-background
+    --profile "$profile_file"
+    --run-dir "$background_dir"
+    --scenario "$scenario_name"
+    --queue "$queue"
+    --drain-timeout "$drain_timeout"
+    --poll-interval "$poll_interval"
+  )
+
+  if [[ -n "$percent" ]]; then
+    args+=(--percent "$percent")
+  fi
+  if [[ "$wait_drain" == "false" ]]; then
+    args+=(--wait-drain=false)
+  fi
+
+  loadtest_log "running $scenario_name for $variant"
+  if [[ ${#extra_background_args[@]} -gt 0 ]]; then
+    run_authproxy "${args[@]}" "${extra_background_args[@]}"
+  else
+    run_authproxy "${args[@]}"
+  fi
+  append_index "$variant" "$scenario_name" "$percent" "$seed_dir" "$background_dir"
+}
+
+profile_percent_values() {
+  local key=$1
+  local found=false
+  while IFS= read -r value; do
+    [[ -n "$value" ]] || continue
+    found=true
+    printf "%s\n" "$value"
+  done < <(loadtest_yaml_section_list "$profile_file" objects "$key")
+
+  if [[ "$found" == "false" ]]; then
+    printf "0\n"
+  fi
+}
+
+run_refresh_sweep() {
+  local pct
+  while IFS= read -r pct; do
+    [[ -n "$pct" ]] || continue
+    local variant="refresh-${pct}pct"
+    seed_variant "$variant" \
+      --oauth-expiring-percent "$pct" \
+      --periodic-probe-percent 0 \
+      --stale-setup-connections 0
+    run_background_scenario "$variant" refresh-sweep "$pct"
+  done < <(profile_percent_values oauth_tokens_expiring_percent)
+}
+
+run_scheduler_sync() {
+  local pct
+  while IFS= read -r pct; do
+    [[ -n "$pct" ]] || continue
+    local variant="probe-${pct}pct"
+    seed_variant "$variant" \
+      --oauth-expiring-percent 0 \
+      --periodic-probe-percent "$pct" \
+      --stale-setup-connections 0
+    run_background_scenario "$variant" scheduler-sync "$pct"
+  done < <(profile_percent_values periodic_probe_percent)
+}
+
+run_resource_snapshot() {
+  local variant="resource-snapshot"
+  seed_variant "$variant" \
+    --oauth-expiring-percent 0 \
+    --periodic-probe-percent 0 \
+    --stale-setup-connections 0
+  run_background_scenario "$variant" resource-snapshot
+}
+
+run_stale_setup_cleanup() {
+  local variant="stale-setup-cleanup"
+  local stale_count
+  stale_count=$(loadtest_yaml_section_value "$profile_file" objects stale_setup_connections)
+  stale_count=${LOADTEST_STALE_SETUP_CONNECTIONS:-${stale_count:-0}}
+
+  seed_variant "$variant" \
+    --oauth-expiring-percent 0 \
+    --periodic-probe-percent 0 \
+    --stale-setup-connections "$stale_count"
+
+  if [[ "$stale_count" != "0" && "$stale_settle" != "0" && "$seed_enabled" != "false" ]]; then
+    loadtest_log "waiting $stale_settle for setup TTL before stale cleanup"
+    sleep "$stale_settle"
+  fi
+
+  run_background_scenario "$variant" stale-setup-cleanup
+}
+
+run_probe_outcome_cleanup() {
+  local variant="probe-outcome-cleanup"
+  seed_variant "$variant" \
+    --oauth-expiring-percent 0 \
+    --periodic-probe-percent 100 \
+    --stale-setup-connections 0
+  run_background_scenario "$variant" probe-outcome-cleanup
+}
+
+case "$scenario" in
+  all)
+    run_refresh_sweep
+    run_scheduler_sync
+    run_resource_snapshot
+    run_stale_setup_cleanup
+    ;;
+  refresh-sweep)
+    run_refresh_sweep
+    ;;
+  scheduler-sync)
+    run_scheduler_sync
+    ;;
+  resource-snapshot)
+    run_resource_snapshot
+    ;;
+  stale-setup-cleanup)
+    run_stale_setup_cleanup
+    ;;
+  probe-outcome-cleanup)
+    run_probe_outcome_cleanup
+    ;;
+  *)
+    loadtest_die "unknown background scenario: $scenario"
+    ;;
+esac
+
+loadtest_log "background scenarios recorded for profile $profile_name"
+loadtest_log "run artifacts: $run_dir"

--- a/loadtest/scripts/lib/loadtest.sh
+++ b/loadtest/scripts/lib/loadtest.sh
@@ -138,6 +138,10 @@ loadtest_yaml_section_list() {
           }
           exit
         }
+        if (value != "") {
+          print value
+          exit
+        }
         in_list = 1
         key_indent = current_indent
       }

--- a/loadtest/scripts/seed
+++ b/loadtest/scripts/seed
@@ -22,6 +22,12 @@ if [[ -z "$config_file" ]]; then
 host_application:
   initiate_session_url: http://placeholder.invalid/login
 
+connections:
+  setup_ttl: 1s
+
+tasks:
+  default_retention: 24h
+
 database:
   provider: sqlite
   auto_migrate: true


### PR DESCRIPTION
## Summary
- add an authproxy loadtest-background command for refresh sweeps, scheduler sync, resource snapshots, stale setup cleanup, and probe outcome cleanup
- extend the load-test seeder/profiles/artifacts with stale setup rows and stable probe-gated connector definitions
- add scripts/docs/schema support for running background scenario variants and collecting queue/scheduler summaries

Closes #719

## Tests
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/loadtest/seeder ./internal/schema/config ./cmd/server
- LOADTEST_BACKGROUND_VERIFY_SAMPLES=1 LOADTEST_BACKGROUND_PROGRESS_EVERY=100 ./loadtest/scripts/background smoke scheduler-sync
- ./scripts/preflight.sh