### PR TITLE
Use logarithmic scale for Asynq p95 dashboard

### DIFF
--- a/loadtest/grafana/dashboards/background-jobs.json
+++ b/loadtest/grafana/dashboards/background-jobs.json
@@ -29,7 +29,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "loadtest-prometheus" },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log" } }, "unit": "s" }, "overrides": [] },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },


### PR DESCRIPTION
## Summary
- render the Asynq task p95 duration panel with a logarithmic y-axis
- retain the existing seconds unit and Prometheus query

## Validation
- `jq` assertion for the panel scale distribution
- `./scripts/preflight.sh`