### PR TITLE
Add resource name API behavior

### DIFF
--- a/internal/core/connection.go
+++ b/internal/core/connection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
@@ -56,6 +57,10 @@ func (c *connection) GetId() apid.ID {
 
 func (c *connection) GetNamespace() string {
 	return c.Namespace
+}
+
+func (c *connection) GetName() scommon.ResourceName {
+	return c.Name
 }
 
 func (c *connection) GetState() database.ConnectionState {

--- a/internal/core/connector.go
+++ b/internal/core/connector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -54,6 +55,10 @@ func (c *Connector) GetId() apid.ID {
 
 func (c *Connector) GetNamespace() string {
 	return c.ConnectorWithDefinition.Namespace
+}
+
+func (c *Connector) GetName() scommon.ResourceName {
+	return c.ConnectorWithDefinition.Name
 }
 
 func (c *Connector) GetVersion() uint64 {

--- a/internal/core/iface/connection.go
+++ b/internal/core/iface/connection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apjs"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -19,6 +20,7 @@ type Connection interface {
 
 	GetId() apid.ID
 	GetNamespace() string
+	GetName() common.ResourceName
 	GetState() database.ConnectionState
 	GetHealthState() database.ConnectionHealthState
 	GetConnectorId() apid.ID

--- a/internal/core/iface/connector.go
+++ b/internal/core/iface/connector.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -14,6 +15,7 @@ import (
 type Connector interface {
 	GetId() apid.ID
 	GetNamespace() string
+	GetName() common.ResourceName
 	GetVersion() uint64
 	GetState() database.ConnectorDefinitionVersionState
 	GetHash() string

--- a/internal/core/iface/key.go
+++ b/internal/core/iface/key.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 type Key interface {
 	GetId() apid.ID
 	GetNamespace() string
+	GetName() common.ResourceName
 	GetState() database.KeyState
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
@@ -29,6 +31,7 @@ type ListKeysBuilder interface {
 	Limit(int32) ListKeysBuilder
 	ForNamespaceMatcher(matcher string) ListKeysBuilder
 	ForNamespaceMatchers(matchers []string) ListKeysBuilder
+	ForName(name common.ResourceName) ListKeysBuilder
 	ForState(database.KeyState) ListKeysBuilder
 	OrderBy(database.KeyOrderByField, pagination.OrderBy) ListKeysBuilder
 	IncludeDeleted() ListKeysBuilder

--- a/internal/core/iface/list_connections.go
+++ b/internal/core/iface/list_connections.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -21,6 +22,7 @@ type ListConnectionsBuilder interface {
 	ForConnectorId(id apid.ID) ListConnectionsBuilder
 	ForNamespaceMatcher(matcher string) ListConnectionsBuilder
 	ForNamespaceMatchers(matchers []string) ListConnectionsBuilder
+	ForName(name common.ResourceName) ListConnectionsBuilder
 	OrderBy(database.ConnectionOrderByField, pagination.OrderBy) ListConnectionsBuilder
 	IncludeDeleted() ListConnectionsBuilder
 	WithDeletedHandling(database.DeletedHandling) ListConnectionsBuilder

--- a/internal/core/iface/list_connector_versions.go
+++ b/internal/core/iface/list_connector_versions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -26,6 +27,7 @@ type ListConnectorVersionsBuilder interface {
 	ForStates([]database.ConnectorDefinitionVersionState) ListConnectorVersionsBuilder
 	ForNamespaceMatcher(string) ListConnectorVersionsBuilder
 	ForNamespaceMatchers([]string) ListConnectorVersionsBuilder
+	ForName(name common.ResourceName) ListConnectorVersionsBuilder
 	OrderBy(database.ConnectorDefinitionVersionOrderByField, pagination.OrderBy) ListConnectorVersionsBuilder
 	IncludeDeleted() ListConnectorVersionsBuilder
 	ForLabelSelector(selector string) ListConnectorVersionsBuilder

--- a/internal/core/iface/list_connectors.go
+++ b/internal/core/iface/list_connectors.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -21,6 +22,7 @@ type ListConnectorsBuilder interface {
 	ForStates([]database.ConnectorDefinitionVersionState) ListConnectorsBuilder
 	ForNamespaceMatcher(string) ListConnectorsBuilder
 	ForNamespaceMatchers([]string) ListConnectorsBuilder
+	ForName(name common.ResourceName) ListConnectorsBuilder
 	OrderBy(database.ConnectorOrderByField, pagination.OrderBy) ListConnectorsBuilder
 	IncludeDeleted() ListConnectorsBuilder
 	ForLabelSelector(selector string) ListConnectorsBuilder

--- a/internal/core/iface/namespace.go
+++ b/internal/core/iface/namespace.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
 type Namespace interface {
 	GetPath() string
+	GetName() common.ResourceName
 	GetState() database.NamespaceState
 	GetKeyId() *apid.ID
 	GetCreatedAt() time.Time
@@ -36,6 +38,7 @@ type ListNamespacesBuilder interface {
 	ForChildrenOf(path string) ListNamespacesBuilder
 	ForNamespaceMatcher(matcher string) ListNamespacesBuilder
 	ForNamespaceMatchers(matchers []string) ListNamespacesBuilder
+	ForName(name common.ResourceName) ListNamespacesBuilder
 	ForState(database.NamespaceState) ListNamespacesBuilder
 	OrderBy(database.NamespaceOrderByField, pagination.OrderBy) ListNamespacesBuilder
 	IncludeDeleted() ListNamespacesBuilder

--- a/internal/core/iface/rate_limit.go
+++ b/internal/core/iface/rate_limit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -14,6 +15,7 @@ import (
 type RateLimit interface {
 	GetId() apid.ID
 	GetNamespace() string
+	GetName() common.ResourceName
 	GetDefinition() rlschema.RateLimit
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
@@ -31,6 +33,7 @@ type ListRateLimitsBuilder interface {
 	Limit(int32) ListRateLimitsBuilder
 	ForNamespaceMatcher(matcher string) ListRateLimitsBuilder
 	ForNamespaceMatchers(matchers []string) ListRateLimitsBuilder
+	ForName(name common.ResourceName) ListRateLimitsBuilder
 	OrderBy(database.RateLimitOrderByField, pagination.OrderBy) ListRateLimitsBuilder
 	IncludeDeleted() ListRateLimitsBuilder
 	ForLabelSelector(selector string) ListRateLimitsBuilder

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -8,6 +8,7 @@ import (
 	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
@@ -90,7 +91,10 @@ type C interface {
 	ListConnectorVersionsFromCursor(ctx context.Context, cursor string) (ListConnectorVersionsExecutor, error)
 
 	// CreateConnectorVersion creates a new connector with version 1 in draft state.
-	CreateConnectorVersion(ctx context.Context, namespace string, definition *cschema.Connector, labels map[string]string, annotations map[string]string) (Connector, error)
+	CreateConnectorVersion(ctx context.Context, namespace string, name scommon.ResourceName, definition *cschema.Connector, labels map[string]string, annotations map[string]string) (Connector, error)
+
+	// UpdateConnectorName renames a logical connector without changing its definition-version history.
+	UpdateConnectorName(ctx context.Context, id apid.ID, name scommon.ResourceName) error
 
 	// CreateDraftConnectorVersion creates a new draft version for an existing connector.
 	// Returns ErrDraftAlreadyExists if a draft version already exists.
@@ -131,7 +135,10 @@ type C interface {
 	GetConnection(ctx context.Context, id apid.ID) (Connection, error)
 
 	// CreateConnection creates a new connection.
-	CreateConnection(ctx context.Context, namespace string, c Connector) (Connection, error)
+	CreateConnection(ctx context.Context, namespace string, name scommon.ResourceName, c Connector) (Connection, error)
+
+	// UpdateConnectionName renames a connection addressed by immutable ID.
+	UpdateConnectionName(ctx context.Context, id apid.ID, name scommon.ResourceName) (Connection, error)
 
 	// ListConnectionsBuilder returns a builder to allow the caller to list connections matching certain criteria.
 	ListConnectionsBuilder() ListConnectionsBuilder
@@ -258,7 +265,10 @@ type C interface {
 	GetKey(ctx context.Context, id apid.ID) (Key, error)
 
 	// CreateKey creates a new key.
-	CreateKey(ctx context.Context, namespace string, keyData *cfgschema.KeyData, labels map[string]string) (Key, error)
+	CreateKey(ctx context.Context, namespace string, name scommon.ResourceName, keyData *cfgschema.KeyData, labels map[string]string) (Key, error)
+
+	// UpdateKeyName renames a key addressed by immutable ID.
+	UpdateKeyName(ctx context.Context, id apid.ID, name scommon.ResourceName) (Key, error)
 
 	// GetKeyData returns the decrypted provider configuration for a key.
 	GetKeyData(ctx context.Context, id apid.ID) (*cfgschema.KeyData, error)
@@ -306,7 +316,10 @@ type C interface {
 	GetRateLimit(ctx context.Context, id apid.ID) (RateLimit, error)
 
 	// CreateRateLimit creates a new rate-limit resource. Definition is validated before insert.
-	CreateRateLimit(ctx context.Context, namespace string, def rlschema.RateLimit, labels, annotations map[string]string) (RateLimit, error)
+	CreateRateLimit(ctx context.Context, namespace string, name scommon.ResourceName, def rlschema.RateLimit, labels, annotations map[string]string) (RateLimit, error)
+
+	// UpdateRateLimitName renames a rate limit addressed by immutable ID.
+	UpdateRateLimitName(ctx context.Context, id apid.ID, name scommon.ResourceName) (RateLimit, error)
 
 	// UpdateRateLimitDefinition replaces a rate limit's definition payload.
 	UpdateRateLimitDefinition(ctx context.Context, id apid.ID, def rlschema.RateLimit) (RateLimit, error)

--- a/internal/core/key.go
+++ b/internal/core/key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 )
 
 // Key is the core abstraction around encryption keys.
@@ -34,6 +35,10 @@ func (ek *Key) GetId() apid.ID {
 
 func (ek *Key) GetNamespace() string {
 	return ek.Namespace
+}
+
+func (ek *Key) GetName() scommon.ResourceName {
+	return ek.Name
 }
 
 func (ek *Key) GetState() database.KeyState {

--- a/internal/core/mock/connection.go
+++ b/internal/core/mock/connection.go
@@ -11,12 +11,14 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 type Connection struct {
 	Id                apid.ID
 	Namespace         string
+	Name              common.ResourceName
 	State             database.ConnectionState
 	HealthState       database.ConnectionHealthState
 	ConnectorId       apid.ID
@@ -38,6 +40,10 @@ func (m *Connection) GetId() apid.ID {
 
 func (m *Connection) GetNamespace() string {
 	return m.Namespace
+}
+
+func (m *Connection) GetName() common.ResourceName {
+	return m.Name
 }
 
 func (m *Connection) GetState() database.ConnectionState {

--- a/internal/core/mock/connector.go
+++ b/internal/core/mock/connector.go
@@ -8,12 +8,14 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 type Connector struct {
 	Id          apid.ID
 	Namespace   string
+	Name        common.ResourceName
 	Version     uint64
 	State       database.ConnectorDefinitionVersionState
 	Type        string
@@ -31,6 +33,10 @@ func (m *Connector) GetId() apid.ID {
 
 func (m *Connector) GetNamespace() string {
 	return m.Namespace
+}
+
+func (m *Connector) GetName() common.ResourceName {
+	return m.Name
 }
 
 func (m *Connector) GetVersion() uint64 {

--- a/internal/core/mock/namespace.go
+++ b/internal/core/mock/namespace.go
@@ -8,10 +8,13 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	nsschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 type Namespace struct {
 	Path        string
+	Name        common.ResourceName
 	State       database.NamespaceState
 	KeyId       *apid.ID
 	CreatedAt   time.Time
@@ -22,6 +25,13 @@ type Namespace struct {
 
 func (m *Namespace) GetPath() string {
 	return m.Path
+}
+
+func (m *Namespace) GetName() common.ResourceName {
+	if m.Name != "" {
+		return m.Name
+	}
+	return nsschema.NameFromPath(m.Path)
 }
 
 func (m *Namespace) GetState() database.NamespaceState {

--- a/internal/core/namespace.go
+++ b/internal/core/namespace.go
@@ -8,6 +8,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 // Namespace is the core abstraction around namespaces.
@@ -34,6 +36,10 @@ func (ns *Namespace) GetNamespace() string {
 
 func (ns *Namespace) GetPath() string {
 	return ns.Path
+}
+
+func (ns *Namespace) GetName() scommon.ResourceName {
+	return nschema.NameFromPath(ns.Path)
 }
 
 func (ns *Namespace) GetState() database.NamespaceState {

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 )
 
@@ -31,6 +32,7 @@ func wrapRateLimit(rl database.RateLimit, s *service) *RateLimit {
 
 func (r *RateLimit) GetId() apid.ID                    { return r.Id }
 func (r *RateLimit) GetNamespace() string              { return r.Namespace }
+func (r *RateLimit) GetName() scommon.ResourceName     { return r.Name }
 func (r *RateLimit) GetDefinition() rlschema.RateLimit { return r.Definition }
 func (r *RateLimit) GetLabels() map[string]string      { return r.Labels }
 func (r *RateLimit) GetAnnotations() map[string]string { return r.Annotations }

--- a/internal/core/service_connection_create.go
+++ b/internal/core/service_connection_create.go
@@ -10,12 +10,14 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	ns "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 func (s *service) CreateConnection(
 	ctx context.Context,
 	namespace string,
+	name scommon.ResourceName,
 	c iface.Connector,
 ) (connection iface.Connection, err error) {
 	logger := aplog.LoggerOrDefault(c, s)
@@ -35,6 +37,7 @@ func (s *service) CreateConnection(
 	dbConn := database.Connection{
 		Id:               id,
 		Namespace:        namespace,
+		Name:             name,
 		ConnectorId:      c.GetId(),
 		ConnectorVersion: c.GetVersion(),
 		CreatedAt:        now,
@@ -57,4 +60,20 @@ func (s *service) CreateConnection(
 		"connection_id", id)
 
 	return wrapConnection(&dbConn, connector, s), nil
+}
+
+func (s *service) UpdateConnectionName(ctx context.Context, id apid.ID, name scommon.ResourceName) (iface.Connection, error) {
+	dbConn, err := s.db.UpdateConnectionName(ctx, id, name)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	c, err := s.getConnectorVersion(ctx, dbConn.ConnectorId, dbConn.ConnectorVersion)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConnection(dbConn, c, s), nil
 }

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
@@ -72,9 +73,16 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 		return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 	}
 
-	connectionIface, err := s.CreateConnection(ctx, targetNamespace, c)
+	var name scommon.ResourceName
+	if req.Name != nil {
+		name = *req.Name
+	}
+	connectionIface, err := s.CreateConnection(ctx, targetNamespace, name, c)
 	if err != nil {
 		val.MarkErrorReturn()
+		if errors.Is(err, database.ErrDuplicate) {
+			return nil, httperr.Conflictf("connection name '%s' already exists in namespace '%s'", name, targetNamespace)
+		}
 		return nil, httperr.InternalServerError(httperr.WithInternalErr(err))
 	}
 	// CreateConnection returns the concrete *connection typed as iface; we

--- a/internal/core/service_connection_list.go
+++ b/internal/core/service_connection_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -112,6 +113,10 @@ func (l *listConnectionsWrapper) ForNamespaceMatcher(m string) iface.ListConnect
 
 func (l *listConnectionsWrapper) ForNamespaceMatchers(matchers []string) iface.ListConnectionsBuilder {
 	return l.cloneWithBuilder(l.l.ForNamespaceMatchers(matchers))
+}
+
+func (l *listConnectionsWrapper) ForName(name common.ResourceName) iface.ListConnectionsBuilder {
+	return l.cloneWithBuilder(l.l.ForName(name))
 }
 
 func (l *listConnectionsWrapper) OrderBy(f database.ConnectionOrderByField, o pagination.OrderBy) iface.ListConnectionsBuilder {

--- a/internal/core/service_connector_list.go
+++ b/internal/core/service_connector_list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -96,6 +97,13 @@ func (l *listConnectorWrapper) ForNamespaceMatcher(m string) iface.ListConnector
 func (l *listConnectorWrapper) ForNamespaceMatchers(matchers []string) iface.ListConnectorsBuilder {
 	return &listConnectorWrapper{
 		l: l.l.ForNamespaceMatchers(matchers),
+		s: l.s,
+	}
+}
+
+func (l *listConnectorWrapper) ForName(name common.ResourceName) iface.ListConnectorsBuilder {
+	return &listConnectorWrapper{
+		l: l.l.ForName(name),
 		s: l.s,
 	}
 }

--- a/internal/core/service_connector_version_create.go
+++ b/internal/core/service_connector_version_create.go
@@ -9,11 +9,12 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 )
 
-func (s *service) CreateConnectorVersion(ctx context.Context, namespace string, definition *cschema.Connector, labels map[string]string, annotations map[string]string) (iface.Connector, error) {
+func (s *service) CreateConnectorVersion(ctx context.Context, namespace string, name scommon.ResourceName, definition *cschema.Connector, labels map[string]string, annotations map[string]string) (iface.Connector, error) {
 	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnectorVersion)
 
 	def := definition.Clone()
@@ -34,12 +35,23 @@ func (s *service) CreateConnectorVersion(ctx context.Context, namespace string, 
 
 	c.ConnectorWithDefinition.Labels = labels
 	c.ConnectorWithDefinition.Annotations = annotations
+	c.ConnectorWithDefinition.Name = name
 
 	if err := s.db.UpsertConnectorDefinitionVersion(ctx, &c.ConnectorWithDefinition); err != nil {
 		return nil, fmt.Errorf("failed to upsert connector version: %w", err)
 	}
 
 	return s.getConnectorVersion(ctx, id, 1)
+}
+
+func (s *service) UpdateConnectorName(ctx context.Context, id apid.ID, name scommon.ResourceName) error {
+	if err := s.db.UpdateConnectorName(ctx, id, name); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *service) CreateDraftConnectorVersion(ctx context.Context, id apid.ID, definition *cschema.Connector, labels map[string]string, annotations map[string]string) (iface.Connector, error) {

--- a/internal/core/service_connector_version_create_test.go
+++ b/internal/core/service_connector_version_create_test.go
@@ -50,7 +50,7 @@ func TestCreateConnectorVersion(t *testing.T) {
 			Labels:      labels,
 		})
 
-		result, err := s.CreateConnectorVersion(ctx, "root", definition, labels, nil)
+		result, err := s.CreateConnectorVersion(ctx, "root", "", definition, labels, nil)
 		require.NoError(t, err)
 		require.Equal(t, fixedId, result.GetId())
 		require.Equal(t, uint64(1), result.GetVersion())
@@ -77,7 +77,7 @@ func TestCreateConnectorVersion(t *testing.T) {
 			UpsertConnectorDefinitionVersion(gomock.Any(), gomock.Any()).
 			Return(errors.New("db write failed"))
 
-		_, err := s.CreateConnectorVersion(ctx, "root", definition, nil, nil)
+		_, err := s.CreateConnectorVersion(ctx, "root", "", definition, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to upsert connector version")
 	})

--- a/internal/core/service_connector_version_list.go
+++ b/internal/core/service_connector_version_list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -96,6 +97,13 @@ func (l *listConnectorVersionWrapper) ForNamespaceMatcher(m string) iface.ListCo
 func (l *listConnectorVersionWrapper) ForNamespaceMatchers(matchers []string) iface.ListConnectorVersionsBuilder {
 	return &listConnectorVersionWrapper{
 		l: l.l.ForNamespaceMatchers(matchers),
+		s: l.s,
+	}
+}
+
+func (l *listConnectorVersionWrapper) ForName(name common.ResourceName) iface.ListConnectorVersionsBuilder {
+	return &listConnectorVersionWrapper{
+		l: l.l.ForName(name),
 		s: l.s,
 	}
 }

--- a/internal/core/service_key.go
+++ b/internal/core/service_key.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cfgschema "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -26,10 +27,11 @@ func (s *service) GetKey(ctx context.Context, id apid.ID) (iface.Key, error) {
 	return wrapKey(*ek, s), nil
 }
 
-func (s *service) CreateKey(ctx context.Context, namespace string, keyData *cfgschema.KeyData, labels map[string]string) (iface.Key, error) {
+func (s *service) CreateKey(ctx context.Context, namespace string, name common.ResourceName, keyData *cfgschema.KeyData, labels map[string]string) (iface.Key, error) {
 	ek := &database.Key{
 		Id:        apid.New(apid.PrefixKey),
 		Namespace: namespace,
+		Name:      name,
 		State:     database.KeyStateActive,
 		Labels:    database.Labels(labels),
 	}
@@ -60,6 +62,20 @@ func (s *service) CreateKey(ctx context.Context, namespace string, keyData *cfgs
 	encrypt.EnqueueGenerateDataEncryptionKeysToDatabase(ctx, s.ac, s.logger)
 	encrypt.EnqueueForceSyncKeysToDatabase(ctx, s.r, s.ac, s.logger)
 
+	return wrapKey(*ek, s), nil
+}
+
+func (s *service) UpdateKeyName(ctx context.Context, id apid.ID, name common.ResourceName) (iface.Key, error) {
+	if err := name.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid key name: %w", err)
+	}
+	ek, err := s.db.UpdateKey(ctx, id, map[string]interface{}{"name": name})
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
 	return wrapKey(*ek, s), nil
 }
 
@@ -272,6 +288,10 @@ func (l *listKeyWrapper) ForNamespaceMatcher(matcher string) iface.ListKeysBuild
 
 func (l *listKeyWrapper) ForNamespaceMatchers(matchers []string) iface.ListKeysBuilder {
 	return &listKeyWrapper{l: l.l.ForNamespaceMatchers(matchers), s: l.s}
+}
+
+func (l *listKeyWrapper) ForName(name common.ResourceName) iface.ListKeysBuilder {
+	return &listKeyWrapper{l: l.l.ForName(name), s: l.s}
 }
 
 func (l *listKeyWrapper) ForState(state database.KeyState) iface.ListKeysBuilder {

--- a/internal/core/service_key_test.go
+++ b/internal/core/service_key_test.go
@@ -66,7 +66,7 @@ func TestCreateKeyEnqueuesDEKGeneration(t *testing.T) {
 			Return(nil, nil),
 	)
 
-	created, err := s.CreateKey(ctx, "root.dev", keyData, map[string]string{"purpose": "test"})
+	created, err := s.CreateKey(ctx, "root.dev", "", keyData, map[string]string{"purpose": "test"})
 
 	require.NoError(t, err)
 	require.Equal(t, "root.dev", created.GetNamespace())

--- a/internal/core/service_namespace.go
+++ b/internal/core/service_namespace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	dbtasks "github.com/rmorlok/authproxy/internal/database/tasks"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -283,6 +284,13 @@ func (l *listNamespaceWrapper) ForNamespaceMatcher(matcher string) iface.ListNam
 func (l *listNamespaceWrapper) ForNamespaceMatchers(matchers []string) iface.ListNamespacesBuilder {
 	return &listNamespaceWrapper{
 		l: l.l.ForNamespaceMatchers(matchers),
+		s: l.s,
+	}
+}
+
+func (l *listNamespaceWrapper) ForName(name common.ResourceName) iface.ListNamespacesBuilder {
+	return &listNamespaceWrapper{
+		l: l.l.ForName(name),
 		s: l.s,
 	}
 }

--- a/internal/core/service_rate_limit.go
+++ b/internal/core/service_rate_limit.go
@@ -27,16 +27,28 @@ func (s *service) GetRateLimit(ctx context.Context, id apid.ID) (iface.RateLimit
 	return wrapRateLimit(*rl, s), nil
 }
 
-func (s *service) CreateRateLimit(ctx context.Context, namespace string, def rlschema.RateLimit, labels, annotations map[string]string) (iface.RateLimit, error) {
+func (s *service) CreateRateLimit(ctx context.Context, namespace string, name common.ResourceName, def rlschema.RateLimit, labels, annotations map[string]string) (iface.RateLimit, error) {
 	rl := &database.RateLimit{
 		Id:          apid.New(apid.PrefixRateLimit),
 		Namespace:   namespace,
+		Name:        name,
 		Definition:  def,
 		Labels:      database.Labels(labels),
 		Annotations: database.Annotations(annotations),
 	}
 
 	if err := s.db.CreateRateLimit(ctx, rl); err != nil {
+		return nil, err
+	}
+	return wrapRateLimit(*rl, s), nil
+}
+
+func (s *service) UpdateRateLimitName(ctx context.Context, id apid.ID, name common.ResourceName) (iface.RateLimit, error) {
+	rl, err := s.db.UpdateRateLimitName(ctx, id, name)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	return wrapRateLimit(*rl, s), nil
@@ -180,6 +192,10 @@ func (l *listRateLimitsWrapper) ForNamespaceMatcher(matcher string) iface.ListRa
 
 func (l *listRateLimitsWrapper) ForNamespaceMatchers(matchers []string) iface.ListRateLimitsBuilder {
 	return &listRateLimitsWrapper{l: l.l.ForNamespaceMatchers(matchers), s: l.s}
+}
+
+func (l *listRateLimitsWrapper) ForName(name common.ResourceName) iface.ListRateLimitsBuilder {
+	return &listRateLimitsWrapper{l: l.l.ForName(name), s: l.s}
 }
 
 func (l *listRateLimitsWrapper) OrderBy(f database.RateLimitOrderByField, o pagination.OrderBy) iface.ListRateLimitsBuilder {

--- a/internal/core/service_rate_limit_dry_run_test.go
+++ b/internal/core/service_rate_limit_dry_run_test.go
@@ -56,7 +56,7 @@ func newDryRunService(t *testing.T) (iface.C, ratelimit.MutableCache, func()) {
 
 func installRule(t *testing.T, svc iface.C, rlCache ratelimit.MutableCache, namespace string, def rlschema.RateLimit) *database.RateLimit {
 	t.Helper()
-	created, err := svc.CreateRateLimit(context.Background(), namespace, def, nil, nil)
+	created, err := svc.CreateRateLimit(context.Background(), namespace, "", def, nil, nil)
 	require.NoError(t, err)
 	// The cache the enforcer reads holds *database.RateLimit rows
 	// (loaded by the refresher). Read straight back from the iface

--- a/internal/core/service_tasks_test.go
+++ b/internal/core/service_tasks_test.go
@@ -117,6 +117,10 @@ func (b *staticListConnectionsBuilder) ForNamespaceMatchers([]string) database.L
 	return b
 }
 
+func (b *staticListConnectionsBuilder) ForName(common.ResourceName) database.ListConnectionsBuilder {
+	return b
+}
+
 func (b *staticListConnectionsBuilder) OrderBy(database.ConnectionOrderByField, pagination.OrderBy) database.ListConnectionsBuilder {
 	return b
 }

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -246,6 +246,10 @@ func (a *Actor) GetNamespace() string {
 	return a.Namespace
 }
 
+func (a *Actor) GetName() scommon.ResourceName {
+	return a.Name
+}
+
 func (a *Actor) GetLabels() map[string]string {
 	return a.Labels
 }
@@ -430,7 +434,7 @@ func (s *service) CreateActor(ctx context.Context, a *Actor) error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return err
+			return wrapDatabaseMutationError("failed to create actor", err)
 		}
 
 		affected, err := result.RowsAffected()
@@ -523,7 +527,7 @@ func (s *service) UpsertActor(ctx context.Context, d IActorData) (*Actor, error)
 					RunWith(tx).
 					Exec()
 				if err != nil {
-					return fmt.Errorf("failed to create actor on upsert: %w", err)
+					return wrapDatabaseMutationError("failed to create actor on upsert", err)
 				}
 
 				affected, err := dbResult.RowsAffected()
@@ -567,7 +571,7 @@ func (s *service) UpsertActor(ctx context.Context, d IActorData) (*Actor, error)
 				RunWith(tx).
 				Exec()
 			if err != nil {
-				return fmt.Errorf("failed to update existing actor: %w", err)
+				return wrapDatabaseMutationError("failed to update existing actor", err)
 			}
 
 			affected, err := dbResult.RowsAffected()
@@ -590,6 +594,42 @@ func (s *service) UpsertActor(ctx context.Context, d IActorData) (*Actor, error)
 	}
 
 	return result, nil
+}
+
+// UpdateActorName renames one live actor without changing its immutable ID or
+// external identity.
+func (s *service) UpdateActorName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Actor, error) {
+	if id.IsNil() {
+		return nil, errors.New("actor id is required")
+	}
+	if err := id.ValidatePrefix(apid.PrefixActor); err != nil {
+		return nil, fmt.Errorf("invalid actor id: %w", err)
+	}
+	if err := name.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid actor name: %w", err)
+	}
+
+	result, err := s.sq.
+		Update(ActorTable).
+		Set("name", name).
+		Set("updated_at", apctx.GetClock(ctx).Now()).
+		Where(sq.Eq{"id": id, "deleted_at": nil}).
+		RunWith(s.db).
+		ExecContext(ctx)
+	if err != nil {
+		return nil, wrapDatabaseMutationError("failed to update actor name", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update actor name: %w", err)
+	}
+	if affected == 0 {
+		return nil, ErrNotFound
+	}
+	if affected > 1 {
+		return nil, fmt.Errorf("multiple actors were renamed: %w", ErrViolation)
+	}
+	return s.GetActor(ctx, id)
 }
 
 func (s *service) DeleteActor(ctx context.Context, id apid.ID) error {
@@ -629,6 +669,7 @@ type ListActorsExecutor interface {
 type ListActorsBuilder interface {
 	ListActorsExecutor
 	ForExternalId(externalId string) ListActorsBuilder
+	ForName(name scommon.ResourceName) ListActorsBuilder
 	ForNamespaceMatcher(matcher string) ListActorsBuilder
 	ForNamespaceMatchers(matchers []string) ListActorsBuilder
 	Limit(int32) ListActorsBuilder
@@ -638,16 +679,17 @@ type ListActorsBuilder interface {
 }
 
 type listActorsFilters struct {
-	s                 *service            `json:"-"`
-	LimitVal          uint64              `json:"limit"`
-	Offset            uint64              `json:"offset"`
-	OrderByFieldVal   *ActorOrderByField  `json:"order_by_field"`
-	OrderByVal        *pagination.OrderBy `json:"order_by"`
-	IncludeDeletedVal bool                `json:"include_deleted,omitempty"`
-	ExternalIdVal     *string             `json:"external_id,omitempty"`
-	NamespaceMatchers []string            `json:"namespace_matchers,omitempty"`
-	LabelSelectorVal  *string             `json:"label_selector,omitempty"`
-	Errors            *multierror.Error   `json:"-"`
+	s                 *service              `json:"-"`
+	LimitVal          uint64                `json:"limit"`
+	Offset            uint64                `json:"offset"`
+	OrderByFieldVal   *ActorOrderByField    `json:"order_by_field"`
+	OrderByVal        *pagination.OrderBy   `json:"order_by"`
+	IncludeDeletedVal bool                  `json:"include_deleted,omitempty"`
+	ExternalIdVal     *string               `json:"external_id,omitempty"`
+	NameVal           *scommon.ResourceName `json:"name,omitempty"`
+	NamespaceMatchers []string              `json:"namespace_matchers,omitempty"`
+	LabelSelectorVal  *string               `json:"label_selector,omitempty"`
+	Errors            *multierror.Error     `json:"-"`
 }
 
 func (l *listActorsFilters) Limit(limit int32) ListActorsBuilder {
@@ -670,6 +712,14 @@ func (l *listActorsFilters) IncludeDeleted() ListActorsBuilder {
 
 func (l *listActorsFilters) ForExternalId(externalId string) ListActorsBuilder {
 	l.ExternalIdVal = &externalId
+	return l
+}
+
+func (l *listActorsFilters) ForName(name scommon.ResourceName) ListActorsBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -742,6 +792,14 @@ func (l *listActorsFilters) applyRestrictions(ctx context.Context) sq.SelectBuil
 
 	if len(l.NamespaceMatchers) > 0 {
 		q = restrictToNamespaceMatchers(q, "namespace", l.NamespaceMatchers)
+	}
+
+	if l.ExternalIdVal != nil {
+		q = q.Where(sq.Eq{"external_id": *l.ExternalIdVal})
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"name": *l.NameVal})
 	}
 
 	if l.OrderByFieldVal != nil {

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -309,7 +309,7 @@ func (s *service) CreateConnection(ctx context.Context, c *Connection) error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return err
+			return wrapDatabaseMutationError("failed to create connection", err)
 		}
 
 		affected, err := result.RowsAffected()
@@ -343,6 +343,41 @@ func (s *service) GetConnection(ctx context.Context, id apid.ID) (*Connection, e
 	}
 
 	return &result, nil
+}
+
+// UpdateConnectionName renames one live connection addressed by immutable ID.
+func (s *service) UpdateConnectionName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Connection, error) {
+	if id.IsNil() {
+		return nil, errors.New("connection id is required")
+	}
+	if err := id.ValidatePrefix(apid.PrefixConnection); err != nil {
+		return nil, fmt.Errorf("invalid connection id: %w", err)
+	}
+	if err := name.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid connection name: %w", err)
+	}
+
+	result, err := s.sq.
+		Update(ConnectionsTable).
+		Set("name", name).
+		Set("updated_at", apctx.GetClock(ctx).Now()).
+		Where(sq.Eq{"id": id, "deleted_at": nil}).
+		RunWith(s.db).
+		ExecContext(ctx)
+	if err != nil {
+		return nil, wrapDatabaseMutationError("failed to update connection name", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update connection name: %w", err)
+	}
+	if affected == 0 {
+		return nil, ErrNotFound
+	}
+	if affected > 1 {
+		return nil, fmt.Errorf("multiple connections were renamed: %w", ErrViolation)
+	}
+	return s.GetConnection(ctx, id)
 }
 
 func (s *service) DeleteConnection(ctx context.Context, id apid.ID) error {
@@ -724,6 +759,7 @@ type ListConnectionsBuilder interface {
 	ForConnectorId(id apid.ID) ListConnectionsBuilder
 	ForNamespaceMatcher(matcher string) ListConnectionsBuilder
 	ForNamespaceMatchers(matchers []string) ListConnectionsBuilder
+	ForName(name scommon.ResourceName) ListConnectionsBuilder
 	OrderBy(ConnectionOrderByField, pagination.OrderBy) ListConnectionsBuilder
 	IncludeDeleted() ListConnectionsBuilder
 	WithDeletedHandling(DeletedHandling) ListConnectionsBuilder
@@ -739,6 +775,7 @@ type listConnectionsFilters struct {
 	StatesVal           []ConnectionState       `json:"states,omitempty"`
 	ConnectorIdsVal     []apid.ID               `json:"connector_ids,omitempty"`
 	NamespaceMatchers   []string                `json:"namespace_matchers,omitempty"`
+	NameVal             *scommon.ResourceName   `json:"name,omitempty"`
 	OrderByFieldVal     *ConnectionOrderByField `json:"order_by_field"`
 	OrderByVal          *pagination.OrderBy     `json:"order_by"`
 	IncludeDeletedVal   bool                    `json:"include_deleted,omitempty"`
@@ -784,6 +821,14 @@ func (l *listConnectionsFilters) ForNamespaceMatchers(matchers []string) ListCon
 		}
 	}
 	l.NamespaceMatchers = matchers
+	return l
+}
+
+func (l *listConnectionsFilters) ForName(name scommon.ResourceName) ListConnectionsBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -880,6 +925,10 @@ func (l *listConnectionsFilters) applyRestrictions(ctx context.Context) sq.Selec
 
 	if len(l.NamespaceMatchers) > 0 {
 		q = restrictToNamespaceMatchers(q, "namespace", l.NamespaceMatchers)
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"name": *l.NameVal})
 	}
 
 	if l.SetupStepNotNullVal {

--- a/internal/database/connector.go
+++ b/internal/database/connector.go
@@ -182,7 +182,7 @@ func (s *service) ensureConnectorForDefinition(
 		Values(connector.values()...).
 		ExecContext(ctx)
 	if err != nil {
-		return err
+		return wrapDatabaseMutationError("failed to create connector", err)
 	}
 	cv.Name = connector.Name
 	cv.Labels = connector.Labels
@@ -213,7 +213,7 @@ func (s *service) UpdateConnectorName(ctx context.Context, id apid.ID, name scom
 		RunWith(s.db).
 		ExecContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to update connector name: %w", err)
+		return wrapDatabaseMutationError("failed to update connector name", err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {

--- a/internal/database/connector_definition_version.go
+++ b/internal/database/connector_definition_version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -707,6 +708,7 @@ type ListConnectorDefinitionVersionsBuilder interface {
 	ForStates([]ConnectorDefinitionVersionState) ListConnectorDefinitionVersionsBuilder
 	ForNamespaceMatcher(string) ListConnectorDefinitionVersionsBuilder
 	ForNamespaceMatchers([]string) ListConnectorDefinitionVersionsBuilder
+	ForName(name scommon.ResourceName) ListConnectorDefinitionVersionsBuilder
 	OrderBy(ConnectorDefinitionVersionOrderByField, pagination.OrderBy) ListConnectorDefinitionVersionsBuilder
 	IncludeDeleted() ListConnectorDefinitionVersionsBuilder
 	ForLabelSelector(selector string) ListConnectorDefinitionVersionsBuilder
@@ -720,6 +722,7 @@ type listConnectorDefinitionVersionsFilters struct {
 	NamespaceMatchers []string                                `json:"namespace_matchers,omitempty"`
 	IdsVal            []apid.ID                               `json:"ids,omitempty"`
 	VersionsVal       []uint64                                `json:"versions,omitempty"`
+	NameVal           *scommon.ResourceName                   `json:"name,omitempty"`
 	OrderByFieldVal   *ConnectorDefinitionVersionOrderByField `json:"order_by_field"`
 	OrderByVal        *pagination.OrderBy                     `json:"order_by"`
 	IncludeDeletedVal bool                                    `json:"include_deleted,omitempty"`
@@ -777,6 +780,14 @@ func (l *listConnectorDefinitionVersionsFilters) ForVersion(version uint64) List
 	return l
 }
 
+func (l *listConnectorDefinitionVersionsFilters) ForName(name scommon.ResourceName) ListConnectorDefinitionVersionsBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
+	return l
+}
+
 func (l *listConnectorDefinitionVersionsFilters) OrderBy(field ConnectorDefinitionVersionOrderByField, by pagination.OrderBy) ListConnectorDefinitionVersionsBuilder {
 	if IsValidConnectorDefinitionVersionOrderByField(field) {
 		l.OrderByFieldVal = &field
@@ -831,6 +842,10 @@ func (l *listConnectorDefinitionVersionsFilters) applyRestrictions(ctx context.C
 
 	if len(l.VersionsVal) > 0 {
 		q = q.Where(sq.Eq{"dv.version": l.VersionsVal})
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"c.name": *l.NameVal})
 	}
 
 	if len(l.StatesVal) > 0 {

--- a/internal/database/connector_test.go
+++ b/internal/database/connector_test.go
@@ -127,6 +127,46 @@ func TestConnectorNameUniquenessAndDeleteReuse(t *testing.T) {
 	require.ErrorIs(t, db.UpdateConnectorName(ctx, firstID, "deleted"), ErrNotFound)
 }
 
+func TestConnectorNameExactListPaginationAndNamespaceRestrictions(t *testing.T) {
+	_, db := MustApplyBlankTestDbConfig(t, nil)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.allowed"))
+	require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.hidden"))
+
+	allowedID := apid.New(apid.PrefixConnectorVersion)
+	hiddenID := apid.New(apid.PrefixConnectorVersion)
+	otherID := apid.New(apid.PrefixConnectorVersion)
+	require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, testConnectorWithDefinition(allowedID, "root.allowed", "shared", 1)))
+	require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, testConnectorWithDefinition(hiddenID, "root.hidden", "shared", 1)))
+	require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, testConnectorWithDefinition(otherID, "root.allowed", "other", 1)))
+
+	allowed := db.ListConnectorsBuilder().ForName("shared").ForNamespaceMatchers([]string{"root.allowed"}).FetchPage(ctx)
+	require.NoError(t, allowed.Error)
+	require.Len(t, allowed.Results, 1)
+	require.Equal(t, allowedID, allowed.Results[0].Id)
+
+	first := db.ListConnectorsBuilder().ForName("shared").ForNamespaceMatchers([]string{"root.**"}).Limit(1).FetchPage(ctx)
+	require.NoError(t, first.Error)
+	require.Len(t, first.Results, 1)
+	require.NotEmpty(t, first.Cursor)
+	executor, err := db.ListConnectorsFromCursor(ctx, first.Cursor)
+	require.NoError(t, err)
+	second := executor.FetchPage(ctx)
+	require.NoError(t, second.Error)
+	require.Len(t, second.Results, 1)
+	require.ElementsMatch(t, []apid.ID{allowedID, hiddenID}, []apid.ID{first.Results[0].Id, second.Results[0].Id})
+
+	versions := db.ListConnectorDefinitionVersionsBuilder().ForName("shared").ForNamespaceMatchers([]string{"root.**"}).FetchPage(ctx)
+	require.NoError(t, versions.Error)
+	require.Len(t, versions.Results, 2)
+	for _, version := range versions.Results {
+		require.Equal(t, scommon.ResourceName("shared"), version.Name)
+	}
+
+	err = db.UpdateConnectorName(ctx, otherID, "shared")
+	require.ErrorIs(t, err, ErrDuplicate)
+}
+
 func TestConnectorDefinitionVersionLifecyclePreservesName(t *testing.T) {
 	_, db := MustApplyBlankTestDbConfig(t, nil)
 	ctx := context.Background()

--- a/internal/database/connector_with_definition.go
+++ b/internal/database/connector_with_definition.go
@@ -181,6 +181,7 @@ type ListConnectorsBuilder interface {
 	ForId(apid.ID) ListConnectorsBuilder
 	ForNamespaceMatcher(string) ListConnectorsBuilder
 	ForNamespaceMatchers([]string) ListConnectorsBuilder
+	ForName(name scommon.ResourceName) ListConnectorsBuilder
 	ForState(ConnectorDefinitionVersionState) ListConnectorsBuilder
 	ForStates([]ConnectorDefinitionVersionState) ListConnectorsBuilder
 	OrderBy(ConnectorOrderByField, pagination.OrderBy) ListConnectorsBuilder
@@ -196,6 +197,7 @@ type listConnectorsFilters struct {
 	NamespaceMatchers []string                          `json:"namespace_matchers,omitempty"`
 	TypeVal           []string                          `json:"types,omitempty"`
 	IdsVal            []apid.ID                         `json:"ids,omitempty"`
+	NameVal           *scommon.ResourceName             `json:"name,omitempty"`
 	OrderByFieldVal   *ConnectorOrderByField            `json:"order_by_field"`
 	OrderByVal        *pagination.OrderBy               `json:"order_by"`
 	IncludeDeletedVal bool                              `json:"include_deleted,omitempty"`
@@ -250,6 +252,14 @@ func (l *listConnectorsFilters) ForType(t string) ListConnectorsBuilder {
 
 func (l *listConnectorsFilters) ForId(id apid.ID) ListConnectorsBuilder {
 	l.IdsVal = []apid.ID{id}
+	return l
+}
+
+func (l *listConnectorsFilters) ForName(name scommon.ResourceName) ListConnectorsBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -345,6 +355,10 @@ c.deleted_at as deleted_at
 
 	if len(l.IdsVal) > 0 {
 		q = q.Where(sq.Eq{"c.id": l.IdsVal})
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"c.name": *l.NameVal})
 	}
 
 	if len(l.StatesVal) > 0 {

--- a/internal/database/error.go
+++ b/internal/database/error.go
@@ -1,6 +1,12 @@
 package database
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
 
 // ErrNotFound is returned when a database operation that is expected to find a record does not find the record.
 var ErrNotFound = errors.New("record not found")
@@ -20,3 +26,24 @@ var ErrViolation = errors.New("database constraint violation")
 // ErrProtected is returned when an operation is attempted on a protected resource that cannot be modified in
 // the requested way.
 var ErrProtected = errors.New("resource is protected")
+
+// wrapDatabaseMutationError normalizes provider-specific unique-constraint
+// errors so API callers can return a stable conflict response without leaking
+// SQLite or PostgreSQL details.
+func wrapDatabaseMutationError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) && (sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique || sqliteErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey) {
+		return fmt.Errorf("%s: %w", operation, ErrDuplicate)
+	}
+
+	var postgresErr *pgconn.PgError
+	if errors.As(err, &postgresErr) && postgresErr.Code == "23505" {
+		return fmt.Errorf("%s: %w", operation, ErrDuplicate)
+	}
+
+	return fmt.Errorf("%s: %w", operation, err)
+}

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -82,6 +82,7 @@ type DB interface {
 	GetActorByExternalId(ctx context.Context, namespace, externalId string) (*Actor, error)
 	CreateActor(ctx context.Context, actor *Actor) error
 	UpsertActor(ctx context.Context, actor IActorData) (*Actor, error)
+	UpdateActorName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Actor, error)
 	DeleteActor(ctx context.Context, id apid.ID) error
 	PutActorLabels(ctx context.Context, id apid.ID, labels map[string]string) (*Actor, error)
 	DeleteActorLabels(ctx context.Context, id apid.ID, keys []string) (*Actor, error)
@@ -117,6 +118,7 @@ type DB interface {
 
 	GetConnection(ctx context.Context, id apid.ID) (*Connection, error)
 	CreateConnection(ctx context.Context, c *Connection) error
+	UpdateConnectionName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Connection, error)
 	DeleteConnection(ctx context.Context, id apid.ID) error
 	SetConnectionState(ctx context.Context, id apid.ID, state ConnectionState) error
 	SetConnectionHealthState(ctx context.Context, id apid.ID, state ConnectionHealthState) error
@@ -248,6 +250,7 @@ type DB interface {
 
 	GetRateLimit(ctx context.Context, id apid.ID) (*RateLimit, error)
 	CreateRateLimit(ctx context.Context, rl *RateLimit) error
+	UpdateRateLimitName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*RateLimit, error)
 	UpdateRateLimitDefinition(ctx context.Context, id apid.ID, def rlschema.RateLimit) (*RateLimit, error)
 	DeleteRateLimit(ctx context.Context, id apid.ID) error
 	UpdateRateLimitLabels(ctx context.Context, id apid.ID, labels map[string]string) (*RateLimit, error)

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -280,7 +280,7 @@ func (s *service) CreateKey(ctx context.Context, ek *Key) error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return fmt.Errorf("failed to create key: %w", err)
+			return wrapDatabaseMutationError("failed to create key", err)
 		}
 
 		affected, err := dbResult.RowsAffected()
@@ -310,7 +310,7 @@ func (s *service) UpdateKey(ctx context.Context, id apid.ID, updates map[string]
 
 	dbResult, err := q.RunWith(s.db).Exec()
 	if err != nil {
-		return nil, fmt.Errorf("failed to update key: %w", err)
+		return nil, wrapDatabaseMutationError("failed to update key", err)
 	}
 
 	affected, err := dbResult.RowsAffected()
@@ -702,6 +702,7 @@ type ListKeysBuilder interface {
 	Limit(int32) ListKeysBuilder
 	ForNamespaceMatcher(matcher string) ListKeysBuilder
 	ForNamespaceMatchers(matchers []string) ListKeysBuilder
+	ForName(name scommon.ResourceName) ListKeysBuilder
 	ForState(KeyState) ListKeysBuilder
 	OrderBy(KeyOrderByField, pagination.OrderBy) ListKeysBuilder
 	IncludeDeleted() ListKeysBuilder
@@ -709,16 +710,17 @@ type ListKeysBuilder interface {
 }
 
 type listKeysFilters struct {
-	s                 *service            `json:"-"`
-	LimitVal          uint64              `json:"limit"`
-	Offset            uint64              `json:"offset"`
-	StatesVal         []KeyState          `json:"states,omitempty"`
-	NamespaceMatchers []string            `json:"namespace_matchers,omitempty"`
-	OrderByFieldVal   *KeyOrderByField    `json:"order_by_field"`
-	OrderByVal        *pagination.OrderBy `json:"order_by"`
-	IncludeDeletedVal bool                `json:"include_deleted,omitempty"`
-	LabelSelectorVal  *string             `json:"label_selector,omitempty"`
-	Errors            *multierror.Error   `json:"-"`
+	s                 *service              `json:"-"`
+	LimitVal          uint64                `json:"limit"`
+	Offset            uint64                `json:"offset"`
+	StatesVal         []KeyState            `json:"states,omitempty"`
+	NamespaceMatchers []string              `json:"namespace_matchers,omitempty"`
+	NameVal           *scommon.ResourceName `json:"name,omitempty"`
+	OrderByFieldVal   *KeyOrderByField      `json:"order_by_field"`
+	OrderByVal        *pagination.OrderBy   `json:"order_by"`
+	IncludeDeletedVal bool                  `json:"include_deleted,omitempty"`
+	LabelSelectorVal  *string               `json:"label_selector,omitempty"`
+	Errors            *multierror.Error     `json:"-"`
 }
 
 func (l *listKeysFilters) addError(e error) ListKeysBuilder {
@@ -751,6 +753,14 @@ func (l *listKeysFilters) ForNamespaceMatchers(matchers []string) ListKeysBuilde
 		}
 	}
 	l.NamespaceMatchers = matchers
+	return l
+}
+
+func (l *listKeysFilters) ForName(name scommon.ResourceName) ListKeysBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -811,6 +821,10 @@ func (l *listKeysFilters) applyRestrictions(ctx context.Context) sq.SelectBuilde
 
 	if len(l.NamespaceMatchers) > 0 {
 		q = restrictToNamespaceMatchers(q, "namespace", l.NamespaceMatchers)
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"name": *l.NameVal})
 	}
 
 	q = q.Limit(l.LimitVal + 1).Offset(l.Offset)

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -1873,6 +1873,21 @@ func (mr *MockDBMockRecorder) UpdateActorAnnotations(ctx, id, annotations interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActorAnnotations", reflect.TypeOf((*MockDB)(nil).UpdateActorAnnotations), ctx, id, annotations)
 }
 
+// UpdateActorName mocks base method.
+func (m *MockDB) UpdateActorName(ctx context.Context, id apid.ID, name common.ResourceName) (*database.Actor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateActorName", ctx, id, name)
+	ret0, _ := ret[0].(*database.Actor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateActorName indicates an expected call of UpdateActorName.
+func (mr *MockDBMockRecorder) UpdateActorName(ctx, id, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActorName", reflect.TypeOf((*MockDB)(nil).UpdateActorName), ctx, id, name)
+}
+
 // UpdateApiKeyCredentialLastValidated mocks base method.
 func (m *MockDB) UpdateApiKeyCredentialLastValidated(ctx context.Context, credentialId apid.ID, at time.Time) error {
 	m.ctrl.T.Helper()
@@ -1930,6 +1945,21 @@ func (m *MockDB) UpdateConnectionLabels(ctx context.Context, id apid.ID, labels 
 func (mr *MockDBMockRecorder) UpdateConnectionLabels(ctx, id, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConnectionLabels", reflect.TypeOf((*MockDB)(nil).UpdateConnectionLabels), ctx, id, labels)
+}
+
+// UpdateConnectionName mocks base method.
+func (m *MockDB) UpdateConnectionName(ctx context.Context, id apid.ID, name common.ResourceName) (*database.Connection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateConnectionName", ctx, id, name)
+	ret0, _ := ret[0].(*database.Connection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateConnectionName indicates an expected call of UpdateConnectionName.
+func (mr *MockDBMockRecorder) UpdateConnectionName(ctx, id, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConnectionName", reflect.TypeOf((*MockDB)(nil).UpdateConnectionName), ctx, id, name)
 }
 
 // UpdateConnectorName mocks base method.
@@ -2078,6 +2108,21 @@ func (m *MockDB) UpdateRateLimitLabels(ctx context.Context, id apid.ID, labels m
 func (mr *MockDBMockRecorder) UpdateRateLimitLabels(ctx, id, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRateLimitLabels", reflect.TypeOf((*MockDB)(nil).UpdateRateLimitLabels), ctx, id, labels)
+}
+
+// UpdateRateLimitName mocks base method.
+func (m *MockDB) UpdateRateLimitName(ctx context.Context, id apid.ID, name common.ResourceName) (*database.RateLimit, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRateLimitName", ctx, id, name)
+	ret0, _ := ret[0].(*database.RateLimit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateRateLimitName indicates an expected call of UpdateRateLimitName.
+func (mr *MockDBMockRecorder) UpdateRateLimitName(ctx, id, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRateLimitName", reflect.TypeOf((*MockDB)(nil).UpdateRateLimitName), ctx, id, name)
 }
 
 // UpsertActor mocks base method.

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -522,6 +523,7 @@ type ListNamespacesBuilder interface {
 	ForChildrenOf(path string) ListNamespacesBuilder
 	ForNamespaceMatcher(matcher string) ListNamespacesBuilder
 	ForNamespaceMatchers(matchers []string) ListNamespacesBuilder
+	ForName(name scommon.ResourceName) ListNamespacesBuilder
 	ForState(NamespaceState) ListNamespacesBuilder
 	OrderBy(NamespaceOrderByField, pagination.OrderBy) ListNamespacesBuilder
 	IncludeDeleted() ListNamespacesBuilder
@@ -536,6 +538,7 @@ type listNamespacesFilters struct {
 	PathPrefixVal     string                 `json:"path_prefix,omitempty"`
 	DepthVal          *uint64                `json:"depth,omitempty"`
 	NamespaceMatchers []string               `json:"namespace_matchers,omitempty"`
+	NameVal           *scommon.ResourceName  `json:"name,omitempty"`
 	OrderByFieldVal   *NamespaceOrderByField `json:"order_by_field"`
 	OrderByVal        *pagination.OrderBy    `json:"order_by"`
 	IncludeDeletedVal bool                   `json:"include_deleted,omitempty"`
@@ -596,6 +599,14 @@ func (l *listNamespacesFilters) ForNamespaceMatchers(matchers []string) ListName
 		}
 	}
 	l.NamespaceMatchers = matchers
+	return l
+}
+
+func (l *listNamespacesFilters) ForName(name scommon.ResourceName) ListNamespacesBuilder {
+	if err := namespace.ValidateName(string(name)); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -669,6 +680,14 @@ func (l *listNamespacesFilters) applyRestrictions(ctx context.Context) sq.Select
 
 	if len(l.NamespaceMatchers) > 0 {
 		q = restrictToNamespaceMatchers(q, "path", l.NamespaceMatchers)
+	}
+
+	if l.NameVal != nil {
+		escapedName := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(string(*l.NameVal))
+		q = q.Where(sq.Or{
+			sq.Eq{"path": *l.NameVal},
+			sq.Expr(`path LIKE ? ESCAPE '\'`, "%"+namespace.PathSeparator+escapedName),
+		})
 	}
 
 	// Always limit to one more than limit to check if there are more records

--- a/internal/database/rate_limit.go
+++ b/internal/database/rate_limit.go
@@ -196,7 +196,7 @@ func (s *service) CreateRateLimit(ctx context.Context, rl *RateLimit) error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return fmt.Errorf("failed to create rate limit: %w", err)
+			return wrapDatabaseMutationError("failed to create rate limit", err)
 		}
 
 		affected, err := dbResult.RowsAffected()
@@ -249,6 +249,41 @@ func (s *service) UpdateRateLimitDefinition(ctx context.Context, id apid.ID, def
 		return nil, ErrNotFound
 	}
 
+	return s.GetRateLimit(ctx, id)
+}
+
+// UpdateRateLimitName renames one live rate limit addressed by immutable ID.
+func (s *service) UpdateRateLimitName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*RateLimit, error) {
+	if id.IsNil() {
+		return nil, errors.New("rate limit id is required")
+	}
+	if err := id.ValidatePrefix(apid.PrefixRateLimit); err != nil {
+		return nil, fmt.Errorf("invalid rate limit id: %w", err)
+	}
+	if err := name.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid rate limit name: %w", err)
+	}
+
+	result, err := s.sq.
+		Update(RateLimitsTable).
+		Set("name", name).
+		Set("updated_at", apctx.GetClock(ctx).Now()).
+		Where(sq.Eq{"id": id, "deleted_at": nil}).
+		RunWith(s.db).
+		ExecContext(ctx)
+	if err != nil {
+		return nil, wrapDatabaseMutationError("failed to update rate limit name", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update rate limit name: %w", err)
+	}
+	if affected == 0 {
+		return nil, ErrNotFound
+	}
+	if affected > 1 {
+		return nil, fmt.Errorf("multiple rate limits were renamed: %w", ErrViolation)
+	}
 	return s.GetRateLimit(ctx, id)
 }
 
@@ -574,6 +609,7 @@ type ListRateLimitsBuilder interface {
 	Limit(int32) ListRateLimitsBuilder
 	ForNamespaceMatcher(matcher string) ListRateLimitsBuilder
 	ForNamespaceMatchers(matchers []string) ListRateLimitsBuilder
+	ForName(name scommon.ResourceName) ListRateLimitsBuilder
 	OrderBy(RateLimitOrderByField, pagination.OrderBy) ListRateLimitsBuilder
 	IncludeDeleted() ListRateLimitsBuilder
 	ForLabelSelector(selector string) ListRateLimitsBuilder
@@ -584,6 +620,7 @@ type listRateLimitsFilters struct {
 	LimitVal          uint64                 `json:"limit"`
 	Offset            uint64                 `json:"offset"`
 	NamespaceMatchers []string               `json:"namespace_matchers,omitempty"`
+	NameVal           *scommon.ResourceName  `json:"name,omitempty"`
 	OrderByFieldVal   *RateLimitOrderByField `json:"order_by_field"`
 	OrderByVal        *pagination.OrderBy    `json:"order_by"`
 	IncludeDeletedVal bool                   `json:"include_deleted,omitempty"`
@@ -616,6 +653,14 @@ func (l *listRateLimitsFilters) ForNamespaceMatchers(matchers []string) ListRate
 		}
 	}
 	l.NamespaceMatchers = matchers
+	return l
+}
+
+func (l *listRateLimitsFilters) ForName(name scommon.ResourceName) ListRateLimitsBuilder {
+	if err := name.Validate(); err != nil {
+		return l.addError(err)
+	}
+	l.NameVal = &name
 	return l
 }
 
@@ -670,6 +715,10 @@ func (l *listRateLimitsFilters) applyRestrictions(ctx context.Context) sq.Select
 
 	if len(l.NamespaceMatchers) > 0 {
 		q = restrictToNamespaceMatchers(q, "namespace", l.NamespaceMatchers)
+	}
+
+	if l.NameVal != nil {
+		q = q.Where(sq.Eq{"name": *l.NameVal})
 	}
 
 	q = q.Limit(l.LimitVal + 1).Offset(l.Offset)

--- a/internal/database/resource_name_test.go
+++ b/internal/database/resource_name_test.go
@@ -16,7 +16,16 @@ type namedResourceHarness struct {
 	prefix       apid.Prefix
 	create       func(context.Context, DB, apid.ID, string, scommon.ResourceName) error
 	getName      func(context.Context, DB, apid.ID) (scommon.ResourceName, error)
+	rename       func(context.Context, DB, apid.ID, scommon.ResourceName) error
+	list         func(context.Context, DB, scommon.ResourceName, []string, int32) namedResourcePage
+	listCursor   func(context.Context, DB, string) namedResourcePage
 	delete       func(context.Context, DB, apid.ID) error
+}
+
+type namedResourcePage struct {
+	ids    []apid.ID
+	cursor string
+	err    error
 }
 
 func namedResourceHarnesses() []namedResourceHarness {
@@ -39,6 +48,30 @@ func namedResourceHarnesses() []namedResourceHarness {
 					return "", err
 				}
 				return value.Name, nil
+			},
+			rename: func(ctx context.Context, db DB, id apid.ID, name scommon.ResourceName) error {
+				_, err := db.UpdateActorName(ctx, id, name)
+				return err
+			},
+			list: func(ctx context.Context, db DB, name scommon.ResourceName, matchers []string, limit int32) namedResourcePage {
+				page := db.ListActorsBuilder().ForName(name).ForNamespaceMatchers(matchers).Limit(limit).FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
+			},
+			listCursor: func(ctx context.Context, db DB, cursor string) namedResourcePage {
+				executor, err := db.ListActorsFromCursor(ctx, cursor)
+				if err != nil {
+					return namedResourcePage{err: err}
+				}
+				page := executor.FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
 			},
 			delete: func(ctx context.Context, db DB, id apid.ID) error {
 				return db.DeleteActor(ctx, id)
@@ -65,6 +98,30 @@ func namedResourceHarnesses() []namedResourceHarness {
 				}
 				return value.Name, nil
 			},
+			rename: func(ctx context.Context, db DB, id apid.ID, name scommon.ResourceName) error {
+				_, err := db.UpdateConnectionName(ctx, id, name)
+				return err
+			},
+			list: func(ctx context.Context, db DB, name scommon.ResourceName, matchers []string, limit int32) namedResourcePage {
+				page := db.ListConnectionsBuilder().ForName(name).ForNamespaceMatchers(matchers).Limit(limit).FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
+			},
+			listCursor: func(ctx context.Context, db DB, cursor string) namedResourcePage {
+				executor, err := db.ListConnectionsFromCursor(ctx, cursor)
+				if err != nil {
+					return namedResourcePage{err: err}
+				}
+				page := executor.FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
+			},
 			delete: func(ctx context.Context, db DB, id apid.ID) error {
 				return db.DeleteConnection(ctx, id)
 			},
@@ -86,6 +143,30 @@ func namedResourceHarnesses() []namedResourceHarness {
 					return "", err
 				}
 				return value.Name, nil
+			},
+			rename: func(ctx context.Context, db DB, id apid.ID, name scommon.ResourceName) error {
+				_, err := db.UpdateKey(ctx, id, map[string]interface{}{"name": name})
+				return err
+			},
+			list: func(ctx context.Context, db DB, name scommon.ResourceName, matchers []string, limit int32) namedResourcePage {
+				page := db.ListKeysBuilder().ForName(name).ForNamespaceMatchers(matchers).Limit(limit).FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
+			},
+			listCursor: func(ctx context.Context, db DB, cursor string) namedResourcePage {
+				executor, err := db.ListKeysFromCursor(ctx, cursor)
+				if err != nil {
+					return namedResourcePage{err: err}
+				}
+				page := executor.FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
 			},
 			delete: func(ctx context.Context, db DB, id apid.ID) error {
 				return db.DeleteKey(ctx, id)
@@ -109,6 +190,30 @@ func namedResourceHarnesses() []namedResourceHarness {
 					return "", err
 				}
 				return value.Name, nil
+			},
+			rename: func(ctx context.Context, db DB, id apid.ID, name scommon.ResourceName) error {
+				_, err := db.UpdateRateLimitName(ctx, id, name)
+				return err
+			},
+			list: func(ctx context.Context, db DB, name scommon.ResourceName, matchers []string, limit int32) namedResourcePage {
+				page := db.ListRateLimitsBuilder().ForName(name).ForNamespaceMatchers(matchers).Limit(limit).FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
+			},
+			listCursor: func(ctx context.Context, db DB, cursor string) namedResourcePage {
+				executor, err := db.ListRateLimitsFromCursor(ctx, cursor)
+				if err != nil {
+					return namedResourcePage{err: err}
+				}
+				page := executor.FetchPage(ctx)
+				ids := make([]apid.ID, len(page.Results))
+				for i := range page.Results {
+					ids[i] = page.Results[i].Id
+				}
+				return namedResourcePage{ids: ids, cursor: page.Cursor, err: page.Error}
 			},
 			delete: func(ctx context.Context, db DB, id apid.ID) error {
 				return db.DeleteRateLimit(ctx, id)
@@ -183,6 +288,84 @@ func TestResourceNameCanBeChangedByIDWithoutConflicts(t *testing.T) {
 			require.Equal(t, scommon.ResourceName("second"), name)
 		})
 	}
+}
+
+func TestResourceNameRenameAndExactListBehavior(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db := MustApplyBlankTestDbConfig(t, nil)
+			ctx := context.Background()
+			require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.allowed"))
+			require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.hidden"))
+
+			firstID := apid.New(harness.prefix)
+			secondID := apid.New(harness.prefix)
+			hiddenID := apid.New(harness.prefix)
+			conflictID := apid.New(harness.prefix)
+			require.NoError(t, harness.create(ctx, db, firstID, "root.allowed", "first"))
+			require.NoError(t, harness.create(ctx, db, secondID, "root.allowed", "shared"))
+			require.NoError(t, harness.create(ctx, db, hiddenID, "root.hidden", "shared"))
+			require.NoError(t, harness.create(ctx, db, conflictID, "root.allowed", "conflict"))
+
+			require.NoError(t, harness.rename(ctx, db, firstID, "renamed"))
+			name, err := harness.getName(ctx, db, firstID)
+			require.NoError(t, err)
+			require.Equal(t, scommon.ResourceName("renamed"), name)
+
+			err = harness.rename(ctx, db, conflictID, "shared")
+			require.ErrorIs(t, err, ErrDuplicate)
+			name, getErr := harness.getName(ctx, db, conflictID)
+			require.NoError(t, getErr)
+			require.Equal(t, scommon.ResourceName("conflict"), name)
+
+			allowed := harness.list(ctx, db, "shared", []string{"root.allowed"}, 10)
+			require.NoError(t, allowed.err)
+			require.Equal(t, []apid.ID{secondID}, allowed.ids)
+
+			firstPage := harness.list(ctx, db, "shared", []string{"root.**"}, 1)
+			require.NoError(t, firstPage.err)
+			require.Len(t, firstPage.ids, 1)
+			require.NotEmpty(t, firstPage.cursor)
+
+			secondPage := harness.listCursor(ctx, db, firstPage.cursor)
+			require.NoError(t, secondPage.err)
+			require.Len(t, secondPage.ids, 1)
+			require.ElementsMatch(t, []apid.ID{secondID, hiddenID}, append(firstPage.ids, secondPage.ids...))
+
+			broad := harness.list(ctx, db, "shared", []string{"root.**"}, 10)
+			require.NoError(t, broad.err)
+			require.ElementsMatch(t, []apid.ID{secondID, hiddenID}, broad.ids)
+		})
+	}
+}
+
+func TestNamespaceFinalSegmentExactNameListAndPagination(t *testing.T) {
+	_, db := MustApplyBlankTestDbConfig(t, nil)
+	ctx := context.Background()
+	for _, path := range []string{"root.allowed", "root.allowed.shared", "root.hidden", "root.hidden.shared", "root.allowed.other", "root.allowed._shared-"} {
+		require.NoError(t, db.EnsureNamespaceByPath(ctx, path))
+	}
+
+	allowed := db.ListNamespacesBuilder().ForName("shared").ForNamespaceMatchers([]string{"root.allowed.**"}).FetchPage(ctx)
+	require.NoError(t, allowed.Error)
+	require.Len(t, allowed.Results, 1)
+	require.Equal(t, "root.allowed.shared", allowed.Results[0].Path)
+
+	first := db.ListNamespacesBuilder().ForName("shared").ForNamespaceMatchers([]string{"root.**"}).Limit(1).FetchPage(ctx)
+	require.NoError(t, first.Error)
+	require.Len(t, first.Results, 1)
+	require.NotEmpty(t, first.Cursor)
+	executor, err := db.ListNamespacesFromCursor(ctx, first.Cursor)
+	require.NoError(t, err)
+	second := executor.FetchPage(ctx)
+	require.NoError(t, second.Error)
+	require.Len(t, second.Results, 1)
+	require.ElementsMatch(t, []string{"root.allowed.shared", "root.hidden.shared"}, []string{first.Results[0].Path, second.Results[0].Path})
+
+	escapedWildcard := db.ListNamespacesBuilder().ForName("_shared-").FetchPage(ctx)
+	require.NoError(t, escapedWildcard.Error)
+	require.Len(t, escapedWildcard.Results, 1)
+	require.Equal(t, "root.allowed._shared-", escapedWildcard.Results[0].Path)
 }
 
 func TestResourceNamesDoNotConflictAcrossTypes(t *testing.T) {

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -48,6 +49,7 @@ func DatabaseActorToJson(a *database.Actor) ActorJson {
 	return ActorJson{
 		Id:          a.Id,
 		Namespace:   a.GetNamespace(),
+		Name:        a.GetName(),
 		Labels:      a.GetLabels(),
 		Annotations: a.GetAnnotations(),
 		ExternalId:  a.ExternalId,
@@ -60,6 +62,7 @@ type ListActorsRequestQuery struct {
 	Cursor        *string `form:"cursor"`
 	LimitVal      *int32  `form:"limit"`
 	ExternalId    *string `form:"external_id"`
+	NameVal       *string `form:"name"`
 	NamespaceVal  *string `form:"namespace"`
 	LabelSelector *string `form:"label_selector"`
 	OrderByVal    *string `form:"order_by"`
@@ -73,6 +76,7 @@ type ListActorsRequestQuery struct {
 // @Param			cursor			query		string	false	"Pagination cursor"
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			external_id		query		string	false	"Filter by external ID"
+// @Param			name			query		string	false	"Filter by exact resource name"
 // @Param			namespace		query		string	false	"Filter by namespace"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:asc')"
@@ -113,6 +117,16 @@ func (r *ActorsRoutes) list(gctx *gin.Context) {
 
 		if req.ExternalId != nil {
 			b = b.ForExternalId(*req.ExternalId)
+		}
+
+		if req.NameVal != nil {
+			name := scommon.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, r.logger, httperr.BadRequestf("invalid actor name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
@@ -439,6 +453,13 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 		return
 	}
 
+	name, httpErr := optionalResourceName(req.Name, "actor")
+	if httpErr != nil {
+		apgin.WriteError(gctx, r.logger, httpErr)
+		val.MarkErrorReturn()
+		return
+	}
+
 	// Validate namespace path
 	if err := namespace.ValidatePath(req.Namespace); err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid namespace '%s': %s", req.Namespace, err.Error()), httperr.WithInternalErr(err)))
@@ -489,6 +510,7 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 	actor := &database.Actor{
 		Id:          apid.New(apid.PrefixActor),
 		Namespace:   req.Namespace,
+		Name:        name,
 		ExternalId:  req.ExternalId,
 		Labels:      req.Labels,
 		Annotations: req.Annotations,
@@ -503,7 +525,11 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 		}
 
 		if errors.Is(err, database.ErrDuplicate) {
-			apgin.WriteError(gctx, r.logger, httperr.Conflictf("actor with external_id '%s' already exists in namespace '%s'", req.ExternalId, req.Namespace))
+			if conflictErr := resourceNameConflictError(err, "actor", name, req.Namespace); conflictErr != nil && name != "" {
+				apgin.WriteError(gctx, r.logger, conflictErr)
+			} else {
+				apgin.WriteError(gctx, r.logger, httperr.Conflictf("actor with external_id '%s' already exists in namespace '%s'", req.ExternalId, req.Namespace))
+			}
 			val.MarkErrorReturn()
 			return
 		}
@@ -536,6 +562,7 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/actors/{id} [patch]
@@ -607,6 +634,27 @@ func (r *ActorsRoutes) update(gctx *gin.Context) {
 		return
 	}
 
+	if req.Name != nil {
+		name, httpErr := optionalResourceName(req.Name, "actor")
+		if httpErr != nil {
+			apgin.WriteError(gctx, r.logger, httpErr)
+			val.MarkErrorReturn()
+			return
+		}
+		updated, err := r.db.UpdateActorName(ctx, id, name)
+		if err != nil {
+			if conflictErr := resourceNameConflictError(err, "actor", name, existingActor.Namespace); conflictErr != nil {
+				apgin.WriteError(gctx, r.logger, conflictErr)
+				val.MarkErrorReturn()
+				return
+			}
+			apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
+		existingActor = updated
+	}
+
 	if req.Labels != nil {
 		existingActor.Labels = req.Labels
 	}
@@ -661,6 +709,12 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 	var req UpdateActorRequestJson
 	if err := gctx.ShouldBindBodyWithJSON(&req); err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.BadRequest("invalid request body", httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if req.Name != nil {
+		apgin.WriteError(gctx, r.logger, httperr.BadRequest("actor names can only be changed through the ID-addressed update endpoint"))
 		val.MarkErrorReturn()
 		return
 	}

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -1868,4 +1868,74 @@ func TestActorsRoutes(t *testing.T) {
 			require.False(t, exists)
 		})
 	})
+
+	t.Run("resource name API", func(t *testing.T) {
+		tu, done := setup(t, nil)
+		defer done()
+
+		create := func(externalID string, name *string) ActorJson {
+			body := map[string]interface{}{"external_id": externalID, "namespace": "root"}
+			if name != nil {
+				body["name"] = *name
+			}
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodPost, "/actors", util.JsonToReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req = authenticate(t, tu, req)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+			var actor ActorJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &actor))
+			return actor
+		}
+
+		customName := "billing"
+		custom := create("named-actor", &customName)
+		require.Equal(t, customName, string(custom.Name))
+		defaulted := create("default-named-actor", nil)
+		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/actors/"+custom.Id.String(), nil)
+		require.NoError(t, err)
+		req = authenticate(t, tu, req)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var got ActorJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, customName, string(got.Name))
+
+		w = httptest.NewRecorder()
+		req, err = http.NewRequest(http.MethodPatch, "/actors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": "renamed"}))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req = authenticate(t, tu, req)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, "renamed", string(got.Name))
+
+		conflictName := "conflict"
+		_ = create("conflicting-actor", &conflictName)
+		w = httptest.NewRecorder()
+		req, err = http.NewRequest(http.MethodPatch, "/actors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": conflictName}))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req = authenticate(t, tu, req)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		require.NotContains(t, w.Body.String(), "UNIQUE")
+
+		w = httptest.NewRecorder()
+		req, err = http.NewRequest(http.MethodGet, "/actors?name=renamed", nil)
+		require.NoError(t, err)
+		req = authenticate(t, tu, req)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var listed ListActorsResponseJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+		require.Len(t, listed.Items, 1)
+		require.Equal(t, custom.Id, listed.Items[0].Id)
+	})
 }

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -77,6 +78,7 @@ type OpenAPIProxyResponseJson = schemaapiopenapi.ProxyResponseJson
 // @Success		200		{object}	ConnectionSetupRedirect
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/_initiate [post]
@@ -284,6 +286,7 @@ func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
 	return ConnectionJson{
 		Id:          conn.GetId(),
 		Namespace:   conn.GetNamespace(),
+		Name:        conn.GetName(),
 		Labels:      conn.GetLabels(),
 		Annotations: conn.GetAnnotations(),
 		State:       schemaapi.ConnectionState(conn.GetState()),
@@ -302,6 +305,7 @@ type ListConnectionRequestQuery struct {
 	StateVal      *database.ConnectionState `form:"state"`
 	ConnectorId   *string                   `form:"connector_id"`
 	NamespaceVal  *string                   `form:"namespace"`
+	NameVal       *string                   `form:"name"`
 	LabelSelector *string                   `form:"label_selector"`
 	OrderByVal    *string                   `form:"order_by"`
 }
@@ -316,6 +320,7 @@ type ListConnectionRequestQuery struct {
 // @Param			state			query		string	false	"Filter by connection state"
 // @Param			connector_id	query		string	false	"Filter by connector ID"
 // @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			name			query		string	false	"Filter by exact resource name"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:asc')"
 // @Success		200				{object}	OpenAPIListConnectionResponseJson
@@ -373,6 +378,16 @@ func (r *ConnectionsRoutes) list(gctx *gin.Context) {
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.NameVal != nil {
+			name := scommon.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connection name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
 
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)
@@ -1055,7 +1070,7 @@ func (r *ConnectionsRoutes) forceState(gctx *gin.Context) {
 }
 
 // @Summary		Update connection
-// @Description	Update a connection's labels
+// @Description	Update a connection's name or labels
 // @Tags			connections
 // @Accept			json
 // @Produce		json
@@ -1066,6 +1081,7 @@ func (r *ConnectionsRoutes) forceState(gctx *gin.Context) {
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connections/{id} [patch]
@@ -1117,6 +1133,27 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 	if httpErr := val.ValidateHttpStatusError(c); httpErr != nil {
 		apgin.WriteError(gctx, nil, httpErr)
 		return
+	}
+
+	if req.Name != nil {
+		name, httpErr := optionalResourceName(req.Name, "connection")
+		if httpErr != nil {
+			apgin.WriteError(gctx, nil, httpErr)
+			val.MarkErrorReturn()
+			return
+		}
+		originalNamespace := c.GetNamespace()
+		c, err = r.core.UpdateConnectionName(ctx, id, name)
+		if err != nil {
+			if conflictErr := resourceNameConflictError(err, "connection", name, originalNamespace); conflictErr != nil {
+				apgin.WriteError(gctx, nil, conflictErr)
+				val.MarkErrorReturn()
+				return
+			}
+			apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
 	}
 
 	if req.Labels != nil {

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
+	"github.com/redis/go-redis/v9"
 	asynqmock "github.com/rmorlok/authproxy/internal/apasynq/mock"
 	auth2 "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apctx"
@@ -78,6 +79,7 @@ func TestConnections(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		ac := asynqmock.NewMockClient(ctrl)
 		rs := mock.NewMockClient(ctrl)
+		rs.EXPECT().Incr(gomock.Any(), gomock.Any()).Return(redis.NewIntCmd(context.Background())).AnyTimes()
 		c := core.NewCoreService(cfg, db, e, rs, h, ac, test_utils.NewTestLogger())
 		assert.NoError(t, c.Migrate(context.Background()))
 		cr := NewConnectionsRoutes(cfg, auth, db, rds, c, h, e, test_utils.NewTestLogger())
@@ -2172,5 +2174,95 @@ func TestConnections(t *testing.T) {
 			assert.Equal(t, []string{"read", "write", "admin"}, resp.Requested)
 			assert.Equal(t, []string{"read", "write"}, resp.Granted)
 		})
+	})
+
+	t.Run("resource name API", func(t *testing.T) {
+		tu, done := setup(t, nil)
+		defer done()
+
+		initiate := func(name *string, expectedStatus int) apid.ID {
+			body := map[string]interface{}{
+				"connector_id":  connectorId.String(),
+				"return_to_url": "https://example.com/callback",
+			}
+			if name != nil {
+				body["name"] = *name
+			}
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/connections/_initiate", util.JsonToReader(body),
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, expectedStatus, w.Code, w.Body.String())
+			if expectedStatus != http.StatusOK {
+				require.NotContains(t, w.Body.String(), "UNIQUE")
+				return apid.Nil
+			}
+			var resp struct {
+				Id apid.ID `json:"id"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			return resp.Id
+		}
+
+		customName := "production-crm"
+		customID := initiate(&customName, http.StatusOK)
+		defaultID := initiate(nil, http.StatusOK)
+		initiate(&customName, http.StatusConflict)
+
+		for id, expectedName := range map[apid.ID]string{customID: customName, defaultID: defaultID.String()} {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/connections/"+id.String(), nil,
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var connection ConnectionJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &connection))
+			require.Equal(t, expectedName, string(connection.Name))
+		}
+
+		otherName := "other-connection"
+		_ = initiate(&otherName, http.StatusOK)
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/connections/"+customID.String(), util.JsonToReader(map[string]string{"name": "renamed-connection"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var renamed ConnectionJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &renamed))
+		require.Equal(t, "renamed-connection", string(renamed.Name))
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/connections/"+customID.String(), util.JsonToReader(map[string]string{"name": otherName}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/connections?name=renamed-connection", nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var listed ListConnectionResponseJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+		require.Len(t, listed.Items, 1)
+		require.Equal(t, customID, listed.Items[0].Id)
 	})
 }

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -46,6 +46,7 @@ type OpenAPIConnectorVersionJson = schemaapiopenapi.ConnectorVersionJson
 type OpenAPIListConnectorVersionsResponseJson = schemaapiopenapi.ListConnectorVersionsResponseJson
 type OpenAPICreateConnectorRequestJson = schemaapiopenapi.CreateConnectorRequestJson
 type OpenAPIUpdateConnectorRequestJson = schemaapiopenapi.UpdateConnectorRequestJson
+type OpenAPIUpdateConnectorVersionRequestJson = schemaapiopenapi.UpdateConnectorVersionRequestJson
 type OpenAPICreateConnectorVersionRequestJson = schemaapiopenapi.CreateConnectorVersionRequestJson
 type OpenAPIConnectorLifecycleRequestJson = schemaapiopenapi.ConnectorLifecycleRequestJson
 type OpenAPIConnectorLifecycleResponseJson = schemaapiopenapi.ConnectorLifecycleResponseJson
@@ -65,6 +66,7 @@ func ConnectorVersionToConnectorJson(c connIface.Connector) ConnectorJson {
 		Id:            c.GetId(),
 		Version:       c.GetVersion(),
 		Namespace:     c.GetNamespace(),
+		Name:          c.GetName(),
 		State:         schemaapi.ConnectorVersionState(c.GetState()),
 		Highlight:     def.Highlight,
 		DisplayName:   def.DisplayName,
@@ -84,6 +86,7 @@ type ListConnectorsRequestQueryParams struct {
 	LimitVal      *int32                                    `form:"limit"`
 	StateVal      *database.ConnectorDefinitionVersionState `form:"state"`
 	NamespaceVal  *string                                   `form:"namespace"`
+	NameVal       *string                                   `form:"name"`
 	LabelSelector *string                                   `form:"label_selector"`
 	OrderByVal    *string                                   `form:"order_by"`
 }
@@ -95,6 +98,7 @@ func ConnectorVersionToJson(c connIface.Connector) ConnectorVersionJson {
 		Id:          c.GetId(),
 		Version:     c.GetVersion(),
 		Namespace:   c.GetNamespace(),
+		Name:        c.GetName(),
 		State:       schemaapi.ConnectorVersionState(c.GetState()),
 		Definition:  *def,
 		Labels:      c.GetLabels(),
@@ -109,6 +113,7 @@ type ListConnectorVersionsRequestQueryParams struct {
 	LimitVal      *int32                                    `form:"limit"`
 	StateVal      *database.ConnectorDefinitionVersionState `form:"state"`
 	NamespaceVal  *string                                   `form:"namespace"`
+	NameVal       *string                                   `form:"name"`
 	LabelSelector *string                                   `form:"label_selector"`
 	OrderByVal    *string                                   `form:"order_by"`
 }
@@ -217,6 +222,7 @@ func (r *ConnectorsRoutes) get(gctx *gin.Context) {
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			state			query		string	false	"Filter by connector state"
 // @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			name			query		string	false	"Filter by exact resource name"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:asc')"
 // @Success		200				{object}	OpenAPIListConnectorsResponseJson
@@ -258,6 +264,16 @@ func (r *ConnectorsRoutes) list(gctx *gin.Context) {
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.NameVal != nil {
+			name := common.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
 
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)
@@ -366,6 +382,7 @@ func (r *ConnectorsRoutes) getVersion(gctx *gin.Context) {
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			state			query		string	false	"Filter by version state"
 // @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			name			query		string	false	"Filter by exact resource name"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'version:desc')"
 // @Success		200				{object}	OpenAPIListConnectorVersionsResponseJson
@@ -431,6 +448,16 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 			b = b.ForNamespaceMatcher(*req.NamespaceVal)
 		}
 
+		if req.NameVal != nil {
+			name := common.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
+
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)
 		}
@@ -479,6 +506,7 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors [post]
@@ -500,6 +528,13 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 
 	if err := namespace.ValidatePath(req.Namespace); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid namespace '%s': %s", req.Namespace, err.Error()))
+		val.MarkErrorReturn()
+		return
+	}
+
+	name, httpErr := optionalResourceName(req.Name, "connector")
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
@@ -527,8 +562,13 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 		return
 	}
 
-	result, err := r.connectors.CreateConnectorVersion(ctx, req.Namespace, &req.Definition, req.Labels, req.Annotations)
+	result, err := r.connectors.CreateConnectorVersion(ctx, req.Namespace, name, &req.Definition, req.Labels, req.Annotations)
 	if err != nil {
+		if conflictErr := resourceNameConflictError(err, "connector", name, req.Namespace); conflictErr != nil {
+			apgin.WriteError(gctx, nil, conflictErr)
+			val.MarkErrorReturn()
+			return
+		}
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
 		return
@@ -538,7 +578,7 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 }
 
 // @Summary		Update connector
-// @Description	Update an existing connector's draft version, creating one if needed
+// @Description	Update a connector-level name and/or its draft definition metadata
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
@@ -549,6 +589,7 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/connectors/{id} [patch]
@@ -589,6 +630,52 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 			val.MarkErrorReturn()
 			return
 		}
+	}
+
+	current, err := r.loadConnectorByID(ctx, connectorId)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+			val.MarkErrorReturn()
+			return
+		}
+		apgin.WriteErr(gctx, nil, err)
+		val.MarkErrorReturn()
+		return
+	}
+	if httpErr := val.ValidateHttpStatusError(current); httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		return
+	}
+
+	if req.Name != nil {
+		name, httpErr := optionalResourceName(req.Name, "connector")
+		if httpErr != nil {
+			apgin.WriteError(gctx, nil, httpErr)
+			val.MarkErrorReturn()
+			return
+		}
+		if err := r.connectors.UpdateConnectorName(ctx, connectorId, name); err != nil {
+			if conflictErr := resourceNameConflictError(err, "connector", name, current.GetNamespace()); conflictErr != nil {
+				apgin.WriteError(gctx, nil, conflictErr)
+				val.MarkErrorReturn()
+				return
+			}
+			apgin.WriteErr(gctx, nil, err)
+			val.MarkErrorReturn()
+			return
+		}
+		current, err = r.connectors.GetConnectorVersion(ctx, connectorId, current.GetVersion())
+		if err != nil {
+			apgin.WriteErr(gctx, nil, err)
+			val.MarkErrorReturn()
+			return
+		}
+	}
+
+	if req.Definition == nil && req.Labels == nil && req.Annotations == nil {
+		apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(current))
+		return
 	}
 
 	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
@@ -759,7 +846,7 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string							true	"Connector UUID"
 // @Param			version	path		integer							true	"Version number"
-// @Param			request	body		OpenAPIUpdateConnectorRequestJson	true	"Version update request"
+// @Param			request	body		OpenAPIUpdateConnectorVersionRequestJson	true	"Version update request"
 // @Success		200		{object}	OpenAPIConnectorVersionJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
@@ -790,6 +877,12 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 	}
 	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+		return
+	}
+
+	if req.Name != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("connector names can only be changed through the connector-level update endpoint"))
 		val.MarkErrorReturn()
 		return
 	}

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -2757,4 +2757,122 @@ func TestConnectors(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("resource name API", func(t *testing.T) {
+		tu := setup(t, nil)
+
+		createNamed := func(name *string, displayName string, expectedStatus int) ConnectorVersionJson {
+			body := map[string]interface{}{
+				"namespace": "root",
+				"definition": map[string]interface{}{
+					"display_name": displayName,
+				},
+			}
+			if name != nil {
+				body["name"] = *name
+			}
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/connectors", util.JsonToReader(body),
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, expectedStatus, w.Code, w.Body.String())
+			if expectedStatus != http.StatusCreated {
+				require.NotContains(t, w.Body.String(), "UNIQUE")
+				return ConnectorVersionJson{}
+			}
+			var connector ConnectorVersionJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &connector))
+			return connector
+		}
+
+		customName := "salesforce"
+		custom := createNamed(&customName, "Salesforce", http.StatusCreated)
+		require.Equal(t, customName, string(custom.Name))
+		defaulted := createNamed(nil, "Defaulted", http.StatusCreated)
+		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+		createNamed(&customName, "Conflicting", http.StatusConflict)
+
+		otherName := "other-connector"
+		_ = createNamed(&otherName, "Other", http.StatusCreated)
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/connectors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": "renamed-connector"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var renamed ConnectorVersionJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &renamed))
+		require.Equal(t, "renamed-connector", string(renamed.Name))
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/connectors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": otherName}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+		for _, path := range []string{
+			"/connectors/" + custom.Id.String(),
+			fmt.Sprintf("/connectors/%s/versions/%d", custom.Id, custom.Version),
+		} {
+			w = httptest.NewRecorder()
+			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, path, nil, "root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Contains(t, w.Body.String(), `"name":"renamed-connector"`)
+		}
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/connectors?name=renamed-connector", nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var listed ListConnectorsResponseJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+		require.Len(t, listed.Items, 1)
+		require.Equal(t, custom.Id, listed.Items[0].Id)
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, fmt.Sprintf("/connectors/%s/versions/%d", custom.Id, custom.Version),
+			util.JsonToReader(map[string]string{"name": "divergent"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+		seededID := apid.MustParse("cxr_test0000000000001")
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPost, "/connectors/"+seededID.String()+"/versions",
+			util.JsonToReader(map[string]string{"name": "divergent"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		var version ConnectorVersionJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &version))
+		require.Equal(t, seededID.String(), string(version.Name))
+		require.NotEqual(t, "divergent", string(version.Name))
+	})
 }

--- a/internal/routes/keys.go
+++ b/internal/routes/keys.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -37,6 +38,7 @@ type ListKeysRequestQueryParams struct {
 	LimitVal      *int32             `form:"limit"`
 	StateVal      *database.KeyState `form:"state"`
 	NamespaceVal  *string            `form:"namespace"`
+	NameVal       *string            `form:"name"`
 	LabelSelector *string            `form:"label_selector"`
 	OrderByVal    *string            `form:"order_by"`
 }
@@ -71,6 +73,7 @@ func keyMetadataToJson(ek coreIface.Key) KeyJson {
 	return KeyJson{
 		Id:          ek.GetId(),
 		Namespace:   ek.GetNamespace(),
+		Name:        ek.GetName(),
 		State:       schemaapi.KeyState(ek.GetState()),
 		Labels:      ek.GetLabels(),
 		Annotations: ek.GetAnnotations(),
@@ -149,6 +152,7 @@ func (r *KeysRoutes) get(gctx *gin.Context) {
 // @Success		200		{object}	OpenAPIKeyJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/keys [post]
@@ -174,6 +178,13 @@ func (r *KeysRoutes) create(gctx *gin.Context) {
 		return
 	}
 
+	name, httpErr := optionalResourceName(req.Name, "key")
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
+		val.MarkErrorReturn()
+		return
+	}
+
 	if err := val.ValidateNamespace(req.Namespace); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 		val.MarkErrorReturn()
@@ -188,8 +199,13 @@ func (r *KeysRoutes) create(gctx *gin.Context) {
 		}
 	}
 
-	ek, err := r.core.CreateKey(ctx, req.Namespace, req.KeyData, req.Labels)
+	ek, err := r.core.CreateKey(ctx, req.Namespace, name, req.KeyData, req.Labels)
 	if err != nil {
+		if conflictErr := resourceNameConflictError(err, "key", name, req.Namespace); conflictErr != nil {
+			apgin.WriteError(gctx, nil, conflictErr)
+			val.MarkErrorReturn()
+			return
+		}
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
 		return
@@ -230,6 +246,7 @@ func (r *KeysRoutes) create(gctx *gin.Context) {
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			state			query		string	false	"Filter by state"
 // @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			name			query		string	false	"Filter by exact resource name"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'state:asc')"
 // @Success		200				{object}	OpenAPIListKeysResponseJson
@@ -271,6 +288,16 @@ func (r *KeysRoutes) list(gctx *gin.Context) {
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.NameVal != nil {
+			name := scommon.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid key name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
 
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)
@@ -334,6 +361,7 @@ func (r *KeysRoutes) list(gctx *gin.Context) {
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/keys/{id} [patch]
@@ -403,6 +431,27 @@ func (r *KeysRoutes) update(gctx *gin.Context) {
 	if httpErr := val.ValidateHttpStatusError(ek); httpErr != nil {
 		apgin.WriteError(gctx, nil, httpErr)
 		return
+	}
+
+	if req.Name != nil {
+		name, httpErr := optionalResourceName(req.Name, "key")
+		if httpErr != nil {
+			apgin.WriteError(gctx, nil, httpErr)
+			val.MarkErrorReturn()
+			return
+		}
+		originalNamespace := ek.GetNamespace()
+		ek, err = r.core.UpdateKeyName(ctx, id, name)
+		if err != nil {
+			if conflictErr := resourceNameConflictError(err, "key", name, originalNamespace); conflictErr != nil {
+				apgin.WriteError(gctx, nil, conflictErr)
+				val.MarkErrorReturn()
+				return
+			}
+			apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
 	}
 
 	if req.State != nil {

--- a/internal/routes/keys_test.go
+++ b/internal/routes/keys_test.go
@@ -35,6 +35,7 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -1827,5 +1828,84 @@ func TestKeys(t *testing.T) {
 			_, exists := got.Annotations["annotation"]
 			require.False(t, exists)
 		})
+	})
+
+	t.Run("resource name API", func(t *testing.T) {
+		tu, done := setup(t, context.Background(), nil)
+		defer done()
+
+		createNamed := func(name string) KeyJson {
+			body := map[string]interface{}{
+				"namespace": "root",
+				"name":      name,
+				"key_data":  map[string]interface{}{"value": "named-key-data"},
+			}
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/keys", util.JsonToReader(body),
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var key KeyJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &key))
+			return key
+		}
+
+		named := createNamed("primary-key")
+		require.Equal(t, "primary-key", string(named.Name))
+		defaulted := createKey(t, tu, "root", nil)
+		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/keys/"+named.Id.String(), nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var got KeyJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, "primary-key", string(got.Name))
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/keys/"+named.Id.String(), util.JsonToReader(map[string]string{"name": "renamed-key"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, "renamed-key", string(got.Name))
+
+		_ = createNamed("conflicting-key")
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/keys/"+named.Id.String(), util.JsonToReader(map[string]string{"name": "conflicting-key"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		require.NotContains(t, w.Body.String(), "UNIQUE")
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/keys?name=renamed-key", nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var listed ListKeysResponseJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+		require.Len(t, listed.Items, 1)
+		require.Equal(t, named.Id, listed.Items[0].Id)
 	})
 }

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -321,7 +321,7 @@ func (r *NamespacesRoutes) list(gctx *gin.Context) {
 }
 
 // @Summary		Update namespace
-// @Description	Update a namespace's labels
+// @Description	Update a namespace's labels and annotations. Its path and derived name cannot be changed.
 // @Tags			namespaces
 // @Accept			json
 // @Produce		json

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -41,6 +42,7 @@ func NamespaceToJson(ns coreIface.Namespace) NamespaceJson {
 
 	return NamespaceJson{
 		Path:        ns.GetPath(),
+		Name:        ns.GetName(),
 		State:       schemaapi.NamespaceState(ns.GetState()),
 		KeyId:       ekId,
 		Labels:      ns.GetLabels(),
@@ -56,6 +58,7 @@ type ListNamespacesRequestQueryParams struct {
 	StateVal      *database.NamespaceState `form:"state"`
 	ChildrenOf    *string                  `form:"children_of"`
 	NamespaceVal  *string                  `form:"namespace"`
+	NameVal       *string                  `form:"name"`
 	LabelSelector *string                  `form:"label_selector"`
 	OrderByVal    *string                  `form:"order_by"`
 }
@@ -208,6 +211,7 @@ func (r *NamespacesRoutes) create(gctx *gin.Context) {
 // @Param			state			query		string	false	"Filter by namespace state"
 // @Param			children_of		query		string	false	"Filter to children of a parent namespace"
 // @Param			namespace		query		string	false	"Filter by namespace path pattern"
+// @Param			name			query		string	false	"Filter by exact final path segment"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'path:asc')"
 // @Success		200				{object}	OpenAPIListNamespacesResponseJson
@@ -267,6 +271,16 @@ func (r *NamespacesRoutes) list(gctx *gin.Context) {
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.NameVal != nil {
+			name := scommon.ResourceName(*req.NameVal)
+			if err := namespace.ValidateName(*req.NameVal); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid namespace name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
 
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -150,6 +151,7 @@ func TestNamespaces(t *testing.T) {
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "root.dev", resp.Path)
+			require.Equal(t, "dev", string(resp.Name))
 			require.Equal(t, string(database.NamespaceStateActive), string(resp.State))
 		})
 
@@ -421,6 +423,12 @@ func TestNamespaces(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		err = tu.Db.CreateNamespace(ctx, &database.Namespace{
+			Path:  "root.prod.old",
+			State: database.NamespaceStateActive,
+		})
+		require.NoError(t, err)
+
 		t.Run("unauthorized", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, "/namespaces", nil)
@@ -464,7 +472,7 @@ func TestNamespaces(t *testing.T) {
 			var resp ListNamespacesResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Len(t, resp.Items, 4)
+			require.Len(t, resp.Items, 5)
 		})
 
 		t.Run("bad request for invalid children_of namespace", func(t *testing.T) {
@@ -520,6 +528,50 @@ func TestNamespaces(t *testing.T) {
 			require.Len(t, resp.Items, 2)
 			require.Equal(t, "root.dev", resp.Items[0].Path)
 			require.Equal(t, "root.dev.old", resp.Items[1].Path)
+		})
+
+		t.Run("filter by derived name preserves pagination and authorization", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/namespaces?name=old&limit=1", nil,
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var first ListNamespacesResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &first))
+			require.Len(t, first.Items, 1)
+			require.Equal(t, "old", string(first.Items[0].Name))
+			require.NotEmpty(t, first.Cursor)
+
+			w = httptest.NewRecorder()
+			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/namespaces?cursor="+url.QueryEscape(first.Cursor), nil,
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var second ListNamespacesResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &second))
+			require.Len(t, second.Items, 1)
+			require.Equal(t, "old", string(second.Items[0].Name))
+			require.NotEqual(t, first.Items[0].Path, second.Items[0].Path)
+
+			w = httptest.NewRecorder()
+			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet, "/namespaces?name=old", nil,
+				"root", "some-actor", aschema.PermissionsSingle("root.dev.**", "namespaces", "list"),
+			)
+			require.NoError(t, err)
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var authorized ListNamespacesResponseJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &authorized))
+			require.Len(t, authorized.Items, 1)
+			require.Equal(t, "root.dev.old", authorized.Items[0].Path)
 		})
 
 		t.Run("filter to namespace", func(t *testing.T) {

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -287,6 +287,7 @@ func TestNamespaces(t *testing.T) {
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Equal(t, "root.allowed", resp.Path)
+			require.Equal(t, "allowed", string(resp.Name))
 			require.Equal(t, string(database.NamespaceStateActive), string(resp.State))
 		})
 
@@ -724,6 +725,7 @@ func TestNamespaces(t *testing.T) {
 			var resp NamespaceJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, "root.patchns", resp.Path)
+			require.Equal(t, "patchns", string(resp.Name))
 			require.Equal(t, "production", resp.Labels["env"])
 			require.Equal(t, "backend", resp.Labels["team"])
 

--- a/internal/routes/rate_limits.go
+++ b/internal/routes/rate_limits.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -43,6 +44,7 @@ type ListRateLimitsRequestQueryParams struct {
 	Cursor        *string `form:"cursor"`
 	LimitVal      *int32  `form:"limit"`
 	NamespaceVal  *string `form:"namespace"`
+	NameVal       *string `form:"name"`
 	LabelSelector *string `form:"label_selector"`
 	OrderByVal    *string `form:"order_by"`
 }
@@ -51,6 +53,7 @@ func RateLimitToJson(r coreIface.RateLimit) RateLimitJson {
 	return RateLimitJson{
 		Id:          r.GetId(),
 		Namespace:   r.GetNamespace(),
+		Name:        r.GetName(),
 		Definition:  r.GetDefinition(),
 		Labels:      r.GetLabels(),
 		Annotations: r.GetAnnotations(),
@@ -171,6 +174,7 @@ func (r *RateLimitsRoutes) get(gctx *gin.Context) {
 // @Success		200		{object}	OpenAPIRateLimitJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/rate-limits [post]
@@ -187,6 +191,13 @@ func (r *RateLimitsRoutes) create(gctx *gin.Context) {
 
 	if req.Namespace == "" {
 		apgin.WriteError(gctx, nil, httperr.BadRequest("namespace is required"))
+		val.MarkErrorReturn()
+		return
+	}
+
+	name, httpErr := optionalResourceName(req.Name, "rate limit")
+	if httpErr != nil {
+		apgin.WriteError(gctx, nil, httpErr)
 		val.MarkErrorReturn()
 		return
 	}
@@ -219,8 +230,13 @@ func (r *RateLimitsRoutes) create(gctx *gin.Context) {
 		}
 	}
 
-	rl, err := r.core.CreateRateLimit(ctx, req.Namespace, req.Definition, req.Labels, req.Annotations)
+	rl, err := r.core.CreateRateLimit(ctx, req.Namespace, name, req.Definition, req.Labels, req.Annotations)
 	if err != nil {
+		if conflictErr := resourceNameConflictError(err, "rate limit", name, req.Namespace); conflictErr != nil {
+			apgin.WriteError(gctx, nil, conflictErr)
+			val.MarkErrorReturn()
+			return
+		}
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
 		return
@@ -237,6 +253,7 @@ func (r *RateLimitsRoutes) create(gctx *gin.Context) {
 // @Param			cursor			query		string	false	"Pagination cursor"
 // @Param			limit			query		integer	false	"Maximum number of results to return"
 // @Param			namespace		query		string	false	"Filter by namespace"
+// @Param			name			query		string	false	"Filter by exact name"
 // @Param			label_selector	query		string	false	"Filter by label selector"
 // @Param			order_by		query		string	false	"Order by field (e.g., 'created_at:desc')"
 // @Success		200				{object}	OpenAPIListRateLimitsResponseJson
@@ -274,6 +291,16 @@ func (r *RateLimitsRoutes) list(gctx *gin.Context) {
 		}
 
 		b = b.ForNamespaceMatchers(val.GetEffectiveNamespaceMatchers(req.NamespaceVal))
+
+		if req.NameVal != nil {
+			name := scommon.ResourceName(*req.NameVal)
+			if err := name.Validate(); err != nil {
+				apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid rate limit name: %s", err.Error()))
+				val.MarkErrorReturn()
+				return
+			}
+			b = b.ForName(name)
+		}
 
 		if req.LabelSelector != nil {
 			b = b.ForLabelSelector(*req.LabelSelector)
@@ -313,7 +340,7 @@ func (r *RateLimitsRoutes) list(gctx *gin.Context) {
 }
 
 // @Summary		Update rate limit
-// @Description	Update a rate limit's definition, labels, or annotations
+// @Description	Update a rate limit's name, definition, labels, or annotations
 // @Tags			rate_limits
 // @Accept			json
 // @Produce		json
@@ -323,6 +350,7 @@ func (r *RateLimitsRoutes) list(gctx *gin.Context) {
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
+// @Failure		409		{object}	ErrorResponse
 // @Failure		500		{object}	ErrorResponse
 // @Security		BearerAuth
 // @Router			/rate-limits/{id} [patch]
@@ -383,6 +411,24 @@ func (r *RateLimitsRoutes) update(gctx *gin.Context) {
 	if httpErr := val.ValidateHttpStatusError(rl); httpErr != nil {
 		apgin.WriteError(gctx, nil, httpErr)
 		return
+	}
+
+	if req.Name != nil {
+		name, httpErr := optionalResourceName(req.Name, "rate limit")
+		if httpErr != nil {
+			apgin.WriteError(gctx, nil, httpErr)
+			val.MarkErrorReturn()
+			return
+		}
+		if _, err := r.core.UpdateRateLimitName(ctx, id, name); err != nil {
+			if conflictErr := resourceNameConflictError(err, "rate limit", name, rl.GetNamespace()); conflictErr != nil {
+				apgin.WriteError(gctx, nil, conflictErr)
+				val.MarkErrorReturn()
+				return
+			}
+			r.handleMutateError(gctx, val, id, err)
+			return
+		}
 	}
 
 	if req.Definition != nil {

--- a/internal/routes/rate_limits_test.go
+++ b/internal/routes/rate_limits_test.go
@@ -30,6 +30,7 @@ import (
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/test_utils"
+	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -658,7 +659,7 @@ func TestRateLimits(t *testing.T) {
 		ctx := context.Background()
 		ids := make([]apid.ID, 0, len(defs))
 		for _, def := range defs {
-			rl, err := tu.Core.CreateRateLimit(ctx, namespace, def, nil, nil)
+			rl, err := tu.Core.CreateRateLimit(ctx, namespace, "", def, nil, nil)
 			require.NoError(t, err)
 			ids = append(ids, rl.GetId())
 		}
@@ -953,6 +954,85 @@ func TestRateLimits(t *testing.T) {
 				require.Equal(t, 1, resp.Matched[0].Remaining, "iteration %d", i+1)
 			}
 		})
+	})
+
+	t.Run("resource name API", func(t *testing.T) {
+		tu, done := setup(t)
+		defer done()
+
+		createNamed := func(name string) RateLimitJson {
+			body := map[string]interface{}{
+				"namespace":  "root",
+				"name":       name,
+				"definition": validDef(),
+			}
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost, "/rate-limits", util.JsonToReader(body),
+				"root", "some-actor", aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var rateLimit RateLimitJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rateLimit))
+			return rateLimit
+		}
+
+		named := createNamed("public-api")
+		require.Equal(t, "public-api", string(named.Name))
+		defaulted := createRateLimit(t, tu, "root", nil)
+		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+
+		w := httptest.NewRecorder()
+		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/rate-limits/"+named.Id.String(), nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var got RateLimitJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, "public-api", string(got.Name))
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/rate-limits/"+named.Id.String(), util.JsonToReader(map[string]string{"name": "renamed-limit"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		require.Equal(t, "renamed-limit", string(got.Name))
+
+		_ = createNamed("conflicting-limit")
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodPatch, "/rate-limits/"+named.Id.String(), util.JsonToReader(map[string]string{"name": "conflicting-limit"}),
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		require.NotContains(t, w.Body.String(), "UNIQUE")
+
+		w = httptest.NewRecorder()
+		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
+			http.MethodGet, "/rate-limits?name=renamed-limit", nil,
+			"root", "some-actor", aschema.AllPermissions(),
+		)
+		require.NoError(t, err)
+		tu.Gin.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var listed ListRateLimitsResponseJson
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+		require.Len(t, listed.Items, 1)
+		require.Equal(t, named.Id, listed.Items[0].Id)
 	})
 }
 

--- a/internal/routes/resource_name.go
+++ b/internal/routes/resource_name.go
@@ -1,0 +1,27 @@
+package routes
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httperr"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+func optionalResourceName(name *scommon.ResourceName, resourceType string) (scommon.ResourceName, *httperr.Error) {
+	if name == nil {
+		return "", nil
+	}
+	if err := name.Validate(); err != nil {
+		return "", httperr.BadRequest(fmt.Sprintf("invalid %s name: %s", resourceType, err.Error()), httperr.WithInternalErr(err))
+	}
+	return *name, nil
+}
+
+func resourceNameConflictError(err error, resourceType string, name scommon.ResourceName, namespace string) *httperr.Error {
+	if !errors.Is(err, database.ErrDuplicate) {
+		return nil
+	}
+	return httperr.Conflictf("%s name '%s' already exists in namespace '%s'", resourceType, name, namespace)
+}

--- a/internal/schema/api/actor.go
+++ b/internal/schema/api/actor.go
@@ -4,37 +4,41 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 )
 
 // ActorJson represents an actor returned by the API.
 //
 //	@Description	Actor identity within a namespace
 type ActorJson struct {
-	Id          apid.ID           `json:"id" yaml:"id" swaggertype:"string" example:"act_test550e8400abcde"`
-	Namespace   string            `json:"namespace" yaml:"namespace" example:"root.acme"`
-	ExternalId  string            `json:"external_id" yaml:"external_id" example:"user-123"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at" yaml:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at" yaml:"updated_at"`
+	Id          apid.ID             `json:"id" yaml:"id" swaggertype:"string" example:"act_test550e8400abcde"`
+	Namespace   string              `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        common.ResourceName `json:"name" yaml:"name" swaggertype:"string" example:"billing-service"`
+	ExternalId  string              `json:"external_id" yaml:"external_id" example:"user-123"`
+	Labels      map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time           `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at" yaml:"updated_at"`
 }
 
 // CreateActorRequestJson represents a request to create an actor.
 //
 //	@Description	Actor creation request
 type CreateActorRequestJson struct {
-	ExternalId  string            `json:"external_id" yaml:"external_id" example:"user-123"`
-	Namespace   string            `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	ExternalId  string               `json:"external_id" yaml:"external_id" example:"user-123"`
+	Namespace   string               `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"billing-service"`
+	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // UpdateActorRequestJson represents a request to update actor metadata.
 //
 //	@Description	Actor update request
 type UpdateActorRequestJson struct {
-	Labels      map[string]string `json:"labels" yaml:"labels"`
-	Annotations map[string]string `json:"annotations" yaml:"annotations"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"billing-service"`
+	Labels      map[string]string    `json:"labels" yaml:"labels"`
+	Annotations map[string]string    `json:"annotations" yaml:"annotations"`
 }
 
 // ListActorsResponseJson is a paginated actor list response.

--- a/internal/schema/api/connection_setup.go
+++ b/internal/schema/api/connection_setup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
@@ -23,6 +24,9 @@ type InitiateConnectionRequest struct {
 	// namespace. Defaults to the connector namespace if not specified.
 	IntoNamespace string `json:"into_namespace,omitempty" yaml:"into_namespace,omitempty" example:"root.acme"`
 
+	// Optional mutable name for the connection. Defaults to the generated connection ID.
+	Name *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"production-crm"`
+
 	// The URL to return to after the connection is completed.
 	ReturnToUrl string `json:"return_to_url" yaml:"return_to_url" example:"https://example.com/callback"`
 }
@@ -37,6 +41,12 @@ func (icr *InitiateConnectionRequest) Validate() error {
 	if icr.HasIntoNamespace() {
 		if err := nschema.ValidatePath(icr.IntoNamespace); err != nil {
 			result = multierror.Append(result, err)
+		}
+	}
+
+	if icr.Name != nil {
+		if err := icr.Name.Validate(); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid connection name: %w", err))
 		}
 	}
 

--- a/internal/schema/api/connections.go
+++ b/internal/schema/api/connections.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -32,6 +33,7 @@ const (
 type ConnectionJson struct {
 	Id          apid.ID               `json:"id" yaml:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
 	Namespace   string                `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        common.ResourceName   `json:"name" yaml:"name" swaggertype:"string" example:"production-crm"`
 	Labels      map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	State       ConnectionState       `json:"state" yaml:"state" swaggertype:"string" example:"configured"`
@@ -89,8 +91,9 @@ type ForceConnectionStateRequestJson struct {
 //
 //	@Description	Request to update a connection's labels and annotations
 type UpdateConnectionRequestJson struct {
-	Labels      map[string]string `json:"labels" yaml:"labels"`
-	Annotations map[string]string `json:"annotations" yaml:"annotations"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"production-crm"`
+	Labels      map[string]string    `json:"labels" yaml:"labels"`
+	Annotations map[string]string    `json:"annotations" yaml:"annotations"`
 }
 
 // ProxyResponseJson is the response from a proxied request.

--- a/internal/schema/api/connectors.go
+++ b/internal/schema/api/connectors.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -24,6 +25,7 @@ type ConnectorJson struct {
 	Id            apid.ID               `json:"id" yaml:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
 	Version       uint64                `json:"version" yaml:"version" example:"1"`
 	Namespace     string                `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name          common.ResourceName   `json:"name" yaml:"name" swaggertype:"string" example:"salesforce"`
 	State         ConnectorVersionState `json:"state" yaml:"state" swaggertype:"string" example:"primary"`
 	DisplayName   string                `json:"display_name" yaml:"display_name" example:"Salesforce"`
 	Highlight     string                `json:"highlight,omitempty" yaml:"highlight,omitempty" example:"CRM platform"`
@@ -49,6 +51,7 @@ type ConnectorVersionJson struct {
 	Id          apid.ID               `json:"id" yaml:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
 	Version     uint64                `json:"version" yaml:"version" example:"1"`
 	Namespace   string                `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        common.ResourceName   `json:"name" yaml:"name" swaggertype:"string" example:"salesforce"`
 	State       ConnectorVersionState `json:"state" yaml:"state" swaggertype:"string" example:"primary"`
 	Definition  cschema.Connector     `json:"definition" yaml:"definition"`
 	Labels      map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
@@ -66,16 +69,28 @@ type ListConnectorVersionsResponseJson struct {
 //
 //	@Description	Request to create a new connector
 type CreateConnectorRequestJson struct {
-	Namespace   string            `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Definition  cschema.Connector `json:"definition" yaml:"definition"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Namespace   string               `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"salesforce"`
+	Definition  cschema.Connector    `json:"definition" yaml:"definition"`
+	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
-// UpdateConnectorRequestJson is the request body for PATCH /connectors/:id and PATCH /connectors/:id/versions/:version.
+// UpdateConnectorRequestJson is the request body for PATCH /connectors/:id.
 //
-//	@Description	Request to update a connector or connector version
+//	@Description	Request to update a logical connector
 type UpdateConnectorRequestJson struct {
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"salesforce"`
+	Definition  *cschema.Connector   `json:"definition,omitempty" yaml:"definition,omitempty"`
+	Labels      *map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// UpdateConnectorVersionRequestJson is the request body for PATCH /connectors/:id/versions/:version.
+// Connector-level fields such as name are intentionally excluded.
+//
+//	@Description Request to update a connector definition version
+type UpdateConnectorVersionRequestJson struct {
 	Definition  *cschema.Connector `json:"definition,omitempty" yaml:"definition,omitempty"`
 	Labels      *map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations *map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`

--- a/internal/schema/api/keys.go
+++ b/internal/schema/api/keys.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
 )
 
@@ -19,14 +20,15 @@ const (
 //
 //	@Description	Key API response
 type KeyJson struct {
-	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"key_test550e8400abcd"`
-	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
-	State       KeyState           `json:"state" yaml:"state" swaggertype:"string" example:"active"`
-	KeyData     *keyschema.KeyData `json:"key_data,omitempty" yaml:"key_data,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt   time.Time          `json:"created_at" yaml:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at" yaml:"updated_at"`
+	Id          apid.ID             `json:"id" yaml:"id" swaggertype:"string" example:"key_test550e8400abcd"`
+	Namespace   string              `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        common.ResourceName `json:"name" yaml:"name" swaggertype:"string" example:"primary-encryption-key"`
+	State       KeyState            `json:"state" yaml:"state" swaggertype:"string" example:"active"`
+	KeyData     *keyschema.KeyData  `json:"key_data,omitempty" yaml:"key_data,omitempty"`
+	Labels      map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time           `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at" yaml:"updated_at"`
 }
 
 type ListKeysResponseJson struct {
@@ -38,18 +40,20 @@ type ListKeysResponseJson struct {
 //
 //	@Description	Request to create a new key
 type CreateKeyRequestJson struct {
-	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
-	KeyData     *keyschema.KeyData `json:"key_data,omitempty" yaml:"key_data,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Namespace   string               `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"primary-encryption-key"`
+	KeyData     *keyschema.KeyData   `json:"key_data,omitempty" yaml:"key_data,omitempty"`
+	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // UpdateKeyRequestJson is the request body for PATCH /keys/:id.
 //
 //	@Description	Request to update a key
 type UpdateKeyRequestJson struct {
-	State       *KeyState          `json:"state,omitempty" yaml:"state,omitempty"`
-	KeyData     *keyschema.KeyData `json:"key_data,omitempty" yaml:"key_data,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"primary-encryption-key"`
+	State       *KeyState            `json:"state,omitempty" yaml:"state,omitempty"`
+	KeyData     *keyschema.KeyData   `json:"key_data,omitempty" yaml:"key_data,omitempty"`
+	Labels      *map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }

--- a/internal/schema/api/namespace.go
+++ b/internal/schema/api/namespace.go
@@ -1,6 +1,10 @@
 package api
 
-import "time"
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
 
 // NamespaceState is the lifecycle state of a namespace.
 type NamespaceState string
@@ -15,13 +19,14 @@ const (
 //
 //	@Description	Namespace for organizing resources
 type NamespaceJson struct {
-	Path        string            `json:"path" yaml:"path" example:"root.acme"`
-	State       NamespaceState    `json:"state" yaml:"state" swaggertype:"string" example:"active"`
-	KeyId       *string           `json:"key_id,omitempty" yaml:"key_id,omitempty" example:"key_test550e8400abcd"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at" yaml:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at" yaml:"updated_at"`
+	Path        string              `json:"path" yaml:"path" example:"root.acme"`
+	Name        common.ResourceName `json:"name" yaml:"name" swaggertype:"string" example:"acme"`
+	State       NamespaceState      `json:"state" yaml:"state" swaggertype:"string" example:"active"`
+	KeyId       *string             `json:"key_id,omitempty" yaml:"key_id,omitempty" example:"key_test550e8400abcd"`
+	Labels      map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time           `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at" yaml:"updated_at"`
 }
 
 // CreateNamespaceRequestJson represents a request to create a namespace.

--- a/internal/schema/api/namespace.go
+++ b/internal/schema/api/namespace.go
@@ -19,7 +19,8 @@ const (
 //
 //	@Description	Namespace for organizing resources
 type NamespaceJson struct {
-	Path        string              `json:"path" yaml:"path" example:"root.acme"`
+	Path string `json:"path" yaml:"path" example:"root.acme"`
+	// Name is automatically set to the final segment of Path and cannot be changed.
 	Name        common.ResourceName `json:"name" yaml:"name" swaggertype:"string" example:"acme"`
 	State       NamespaceState      `json:"state" yaml:"state" swaggertype:"string" example:"active"`
 	KeyId       *string             `json:"key_id,omitempty" yaml:"key_id,omitempty" example:"key_test550e8400abcd"`

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -44,6 +44,7 @@ type ConnectorVersionJson struct {
 	Id          apid.ID                         `json:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
 	Version     uint64                          `json:"version" example:"1"`
 	Namespace   string                          `json:"namespace" example:"root.acme"`
+	Name        string                          `json:"name" example:"salesforce"`
 	State       schemaapi.ConnectorVersionState `json:"state" swaggertype:"string" example:"primary"`
 	Definition  interface{}                     `json:"definition"`
 	Labels      map[string]string               `json:"labels,omitempty"`
@@ -69,6 +70,7 @@ type ListConnectorVersionsResponseJson struct {
 type ConnectionJson struct {
 	Id          apid.ID           `json:"id" swaggertype:"string" example:"cxn_test550e8400abcde"`
 	Namespace   string            `json:"namespace" example:"root.acme"`
+	Name        string            `json:"name" example:"production-crm"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 	State       string            `json:"state" example:"configured"`
@@ -156,6 +158,7 @@ type ListNotificationsResponseJson struct {
 //	@Description	Request to create a new connector
 type CreateConnectorRequestJson struct {
 	Namespace   string            `json:"namespace" example:"root.acme"`
+	Name        *string           `json:"name,omitempty" example:"salesforce"`
 	Definition  interface{}       `json:"definition"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
@@ -163,8 +166,18 @@ type CreateConnectorRequestJson struct {
 
 // UpdateConnectorRequestJson documents the connector update body.
 //
-//	@Description	Request to update a connector or connector version
+//	@Description	Request to update a logical connector
 type UpdateConnectorRequestJson struct {
+	Name        *string            `json:"name,omitempty" example:"salesforce"`
+	Definition  interface{}        `json:"definition,omitempty"`
+	Labels      *map[string]string `json:"labels,omitempty"`
+	Annotations *map[string]string `json:"annotations,omitempty"`
+}
+
+// UpdateConnectorVersionRequestJson documents connector definition-version updates.
+//
+//	@Description Request to update a connector definition version
+type UpdateConnectorVersionRequestJson struct {
 	Definition  interface{}        `json:"definition,omitempty"`
 	Labels      *map[string]string `json:"labels,omitempty"`
 	Annotations *map[string]string `json:"annotations,omitempty"`
@@ -200,6 +213,7 @@ type ConnectorLifecycleResponseJson struct {
 type KeyJson struct {
 	Id          apid.ID                `json:"id" swaggertype:"string" example:"key_test550e8400abcd"`
 	Namespace   string                 `json:"namespace" example:"root.acme"`
+	Name        string                 `json:"name" example:"primary-encryption-key"`
 	State       string                 `json:"state" example:"active"`
 	KeyData     map[string]interface{} `json:"key_data,omitempty" swaggertype:"object"`
 	Labels      map[string]string      `json:"labels,omitempty"`
@@ -213,6 +227,7 @@ type KeyJson struct {
 //	@Description	Request to create a key
 type CreateKeyRequestJson struct {
 	Namespace   string                 `json:"namespace" example:"root.acme"`
+	Name        *string                `json:"name,omitempty" example:"primary-encryption-key"`
 	KeyData     map[string]interface{} `json:"key_data,omitempty"`
 	Labels      map[string]string      `json:"labels,omitempty"`
 	Annotations map[string]string      `json:"annotations,omitempty"`
@@ -282,6 +297,7 @@ type TaskInfoJson struct {
 //
 //	@Description	Request to update a key
 type UpdateKeyRequestJson struct {
+	Name        *string                 `json:"name,omitempty" example:"primary-encryption-key"`
 	State       *string                 `json:"state,omitempty" example:"disabled"`
 	KeyData     *map[string]interface{} `json:"key_data,omitempty"`
 	Labels      *map[string]string      `json:"labels,omitempty"`
@@ -295,6 +311,7 @@ type UpdateKeyRequestJson struct {
 type RateLimitJson struct {
 	Id          apid.ID           `json:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
 	Namespace   string            `json:"namespace" example:"root.acme"`
+	Name        string            `json:"name" example:"public-api"`
 	Definition  map[string]any    `json:"definition"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
@@ -315,6 +332,7 @@ type ListRateLimitsResponseJson struct {
 //	@Description	Request to create a rate limit
 type CreateRateLimitRequestJson struct {
 	Namespace   string            `json:"namespace" example:"root.acme"`
+	Name        *string           `json:"name,omitempty" example:"public-api"`
 	Definition  map[string]any    `json:"definition"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
@@ -324,6 +342,7 @@ type CreateRateLimitRequestJson struct {
 //
 //	@Description	Request to update a rate limit
 type UpdateRateLimitRequestJson struct {
+	Name        *string            `json:"name,omitempty" example:"public-api"`
 	Definition  map[string]any     `json:"definition,omitempty"`
 	Labels      *map[string]string `json:"labels,omitempty"`
 	Annotations *map[string]string `json:"annotations,omitempty"`

--- a/internal/schema/api/rate_limits.go
+++ b/internal/schema/api/rate_limits.go
@@ -12,13 +12,14 @@ import (
 //
 //	@Description	Rate-limit API response
 type RateLimitJson struct {
-	Id          apid.ID            `json:"id" yaml:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
-	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Definition  rlschema.RateLimit `json:"definition" yaml:"definition"`
-	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt   time.Time          `json:"created_at" yaml:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at" yaml:"updated_at"`
+	Id          apid.ID             `json:"id" yaml:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
+	Namespace   string              `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        common.ResourceName `json:"name" yaml:"name" swaggertype:"string" example:"public-api"`
+	Definition  rlschema.RateLimit  `json:"definition" yaml:"definition"`
+	Labels      map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   time.Time           `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at" yaml:"updated_at"`
 }
 
 type ListRateLimitsResponseJson struct {
@@ -30,19 +31,21 @@ type ListRateLimitsResponseJson struct {
 //
 //	@Description	Request to create a rate limit
 type CreateRateLimitRequestJson struct {
-	Namespace   string             `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Definition  rlschema.RateLimit `json:"definition" yaml:"definition"`
-	Labels      map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Namespace   string               `json:"namespace" yaml:"namespace" example:"root.acme"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"public-api"`
+	Definition  rlschema.RateLimit   `json:"definition" yaml:"definition"`
+	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // UpdateRateLimitRequestJson is the request body for PATCH /rate-limits/:id.
 //
 //	@Description	Request to update a rate limit
 type UpdateRateLimitRequestJson struct {
-	Definition  *rlschema.RateLimit `json:"definition,omitempty" yaml:"definition,omitempty"`
-	Labels      *map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations *map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"public-api"`
+	Definition  *rlschema.RateLimit  `json:"definition,omitempty" yaml:"definition,omitempty"`
+	Labels      *map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // ProxyRequestJson is the wire shape used by API endpoints that accept a

--- a/internal/schema/resources/namespace/README.md
+++ b/internal/schema/resources/namespace/README.md
@@ -6,6 +6,7 @@ Use this package for namespace resource semantics. Auth permissions reference na
 
 API request and response DTOs for namespace routes live in `internal/schema/api`. Keep this package focused on reusable namespace primitives: paths, matchers, hierarchy helpers, and the JSON Schema definitions other packages can reference.
 
-A namespace's read-only resource name is the final segment of its path. For
-example, `root.prod.billing` has the name `billing`; renaming still requires a
-path change and is not a namespace API operation.
+A namespace's read-only resource name is set automatically to the final segment
+of its path when the namespace is created. For example, `root.prod.billing` has
+the name `billing`. Namespace paths are immutable, so namespace names cannot be
+changed after creation.

--- a/internal/schema/resources/namespace/README.md
+++ b/internal/schema/resources/namespace/README.md
@@ -5,3 +5,7 @@ This package owns namespace path and matcher validation plus constants for names
 Use this package for namespace resource semantics. Auth permissions reference namespace matchers, but namespace validation itself is not auth-specific.
 
 API request and response DTOs for namespace routes live in `internal/schema/api`. Keep this package focused on reusable namespace primitives: paths, matchers, hierarchy helpers, and the JSON Schema definitions other packages can reference.
+
+A namespace's read-only resource name is the final segment of its path. For
+example, `root.prod.billing` has the name `billing`; renaming still requires a
+path change and is not a namespace API operation.

--- a/internal/schema/resources/namespace/namespace.go
+++ b/internal/schema/resources/namespace/namespace.go
@@ -6,10 +6,34 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util"
 )
 
+// NameFromPath returns the read-only resource name derived from the final
+// segment of a namespace path.
+func NameFromPath(path string) common.ResourceName {
+	if i := strings.LastIndex(path, PathSeparator); i >= 0 {
+		return common.ResourceName(path[i+len(PathSeparator):])
+	}
+	return common.ResourceName(path)
+}
+
 var validPathRegex = regexp.MustCompile(`^root(?:\.[a-zA-Z0-9_]+[a-zA-Z0-9_\-]*)*$`)
+var validNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+[a-zA-Z0-9_\-]*$`)
+
+// ValidateName checks a namespace's derived final path segment. Namespace
+// names retain the established namespace-segment grammar, including leading
+// underscores and trailing hyphens.
+func ValidateName(name string) error {
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if !validNameRegex.MatchString(name) {
+		return errors.New("name must be a valid namespace path segment")
+	}
+	return nil
+}
 
 // Root represents the base namespace for all hierarchical paths in the system. Other namespaces
 // follow from this path using PathSeparator, e.g. root.child.grandchild.

--- a/internal/schema/resources/namespace/namespace.go
+++ b/internal/schema/resources/namespace/namespace.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/util"
 )
 
-// NameFromPath returns the read-only resource name derived from the final
-// segment of a namespace path.
+// NameFromPath returns the read-only resource name automatically derived from
+// the final segment of a namespace's immutable path.
 func NameFromPath(path string) common.ResourceName {
 	if i := strings.LastIndex(path, PathSeparator); i >= 0 {
 		return common.ResourceName(path[i+len(PathSeparator):])

--- a/internal/schema/resources/namespace/namespace_test.go
+++ b/internal/schema/resources/namespace/namespace_test.go
@@ -84,6 +84,13 @@ func TestMatches(t *testing.T) {
 	}
 }
 
+func TestNamespaceName(t *testing.T) {
+	require.Equal(t, "root", string(NameFromPath("root")))
+	require.Equal(t, "billing", string(NameFromPath("root.prod.billing")))
+	require.NoError(t, ValidateName("_billing-"))
+	require.Error(t, ValidateName("billing.prod"))
+}
+
 func TestNamespaces(t *testing.T) {
 	t.Run("path", func(t *testing.T) {
 		t.Run("validation", func(t *testing.T) {

--- a/internal/schema/resources/namespace/schema.json
+++ b/internal/schema/resources/namespace/schema.json
@@ -2,6 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/resources/namespace/schema.json",
   "$defs": {
+    "NamespaceName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_]+[a-zA-Z0-9_\\-]*$",
+      "description": "The read-only name of a namespace, derived from the final segment of its path."
+    },
     "NamespacePath": {
       "type": "string",
       "pattern": "^root(?:\\.[a-zA-Z0-9_]+[a-zA-Z0-9_\\-]*)*$",

--- a/internal/schema/resources/namespace/schema.json
+++ b/internal/schema/resources/namespace/schema.json
@@ -5,7 +5,7 @@
     "NamespaceName": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9_]+[a-zA-Z0-9_\\-]*$",
-      "description": "The read-only name of a namespace, derived from the final segment of its path."
+      "description": "The read-only name automatically set to the final segment of a namespace's immutable path when the namespace is created."
     },
     "NamespacePath": {
       "type": "string",

--- a/internal/schema/resources/namespace/schema_test.go
+++ b/internal/schema/resources/namespace/schema_test.go
@@ -40,6 +40,22 @@ func TestSchema(t *testing.T) {
 		}
 	}{
 		{
+			name: "NamespaceName",
+			ref:  "./schema.json#/$defs/NamespaceName",
+			tests: []struct {
+				name  string
+				valid bool
+				data  string
+			}{
+				{name: "bad value", valid: false, data: `{"test": "bad.name"}`},
+				{name: "wrong type", valid: false, data: `{"test": 99}`},
+				{name: "empty", valid: false, data: `{"test": ""}`},
+				{name: "simple", valid: true, data: `{"test": "billing"}`},
+				{name: "leading underscore", valid: true, data: `{"test": "_billing"}`},
+				{name: "trailing dash", valid: true, data: `{"test": "billing-"}`},
+			},
+		},
+		{
 			name: "NamespacePath",
 			ref:  "./schema.json#/$defs/NamespacePath",
 			tests: []struct {

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -6213,7 +6213,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a namespace's labels",
+                "description": "Update a namespace's labels and annotations. Its path and derived name cannot be changed.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8334,6 +8334,7 @@ const docTemplateadmin_api = `{
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },
@@ -8735,6 +8736,7 @@ const docTemplateadmin_api = `{
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -54,6 +54,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"
@@ -553,6 +559,12 @@ const docTemplateadmin_api = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -1145,6 +1157,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -1232,6 +1250,12 @@ const docTemplateadmin_api = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1307,7 +1331,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a connection's labels",
+                "description": "Update a connection's name or labels",
                 "consumes": [
                     "application/json"
                 ],
@@ -1363,6 +1387,12 @@ const docTemplateadmin_api = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -2772,6 +2802,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -2863,6 +2899,12 @@ const docTemplateadmin_api = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2938,7 +2980,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update an existing connector's draft version, creating one if needed",
+                "description": "Update a connector-level name and/or its draft definition metadata",
                 "consumes": [
                     "application/json"
                 ],
@@ -2994,6 +3036,12 @@ const docTemplateadmin_api = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -3773,6 +3821,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -3996,7 +4050,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
                         }
                     }
                 ],
@@ -4806,6 +4860,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -4887,6 +4947,12 @@ const docTemplateadmin_api = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5066,6 +5132,12 @@ const docTemplateadmin_api = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5965,6 +6037,12 @@ const docTemplateadmin_api = `{
                         "type": "string",
                         "description": "Filter by namespace path pattern",
                         "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact final path segment",
+                        "name": "name",
                         "in": "query"
                     },
                     {
@@ -6967,6 +7045,12 @@ const docTemplateadmin_api = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -7048,6 +7132,12 @@ const docTemplateadmin_api = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -7246,7 +7336,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a rate limit's definition, labels, or annotations",
+                "description": "Update a rate limit's name, definition, labels, or annotations",
                 "consumes": [
                     "application/json"
                 ],
@@ -7296,6 +7386,12 @@ const docTemplateadmin_api = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -8100,6 +8196,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8151,6 +8251,10 @@ const docTemplateadmin_api = `{
                 "logo": {
                     "type": "string",
                     "example": "https://example.com/logo.png"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8229,6 +8333,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8268,6 +8376,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8413,6 +8525,10 @@ const docTemplateadmin_api = `{
                     "type": "string",
                     "example": "https://example.com/logo.png"
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8453,6 +8569,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8552,6 +8672,11 @@ const docTemplateadmin_api = `{
                     "type": "string",
                     "example": "root.acme"
                 },
+                "name": {
+                    "description": "Optional mutable name for the connection. Defaults to the generated connection ID.",
+                    "type": "string",
+                    "example": "production-crm"
+                },
                 "return_to_url": {
                     "description": "The URL to return to after the connection is completed.",
                     "type": "string",
@@ -8609,6 +8734,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8649,6 +8778,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 },
                 "namespace": {
                     "type": "string",
@@ -8717,6 +8850,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8750,6 +8887,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8796,6 +8937,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8821,6 +8966,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 },
                 "namespace": {
                     "type": "string",
@@ -8905,6 +9054,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
                 },
                 "namespace": {
                     "type": "string",
@@ -9150,6 +9303,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -9325,7 +9482,30 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a connector or connector version",
+            "description": "Request to update a logical connector",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {},
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                }
+            }
+        },
+        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
+            "description": "Request to update a connector definition version",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -9363,6 +9543,10 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "state": {
                     "type": "string",
                     "example": "disabled"
@@ -9388,6 +9572,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 }
             }
         },
@@ -9508,6 +9696,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 }
             }
         },
@@ -9526,6 +9718,10 @@ const docTemplateadmin_api = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -48,6 +48,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"
@@ -547,6 +553,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -1139,6 +1151,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -1226,6 +1244,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1301,7 +1325,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a connection's labels",
+                "description": "Update a connection's name or labels",
                 "consumes": [
                     "application/json"
                 ],
@@ -1357,6 +1381,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -2766,6 +2796,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -2857,6 +2893,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2932,7 +2974,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update an existing connector's draft version, creating one if needed",
+                "description": "Update a connector-level name and/or its draft definition metadata",
                 "consumes": [
                     "application/json"
                 ],
@@ -2988,6 +3030,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -3767,6 +3815,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -3990,7 +4044,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
                         }
                     }
                 ],
@@ -4800,6 +4854,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -4881,6 +4941,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5060,6 +5126,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5959,6 +6031,12 @@
                         "type": "string",
                         "description": "Filter by namespace path pattern",
                         "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact final path segment",
+                        "name": "name",
                         "in": "query"
                     },
                     {
@@ -6961,6 +7039,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -7042,6 +7126,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -7240,7 +7330,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a rate limit's definition, labels, or annotations",
+                "description": "Update a rate limit's name, definition, labels, or annotations",
                 "consumes": [
                     "application/json"
                 ],
@@ -7290,6 +7380,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -8094,6 +8190,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8145,6 +8245,10 @@
                 "logo": {
                     "type": "string",
                     "example": "https://example.com/logo.png"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8223,6 +8327,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8262,6 +8370,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8407,6 +8519,10 @@
                     "type": "string",
                     "example": "https://example.com/logo.png"
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8447,6 +8563,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8546,6 +8666,11 @@
                     "type": "string",
                     "example": "root.acme"
                 },
+                "name": {
+                    "description": "Optional mutable name for the connection. Defaults to the generated connection ID.",
+                    "type": "string",
+                    "example": "production-crm"
+                },
                 "return_to_url": {
                     "description": "The URL to return to after the connection is completed.",
                     "type": "string",
@@ -8603,6 +8728,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8643,6 +8772,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 },
                 "namespace": {
                     "type": "string",
@@ -8711,6 +8844,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8744,6 +8881,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8790,6 +8931,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8815,6 +8960,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 },
                 "namespace": {
                     "type": "string",
@@ -8899,6 +9048,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
                 },
                 "namespace": {
                     "type": "string",
@@ -9144,6 +9297,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -9319,7 +9476,30 @@
             }
         },
         "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a connector or connector version",
+            "description": "Request to update a logical connector",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {},
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                }
+            }
+        },
+        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
+            "description": "Request to update a connector definition version",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -9357,6 +9537,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "state": {
                     "type": "string",
                     "example": "disabled"
@@ -9382,6 +9566,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 }
             }
         },
@@ -9502,6 +9690,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 }
             }
         },
@@ -9520,6 +9712,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -6207,7 +6207,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a namespace's labels",
+                "description": "Update a namespace's labels and annotations. Its path and derived name cannot be changed.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8328,6 +8328,7 @@
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },
@@ -8729,6 +8730,7 @@
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -19,6 +19,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -55,6 +58,9 @@ definitions:
         type: object
       logo:
         example: https://example.com/logo.png
+        type: string
+      name:
+        example: salesforce
         type: string
       namespace:
         example: root.acme
@@ -110,6 +116,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: acme
+        type: string
       path:
         example: root.acme
         type: string
@@ -138,6 +147,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -243,6 +255,9 @@ definitions:
       logo:
         example: https://example.com/logo.png
         type: string
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -272,6 +287,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -346,6 +364,11 @@ definitions:
           namespace. Defaults to the connector namespace if not specified.
         example: root.acme
         type: string
+      name:
+        description: Optional mutable name for the connection. Defaults to the generated
+          connection ID.
+        example: production-crm
+        type: string
       return_to_url:
         description: The URL to return to after the connection is completed.
         example: https://example.com/callback
@@ -385,6 +408,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: acme
+        type: string
       path:
         example: root.acme
         type: string
@@ -414,6 +440,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: production-crm
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -461,6 +490,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -485,6 +517,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -516,6 +551,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -534,6 +572,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -594,6 +635,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -765,6 +809,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -889,7 +936,23 @@ definitions:
         type: string
     type: object
   routes.OpenAPIUpdateConnectorRequestJson:
-    description: Request to update a connector or connector version
+    description: Request to update a logical connector
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition: {}
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      name:
+        example: salesforce
+        type: string
+    type: object
+  routes.OpenAPIUpdateConnectorVersionRequestJson:
+    description: Request to update a connector definition version
     properties:
       annotations:
         additionalProperties:
@@ -915,6 +978,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       state:
         example: disabled
         type: string
@@ -933,6 +999,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
     type: object
   routes.ProxyRequest:
     description: Request to proxy or simulate an HTTP request
@@ -1018,6 +1087,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
     type: object
   routes.UpdateConnectionRequestJson:
     description: Request to update a connection's labels and annotations
@@ -1030,6 +1102,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: production-crm
+        type: string
     type: object
   routes.UpdateNamespaceRequestJson:
     description: Namespace update request
@@ -1069,6 +1144,10 @@ paths:
       - description: Filter by external ID
         in: query
         name: external_id
+        type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
         type: string
       - description: Filter by namespace
         in: query
@@ -1261,6 +1340,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -1775,6 +1858,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -1834,6 +1921,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -1885,7 +1976,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a connection's labels
+      description: Update a connection's name or labels
       parameters:
       - description: Connection UUID
         in: path
@@ -1919,6 +2010,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -2841,6 +2936,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -2903,6 +3002,10 @@ paths:
           description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -2954,7 +3057,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update an existing connector's draft version, creating one if needed
+      description: Update a connector-level name and/or its draft definition metadata
       parameters:
       - description: Connector UUID
         in: path
@@ -2988,6 +3091,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -3494,6 +3601,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -3641,7 +3752,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson'
       produces:
       - application/json
       responses:
@@ -4172,6 +4283,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -4228,6 +4343,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4343,6 +4462,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4922,6 +5045,10 @@ paths:
       - description: Filter by namespace path pattern
         in: query
         name: namespace
+        type: string
+      - description: Filter by exact final path segment
+        in: query
+        name: name
         type: string
       - description: Filter by label selector
         in: query
@@ -5566,6 +5693,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -5622,6 +5753,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -5754,7 +5889,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a rate limit's definition, labels, or annotations
+      description: Update a rate limit's name, definition, labels, or annotations
       parameters:
       - description: Rate limit ID
         in: path
@@ -5784,6 +5919,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -117,6 +117,8 @@ definitions:
           type: string
         type: object
       name:
+        description: Name is automatically set to the final segment of Path and cannot
+          be changed.
         example: acme
         type: string
       path:
@@ -409,6 +411,8 @@ definitions:
           type: string
         type: object
       name:
+        description: Name is automatically set to the final segment of Path and cannot
+          be changed.
         example: acme
         type: string
       path:
@@ -5163,7 +5167,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a namespace's labels
+      description: Update a namespace's labels and annotations. Its path and derived
+        name cannot be changed.
       parameters:
       - description: Namespace path
         in: path

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -6213,7 +6213,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a namespace's labels",
+                "description": "Update a namespace's labels and annotations. Its path and derived name cannot be changed.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8334,6 +8334,7 @@ const docTemplateApi = `{
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },
@@ -8735,6 +8736,7 @@ const docTemplateApi = `{
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -54,6 +54,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"
@@ -553,6 +559,12 @@ const docTemplateApi = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -1145,6 +1157,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -1232,6 +1250,12 @@ const docTemplateApi = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1307,7 +1331,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a connection's labels",
+                "description": "Update a connection's name or labels",
                 "consumes": [
                     "application/json"
                 ],
@@ -1363,6 +1387,12 @@ const docTemplateApi = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -2772,6 +2802,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -2863,6 +2899,12 @@ const docTemplateApi = `{
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2938,7 +2980,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update an existing connector's draft version, creating one if needed",
+                "description": "Update a connector-level name and/or its draft definition metadata",
                 "consumes": [
                     "application/json"
                 ],
@@ -2994,6 +3036,12 @@ const docTemplateApi = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -3773,6 +3821,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -3996,7 +4050,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
                         }
                     }
                 ],
@@ -4806,6 +4860,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -4887,6 +4947,12 @@ const docTemplateApi = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5066,6 +5132,12 @@ const docTemplateApi = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5965,6 +6037,12 @@ const docTemplateApi = `{
                         "type": "string",
                         "description": "Filter by namespace path pattern",
                         "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact final path segment",
+                        "name": "name",
                         "in": "query"
                     },
                     {
@@ -6967,6 +7045,12 @@ const docTemplateApi = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -7048,6 +7132,12 @@ const docTemplateApi = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -7246,7 +7336,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a rate limit's definition, labels, or annotations",
+                "description": "Update a rate limit's name, definition, labels, or annotations",
                 "consumes": [
                     "application/json"
                 ],
@@ -7296,6 +7386,12 @@ const docTemplateApi = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -8100,6 +8196,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8151,6 +8251,10 @@ const docTemplateApi = `{
                 "logo": {
                     "type": "string",
                     "example": "https://example.com/logo.png"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8229,6 +8333,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8268,6 +8376,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8413,6 +8525,10 @@ const docTemplateApi = `{
                     "type": "string",
                     "example": "https://example.com/logo.png"
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8453,6 +8569,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8552,6 +8672,11 @@ const docTemplateApi = `{
                     "type": "string",
                     "example": "root.acme"
                 },
+                "name": {
+                    "description": "Optional mutable name for the connection. Defaults to the generated connection ID.",
+                    "type": "string",
+                    "example": "production-crm"
+                },
                 "return_to_url": {
                     "description": "The URL to return to after the connection is completed.",
                     "type": "string",
@@ -8609,6 +8734,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8649,6 +8778,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 },
                 "namespace": {
                     "type": "string",
@@ -8717,6 +8850,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8750,6 +8887,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8796,6 +8937,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8821,6 +8966,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 },
                 "namespace": {
                     "type": "string",
@@ -8905,6 +9054,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
                 },
                 "namespace": {
                     "type": "string",
@@ -9150,6 +9303,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -9325,7 +9482,30 @@ const docTemplateApi = `{
             }
         },
         "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a connector or connector version",
+            "description": "Request to update a logical connector",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {},
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                }
+            }
+        },
+        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
+            "description": "Request to update a connector definition version",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -9363,6 +9543,10 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "state": {
                     "type": "string",
                     "example": "disabled"
@@ -9388,6 +9572,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 }
             }
         },
@@ -9508,6 +9696,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 }
             }
         },
@@ -9526,6 +9718,10 @@ const docTemplateApi = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -48,6 +48,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by namespace",
                         "name": "namespace",
                         "in": "query"
@@ -547,6 +553,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -1139,6 +1151,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -1226,6 +1244,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1301,7 +1325,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a connection's labels",
+                "description": "Update a connection's name or labels",
                 "consumes": [
                     "application/json"
                 ],
@@ -1357,6 +1381,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -2766,6 +2796,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -2857,6 +2893,12 @@
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2932,7 +2974,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update an existing connector's draft version, creating one if needed",
+                "description": "Update a connector-level name and/or its draft definition metadata",
                 "consumes": [
                     "application/json"
                 ],
@@ -2988,6 +3030,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -3767,6 +3815,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -3990,7 +4044,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
                         }
                     }
                 ],
@@ -4800,6 +4854,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact resource name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -4881,6 +4941,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5060,6 +5126,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -5959,6 +6031,12 @@
                         "type": "string",
                         "description": "Filter by namespace path pattern",
                         "name": "namespace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact final path segment",
+                        "name": "name",
                         "in": "query"
                     },
                     {
@@ -6961,6 +7039,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by exact name",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by label selector",
                         "name": "label_selector",
                         "in": "query"
@@ -7042,6 +7126,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -7240,7 +7330,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a rate limit's definition, labels, or annotations",
+                "description": "Update a rate limit's name, definition, labels, or annotations",
                 "consumes": [
                     "application/json"
                 ],
@@ -7290,6 +7380,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/routes.ErrorResponse"
                         }
@@ -8094,6 +8190,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8145,6 +8245,10 @@
                 "logo": {
                     "type": "string",
                     "example": "https://example.com/logo.png"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8223,6 +8327,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8262,6 +8370,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8407,6 +8519,10 @@
                     "type": "string",
                     "example": "https://example.com/logo.png"
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8447,6 +8563,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 },
                 "namespace": {
                     "type": "string",
@@ -8546,6 +8666,11 @@
                     "type": "string",
                     "example": "root.acme"
                 },
+                "name": {
+                    "description": "Optional mutable name for the connection. Defaults to the generated connection ID.",
+                    "type": "string",
+                    "example": "production-crm"
+                },
                 "return_to_url": {
                     "description": "The URL to return to after the connection is completed.",
                     "type": "string",
@@ -8603,6 +8728,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "acme"
+                },
                 "path": {
                     "type": "string",
                     "example": "root.acme"
@@ -8643,6 +8772,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 },
                 "namespace": {
                     "type": "string",
@@ -8711,6 +8844,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8744,6 +8881,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
                 },
                 "namespace": {
                     "type": "string",
@@ -8790,6 +8931,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -8815,6 +8960,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 },
                 "namespace": {
                     "type": "string",
@@ -8899,6 +9048,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
                 },
                 "namespace": {
                     "type": "string",
@@ -9144,6 +9297,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
+                },
                 "namespace": {
                     "type": "string",
                     "example": "root.acme"
@@ -9319,7 +9476,30 @@
             }
         },
         "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a connector or connector version",
+            "description": "Request to update a logical connector",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "definition": {},
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "salesforce"
+                }
+            }
+        },
+        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
+            "description": "Request to update a connector definition version",
             "type": "object",
             "properties": {
                 "annotations": {
@@ -9357,6 +9537,10 @@
                         "type": "string"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "primary-encryption-key"
+                },
                 "state": {
                     "type": "string",
                     "example": "disabled"
@@ -9382,6 +9566,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "public-api"
                 }
             }
         },
@@ -9502,6 +9690,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
                 }
             }
         },
@@ -9520,6 +9712,10 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production-crm"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -6207,7 +6207,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update a namespace's labels",
+                "description": "Update a namespace's labels and annotations. Its path and derived name cannot be changed.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8328,6 +8328,7 @@
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },
@@ -8729,6 +8730,7 @@
                     }
                 },
                 "name": {
+                    "description": "Name is automatically set to the final segment of Path and cannot be changed.",
                     "type": "string",
                     "example": "acme"
                 },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -19,6 +19,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -55,6 +58,9 @@ definitions:
         type: object
       logo:
         example: https://example.com/logo.png
+        type: string
+      name:
+        example: salesforce
         type: string
       namespace:
         example: root.acme
@@ -110,6 +116,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: acme
+        type: string
       path:
         example: root.acme
         type: string
@@ -138,6 +147,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -243,6 +255,9 @@ definitions:
       logo:
         example: https://example.com/logo.png
         type: string
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -272,6 +287,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -346,6 +364,11 @@ definitions:
           namespace. Defaults to the connector namespace if not specified.
         example: root.acme
         type: string
+      name:
+        description: Optional mutable name for the connection. Defaults to the generated
+          connection ID.
+        example: production-crm
+        type: string
       return_to_url:
         description: The URL to return to after the connection is completed.
         example: https://example.com/callback
@@ -385,6 +408,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: acme
+        type: string
       path:
         example: root.acme
         type: string
@@ -414,6 +440,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: production-crm
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -461,6 +490,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -485,6 +517,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: salesforce
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -516,6 +551,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -534,6 +572,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -594,6 +635,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -765,6 +809,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
       namespace:
         example: root.acme
         type: string
@@ -889,7 +936,23 @@ definitions:
         type: string
     type: object
   routes.OpenAPIUpdateConnectorRequestJson:
-    description: Request to update a connector or connector version
+    description: Request to update a logical connector
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        type: object
+      definition: {}
+      labels:
+        additionalProperties:
+          type: string
+        type: object
+      name:
+        example: salesforce
+        type: string
+    type: object
+  routes.OpenAPIUpdateConnectorVersionRequestJson:
+    description: Request to update a connector definition version
     properties:
       annotations:
         additionalProperties:
@@ -915,6 +978,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: primary-encryption-key
+        type: string
       state:
         example: disabled
         type: string
@@ -933,6 +999,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: public-api
+        type: string
     type: object
   routes.ProxyRequest:
     description: Request to proxy or simulate an HTTP request
@@ -1018,6 +1087,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: billing-service
+        type: string
     type: object
   routes.UpdateConnectionRequestJson:
     description: Request to update a connection's labels and annotations
@@ -1030,6 +1102,9 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      name:
+        example: production-crm
+        type: string
     type: object
   routes.UpdateNamespaceRequestJson:
     description: Namespace update request
@@ -1069,6 +1144,10 @@ paths:
       - description: Filter by external ID
         in: query
         name: external_id
+        type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
         type: string
       - description: Filter by namespace
         in: query
@@ -1261,6 +1340,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -1775,6 +1858,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -1834,6 +1921,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -1885,7 +1976,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a connection's labels
+      description: Update a connection's name or labels
       parameters:
       - description: Connection UUID
         in: path
@@ -1919,6 +2010,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -2841,6 +2936,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -2903,6 +3002,10 @@ paths:
           description: Forbidden
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -2954,7 +3057,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update an existing connector's draft version, creating one if needed
+      description: Update a connector-level name and/or its draft definition metadata
       parameters:
       - description: Connector UUID
         in: path
@@ -2988,6 +3091,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -3494,6 +3601,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -3641,7 +3752,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson'
       produces:
       - application/json
       responses:
@@ -4172,6 +4283,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact resource name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -4228,6 +4343,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4343,6 +4462,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -4922,6 +5045,10 @@ paths:
       - description: Filter by namespace path pattern
         in: query
         name: namespace
+        type: string
+      - description: Filter by exact final path segment
+        in: query
+        name: name
         type: string
       - description: Filter by label selector
         in: query
@@ -5566,6 +5693,10 @@ paths:
         in: query
         name: namespace
         type: string
+      - description: Filter by exact name
+        in: query
+        name: name
+        type: string
       - description: Filter by label selector
         in: query
         name: label_selector
@@ -5622,6 +5753,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":
@@ -5754,7 +5889,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a rate limit's definition, labels, or annotations
+      description: Update a rate limit's name, definition, labels, or annotations
       parameters:
       - description: Rate limit ID
         in: path
@@ -5784,6 +5919,10 @@ paths:
             $ref: '#/definitions/routes.ErrorResponse'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/routes.ErrorResponse'
         "500":

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -117,6 +117,8 @@ definitions:
           type: string
         type: object
       name:
+        description: Name is automatically set to the final segment of Path and cannot
+          be changed.
         example: acme
         type: string
       path:
@@ -409,6 +411,8 @@ definitions:
           type: string
         type: object
       name:
+        description: Name is automatically set to the final segment of Path and cannot
+          be changed.
         example: acme
         type: string
       path:
@@ -5163,7 +5167,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Update a namespace's labels
+      description: Update a namespace's labels and annotations. Its path and derived
+        name cannot be changed.
       parameters:
       - description: Namespace path
         in: path


### PR DESCRIPTION
## Summary

- expose names when creating, retrieving, updating, and listing actors, connections, connectors, keys, rate limits, and namespaces
- keep one logical connector name across versions and derive namespace names from the final path segment
- add exact name filtering with cursor pagination and namespace authorization constraints
- normalize SQLite and PostgreSQL uniqueness conflicts to stable HTTP 409 responses
- regenerate the public API documentation and add provider-level and route-level coverage

## Testing

- full Go test suite with SQLite
- database resource-name tests with PostgreSQL
- focused resource-name route tests with SQLite and PostgreSQL
- ./scripts/preflight.sh

Closes #773