### PR TITLE
Support resuming load-test seeds

### DIFF
--- a/cmd/loadtest/seed.go
+++ b/cmd/loadtest/seed.go
@@ -19,6 +19,7 @@ func cmdSeed() *cobra.Command {
 	var distributedMigrationLocks bool
 	var verifySamples int
 	var progressEvery int
+	var skipNamespaceEnsure bool
 	var oauthExpiringPercent int
 	var periodicProbePercent int
 	var staleSetupConnections int
@@ -88,6 +89,7 @@ func cmdSeed() *cobra.Command {
 				Encrypt:                 enc,
 				ProviderBaseURL:         providerBaseURL,
 				ProviderClientBootstrap: true,
+				SkipNamespaceEnsure:     skipNamespaceEnsure,
 				OAuthExpiringPercent:    oauthOverride,
 				PeriodicProbePercent:    probeOverride,
 				StaleSetupConnections:   staleSetupOverride,
@@ -128,6 +130,7 @@ func cmdSeed() *cobra.Command {
 	cmd.Flags().BoolVar(&distributedMigrationLocks, "distributed-migration-locks", false, "use Redis-backed distributed migration locks")
 	cmd.Flags().IntVar(&verifySamples, "verify-samples", 3, "number of seeded connections to verify through AuthProxy internals")
 	cmd.Flags().IntVar(&progressEvery, "progress-every", 1000, "log progress every N connections")
+	cmd.Flags().BoolVar(&skipNamespaceEnsure, "skip-namespace-ensure", false, "reuse the profile namespace tree from a prior checkpointed seed")
 	cmd.Flags().IntVar(&oauthExpiringPercent, "oauth-expiring-percent", 0, "override percent of tokens expiring inside the refresh window")
 	cmd.Flags().IntVar(&periodicProbePercent, "periodic-probe-percent", 0, "override percent of connections marked for periodic probes")
 	cmd.Flags().IntVar(&staleSetupConnections, "stale-setup-connections", 0, "override number of setup-state connections to seed for stale cleanup runs")

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -30,6 +30,7 @@ type Options struct {
 	ProviderBaseURL         string
 	ProviderClientBootstrap bool
 	ProviderHTTPClient      HTTPClient
+	SkipNamespaceEnsure     bool
 	OAuthExpiringPercent    *int
 	PeriodicProbePercent    *int
 	StaleSetupConnections   *int
@@ -170,16 +171,22 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 		logf = func(string, ...any) {}
 	}
 
-	logf("ensuring namespace tree under %s", baseNamespace)
-	if err := opts.DB.EnsureNamespaceByPath(ctx, baseNamespace); err != nil {
-		return nil, fmt.Errorf("ensure base namespace: %w", err)
+	if opts.SkipNamespaceEnsure {
+		logf("reusing namespace tree under %s", baseNamespace)
+	} else {
+		logf("ensuring namespace tree under %s", baseNamespace)
+		if err := opts.DB.EnsureNamespaceByPath(ctx, baseNamespace); err != nil {
+			return nil, fmt.Errorf("ensure base namespace: %w", err)
+		}
 	}
 
 	tenantNamespaces := make([]string, 0, tenantCount)
 	for i := 1; i <= tenantCount; i++ {
 		ns := fmt.Sprintf("%s.tenant%06d", baseNamespace, i)
-		if err := opts.DB.EnsureNamespaceByPath(ctx, ns); err != nil {
-			return nil, fmt.Errorf("ensure tenant namespace %s: %w", ns, err)
+		if !opts.SkipNamespaceEnsure {
+			if err := opts.DB.EnsureNamespaceByPath(ctx, ns); err != nil {
+				return nil, fmt.Errorf("ensure tenant namespace %s: %w", ns, err)
+			}
 		}
 		tenantNamespaces = append(tenantNamespaces, ns)
 		result.Namespaces = append(result.Namespaces, NamespaceRecord{Namespace: ns})

--- a/internal/loadtest/seeder/seed_test.go
+++ b/internal/loadtest/seeder/seed_test.go
@@ -119,11 +119,12 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 	assert.Equal(t, "http://go-oauth2-server", first.ProviderBaseURL)
 
 	second, err := Seed(context.Background(), Options{
-		Profile:       profile,
-		DB:            db,
-		Encrypt:       enc,
-		VerifySamples: 2,
-		Now:           time.Date(2026, 7, 13, 12, 30, 0, 0, time.UTC),
+		Profile:             profile,
+		DB:                  db,
+		Encrypt:             enc,
+		SkipNamespaceEnsure: true,
+		VerifySamples:       2,
+		Now:                 time.Date(2026, 7, 13, 12, 30, 0, 0, time.UTC),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 0, second.CreatedConnections)


### PR DESCRIPTION
## Summary
- add an explicit `--skip-namespace-ensure` checkpoint-resume flag to the load-test seed command
- reuse an already-established profile namespace tree while still upserting actors, connections, and tokens
- cover the resumed idempotent seed path

Fixes #761.

## Validation
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/loadtest/seeder ./cmd/loadtest -count=1`
- `./scripts/preflight.sh`