### PR TITLE
Add implicit resource name labels

### DIFF
--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -3,11 +3,13 @@ package core
 import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 type IActorData interface {
 	GetId() apid.ID
+	GetName() scommon.ResourceName
 	GetExternalId() string
 	GetPermissions() []aschema.Permission
 	GetNamespace() string
@@ -22,6 +24,7 @@ type Actor struct {
 	// how the JWT is structured.
 
 	Id          apid.ID              `json:"-"` // This is the database ID of the actor. It cannot be set in the JWT directly.
+	Name        scommon.ResourceName `json:"name,omitempty"`
 	ExternalId  string               `json:"external_id"`
 	Namespace   string               `json:"namespace,omitempty"`
 	Labels      map[string]string    `json:"labels,omitempty"`
@@ -31,6 +34,13 @@ type Actor struct {
 
 func (a *Actor) GetId() apid.ID {
 	return a.Id
+}
+
+func (a *Actor) GetName() scommon.ResourceName {
+	if a.Name == "" && !a.Id.IsNil() {
+		return scommon.ResourceName(a.Id.String())
+	}
+	return a.Name
 }
 
 func (a *Actor) GetExternalId() string {
@@ -87,14 +97,16 @@ func CreateActor(data IActorData) *Actor {
 		return a
 	}
 
-	return &Actor{
+	actor := &Actor{
 		Id:          data.GetId(),
+		Name:        data.GetName(),
 		ExternalId:  data.GetExternalId(),
 		Namespace:   data.GetNamespace(),
 		Labels:      data.GetLabels(),
 		Annotations: data.GetAnnotations(),
 		Permissions: data.GetPermissions(),
 	}
+	return actor
 }
 
 var _ IActorData = &Actor{}

--- a/internal/apauth/core/actor_test.go
+++ b/internal/apauth/core/actor_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/apid"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +23,13 @@ func TestActor(t *testing.T) {
 
 		u.Namespace = "test-namespace"
 		assert.Equal(t, "test-namespace", u.GetNamespace())
+	})
+	t.Run("GetName", func(t *testing.T) {
+		u := Actor{Id: apid.MustParse("act_test1234567890ab")}
+		assert.Equal(t, scommon.ResourceName("act_test1234567890ab"), u.GetName())
+
+		u.Name = "billing-user"
+		assert.Equal(t, scommon.ResourceName("billing-user"), u.GetName())
 	})
 	t.Run("GetLabels", func(t *testing.T) {
 		u := Actor{}

--- a/internal/auth_methods/oauth2/interface.go
+++ b/internal/auth_methods/oauth2/interface.go
@@ -8,11 +8,13 @@ import (
 	"github.com/rmorlok/authproxy/internal/auth_methods"
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 type IActorData interface {
 	GetId() apid.ID
+	GetName() scommon.ResourceName
 	GetExternalId() string
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string

--- a/internal/auth_methods/oauth2/mock/oauth2.go
+++ b/internal/auth_methods/oauth2/mock/oauth2.go
@@ -15,6 +15,7 @@ import (
 	oauth2 "github.com/rmorlok/authproxy/internal/auth_methods/oauth2"
 	iface "github.com/rmorlok/authproxy/internal/core/iface"
 	auth "github.com/rmorlok/authproxy/internal/schema/auth"
+	common "github.com/rmorlok/authproxy/internal/schema/common"
 	connectors "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
@@ -39,6 +40,20 @@ func NewMockIActorData(ctrl *gomock.Controller) *MockIActorData {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIActorData) EXPECT() *MockIActorDataMockRecorder {
 	return m.recorder
+}
+
+// GetAnnotations mocks base method.
+func (m *MockIActorData) GetAnnotations() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnnotations")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetAnnotations indicates an expected call of GetAnnotations.
+func (mr *MockIActorDataMockRecorder) GetAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockIActorData)(nil).GetAnnotations))
 }
 
 // GetExternalId mocks base method.
@@ -83,18 +98,18 @@ func (mr *MockIActorDataMockRecorder) GetLabels() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabels", reflect.TypeOf((*MockIActorData)(nil).GetLabels))
 }
 
-// GetAnnotations mocks base method.
-func (m *MockIActorData) GetAnnotations() map[string]string {
+// GetName mocks base method.
+func (m *MockIActorData) GetName() common.ResourceName {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAnnotations")
-	ret0, _ := ret[0].(map[string]string)
+	ret := m.ctrl.Call(m, "GetName")
+	ret0, _ := ret[0].(common.ResourceName)
 	return ret0
 }
 
-// GetAnnotations indicates an expected call of GetAnnotations.
-func (mr *MockIActorDataMockRecorder) GetAnnotations() *gomock.Call {
+// GetName indicates an expected call of GetName.
+func (mr *MockIActorDataMockRecorder) GetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockIActorData)(nil).GetAnnotations))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockIActorData)(nil).GetName))
 }
 
 // GetNamespace mocks base method.

--- a/internal/auth_methods/oauth2/mustache_test.go
+++ b/internal/auth_methods/oauth2/mustache_test.go
@@ -583,6 +583,7 @@ type mockActorData struct {
 }
 
 func (m *mockActorData) GetId() apid.ID                       { return m.id }
+func (m *mockActorData) GetName() common.ResourceName         { return common.ResourceName(m.id.String()) }
 func (m *mockActorData) GetExternalId() string                { return "ext-123" }
 func (m *mockActorData) GetLabels() map[string]string         { return nil }
 func (m *mockActorData) GetAnnotations() map[string]string    { return nil }

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,7 @@ type stateTestActor struct {
 }
 
 func (a stateTestActor) GetId() apid.ID                       { return a.id }
+func (a stateTestActor) GetName() scommon.ResourceName        { return scommon.ResourceName(a.id.String()) }
 func (a stateTestActor) GetExternalId() string                { return "" }
 func (a stateTestActor) GetLabels() map[string]string         { return nil }
 func (a stateTestActor) GetAnnotations() map[string]string    { return nil }

--- a/internal/core/service_connector_version_create.go
+++ b/internal/core/service_connector_version_create.go
@@ -51,6 +51,7 @@ func (s *service) UpdateConnectorName(ctx context.Context, id apid.ID, name scom
 		}
 		return err
 	}
+	s.enqueueConnectorLabelPropagation(ctx, id)
 	return nil
 }
 

--- a/internal/core/service_connector_version_create_test.go
+++ b/internal/core/service_connector_version_create_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/core/mock"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +81,29 @@ func TestCreateConnectorVersion(t *testing.T) {
 		_, err := s.CreateConnectorVersion(ctx, "root", "", definition, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to upsert connector version")
+	})
+}
+
+func TestUpdateConnectorName(t *testing.T) {
+	t.Run("enqueues connection label propagation", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s, db, _, _, ac, _ := FullMockService(t, ctrl)
+		id := apid.MustParse("cxr_testrename000001")
+
+		db.EXPECT().UpdateConnectorName(gomock.Any(), id, scommon.ResourceName("renamed")).Return(nil)
+		ac.EXPECT().EnqueueContext(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+		require.NoError(t, s.UpdateConnectorName(context.Background(), id, "renamed"))
+	})
+
+	t.Run("does not enqueue after database failure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s, db, _, _, _, _ := FullMockService(t, ctrl)
+		id := apid.MustParse("cxr_testrename000002")
+
+		db.EXPECT().UpdateConnectorName(gomock.Any(), id, scommon.ResourceName("renamed")).Return(database.ErrNotFound)
+
+		require.ErrorIs(t, s.UpdateConnectorName(context.Background(), id, "renamed"), ErrNotFound)
 	})
 }
 

--- a/internal/core/service_key.go
+++ b/internal/core/service_key.go
@@ -69,7 +69,7 @@ func (s *service) UpdateKeyName(ctx context.Context, id apid.ID, name common.Res
 	if err := name.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid key name: %w", err)
 	}
