### PR TITLE
Use keyset pagination for namespace encryption walks

### DIFF
--- a/internal/database/migrations/postgres/000014_add_namespace_encryption_target_index.down.sql
+++ b/internal/database/migrations/postgres/000014_add_namespace_encryption_target_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_namespaces_active_depth_path;

--- a/internal/database/migrations/postgres/000014_add_namespace_encryption_target_index.up.sql
+++ b/internal/database/migrations/postgres/000014_add_namespace_encryption_target_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_namespaces_active_depth_path
+    ON namespaces (depth, path)
+    WHERE deleted_at IS NULL;

--- a/internal/database/migrations/sqlite/000014_add_namespace_encryption_target_index.down.sql
+++ b/internal/database/migrations/sqlite/000014_add_namespace_encryption_target_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_namespaces_active_depth_path;

--- a/internal/database/migrations/sqlite/000014_add_namespace_encryption_target_index.up.sql
+++ b/internal/database/migrations/sqlite/000014_add_namespace_encryption_target_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_namespaces_active_depth_path
+    ON namespaces (depth, path)
+    WHERE deleted_at IS NULL;

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -1002,18 +1002,28 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 	callback func(targets []NamespaceEncryptionTarget, lastPage bool) (updates []NamespaceTargetDataEncryptionKeyUpdate, keepGoing pagination.KeepGoing, err error),
 ) error {
 	const pageSize = 100
-	offset := uint64(0)
+	var lastDepth uint64
+	var lastPath string
+	hasCursor := false
 
 	for {
-		rows, err := s.sq.
+		query := s.sq.
 			Select("path", "depth", "key_id", "target_data_encryption_key_id").
 			From(NamespacesTable).
 			Where(sq.Eq{"deleted_at": nil}).
 			OrderBy("depth, path").
-			Limit(pageSize + 1).
-			Offset(offset).
-			RunWith(s.db).
-			Query()
+			Limit(pageSize + 1)
+		if hasCursor {
+			query = query.Where(sq.Or{
+				sq.Gt{"depth": lastDepth},
+				sq.And{
+					sq.Eq{"depth": lastDepth},
+					sq.Gt{"path": lastPath},
+				},
+			})
+		}
+
+		rows, err := query.RunWith(s.db).Query()
 		if err != nil {
 			return err
 		}
@@ -1061,7 +1071,10 @@ func (s *service) EnumerateNamespaceEncryptionTargets(
 			break
 		}
 
-		offset += pageSize
+		last := results[len(results)-1]
+		lastDepth = last.Depth
+		lastPath = last.Path
+		hasCursor = true
 	}
 
 	return nil

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -1828,6 +1828,35 @@ INSERT INTO namespaces
 			require.Len(t, lastPageValues, 1)
 			require.True(t, lastPageValues[0])
 		})
+
+		t.Run("paginates with an ordered keyset", func(t *testing.T) {
+			_, db, _ := MustApplyBlankTestDbConfigRaw(t, nil)
+			ctx := apctx.NewBuilderBackground().Build()
+
+			for i := 0; i < 205; i++ {
+				require.NoError(t, db.CreateNamespace(ctx, &Namespace{
+					Path: fmt.Sprintf("root.keyset-%03d", i),
+				}))
+			}
+
+			var paths []string
+			var lastPageValues []bool
+			err := db.EnumerateNamespaceEncryptionTargets(ctx,
+				func(targets []NamespaceEncryptionTarget, lastPage bool) ([]NamespaceTargetDataEncryptionKeyUpdate, pagination.KeepGoing, error) {
+					for _, target := range targets {
+						paths = append(paths, target.Path)
+					}
+					lastPageValues = append(lastPageValues, lastPage)
+					return nil, pagination.Continue, nil
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, paths, 206)
+			require.Equal(t, []bool{false, false, true}, lastPageValues)
+			require.Equal(t, "root", paths[0])
+			require.Equal(t, "root.keyset-000", paths[1])
+			require.Equal(t, "root.keyset-204", paths[len(paths)-1])
+		})
 	})
 
 	t.Run("Labels", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace offset-based namespace encryption-target iteration with a stable `(depth, path)` keyset
- add the matching active-namespace partial index in PostgreSQL and SQLite
- cover multi-page traversal and the encryption startup path

Fixes #759.

## Validation
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/database ./internal/encrypt -count=1`
- `./scripts/preflight.sh`

PostgreSQL tests require a local PostgreSQL test server, which is not available in this workspace. The measured EKS plan uses the new active-namespace index.