### PR TITLE
Add load-test observability and artifacts

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -12,6 +12,7 @@ cleanup pressure runs against the same seeded profiles.
 - `kubectl` pointed at the target cluster.
 - `helm` for installing AuthProxy from the local chart.
 - `openssl` for disposable JWT, actor, and AES keys.
+- `curl` for Prometheus snapshots during `collect`.
 - Metrics Server in the cluster when validating HPA behavior.
 - k6 Operator installed when using `LOADTEST_K6_MODE=operator`; the default
   smoke path runs k6 as a plain Kubernetes Job.
@@ -49,7 +50,8 @@ capacity.
 # points at the same Postgres/Redis/app-metrics stores as running workers.
 LOADTEST_AUTHPROXY_CONFIG=/path/to/loadtest-authproxy.yaml ./loadtest/scripts/background 100k all
 
-# Capture pods, deployments, services, Helm values, logs, and k6 summary JSON.
+# Capture Kubernetes/HPA state, image digests, Prometheus alert/query snapshots,
+# Postgres EXPLAIN plans, logs, and k6 summary JSON.
 ./loadtest/scripts/collect smoke
 
 # Remove Helm releases and load-test manifests. The namespace is kept by default.
@@ -183,6 +185,10 @@ https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/executing-
 - `LOADTEST_INSTALL_K6_OPERATOR=true`: install or upgrade the k6 Operator with
   Helm during `up`.
 - `LOADTEST_INSTALL_KEDA=true`: install or upgrade KEDA with Helm during `up`.
+- `LOADTEST_PROMETHEUS_URL`: use an externally reachable Prometheus URL instead
+  of a temporary port-forward during collection.
+- `LOADTEST_PROMETHEUS_PORT`: local port for that temporary port-forward;
+  defaults to `19090`.
 
 ## What `up` Deploys
 
@@ -193,6 +199,13 @@ The smoke environment installs:
 - ClickHouse as a placeholder app-metrics backend for future pressure tests.
 - Grafana's `otel-lgtm` image for local OTel, Prometheus, Grafana, Tempo, and
   Loki endpoints.
+- A dedicated Prometheus instance that federates the OTel-LGTM metrics,
+  receives k6 remote-write metrics, evaluates the load-test alert and recording
+  rules, and serves the provisioned Grafana dashboards.
+- Namespace-scoped kube-state-metrics plus Postgres and Redis exporters. These
+  expose the HPA/deployment state, pod restarts, database connection/lock
+  pressure, and Redis memory/command pressure that application metrics alone
+  cannot show.
 - `go-oauth2-server` in test mode.
 - Four separate AuthProxy Helm releases:
   - `authproxy-admin-api`
@@ -215,6 +228,21 @@ Each script writes or appends to a run directory containing:
 - `helm/`: `helm list`, rendered values, and manifest snapshots.
 - `k6/`: k6 logs, generated TestRun manifests, environment snapshots, summary
   JSON when available, and `scale-results.tsv` for Job-backed replica sweeps.
+- `observability/`: the exact Grafana dashboards, datasource definition, and
+  alerting configuration provisioned for the run.
+- `prometheus/`: targets, active alerts, loaded rules, metric-name inventory,
+  and responses to the standard proxy, k6, worker, HPA, Postgres, and Redis
+  queries. k6 sends live metrics through its Prometheus remote-write output in
+  addition to preserving its JSON summary.
+- `db-explain/`: `EXPLAIN (ANALYZE, BUFFERS)` output for the OAuth refresh
+  token walk, periodic scheduler connection walk, and stale-setup cleanup
+  walk, their exact source SQL, and a Postgres activity/lock/size snapshot.
+  Collection leaves an error artifact when the target database has not been
+  migrated rather than hiding the missing measurement.
+- `kubernetes/hpa-timeline.tsv`: HPA desired/current replica samples from
+  environment setup, traffic-run start/end, and explicit collection. The same
+  directory contains `image-shas.tsv`, pod resource usage, pod/deployment
+  YAML, events, and rollout state.
 
 The `seed` step also writes:
 
@@ -241,6 +269,28 @@ and:
 
 These artifacts are the handoff point for follow-up optimization work such as DB
 indexes, keyset pagination, request-event buffering, or worker tuning.
+
+## Monitoring and Gates
+
+Grafana provisions four dashboards under **AuthProxy Load Test**:
+
+- **Proxy and Autoscaling**: upstream and inbound RPS, 5xx rate, proxy latency,
+  k6 achieved rate, and API HPA/deployment state.
+- **Background Jobs**: queue depth, task duration/completion rate, OAuth refresh
+  results, and worker scaling.
+- **Upstream Provider**: go-oauth2-server request rate, latency, 5xx rate, and
+  restarts, so provider saturation is not mistaken for proxy capacity.
+- **Datastores**: SQL pool pressure, Postgres connections/locks/writes, Redis
+  memory and command rate, and instrumented client latency.
+
+The Prometheus rules record the proxy request rate, 5xx rate, p95 duration,
+queue depth, refresh-failure rate, and datastore p95. Alerts flag the initial
+proxy 0.1% 5xx gate, the selected profile's proxy p95, sustained queue depth
+above 1,000, refresh failures, SQL pool waits, Redis command p95 above 50ms,
+and container restarts. The rendered rule file is saved with the run artifacts.
+The k6 profile's own failure thresholds remain the source of truth for a
+profile-specific acceptance decision; adjust them in the profile or with the
+documented `K6_*` overrides.
 
 ## Optional k6 Operator Mode
 

