### PR TITLE
Correct load-test Asynq queue depth

### DIFF
--- a/internal/apasynq/telemetry.go
+++ b/internal/apasynq/telemetry.go
@@ -44,14 +44,14 @@ type Telemetry struct {
 
 	taskDuration metric.Float64Histogram
 
-	inspector *asynq.Inspector
+	inspector Inspector
 }
 
 // NewTelemetry constructs a Telemetry surface from the providers + config.
 // providers being nil or in no-op mode, or both signals being off, produces
 // a Telemetry whose methods are inert — callers don't need to gate on this
 // themselves.
-func NewTelemetry(providers *aptelemetry.Providers, cfg *sconfig.Telemetry, inspector *asynq.Inspector) (*Telemetry, error) {
+func NewTelemetry(providers *aptelemetry.Providers, cfg *sconfig.Telemetry, inspector Inspector) (*Telemetry, error) {
 	t := &Telemetry{inspector: inspector}
 
 	if providers == nil || !providers.Enabled {
@@ -221,7 +221,7 @@ func (t *Telemetry) StartQueueDepthGauge(queues []string) (stop func(), err erro
 				}
 				observer.ObserveInt64(
 					gauge,
-					int64(info.Size),
+					int64(info.Pending),
 					metric.WithAttributes(attribute.String("messaging.destination.name", q)),
 				)
 			}

--- a/internal/apasynq/telemetry.go
+++ b/internal/apasynq/telemetry.go
@@ -51,7 +51,11 @@ type Telemetry struct {
 // providers being nil or in no-op mode, or both signals being off, produces
 // a Telemetry whose methods are inert — callers don't need to gate on this
 // themselves.
-func NewTelemetry(providers *aptelemetry.Providers, cfg *sconfig.Telemetry, inspector Inspector) (*Telemetry, error) {
+func NewTelemetry(
+	providers *aptelemetry.Providers,
+	cfg *sconfig.Telemetry,
+	inspector Inspector,
+) (*Telemetry, error) {
 	t := &Telemetry{inspector: inspector}
 
 	if providers == nil || !providers.Enabled {

--- a/internal/apasynq/telemetry_test.go
+++ b/internal/apasynq/telemetry_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hibiken/asynq"
+	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -61,8 +62,6 @@ func (f *asynqTelemetryFixture) readMetrics(t *testing.T) metricdata.ResourceMet
 	return rm
 }
 
-func enabledPtr(b bool) *bool { return &b }
-
 // runHandlerThroughMiddleware executes a handler (success or failure) through
 // the telemetry middleware to produce span + metric output. No real asynq
 // server / queue is involved — the middleware sees only the *asynq.Task and
@@ -75,7 +74,7 @@ func runHandlerThroughMiddleware(t *testing.T, tel *Telemetry, handler asynq.Han
 
 func TestAsynqTelemetry_HandlerEmitsSpanAndMetric(t *testing.T) {
 	fx := newAsynqTelemetryFixture(t)
-	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, nil)
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: util.ToPtr(true)}, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, runHandlerThroughMiddleware(t, tel, func(_ context.Context, _ *asynq.Task) error {
@@ -95,7 +94,7 @@ func TestAsynqTelemetry_HandlerEmitsSpanAndMetric(t *testing.T) {
 
 func TestAsynqTelemetry_HandlerErrorMarksSpanErrored(t *testing.T) {
 	fx := newAsynqTelemetryFixture(t)
-	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, nil)
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: util.ToPtr(true)}, nil)
 	require.NoError(t, err)
 
 	wantErr := errors.New("handler blew up")
@@ -114,7 +113,7 @@ func TestAsynqTelemetry_HandlerErrorMarksSpanErrored(t *testing.T) {
 
 func TestAsynqTelemetry_NoOpWhenProvidersDisabled(t *testing.T) {
 	fx := newAsynqTelemetryFixture(t)
-	tel, err := NewTelemetry(aptelemetry.NoopProviders(), &sconfig.Telemetry{Enabled: enabledPtr(true)}, nil)
+	tel, err := NewTelemetry(aptelemetry.NoopProviders(), &sconfig.Telemetry{Enabled: util.ToPtr(true)}, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, runHandlerThroughMiddleware(t, tel, func(_ context.Context, _ *asynq.Task) error {
@@ -167,7 +166,7 @@ func TestAsynqTelemetry_NilTelemetryIsSafe(t *testing.T) {
 
 func TestAsynqTelemetry_SchedulerSyncSpan(t *testing.T) {
 	fx := newAsynqTelemetryFixture(t)
-	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, nil)
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: util.ToPtr(true)}, nil)
 	require.NoError(t, err)
 
 	configs, err := tel.WithSchedulerSyncSpan(context.Background(), func() ([]*asynq.PeriodicTaskConfig, error) {
@@ -186,7 +185,7 @@ func TestAsynqTelemetry_SchedulerSyncSpan(t *testing.T) {
 
 func TestAsynqTelemetry_SchedulerSyncErrorMarksSpan(t *testing.T) {
 	fx := newAsynqTelemetryFixture(t)
-	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, nil)
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: util.ToPtr(true)}, nil)
 	require.NoError(t, err)
 
 	wantErr := errors.New("registrar fetch failed")
@@ -209,7 +208,7 @@ func TestAsynqTelemetry_QueueDepthGaugeReportsPendingTasks(t *testing.T) {
 		Return(&asynq.QueueInfo{Queue: "default", Size: 20_000, Pending: 0}, nil).
 		AnyTimes()
 
-	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, inspector)
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: util.ToPtr(true)}, inspector)
 	require.NoError(t, err)
 
 	stop, err := tel.StartQueueDepthGauge([]string{"default"})

--- a/internal/apasynq/telemetry_test.go
+++ b/internal/apasynq/telemetry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
@@ -14,6 +15,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	apasynqmock "github.com/rmorlok/authproxy/internal/apasynq/mock"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 )
@@ -196,6 +198,39 @@ func TestAsynqTelemetry_SchedulerSyncErrorMarksSpan(t *testing.T) {
 	gotSpans := fx.spans.Ended()
 	require.Len(t, gotSpans, 1)
 	require.Equal(t, codes.Error, gotSpans[0].Status().Code)
+}
+
+func TestAsynqTelemetry_QueueDepthGaugeReportsPendingTasks(t *testing.T) {
+	fx := newAsynqTelemetryFixture(t)
+	ctrl := gomock.NewController(t)
+	inspector := apasynqmock.NewMockInspector(ctrl)
+	inspector.EXPECT().
+		GetQueueInfo("default").
+		Return(&asynq.QueueInfo{Queue: "default", Size: 20_000, Pending: 0}, nil).
+		AnyTimes()
+
+	tel, err := NewTelemetry(fx.providers, &sconfig.Telemetry{Enabled: enabledPtr(true)}, inspector)
+	require.NoError(t, err)
+
+	stop, err := tel.StartQueueDepthGauge([]string{"default"})
+	require.NoError(t, err)
+	t.Cleanup(stop)
+
+	rm := fx.readMetrics(t)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "authproxy.asynq.queue.size" {
+				continue
+			}
+
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			require.Len(t, gauge.DataPoints, 1)
+			require.EqualValues(t, 0, gauge.DataPoints[0].Value)
+			return
+		}
+	}
+	t.Fatal("queue depth gauge was not emitted")
 }
 
 // --- helpers ----------------------------------------------------------------

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -214,7 +214,8 @@ The smoke environment installs:
   - `authproxy-admin-api`
   - `authproxy-api` with HPA enabled for CPU-based proxy scaling
   - `authproxy-public`
-  - `authproxy-worker` with HPA enabled for CPU and queue-depth metric examples
+  - `authproxy-worker` with CPU-based HPA; queue-depth scaling requires a
+    custom-metrics adapter or KEDA
 
 The chart's current model is one Deployment per release. Installing separate
 releases lets later issues add independent autoscaling and per-service resource

--- a/loadtest/grafana/dashboards/background-jobs.json
+++ b/loadtest/grafana/dashboards/background-jobs.json
@@ -10,7 +10,7 @@
       "id": 1,
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
-        { "expr": "sum by (messaging_destination_name) (authproxy_asynq_queue_size)", "legendFormat": "{{messaging_destination_name}}", "refId": "A" }
+        { "expr": "max by (messaging_destination_name) (authproxy_asynq_queue_size)", "legendFormat": "{{messaging_destination_name}}", "refId": "A" }
       ],
       "title": "Asynq queue depth",
       "type": "timeseries"

--- a/loadtest/helm-values/worker.yaml
+++ b/loadtest/helm-values/worker.yaml
@@ -5,14 +5,9 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 8
   targetCPUUtilizationPercentage: 75
-  metrics:
-    - type: Pods
-      pods:
-        metric:
-          name: authproxy_asynq_queue_size
-        target:
-          type: AverageValue
-          averageValue: "100"
+  # Queue-depth scaling requires a custom-metrics adapter or KEDA. The
+  # baseline profile uses CPU scaling until that dependency is configured.
+  metrics: []
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 30


### PR DESCRIPTION
Closes #765.

The load-test dashboard showed more than 100k Asynq queue entries during the 100k seed, but Redis had zero pending/retry tasks and roughly 20k retained completed tasks.

The queue telemetry was incorrectly emitting `asynq.QueueInfo.Size`, which includes completed tasks, while documenting the metric as pending work. The Grafana panel then summed the same global queue value across all worker replicas.

This change emits `Pending`, uses a replica-safe `max by (messaging_destination_name)` panel query, and makes the default worker HPA CPU-only until a custom-metrics adapter or KEDA is configured.

Validation:
- `go test ./internal/apasynq ./internal/service/worker -count=1`
- `helm lint deploy/charts/authproxy -f loadtest/helm-values/common.yaml -f loadtest/helm-values/worker.yaml`
- Worker `helm template` confirms CPU-only HPA.
- `./scripts/preflight.sh`