### PR TITLE
Route load-test app metrics to ClickHouse

### DIFF
--- a/deploy/charts/authproxy/templates/deployment.yaml
+++ b/deploy/charts/authproxy/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               protocol: TCP
             {{- end }}
           {{- end }}
-          {{- if or .Values.database.existingSecret .Values.redis.existingSecret .Values.s3.existingSecret }}
+          {{- if or .Values.database.existingSecret .Values.redis.existingSecret .Values.appMetrics.existingSecret .Values.s3.existingSecret }}
           envFrom:
             {{- /*
               `tpl` re-renders the value as a template using the root
@@ -72,6 +72,10 @@ spec:
                 name: {{ tpl . $ }}
             {{- end }}
             {{- with .Values.redis.existingSecret }}
+            - secretRef:
+                name: {{ tpl . $ }}
+            {{- end }}
+            {{- with .Values.appMetrics.existingSecret }}
             - secretRef:
                 name: {{ tpl . $ }}
             {{- end }}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -273,6 +273,7 @@
         "shareMainDatabase":    { "type": "boolean" },
         "autoMigrate":          { "type": "boolean" },
         "database":             { "type": "object" },
+        "existingSecret":       { "type": "string" },
         "fullRequestRecording": { "type": "string", "enum": ["never", "always"] }
       }
     },

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -290,6 +290,11 @@ appMetrics:
   # `shareMainDatabase` is false. Same field shape as the top-level
   # `database` block (provider, host, port, etc.).
   database: {}
+  # -- Secret whose values are exposed to the AuthProxy container for a
+  # dedicated app-metrics database. The rendered app-metrics config can
+  # reference a value with `{ env_var: NAME }` without storing credentials in
+  # the ConfigMap.
+  existingSecret: ""
   # -- Full request/response recording mode (`never` or `always`).
   # Lives under `request_events` in the rendered server config.
   fullRequestRecording: never

--- a/loadtest/helm-values/common.yaml
+++ b/loadtest/helm-values/common.yaml
@@ -68,8 +68,17 @@ connectors:
   loadFromList: []
 
 appMetrics:
-  shareMainDatabase: true
-  autoMigrate: false
+  shareMainDatabase: false
+  autoMigrate: true
+  existingSecret: authproxy-load-clickhouse
+  database:
+    provider: clickhouse
+    addresses:
+      - clickhouse:8123
+    database: authproxy_app_metrics
+    user: authproxy
+    password:
+      env_var: CLICKHOUSE_PASSWORD
   fullRequestRecording: never
 
 config:


### PR DESCRIPTION
Closes #763.

The load-test environment was sharing its primary Postgres database with app-metrics resource snapshots even though it deploys ClickHouse. At the active 100k seed this contributed roughly one-second bulk sample inserts to the aggregate SQL p95.

This change configures the load-test releases with a dedicated ClickHouse app-metrics store, adds chart support for importing a dedicated app-metrics secret, and references the password only through `CLICKHOUSE_PASSWORD`.

Validation:
- `helm template` for worker and admin-api confirms the ClickHouse config and secret import.
- `helm lint deploy/charts/authproxy -f loadtest/helm-values/common.yaml -f loadtest/helm-values/worker.yaml`
- `./scripts/preflight.sh`