--- a/loadtest/grafana/dashboards.yaml
+++ b/loadtest/grafana/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: authproxy-loadtest
+    orgId: 1
+    folder: AuthProxy Load Test
+    type: file
+    disableDeletion: true
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/loadtest/grafana/dashboards/background-jobs.json
+++ b/loadtest/grafana/dashboards/background-jobs.json
@@ -1,0 +1,79 @@
+{
+  "annotations": { "list": [] },
+  "description": "OAuth refresh sweeps, Asynq task handling, queue depth, and worker scaling during cardinality runs.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (messaging_destination_name) (authproxy_asynq_queue_size)", "legendFormat": "{{messaging_destination_name}}", "refId": "A" }
+      ],
+      "title": "Asynq queue depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (authproxy_asynq_task_type,authproxy_asynq_result) (rate(authproxy_asynq_task_duration_seconds_count[1m]))", "legendFormat": "{{authproxy_asynq_task_type}} {{authproxy_asynq_result}}", "refId": "A" }
+      ],
+      "title": "Asynq task completion rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le,authproxy_asynq_task_type) (rate(authproxy_asynq_task_duration_seconds_bucket[5m])))", "legendFormat": "{{authproxy_asynq_task_type}} p95", "refId": "A" }
+      ],
+      "title": "Asynq task p95 duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (authproxy_oauth2_result) (rate(authproxy_oauth2_refresh_attempts_total[1m]))", "legendFormat": "attempt {{authproxy_oauth2_result}}", "refId": "A" },
+        { "expr": "sum by (authproxy_oauth2_reason) (rate(authproxy_oauth2_refresh_failures_total[1m]))", "legendFormat": "failure {{authproxy_oauth2_reason}}", "refId": "B" }
+      ],
+      "title": "OAuth refresh attempts and failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler=\"authproxy-worker\"}", "legendFormat": "worker current", "refId": "A" },
+        { "expr": "kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler=\"authproxy-worker\"}", "legendFormat": "worker desired", "refId": "B" },
+        { "expr": "kube_deployment_status_replicas_available{deployment=\"authproxy-worker\"}", "legendFormat": "worker available", "refId": "C" }
+      ],
+      "title": "Worker autoscaling",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [ "authproxy", "loadtest", "background" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timezone": "browser",
+  "title": "AuthProxy Load Test - Background Jobs",
+  "uid": "authproxy-loadtest-background",
+  "version": 1
+}

--- a/loadtest/grafana/dashboards/datastores.json
+++ b/loadtest/grafana/dashboards/datastores.json
@@ -1,0 +1,84 @@
+{
+  "annotations": { "list": [] },
+  "description": "Postgres, Redis, and AuthProxy client instrumentation for identifying datastore limits during load tests.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (status) (db_sql_connection_open)", "legendFormat": "SQL {{status}}", "refId": "A" },
+        { "expr": "sum(db_sql_connection_max_open)", "legendFormat": "SQL maximum", "refId": "B" },
+        { "expr": "pg_stat_database_numbackends{datname=\"authproxy\"}", "legendFormat": "Postgres backends", "refId": "C" }
+      ],
+      "title": "Postgres connection pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(db_sql_latency_milliseconds_bucket[5m]))) / 1000", "legendFormat": "SQL p95", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(db_client_connections_use_time_milliseconds_bucket{type=\"command\"}[5m]))) / 1000", "legendFormat": "Redis command p95", "refId": "B" }
+      ],
+      "title": "SQL and Redis client p95 latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "redis_memory_used_bytes", "legendFormat": "used", "refId": "A" },
+        { "expr": "redis_memory_max_bytes", "legendFormat": "max", "refId": "B" },
+        { "expr": "redis_connected_clients", "legendFormat": "clients", "refId": "C" }
+      ],
+      "title": "Redis memory and client count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum(rate(pg_stat_database_tup_inserted{datname=\"authproxy\"}[1m]))", "legendFormat": "Postgres inserts/s", "refId": "A" },
+        { "expr": "sum(rate(redis_commands_processed_total[1m]))", "legendFormat": "Redis commands/s", "refId": "B" },
+        { "expr": "sum(rate(db_sql_latency_milliseconds_count[1m]))", "legendFormat": "AuthProxy SQL operations/s", "refId": "C" }
+      ],
+      "title": "Datastore write and operation pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum(pg_locks_count) by (mode)", "legendFormat": "{{mode}}", "refId": "A" },
+        { "expr": "sum by (pod) (kube_pod_container_status_restarts_total{pod=~\"(postgresql|redis-master|clickhouse)-.*\"})", "legendFormat": "{{pod}} restarts", "refId": "B" }
+      ],
+      "title": "Database locks and datastore pod restarts",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [ "authproxy", "loadtest", "datastores" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timezone": "browser",
+  "title": "AuthProxy Load Test - Datastores",
+  "uid": "authproxy-loadtest-datastores",
+  "version": 1
+}

--- a/loadtest/grafana/dashboards/provider.json
+++ b/loadtest/grafana/dashboards/provider.json
@@ -1,0 +1,67 @@
+{
+  "annotations": { "list": [] },
+  "description": "Receiving go-oauth2-server behavior. It is intentionally independent from AuthProxy so an upstream bottleneck is visible during proxy QPS scaling.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_name=~\"go-oauth2-server.*\"}[1m]))", "legendFormat": "{{http_response_status_code}}", "refId": "A" }
+      ],
+      "title": "Provider request rate by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum(rate(http_server_request_duration_seconds_count{service_name=~\"go-oauth2-server.*\",http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{service_name=~\"go-oauth2-server.*\"}[5m])), 1)", "legendFormat": "provider 5xx", "refId": "A" }
+      ],
+      "title": "Provider 5xx rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"go-oauth2-server.*\"}[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"go-oauth2-server.*\"}[5m])))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"go-oauth2-server.*\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+      ],
+      "title": "Provider HTTP latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "kube_deployment_status_replicas_available{deployment=\"go-oauth2-server\"}", "legendFormat": "available", "refId": "A" },
+        { "expr": "kube_pod_container_status_restarts_total{container=\"go-oauth2-server\"}", "legendFormat": "{{pod}} restarts", "refId": "B" }
+      ],
+      "title": "Provider capacity and restarts",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [ "authproxy", "loadtest", "provider" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timezone": "browser",
+  "title": "AuthProxy Load Test - Upstream Provider",
+  "uid": "authproxy-loadtest-provider",
+  "version": 1
+}