-	ek, err := s.db.UpdateKey(ctx, id, map[string]interface{}{"name": name})
+	ek, err := s.db.UpdateKeyName(ctx, id, name)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return nil, ErrNotFound

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -422,7 +422,7 @@ func (s *service) CreateActor(ctx context.Context, a *Actor) error {
 			cpy.Labels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
+		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Name, cpy.Namespace, cpy.Labels)
 		now := apctx.GetClock(ctx).Now()
 		cpy.CreatedAt = now
 		cpy.UpdatedAt = now
@@ -514,7 +514,7 @@ func (s *service) UpsertActor(ctx context.Context, d IActorData) (*Actor, error)
 					newActor.Labels,
 					ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 				)
-				newActor.Labels = InjectSelfImplicitLabels(newActor.Id, newActor.Namespace, newActor.Labels)
+				newActor.Labels = InjectSelfImplicitLabels(newActor.Id, newActor.Name, newActor.Namespace, newActor.Labels)
 				validationErr := newActor.validate()
 				if validationErr != nil {
 					return validationErr
@@ -609,25 +609,8 @@ func (s *service) UpdateActorName(ctx context.Context, id apid.ID, name scommon.
 		return nil, fmt.Errorf("invalid actor name: %w", err)
 	}
 
-	result, err := s.sq.
-		Update(ActorTable).
-		Set("name", name).
-		Set("updated_at", apctx.GetClock(ctx).Now()).
-		Where(sq.Eq{"id": id, "deleted_at": nil}).
-		RunWith(s.db).
-		ExecContext(ctx)
-	if err != nil {
-		return nil, wrapDatabaseMutationError("failed to update actor name", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to update actor name: %w", err)
-	}
-	if affected == 0 {
-		return nil, ErrNotFound
-	}
-	if affected > 1 {
-		return nil, fmt.Errorf("multiple actors were renamed: %w", ErrViolation)
+	if err := s.updateResourceNameAndSelfLabels(ctx, ActorTable, id, name); err != nil {
+		return nil, err
 	}
 	return s.GetActor(ctx, id)
 }

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -296,7 +296,7 @@ func (s *service) CreateConnection(ctx context.Context, c *Connection) error {
 			ParentCarryForward{Rt: ApidPrefixToLabelToken(apid.PrefixConnectorVersion), Labels: cvLabels},
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Namespace, cpy.Labels)
+		cpy.Labels = InjectSelfImplicitLabels(cpy.Id, cpy.Name, cpy.Namespace, cpy.Labels)
 
 		now := apctx.GetClock(ctx).Now()
 		cpy.CreatedAt = now
@@ -357,25 +357,8 @@ func (s *service) UpdateConnectionName(ctx context.Context, id apid.ID, name sco
 		return nil, fmt.Errorf("invalid connection name: %w", err)
 	}
 
-	result, err := s.sq.
-		Update(ConnectionsTable).
-		Set("name", name).
-		Set("updated_at", apctx.GetClock(ctx).Now()).
-		Where(sq.Eq{"id": id, "deleted_at": nil}).
-		RunWith(s.db).
-		ExecContext(ctx)
-	if err != nil {
-		return nil, wrapDatabaseMutationError("failed to update connection name", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to update connection name: %w", err)
-	}
-	if affected == 0 {
-		return nil, ErrNotFound
-	}
-	if affected > 1 {
-		return nil, fmt.Errorf("multiple connections were renamed: %w", ErrViolation)
+	if err := s.updateResourceNameAndSelfLabels(ctx, ConnectionsTable, id, name); err != nil {
+		return nil, err
 	}
 	return s.GetConnection(ctx, id)
 }
@@ -670,7 +653,7 @@ func (s *service) UpdateConnectionForVersionMigration(ctx context.Context, updat
 			ParentCarryForward{Rt: ApidPrefixToLabelToken(apid.PrefixConnectorVersion), Labels: cvLabels},
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(update.Id, existing.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(update.Id, existing.Name, existing.Namespace, newLabels)
 
 		now := apctx.GetClock(ctx).Now()
 		healthState := existing.HealthState

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -618,6 +618,7 @@ func TestConnections(t *testing.T) {
 			assert.False(t, exists)
 			// apxy/ self-implicit labels are preserved across user-driven updates.
 			assert.Equal(t, string(u), apxyLabels["apxy/cxn/-/id"])
+			assert.Equal(t, string(u), apxyLabels["apxy/cxn/-/name"])
 			assert.Equal(t, "root.some-namespace", apxyLabels["apxy/cxn/-/ns"])
 			assert.Equal(t, newNow, c.UpdatedAt)
 		})

--- a/internal/database/connector.go
+++ b/internal/database/connector.go
@@ -118,7 +118,7 @@ func (s *service) ensureConnectorForDefinition(
 		labels := existing.Labels
 		if cv.Labels != nil {
 			labels = MergeUpsertLabels(cv.Labels, existing.Labels)
-			labels = InjectSelfImplicitLabels(existing.Id, existing.Namespace, labels)
+			labels = InjectSelfImplicitLabels(existing.Id, existing.Name, existing.Namespace, labels)
 		}
 		annotations := existing.Annotations
 		if cv.Annotations != nil {
@@ -160,7 +160,7 @@ func (s *service) ensureConnectorForDefinition(
 		cv.Labels,
 		ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 	)
-	labels = InjectSelfImplicitLabels(cv.Id, cv.Namespace, labels)
+	labels = InjectSelfImplicitLabels(cv.Id, name, cv.Namespace, labels)
 
 	now := apctx.GetClock(ctx).Now()
 	connector := Connector{
@@ -205,25 +205,5 @@ func (s *service) UpdateConnectorName(ctx context.Context, id apid.ID, name scom
 		return fmt.Errorf("invalid connector name: %w", err)
 	}
 
-	result, err := s.sq.
-		Update(ConnectorsTable).
-		Set("name", name).
-		Set("updated_at", apctx.GetClock(ctx).Now()).
-		Where(sq.Eq{"id": id, "deleted_at": nil}).
-		RunWith(s.db).
-		ExecContext(ctx)
-	if err != nil {
-		return wrapDatabaseMutationError("failed to update connector name", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to update connector name: %w", err)
-	}
-	if affected == 0 {
-		return ErrNotFound
-	}
-	if affected > 1 {
-		return fmt.Errorf("multiple connectors were renamed: %w", ErrViolation)
-	}
-	return nil
+	return s.updateResourceNameAndSelfLabels(ctx, ConnectorsTable, id, name)
 }

--- a/internal/database/connector_definition_version_test.go
+++ b/internal/database/connector_definition_version_test.go
@@ -877,6 +877,7 @@ INSERT INTO connector_definition_versions
 				Labels: Labels{
 					"type":            "t",
 					"apxy/cxr/source": "config",
+					"apxy/cxr/-/name": "caller-cannot-override",
 				},
 				EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("dek_test000000000001"), Data: "e1"},
 			})
@@ -888,6 +889,7 @@ INSERT INTO connector_definition_versions
 			require.Equal(t, "t", saved.Labels["type"])
 			// self-implicit labels still injected
 			require.Equal(t, string(connectorID), saved.Labels["apxy/cxr/-/id"])
+			require.Equal(t, string(connectorID), saved.Labels["apxy/cxr/-/name"])
 		})
 
 		t.Run("caller-supplied apxy labels override stored apxy on update", func(t *testing.T) {
@@ -926,6 +928,7 @@ INSERT INTO connector_definition_versions
 			require.Equal(t, "config", saved.Labels["apxy/cxr/source"], "caller's apxy value must override stored")
 			// self-implicit labels stay intact
 			require.Equal(t, string(connectorID), saved.Labels["apxy/cxr/-/id"])
+			require.Equal(t, string(connectorID), saved.Labels["apxy/cxr/-/name"])
 		})
 
 		t.Run("stored apxy labels not in caller are preserved on update", func(t *testing.T) {

--- a/internal/database/connector_test.go
+++ b/internal/database/connector_test.go
@@ -46,6 +46,7 @@ func TestConnectorNameDefaultsAndProjectsAcrossVersions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, scommon.ResourceName(id.String()), first.Name)
 	require.Equal(t, first.Name, second.Name)
+	require.Equal(t, id.String(), first.Labels["apxy/cxr/-/name"])
 
 	versions := db.ListConnectorDefinitionVersionsBuilder().ForId(id).FetchPage(ctx)
 	require.NoError(t, versions.Error)
@@ -74,6 +75,7 @@ func TestConnectorRenameDoesNotRewriteVersions(t *testing.T) {
 		projected, err := db.GetConnectorDefinitionVersion(ctx, id, version)
 		require.NoError(t, err)
 		require.Equal(t, scommon.ResourceName("renamed"), projected.Name)
+		require.Equal(t, "renamed", projected.Labels["apxy/cxr/-/name"])
 	}
 
 	renamedDefinitions := connectorDefinitionPayloads(t, rawDB, id)
@@ -165,6 +167,9 @@ func TestConnectorNameExactListPaginationAndNamespaceRestrictions(t *testing.T) 
 
 	err = db.UpdateConnectorName(ctx, otherID, "shared")
 	require.ErrorIs(t, err, ErrDuplicate)
+	unchanged, getErr := db.GetConnectorDefinitionVersion(ctx, otherID, 1)
+	require.NoError(t, getErr)
+	require.Equal(t, "other", unchanged.Labels["apxy/cxr/-/name"])
 }
 
 func TestConnectorDefinitionVersionLifecyclePreservesName(t *testing.T) {

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -206,6 +206,7 @@ type DB interface {
 
 	GetKey(ctx context.Context, id apid.ID) (*Key, error)
 	CreateKey(ctx context.Context, ek *Key) error
+	UpdateKeyName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Key, error)
 	UpdateKey(ctx context.Context, id apid.ID, updates map[string]interface{}) (*Key, error)
 	DeleteKey(ctx context.Context, id apid.ID) error
 	SetKeyState(ctx context.Context, id apid.ID, state KeyState) error

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -268,7 +268,7 @@ func (s *service) CreateKey(ctx context.Context, ek *Key) error {
 			ek.Labels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		ek.Labels = InjectSelfImplicitLabels(ek.Id, ek.Namespace, ek.Labels)
+		ek.Labels = InjectSelfImplicitLabels(ek.Id, ek.Name, ek.Namespace, ek.Labels)
 		now := apctx.GetClock(ctx).Now()
 		ek.CreatedAt = now
 		ek.UpdatedAt = now
@@ -322,6 +322,24 @@ func (s *service) UpdateKey(ctx context.Context, id apid.ID, updates map[string]
 		return nil, ErrNotFound
 	}
 
+	return s.GetKey(ctx, id)
+}
+
+// UpdateKeyName renames one live key and refreshes its self-implicit name
+// label without changing its immutable ID.
+func (s *service) UpdateKeyName(ctx context.Context, id apid.ID, name scommon.ResourceName) (*Key, error) {
+	if id.IsNil() {
+		return nil, errors.New("key id is required")
+	}
+	if err := id.ValidatePrefix(apid.PrefixKey); err != nil {
+		return nil, fmt.Errorf("invalid key id: %w", err)
+	}
+	if err := name.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid key name: %w", err)
+	}
+	if err := s.updateResourceNameAndSelfLabels(ctx, KeysTable, id, name); err != nil {
+		return nil, err
+	}
 	return s.GetKey(ctx, id)
 }
 

--- a/internal/database/key_test.go
+++ b/internal/database/key_test.go
@@ -158,12 +158,14 @@ func TestKey(t *testing.T) {
 		updatedUser, _ := SplitUserAndApxyLabels(updated.Labels)
 		require.Equal(t, Labels{"new-label": "value"}, updatedUser)
 		require.Equal(t, string(ek.Id), updated.Labels["apxy/key/-/id"])
+		require.Equal(t, string(ek.Id), updated.Labels["apxy/key/-/name"])
 
 		// DeleteLabels
 		updated, err = db.DeleteKeyLabels(ctx, ek.Id, []string{"new-label"})
 		require.NoError(t, err)
 		updatedUser, _ = SplitUserAndApxyLabels(updated.Labels)
 		require.Empty(t, updatedUser)
+		require.Equal(t, string(ek.Id), updated.Labels["apxy/key/-/name"])
 	})
 
 	t.Run("Annotations", func(t *testing.T) {

--- a/internal/database/labels.go
+++ b/internal/database/labels.go
@@ -15,6 +15,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 // Kubernetes-style label restrictions
@@ -69,10 +72,11 @@ var (
 	// implicit identifier labels (e.g. apxy/cxr/-/id).
 	apxyPathSegmentRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|-)$`)
 
-	// apxyLabelValueRegex matches the same character classes as labelValueRegex
-	// but allows up to ApxyLabelValueMaxLength characters total. Used for
-	// system-managed apxy/-prefixed values such as namespace paths.
-	apxyLabelValueRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9._-]{0,251}[a-zA-Z0-9])?)?$|^[a-zA-Z0-9]?$`)
+	// apxyLabelValueRegex accepts the trusted system-value character set and
+	// allows leading/trailing underscores or hyphens used by the established
+	// namespace-segment grammar. User label values retain the stricter
+	// Kubernetes-style boundary rules.
+	apxyLabelValueRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,253}$`)
 )
 
 // Labels is a map of key-value pairs following Kubernetes label restrictions.
@@ -254,15 +258,15 @@ func ValidateLabelValue(value string) error {
 
 // ValidateApxyLabelValue validates a label value stored under an apxy/-prefixed
 // key. It allows up to ApxyLabelValueMaxLength characters so namespace paths
-// (e.g. root.foo.bar.baz...) can fit. Character rules are otherwise the same
-// as ValidateLabelValue.
+// (e.g. root.foo.bar.baz...) can fit, including the leading underscores and
+// trailing hyphens accepted in namespace path segments.
 func ValidateApxyLabelValue(value string) error {
 	if len(value) > ApxyLabelValueMaxLength {
 		return fmt.Errorf("apxy label value exceeds maximum length of %d characters", ApxyLabelValueMaxLength)
 	}
 
 	if value != "" && !apxyLabelValueRegex.MatchString(value) {
-		return fmt.Errorf("apxy label value %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", value)
+		return fmt.Errorf("apxy label value %q may contain only alphanumeric characters, '-', '_', or '.'", value)
 	}
 
 	return nil
@@ -555,32 +559,36 @@ func ApidPrefixToLabelToken(p apid.Prefix) string {
 	return strings.TrimSuffix(string(p), "_")
 }
 
-// BuildImplicitIdentifierLabelsForToken builds the apxy/<rt>/-/id and
-// apxy/<rt>/-/ns implicit identifier labels for any resource type, keyed by
-// the supplied <rt> token and identifier string. This is the underlying
-// builder used by both apid-keyed and path-keyed resources.
-func BuildImplicitIdentifierLabelsForToken(rt, id, namespacePath string) Labels {
+// BuildImplicitResourceLabelsForToken builds the apxy/<rt>/-/id,
+// apxy/<rt>/-/name, and apxy/<rt>/-/ns implicit identity labels for any
+// resource type, keyed by the supplied <rt> token and identifier string. This
+// is the underlying builder used by both apid-keyed and path-keyed resources.
+func BuildImplicitResourceLabelsForToken(rt, id string, name scommon.ResourceName, namespacePath string) Labels {
 	if rt == "" || id == "" {
 		return nil
 	}
+	if name == "" {
+		name = scommon.ResourceName(id)
+	}
 	return Labels{
-		fmt.Sprintf("%s%s/%s/id", ApxyReservedPrefix, rt, ApxyImplicitSegment): id,
-		fmt.Sprintf("%s%s/%s/ns", ApxyReservedPrefix, rt, ApxyImplicitSegment): namespacePath,
+		fmt.Sprintf("%s%s/%s/id", ApxyReservedPrefix, rt, ApxyImplicitSegment):   id,
+		fmt.Sprintf("%s%s/%s/name", ApxyReservedPrefix, rt, ApxyImplicitSegment): string(name),
+		fmt.Sprintf("%s%s/%s/ns", ApxyReservedPrefix, rt, ApxyImplicitSegment):   namespacePath,
 	}
 }
 
-// BuildNamespaceImplicitIdentifierLabels builds the self-implicit identifier
-// labels for a namespace. Both the -/id and -/ns labels carry the namespace's
-// own path (a namespace is its own namespace).
-func BuildNamespaceImplicitIdentifierLabels(path string) Labels {
-	return BuildImplicitIdentifierLabelsForToken(NamespaceLabelToken, path, path)
+// BuildNamespaceImplicitResourceLabels builds a namespace's self-implicit
+// identity labels. Both -/id and -/ns carry the namespace path, while -/name
+// carries the final path segment.
+func BuildNamespaceImplicitResourceLabels(path string) Labels {
+	return BuildImplicitResourceLabelsForToken(NamespaceLabelToken, path, namespace.NameFromPath(path), path)
 }
 
 // InjectNamespaceSelfImplicitLabels returns a copy of existing with a
-// namespace's own apxy/ns/-/id and apxy/ns/-/ns labels added. Mirrors
+// namespace's own apxy/ns/-/id, apxy/ns/-/name, and apxy/ns/-/ns labels added. Mirrors
 // InjectSelfImplicitLabels but for path-keyed namespace resources.
 func InjectNamespaceSelfImplicitLabels(path string, existing Labels) Labels {
-	implicit := BuildNamespaceImplicitIdentifierLabels(path)
+	implicit := BuildNamespaceImplicitResourceLabels(path)
 	if len(implicit) == 0 {
 		if existing == nil {
 			return nil
@@ -597,25 +605,23 @@ func InjectNamespaceSelfImplicitLabels(path string, existing Labels) Labels {
 	return out
 }
 
-// BuildImplicitIdentifierLabels returns the two implicit identifier labels
-// for an apid-keyed resource: apxy/<rt>/-/id and apxy/<rt>/-/ns, where <rt>
-// is derived from the resource's id prefix. The id and namespacePath are
-// stored as label values verbatim — callers must ensure they have already
-// been validated by their respective rules.
-func BuildImplicitIdentifierLabels(id apid.ID, namespacePath string) Labels {
+// BuildImplicitResourceLabels returns the three implicit identity labels for
+// an apid-keyed resource: apxy/<rt>/-/id, apxy/<rt>/-/name, and
+// apxy/<rt>/-/ns, where <rt> is derived from the resource's id prefix.
+func BuildImplicitResourceLabels(id apid.ID, name scommon.ResourceName, namespacePath string) Labels {
 	if id.IsNil() {
 		return nil
 	}
-	return BuildImplicitIdentifierLabelsForToken(ApidPrefixToLabelToken(id.Prefix()), string(id), namespacePath)
+	return BuildImplicitResourceLabelsForToken(ApidPrefixToLabelToken(id.Prefix()), string(id), name, namespacePath)
 }
 
 // InjectSelfImplicitLabels returns a copy of existing with the resource's own
-// apxy/<rt>/-/id and apxy/<rt>/-/ns labels added. The self-implicit labels
+// apxy/<rt>/-/id, apxy/<rt>/-/name, and apxy/<rt>/-/ns labels added. The self-implicit labels
 // override any same-keyed entries already in existing (deeper-overrides-
 // shallower across the carry-forward chain). Callers pass this to the create
-// path so the row is persisted with the implicit identifier labels in place.
-func InjectSelfImplicitLabels(id apid.ID, namespacePath string, existing Labels) Labels {
-	implicit := BuildImplicitIdentifierLabels(id, namespacePath)
+// path so the row is persisted with the implicit identity labels in place.
+func InjectSelfImplicitLabels(id apid.ID, name scommon.ResourceName, namespacePath string, existing Labels) Labels {
+	implicit := BuildImplicitResourceLabels(id, name, namespacePath)
 	if len(implicit) == 0 {
 		if existing == nil {
 			return nil
@@ -630,6 +636,59 @@ func InjectSelfImplicitLabels(id apid.ID, namespacePath string, existing Labels)
 		out[k] = v
 	}
 	return out
+}
+
+// updateResourceNameAndSelfLabels atomically updates a mutable resource name
+// and its self-implicit name label. PostgreSQL locks the row between the read
+// and write so a concurrent label mutation cannot be lost; SQLite serializes
+// the write transaction itself.
+func (s *service) updateResourceNameAndSelfLabels(
+	ctx context.Context,
+	table string,
+	id apid.ID,
+	name scommon.ResourceName,
+) error {
+	return s.transaction(func(tx *sql.Tx) error {
+		var namespacePath string
+		var labels Labels
+		query := s.sq.
+			Select("namespace", "labels").
+			From(table).
+			Where(sq.Eq{"id": id, "deleted_at": nil})
+		if s.cfg.GetProvider() == sconfig.DatabaseProviderPostgres {
+			query = query.Suffix("FOR UPDATE")
+		}
+		if err := query.RunWith(tx).QueryRowContext(ctx).Scan(&namespacePath, &labels); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to read %s before rename: %w", table, err)
+		}
+
+		labels = InjectSelfImplicitLabels(id, name, namespacePath, labels)
+		result, err := s.sq.
+			Update(table).
+			Set("name", name).
+			Set("labels", labels).
+			Set("updated_at", apctx.GetClock(ctx).Now()).
+			Where(sq.Eq{"id": id, "deleted_at": nil}).
+			RunWith(tx).
+			ExecContext(ctx)
+		if err != nil {
+			return wrapDatabaseMutationError(fmt.Sprintf("failed to update %s name", table), err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to update %s name: %w", table, err)
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		if affected > 1 {
+			return fmt.Errorf("multiple %s rows were renamed: %w", table, ErrViolation)
+		}
+		return nil
+	})
 }
 
 // SplitUserAndApxyLabels partitions a labels map into the user-provided

--- a/internal/database/labels_propagate.go
+++ b/internal/database/labels_propagate.go
@@ -271,7 +271,7 @@ func (s *service) recomputeConnectionLabelsTx(ctx context.Context, id apid.ID) (
 			ParentCarryForward{Rt: ApidPrefixToLabelToken(apid.PrefixConnectorVersion), Labels: cvLabels},
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(conn.Id, conn.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(conn.Id, conn.Name, conn.Namespace, newLabels)
 
 		var werr error
 		corrected, werr = s.writeRecomputedLabels(ctx, tx, ConnectionsTable, sq.Eq{"id": id, "deleted_at": nil}, conn.Labels, newLabels)
@@ -314,7 +314,7 @@ func (s *service) recomputeActorLabelsTx(ctx context.Context, id apid.ID) (bool,
 			userLabels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(a.Id, a.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(a.Id, a.Name, a.Namespace, newLabels)
 
 		var werr error
 		corrected, werr = s.writeRecomputedLabels(ctx, tx, ActorTable, sq.Eq{"id": id, "deleted_at": nil}, a.Labels, newLabels)
@@ -357,7 +357,7 @@ func (s *service) recomputeEncryptionKeyLabelsTx(ctx context.Context, id apid.ID
 			userLabels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(ek.Id, ek.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(ek.Id, ek.Name, ek.Namespace, newLabels)
 
 		var werr error
 		corrected, werr = s.writeRecomputedLabels(ctx, tx, KeysTable, sq.Eq{"id": id, "deleted_at": nil}, ek.Labels, newLabels)
@@ -400,7 +400,7 @@ func (s *service) recomputeRateLimitLabelsTx(ctx context.Context, id apid.ID) (b
 			userLabels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(rl.Id, rl.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(rl.Id, rl.Name, rl.Namespace, newLabels)
 
 		var werr error
 		corrected, werr = s.writeRecomputedLabels(ctx, tx, RateLimitsTable, sq.Eq{"id": id, "deleted_at": nil}, rl.Labels, newLabels)
@@ -443,7 +443,7 @@ func (s *service) recomputeConnectorLabelsTx(ctx context.Context, id apid.ID) (b
 			userLabels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		newLabels = InjectSelfImplicitLabels(connector.Id, connector.Namespace, newLabels)
+		newLabels = InjectSelfImplicitLabels(connector.Id, connector.Name, connector.Namespace, newLabels)
 
 		var werr error
 		corrected, werr = s.writeRecomputedLabels(

--- a/internal/database/labels_propagate_test.go
+++ b/internal/database/labels_propagate_test.go
@@ -89,7 +89,9 @@ func TestRateLimitLabelChangePropagation(t *testing.T) {
 	// User labels are still empty (we never set any) and identifier labels
 	// survived.
 	require.Equal(t, string(rlIn_child), r.Labels["apxy/rl/-/id"])
+	require.Equal(t, string(rlIn_child), r.Labels["apxy/rl/-/name"])
 	require.Equal(t, "root.rl.child", r.Labels["apxy/rl/-/ns"])
+	require.Equal(t, "child", r.Labels["apxy/ns/-/name"])
 }
 
 // TestRateLimitDriftReconciliation simulates label-column drift on a
@@ -132,6 +134,8 @@ func TestRateLimitDriftReconciliation(t *testing.T) {
 	got, err := db.GetRateLimit(ctx, rlID)
 	require.NoError(t, err)
 	require.Equal(t, "platform", got.Labels["apxy/ns/team"], "carry-forward should overwrite the stale value")
+	require.Equal(t, rlID.String(), got.Labels["apxy/rl/-/name"], "repair should restore the missing self name")
+	require.Equal(t, "drift", got.Labels["apxy/ns/-/name"], "repair should restore the namespace name")
 }
 
 // TestRateLimitRecomputeIdempotent confirms recomputeRateLimitLabelsTx returns

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -447,25 +447,34 @@ func TestApidPrefixToLabelToken(t *testing.T) {
 	require.Equal(t, "", ApidPrefixToLabelToken(apid.Prefix("")))
 }
 
-func TestBuildImplicitIdentifierLabels(t *testing.T) {
-	t.Run("builds id and ns labels", func(t *testing.T) {
+func TestBuildImplicitResourceLabels(t *testing.T) {
+	t.Run("builds id name and ns labels", func(t *testing.T) {
 		id := apid.MustParse("cxn_test1234567890ab")
-		labels := BuildImplicitIdentifierLabels(id, "root.foo.bar")
+		labels := BuildImplicitResourceLabels(id, "billing", "root.foo.bar")
 		require.Equal(t, Labels{
-			"apxy/cxn/-/id": "cxn_test1234567890ab",
-			"apxy/cxn/-/ns": "root.foo.bar",
+			"apxy/cxn/-/id":   "cxn_test1234567890ab",
+			"apxy/cxn/-/name": "billing",
+			"apxy/cxn/-/ns":   "root.foo.bar",
 		}, labels)
 		// Result must validate under the system rules.
 		require.NoError(t, labels.Validate())
 	})
 
 	t.Run("nil id returns nil", func(t *testing.T) {
-		require.Nil(t, BuildImplicitIdentifierLabels(apid.Nil, "/foo"))
+		require.Nil(t, BuildImplicitResourceLabels(apid.Nil, "billing", "/foo"))
+	})
+
+	t.Run("empty name defaults to id", func(t *testing.T) {
+		id := apid.MustParse("act_test1234567890ab")
+		labels := BuildImplicitResourceLabels(id, "", "root")
+		require.Equal(t, id.String(), labels["apxy/act/-/name"])
 	})
 
 	t.Run("uses correct rt token per resource type", func(t *testing.T) {
-		labels := BuildImplicitIdentifierLabels(apid.MustParse("cxr_test1234567890ab"), "root")
+		labels := BuildImplicitResourceLabels(apid.MustParse("cxr_test1234567890ab"), "connector", "root")
 		_, ok := labels["apxy/cxr/-/id"]
+		require.True(t, ok)
+		_, ok = labels["apxy/cxr/-/name"]
 		require.True(t, ok)
 		_, ok = labels["apxy/cxr/-/ns"]
 		require.True(t, ok)
@@ -613,6 +622,11 @@ func TestApxyLabelValueValidation(t *testing.T) {
 		require.NoError(t, ValidateApxyLabelValue(longPath))
 	})
 
+	t.Run("apxy mode accepts namespace name boundaries", func(t *testing.T) {
+		require.NoError(t, ValidateApxyLabelValue("_billing-"))
+		require.Error(t, ValidateLabelValue("_billing-"))
+	})
+
 	t.Run("apxy mode rejects values exceeding apxy cap", func(t *testing.T) {
 		// 254 chars: starts/ends alphanumeric so the regex is the only constraint.
 		tooLong := "a" + strings.Repeat("b", 252) + "c"
@@ -633,23 +647,24 @@ func TestApxyLabelValueValidation(t *testing.T) {
 }
 
 func TestInjectSelfImplicitLabels(t *testing.T) {
-	t.Run("adds id and ns labels", func(t *testing.T) {
+	t.Run("adds id name and ns labels", func(t *testing.T) {
 		id := apid.MustParse("cxn_test1234567890ab")
-		out := InjectSelfImplicitLabels(id, "root.foo", Labels{"team": "platform"})
+		out := InjectSelfImplicitLabels(id, "billing", "root.foo", Labels{"team": "platform"})
 		require.Equal(t, "cxn_test1234567890ab", out["apxy/cxn/-/id"])
+		require.Equal(t, "billing", out["apxy/cxn/-/name"])
 		require.Equal(t, "root.foo", out["apxy/cxn/-/ns"])
 		require.Equal(t, "platform", out["team"])
 	})
 
 	t.Run("nil input still produces implicit labels", func(t *testing.T) {
 		id := apid.MustParse("cxn_test1234567890ab")
-		out := InjectSelfImplicitLabels(id, "root", nil)
-		require.Len(t, out, 2)
+		out := InjectSelfImplicitLabels(id, "billing", "root", nil)
+		require.Len(t, out, 3)
 		require.Equal(t, "root", out["apxy/cxn/-/ns"])
 	})
 
 	t.Run("nil id is a no-op pass-through", func(t *testing.T) {
-		out := InjectSelfImplicitLabels(apid.Nil, "root", Labels{"team": "platform"})
+		out := InjectSelfImplicitLabels(apid.Nil, "billing", "root", Labels{"team": "platform"})
 		require.Equal(t, Labels{"team": "platform"}, out)
 	})
 }
@@ -657,6 +672,7 @@ func TestInjectSelfImplicitLabels(t *testing.T) {
 func TestInjectNamespaceSelfImplicitLabels(t *testing.T) {
 	out := InjectNamespaceSelfImplicitLabels("root.foo.bar", Labels{"pig": "oink"})
 	require.Equal(t, "root.foo.bar", out["apxy/ns/-/id"])
+	require.Equal(t, "bar", out["apxy/ns/-/name"])
 	require.Equal(t, "root.foo.bar", out["apxy/ns/-/ns"])
 	require.Equal(t, "oink", out["pig"])
 }

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -2035,6 +2035,21 @@ func (mr *MockDBMockRecorder) UpdateKeyLabels(ctx, id, labels interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyLabels", reflect.TypeOf((*MockDB)(nil).UpdateKeyLabels), ctx, id, labels)
 }
 
+// UpdateKeyName mocks base method.
+func (m *MockDB) UpdateKeyName(ctx context.Context, id apid.ID, name common.ResourceName) (*database.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateKeyName", ctx, id, name)
+	ret0, _ := ret[0].(*database.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateKeyName indicates an expected call of UpdateKeyName.
+func (mr *MockDBMockRecorder) UpdateKeyName(ctx, id, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyName", reflect.TypeOf((*MockDB)(nil).UpdateKeyName), ctx, id, name)
+}
+
 // UpdateNamespaceAnnotations mocks base method.
 func (m *MockDB) UpdateNamespaceAnnotations(ctx context.Context, path string, annotations map[string]string) (*database.Namespace, error) {
 	m.ctrl.T.Helper()

--- a/internal/database/namespace_test.go
+++ b/internal/database/namespace_test.go
@@ -681,6 +681,7 @@ INSERT INTO namespaces
 			require.False(t, existsAlsoOld)
 			// apxy/ self-implicit labels are preserved across user-driven updates.
 			require.Equal(t, "root.updlabels2", updated.Labels["apxy/ns/-/id"])
+			require.Equal(t, "updlabels2", updated.Labels["apxy/ns/-/name"])
 
 			// Verify in database
 			retrieved, err := db.GetNamespace(ctx, "root.updlabels2")
@@ -1932,6 +1933,7 @@ INSERT INTO namespaces
 
 		// Child's own self-implicit wins over the parent's pass-through.
 		require.Equal(t, "root.foo.bar", bar.Labels["apxy/ns/-/id"])
+		require.Equal(t, "bar", bar.Labels["apxy/ns/-/name"])
 		require.Equal(t, "root.foo.bar", bar.Labels["apxy/ns/-/ns"])
 
 		// And the parent's user labels did NOT silently leak into the
@@ -2240,10 +2242,13 @@ func TestNamespaceLabelChangePropagation(t *testing.T) {
 		a, err := db.GetActor(ctx, actorIn_t)
 		require.NoError(t, err)
 		require.Equal(t, "woof", a.Labels["apxy/ns/dog"])
+		require.Equal(t, "t", a.Labels["apxy/ns/-/name"])
 		ek, err := db.GetKey(ctx, ekIn_b)
 		require.NoError(t, err)
 		require.Equal(t, "woof", ek.Labels["apxy/ns/dog"])
 		require.Equal(t, "oink", ek.Labels["apxy/ns/pig"])
+		require.Equal(t, "b", ek.Labels["apxy/ns/-/name"])
+		require.NotContains(t, ek.Labels, "apxy/ns/apxy/ns/-/name")
 
 		// Replace root.t's labels — dog goes away, cow comes in.
 		_, err = db.UpdateNamespaceLabels(ctx, "root.t", map[string]string{"cow": "moo"})
@@ -2341,6 +2346,7 @@ func TestConnectorLabelChangePropagation(t *testing.T) {
 		cvID := apid.New(apid.PrefixConnectorVersion)
 		require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, &ConnectorWithDefinition{
 			Id:                  cvID,
+			Name:                "drive",
 			Version:             1,
 			Namespace:           "root.cv",
 			State:               ConnectorDefinitionVersionStateDraft,
@@ -2360,6 +2366,7 @@ func TestConnectorLabelChangePropagation(t *testing.T) {
 		c, err := db.GetConnection(ctx, connID)
 		require.NoError(t, err)
 		require.Equal(t, "google-drive", c.Labels["apxy/cxr/type"])
+		require.Equal(t, "drive", c.Labels["apxy/cxr/-/name"])
 
 		// Re-upsert the draft cv with new user labels.
 		require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, &ConnectorWithDefinition{
@@ -2376,6 +2383,12 @@ func TestConnectorLabelChangePropagation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "slack", c.Labels["apxy/cxr/type"])
 		require.Equal(t, "x", c.Labels["apxy/cxr/extra"])
+
+		require.NoError(t, db.UpdateConnectorName(ctx, cvID, "slack"))
+		require.NoError(t, db.RefreshConnectionsForConnector(ctx, cvID))
+		c, err = db.GetConnection(ctx, connID)
+		require.NoError(t, err)
+		require.Equal(t, "slack", c.Labels["apxy/cxr/-/name"])
 	})
 }
 
@@ -2392,7 +2405,7 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 		}))
 		cvID := apid.New(apid.PrefixConnectorVersion)
 		require.NoError(t, db.UpsertConnectorDefinitionVersion(ctx, &ConnectorWithDefinition{
-			Id: cvID, Version: 1, Namespace: "root.recon",
+			Id: cvID, Name: "recon-connector", Version: 1, Namespace: "root.recon",
 			State: ConnectorDefinitionVersionStateDraft, Labels: Labels{"type": "google-drive"},
 			EncryptedDefinition: encfield.EncryptedField{ID: apid.MustParse("dek_test000000000001"), Data: "d"},
 		}))
@@ -2430,6 +2443,9 @@ func TestReconcileCarryForwardLabels(t *testing.T) {
 		c, err := db.GetConnection(ctx, connID)
 		require.NoError(t, err)
 		require.Equal(t, "google-drive", c.Labels["apxy/cxr/type"])
+		require.Equal(t, "recon-connector", c.Labels["apxy/cxr/-/name"])
+		require.Equal(t, connID.String(), c.Labels["apxy/cxn/-/name"])
+		require.Equal(t, "recon", c.Labels["apxy/ns/-/name"])
 	})
 
 	t.Run("idempotent - subsequent runs after a clean pass find nothing", func(t *testing.T) {

--- a/internal/database/rate_limit.go
+++ b/internal/database/rate_limit.go
@@ -183,7 +183,7 @@ func (s *service) CreateRateLimit(ctx context.Context, rl *RateLimit) error {
 			rl.Labels,
 			ParentCarryForward{Rt: NamespaceLabelToken, Labels: nsLabels},
 		)
-		rl.Labels = InjectSelfImplicitLabels(rl.Id, rl.Namespace, rl.Labels)
+		rl.Labels = InjectSelfImplicitLabels(rl.Id, rl.Name, rl.Namespace, rl.Labels)
 
 		now := apctx.GetClock(ctx).Now()
 		rl.CreatedAt = now
@@ -264,25 +264,8 @@ func (s *service) UpdateRateLimitName(ctx context.Context, id apid.ID, name scom
 		return nil, fmt.Errorf("invalid rate limit name: %w", err)
 	}
 
-	result, err := s.sq.
-		Update(RateLimitsTable).
-		Set("name", name).
-		Set("updated_at", apctx.GetClock(ctx).Now()).
-		Where(sq.Eq{"id": id, "deleted_at": nil}).
-		RunWith(s.db).
-		ExecContext(ctx)
-	if err != nil {
-		return nil, wrapDatabaseMutationError("failed to update rate limit name", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to update rate limit name: %w", err)
-	}
-	if affected == 0 {
-		return nil, ErrNotFound
-	}
-	if affected > 1 {
-		return nil, fmt.Errorf("multiple rate limits were renamed: %w", ErrViolation)
+	if err := s.updateResourceNameAndSelfLabels(ctx, RateLimitsTable, id, name); err != nil {
+		return nil, err
 	}
 	return s.GetRateLimit(ctx, id)
 }

--- a/internal/database/rate_limit_test.go
+++ b/internal/database/rate_limit_test.go
@@ -186,12 +186,14 @@ func TestRateLimit_Labels(t *testing.T) {
 	user, _ := SplitUserAndApxyLabels(updated.Labels)
 	require.Equal(t, Labels{"only-this": "now"}, user)
 	require.Equal(t, string(rl.Id), updated.Labels["apxy/rl/-/id"])
+	require.Equal(t, string(rl.Id), updated.Labels["apxy/rl/-/name"])
 
 	// DeleteLabels
 	updated, err = db.DeleteRateLimitLabels(ctx, rl.Id, []string{"only-this"})
 	require.NoError(t, err)
 	user, _ = SplitUserAndApxyLabels(updated.Labels)
 	require.Empty(t, user)
+	require.Equal(t, string(rl.Id), updated.Labels["apxy/rl/-/name"])
 
 	// Not found cases
 	fake := apid.New(apid.PrefixRateLimit)

--- a/internal/database/resource_name_test.go
+++ b/internal/database/resource_name_test.go
@@ -145,7 +145,7 @@ func namedResourceHarnesses() []namedResourceHarness {
 				return value.Name, nil
 			},
 			rename: func(ctx context.Context, db DB, id apid.ID, name scommon.ResourceName) error {
-				_, err := db.UpdateKey(ctx, id, map[string]interface{}{"name": name})
+				_, err := db.UpdateKeyName(ctx, id, name)
 				return err
 			},
 			list: func(ctx context.Context, db DB, name scommon.ResourceName, matchers []string, limit int32) namedResourcePage {
@@ -233,6 +233,43 @@ func TestResourceNamesDefaultToID(t *testing.T) {
 			name, err := harness.getName(ctx, db, id)
 			require.NoError(t, err)
 			require.Equal(t, scommon.ResourceName(id.String()), name)
+		})
+	}
+}
+
+func TestResourceNameImplicitLabelsOnCreateAndRename(t *testing.T) {
+	for _, harness := range namedResourceHarnesses() {
+		t.Run(harness.resourceType, func(t *testing.T) {
+			_, db, rawDB := MustApplyBlankTestDbConfigRaw(t, nil)
+			ctx := context.Background()
+			id := apid.New(harness.prefix)
+			labelKey := fmt.Sprintf("apxy/%s/-/name", ApidPrefixToLabelToken(harness.prefix))
+
+			require.NoError(t, harness.create(ctx, db, id, "root", "before"))
+			var labels Labels
+			require.NoError(t, rawDB.QueryRow(fmt.Sprintf(
+				"SELECT labels FROM %s WHERE id = '%s'",
+				harness.table,
+				id.String(),
+			)).Scan(&labels))
+			require.Equal(t, "before", labels[labelKey])
+
+			require.NoError(t, harness.rename(ctx, db, id, "after"))
+			require.NoError(t, rawDB.QueryRow(fmt.Sprintf(
+				"SELECT labels FROM %s WHERE id = '%s'",
+				harness.table,
+				id.String(),
+			)).Scan(&labels))
+			require.Equal(t, "after", labels[labelKey])
+
+			require.NoError(t, harness.create(ctx, db, apid.New(harness.prefix), "root", "taken"))
+			require.ErrorIs(t, harness.rename(ctx, db, id, "taken"), ErrDuplicate)
+			require.NoError(t, rawDB.QueryRow(fmt.Sprintf(
+				"SELECT labels FROM %s WHERE id = '%s'",
+				harness.table,
+				id.String(),
+			)).Scan(&labels))
+			require.Equal(t, "after", labels[labelKey], "a failed rename must not change the implicit name label")
 		})
 	}
 }

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -127,8 +127,8 @@ func (f *clientFactory) ForConnection(c Connection) F {
 
 // ForActor attaches the initiating actor's identity and labels to the
 // request snapshot. The actor's user labels are re-keyed under
-// apxy/act/<k> and the apxy/act/-/id and apxy/act/-/ns self-implicit
-// labels are added. Other apxy/-prefixed entries on the actor (e.g.
+// apxy/act/<k> and the apxy/act/-/id, apxy/act/-/name, and
+// apxy/act/-/ns self-implicit labels are added. Other apxy/-prefixed entries on the actor (e.g.
 // apxy/ns/<k> from the actor's namespace) are NOT forwarded — those
 // describe the actor's own context and would collide with the
 // connection's namespace context, which the request is acting under.
@@ -148,7 +148,7 @@ func (f *clientFactory) ForActor(actor Actor) F {
 		}
 		actorContribution[fmt.Sprintf("%s%s/%s", database.ApxyReservedPrefix, actToken, k)] = v
 	}
-	for k, v := range database.BuildImplicitIdentifierLabels(actor.GetId(), actor.GetNamespace()) {
+	for k, v := range database.BuildImplicitResourceLabels(actor.GetId(), actor.GetName(), actor.GetNamespace()) {
 		actorContribution[k] = v
 	}
 

--- a/internal/httpf/factory_labels_test.go
+++ b/internal/httpf/factory_labels_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,22 +18,24 @@ type stubConnection struct {
 	labels    map[string]string
 }
 
-func (s *stubConnection) GetId() apid.ID                  { return s.id }
-func (s *stubConnection) GetNamespace() string            { return s.namespace }
-func (s *stubConnection) GetConnectorId() apid.ID         { return s.cvID }
-func (s *stubConnection) GetConnectorVersion() uint64     { return s.cvVersion }
-func (s *stubConnection) GetLabels() map[string]string    { return s.labels }
+func (s *stubConnection) GetId() apid.ID               { return s.id }
+func (s *stubConnection) GetNamespace() string         { return s.namespace }
+func (s *stubConnection) GetConnectorId() apid.ID      { return s.cvID }
+func (s *stubConnection) GetConnectorVersion() uint64  { return s.cvVersion }
+func (s *stubConnection) GetLabels() map[string]string { return s.labels }
 
 // stubActor is a minimal Actor implementation for testing.
 type stubActor struct {
 	id        apid.ID
+	name      scommon.ResourceName
 	namespace string
 	labels    map[string]string
 }
 
-func (s *stubActor) GetId() apid.ID               { return s.id }
-func (s *stubActor) GetNamespace() string         { return s.namespace }
-func (s *stubActor) GetLabels() map[string]string { return s.labels }
+func (s *stubActor) GetId() apid.ID                { return s.id }
+func (s *stubActor) GetName() scommon.ResourceName { return s.name }
+func (s *stubActor) GetNamespace() string          { return s.namespace }
+func (s *stubActor) GetLabels() map[string]string  { return s.labels }
 
 func newTestFactory() *clientFactory {
 	return &clientFactory{
@@ -47,11 +50,11 @@ func TestForConnectionCopiesAllLabels(t *testing.T) {
 		cvID:      apid.MustParse("cxr_test1234567890ab"),
 		cvVersion: 1,
 		labels: map[string]string{
-			"team":             "platform",
-			"apxy/cxn/-/id":    "cxn_test1234567890ab",
-			"apxy/cxn/-/ns":    "root.foo",
-			"apxy/cxr/type":    "google_drive",
-			"apxy/ns/tier":     "pro",
+			"team":          "platform",
+			"apxy/cxn/-/id": "cxn_test1234567890ab",
+			"apxy/cxn/-/ns": "root.foo",
+			"apxy/cxr/type": "google_drive",
+			"apxy/ns/tier":  "pro",
 		},
 	}
 
@@ -139,10 +142,11 @@ func TestForActorAddsActorLabels(t *testing.T) {
 	}
 	actor := &stubActor{
 		id:        apid.MustParse("act_test1234567890ab"),
+		name:      "marketplace-user",
 		namespace: "root.bar",
 		labels: map[string]string{
-			"team":  "marketplace",
-			"role":  "admin",
+			"team": "marketplace",
+			"role": "admin",
 		},
 	}
 
@@ -154,6 +158,7 @@ func TestForActorAddsActorLabels(t *testing.T) {
 
 	// Actor's self-implicit identifier labels are present.
 	require.Equal(t, "act_test1234567890ab", f.requestInfo.Labels["apxy/act/-/id"])
+	require.Equal(t, "marketplace-user", f.requestInfo.Labels["apxy/act/-/name"])
 	require.Equal(t, "root.bar", f.requestInfo.Labels["apxy/act/-/ns"])
 
 	// Connection's apxy/ labels survive — actor doesn't trample them.
@@ -172,8 +177,8 @@ func TestForActorDoesNotForwardActorApxyKeys(t *testing.T) {
 		namespace: "root.bar",
 		labels: map[string]string{
 			"team":          "marketplace",
-			"apxy/ns/tier":  "free",     // should NOT propagate
-			"apxy/act/-/id": "ignored",  // self-implicit comes from id, not from labels
+			"apxy/ns/tier":  "free",    // should NOT propagate
+			"apxy/act/-/id": "ignored", // self-implicit comes from id, not from labels
 		},
 	}
 
@@ -181,8 +186,24 @@ func TestForActorDoesNotForwardActorApxyKeys(t *testing.T) {
 
 	require.Equal(t, "marketplace", f.requestInfo.Labels["apxy/act/team"])
 	require.Equal(t, "act_test1234567890ab", f.requestInfo.Labels["apxy/act/-/id"])
+	require.Equal(t, "act_test1234567890ab", f.requestInfo.Labels["apxy/act/-/name"])
 	_, hasNs := f.requestInfo.Labels["apxy/ns/tier"]
 	require.False(t, hasNs, "actor's apxy/ns/* must not leak through to the request")
+}
+
+func TestForActorNameSnapshotUsesCurrentValueWithoutRewritingHistory(t *testing.T) {
+	actor := &stubActor{
+		id:        apid.MustParse("act_test1234567890ab"),
+		name:      "before",
+		namespace: "root",
+	}
+
+	before := newTestFactory().ForActor(actor).(*clientFactory)
+	actor.name = "after"
+	after := newTestFactory().ForActor(actor).(*clientFactory)
+
+	require.Equal(t, "before", before.requestInfo.Labels["apxy/act/-/name"])
+	require.Equal(t, "after", after.requestInfo.Labels["apxy/act/-/name"])
 }
 
 func TestForActorNilIsNoop(t *testing.T) {

--- a/internal/httpf/interface.go
+++ b/internal/httpf/interface.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"gopkg.in/h2non/gentleman.v2"
 )
@@ -47,6 +48,7 @@ type Connection interface {
 // actor initiated the call) is a valid input for ForActor.
 type Actor interface {
 	GetId() apid.ID
+	GetName() common.ResourceName
 	GetNamespace() string
 	GetLabels() map[string]string
 }

--- a/internal/httpf/mock/httpf.go
+++ b/internal/httpf/mock/httpf.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	apid "github.com/rmorlok/authproxy/internal/apid"
 	httpf "github.com/rmorlok/authproxy/internal/httpf"
+	common "github.com/rmorlok/authproxy/internal/schema/common"
 	connectors "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	gentleman "gopkg.in/h2non/gentleman.v2"
 )
@@ -333,6 +334,20 @@ func (m *MockActor) GetLabels() map[string]string {
 func (mr *MockActorMockRecorder) GetLabels() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabels", reflect.TypeOf((*MockActor)(nil).GetLabels))
+}
+
+// GetName mocks base method.
+func (m *MockActor) GetName() common.ResourceName {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetName")
+	ret0, _ := ret[0].(common.ResourceName)
+	return ret0
+}
+
+// GetName indicates an expected call of GetName.
+func (mr *MockActorMockRecorder) GetName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockActor)(nil).GetName))
 }
 
 // GetNamespace mocks base method.

--- a/internal/routes/actors_test.go
+++ b/internal/routes/actors_test.go
@@ -968,6 +968,7 @@ func TestActorsRoutes(t *testing.T) {
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			respUser, _ := database.SplitUserAndApxyLabels(database.Labels(resp.Labels))
 			require.Empty(t, respUser)
+			require.Equal(t, string(resp.Name), resp.Labels["apxy/act/-/name"])
 
 			// Verify the labels are cleared in the database (user portion only;
 			// apxy/ self-implicit labels remain).
@@ -975,6 +976,7 @@ func TestActorsRoutes(t *testing.T) {
 			require.NoError(t, err)
 			updatedUser, _ := database.SplitUserAndApxyLabels(updatedActor.Labels)
 			require.Empty(t, updatedUser)
+			require.Equal(t, string(updatedActor.Name), updatedActor.Labels["apxy/act/-/name"])
 		})
 
 		t.Run("success - labels unchanged", func(t *testing.T) {
@@ -1893,8 +1895,10 @@ func TestActorsRoutes(t *testing.T) {
 		customName := "billing"
 		custom := create("named-actor", &customName)
 		require.Equal(t, customName, string(custom.Name))
+		require.Equal(t, customName, custom.Labels["apxy/act/-/name"])
 		defaulted := create("default-named-actor", nil)
 		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+		require.Equal(t, defaulted.Id.String(), defaulted.Labels["apxy/act/-/name"])
 
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "/actors/"+custom.Id.String(), nil)
@@ -1915,6 +1919,7 @@ func TestActorsRoutes(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 		require.Equal(t, "renamed", string(got.Name))
+		require.Equal(t, "renamed", got.Labels["apxy/act/-/name"])
 
 		conflictName := "conflict"
 		_ = create("conflicting-actor", &conflictName)

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -2225,6 +2225,7 @@ func TestConnections(t *testing.T) {
 			var connection ConnectionJson
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &connection))
 			require.Equal(t, expectedName, string(connection.Name))
+			require.Equal(t, expectedName, connection.Labels["apxy/cxn/-/name"])
 		}
 
 		otherName := "other-connection"
@@ -2241,6 +2242,7 @@ func TestConnections(t *testing.T) {
 		var renamed ConnectionJson
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &renamed))
 		require.Equal(t, "renamed-connection", string(renamed.Name))
+		require.Equal(t, "renamed-connection", renamed.Labels["apxy/cxn/-/name"])
 
 		w = httptest.NewRecorder()
 		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -2792,8 +2792,10 @@ func TestConnectors(t *testing.T) {
 		customName := "salesforce"
 		custom := createNamed(&customName, "Salesforce", http.StatusCreated)
 		require.Equal(t, customName, string(custom.Name))
+		require.Equal(t, customName, custom.Labels["apxy/cxr/-/name"])
 		defaulted := createNamed(nil, "Defaulted", http.StatusCreated)
 		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+		require.Equal(t, defaulted.Id.String(), defaulted.Labels["apxy/cxr/-/name"])
 		createNamed(&customName, "Conflicting", http.StatusConflict)
 
 		otherName := "other-connector"
@@ -2810,6 +2812,7 @@ func TestConnectors(t *testing.T) {
 		var renamed ConnectorVersionJson
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &renamed))
 		require.Equal(t, "renamed-connector", string(renamed.Name))
+		require.Equal(t, "renamed-connector", renamed.Labels["apxy/cxr/-/name"])
 
 		w = httptest.NewRecorder()
 		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(

--- a/internal/routes/keys_test.go
+++ b/internal/routes/keys_test.go
@@ -1856,8 +1856,10 @@ func TestKeys(t *testing.T) {
 
 		named := createNamed("primary-key")
 		require.Equal(t, "primary-key", string(named.Name))
+		require.Equal(t, "primary-key", named.Labels["apxy/key/-/name"])
 		defaulted := createKey(t, tu, "root", nil)
 		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+		require.Equal(t, defaulted.Id.String(), defaulted.Labels["apxy/key/-/name"])
 
 		w := httptest.NewRecorder()
 		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1882,6 +1884,7 @@ func TestKeys(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 		require.Equal(t, "renamed-key", string(got.Name))
+		require.Equal(t, "renamed-key", got.Labels["apxy/key/-/name"])
 
 		_ = createNamed("conflicting-key")
 		w = httptest.NewRecorder()

--- a/internal/routes/namespaces_test.go
+++ b/internal/routes/namespaces_test.go
@@ -288,6 +288,7 @@ func TestNamespaces(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "root.allowed", resp.Path)
 			require.Equal(t, "allowed", string(resp.Name))
+			require.Equal(t, "allowed", resp.Labels["apxy/ns/-/name"])
 			require.Equal(t, string(database.NamespaceStateActive), string(resp.State))
 		})
 

--- a/internal/routes/rate_limits_test.go
+++ b/internal/routes/rate_limits_test.go
@@ -982,8 +982,10 @@ func TestRateLimits(t *testing.T) {
 
 		named := createNamed("public-api")
 		require.Equal(t, "public-api", string(named.Name))
+		require.Equal(t, "public-api", named.Labels["apxy/rl/-/name"])
 		defaulted := createRateLimit(t, tu, "root", nil)
 		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
+		require.Equal(t, defaulted.Id.String(), defaulted.Labels["apxy/rl/-/name"])
 
 		w := httptest.NewRecorder()
 		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1008,6 +1010,7 @@ func TestRateLimits(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 		require.Equal(t, "renamed-limit", string(got.Name))
+		require.Equal(t, "renamed-limit", got.Labels["apxy/rl/-/name"])
 
 		_ = createNamed("conflicting-limit")
 		w = httptest.NewRecorder()


### PR DESCRIPTION
Closes #774

## Summary

- add `apxy/<rt>/-/name` to the implicit identity labels for namespaces, actors, connectors, connections, keys, and rate limits
- carry namespace and connector names through materialized labels, and include actor names in newly composed request snapshots
- update mutable names and self labels atomically, enqueue connector reconciliation after renames, and repair missing or stale name labels in the daily consistency pass
- preserve implicit name labels across user label replacement and deletion, and roll back both name and labels when uniqueness checks fail

## Testing

- `./scripts/preflight.sh`
- SQLite: full `./internal/database` suite
- PostgreSQL: focused resource-name, propagation, and reconciliation database suite
- repository-wide Go compile (`go test ./... -run ^$`)
- focused core connector reconciliation and HTTP actor snapshot tests