### PR TITLE
Add OAuth version migration scenarios

### DIFF
--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -254,6 +254,36 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 	return resp.Id.String(), resp.RedirectUrl
 }
 
+// ReauthOAuth2Connection starts an OAuth2 reauthorization flow for an
+// existing connection and returns the proxy redirect URL. The supplied
+// return-to URL is carried through the OAuth callback after successful token
+// exchange.
+func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID, returnToUrl string, opts ...OAuth2Option) string {
+	t.Helper()
+
+	body, err := jsonMarshal(struct {
+		ReturnToUrl string `json:"return_to_url,omitempty"`
+	}{
+		ReturnToUrl: returnToUrl,
+	})
+	require.NoError(t, err)
+
+	w := env.doSignedRequest(
+		t,
+		http.MethodPost,
+		"/api/v1/connections/"+connectionID+"/_reauth",
+		body,
+		env.resolveOAuth2Options(opts),
+	)
+	require.Equalf(t, http.StatusOK, w.Code, "reauth failed: %s", w.Body.String())
+
+	var resp coreIface.ConnectionSetupRedirect
+	require.NoErrorf(t, jsonUnmarshal(w.Body.Bytes(), &resp), "decode reauth response: %s", w.Body.String())
+	require.Equal(t, coreIface.ConnectionSetupResponseTypeRedirect, resp.Type)
+	require.NotEmpty(t, resp.RedirectUrl)
+	return resp.RedirectUrl
+}
+
 // FollowOAuth2Redirect issues an in-process GET to the public service's
 // `/oauth2/redirect` endpoint with the same state_id and signed JWT the user's
 // browser would carry, and returns the Location header — the URL of the OAuth

--- a/integration_tests/version_migration/README.md
+++ b/integration_tests/version_migration/README.md
@@ -10,8 +10,8 @@ Scenario files:
 
 - API-key configure migration: [api_key_configure_change_test.md](api_key_configure_change_test.md).
 - API-key preconnect migration: [api_key_preconnect_change_test.md](api_key_preconnect_change_test.md).
-- OAuth required-scope reauth migration: tracked by #740.
-- OAuth required-scope rollback migration: tracked by #740.
+- OAuth required-scope reauth migration: [oauth_scope_expansion_reauth_test.md](oauth_scope_expansion_reauth_test.md).
+- OAuth required-scope rollback migration: [oauth_scope_expansion_rollback_test.md](oauth_scope_expansion_rollback_test.md).
 - No-auth defaults and probe migration: tracked by #741.
 
 Shared harness work is tracked by #738.

--- a/integration_tests/version_migration/oauth_scope_expansion_reauth_test.md
+++ b/integration_tests/version_migration/oauth_scope_expansion_reauth_test.md
@@ -1,0 +1,25 @@
+# OAuth scope expansion requires reauthentication
+
+## Fixture
+
+- An OAuth2 connector at version 1 requests the required `read` scope.
+- A user authorizes the connection and the provider grants `read`.
+- Version 2 adds the required `write` scope.
+
+## Flow
+
+1. Publish version 2 and script its refresh response to grant only `read`.
+2. Migrate the connection to version 2 through `_migrate_version` and wait for
+   the durable workflow.
+3. Start `_reauth`, inspect the generated authorization URL, and complete the
+   callback after granting `read write`.
+
+## Assertions
+
+- The migration requests `read write`, persists the actual `read` grant, and
+  leaves the configured connection unhealthy with one `auth_required`
+  notification.
+- Reauthorization requests `read write`, replaces the migration-time token,
+  records both the requested and granted `read write` scopes, restores health,
+  and resolves the notification.
+- The connection remains usable through the proxy after reauthorization.

--- a/integration_tests/version_migration/oauth_scope_expansion_rollback_test.md
+++ b/integration_tests/version_migration/oauth_scope_expansion_rollback_test.md
@@ -1,0 +1,22 @@
+# OAuth scope expansion rollback restores the connection
+
+## Fixture
+
+- An OAuth2 connector at version 1 requests the required `read` scope.
+- Version 2 adds the required `write` scope.
+- The migration-time refresh is scripted to grant only `read`, so version 2
+  requires reauthentication.
+
+## Flow
+
+1. Migrate from version 1 to version 2 and confirm the connection requires
+   reauthentication.
+2. Target version 1 with `_migrate_version` and wait for the rollback
+   workflow.
+
+## Assertions
+
+- Rollback restores connector version 1, the configured state, and healthy
+  health state without requiring a user callback.
+- The target-version refresh records requested and granted `read` scope.
+- The `auth_required` notification resolves and the proxy request succeeds.

