### PR TITLE
Resource names: add shared validation and unversioned database storage

### DIFF
--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -92,6 +93,7 @@ const ActorTable = "actors"
 // Actor is some entity taking action within the system.
 type Actor struct {
 	Id           apid.ID
+	Name         scommon.ResourceName
 	Namespace    string
 	ExternalId   string
 	Permissions  Permissions
@@ -133,6 +135,7 @@ func (a *Actor) cols() []string {
 		"updated_at",
 		"encrypted_at",
 		"deleted_at",
+		"name",
 	}
 }
 
@@ -149,6 +152,7 @@ func (a *Actor) fields() []any {
 		&a.UpdatedAt,
 		&a.EncryptedAt,
 		&a.DeletedAt,
+		&a.Name,
 	}
 }
 
@@ -165,6 +169,7 @@ func (a *Actor) values() []any {
 		a.UpdatedAt,
 		a.EncryptedAt,
 		a.DeletedAt,
+		a.Name,
 	}
 }
 
@@ -254,7 +259,9 @@ func (a *Actor) GetEncryptedKey() *encfield.EncryptedField {
 }
 
 func (a *Actor) normalize() {
-	// No actions currently
+	if a.Name == "" && !a.Id.IsNil() {
+		a.Name = scommon.ResourceName(a.Id.String())
+	}
 }
 
 func (a *Actor) validate() error {
@@ -266,6 +273,10 @@ func (a *Actor) validate() error {
 
 	if err := a.Id.ValidatePrefix(apid.PrefixActor); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid actor id: %w", err))
+	}
+
+	if err := a.Name.Validate(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("invalid actor name: %w", err))
 	}
 
 	if err := namespace.ValidatePath(a.Namespace); err != nil {

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -93,8 +93,8 @@ const ActorTable = "actors"
 // Actor is some entity taking action within the system.
 type Actor struct {
 	Id           apid.ID
-	Name         scommon.ResourceName
 	Namespace    string
+	Name         scommon.ResourceName
 	ExternalId   string
 	Permissions  Permissions
 	Labels       Labels
@@ -126,6 +126,7 @@ func (a *Actor) cols() []string {
 	return []string{
 		"id",
 		"namespace",
+		"name",
 		"external_id",
 		"permissions",
 		"labels",
@@ -135,7 +136,6 @@ func (a *Actor) cols() []string {
 		"updated_at",
 		"encrypted_at",
 		"deleted_at",
-		"name",
 	}
 }
 
@@ -143,6 +143,7 @@ func (a *Actor) fields() []any {
 	return []any{
 		&a.Id,
 		&a.Namespace,
+		&a.Name,
 		&a.ExternalId,
 		&a.Permissions,
 		&a.Labels,
@@ -152,7 +153,6 @@ func (a *Actor) fields() []any {
 		&a.UpdatedAt,
 		&a.EncryptedAt,
 		&a.DeletedAt,
-		&a.Name,
 	}
 }
 
@@ -160,6 +160,7 @@ func (a *Actor) values() []any {
 	return []any{
 		a.Id,
 		a.Namespace,
+		a.Name,
 		a.ExternalId,
 		a.Permissions,
 		a.Labels,
@@ -169,7 +170,6 @@ func (a *Actor) values() []any {
 		a.UpdatedAt,
 		a.EncryptedAt,
 		a.DeletedAt,
-		a.Name,
 	}
 }
 

--- a/internal/database/actor_test.go
+++ b/internal/database/actor_test.go
@@ -30,6 +30,7 @@ func TestActor(t *testing.T) {
 	t.Run("Validation", func(t *testing.T) {
 		require.NoError(t, util.ToPtr(Actor{
 			Id:         apid.New(apid.PrefixActor),
+			Name:       "valid",
 			Namespace:  "root",
 			ExternalId: "1234567890",
 		}).validate())
@@ -192,10 +193,12 @@ func TestActor(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, externalId, actor.ExternalId)
+			require.Equal(t, actor.Id.String(), string(actor.Name))
 
 			retrieved, err := db.GetActorByExternalId(ctx, "root", externalId)
 			require.NoError(t, err)
 			require.Equal(t, actor.Id, retrieved.Id)
+			require.Equal(t, actor.Name, retrieved.Name)
 		})
 
 		t.Run("updates existing", func(t *testing.T) {
@@ -655,16 +658,19 @@ func TestActor(t *testing.T) {
 			t.Run("valid paths", func(t *testing.T) {
 				require.NoError(t, util.ToPtr(Actor{
 					Id:         apid.New(apid.PrefixActor),
+					Name:       "valid",
 					Namespace:  "root",
 					ExternalId: "test",
 				}).validate())
 				require.NoError(t, util.ToPtr(Actor{
 					Id:         apid.New(apid.PrefixActor),
+					Name:       "valid",
 					Namespace:  "root.tenant1",
 					ExternalId: "test",
 				}).validate())
 				require.NoError(t, util.ToPtr(Actor{
 					Id:         apid.New(apid.PrefixActor),
+					Name:       "valid",
 					Namespace:  "root.tenant1.subtenant",
 					ExternalId: "test",
 				}).validate())

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -85,6 +86,7 @@ const ConnectionsTable = "connections"
 
 type Connection struct {
 	Id                     apid.ID
+	Name                   scommon.ResourceName
 	Namespace              string
 	State                  ConnectionState
 	HealthState            ConnectionHealthState
@@ -118,6 +120,7 @@ func (c *Connection) cols() []string {
 		"created_at",
 		"updated_at",
 		"deleted_at",
+		"name",
 	}
 }
 
@@ -138,6 +141,7 @@ func (c *Connection) fields() []any {
 		&c.CreatedAt,
 		&c.UpdatedAt,
 		&c.DeletedAt,
+		&c.Name,
 	}
 }
 
@@ -158,6 +162,13 @@ func (c *Connection) values() []any {
 		c.CreatedAt,
 		c.UpdatedAt,
 		c.DeletedAt,
+		c.Name,
+	}
+}
+
+func (c *Connection) normalize() {
+	if c.Name == "" && !c.Id.IsNil() {
+		c.Name = scommon.ResourceName(c.Id.String())
 	}
 }
 
@@ -207,6 +218,10 @@ func (c *Connection) Validate() error {
 		result = multierror.Append(result, fmt.Errorf("invalid connection id: %w", err))
 	}
 
+	if err := c.Name.Validate(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("invalid connection name: %w", err))
+	}
+
 	if err := namespace.ValidatePath(c.Namespace); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid connection namespace path: %w", err))
 	}
@@ -246,6 +261,8 @@ func (s *service) CreateConnection(ctx context.Context, c *Connection) error {
 	if c == nil {
 		return errors.New("connection is required")
 	}
+
+	c.normalize()
 
 	if err := c.Validate(); err != nil {
 		return err

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -86,8 +86,8 @@ const ConnectionsTable = "connections"
 
 type Connection struct {
 	Id                     apid.ID
-	Name                   scommon.ResourceName
 	Namespace              string
+	Name                   scommon.ResourceName
 	State                  ConnectionState
 	HealthState            ConnectionHealthState
 	ConnectorId            apid.ID
@@ -107,6 +107,7 @@ func (c *Connection) cols() []string {
 	return []string{
 		"id",
 		"namespace",
+		"name",
 		"state",
 		"health_state",
 		"connector_id",
@@ -120,7 +121,6 @@ func (c *Connection) cols() []string {
 		"created_at",
 		"updated_at",
 		"deleted_at",
-		"name",
 	}
 }
 
@@ -128,6 +128,7 @@ func (c *Connection) fields() []any {
 	return []any{
 		&c.Id,
 		&c.Namespace,
+		&c.Name,
 		&c.State,
 		&c.HealthState,
 		&c.ConnectorId,
@@ -141,7 +142,6 @@ func (c *Connection) fields() []any {
 		&c.CreatedAt,
 		&c.UpdatedAt,
 		&c.DeletedAt,
-		&c.Name,
 	}
 }
 
@@ -149,6 +149,7 @@ func (c *Connection) values() []any {
 	return []any{
 		c.Id,
 		c.Namespace,
+		c.Name,
 		c.State,
 		c.healthStateForInsert(),
 		c.ConnectorId,
@@ -162,7 +163,6 @@ func (c *Connection) values() []any {
 		c.CreatedAt,
 		c.UpdatedAt,
 		c.DeletedAt,
-		c.Name,
 	}
 }
 

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -97,6 +98,7 @@ func IsValidKeyOrderByField[T string | KeyOrderByField](field T) bool {
 // Key represents a user-managed key configuration.
 type Key struct {
 	Id           apid.ID
+	Name         scommon.ResourceName
 	Namespace    string
 	Usage        KeyUsage
 	MaterialType KeyMaterialType
@@ -131,6 +133,7 @@ func (ek *Key) cols() []string {
 		"updated_at",
 		"encrypted_at",
 		"deleted_at",
+		"name",
 	}
 }
 
@@ -148,6 +151,7 @@ func (ek *Key) fields() []any {
 		&ek.UpdatedAt,
 		&ek.EncryptedAt,
 		&ek.DeletedAt,
+		&ek.Name,
 	}
 }
 
@@ -165,10 +169,14 @@ func (ek *Key) values() []any {
 		ek.UpdatedAt,
 		ek.EncryptedAt,
 		ek.DeletedAt,
+		ek.Name,
 	}
 }
 
 func (ek *Key) normalize() {
+	if ek.Name == "" && !ek.Id.IsNil() {
+		ek.Name = scommon.ResourceName(ek.Id.String())
+	}
 	if ek.Usage == "" {
 		ek.Usage = KeyUsageDataEncryption
 	}
@@ -187,6 +195,10 @@ func (ek *Key) Validate() error {
 		result = multierror.Append(result, errors.New("id is required"))
 	} else if err := ek.Id.ValidatePrefix(apid.PrefixKey); err != nil {
 		result = multierror.Append(result, err)
+	}
+
+	if err := ek.Name.Validate(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("invalid key name: %w", err))
 	}
 
 	if ek.Namespace == "" {

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -98,8 +98,8 @@ func IsValidKeyOrderByField[T string | KeyOrderByField](field T) bool {
 // Key represents a user-managed key configuration.
 type Key struct {
 	Id           apid.ID
-	Name         scommon.ResourceName
 	Namespace    string
+	Name         scommon.ResourceName
 	Usage        KeyUsage
 	MaterialType KeyMaterialType
 	// Key provider configuration is encrypted at rest, but it is not registered
@@ -123,6 +123,7 @@ func (ek *Key) cols() []string {
 	return []string{
 		"id",
 		"namespace",
+		"name",
 		"usage",
 		"material_type",
 		"encrypted_key_data",
@@ -133,7 +134,6 @@ func (ek *Key) cols() []string {
 		"updated_at",
 		"encrypted_at",
 		"deleted_at",
-		"name",
 	}
 }
 
@@ -141,6 +141,7 @@ func (ek *Key) fields() []any {
 	return []any{
 		&ek.Id,
 		&ek.Namespace,
+		&ek.Name,
 		&ek.Usage,
 		&ek.MaterialType,
 		&ek.EncryptedKeyData,
@@ -151,7 +152,6 @@ func (ek *Key) fields() []any {
 		&ek.UpdatedAt,
 		&ek.EncryptedAt,
 		&ek.DeletedAt,
-		&ek.Name,
 	}
 }
 
@@ -159,6 +159,7 @@ func (ek *Key) values() []any {
 	return []any{
 		ek.Id,
 		ek.Namespace,
+		ek.Name,
 		ek.Usage,
 		ek.MaterialType,
 		ek.EncryptedKeyData,
@@ -169,7 +170,6 @@ func (ek *Key) values() []any {
 		ek.UpdatedAt,
 		ek.EncryptedAt,
 		ek.DeletedAt,
-		ek.Name,
 	}
 }
 

--- a/internal/database/migrations/postgres/000015_add_resource_names.down.sql
+++ b/internal/database/migrations/postgres/000015_add_resource_names.down.sql
@@ -1,0 +1,9 @@
+drop index if exists idx_actors_live_namespace_name;
+drop index if exists idx_connections_live_namespace_name;
+drop index if exists idx_keys_live_namespace_name;
+drop index if exists idx_rate_limits_live_namespace_name;
+
+alter table actors drop column name;
+alter table connections drop column name;
+alter table keys drop column name;
+alter table rate_limits drop column name;

--- a/internal/database/migrations/postgres/000015_add_resource_names.up.sql
+++ b/internal/database/migrations/postgres/000015_add_resource_names.up.sql
@@ -1,0 +1,35 @@
+alter table actors add column name text;
+update actors set name = id;
+alter table actors alter column name set not null;
+alter table actors add constraint actors_name_nonempty check (name <> '');
+
+alter table connections add column name text;
+update connections set name = id;
+alter table connections alter column name set not null;
+alter table connections add constraint connections_name_nonempty check (name <> '');
+
+alter table keys add column name text;
+update keys set name = id;
+alter table keys alter column name set not null;
+alter table keys add constraint keys_name_nonempty check (name <> '');
+
+alter table rate_limits add column name text;
+update rate_limits set name = id;
+alter table rate_limits alter column name set not null;
+alter table rate_limits add constraint rate_limits_name_nonempty check (name <> '');
+
+create unique index idx_actors_live_namespace_name
+    on actors (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_connections_live_namespace_name
+    on connections (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_keys_live_namespace_name
+    on keys (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_rate_limits_live_namespace_name
+    on rate_limits (namespace, name)
+    where deleted_at is null;

--- a/internal/database/migrations/sqlite/000015_add_resource_names.down.sql
+++ b/internal/database/migrations/sqlite/000015_add_resource_names.down.sql
@@ -1,0 +1,18 @@
+drop trigger if exists actors_name_required_insert;
+drop trigger if exists actors_name_required_update;
+drop trigger if exists connections_name_required_insert;
+drop trigger if exists connections_name_required_update;
+drop trigger if exists keys_name_required_insert;
+drop trigger if exists keys_name_required_update;
+drop trigger if exists rate_limits_name_required_insert;
+drop trigger if exists rate_limits_name_required_update;
+
+drop index if exists idx_actors_live_namespace_name;
+drop index if exists idx_connections_live_namespace_name;
+drop index if exists idx_keys_live_namespace_name;
+drop index if exists idx_rate_limits_live_namespace_name;
+
+alter table actors drop column name;
+alter table connections drop column name;
+alter table keys drop column name;
+alter table rate_limits drop column name;

--- a/internal/database/migrations/sqlite/000015_add_resource_names.up.sql
+++ b/internal/database/migrations/sqlite/000015_add_resource_names.up.sql
@@ -1,0 +1,83 @@
+alter table actors add column name text not null default '';
+update actors set name = id;
+
+alter table connections add column name text not null default '';
+update connections set name = id;
+
+alter table keys add column name text not null default '';
+update keys set name = id;
+
+alter table rate_limits add column name text not null default '';
+update rate_limits set name = id;
+
+create unique index idx_actors_live_namespace_name
+    on actors (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_connections_live_namespace_name
+    on connections (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_keys_live_namespace_name
+    on keys (namespace, name)
+    where deleted_at is null;
+
+create unique index idx_rate_limits_live_namespace_name
+    on rate_limits (namespace, name)
+    where deleted_at is null;
+
+create trigger actors_name_required_insert
+before insert on actors
+when new.name = ''
+begin
+    select raise(abort, 'actors.name is required');
+end;
+
+create trigger actors_name_required_update
+before update of name on actors
+when new.name = ''
+begin
+    select raise(abort, 'actors.name is required');
+end;
+
+create trigger connections_name_required_insert
+before insert on connections
+when new.name = ''
+begin
+    select raise(abort, 'connections.name is required');
+end;
+
+create trigger connections_name_required_update
+before update of name on connections
+when new.name = ''
+begin
+    select raise(abort, 'connections.name is required');
+end;
+
+create trigger keys_name_required_insert
+before insert on keys
+when new.name = ''
+begin
+    select raise(abort, 'keys.name is required');
+end;
+
+create trigger keys_name_required_update
+before update of name on keys
+when new.name = ''
+begin
+    select raise(abort, 'keys.name is required');
+end;
+
+create trigger rate_limits_name_required_insert
+before insert on rate_limits
+when new.name = ''
+begin
+    select raise(abort, 'rate_limits.name is required');
+end;
+
+create trigger rate_limits_name_required_update
+before update of name on rate_limits
+when new.name = ''
+begin
+    select raise(abort, 'rate_limits.name is required');
+end;

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -653,6 +653,7 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 				dbRaw := db.(*service)
 
 				for _, connection := range connections {
+					connection.normalize()
 					_, err := dbRaw.sq.
 						Insert(ConnectionsTable).
 						Columns(connection.cols()...).

--- a/internal/database/rate_limit.go
+++ b/internal/database/rate_limit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -25,6 +26,7 @@ const RateLimitsTable = "rate_limits"
 // holds the JSON-serialised configuration (mode, selector, bucket, algorithm).
 type RateLimit struct {
 	Id          apid.ID
+	Name        scommon.ResourceName
 	Namespace   string
 	Definition  rlschema.RateLimit
 	Labels      Labels
@@ -48,6 +50,7 @@ func (rl *RateLimit) cols() []string {
 		"created_at",
 		"updated_at",
 		"deleted_at",
+		"name",
 	}
 }
 
@@ -61,6 +64,7 @@ func (rl *RateLimit) fields() []any {
 		&rl.CreatedAt,
 		&rl.UpdatedAt,
 		&rl.DeletedAt,
+		&rl.Name,
 	}
 }
 
@@ -74,6 +78,13 @@ func (rl *RateLimit) values() []any {
 		rl.CreatedAt,
 		rl.UpdatedAt,
 		rl.DeletedAt,
+		rl.Name,
+	}
+}
+
+func (rl *RateLimit) normalize() {
+	if rl.Name == "" && !rl.Id.IsNil() {
+		rl.Name = scommon.ResourceName(rl.Id.String())
 	}
 }
 
@@ -107,6 +118,10 @@ func (rl *RateLimit) Validate() error {
 		result = multierror.Append(result, errors.New("id is required"))
 	} else if err := rl.Id.ValidatePrefix(apid.PrefixRateLimit); err != nil {
 		result = multierror.Append(result, err)
+	}
+
+	if err := rl.Name.Validate(); err != nil {
+		result = multierror.Append(result, fmt.Errorf("invalid rate limit name: %w", err))
 	}
 
 	if rl.Namespace == "" {
@@ -149,6 +164,8 @@ func (s *service) GetRateLimit(ctx context.Context, id apid.ID) (*RateLimit, err
 }
 
 func (s *service) CreateRateLimit(ctx context.Context, rl *RateLimit) error {
+	rl.normalize()
+
 	if err := rl.Validate(); err != nil {
 		return err
 	}

--- a/internal/database/rate_limit.go
+++ b/internal/database/rate_limit.go
@@ -26,8 +26,8 @@ const RateLimitsTable = "rate_limits"
 // holds the JSON-serialised configuration (mode, selector, bucket, algorithm).
 type RateLimit struct {
 	Id          apid.ID
-	Name        scommon.ResourceName
 	Namespace   string
+	Name        scommon.ResourceName
 	Definition  rlschema.RateLimit
 	Labels      Labels
 	Annotations Annotations
@@ -44,13 +44,13 @@ func (rl *RateLimit) cols() []string {
 	return []string{
 		"id",
 		"namespace",
+		"name",
 		"definition",
 		"labels",
 		"annotations",
 		"created_at",
 		"updated_at",
 		"deleted_at",
-		"name",
 	}
 }
 
@@ -58,13 +58,13 @@ func (rl *RateLimit) fields() []any {
 	return []any{
 		&rl.Id,
 		&rl.Namespace,
+		&rl.Name,
 		(*rateLimitDefDB)(&rl.Definition),
 		&rl.Labels,
 		&rl.Annotations,
 		&rl.CreatedAt,
 		&rl.UpdatedAt,
 		&rl.DeletedAt,
-		&rl.Name,
 	}
 }
 
@@ -72,13 +72,13 @@ func (rl *RateLimit) values() []any {
 	return []any{
 		rl.Id,
 		rl.Namespace,
+		rl.Name,
 		rateLimitDefDB(rl.Definition),
 		rl.Labels,
 		rl.Annotations,
 		rl.CreatedAt,
 		rl.UpdatedAt,
 		rl.DeletedAt,
-		rl.Name,
 	}
 }
 

--- a/internal/database/reencrypt_registry_test.go
+++ b/internal/database/reencrypt_registry_test.go
@@ -129,8 +129,8 @@ func TestReEncryptRegistry(t *testing.T) {
 		connectorId := apid.New(apid.PrefixConnectorVersion)
 		nowStr := now.Format(time.RFC3339)
 		_, err = rawDb.Exec(fmt.Sprintf(
-			`INSERT INTO connections (id, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
-			string(connId), string(connectorId), nowStr, nowStr,
+			`INSERT INTO connections (id, name, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
+			string(connId), string(connId), string(connectorId), nowStr, nowStr,
 		))
 		require.NoError(t, err)
 
@@ -171,8 +171,8 @@ func TestReEncryptRegistry(t *testing.T) {
 		connectorId := apid.New(apid.PrefixConnectorVersion)
 		nowStr := now.Format(time.RFC3339)
 		_, err = rawDb.Exec(fmt.Sprintf(
-			`INSERT INTO connections (id, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
-			string(connId), string(connectorId), nowStr, nowStr,
+			`INSERT INTO connections (id, name, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
+			string(connId), string(connId), string(connectorId), nowStr, nowStr,
 		))
 		require.NoError(t, err)
 
@@ -218,8 +218,8 @@ func TestReEncryptRegistry(t *testing.T) {
 		connectorId := apid.New(apid.PrefixConnectorVersion)
 		nowStr := now.Format(time.RFC3339)
 		_, err = rawDb.Exec(fmt.Sprintf(
-			`INSERT INTO connections (id, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
-			string(connId), string(connectorId), nowStr, nowStr,
+			`INSERT INTO connections (id, name, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root', 'ready', '%s', 1, '%s', '%s')`,
+			string(connId), string(connId), string(connectorId), nowStr, nowStr,
 		))
 		require.NoError(t, err)
 

--- a/internal/database/resource_name_test.go
+++ b/internal/database/resource_name_test.go
@@ -1,0 +1,314 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/rmorlok/authproxy/internal/apid"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/require"
+)
+
+type namedResourceHarness struct {
+	resourceType string
+	table        string
+	prefix       apid.Prefix
+	create       func(context.Context, DB, apid.ID, string, scommon.ResourceName) error
+	getName      func(context.Context, DB, apid.ID) (scommon.ResourceName, error)
+	delete       func(context.Context, DB, apid.ID) error
+}
+
+func namedResourceHarnesses() []namedResourceHarness {
+	return []namedResourceHarness{
+		{
+			resourceType: "actor",
+			table:        ActorTable,
+			prefix:       apid.PrefixActor,
+			create: func(ctx context.Context, db DB, id apid.ID, ns string, name scommon.ResourceName) error {
+				return db.CreateActor(ctx, &Actor{
+					Id:         id,
+					Name:       name,
+					Namespace:  ns,
+					ExternalId: id.String(),
+				})
+			},
+			getName: func(ctx context.Context, db DB, id apid.ID) (scommon.ResourceName, error) {
+				value, err := db.GetActor(ctx, id)
+				if err != nil {
+					return "", err
+				}
+				return value.Name, nil
+			},
+			delete: func(ctx context.Context, db DB, id apid.ID) error {
+				return db.DeleteActor(ctx, id)
+			},
+		},
+		{
+			resourceType: "connection",
+			table:        ConnectionsTable,
+			prefix:       apid.PrefixConnection,
+			create: func(ctx context.Context, db DB, id apid.ID, ns string, name scommon.ResourceName) error {
+				return db.CreateConnection(ctx, &Connection{
+					Id:               id,
+					Name:             name,
+					Namespace:        ns,
+					State:            ConnectionStateSetup,
+					ConnectorId:      apid.New(apid.PrefixConnectorVersion),
+					ConnectorVersion: 1,
+				})
+			},
+			getName: func(ctx context.Context, db DB, id apid.ID) (scommon.ResourceName, error) {
+				value, err := db.GetConnection(ctx, id)
+				if err != nil {
+					return "", err
+				}
+				return value.Name, nil
+			},
+			delete: func(ctx context.Context, db DB, id apid.ID) error {
+				return db.DeleteConnection(ctx, id)
+			},
+		},
+		{
+			resourceType: "key",
+			table:        KeysTable,
+			prefix:       apid.PrefixKey,
+			create: func(ctx context.Context, db DB, id apid.ID, ns string, name scommon.ResourceName) error {
+				return db.CreateKey(ctx, &Key{
+					Id:        id,
+					Name:      name,
+					Namespace: ns,
+				})
+			},
+			getName: func(ctx context.Context, db DB, id apid.ID) (scommon.ResourceName, error) {
+				value, err := db.GetKey(ctx, id)
+				if err != nil {
+					return "", err
+				}
+				return value.Name, nil
+			},
+			delete: func(ctx context.Context, db DB, id apid.ID) error {
+				return db.DeleteKey(ctx, id)
+			},
+		},
+		{
+			resourceType: "rate limit",
+			table:        RateLimitsTable,
+			prefix:       apid.PrefixRateLimit,
+			create: func(ctx context.Context, db DB, id apid.ID, ns string, name scommon.ResourceName) error {
+				return db.CreateRateLimit(ctx, &RateLimit{
+					Id:         id,
+					Name:       name,
+					Namespace:  ns,
+					Definition: validDef(),
+				})
+			},
+			getName: func(ctx context.Context, db DB, id apid.ID) (scommon.ResourceName, error) {
+				value, err := db.GetRateLimit(ctx, id)
+				if err != nil {
+					return "", err
+				}
+				return value.Name, nil
+			},
+			delete: func(ctx context.Context, db DB, id apid.ID) error {
+				return db.DeleteRateLimit(ctx, id)
+			},
+		},
+	}
+}
+
+func TestResourceNamesDefaultToID(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db := MustApplyBlankTestDbConfig(t, nil)
+			ctx := context.Background()
+			id := apid.New(harness.prefix)
+
+			require.NoError(t, harness.create(ctx, db, id, "root", ""))
+			name, err := harness.getName(ctx, db, id)
+			require.NoError(t, err)
+			require.Equal(t, scommon.ResourceName(id.String()), name)
+		})
+	}
+}
+
+func TestResourceNameLiveUniquenessAndReuse(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db := MustApplyBlankTestDbConfig(t, nil)
+			ctx := context.Background()
+			require.NoError(t, db.CreateNamespace(ctx, &Namespace{Path: "root.other"}))
+
+			firstID := apid.New(harness.prefix)
+			require.NoError(t, harness.create(ctx, db, firstID, "root", "shared"))
+
+			require.Error(t, harness.create(ctx, db, apid.New(harness.prefix), "root", "shared"))
+			require.NoError(t, harness.create(ctx, db, apid.New(harness.prefix), "root.other", "shared"))
+			require.NoError(t, harness.create(ctx, db, apid.New(harness.prefix), "root", "Shared"))
+
+			require.NoError(t, harness.delete(ctx, db, firstID))
+			require.NoError(t, harness.create(ctx, db, apid.New(harness.prefix), "root", "shared"))
+		})
+	}
+}
+
+func TestResourceNameCanBeChangedByIDWithoutConflicts(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db, rawDB := MustApplyBlankTestDbConfigRaw(t, nil)
+			ctx := context.Background()
+			firstID := apid.New(harness.prefix)
+			secondID := apid.New(harness.prefix)
+			require.NoError(t, harness.create(ctx, db, firstID, "root", "first"))
+			require.NoError(t, harness.create(ctx, db, secondID, "root", "second"))
+
+			_, err := rawDB.Exec(fmt.Sprintf(
+				"UPDATE %s SET name = 'renamed' WHERE id = '%s'",
+				harness.table,
+				firstID.String(),
+			))
+			require.NoError(t, err)
+			name, err := harness.getName(ctx, db, firstID)
+			require.NoError(t, err)
+			require.Equal(t, scommon.ResourceName("renamed"), name)
+
+			_, err = rawDB.Exec(fmt.Sprintf(
+				"UPDATE %s SET name = 'renamed' WHERE id = '%s'",
+				harness.table,
+				secondID.String(),
+			))
+			require.Error(t, err)
+			name, err = harness.getName(ctx, db, secondID)
+			require.NoError(t, err)
+			require.Equal(t, scommon.ResourceName("second"), name)
+		})
+	}
+}
+
+func TestResourceNamesDoNotConflictAcrossTypes(t *testing.T) {
+	_, db := MustApplyBlankTestDbConfig(t, nil)
+	ctx := context.Background()
+
+	for _, harness := range namedResourceHarnesses() {
+		require.NoError(t, harness.create(ctx, db, apid.New(harness.prefix), "root", "shared"))
+	}
+}
+
+func TestResourceNameValidationAppliesOnCreate(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db := MustApplyBlankTestDbConfig(t, nil)
+			err := harness.create(context.Background(), db, apid.New(harness.prefix), "root", "not valid")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "name")
+		})
+	}
+}
+
+func TestResourceNameDatabaseRejectsEmptyValues(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db, rawDB := MustApplyBlankTestDbConfigRaw(t, nil)
+			ctx := context.Background()
+			id := apid.New(harness.prefix)
+			require.NoError(t, harness.create(ctx, db, id, "root", "valid"))
+
+			_, err := rawDB.Exec(fmt.Sprintf(
+				"UPDATE %s SET name = '' WHERE id = '%s'",
+				harness.table,
+				id.String(),
+			))
+			require.Error(t, err)
+
+			_, err = rawDB.Exec(fmt.Sprintf(
+				"UPDATE %s SET name = NULL WHERE id = '%s'",
+				harness.table,
+				id.String(),
+			))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestResourceNameMigrationBackfillsExistingRows(t *testing.T) {
+	_, db, rawDB := MustApplyBlankTestDbConfigRaw(t, nil)
+	service := db.(*service)
+	migrateResourceNamesBySteps(t, service, -1)
+
+	_, err := rawDB.Exec(`
+		INSERT INTO actors (id, namespace, external_id)
+		VALUES ('act_migration', 'root', 'migration')
+	`)
+	require.NoError(t, err)
+	_, err = rawDB.Exec(`
+		INSERT INTO connections (id, namespace, state, connector_id, connector_version)
+		VALUES ('cxn_migration', 'root', 'setup', 'cxr_migration', 1)
+	`)
+	require.NoError(t, err)
+	_, err = rawDB.Exec(`
+		INSERT INTO keys (
+			id, namespace, usage, material_type, state, created_at, updated_at
+		)
+		VALUES (
+			'key_migration', 'root', 'data_encryption', 'symmetric', 'active',
+			'2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z'
+		)
+	`)
+	require.NoError(t, err)
+	_, err = rawDB.Exec(`
+		INSERT INTO rate_limits (
+			id, namespace, definition, created_at, updated_at
+		)
+		VALUES (
+			'rl_migration', 'root', '{}',
+			'2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z'
+		)
+	`)
+	require.NoError(t, err)
+
+	migrateResourceNamesBySteps(t, service, 1)
+
+	for table, id := range map[string]string{
+		ActorTable:       "act_migration",
+		ConnectionsTable: "cxn_migration",
+		KeysTable:        "key_migration",
+		RateLimitsTable:  "rl_migration",
+	} {
+		var name string
+		err := rawDB.QueryRow(fmt.Sprintf(
+			"SELECT name FROM %s WHERE id = '%s'",
+			table,
+			id,
+		)).Scan(&name)
+		require.NoError(t, err)
+		require.Equal(t, id, name)
+	}
+
+	var globalKeyName string
+	require.NoError(t, rawDB.QueryRow(
+		"SELECT name FROM keys WHERE id = 'key_global'",
+	).Scan(&globalKeyName))
+	require.Equal(t, "key_global", globalKeyName)
+}
+
+func migrateResourceNamesBySteps(t *testing.T, service *service, steps int) {
+	t.Helper()
+
+	source, err := iofs.New(
+		migrationsFs,
+		fmt.Sprintf("migrations/%s", service.cfg.GetProvider()),
+	)
+	require.NoError(t, err)
+
+	migrator, err := migrate.NewWithSourceInstance("iofs", source, service.cfg.GetUri())
+	require.NoError(t, err)
+	defer func() {
+		sourceErr, databaseErr := migrator.Close()
+		require.NoError(t, sourceErr)
+		require.NoError(t, databaseErr)
+	}()
+
+	require.NoError(t, migrator.Steps(steps))
+}

--- a/internal/database/resource_search_benchmark_test.go
+++ b/internal/database/resource_search_benchmark_test.go
@@ -20,25 +20,27 @@ func BenchmarkSearchResourcesAt100K(b *testing.B) {
 	cfg, db, raw := MustApplyBlankTestDbConfigRaw(b, nil)
 	require.NoError(b, db.EnsureNamespaceByPath(b.Context(), "root.search-load"))
 
-	placeholders := "?, ?, ?, ?, CURRENT_TIMESTAMP, ?"
+	placeholders := "?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?"
 	if cfg.GetRoot().Database.GetProvider() == config.DatabaseProviderPostgres {
-		placeholders = "$1, $2, $3, $4, CURRENT_TIMESTAMP, $5"
+		placeholders = "$1, $2, $3, $4, $5, CURRENT_TIMESTAMP, $6"
 	}
 	tx, err := raw.BeginTx(b.Context(), nil)
 	require.NoError(b, err)
 	statement, err := tx.PrepareContext(b.Context(), fmt.Sprintf(
-		"INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES (%s)",
+		"INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES (%s)",
 		placeholders,
 	))
 	require.NoError(b, err)
 	for i := 0; i < 100_000; i++ {
+		id := fmt.Sprintf("act_searchload%013d", i)
 		label := fmt.Sprintf(`{"name":"resource-%06d"}`, i)
 		if i == 99_999 {
 			label = `{"name":"bounded-search-needle"}`
 		}
 		_, err = statement.ExecContext(
 			b.Context(),
-			fmt.Sprintf("act_searchload%013d", i),
+			id,
+			id,
 			"root.search-load",
 			label,
 			fmt.Sprintf("search-load-%06d", i),

--- a/internal/database/resource_search_test.go
+++ b/internal/database/resource_search_test.go
@@ -19,11 +19,11 @@ func TestSearchResourcesRanksAndBoundsActorLabelMatches(t *testing.T) {
 	deletedID := apid.New(apid.PrefixActor)
 
 	inserts := []string{
-		fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', 'root', '{"team":"acme","literal":"has_value","percent":"rate%%value","slash":"path\\value","apxy/act/-/id":"%s"}', 'exact', CURRENT_TIMESTAMP, '2024-01-01T00:00:00Z')`, exactID, exactID),
-		fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', 'root', '{"team":"acme-prod"}', 'prefix', CURRENT_TIMESTAMP, '2025-01-01T00:00:00Z')`, prefixID),
-		fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', 'root', '{"team":"west-acme"}', 'substring', CURRENT_TIMESTAMP, '2026-01-01T00:00:00Z')`, substringID),
-		fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', 'root', '{"apxy/ns/-/ns":"root.acme"}', 'system-only', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, systemOnlyID),
-		fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at, deleted_at) VALUES ('%s', 'root', '{"team":"acme"}', 'deleted', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, deletedID),
+		fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', '%s', 'root', '{"team":"acme","literal":"has_value","percent":"rate%%value","slash":"path\\value","apxy/act/-/id":"%s"}', 'exact', CURRENT_TIMESTAMP, '2024-01-01T00:00:00Z')`, exactID, exactID, exactID),
+		fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', '%s', 'root', '{"team":"acme-prod"}', 'prefix', CURRENT_TIMESTAMP, '2025-01-01T00:00:00Z')`, prefixID, prefixID),
+		fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', '%s', 'root', '{"team":"west-acme"}', 'substring', CURRENT_TIMESTAMP, '2026-01-01T00:00:00Z')`, substringID, substringID),
+		fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', '%s', 'root', '{"apxy/ns/-/ns":"root.acme"}', 'system-only', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, systemOnlyID, systemOnlyID),
+		fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at, deleted_at) VALUES ('%s', '%s', 'root', '{"team":"acme"}', 'deleted', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, deletedID, deletedID),
 	}
 	for _, statement := range inserts {
 		_, err := raw.Exec(statement)
@@ -67,9 +67,9 @@ func TestSearchResourcesCombinesTextSelectorAndNamespace(t *testing.T) {
 	wrongLabelID := apid.New(apid.PrefixConnection)
 	wrongNamespaceID := apid.New(apid.PrefixConnection)
 	for _, statement := range []string{
-		fmt.Sprintf(`INSERT INTO connections (id, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root.team', '{"name":"payments-api","env":"prod"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, matchID),
-		fmt.Sprintf(`INSERT INTO connections (id, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root.team', '{"name":"payments-api","env":"dev"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, wrongLabelID),
-		fmt.Sprintf(`INSERT INTO connections (id, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', 'root.other', '{"name":"payments-api","env":"prod"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, wrongNamespaceID),
+		fmt.Sprintf(`INSERT INTO connections (id, name, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root.team', '{"name":"payments-api","env":"prod"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, matchID, matchID),
+		fmt.Sprintf(`INSERT INTO connections (id, name, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root.team', '{"name":"payments-api","env":"dev"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, wrongLabelID, wrongLabelID),
+		fmt.Sprintf(`INSERT INTO connections (id, name, namespace, labels, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'root.other', '{"name":"payments-api","env":"prod"}', 'configured', 'cxr_test', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, wrongNamespaceID, wrongNamespaceID),
 	} {
 		_, err := raw.Exec(statement)
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestSearchResourcesCollapsesConnectorVersionsDeterministically(t *testing.T
 func TestSearchResourcesEmptyNamespaceMatchersNeverMeansUnrestricted(t *testing.T) {
 	_, db, raw := MustApplyBlankTestDbConfigRaw(t, nil)
 	id := apid.New(apid.PrefixActor)
-	_, err := raw.Exec(fmt.Sprintf(`INSERT INTO actors (id, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', 'root', '{"name":"visible"}', 'actor', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, id))
+	_, err := raw.Exec(fmt.Sprintf(`INSERT INTO actors (id, name, namespace, labels, external_id, created_at, updated_at) VALUES ('%s', '%s', 'root', '{"name":"visible"}', 'actor', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, id, id))
 	require.NoError(t, err)
 
 	result, err := db.SearchResources(t.Context(), SearchResourcesParams{
@@ -145,8 +145,8 @@ func TestSearchResourcesSeedCoversNamespaceKeyAndRateLimit(t *testing.T) {
 	rateLimitID := apid.New(apid.PrefixRateLimit)
 	for _, statement := range []string{
 		`INSERT INTO namespaces (path, depth, state, labels, created_at, updated_at) VALUES ('root.seed', 1, 'active', '{"name":"seed namespace","apxy/ns/-/ns":"root.seed"}', CURRENT_TIMESTAMP, '2024-01-01T00:00:00Z')`,
-		fmt.Sprintf(`INSERT INTO keys (id, namespace, usage, material_type, state, labels, created_at, updated_at) VALUES ('%s', 'root.seed', 'data_encryption', 'symmetric', 'active', '{"name":"seed key","apxy/key/-/id":"%s"}', CURRENT_TIMESTAMP, '2025-01-01T00:00:00Z')`, keyID, keyID),
-		fmt.Sprintf(`INSERT INTO rate_limits (id, namespace, definition, labels, created_at, updated_at) VALUES ('%s', 'root.seed', '{}', '{"name":"seed rate limit","apxy/rl/-/id":"%s"}', CURRENT_TIMESTAMP, '2026-01-01T00:00:00Z')`, rateLimitID, rateLimitID),
+		fmt.Sprintf(`INSERT INTO keys (id, name, namespace, usage, material_type, state, labels, created_at, updated_at) VALUES ('%s', '%s', 'root.seed', 'data_encryption', 'symmetric', 'active', '{"name":"seed key","apxy/key/-/id":"%s"}', CURRENT_TIMESTAMP, '2025-01-01T00:00:00Z')`, keyID, keyID, keyID),
+		fmt.Sprintf(`INSERT INTO rate_limits (id, name, namespace, definition, labels, created_at, updated_at) VALUES ('%s', '%s', 'root.seed', '{}', '{"name":"seed rate limit","apxy/rl/-/id":"%s"}', CURRENT_TIMESTAMP, '2026-01-01T00:00:00Z')`, rateLimitID, rateLimitID, rateLimitID),
 	} {
 		_, err := raw.Exec(statement)
 		require.NoError(t, err)

--- a/internal/database/schema_test.go
+++ b/internal/database/schema_test.go
@@ -18,11 +18,12 @@ func TestKeyModelSchema(t *testing.T) {
 	})
 
 	t.Run("global key uses key prefix and target defaults", func(t *testing.T) {
-		var id, usage, materialType, state string
-		err := rawDb.QueryRow("SELECT id, usage, material_type, state FROM keys WHERE id = 'key_global'").
-			Scan(&id, &usage, &materialType, &state)
+		var id, name, usage, materialType, state string
+		err := rawDb.QueryRow("SELECT id, name, usage, material_type, state FROM keys WHERE id = 'key_global'").
+			Scan(&id, &name, &usage, &materialType, &state)
 		require.NoError(t, err)
 		require.Equal(t, "key_global", id)
+		require.Equal(t, "key_global", name)
 		require.Equal(t, string(KeyUsageDataEncryption), usage)
 		require.Equal(t, string(KeyMaterialTypeSymmetric), materialType)
 		require.Equal(t, string(KeyStateActive), state)

--- a/internal/encrypt/task_reencrypt_test.go
+++ b/internal/encrypt/task_reencrypt_test.go
@@ -122,8 +122,8 @@ func (env *reencryptTestEnv) createConnection(t *testing.T, namespace string) ap
 	connectorId := apid.New(apid.PrefixConnectorVersion)
 	now := apctx.GetClock(env.ctx).Now().Format(time.RFC3339)
 	_, err := env.rawDb.Exec(fmt.Sprintf(
-		`INSERT INTO connections (id, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', 'ready', '%s', 1, '%s', '%s')`,
-		string(connId), namespace, string(connectorId), now, now,
+		`INSERT INTO connections (id, name, namespace, state, connector_id, connector_version, created_at, updated_at) VALUES ('%s', '%s', '%s', 'ready', '%s', 1, '%s', '%s')`,
+		string(connId), string(connId), namespace, string(connectorId), now, now,
 	))
 	require.NoError(t, err)
 	return connId

--- a/internal/schema/common/README.md
+++ b/internal/schema/common/README.md
@@ -1,5 +1,6 @@
 # Common Schema Types
 
-This package contains reusable primitives used by other schema packages, including string and integer value sources, images, human-readable durations and byte sizes, request types, raw JSON helpers, and setup-form JSON Schema / UI Schema helper subpackages.
+This package contains reusable primitives used by other schema packages, including resource names, string and integer value sources, images, human-readable durations and byte sizes, request types, raw JSON helpers, and setup-form JSON Schema / UI Schema helper subpackages.
 
-Types here should be generic and independent of AuthProxy resources, APIs, or configuration sections.
+Types here should be broadly reusable across AuthProxy resources, APIs, and
+configuration sections rather than owned by one specific contract.

--- a/internal/schema/common/resource_name.go
+++ b/internal/schema/common/resource_name.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+const (
+	// ResourceNameMaxLength keeps resource names compatible with Kubernetes
+	// label values so names can be projected into AuthProxy's implicit labels.
+	ResourceNameMaxLength = 63
+
+	// ResourceNamePattern accepts the same non-empty character grammar as a
+	// Kubernetes label value. AuthProxy IDs contain an underscore separator,
+	// so the stricter Kubernetes DNS-name grammar cannot be used here.
+	ResourceNamePattern = `^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$`
+)
+
+var resourceNameRegex = regexp.MustCompile(ResourceNamePattern)
+
+// ResourceName is a mutable, human-meaningful resource identifier.
+//
+// Values are preserved exactly and compared case-sensitively. AuthProxy does
+// not trim, case-fold, or otherwise normalize resource names.
+type ResourceName string
+
+// Validate checks that the resource name is non-empty and can be used as an
+// implicit label value.
+func (n ResourceName) Validate() error {
+	if n == "" {
+		return errors.New("resource name is required")
+	}
+	if len(n) > ResourceNameMaxLength {
+		return fmt.Errorf("resource name exceeds maximum length of %d characters", ResourceNameMaxLength)
+	}
+	if !resourceNameRegex.MatchString(string(n)) {
+		return errors.New("resource name must start and end with an alphanumeric character and contain only alphanumeric characters, '-', '_', or '.'")
+	}
+	return nil
+}

--- a/internal/schema/common/resource_name_test.go
+++ b/internal/schema/common/resource_name_test.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceNameValidate(t *testing.T) {
+	tests := []struct {
+		name  string
+		value ResourceName
+		valid bool
+	}{
+		{name: "single character", value: "a", valid: true},
+		{name: "generated AuthProxy id", value: "act_01jz6y5ke2nq9gc0fj8x7r3d4m", valid: true},
+		{name: "label compatible punctuation", value: "Prod.us_east-1", valid: true},
+		{name: "maximum length", value: ResourceName(strings.Repeat("a", ResourceNameMaxLength)), valid: true},
+		{name: "empty", value: "", valid: false},
+		{name: "too long", value: ResourceName(strings.Repeat("a", ResourceNameMaxLength+1)), valid: false},
+		{name: "starts with punctuation", value: "-invalid", valid: false},
+		{name: "ends with punctuation", value: "invalid_", valid: false},
+		{name: "contains whitespace", value: "not valid", valid: false},
+		{name: "contains slash", value: "not/valid", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.value.Validate()
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestResourceNamePreservesCase(t *testing.T) {
+	name := ResourceName("Production")
+	require.NoError(t, name.Validate())
+	require.Equal(t, "Production", string(name))
+	require.NotEqual(t, ResourceName("production"), name)
+}

--- a/internal/schema/common/schema.json
+++ b/internal/schema/common/schema.json
@@ -2,6 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/schema.json",
   "$defs": {
+    "ResourceName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$",
+      "description": "A mutable, case-sensitive AuthProxy resource name that is compatible with Kubernetes label values."
+    },
     "HumanByteSize": {
       "type": "string",
       "pattern": "(?i)^[0-9]+\\s?(b|kb|mb|gb|tb|pb|eb|kib|mib|gib|tib|pib|eib)$",

--- a/internal/schema/common/schema_test.go
+++ b/internal/schema/common/schema_test.go
@@ -44,6 +44,32 @@ type entities struct {
 func TestSchema(t *testing.T) {
 	entities := []entities{
 		{
+			Name: "ResourceName",
+			Schema: `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/common/test.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["test"],
+  "properties": {
+    "test": {
+      "$ref": "./schema.json#/$defs/ResourceName"
+    }
+  }
+}`,
+			Tests: []test{
+				{Name: "generated id", Valid: true, Data: `{"test": "act_01jz6y5ke2nq9gc0fj8x7r3d4m"}`},
+				{Name: "label punctuation", Valid: true, Data: `{"test": "Prod.us_east-1"}`},
+				{Name: "empty", Valid: false, Data: `{"test": ""}`},
+				{Name: "leading punctuation", Valid: false, Data: `{"test": "-invalid"}`},
+				{Name: "trailing punctuation", Valid: false, Data: `{"test": "invalid_"}`},
+				{Name: "whitespace", Valid: false, Data: `{"test": "not valid"}`},
+				{Name: "slash", Valid: false, Data: `{"test": "not/valid"}`},
+				{Name: "too long", Valid: false, Data: `{"test": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`},
+			},
+		},
+		{
 			Name: "UUID",
 			Schema: `
 {


### PR DESCRIPTION
## Summary

- add a shared, case-sensitive resource name primitive compatible with implicit label values
- add SQLite and PostgreSQL storage, ID backfills, non-empty enforcement, and live namespace/name uniqueness for actors, connections, keys, and rate limits
- default omitted names to immutable IDs and update entity/fixture plumbing, including the global key
- cover rename conflicts, namespace/type isolation, soft-delete reuse, validation, and migration upgrades

## Testing

- `AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/... -count=1`
- `AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test ./internal/database/... -count=1`
- `./scripts/preflight.sh`

Closes #771