--- a/loadtest/grafana/dashboards/proxy-autoscaling.json
+++ b/loadtest/grafana/dashboards/proxy-autoscaling.json
@@ -1,0 +1,84 @@
+{
+  "annotations": { "list": [] },
+  "description": "Proxy throughput, latency, error rate, and AuthProxy API scaling for the load-test namespace.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type=\"proxy\"}[1m]))", "legendFormat": "upstream proxy RPS", "refId": "A" },
+        { "expr": "sum(rate(http_server_request_duration_seconds_count{authproxy_service=\"api\"}[1m]))", "legendFormat": "API inbound RPS", "refId": "B" },
+        { "expr": "sum(rate(k6_http_reqs_total[1m]))", "legendFormat": "k6 achieved RPS", "refId": "C" }
+      ],
+      "title": "Proxy throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.001 } ] } }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type=\"proxy\",http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type=\"proxy\"}[5m])), 1)", "legendFormat": "upstream 5xx", "refId": "A" },
+        { "expr": "sum(rate(http_server_request_duration_seconds_count{authproxy_service=\"api\",http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_request_duration_seconds_count{authproxy_service=\"api\"}[5m])), 1)", "legendFormat": "API 5xx", "refId": "B" }
+      ],
+      "title": "5xx rate (initial gate: < 0.1%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type=\"proxy\"}[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type=\"proxy\"}[5m])))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type=\"proxy\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+      ],
+      "title": "Outbound proxy latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler=\"authproxy-api\"}", "legendFormat": "current", "refId": "A" },
+        { "expr": "kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler=\"authproxy-api\"}", "legendFormat": "desired", "refId": "B" },
+        { "expr": "kube_deployment_status_replicas_available{deployment=\"authproxy-api\"}", "legendFormat": "available", "refId": "C" }
+      ],
+      "title": "AuthProxy API replicas",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{container!=\"\",pod=~\"authproxy-api-.*\"}[5m]))", "legendFormat": "{{pod}} CPU cores", "refId": "A" },
+        { "expr": "sum by (pod) (container_memory_working_set_bytes{container!=\"\",pod=~\"authproxy-api-.*\"})", "legendFormat": "{{pod}} memory", "refId": "B" }
+      ],
+      "title": "API pod resource pressure (cluster metrics when available)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [ "authproxy", "loadtest", "proxy" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timezone": "browser",
+  "title": "AuthProxy Load Test - Proxy and Autoscaling",
+  "uid": "authproxy-loadtest-proxy",
+  "version": 1
+}

--- a/loadtest/grafana/datasources.yaml
+++ b/loadtest/grafana/datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: AuthProxy Load Test Prometheus
+    uid: loadtest-prometheus
+    type: prometheus
+    access: proxy
+    editable: true
+    isDefault: true
+    url: http://prometheus-loadtest:9090

--- a/loadtest/k8s/base/go-oauth2-server.yaml
+++ b/loadtest/k8s/base/go-oauth2-server.yaml
@@ -30,6 +30,15 @@ spec:
             - --test-mode
             - --test-port
             - "8080"
+          env:
+            # The test-mode server honors standard OTel settings when its
+            # telemetry support is enabled; production manifests omit them.
+            - name: OTEL_SERVICE_NAME
+              value: go-oauth2-server-loadtest
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-lgtm:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
           ports:
             - name: http
               containerPort: 8080

--- a/loadtest/k8s/base/kube-state-metrics.yaml
+++ b/loadtest/k8s/base/kube-state-metrics.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/component: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-state-metrics
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/component: observability
+        loadtest.authproxy.io/component: dependency
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --namespaces=$(POD_NAMESPACE)
+            - --resources=pods,deployments,horizontalpodautoscalers
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: metrics
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/component: observability
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics

--- a/loadtest/k8s/base/observability.yaml
+++ b/loadtest/k8s/base/observability.yaml
@@ -50,6 +50,17 @@ spec:
             limits:
               memory: 2Gi
           volumeMounts:
+            - name: grafana-provisioning
+              mountPath: /etc/grafana/provisioning/datasources/loadtest.yaml
+              subPath: datasources.yaml
+              readOnly: true
+            - name: grafana-provisioning
+              mountPath: /etc/grafana/provisioning/dashboards/loadtest.yaml
+              subPath: dashboards.yaml
+              readOnly: true
+            - name: grafana-dashboards
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
             - name: tempo-data
               mountPath: /data/tempo
             - name: grafana-data
@@ -63,6 +74,12 @@ spec:
             - name: pyroscope-storage
               mountPath: /data/pyroscope
       volumes:
+        - name: grafana-provisioning
+          configMap:
+            name: authproxy-loadtest-grafana-provisioning
+        - name: grafana-dashboards
+          configMap:
+            name: authproxy-loadtest-grafana-dashboards
         - name: tempo-data
           emptyDir: {}
         - name: grafana-data

--- a/loadtest/k8s/base/postgres-exporter.yaml
+++ b/loadtest/k8s/base/postgres-exporter.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-exporter
+  labels:
+    app.kubernetes.io/name: postgres-exporter
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-exporter
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-exporter
+        app.kubernetes.io/component: observability
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: postgres-exporter
+          image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-load-db
+                  key: AUTHPROXY_DB_PASSWORD
+            - name: DATA_SOURCE_NAME
+              value: postgresql://authproxy:$(POSTGRES_PASSWORD)@postgresql:5432/authproxy?sslmode=disable
+          ports:
+            - name: metrics
+              containerPort: 9187
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-exporter
+  labels:
+    app.kubernetes.io/name: postgres-exporter
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgres-exporter
+    app.kubernetes.io/component: observability
+  ports:
+    - name: metrics
+      port: 9187
+      targetPort: metrics