--- a/integration_tests/version_migration/oauth_test.go
+++ b/integration_tests/version_migration/oauth_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+package version_migration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const oauthMigrationTimeout = 20 * time.Second
+
+type oauthMigrationRig struct {
+	env          *helpers.IntegrationTestEnv
+	provider     *helpers.OAuth2TestProvider
+	connectorID  apid.ID
+	clientKey    string
+	clientSecret string
+	userID       string
+	returnToURL  string
+}
+
+func TestOAuth2VersionMigrationScopeExpansionRequiresReauth(t *testing.T) {
+	rig := newOAuthMigrationRig(t, "oauth-migration-scope-reauth")
+	connectionID := rig.createHealthyReadConnection(t)
+	initialToken := rig.requireTokenScopes(t, connectionID, "read", "read")
+
+	rig.publishRequiredScopeVersion(t, []string{"read", "write"})
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		ScopeOverride: stringPointer("read"),
+	})
+
+	rig.env.MigrateConnectionVersionAndWait(t, connectionID, 2, oauthMigrationTimeout)
+
+	migrated := rig.env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), migrated.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, migrated.State)
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, migrated.HealthState)
+	require.Nil(t, migrated.SetupStep)
+
+	migrationToken := rig.requireTokenScopes(t, connectionID, "read write", "read")
+	assert.NotEqual(t, initialToken.Id, migrationToken.Id,
+		"the target-version refresh should persist the provider's granted scope set")
+
+	notification := rig.env.RequireSingleActiveConnectionNotification(
+		t,
+		connectionID,
+		helpers.NotificationKeySuffixAuthRequired,
+	)
+	assertNoAuthProxyCopy(t, notification)
+	assert.True(t, notification.CanAction)
+	assert.Contains(t, notification.ActionUrl, "action=reauth")
+
+	reauthRedirect := rig.env.ReauthOAuth2Connection(t, connectionID, rig.returnToURL)
+	rig.requireRedirectScopes(t, reauthRedirect, "read write")
+	rig.authorizeAndDeliverCallback(t, reauthRedirect, "read write")
+
+	afterReauth := rig.env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), afterReauth.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, afterReauth.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, afterReauth.HealthState)
+	require.Nil(t, afterReauth.SetupStep)
+	require.Nil(t, afterReauth.SetupError)
+
+	reauthedToken := rig.requireTokenScopes(t, connectionID, "read write", "read write")
+	assert.NotEqual(t, migrationToken.Id, reauthedToken.Id,
+		"successful reauthorization should replace the token from the failed migration refresh")
+	assert.Equal(t, http.StatusOK, rig.proxyStatus(t, connectionID))
+
+	rig.env.RequireNoActiveConnectionNotifications(t, connectionID)
+	rig.env.RequireResolvedConnectionNotification(t, connectionID, helpers.NotificationKeySuffixAuthRequired)
+}
+
+func TestOAuth2VersionMigrationScopeExpansionRollbackRestoresConnection(t *testing.T) {
+	rig := newOAuthMigrationRig(t, "oauth-migration-scope-rollback")
+	connectionID := rig.createHealthyReadConnection(t)
+
+	rig.publishRequiredScopeVersion(t, []string{"read", "write"})
+	rig.provider.Script(rig.clientKey, helpers.EndpointRefresh, helpers.ScriptAction{
+		ScopeOverride: stringPointer("read"),
+	})
+	rig.env.MigrateConnectionVersionAndWait(t, connectionID, 2, oauthMigrationTimeout)
+
+	requiresReauth := rig.env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(2), requiresReauth.ConnectorVersion)
+	require.Equal(t, database.ConnectionHealthStateUnhealthy, requiresReauth.HealthState)
+	rig.env.RequireSingleActiveConnectionNotification(
+		t,
+		connectionID,
+		helpers.NotificationKeySuffixAuthRequired,
+	)
+
+	rollback := rig.env.MigrateConnectionVersionAndWait(t, connectionID, 1, oauthMigrationTimeout)
+	require.Equal(t, uint64(2), rollback.SourceVersion)
+	require.Equal(t, uint64(1), rollback.TargetVersion)
+
+	restored := rig.env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(1), restored.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, restored.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, restored.HealthState)
+	require.Nil(t, restored.SetupStep)
+	require.Nil(t, restored.SetupError)
+	rig.requireTokenScopes(t, connectionID, "read", "read")
+	assert.Equal(t, http.StatusOK, rig.proxyStatus(t, connectionID))
+
+	rig.env.RequireNoActiveConnectionNotifications(t, connectionID)
+	rig.env.RequireResolvedConnectionNotification(t, connectionID, helpers.NotificationKeySuffixAuthRequired)
+}
+
+func newOAuthMigrationRig(t *testing.T, name string) *oauthMigrationRig {
+	t.Helper()
+
+	provider := helpers.NewOAuth2TestProvider(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	clientKey := name + "-client-" + suffix
+	clientSecret := name + "-secret-" + suffix
+	connectorID := apid.New(apid.PrefixConnectorVersion)
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:       helpers.ServiceTypeAPI,
+		IncludePublic: true,
+	})
+	t.Cleanup(env.Cleanup)
+	helpers.StartCoreWorkflowWorker(t, env)
+
+	rig := &oauthMigrationRig{
+		env:          env,
+		provider:     provider,
+		connectorID:  connectorID,
+		clientKey:    clientKey,
+		clientSecret: clientSecret,
+		returnToURL:  env.Cfg.GetRoot().Public.GetBaseUrl() + "/connections",
+	}
+
+	created := env.CreateConnector(t, rig.connectorDefinition(name+"-v1", []string{"read"}), nil, nil)
+	require.Equal(t, uint64(1), created.Version)
+	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
+	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
+
+	registered := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     clientKey,
+		Secret:                  clientSecret,
+		RedirectURI:             env.PublicOAuthCallbackURL(),
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read write",
+	})
+	require.Equal(t, clientKey, registered.Key)
+
+	user := provider.CreateUser(helpers.CreateUserRequest{
+		Username: name + "-" + suffix + "@example.com",
+		Password: "p4ssw0rd-" + suffix,
+		Email:    name + "-" + suffix + "@example.com",
+	})
+	require.NotEmpty(t, user.ID)
+	rig.userID = user.ID
+
+	return rig
+}
+
+func (r *oauthMigrationRig) connectorDefinition(displayName string, scopes []string) sconfig.Connector {
+	return helpers.NewOAuth2Connector(r.connectorID, displayName, r.provider, helpers.OAuth2ConnectorOptions{
+		ClientID:     r.clientKey,
+		ClientSecret: r.clientSecret,
+		Scopes:       scopes,
+	})
+}
+
+func (r *oauthMigrationRig) createHealthyReadConnection(t *testing.T) string {
+	t.Helper()
+
+	connectionID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
+	r.requireRedirectScopes(t, redirectURL, "read")
+	r.authorizeAndDeliverCallback(t, redirectURL, "read")
+
+	conn := r.env.GetConnection(t, connectionID)
+	require.Equal(t, uint64(1), conn.ConnectorVersion)
+	require.Equal(t, database.ConnectionStateConfigured, conn.State)
+	require.Equal(t, database.ConnectionHealthStateHealthy, conn.HealthState)
+	require.Nil(t, conn.SetupStep)
+	require.Nil(t, conn.SetupError)
+	return connectionID
+}
+
+func (r *oauthMigrationRig) publishRequiredScopeVersion(t *testing.T, scopes []string) {
+	t.Helper()
+
+	published := r.env.PublishConnectorVersion(
+		t,
+		r.connectorID,
+		r.connectorDefinition("oauth-migration-v2", scopes),
+		nil,
+		nil,
+	)
+	require.Equal(t, uint64(2), published.Version)
+}
+
+func (r *oauthMigrationRig) requireRedirectScopes(t *testing.T, redirectURL, want string) {
+	t.Helper()
+
+	authorizeURL := r.env.FollowOAuth2Redirect(t, redirectURL)
+	parsed, err := url.Parse(authorizeURL)
+	require.NoError(t, err)
+	require.Equal(t, want, parsed.Query().Get("scope"))
+}
+
+func (r *oauthMigrationRig) authorizeAndDeliverCallback(t *testing.T, redirectURL, grantedScope string) {
+	t.Helper()
+
+	parsed, err := url.Parse(redirectURL)
+	require.NoError(t, err)
+	stateID := parsed.Query().Get("state_id")
+	require.NotEmpty(t, stateID, "redirect should embed state_id: %s", redirectURL)
+
+	authorize := r.provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    r.clientKey,
+		UserID:      r.userID,
+		RedirectURI: r.env.PublicOAuthCallbackURL(),
+		Scope:       grantedScope,
+		State:       stateID,
+		Decision:    helpers.AuthorizeApprove,
+	})
+	callback, err := url.Parse(authorize.RedirectURL)
+	require.NoError(t, err)
+	code := callback.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	location := r.env.DeliverOAuth2Callback(t, r.env.ForgeOAuth2CallbackURL(stateID, code))
+	require.Truef(t, strings.HasPrefix(location, r.returnToURL),
+		"OAuth callback should return to %q, got %q", r.returnToURL, location)
+}
+
+func (r *oauthMigrationRig) requireTokenScopes(t *testing.T, connectionID, wantRequested, wantGranted string) *database.OAuth2Token {
+	t.Helper()
+
+	token := r.env.GetOAuth2Token(t, connectionID)
+	require.NotNil(t, token)
+	assert.Equal(t, wantRequested, token.RequestedScopes)
+	assert.Equal(t, wantGranted, token.Scopes)
+	return token
+}
+
+func (r *oauthMigrationRig) proxyStatus(t *testing.T, connectionID string) int {
+	t.Helper()
+	w := r.env.DoProxyRequest(t, connectionID, r.provider.ResourceURL("/echo"), http.MethodGet)
+	return w.Code
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/integration_tests/version_migration/oauth_test.go
+++ b/integration_tests/version_migration/oauth_test.go
@@ -145,6 +145,7 @@ func newOAuthMigrationRig(t *testing.T, name string) *oauthMigrationRig {
 
 	created := env.CreateConnector(t, rig.connectorDefinition(name+"-v1", []string{"read"}), nil, nil)
 	require.Equal(t, uint64(1), created.Version)
+	rig.connectorID = created.Id
 	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
 	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
 

--- a/internal/core/connection_post_auth.go
+++ b/internal/core/connection_post_auth.go
@@ -25,6 +25,13 @@ func (c *connection) HandleCredentialsEstablished(ctx context.Context) (iface.Po
 		return iface.PostAuthOutcome{}, fmt.Errorf("connection has no active setup step")
 	}
 
+	// A successful credential exchange proves the auth requirement has been
+	// satisfied even when this connector has no probes. This also restores a
+	// connection made unhealthy by a migration-time refresh failure.
+	if err := c.MarkHealthState(ctx, database.ConnectionHealthStateHealthy, "credentials_established"); err != nil {
+		return iface.PostAuthOutcome{}, fmt.Errorf("failed to mark connection healthy after credentials were established: %w", err)
+	}
+
 	flow := c.s.buildManifestSetupFlow(c)
 	next, hasNext, err := flow.NextStep(ctx, current.Id())
 	if err != nil {

--- a/internal/core/connection_post_auth_test.go
+++ b/internal/core/connection_post_auth_test.go
@@ -173,6 +173,32 @@ func TestHandleCredentialsEstablished(t *testing.T) {
 		assert.Equal(t, database.ConnectionStateConfigured, conn.GetState())
 	})
 
+	t.Run("restores health after credential establishment without probes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		conn, db := newTestConnectionWithSetupFlow(t, ctrl, &cschema.SetupFlow{})
+		conn.cv = NewTestConnectorVersion(cschema.Connector{
+			Auth: &cschema.Auth{InnerVal: &cschema.AuthOAuth2{Type: cschema.AuthTypeOAuth2}},
+		})
+		conn.ConnectorId = conn.cv.GetId()
+		conn.ConnectorVersion = conn.cv.GetVersion()
+		conn.HealthState = database.ConnectionHealthStateUnhealthy
+		current := cschema.MustNewSetupStep(oauth2.OAuth2AuthorizeStepId)
+		conn.SetupStep = &current
+
+		db.EXPECT().SetConnectionHealthState(gomock.Any(), conn.Id, database.ConnectionHealthStateHealthy).Return(nil)
+		db.EXPECT().SetConnectionSetupStep(gomock.Any(), conn.Id, (*cschema.SetupStep)(nil)).Return(nil)
+		db.EXPECT().SetConnectionState(gomock.Any(), conn.Id, database.ConnectionStateConfigured).Return(nil)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeySetupRequired)
+		expectResolveRequiredActionNotification(db, conn.Id, database.NotificationKeyAuthRequired)
+
+		outcome, err := conn.HandleCredentialsEstablished(context.Background())
+		require.NoError(t, err)
+		assert.False(t, outcome.SetupPending)
+		assert.Equal(t, database.ConnectionHealthStateHealthy, conn.GetHealthState())
+	})
+
 	t.Run("rejects call when connection has no active setup step", func(t *testing.T) {
 		// The OAuth2 callback path always sets setup_step before invoking
 		// HandleCredentialsEstablished. A nil step is a programmer error.

--- a/internal/core/workflow_migrate_connection_version_activity.go
+++ b/internal/core/workflow_migrate_connection_version_activity.go
@@ -97,6 +97,8 @@ func (s *service) applyMigrateConnectionVersionV1(
 			); markErr != nil {
 				return markErr
 			}
+		} else {
+			applySuccessfulMigrationAuthRefresh(candidate)
 		}
 	}
 

--- a/internal/core/workflow_migrate_connection_version_analysis.go
+++ b/internal/core/workflow_migrate_connection_version_analysis.go
@@ -233,6 +233,22 @@ func addAuthRequiredNotification(
 	)
 }
 
+// applySuccessfulMigrationAuthRefresh updates migration state after a target
+// auth refresh succeeds. Candidate analysis runs before the refresh, so it may
+// still contain a stale reauthentication notice from the source version.
+func applySuccessfulMigrationAuthRefresh(candidate *connectionMigrationCandidate) {
+	candidate.HealthState = database.ConnectionHealthStateHealthy
+
+	authKey := connectionNotificationKey(candidate, database.NotificationKeyAuthRequired)
+	if len(candidate.Notifications) != 1 || candidate.Notifications[0].Key != authKey {
+		return
+	}
+
+	candidate.Notifications = nil
+	candidate.NotificationKeys = removeString(candidate.NotificationKeys, authKey)
+	candidate.NotificationRank = 0
+}
+
 // addSetupRequiredNotification adds a setup required notification to a
 // candidate.
 func addSetupRequiredNotification(

--- a/internal/core/workflow_migrate_connection_version_analysis_test.go
+++ b/internal/core/workflow_migrate_connection_version_analysis_test.go
@@ -159,6 +159,24 @@ func TestApplyRequiredActionNotificationPrefersAuthOverSetup(t *testing.T) {
 	require.Equal(t, "/connections/"+candidate.Connection.Id.String()+"?action=reauth", *candidate.Notifications[0].ActionUrl)
 }
 
+func TestApplySuccessfulMigrationAuthRefreshClearsStaleAuthNotification(t *testing.T) {
+	candidate := newMigrationTestCandidate(t)
+	candidate.HealthState = database.ConnectionHealthStateUnhealthy
+	addAuthRequiredNotification(candidate, migrationNotificationMetadata(candidate, "connection_requires_reauth"))
+
+	applySuccessfulMigrationAuthRefresh(candidate)
+
+	require.Equal(t, database.ConnectionHealthStateHealthy, candidate.HealthState)
+	require.Empty(t, candidate.Notifications)
+	require.Empty(t, candidate.NotificationKeys)
+	require.Zero(t, candidate.NotificationRank)
+	require.Contains(
+		t,
+		candidate.NotificationKeysToResolve(),
+		connectionNotificationKey(candidate, database.NotificationKeyAuthRequired),
+	)
+}
+
 func TestSetCandidateNotificationRankAndUnsetHandling(t *testing.T) {
 	candidate := newMigrationTestCandidate(t)
 	authKey := connectionNotificationKey(candidate, database.NotificationKeyAuthRequired)


### PR DESCRIPTION
Closes #740

Summary:
- add OAuth required-scope expansion reauth and rollback integration scenarios
- add Markdown specifications for both migration paths
- restore connection health after successful OAuth credential establishment without probes

Verification:
- SQLite-focused core migration and notification tests passed
- OAuth migration and existing OAuth integration packages compile with integration tag
- scripts/preflight.sh passed

The Docker-backed scenario run is blocked locally because Docker Desktop is not running.