--- a/loadtest/k8s/base/prometheus.yaml
+++ b/loadtest/k8s/base/prometheus.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-loadtest-config
+  labels:
+    app.kubernetes.io/name: prometheus-loadtest
+    app.kubernetes.io/component: observability
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+      scrape_timeout: 10s
+    rule_files:
+      - /etc/prometheus/rules/*.yaml
+    scrape_configs:
+      - job_name: otel-lgtm-federate
+        honor_labels: true
+        metrics_path: /federate
+        params:
+          match[]:
+            - '{__name__=~".+"}'
+        static_configs:
+          - targets:
+              - otel-lgtm:9090
+      - job_name: kube-state-metrics
+        static_configs:
+          - targets:
+              - kube-state-metrics:8080
+      - job_name: postgres-exporter
+        static_configs:
+          - targets:
+              - postgres-exporter:9187
+      - job_name: redis-exporter
+        static_configs:
+          - targets:
+              - redis-exporter:9121
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-loadtest
+  labels:
+    app.kubernetes.io/name: prometheus-loadtest
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-loadtest
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-loadtest
+        app.kubernetes.io/component: observability
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: prometheus
+          image: docker.io/prom/prometheus:v2.54.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --web.enable-lifecycle
+            - --web.enable-remote-write-receiver
+          ports:
+            - name: http
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+              readOnly: true
+            - name: rules
+              mountPath: /etc/prometheus/rules
+              readOnly: true
+            - name: storage
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-loadtest-config
+        - name: rules
+          configMap:
+            name: authproxy-loadtest-prometheus-rules
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-loadtest
+  labels:
+    app.kubernetes.io/name: prometheus-loadtest
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus-loadtest
+    app.kubernetes.io/component: observability
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/loadtest/k8s/base/redis-exporter.yaml
+++ b/loadtest/k8s/base/redis-exporter.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-exporter
+  labels:
+    app.kubernetes.io/name: redis-exporter
+    app.kubernetes.io/component: observability
+    loadtest.authproxy.io/component: dependency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis-exporter
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis-exporter
+        app.kubernetes.io/component: observability
+        loadtest.authproxy.io/component: dependency
+    spec:
+      containers:
+        - name: redis-exporter
+          image: oliver006/redis_exporter:v1.66.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REDIS_ADDR
+              value: redis://redis-master:6379
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: authproxy-load-redis
+                  key: AUTHPROXY_REDIS_PASSWORD
+          ports:
+            - name: metrics
+              containerPort: 9121
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-exporter
+  labels:
+    app.kubernetes.io/name: redis-exporter
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis-exporter
+    app.kubernetes.io/component: observability
+  ports:
+    - name: metrics
+      port: 9121
+      targetPort: metrics

--- a/loadtest/k8s/k6/proxy-job.yaml
+++ b/loadtest/k8s/k6/proxy-job.yaml
@@ -26,6 +26,8 @@ spec:
             - /scripts/proxy.js
             - --summary-export
             - /artifacts/summary.json
+            - --out
+            - experimental-prometheus-rw
           env:
             - name: AUTHPROXY_BEARER_TOKEN
               valueFrom:
@@ -34,6 +36,8 @@ spec:
                   key: AUTHPROXY_BEARER_TOKEN
             - name: K6_CONNECTIONS_FILE
               value: /scripts/connections.csv
+            - name: K6_PROMETHEUS_RW_SERVER_URL
+              value: http://prometheus-loadtest:9090/api/v1/write
           envFrom:
             - configMapRef:
                 name: authproxy-loadtest-k6-env

--- a/loadtest/k8s/k6/proxy-testrun.yaml
+++ b/loadtest/k8s/k6/proxy-testrun.yaml
@@ -8,7 +8,7 @@ metadata:
     loadtest.authproxy.io/scenario: proxy
 spec:
   parallelism: 1
-  arguments: --summary-export /tmp/summary.json
+  arguments: --summary-export /tmp/summary.json --out experimental-prometheus-rw
   script:
     configMap:
       name: authproxy-loadtest-k6
@@ -28,6 +28,8 @@ spec:
             key: AUTHPROXY_BEARER_TOKEN
       - name: K6_CONNECTIONS_FILE
         value: ./connections.csv
+      - name: K6_PROMETHEUS_RW_SERVER_URL
+        value: http://prometheus-loadtest:9090/api/v1/write
     envFrom:
       - configMapRef:
           name: authproxy-loadtest-k6-env

--- a/loadtest/k8s/k6/smoke-job.yaml
+++ b/loadtest/k8s/k6/smoke-job.yaml
@@ -26,6 +26,8 @@ spec:
             - /scripts/smoke.js
             - --summary-export
             - /artifacts/summary.json
+            - --out
+            - experimental-prometheus-rw
           env:
             - name: AUTHPROXY_PUBLIC_URL
               value: http://authproxy-public:8080
@@ -45,6 +47,8 @@ spec:
               value: "4"
             - name: K6_MAX_VUS
               value: "16"
+            - name: K6_PROMETHEUS_RW_SERVER_URL
+              value: http://prometheus-loadtest:9090/api/v1/write
           volumeMounts:
             - name: scripts
               mountPath: /scripts

--- a/loadtest/k8s/k6/smoke-testrun.yaml
+++ b/loadtest/k8s/k6/smoke-testrun.yaml
@@ -8,6 +8,7 @@ metadata:
     loadtest.authproxy.io/scenario: smoke
 spec:
   parallelism: 1
+  arguments: --summary-export /tmp/summary.json --out experimental-prometheus-rw
   script:
     configMap:
       name: authproxy-loadtest-k6
@@ -33,3 +34,5 @@ spec:
         value: "4"
       - name: K6_MAX_VUS
         value: "16"
+      - name: K6_PROMETHEUS_RW_SERVER_URL
+        value: http://prometheus-loadtest:9090/api/v1/write

--- a/loadtest/prometheus/alerts.yaml
+++ b/loadtest/prometheus/alerts.yaml
@@ -1,0 +1,91 @@
+groups:
+  - name: authproxy-loadtest-proxy
+    rules:
+      - record: authproxy_loadtest:proxy_request_rate:5m
+        expr: sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy"}[5m]))
+      - record: authproxy_loadtest:proxy_5xx_rate:5m
+        expr: |
+          sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy",http_response_status_code=~"5.."}[5m]))
+          / clamp_min(sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy"}[5m])), 1)
+      - record: authproxy_loadtest:proxy_p95_seconds:5m
+        expr: |
+          histogram_quantile(0.95, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type="proxy"}[5m])))
+      - alert: AuthProxyLoadTestProxy5xxRateHigh
+        expr: |
+          sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy",http_response_status_code=~"5.."}[5m]))
+          / clamp_min(sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy"}[5m])), 1) > 0.001
+        for: 2m
+        labels:
+          severity: warning
+          component: proxy
+        annotations:
+          summary: AuthProxy proxy 5xx rate is above the 0.1% load-test gate.
+          runbook: Inspect the Proxy and Autoscaling dashboard and the k6 summary artifact.
+      - alert: AuthProxyLoadTestProxyP95High
+        expr: |
+          histogram_quantile(0.95, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type="proxy"}[5m]))) > 1 # LOADTEST_PROXY_P95_SECONDS
+        for: 5m
+        labels:
+          severity: warning
+          component: proxy
+        annotations:
+          summary: AuthProxy outbound proxy p95 is above the selected profile target.
+          runbook: Compare the profile-specific p95 target with the Proxy and Autoscaling dashboard.
+  - name: authproxy-loadtest-background
+    rules:
+      - record: authproxy_loadtest:asynq_queue_size:max
+        expr: max(authproxy_asynq_queue_size)
+      - record: authproxy_loadtest:oauth_refresh_failure_rate:5m
+        expr: sum(rate(authproxy_oauth2_refresh_failures_total[5m]))
+      - alert: AuthProxyLoadTestQueueBacklog
+        expr: max(authproxy_asynq_queue_size) > 1000
+        for: 5m
+        labels:
+          severity: warning
+          component: worker
+        annotations:
+          summary: AuthProxy Asynq queue has remained above 1,000 tasks.
+          runbook: Inspect worker replicas, task duration, and queue samples before changing the threshold for a profile.
+      - alert: AuthProxyLoadTestRefreshFailures
+        expr: sum(rate(authproxy_oauth2_refresh_failures_total[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+          component: oauth2
+        annotations:
+          summary: OAuth refresh failures are occurring during a load test.
+          runbook: Inspect failure reason labels and the upstream provider dashboard.
+  - name: authproxy-loadtest-datastores
+    rules:
+      - record: authproxy_loadtest:sql_p95_seconds:5m
+        expr: histogram_quantile(0.95, sum by (le) (rate(db_sql_latency_milliseconds_bucket[5m]))) / 1000
+      - record: authproxy_loadtest:redis_command_p95_seconds:5m
+        expr: histogram_quantile(0.95, sum by (le) (rate(db_client_connections_use_time_milliseconds_bucket{type="command"}[5m]))) / 1000
+      - alert: AuthProxyLoadTestDBPoolWait
+        expr: sum(rate(db_sql_connection_wait_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: postgres
+        annotations:
+          summary: AuthProxy SQL clients are waiting for database connections.
+          runbook: Inspect connection pressure, lock counts, and query plans in the run artifacts.
+      - alert: AuthProxyLoadTestRedisClientP95High
+        expr: |
+          histogram_quantile(0.95, sum by (le) (rate(db_client_connections_use_time_milliseconds_bucket{type="command"}[5m]))) > 50
+        for: 5m
+        labels:
+          severity: warning
+          component: redis
+        annotations:
+          summary: Redis client p95 latency is above 50 milliseconds.
+          runbook: Inspect Redis memory, command rate, and worker queue depth.
+      - alert: AuthProxyLoadTestPodRestarted
+        expr: increase(kube_pod_container_status_restarts_total[15m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          component: kubernetes
+        annotations:
+          summary: A load-test workload container restarted in the last 15 minutes.
+          runbook: Inspect pod events and the datastore or provider dashboard for the affected pod.

--- a/loadtest/prometheus/queries.tsv
+++ b/loadtest/prometheus/queries.tsv
@@ -1,0 +1,16 @@
+# name<TAB>instant PromQL query. The collector stores each response under prometheus/queries/.
+proxy-request-rate	sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy"}[5m]))
+proxy-5xx-rate	sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy",http_response_status_code=~"5.."}[5m])) / clamp_min(sum(rate(authproxy_client_request_duration_seconds_count{authproxy_request_type="proxy"}[5m])), 1)
+proxy-p95-seconds	histogram_quantile(0.95, sum by (le) (rate(authproxy_client_request_duration_seconds_bucket{authproxy_request_type="proxy"}[5m])))
+k6-http-request-rate	sum(rate(k6_http_reqs_total[5m]))
+k6-dropped-iterations	sum(k6_dropped_iterations_total)
+oauth-refresh-attempt-rate	sum(rate(authproxy_oauth2_refresh_attempts_total[5m]))
+oauth-refresh-failure-rate	sum(rate(authproxy_oauth2_refresh_failures_total[5m]))
+asynq-queue-size	max(authproxy_asynq_queue_size)
+asynq-task-p95-seconds	histogram_quantile(0.95, sum by (le) (rate(authproxy_asynq_task_duration_seconds_bucket[5m])))
+api-hpa-current-replicas	kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="authproxy-api"}
+api-hpa-desired-replicas	kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="authproxy-api"}
+postgres-connections	pg_stat_database_numbackends{datname="authproxy"}
+sql-p95-seconds	histogram_quantile(0.95, sum by (le) (rate(db_sql_latency_milliseconds_bucket[5m]))) / 1000
+redis-command-p95-seconds	histogram_quantile(0.95, sum by (le) (rate(db_client_connections_use_time_milliseconds_bucket{type="command"}[5m]))) / 1000
+redis-memory-bytes	redis_memory_used_bytes

--- a/loadtest/scripts/collect
+++ b/loadtest/scripts/collect
@@ -12,9 +12,12 @@ run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" col
 
 loadtest_require_cmd kubectl
 loadtest_require_cmd helm
+loadtest_require_cmd curl
 
 loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 loadtest_capture_helm_snapshot "$namespace" "$run_dir"
+loadtest_capture_prometheus_snapshot "$namespace" "$run_dir"
+loadtest_capture_postgres_explain "$namespace" "$run_dir"
 
 kubectl -n "$namespace" get jobs -o wide > "$run_dir/kubernetes/jobs.txt" 2>&1 || true
 kubectl -n "$namespace" get jobs -l app.kubernetes.io/name=k6 -o yaml > "$run_dir/k6/jobs.yaml" 2>&1 || true

--- a/loadtest/scripts/down
+++ b/loadtest/scripts/down
@@ -27,6 +27,11 @@ kubectl -n "$namespace" delete jobs -l app.kubernetes.io/name=k6 --ignore-not-fo
 kubectl -n "$namespace" delete configmaps -l app.kubernetes.io/name=k6 --ignore-not-found=true >/dev/null 2>&1 || true
 kubectl -n "$namespace" delete configmap authproxy-loadtest-k6 authproxy-loadtest-k6-env --ignore-not-found=true >/dev/null 2>&1 || true
 kubectl -n "$namespace" delete secret authproxy-loadtest-k6-auth --ignore-not-found=true >/dev/null 2>&1 || true
+kubectl -n "$namespace" delete configmap \
+  authproxy-loadtest-grafana-provisioning \
+  authproxy-loadtest-grafana-dashboards \
+  authproxy-loadtest-prometheus-rules \
+  --ignore-not-found=true >/dev/null 2>&1 || true
 kubectl -n "$namespace" delete testruns.k6.io -l app.kubernetes.io/name=k6 --ignore-not-found=true >/dev/null 2>&1 || true
 kubectl -n "$namespace" delete testrun authproxy-smoke authproxy-proxy --ignore-not-found=true >/dev/null 2>&1 || true
 

--- a/loadtest/scripts/lib/loadtest.sh
+++ b/loadtest/scripts/lib/loadtest.sh
@@ -216,9 +216,22 @@ loadtest_init_run_dir() {
   now=$(loadtest_timestamp)
 
   local run_dir="${LOADTEST_RUN_DIR:-$LOADTEST_ROOT/runs/${now}-${profile_name}-${command_name}}"
-  mkdir -p "$run_dir/helm-values" "$run_dir/kubernetes" "$run_dir/helm" "$run_dir/k6"
+  mkdir -p \
+    "$run_dir/helm-values" \
+    "$run_dir/kubernetes" \
+    "$run_dir/helm" \
+    "$run_dir/k6" \
+    "$run_dir/observability/dashboards" \
+    "$run_dir/prometheus/queries" \
+    "$run_dir/db-explain/sql"
   cp "$profile_file" "$run_dir/profile.yaml"
   cp "$LOADTEST_ROOT"/helm-values/*.yaml "$run_dir/helm-values/"
+  cp "$LOADTEST_ROOT/grafana/dashboards.yaml" "$run_dir/observability/"
+  cp "$LOADTEST_ROOT/grafana/datasources.yaml" "$run_dir/observability/"
+  cp "$LOADTEST_ROOT/grafana/dashboards"/*.json "$run_dir/observability/dashboards/"
+  cp "$LOADTEST_ROOT/prometheus/alerts.yaml" "$run_dir/prometheus/"
+  cp "$LOADTEST_ROOT/prometheus/queries.tsv" "$run_dir/prometheus/"
+  cp "$LOADTEST_ROOT/sql"/*.sql "$run_dir/db-explain/sql/"
 
   {
     printf "command=%s\n" "$command_name"
@@ -230,11 +243,69 @@ loadtest_init_run_dir() {
     printf "authproxy_image_tag=%s\n" "${AUTHPROXY_IMAGE_TAG:-main}"
     printf "go_oauth2_server_image=%s\n" "${GO_OAUTH2_SERVER_IMAGE:-ghcr.io/rmorlok/go-oauth2-server:master}"
     printf "k6_image=%s\n" "${K6_IMAGE:-grafana/k6:0.54.0}"
+    printf "prometheus_url=%s\n" "${LOADTEST_PROMETHEUS_URL:-service/prometheus-loadtest}"
     printf "install_k6_operator=%s\n" "${LOADTEST_INSTALL_K6_OPERATOR:-false}"
     printf "install_keda=%s\n" "${LOADTEST_INSTALL_KEDA:-false}"
   } > "$run_dir/metadata.env"
 
   printf "%s\n" "$run_dir"
+}
+
+loadtest_profile_p95_seconds() {
+  local profile_file=$1
+  local value
+  value=$(loadtest_yaml_section_value "$profile_file" k6 p95_latency_ms)
+  if [[ -z "$value" ]]; then
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95_latency_target)
+  fi
+
+  case "$value" in
+    ""|profile-configured)
+      printf "1\n"
+      ;;
+    *ms)
+      awk -v milliseconds="${value%ms}" 'BEGIN { printf "%.6f\n", milliseconds / 1000 }'
+      ;;
+    *s)
+      printf "%s\n" "${value%s}"
+      ;;
+    *)
+      awk -v milliseconds="$value" 'BEGIN { printf "%.6f\n", milliseconds / 1000 }'
+      ;;
+  esac
+}
+
+loadtest_apply_observability_assets() {
+  local namespace=$1
+  local profile_file=$2
+  local run_dir=$3
+  local tmp
+  local proxy_p95_seconds
+  tmp=$(mktemp -d)
+  proxy_p95_seconds=$(loadtest_profile_p95_seconds "$profile_file")
+
+  kubectl -n "$namespace" create configmap authproxy-loadtest-grafana-provisioning \
+    --from-file=datasources.yaml="$LOADTEST_ROOT/grafana/datasources.yaml" \
+    --from-file=dashboards.yaml="$LOADTEST_ROOT/grafana/dashboards.yaml" \
+    --dry-run=client -o yaml > "$tmp/grafana-provisioning.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/grafana-provisioning.yaml"
+
+  kubectl -n "$namespace" create configmap authproxy-loadtest-grafana-dashboards \
+    --from-file="$LOADTEST_ROOT/grafana/dashboards" \
+    --dry-run=client -o yaml > "$tmp/grafana-dashboards.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/grafana-dashboards.yaml"
+
+  sed "s/> 1 # LOADTEST_PROXY_P95_SECONDS/> $proxy_p95_seconds/" \
+    "$LOADTEST_ROOT/prometheus/alerts.yaml" > "$tmp/alerts.yaml"
+  cp "$tmp/alerts.yaml" "$run_dir/prometheus/alerts.rendered.yaml"
+  printf "proxy_p95_target_seconds=%s\n" "$proxy_p95_seconds" >> "$run_dir/metadata.env"
+
+  kubectl -n "$namespace" create configmap authproxy-loadtest-prometheus-rules \
+    --from-file=alerts.yaml="$tmp/alerts.yaml" \
+    --dry-run=client -o yaml > "$tmp/prometheus-rules.yaml"
+  kubectl -n "$namespace" apply -f "$tmp/prometheus-rules.yaml"
+
+  rm -rf "$tmp"
 }
 
 loadtest_ensure_namespace() {
@@ -319,12 +390,34 @@ loadtest_ensure_generated_secrets() {
 loadtest_capture_cluster_snapshot() {
   local namespace=$1
   local run_dir=$2
+  local captured_at
+  captured_at=$(loadtest_timestamp)
 
   kubectl -n "$namespace" get pods -o wide > "$run_dir/kubernetes/pods.txt" 2>&1 || true
+  kubectl -n "$namespace" get pods -o yaml > "$run_dir/kubernetes/pods.yaml" 2>&1 || true
   kubectl -n "$namespace" get deployments -o wide > "$run_dir/kubernetes/deployments.txt" 2>&1 || true
+  kubectl -n "$namespace" get deployments -o yaml > "$run_dir/kubernetes/deployments.yaml" 2>&1 || true
   kubectl -n "$namespace" get services -o wide > "$run_dir/kubernetes/services.txt" 2>&1 || true
   kubectl -n "$namespace" get hpa -o yaml > "$run_dir/kubernetes/hpa.yaml" 2>&1 || true
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp > "$run_dir/kubernetes/events.txt" 2>&1 || true
+  kubectl -n "$namespace" get replicasets -o wide > "$run_dir/kubernetes/replicasets.txt" 2>&1 || true
+  kubectl -n "$namespace" top pods > "$run_dir/kubernetes/pod-resource-usage.txt" 2>&1 || true
+
+  if [[ ! -s "$run_dir/kubernetes/hpa-timeline.tsv" ]]; then
+    printf "captured_at\tnamespace\thpa\tmin_replicas\tcurrent_replicas\tdesired_replicas\tmax_replicas\n" > "$run_dir/kubernetes/hpa-timeline.tsv"
+  fi
+  kubectl -n "$namespace" get hpa \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.minReplicas}{"\t"}{.status.currentReplicas}{"\t"}{.status.desiredReplicas}{"\t"}{.spec.maxReplicas}{"\n"}{end}' \
+    2>/dev/null | awk -v captured_at="$captured_at" -v namespace="$namespace" 'BEGIN { OFS="\t" } NF { print captured_at, namespace, $0 }' \
+    >> "$run_dir/kubernetes/hpa-timeline.tsv" || true
+
+  if [[ ! -s "$run_dir/kubernetes/image-shas.tsv" ]]; then
+    printf "captured_at\tnamespace\tpod\tcontainer\timage\timage_id\trestarts\n" > "$run_dir/kubernetes/image-shas.tsv"
+  fi
+  kubectl -n "$namespace" get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.name}{"\t"}{.image}{"\t"}{.imageID}{"\t"}{.restartCount}{"\n"}{end}{end}' \
+    2>/dev/null | awk -v captured_at="$captured_at" -v namespace="$namespace" 'BEGIN { OFS="\t" } NF { print captured_at, namespace, $0 }' \
+    >> "$run_dir/kubernetes/image-shas.tsv" || true
 }
 
 loadtest_capture_helm_snapshot() {
@@ -336,5 +429,72 @@ loadtest_capture_helm_snapshot() {
   for release in "${LOADTEST_AUTH_PROXY_RELEASES[@]}"; do
     helm -n "$namespace" get values "$release" --all > "$run_dir/helm/${release}-values.yaml" 2>&1 || true
     helm -n "$namespace" get manifest "$release" > "$run_dir/helm/${release}-manifest.yaml" 2>&1 || true
+  done
+}
+
+loadtest_capture_prometheus_snapshot() {
+  local namespace=$1
+  local run_dir=$2
+  local snapshot_dir="$run_dir/prometheus"
+  local url=${LOADTEST_PROMETHEUS_URL:-}
+  local port_forward_pid=""
+  local port=${LOADTEST_PROMETHEUS_PORT:-19090}
+  local port_forward_log="$snapshot_dir/port-forward.log"
+
+  mkdir -p "$snapshot_dir/queries"
+
+  if [[ -z "$url" ]]; then
+    kubectl -n "$namespace" port-forward service/prometheus-loadtest "$port:9090" > "$port_forward_log" 2>&1 &
+    port_forward_pid=$!
+    url="http://127.0.0.1:$port"
+
+    local attempt
+    for attempt in $(seq 1 20); do
+      if curl --connect-timeout 1 --max-time 3 -fsS "$url/-/ready" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+    done
+  fi
+
+  if curl --connect-timeout 2 --max-time 10 -fsS "$url/-/ready" >/dev/null 2>&1; then
+    printf "url=%s\ncaptured_at=%s\n" "$url" "$(loadtest_timestamp)" > "$snapshot_dir/metadata.env"
+    curl --connect-timeout 2 --max-time 30 -fsS "$url/api/v1/status/buildinfo" > "$snapshot_dir/buildinfo.json" 2>&1 || true
+    curl --connect-timeout 2 --max-time 30 -fsS "$url/api/v1/targets" > "$snapshot_dir/targets.json" 2>&1 || true
+    curl --connect-timeout 2 --max-time 30 -fsS "$url/api/v1/rules" > "$snapshot_dir/rules.json" 2>&1 || true
+    curl --connect-timeout 2 --max-time 30 -fsS "$url/api/v1/alerts" > "$snapshot_dir/alerts.json" 2>&1 || true
+    curl --connect-timeout 2 --max-time 30 -fsS "$url/api/v1/label/__name__/values" > "$snapshot_dir/metric-names.json" 2>&1 || true
+
+    local query_name
+    local query
+    while IFS=$'\t' read -r query_name query; do
+      [[ -n "$query_name" ]] || continue
+      [[ "$query_name" == \#* ]] && continue
+      curl --connect-timeout 2 --max-time 30 -fsSG "$url/api/v1/query" \
+        --data-urlencode "query=$query" > "$snapshot_dir/queries/${query_name}.json" 2>&1 || true
+    done < "$LOADTEST_ROOT/prometheus/queries.tsv"
+  else
+    printf "Prometheus was not ready at %s\n" "$url" > "$snapshot_dir/error.txt"
+  fi
+
+  if [[ -n "$port_forward_pid" ]]; then
+    kill "$port_forward_pid" >/dev/null 2>&1 || true
+    wait "$port_forward_pid" 2>/dev/null || true
+  fi
+}
+
+loadtest_capture_postgres_explain() {
+  local namespace=$1
+  local run_dir=$2
+  local sql_file
+  local name
+  local output
+
+  for sql_file in "$LOADTEST_ROOT"/sql/*.sql; do
+    name=$(basename "$sql_file" .sql)
+    output="$run_dir/db-explain/${name}.txt"
+    kubectl -n "$namespace" exec -i deployment/postgresql -- \
+      sh -c 'PGPASSWORD="$POSTGRESQL_PASSWORD" psql -U authproxy -d authproxy -v ON_ERROR_STOP=1' \
+      < "$sql_file" > "$output" 2>&1 || true
   done
 }

--- a/loadtest/scripts/run
+++ b/loadtest/scripts/run
@@ -13,6 +13,7 @@ scenario=${2:-${LOADTEST_SCENARIO:-${default_scenario:-smoke}}}
 run_dir=$(loadtest_init_run_dir "$profile_name" "$profile_file" "$namespace" run)
 
 loadtest_require_cmd kubectl
+loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 
 profile_k6_mode=$(loadtest_yaml_section_value "$profile_file" k6 mode)
 k6_mode=${LOADTEST_K6_MODE:-${profile_k6_mode:-job}}
@@ -293,7 +294,7 @@ metadata:
     loadtest.authproxy.io/scenario: proxy
 spec:
   parallelism: $parallelism
-  arguments: --summary-export /tmp/summary.json
+  arguments: --summary-export /tmp/summary.json --out experimental-prometheus-rw
   script:
     configMap:
       name: authproxy-loadtest-k6
@@ -313,6 +314,8 @@ spec:
             key: AUTHPROXY_BEARER_TOKEN
       - name: K6_CONNECTIONS_FILE
         value: ./connections.csv
+      - name: K6_PROMETHEUS_RW_SERVER_URL
+        value: http://prometheus-loadtest:9090/api/v1/write
     envFrom:
       - configMapRef:
           name: $env_configmap
@@ -429,6 +432,8 @@ run_proxy_once() {
       record_scale_result "$api_replicas" "$scenario_name" "$run_dir/k6/${run_name}-summary.json" "$run_dir/k6/${run_name}.log"
     fi
   fi
+
+  loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 }
 
 record_scale_result() {
@@ -476,6 +481,7 @@ set_api_replicas() {
     kubectl -n "$namespace" scale deployment/authproxy-api "--replicas=$replicas"
   fi
   kubectl -n "$namespace" rollout status deployment/authproxy-api "--timeout=$timeout"
+  loadtest_capture_cluster_snapshot "$namespace" "$run_dir"
 }
 
 run_proxy_suite() {

--- a/loadtest/scripts/up
+++ b/loadtest/scripts/up
@@ -25,6 +25,7 @@ loadtest_log "artifacts: $run_dir"
 
 loadtest_ensure_namespace "$namespace"
 loadtest_ensure_generated_secrets "$namespace"
+loadtest_apply_observability_assets "$namespace" "$profile_file" "$run_dir"
 
 if [[ "${LOADTEST_INSTALL_K6_OPERATOR:-false}" == "true" ]]; then
   loadtest_log "installing k6 Operator"
@@ -54,6 +55,10 @@ loadtest_wait_for_deployment "$namespace" postgresql "$helm_timeout"
 loadtest_wait_for_deployment "$namespace" redis-master "$helm_timeout"
 loadtest_wait_for_deployment "$namespace" clickhouse "$helm_timeout"
 loadtest_wait_for_deployment "$namespace" otel-lgtm "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" prometheus-loadtest "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" kube-state-metrics "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" postgres-exporter "$helm_timeout"
+loadtest_wait_for_deployment "$namespace" redis-exporter "$helm_timeout"
 loadtest_wait_for_deployment "$namespace" go-oauth2-server "$helm_timeout"
 
 chart="$REPO_ROOT/deploy/charts/authproxy"

--- a/loadtest/sql/periodic-scheduler-walk.sql
+++ b/loadtest/sql/periodic-scheduler-walk.sql
@@ -1,0 +1,8 @@
+-- Mirrors core.GetCronTasks's ListConnectionsBuilder page for setup/configured connections.
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT *
+FROM connections
+WHERE deleted_at IS NULL
+  AND state IN ('setup', 'configured')
+ORDER BY created_at ASC, id ASC
+LIMIT 101 OFFSET 0;

--- a/loadtest/sql/postgres-stats.sql
+++ b/loadtest/sql/postgres-stats.sql
@@ -1,0 +1,20 @@
+SELECT now() AS captured_at,
+       datname,
+       numbackends,
+       xact_commit,
+       xact_rollback,
+       blks_read,
+       blks_hit,
+       tup_inserted,
+       tup_updated,
+       tup_deleted,
+       deadlocks
+FROM pg_stat_database
+WHERE datname = current_database();
+
+SELECT mode, count(*) AS lock_count
+FROM pg_locks
+GROUP BY mode
+ORDER BY mode;
+
+SELECT pg_size_pretty(pg_database_size(current_database())) AS database_size;

--- a/loadtest/sql/refresh-token-walk.sql
+++ b/loadtest/sql/refresh-token-walk.sql
@@ -1,0 +1,11 @@
+-- Mirrors database.EnumerateOAuth2TokensExpiringWithin's first 100-row page.
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT t.*, c.*
+FROM oauth2_tokens AS t
+INNER JOIN connections AS c ON c.id = t.connection_id
+WHERE t.deleted_at IS NULL
+  AND c.deleted_at IS NULL
+  AND c.state = 'configured'
+  AND t.access_token_expires_at <= CURRENT_TIMESTAMP + INTERVAL '5 minutes'
+ORDER BY t.created_at DESC
+LIMIT 101 OFFSET 0;

--- a/loadtest/sql/stale-setup-cleanup-walk.sql
+++ b/loadtest/sql/stale-setup-cleanup-walk.sql
@@ -1,0 +1,10 @@
+-- Mirrors database:cleanup_stale_connections's ListConnectionsBuilder page.
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT *
+FROM connections
+WHERE deleted_at IS NULL
+  AND state = 'setup'
+  AND setup_step_id IS NOT NULL
+  AND updated_at < CURRENT_TIMESTAMP - INTERVAL '1 second'
+ORDER BY created_at ASC, id ASC
+LIMIT 101 OFFSET 0;


### PR DESCRIPTION
Closes #715

## Summary
- provision Grafana dashboards, a dedicated Prometheus receiver/rule evaluator, kube-state-metrics, and Postgres/Redis exporters for load-test runs
- publish k6 live metrics through Prometheus remote write and configure test-mode provider OTLP settings
- collect Prometheus snapshots, HPA/image timelines, and refresh/scheduler/stale-cleanup EXPLAIN ANALYZE artifacts

## Verification
- `./scripts/preflight.sh`
- shell syntax, YAML/JSON parsing, rendered alert-rule checks, artifact-layout smoke check, and Helm template rendering
- Kubernetes client dry-run was attempted but the configured AWS SSO token is expired; rerun after `aws sso login`
