### PR TITLE
Replace connector identifying labels with names

### DIFF
--- a/deploy/charts/authproxy/README.md
+++ b/deploy/charts/authproxy/README.md
@@ -73,7 +73,7 @@ The chart exposes typed values for the common connectivity blocks. See
 | `encryptionKeys` | Secret mount + path for the global AES key                            |
 | `actors`         | Secret mount + ACL permissions for admin actor keypairs               |
 | `hostApplication`| URL the marketplace UI redirects to for login                         |
-| `connectors`     | Inline connector definitions + identifying labels                     |
+| `connectors`     | Inline, named connector definitions                                    |
 | `appMetrics`     | App metrics + request-event storage (defaults to shared main DB)      |
 | `config`         | Free-form overlay merged into the rendered AuthProxy YAML             |
 

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -120,9 +120,6 @@ template syntax.
 
 {{/* --- connectors block (required by validator; empty list is acceptable) --- */}}
 {{- $connectors := dict "auto_migrate" .Values.connectors.autoMigrate "load_from_list" .Values.connectors.loadFromList -}}
-{{- if .Values.connectors.identifyingLabels -}}
-{{-   $_ := set $connectors "identifying_labels" .Values.connectors.identifyingLabels -}}
-{{- end -}}
 {{- $_ := set $cfg "connectors" $connectors -}}
 
 {{/* --- app_metrics (server unconditionally wires up the metrics store) --- */}}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -297,9 +297,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "autoMigrate":       { "type": "boolean" },
-        "loadFromList":      { "type": "array" },
-        "identifyingLabels": { "type": "array", "items": { "type": "string" } }
+        "autoMigrate":  { "type": "boolean" },
+        "loadFromList": { "type": "array" }
       }
     },
 

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -353,9 +353,6 @@ connectors:
   # connector schema docs for the format. Leave empty to manage connectors
   # exclusively through the admin API.
   loadFromList: []
-  # -- Labels used to identify connectors across reloads (matching the
-  # AuthProxy `connectors.identifying_labels` field).
-  identifyingLabels: []
 
 # -- Free-form config overlay merged on top of the rendered AuthProxy YAML.
 # Use this for fields the chart hasn't promoted to typed values yet.

--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -161,9 +161,8 @@ telemetry:
       - /healthz
   proxy:
     # Project an allowlisted subset of connection labels onto proxy
-    # metrics + spans. `type` matches the connectors.identifying_labels
-    # entry above so the Grafana "Proxy RED" dashboard's per-`type`
-    # panel populates automatically.
+    # metrics + spans. `type` is an ordinary connector label used by the
+    # Grafana "Proxy RED" dashboard's per-`type` panel.
     span_attribute_labels:
       - type
       - env
@@ -177,14 +176,12 @@ telemetry:
 connectors:
   auto_migrate: true
   auto_migration_lock_duration: 30s
-  identifying_labels:
-    - type
-    - env
   load_from_list:
   #
   # Root
   #
-  - labels:
+  - name: google-drive
+    labels:
       type: google-drive
       env: prod
     display_name: Google Drive
@@ -224,7 +221,8 @@ connectors:
           required: false
           reason: |
             We need to be able to see what's been going on in drive
-  - labels:
+  - name: greenhouse
+    labels:
       type: greenhouse
       env: prod
     display_name: Greenhouse
@@ -237,7 +235,8 @@ connectors:
       type: api-key
       placement:
         type: bearer
-  - labels:
+  - name: google-calendar
+    labels:
       type: google-calendar
       env: prod
     display_name: Google Calendar
@@ -332,7 +331,8 @@ connectors:
         proxy_http:
           method: GET
           url: https://www.googleapis.com/calendar/v3/users/me/calendarList
-  - labels:
+  - name: gmail
+    labels:
       type: gmail
       env: prod
     display_name: GMail
@@ -359,7 +359,8 @@ connectors:
         - id: https://www.googleapis.com/auth/gmail.readonly
           reason: |
             We need to be able to read your emails
-  - labels:
+  - name: pipedrive
+    labels:
       type: pipedrive
       env: prod
     display_name: pipedrive
@@ -387,7 +388,8 @@ connectors:
         - id: webhooks:full
           reason: |
             Allows us to receive notification of changes in realtime
-  - labels:
+  - name: asana
+    labels:
       type: asana
       env: prod
     display_name: Asana
@@ -418,7 +420,8 @@ connectors:
   #
   # DEV
   #
-#  - labels:
+#  - name: google-drive-dev
+#    labels:
 #      type: google-drive
 #      env: dev
 #    namespace: root.dev
@@ -458,7 +461,8 @@ connectors:
 #          required: false
 #          reason: |
 #            We need to be able to see what's been going on in drive
-#  - labels:
+#  - name: greenhouse-dev
+#    labels:
 #      type: greenhouse
 #      env: dev
 #    namespace: root.dev
@@ -472,7 +476,8 @@ connectors:
 #      type: api-key
 #      placement:
 #        type: bearer
-#  - labels:
+#  - name: google-calendar-dev
+#    labels:
 #      type: google-calendar
 #      env: dev
 #    namespace: root.dev
@@ -502,7 +507,8 @@ connectors:
     #
     # Stage
     #
-#  - labels:
+#  - name: google-drive-stage
+#    labels:
 #      type: google-drive
 #      env: stage
 #    namespace: root.stage
@@ -542,7 +548,8 @@ connectors:
 #          required: false
 #          reason: |
 #            We need to be able to see what's been going on in drive
-#  - labels:
+#  - name: greenhouse-stage
+#    labels:
 #      type: greenhouse
 #      env: stage
 #    namespace: root.stage
@@ -556,7 +563,8 @@ connectors:
 #      type: api-key
 #      placement:
 #        type: bearer
-#  - labels:
+#  - name: google-calendar-stage
+#    labels:
 #      type: google-calendar
 #      env: stage
 #    display_name: Google Calendar (STAGE)

--- a/dev_config/docker.yaml
+++ b/dev_config/docker.yaml
@@ -107,14 +107,12 @@ oauth:
 connectors:
   auto_migrate: true
   auto_migration_lock_duration: 30s
-  identifying_labels:
-    - type
-    - env
   load_from_list:
   #
   # Root
   #
-  - labels:
+  - name: google-drive
+    labels:
       type: google-drive
       env: prod
     display_name: Google Drive

--- a/docs/src/content/docs/deployment/helm.md
+++ b/docs/src/content/docs/deployment/helm.md
@@ -137,7 +137,7 @@ real host-signed session and a test connector before admitting users.
 | `blobStorage`, `s3` | Optional full request/response payload storage |
 | `jwt`, `actors`, `encryptionKeys` | Secret mounts and key paths |
 | `hostApplication` | Browser-session redirect back to the embedding app |
-| `connectors` | Seeded connector definitions and identifying labels |
+| `connectors` | Seeded, named connector definitions |
 | `appMetrics` | Request events, resource metrics, and optional full recording |
 | `config` | Advanced free-form overlay, including telemetry settings not yet typed by the chart |
 

--- a/docs/src/content/docs/operations/telemetry.md
+++ b/docs/src/content/docs/operations/telemetry.md
@@ -148,7 +148,8 @@ Per-connector overrides for trace context propagation live on the connector defi
 ```yaml
 connectors:
   load_from_list:
-    - labels:
+    - name: google-drive
+      labels:
         type: google-drive
       auth: { type: OAuth2, ... }
       telemetry:

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -16,13 +16,49 @@ The development configuration demonstrates the full server shape at
 | `system_auth` | JWT, actors, global encryption key, and DEK policy |
 | `database`, `redis` | Primary database and distributed state |
 | `app_metrics` | Request-event, resource-metric, and optional blob storage |
-| `connectors` | Connector loading, migration, and identifying labels |
+| `connectors` | Connector loading and name-based reconciliation |
 | `tasks` | Task retention and worker behavior |
 | `telemetry` | OTLP exporter, signals, sampling, and label projection |
 
 Fields can use AuthProxy value sources such as direct development values,
 environment variables, and file paths. Never put production credentials or
 key material directly in a committed YAML file.
+
+## Configured connector identity
+
+Give every connector loaded from YAML a stable `name` when you omit its
+immutable `id`:
+
+```yaml
+connectors:
+  auto_migrate: true
+  load_from_list:
+    - name: google-drive
+      namespace: root.integrations
+      labels:
+        type: google-drive
+      display_name: Google Drive
+      logo:
+        public_url: https://example.com/google-drive.svg
+      description: Connect to Google Drive.
+      auth:
+        type: no-auth
+```
+
+At startup, AuthProxy reconciles this entry to the live connector whose exact
+name is `google-drive` in `root.integrations`. Labels are ordinary selectable
+metadata and do not participate in identity. Multiple configured versions use
+the same name and namespace.
+
+An entry with an explicit `id` may omit `name`; a newly created connector then
+defaults its name to the ID. To rename an existing configured connector, keep
+its ID fixed and change `name`. Changing the name of an ID-less entry describes
+a new connector, so the old config-managed connector enters the normal orphan
+cleanup flow.
+
+The former `connectors.identifying_labels` setting has been removed. Delete it
+from existing configuration and add a stable `name` to every connector entry
+that does not already specify `id`.
 
 ## Kubernetes values
 

--- a/integration_tests/config/integration.yaml
+++ b/integration_tests/config/integration.yaml
@@ -92,7 +92,4 @@ oauth:
 connectors:
   auto_migrate: true
   auto_migration_lock_duration: 30s
-  identifying_labels:
-    - type
-    - env
   load_from_list: []

--- a/internal/core/connector.go
+++ b/internal/core/connector.go
@@ -135,7 +135,13 @@ func (c *Connector) getHash() (string, error) {
 func (c *Connector) setDefinition(def *cschema.Connector) error {
 	c.defMu.Lock()
 
-	jsonBytes, err := json.Marshal(def)
+	// A connector name belongs to the logical connector row. Keep it out of
+	// the encrypted, version-specific definition so renaming never changes the
+	// definition hash or produces stale duplicated metadata in API responses.
+	storedDefinition := def.Clone()
+	storedDefinition.Name = ""
+
+	jsonBytes, err := json.Marshal(storedDefinition)
 	if err != nil {
 		c.defMu.Unlock()
 		return err
@@ -146,9 +152,9 @@ func (c *Connector) setDefinition(def *cschema.Connector) error {
 		c.defMu.Unlock()
 		return err
 	}
-	c.Hash = def.Hash()
+	c.Hash = storedDefinition.Hash()
 	c.ConnectorWithDefinition.EncryptedDefinition = encrypted
-	c.def = def
+	c.def = storedDefinition
 	c.defMu.Unlock()
 
 	c.resetJavascriptLibrary()

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -2,20 +2,16 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
-
-	"strings"
 )
 
 // MigrateMutexKeyName is the key that can be used when locking to perform a migration in redis.
@@ -127,7 +123,7 @@ func (s *service) MigrateConnectors(ctx context.Context) error {
 
 	seen := make(map[apid.ID]struct{}, len(cfgRoot.Connectors.GetConnectors()))
 	for _, configConnector := range cfgRoot.Connectors.GetConnectors() {
-		resolvedId, err := s.migrateConnector(ctx, cfgRoot.Connectors, &configConnector)
+		resolvedId, err := s.migrateConnector(ctx, &configConnector)
 		if err != nil {
 			return err
 		}
@@ -235,170 +231,55 @@ func (s *service) connectorVersionHashEquals(cv *database.ConnectorWithDefinitio
 }
 
 func (s *service) precheckConnectorsForMigration(ctx context.Context, configConnectors *config.Connectors) error {
-	type IdVersionStateTuple struct {
-		Id      apid.ID
-		Version uint64
-		State   string
-	}
-
-	type IdVersionTuple struct {
-		Id      apid.ID
-		Version uint64
-	}
-
-	type IdStateTuple struct {
-		Id    apid.ID
-		State string
-	}
-
-	identifyingLabels := configConnectors.GetIdentifyingLabels()
-
-	idVersionStateCounts := make(map[IdVersionStateTuple]int)
-	idVersionCounts := make(map[IdVersionTuple]int)
-	idStateCounts := make(map[IdStateTuple]int)
-	idCounts := make(map[apid.ID]int)
-	identifyingLabelCounts := make(map[string]int)
-
-	// Helper to serialize identifying label values for map key
-	serializeLabels := func(c *config.Connector) string {
-		labelValues := c.GetIdentifyingLabelValues(identifyingLabels)
-		data, _ := json.Marshal(labelValues)
-		return string(data)
+	if err := configConnectors.ValidateIdentities(&scommon.ValidationContext{}); err != nil {
+		return fmt.Errorf("invalid connector configuration: %w", err)
 	}
 
 	for _, configConnector := range configConnectors.GetConnectors() {
-		if err := s.precheckConnectorForMigration(ctx, configConnectors, &configConnector); err != nil {
+		if err := s.precheckConnectorForMigration(ctx, &configConnector); err != nil {
 			return err
 		}
-
-		labelKey := serializeLabels(&configConnector)
-
-		if configConnector.HasId() && configConnector.HasVersion() && configConnector.HasState() {
-			idVersionStateCounts[IdVersionStateTuple{
-				Id:      configConnector.Id,
-				Version: configConnector.Version,
-				State:   configConnector.State,
-			}]++
-
-			// All other entries for this id must have version and state specified if one does
-			for _, cc := range configConnectors.GetConnectors() {
-				if cc.Id == configConnector.Id && cc.Version == configConnector.Version && cc.State == configConnector.State {
-					// Same entry we are checking
-					continue
-				}
-
-				if cc.Id == configConnector.Id {
-					if !cc.HasVersion() || (!configConnector.IsDraft() && !cc.HasState()) {
-						return fmt.Errorf("connector %s version %d has state %s but other entries do not have all these fields specified", configConnector.Id, configConnector.Version, configConnector.State)
-					}
-				}
-
-				ccLabelKey := serializeLabels(&cc)
-				if ccLabelKey == labelKey && !cc.HasId() {
-					return fmt.Errorf("a connector with identifying labels %s exists with an id, but not all connectors with those labels have id", labelKey)
-				}
-			}
-		} else if configConnector.HasId() && configConnector.HasVersion() {
-			idVersionCounts[IdVersionTuple{
-				Id:      configConnector.Id,
-				Version: configConnector.Version,
-			}]++
-
-			// All other entries for this id must have version if one does
-			for _, cc := range configConnectors.GetConnectors() {
-				if cc.Id == configConnector.Id && cc.Version == configConnector.Version {
-					// Same entry we are checking
-					continue
-				}
-
-				if cc.Id == configConnector.Id && !cc.HasVersion() {
-					if !cc.HasVersion() {
-						return fmt.Errorf("connector %s has version %d has but not all other entries do not have version specified", configConnector.Id, configConnector.Version)
-					}
-				}
-
-				ccLabelKey := serializeLabels(&cc)
-				if ccLabelKey == labelKey && !cc.HasId() {
-					return fmt.Errorf("a connector with identifying labels %s exists with an id, but not all connectors with those labels have id", labelKey)
-				}
-			}
-		} else if configConnector.HasId() && configConnector.HasState() {
-			idStateCounts[IdStateTuple{
-				Id:    configConnector.Id,
-				State: configConnector.State,
-			}]++
-
-			// All other entries for this id must have version if one does
-			for _, cc := range configConnectors.GetConnectors() {
-				if cc.Id == configConnector.Id && cc.State == configConnector.State {
-					// Same entry we are checking
-					continue
-				}
-
-				ccLabelKey := serializeLabels(&cc)
-				if ccLabelKey == labelKey && !cc.HasId() {
-					return fmt.Errorf("a connector with identifying labels %s exists with an id, but not all connectors with those labels have id", labelKey)
-				}
-			}
-		} else if configConnector.HasId() {
-			idCounts[configConnector.Id]++
-
-			// All other entries for this id must have version if one does
-			for _, cc := range configConnectors.GetConnectors() {
-				if cc.Id == configConnector.Id && cc.State == configConnector.State {
-					// Same entry we are checking
-					continue
-				}
-
-				ccLabelKey := serializeLabels(&cc)
-				if ccLabelKey == labelKey && !cc.HasId() {
-					return fmt.Errorf("a connector with identifying labels %s exists with an id, but not all connectors with those labels have id", labelKey)
-				}
-			}
-		} else {
-			// Only identifying labels specified
-			identifyingLabelCounts[labelKey]++
-		}
 	}
 
-	result := &multierror.Error{}
+	return nil
+}
 
-	for idVersionState, count := range idVersionStateCounts {
-		if count > 1 {
-			result = multierror.Append(result, fmt.Errorf("connector %s version %d has multiple entries with state %s", idVersionState.Id, idVersionState.Version, idVersionState.State))
-		}
+func (s *service) connectorForConfigName(ctx context.Context, namespace string, name scommon.ResourceName) (*database.ConnectorWithDefinition, error) {
+	page := s.db.ListConnectorsBuilder().
+		ForName(name).
+		ForNamespaceMatchers([]string{namespace}).
+		Limit(2).
+		FetchPage(ctx)
+	if page.Error != nil {
+		return nil, page.Error
 	}
-
-	for idVersion, count := range idVersionCounts {
-		if count > 1 {
-			result = multierror.Append(result, fmt.Errorf("connector %s version %d has multiple entries without differentiating state", idVersion.Id, idVersion.Version))
-		}
+	if len(page.Results) == 0 {
+		return nil, database.ErrNotFound
 	}
-
-	for id, count := range idCounts {
-		if count > 1 {
-			result = multierror.Append(result, fmt.Errorf("connector %s has multiple entries without differentiating state or version", id))
-		}
+	if len(page.Results) > 1 {
+		return nil, fmt.Errorf("multiple connectors named %q exist in namespace %q: %w", name, namespace, database.ErrViolation)
 	}
-
-	for labelKey, count := range identifyingLabelCounts {
-		if count > 1 {
-			result = multierror.Append(result, fmt.Errorf("connector with identifying labels %s has multiple entries without differentiating id or version", labelKey))
-		}
-	}
-
-	return result.ErrorOrNil()
+	return &page.Results[0], nil
 }
 
 // precheckConnectorForMigration checks the database to see if the connector definition aligns with the current state.
 // This covers enforcement that a version that is published cannot change, and what identifiers are required to
 // differentiate this connector definition from others that exist.
-func (s *service) precheckConnectorForMigration(ctx context.Context, configConnectors *config.Connectors, configConnector *config.Connector) error {
+func (s *service) precheckConnectorForMigration(ctx context.Context, configConnector *config.Connector) error {
 	// Don't modify original as we do all the checks
 	configConnector = configConnector.Clone()
-	identifyingLabels := configConnectors.GetIdentifyingLabels()
 
 	if configConnector.HasId() {
+		if configConnector.HasName() {
+			byName, err := s.connectorForConfigName(ctx, configConnector.GetNamespace(), configConnector.Name)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return fmt.Errorf("failed to check connector name during precheck: %w", err)
+			}
+			if byName != nil && byName.Id != configConnector.Id {
+				return fmt.Errorf("connector name %q already belongs to connector %s in namespace %q", configConnector.Name, byName.Id, configConnector.GetNamespace())
+			}
+		}
+
 		if configConnector.HasVersion() {
 			existingVersion, err := s.db.GetConnectorDefinitionVersion(ctx, configConnector.Id, configConnector.Version)
 			if err != nil && !errors.Is(err, database.ErrNotFound) {
@@ -445,53 +326,42 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 					}
 				}
 			}
+		} else {
+			existingVersion, err := s.db.NewestConnectorDefinitionVersionForId(ctx, configConnector.Id)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return fmt.Errorf("failed to get newest version of connector for precheck: %w", err)
+			}
+			if existingVersion != nil && existingVersion.Namespace != configConnector.GetNamespace() {
+				return fmt.Errorf("connector %s currently has namespace path %q and cannot be changed to %q", configConnector.Id, existingVersion.Namespace, configConnector.GetNamespace())
+			}
 		}
 	} else {
-		// No connector id means that we need to look up by identifying labels
-		labelValues := configConnector.GetIdentifyingLabelValues(identifyingLabels)
-		labelSelector := database.BuildLabelSelectorFromMap(labelValues)
-
-		b := s.db.ListConnectorsBuilder().
-			ForLabelSelector(labelSelector).
-			OrderBy(database.ConnectorOrderByCreatedAt, pagination.OrderByDesc).
-			Limit(100)
-
-		results := make([]database.ConnectorWithDefinition, 0)
-		err := b.Enumerate(ctx, func(result pagination.PageResult[database.ConnectorWithDefinition]) (keepGoing pagination.KeepGoing, err error) {
-			results = append(results, result.Results...)
-			return pagination.Continue, nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to check for existing connector for precheck: %w", err)
-		}
-
-		if len(results) > 1 {
-			connectorIds := strings.Join(util.Map(results, func(c database.ConnectorWithDefinition) string { return c.Id.String() }), ", ")
-			return fmt.Errorf("connector with identifying labels %s is not unique among existing defined connectors: %s", labelSelector, connectorIds)
-		} else if len(results) == 1 {
-			if results[0].Namespace != configConnector.GetNamespace() {
-				return fmt.Errorf("connector %s currently has namespace path '%s' and cannot be changed to '%s'", configConnector.Id, results[0].Namespace, configConnector.GetNamespace())
-			}
+		existingConnector, err := s.connectorForConfigName(ctx, configConnector.GetNamespace(), configConnector.Name)
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return fmt.Errorf("failed to check for existing connector by name during precheck: %w", err)
 		}
 
 		if configConnector.HasVersion() {
-			existingVersion, err := s.db.GetConnectorDefinitionVersionForLabelsAndVersion(ctx, labelSelector, configConnector.Version)
-			if err != nil && !errors.Is(err, database.ErrNotFound) {
-				return fmt.Errorf("failed to check for existing connector version for precheck: %w", err)
+			var existingVersion *database.ConnectorWithDefinition
+			if existingConnector != nil {
+				existingVersion, err = s.db.GetConnectorDefinitionVersion(ctx, existingConnector.Id, configConnector.Version)
+				if err != nil && !errors.Is(err, database.ErrNotFound) {
+					return fmt.Errorf("failed to check for existing connector version for precheck: %w", err)
+				}
 			}
 
-			if errors.Is(err, database.ErrNotFound) {
-				if len(results) == 0 {
+			if existingVersion == nil {
+				if existingConnector == nil {
 					if configConnector.Version != 1 {
-						return fmt.Errorf("connector with identifying labels %s does not have previous versions and must start with version 1", labelSelector)
+						return fmt.Errorf("connector %q in namespace %q does not have previous versions and must start with version 1", configConnector.Name, configConnector.GetNamespace())
 					}
 				} else {
-					newestVersion, err := s.db.NewestConnectorDefinitionVersionForId(ctx, results[0].Id)
+					newestVersion, err := s.db.NewestConnectorDefinitionVersionForId(ctx, existingConnector.Id)
 					if err != nil && !errors.Is(err, database.ErrNotFound) {
 						return fmt.Errorf("failed to get newest version of connector for precheck: %w", err)
 					}
 					if newestVersion != nil && newestVersion.Version+1 != configConnector.Version {
-						return fmt.Errorf("connector with identifying labels %s currently has version %d and cannot be incremented to %d", labelSelector, newestVersion.Version, configConnector.Version)
+						return fmt.Errorf("connector %q in namespace %q currently has version %d and cannot be incremented to %d", configConnector.Name, configConnector.GetNamespace(), newestVersion.Version, configConnector.Version)
 					}
 				}
 			} else {
@@ -500,17 +370,13 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 					configConnector.State = string(database.ConnectorDefinitionVersionStatePrimary)
 				}
 
-				if existingVersion.Namespace != configConnector.GetNamespace() {
-					return fmt.Errorf("connector with identifying labels %s currently has namespace '%s' and cannot be changed to %s", labelSelector, existingVersion.Namespace, configConnector.GetNamespace())
-				}
-
 				if existingVersion.State != database.ConnectorDefinitionVersionStateDraft {
 					matches, hashErr := s.connectorVersionHashEquals(existingVersion, configConnector.Hash())
 					if hashErr != nil {
 						return hashErr
 					}
 					if !matches {
-						return fmt.Errorf("connector with identifying labels %s version %d has been published and cannot be modified", labelSelector, configConnector.Version)
+						return fmt.Errorf("connector %q in namespace %q version %d has been published and cannot be modified", configConnector.Name, configConnector.GetNamespace(), configConnector.Version)
 					}
 				}
 			}
@@ -524,11 +390,21 @@ func (s *service) precheckConnectorForMigration(ctx context.Context, configConne
 // Returns the resolved connector id (the id this config entry maps to in the
 // database, whether newly generated or matched against an existing row) so the
 // caller can track which connectors are config-managed and detect orphans.
-func (s *service) migrateConnector(ctx context.Context, configConnectors *config.Connectors, configConnector *config.Connector) (apid.ID, error) {
-	b := newConnectorBuilder(s)
-	identifyingLabels := configConnectors.GetIdentifyingLabels()
+func (s *service) syncConfiguredConnectorName(ctx context.Context, configConnector *config.Connector, existingVersion *database.ConnectorWithDefinition) error {
+	if existingVersion == nil || !configConnector.HasId() || !configConnector.HasName() || existingVersion.Name == configConnector.Name {
+		return nil
+	}
+	if err := s.UpdateConnectorName(ctx, configConnector.Id, configConnector.Name); err != nil {
+		return fmt.Errorf("failed to rename configured connector %s to %q: %w", configConnector.Id, configConnector.Name, err)
+	}
+	existingVersion.Name = configConnector.Name
+	return nil
+}
 
-	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnectorVersion)
+func (s *service) migrateConnector(ctx context.Context, configConnector *config.Connector) (apid.ID, error) {
+	b := newConnectorBuilder(s)
+
+	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnector)
 	if configConnector.HasId() {
 		id = configConnector.Id
 	}
@@ -553,6 +429,16 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 		existingVersion, err = s.db.GetConnectorDefinitionVersion(ctx, configConnector.Id, configConnector.Version)
 		if err != nil && !errors.Is(err, database.ErrNotFound) {
 			return apid.Nil, fmt.Errorf("failed to get connector version: %w", err)
+		}
+		existingConnector := existingVersion
+		if existingConnector == nil && configConnector.HasName() {
+			existingConnector, err = s.db.NewestConnectorDefinitionVersionForId(ctx, configConnector.Id)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return apid.Nil, fmt.Errorf("failed to get connector for rename: %w", err)
+			}
+		}
+		if err := s.syncConfiguredConnectorName(ctx, configConnector, existingConnector); err != nil {
+			return apid.Nil, err
 		}
 
 		if existingVersion != nil {
@@ -579,6 +465,9 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 		if err != nil && !errors.Is(err, database.ErrNotFound) {
 			return apid.Nil, fmt.Errorf("failed to get newest version of connector: %w", err)
 		}
+		if err := s.syncConfiguredConnectorName(ctx, configConnector, existingVersion); err != nil {
+			return apid.Nil, err
+		}
 
 		if existingVersion != nil {
 			c, err := b.
@@ -602,16 +491,21 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 			version = existingVersion.Version + 1
 		}
 	} else if configConnector.HasVersion() {
-		// Pattern C: version only, no ID - use label-based lookup
-		labelValues := configConnector.GetIdentifyingLabelValues(identifyingLabels)
-		labelSelector := database.BuildLabelSelectorFromMap(labelValues)
-		existingVersion, err = s.db.GetConnectorDefinitionVersionForLabelsAndVersion(ctx, labelSelector, configConnector.Version)
-		if err != nil && !errors.Is(err, database.ErrNotFound) {
-			return apid.Nil, fmt.Errorf("failed to get connector version for labels/version: %w", err)
+		// Pattern C: version and name, no ID - resolve the logical connector by
+		// exact name within its namespace, then address the version by its ID.
+		existingConnector, lookupErr := s.connectorForConfigName(ctx, configConnector.GetNamespace(), configConnector.Name)
+		if lookupErr != nil && !errors.Is(lookupErr, database.ErrNotFound) {
+			return apid.Nil, fmt.Errorf("failed to get connector by name: %w", lookupErr)
 		}
-
-		if existingVersion != nil {
-			id = existingVersion.Id
+		if existingConnector != nil {
+			id = existingConnector.Id
+			existingVersion, err = s.db.GetConnectorDefinitionVersion(ctx, id, configConnector.Version)
+			if err != nil && !errors.Is(err, database.ErrNotFound) {
+				return apid.Nil, fmt.Errorf("failed to get connector version by name: %w", err)
+			}
+			if existingVersion == nil {
+				existingVersion = existingConnector
+			}
 
 			c, err := b.
 				WithId(id).
@@ -630,23 +524,13 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 					return id, nil
 				}
 			}
-		} else {
-			existingVersion, err = s.db.GetConnectorDefinitionVersionForLabels(ctx, labelSelector)
-			if err != nil && !errors.Is(err, database.ErrNotFound) {
-				return apid.Nil, fmt.Errorf("failed to get connector version for labels: %w", err)
-			}
-
-			if existingVersion != nil {
-				id = existingVersion.Id
-			}
 		}
 	} else {
-		// Pattern D: no ID, no version - use label-based lookup
-		labelValues := configConnector.GetIdentifyingLabelValues(identifyingLabels)
-		labelSelector := database.BuildLabelSelectorFromMap(labelValues)
-		existingVersion, err = s.db.GetConnectorDefinitionVersionForLabels(ctx, labelSelector)
+		// Pattern D: name only - resolve the logical connector by exact name
+		// within its namespace and let definition changes auto-increment version.
+		existingVersion, err = s.connectorForConfigName(ctx, configConnector.GetNamespace(), configConnector.Name)
 		if err != nil && !errors.Is(err, database.ErrNotFound) {
-			return apid.Nil, fmt.Errorf("failed to get connector version for labels: %w", err)
+			return apid.Nil, fmt.Errorf("failed to get connector by name: %w", err)
 		}
 
 		if existingVersion != nil {
@@ -683,6 +567,9 @@ func (s *service) migrateConnector(ctx context.Context, configConnectors *config
 	if err != nil {
 		return apid.Nil, fmt.Errorf("failed to build connector version: %w", err)
 	}
+	// Name is config reconciliation metadata for the logical connector, not
+	// part of the encrypted definition assembled by connectorBuilder.
+	c.ConnectorWithDefinition.Name = configConnector.Name
 
 	// Final check, though this should be duplicative
 	if existingVersion != nil {

--- a/internal/core/service_migration_test.go
+++ b/internal/core/service_migration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apasynq/mock"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/apredis"
-	apredis2 "github.com/rmorlok/authproxy/internal/apredis"
+	apredismock "github.com/rmorlok/authproxy/internal/apredis/mock"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -65,11 +65,15 @@ func TestMigration(t *testing.T) {
 
 		logger := slog.Default()
 		cfg, db, rawDb = database.MustApplyBlankTestDbConfigRaw(t, cfg)
-		cfg, r = apredis2.MustApplyTestConfig(cfg)
-		e := encrypt.NewEncryptService(cfg, db, logger)
 		ctrl := gomock.NewController(t)
+		r = apredismock.NewMockClient(ctrl)
+		e := encrypt.NewEncryptService(cfg, db, logger)
 
 		asynqClient = mock.NewMockClient(ctrl)
+		asynqClient.(*mock.MockClient).EXPECT().
+			EnqueueContext(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(nil, nil)
 		h = hmock.NewMockF(ctrl)
 
 		service = NewCoreService(cfg, db, e, r, h, asynqClient, logger)
@@ -97,7 +101,107 @@ func TestMigration(t *testing.T) {
 
 			assertSqlWithDisplayName(t, rawDb, cfg, `
 			SELECT connector_id AS id, version, state FROM connector_definition_versions;
-		`, []connectorResult{})
+			`, []connectorResult{})
+		})
+
+		t.Run("names reconcile connector identity", func(t *testing.T) {
+			t.Run("label changes preserve the generated connector id", func(t *testing.T) {
+				cleanup := setup(t, []cschema.Connector{{
+					Name:        "configured",
+					Labels:      map[string]string{"type": "before"},
+					DisplayName: "Before",
+				}})
+				defer cleanup()
+
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+				first := db.ListConnectorsBuilder().ForName("configured").FetchPage(context.Background())
+				require.NoError(t, first.Error)
+				require.Len(t, first.Results, 1)
+				generatedID := first.Results[0].Id
+
+				cfg.GetRoot().Connectors.LoadFromList[0].Labels["type"] = "after"
+				cfg.GetRoot().Connectors.LoadFromList[0].DisplayName = "After"
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+
+				result := db.ListConnectorsBuilder().ForName("configured").FetchPage(context.Background())
+				require.NoError(t, result.Error)
+				require.Len(t, result.Results, 1)
+				require.Equal(t, generatedID, result.Results[0].Id)
+				require.Equal(t, "after", result.Results[0].Labels["type"])
+
+				versions := db.ListConnectorDefinitionVersionsBuilder().ForId(generatedID).FetchPage(context.Background())
+				require.NoError(t, versions.Error)
+				require.Len(t, versions.Results, 2)
+			})
+
+			t.Run("explicit id can rename without creating a version", func(t *testing.T) {
+				connectorID := apid.MustParse("cxr_test0000000000001")
+				cleanup := setup(t, []cschema.Connector{{
+					Id:          connectorID,
+					Name:        "before",
+					Labels:      map[string]string{"type": "same"},
+					DisplayName: "Unchanged definition",
+				}})
+				defer cleanup()
+
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+				cfg.GetRoot().Connectors.LoadFromList[0].Name = "after"
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+
+				renamed := db.ListConnectorsBuilder().ForName("after").FetchPage(context.Background())
+				require.NoError(t, renamed.Error)
+				require.Len(t, renamed.Results, 1)
+				require.Equal(t, connectorID, renamed.Results[0].Id)
+				require.Equal(t, "after", renamed.Results[0].Labels["apxy/cxr/-/name"])
+
+				versions := db.ListConnectorDefinitionVersionsBuilder().ForId(connectorID).FetchPage(context.Background())
+				require.NoError(t, versions.Error)
+				require.Len(t, versions.Results, 1)
+			})
+
+			t.Run("explicit id can rename while adding a version", func(t *testing.T) {
+				connectorID := apid.MustParse("cxr_test0000000000001")
+				cleanup := setup(t, []cschema.Connector{{
+					Id:          connectorID,
+					Name:        "before",
+					Version:     1,
+					Labels:      map[string]string{"type": "same"},
+					DisplayName: "Version one",
+				}})
+				defer cleanup()
+
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+				cfg.GetRoot().Connectors.LoadFromList[0].Name = "after"
+				cfg.GetRoot().Connectors.LoadFromList[0].Version = 2
+				cfg.GetRoot().Connectors.LoadFromList[0].DisplayName = "Version two"
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+
+				renamed := db.ListConnectorsBuilder().ForName("after").FetchPage(context.Background())
+				require.NoError(t, renamed.Error)
+				require.Len(t, renamed.Results, 1)
+				require.Equal(t, connectorID, renamed.Results[0].Id)
+
+				versions := db.ListConnectorDefinitionVersionsBuilder().ForId(connectorID).FetchPage(context.Background())
+				require.NoError(t, versions.Error)
+				require.Len(t, versions.Results, 2)
+			})
+
+			t.Run("same name in different namespaces creates different connectors", func(t *testing.T) {
+				firstNamespace := "root.first"
+				secondNamespace := "root.second"
+				cleanup := setup(t, []cschema.Connector{
+					{Name: "shared", Namespace: &firstNamespace, Labels: map[string]string{"type": "same"}},
+					{Name: "shared", Namespace: &secondNamespace, Labels: map[string]string{"type": "same"}},
+				})
+				defer cleanup()
+
+				require.NoError(t, service.Migrate(context.Background()))
+
+				results := db.ListConnectorsBuilder().ForName("shared").FetchPage(context.Background())
+				require.NoError(t, results.Error)
+				require.Len(t, results.Results, 2)
+				require.NotEqual(t, results.Results[0].Id, results.Results[1].Id)
+			})
 		})
 
 		t.Run("id and version", func(t *testing.T) {
@@ -934,10 +1038,11 @@ func TestMigration(t *testing.T) {
 			})
 		})
 
-		t.Run("type and version", func(t *testing.T) {
+		t.Run("name and version", func(t *testing.T) {
 			t.Run("changed once preserves generated id", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Version:     1,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
@@ -996,6 +1101,7 @@ func TestMigration(t *testing.T) {
 			t.Run("initial version must start at one", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Version:     2,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
@@ -1020,6 +1126,7 @@ func TestMigration(t *testing.T) {
 			t.Run("cannot change published version", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Version:     1,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
@@ -1056,10 +1163,11 @@ func TestMigration(t *testing.T) {
 			})
 		})
 
-		t.Run("type only", func(t *testing.T) {
+		t.Run("name only", func(t *testing.T) {
 			t.Run("single initial", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:   "fake",
 						Labels: map[string]string{"type": "fake"},
 					},
 				})
@@ -1086,6 +1194,7 @@ func TestMigration(t *testing.T) {
 			t.Run("unchanged initial", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:   "fake",
 						Labels: map[string]string{"type": "fake"},
 					},
 				})
@@ -1115,6 +1224,7 @@ func TestMigration(t *testing.T) {
 			t.Run("changed once", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
 					},
@@ -1154,6 +1264,7 @@ func TestMigration(t *testing.T) {
 			t.Run("changed once then unchanged", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
 					},
@@ -1196,6 +1307,7 @@ func TestMigration(t *testing.T) {
 			t.Run("changed twice", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "initial",
 					},
@@ -1242,13 +1354,15 @@ func TestMigration(t *testing.T) {
 				})
 			})
 
-			t.Run("does not allow duplicate type without id initial", func(t *testing.T) {
+			t.Run("does not allow duplicate name without id initial", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "first",
 					},
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "second",
 					},
@@ -1270,9 +1384,10 @@ func TestMigration(t *testing.T) {
 		`, []connectorResult{})
 			})
 
-			t.Run("does not allow duplicate type without id when migrated", func(t *testing.T) {
+			t.Run("does not allow duplicate name without id when migrated", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "first",
 					},
@@ -1283,6 +1398,7 @@ func TestMigration(t *testing.T) {
 				require.NoError(t, err)
 
 				cfg.GetRoot().Connectors.LoadFromList = append(cfg.GetRoot().Connectors.LoadFromList, cschema.Connector{
+					Name:        "fake",
 					Labels:      map[string]string{"type": "fake"},
 					DisplayName: "second",
 				})
@@ -1472,15 +1588,17 @@ func TestMigration(t *testing.T) {
 		`, []connectorResult{})
 			})
 
-			t.Run("id version and type without id", func(t *testing.T) {
+			t.Run("id version and name without id", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Version:     1,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
@@ -1493,11 +1611,13 @@ func TestMigration(t *testing.T) {
 				cleanup2 := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Version:     1,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Version:     2,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
@@ -1511,11 +1631,13 @@ func TestMigration(t *testing.T) {
 				cleanup3 := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Version:     1,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Version:     2,
 						State:       "draft",
 						Labels:      map[string]string{"type": "fake"},
@@ -1539,14 +1661,16 @@ func TestMigration(t *testing.T) {
 		`, []connectorResult{})
 			})
 
-			t.Run("id and type without id", func(t *testing.T) {
+			t.Run("id and name without id", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
@@ -1559,10 +1683,12 @@ func TestMigration(t *testing.T) {
 				cleanup2 := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Version:     2,
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
@@ -1576,10 +1702,12 @@ func TestMigration(t *testing.T) {
 				cleanup3 := setup(t, []cschema.Connector{
 					{
 						Id:          apid.MustParse("cxr_test0000000000001"),
+						Name:        "fake",
 						Labels:      map[string]string{"type": "fake"},
 						DisplayName: "duplicate",
 					},
 					{
+						Name:        "fake",
 						Version:     2,
 						State:       "draft",
 						Labels:      map[string]string{"type": "fake"},

--- a/internal/database/connector_definition_version.go
+++ b/internal/database/connector_definition_version.go
@@ -538,62 +538,6 @@ func (s *service) DeleteConnector(ctx context.Context, id apid.ID) error {
 	})
 }
 
-// GetConnectorDefinitionVersionForLabels finds the newest connector version matching the label selector.
-func (s *service) GetConnectorDefinitionVersionForLabels(ctx context.Context, labelSelector string) (*ConnectorWithDefinition, error) {
-	selector, err := ParseLabelSelector(labelSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	var result ConnectorWithDefinition
-	q := s.selectConnectorDefinitionVersions().
-		Where(sq.Eq{"c.deleted_at": nil, "dv.deleted_at": nil})
-
-	q = selector.ApplyToSqlBuilderWithProvider(q, "c.labels", s.cfg.GetProvider())
-
-	err = q.OrderBy("c.created_at DESC", "dv.version DESC").
-		Limit(1).
-		RunWith(s.db).
-		QueryRow().
-		Scan(result.fields()...)
-
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
-// GetConnectorDefinitionVersionForLabelsAndVersion finds a connector version by labels + specific version.
-func (s *service) GetConnectorDefinitionVersionForLabelsAndVersion(ctx context.Context, labelSelector string, version uint64) (*ConnectorWithDefinition, error) {
-	selector, err := ParseLabelSelector(labelSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	var result ConnectorWithDefinition
-	q := s.selectConnectorDefinitionVersions().
-		Where(sq.Eq{"dv.version": version, "dv.deleted_at": nil, "c.deleted_at": nil})
-
-	q = selector.ApplyToSqlBuilderWithProvider(q, "c.labels", s.cfg.GetProvider())
-
-	err = q.OrderBy("c.created_at DESC").
-		Limit(1).
-		RunWith(s.db).
-		QueryRow().
-		Scan(result.fields()...)
-
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
 func (s *service) GetConnectorDefinitionVersionForState(ctx context.Context, id apid.ID, state ConnectorDefinitionVersionState) (*ConnectorWithDefinition, error) {
 	var result ConnectorWithDefinition
 	err := s.selectConnectorDefinitionVersions().

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -98,8 +98,6 @@ type DB interface {
 
 	GetConnectorDefinitionVersion(ctx context.Context, id apid.ID, version uint64) (*ConnectorWithDefinition, error)
 	GetConnectorDefinitionVersions(ctx context.Context, requested []ConnectorDefinitionVersionId) (map[ConnectorDefinitionVersionId]*ConnectorWithDefinition, error)
-	GetConnectorDefinitionVersionForLabels(ctx context.Context, labelSelector string) (*ConnectorWithDefinition, error)
-	GetConnectorDefinitionVersionForLabelsAndVersion(ctx context.Context, labelSelector string, version uint64) (*ConnectorWithDefinition, error)
 	GetConnectorDefinitionVersionForState(ctx context.Context, id apid.ID, state ConnectorDefinitionVersionState) (*ConnectorWithDefinition, error)
 	NewestConnectorDefinitionVersionForId(ctx context.Context, id apid.ID) (*ConnectorWithDefinition, error)
 	NewestPublishedConnectorDefinitionVersionForId(ctx context.Context, id apid.ID) (*ConnectorWithDefinition, error)

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -894,36 +894,6 @@ func (mr *MockDBMockRecorder) GetConnectorDefinitionVersion(ctx, id, version int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorDefinitionVersion", reflect.TypeOf((*MockDB)(nil).GetConnectorDefinitionVersion), ctx, id, version)
 }
 
-// GetConnectorDefinitionVersionForLabels mocks base method.
-func (m *MockDB) GetConnectorDefinitionVersionForLabels(ctx context.Context, labelSelector string) (*database.ConnectorWithDefinition, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConnectorDefinitionVersionForLabels", ctx, labelSelector)
-	ret0, _ := ret[0].(*database.ConnectorWithDefinition)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConnectorDefinitionVersionForLabels indicates an expected call of GetConnectorDefinitionVersionForLabels.
-func (mr *MockDBMockRecorder) GetConnectorDefinitionVersionForLabels(ctx, labelSelector interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorDefinitionVersionForLabels", reflect.TypeOf((*MockDB)(nil).GetConnectorDefinitionVersionForLabels), ctx, labelSelector)
-}
-
-// GetConnectorDefinitionVersionForLabelsAndVersion mocks base method.
-func (m *MockDB) GetConnectorDefinitionVersionForLabelsAndVersion(ctx context.Context, labelSelector string, version uint64) (*database.ConnectorWithDefinition, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConnectorDefinitionVersionForLabelsAndVersion", ctx, labelSelector, version)
-	ret0, _ := ret[0].(*database.ConnectorWithDefinition)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConnectorDefinitionVersionForLabelsAndVersion indicates an expected call of GetConnectorDefinitionVersionForLabelsAndVersion.
-func (mr *MockDBMockRecorder) GetConnectorDefinitionVersionForLabelsAndVersion(ctx, labelSelector, version interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorDefinitionVersionForLabelsAndVersion", reflect.TypeOf((*MockDB)(nil).GetConnectorDefinitionVersionForLabelsAndVersion), ctx, labelSelector, version)
-}
-
 // GetConnectorDefinitionVersionForState mocks base method.
 func (m *MockDB) GetConnectorDefinitionVersionForState(ctx context.Context, id apid.ID, state database.ConnectorDefinitionVersionState) (*database.ConnectorWithDefinition, error) {
 	m.ctrl.T.Helper()

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -47,15 +47,19 @@
         },
         "load_from_list": {
           "items": {
-            "$ref": "../resources/connectors/schema.json"
+            "allOf": [
+              {
+                "$ref": "../resources/connectors/schema.json"
+              },
+              {
+                "anyOf": [
+                  { "required": ["id"] },
+                  { "required": ["name"] }
+                ]
+              }
+            ]
           },
           "type": "array"
-        },
-        "identifying_labels": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
       },
       "additionalProperties": false,

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -986,14 +986,24 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {}}`,
 				},
 				{
-					Name:  "with identifying_labels",
-					Valid: true,
+					Name:  "identifying_labels was removed",
+					Valid: false,
 					Data:  `{"test": {"identifying_labels": ["type", "region"]}}`,
 				},
 				{
 					Name:  "with auto_migrate",
 					Valid: true,
 					Data:  `{"test": {"auto_migrate": true, "auto_migration_lock_duration": "30s"}}`,
+				},
+				{
+					Name:  "connector with name",
+					Valid: true,
+					Data:  `{"test":{"load_from_list":[{"name":"example","labels":{},"display_name":"Example","logo":{"public_url":"https://example.com/logo.svg"},"auth":{"type":"no-auth"}}]}}`,
+				},
+				{
+					Name:  "connector without id or name",
+					Valid: false,
+					Data:  `{"test":{"load_from_list":[{"labels":{},"display_name":"Example","logo":{"public_url":"https://example.com/logo.svg"},"auth":{"type":"no-auth"}}]}}`,
 				},
 				{
 					Name:  "extra property",

--- a/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
+++ b/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
@@ -4,7 +4,8 @@ connectors:
   auto_migrate: true
   auto_migration_lock_duration: 30s
   load_from_list:
-  - labels:
+  - name: asana
+    labels:
       type: asana
     id: D21753F8-2E91-43E7-ADEF-8ED80A6086AC
     version: 1

--- a/internal/schema/config/test_data/valid.yaml
+++ b/internal/schema/config/test_data/valid.yaml
@@ -80,7 +80,8 @@ connectors:
   auto_migrate: true
   auto_migration_lock_duration: 30s
   load_from_list:
-  - labels:
+  - name: google-drive
+    labels:
       type: google-drive
     display_name: Google Drive
     logo:
@@ -118,7 +119,8 @@ connectors:
           required: false
           reason: |
             We need to be able to see what's been going on in drive
-  - labels:
+  - name: greenhouse
+    labels:
       type: greenhouse
     version: 1
     display_name: Greenhouse
@@ -131,7 +133,8 @@ connectors:
       type: api-key
       placement:
         type: bearer
-  - labels:
+  - name: google-calendar
+    labels:
       type: google-calendar
     display_name: Google Calendar
     logo: https://upload.wikimedia.org/wikipedia/commons/a/a5/Google_Calendar_icon_%282020%29.svg
@@ -155,7 +158,8 @@ connectors:
         - id: https://www.googleapis.com/auth/calendar.readonly
           reason: |
             We need to be able to read the calendar
-  - labels:
+  - name: gmail
+    labels:
       type: gmail
     display_name: GMail
     logo:
@@ -180,7 +184,8 @@ connectors:
         - id: https://www.googleapis.com/auth/gmail.readonly
           reason: |
             We need to be able to read your emails
-  - labels:
+  - name: pipedrive
+    labels:
       type: pipedrive
     display_name: pipedrive
     logo:
@@ -207,7 +212,8 @@ connectors:
         - id: webhooks:full
           reason: |
             Allows us to receive notification of changes in realtime
-  - labels:
+  - name: asana
+    labels:
       type: asana
     display_name: Asana
     logo:

--- a/internal/schema/resources/connectors/connector.go
+++ b/internal/schema/resources/connectors/connector.go
@@ -14,9 +14,13 @@ import (
 
 type Connector struct {
 	// Id is the global id for this connector. This does not change version to version. In the config file, this can
-	// be omitted if there is only one instance of a particular type of connector. If there are multiple connectors that
-	// share the same identifying labels, the ids would need to be explicitly defined.
+	// be omitted when Name is specified; the logical connector is then reconciled by name within its namespace.
 	Id apid.ID `json:"id" yaml:"id"`
+
+	// Name is the mutable name of the logical connector. Config entries without an explicit ID must specify a name so
+	// AuthProxy can reconcile the same logical connector across reloads. When an ID is specified and name is omitted,
+	// a newly created connector defaults its name to the ID.
+	Name common.ResourceName `json:"name,omitempty" yaml:"name,omitempty" swaggerignore:"true"`
 
 	// Version is the logical version of the connector. When auth materially changes, such as adding new scopes,
 	// changing client ids/secrets, adding configuration settings, etc. the logical version of the connector must change
@@ -133,6 +137,11 @@ func (c *Connector) Clone() *Connector {
 
 func (c *Connector) Validate(vc *common.ValidationContext) error {
 	result := &multierror.Error{}
+	if c.Name != "" {
+		if err := c.Name.Validate(); err != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("name", "%v", err))
+		}
+	}
 	javascript, err := apjs.CompileAndValidateLibrary(c.Javascript)
 	if err != nil {
 		result = multierror.Append(result, vc.NewErrorfForField("javascript", "invalid connector javascript: %v", err))
@@ -194,25 +203,18 @@ func (c *Connector) Validate(vc *common.ValidationContext) error {
 	return result.ErrorOrNil()
 }
 
-// GetIdentifyingLabelValues returns the values for the specified identifying labels.
-func (c *Connector) GetIdentifyingLabelValues(identifyingLabels []string) map[string]string {
-	result := make(map[string]string)
-	if c == nil || c.Labels == nil {
-		return result
-	}
-	for _, key := range identifyingLabels {
-		if v, ok := c.Labels[key]; ok {
-			result[key] = v
-		}
-	}
-	return result
-}
-
 // Hash computes a semantic hash of the connector data. It does not account for data that is not stored in the
 // configuration directly (e.g. environment variables referenced). A change in the hash implies that a new version
 // must be created if the existing version is already live.
 func (c *Connector) Hash() string {
-	jsonData, err := json.Marshal(c)
+	if c == nil {
+		return ""
+	}
+	definition := c.Clone()
+	// Name belongs to the logical connector rather than an individual
+	// definition version, so a rename must not change the definition hash.
+	definition.Name = ""
+	jsonData, err := json.Marshal(definition)
 	if err != nil {
 		return ""
 	}
@@ -228,6 +230,11 @@ func (c *Connector) HasId() bool {
 	}
 
 	return c.Id != apid.Nil
+}
+
+// HasName returns true when the configuration explicitly specifies a name.
+func (c *Connector) HasName() bool {
+	return c != nil && c.Name != ""
 }
 
 // HasVersion returns true if the connector has a version. This implies that the configuration set a version explicitly.

--- a/internal/schema/resources/connectors/connector_test.go
+++ b/internal/schema/resources/connectors/connector_test.go
@@ -28,6 +28,7 @@ func TestConnectorRoundtrip(t *testing.T) {
 			name: "Basic Connector with API Key Auth",
 			connector: Connector{
 				Id:          testID,
+				Name:        "test-connector",
 				Labels:      map[string]string{"type": "test-type"},
 				Version:     1,
 				State:       "primary",
@@ -133,4 +134,11 @@ func TestConnectorRoundtrip(t *testing.T) {
 			assert.True(t, cmp.Equal(tc.connector, unmarshaledConnector), "Connector diff: %s", diff)
 		})
 	}
+}
+
+func TestConnectorHashIgnoresLogicalName(t *testing.T) {
+	connector := &Connector{Name: "before", DisplayName: "Test Connector"}
+	before := connector.Hash()
+	connector.Name = "after"
+	require.Equal(t, before, connector.Hash())
 }

--- a/internal/schema/resources/connectors/connectors.go
+++ b/internal/schema/resources/connectors/connectors.go
@@ -1,7 +1,6 @@
 package connectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -17,10 +16,6 @@ type Connectors struct {
 	AutoMigrate               *bool                 `json:"auto_migrate,omitempty" yaml:"auto_migrate,omitempty"`
 	AutoMigrationLockDuration *common.HumanDuration `json:"auto_migration_lock_duration,omitempty" yaml:"auto_migration_lock_duration,omitempty"`
 	LoadFromList              []Connector           `json:"load_from_list,omitempty" yaml:"load_from_list,omitempty"`
-
-	// IdentifyingLabels defines which label keys differentiate connectors when no explicit ID is specified.
-	// Defaults to ["type"] for backwards compatibility.
-	IdentifyingLabels []string `json:"identifying_labels,omitempty" yaml:"identifying_labels,omitempty"`
 }
 
 func FromList(c []Connector) *Connectors {
@@ -47,141 +42,160 @@ func (c *Connectors) GetConnectors() []Connector {
 	return c.LoadFromList
 }
 
-// GetIdentifyingLabels returns the identifying labels for connector differentiation.
-// Defaults to ["type"] for backwards compatibility when not specified.
-func (c *Connectors) GetIdentifyingLabels() []string {
-	if c == nil || len(c.IdentifyingLabels) == 0 {
-		return []string{"type"}
-	}
-	return c.IdentifyingLabels
-}
-
 func (c *Connectors) Validate(vc *common.ValidationContext) error {
 	result := &multierror.Error{}
-	identifyingLabels := c.GetIdentifyingLabels()
-
-	// Track by identifying label values (JSON-serialized) instead of Type
-	identifyingLabelCounts := make(map[string]int)          // serialized labels -> count
-	identifyingLabelHasUuidCount := make(map[string]int)    // serialized labels -> count with uuid
-	identifyingLabelHasVersionCount := make(map[string]int) // serialized labels -> count with version
-	identifyingLabelNoUuidVersionCount := make(map[string]map[uint64]int)
-
-	uuidToCount := make(map[apid.ID]int)
-	uuidHasVersionsCount := make(map[apid.ID]int)
-	uuidVersionCount := make(map[apid.ID]map[uint64]int)
-
-	// Beyond the validation of the individual connector configurations, this validate method checks to make sure that
-	// all connectors in the list are properly differentiated. We allow users to specify connectors only by identifying
-	// labels as long as there is only one of them. Assuming unspecified the system auto manages versions, attempting
-	// to immediately mark the new version as primary. If the user wants to manage this rollout process directly, they
-	// need to specify versions in the config to match what the system is tracking.
-	//
-	// Likewise, it is possible to have multiple connectors with the same identifying labels to provide alternatives
-	// for how to connect. If they want to specify multiple connectors with the same identifying labels, they must
-	// explicitly specify UUIDs to differentiate so that the system knows how to manage the upgrade path.
-
 	for i, connector := range c.GetConnectors() {
 		// We use a blank validation context at the connector level to account for the future of splitting
 		// the connector definition to a separate file.
 		if err := connector.Validate(&common.ValidationContext{}); err != nil {
-			labelValues := connector.GetIdentifyingLabelValues(identifyingLabels)
-			labelKey := serializeLabelValues(labelValues)
-
-			if connector.Id != apid.Nil && labelKey != "{}" {
-				err = multierror.Prefix(err, fmt.Sprintf("connector %s (%s): ", connector.Id.String(), labelKey))
-			} else if connector.Id != apid.Nil {
+			if connector.Id != apid.Nil {
 				err = multierror.Prefix(err, fmt.Sprintf("connector %s: ", connector.Id.String()))
-			} else if labelKey != "{}" {
-				err = multierror.Prefix(err, fmt.Sprintf("connector with labels %s: ", labelKey))
+			} else if connector.Name != "" {
+				err = multierror.Prefix(err, fmt.Sprintf("connector %s: ", connector.Name))
 			} else {
 				err = multierror.Prefix(err, fmt.Sprintf("connector %d: ", i))
 			}
 
 			result = multierror.Append(result, err)
 		}
+	}
+	result = multierror.Append(result, c.ValidateIdentities(vc))
+	return result.ErrorOrNil()
+}
 
-		// Validate all identifying labels are present
-		labelValues := connector.GetIdentifyingLabelValues(identifyingLabels)
-		for _, key := range identifyingLabels {
-			if _, exists := labelValues[key]; !exists {
-				result = multierror.Append(result, vc.NewErrorfForField(
-					"load_from_list",
-					"connector %d missing required identifying label %q", i, key,
-				))
-			}
+// ValidateIdentities validates only the fields used to reconcile configured
+// connector entries. Migration uses it for its identity precheck; full
+// connector-definition validation remains the responsibility of Validate.
+func (c *Connectors) ValidateIdentities(vc *common.ValidationContext) error {
+	result := &multierror.Error{}
+	type nameKey struct {
+		Namespace string
+		Name      common.ResourceName
+	}
+	type logicalKey struct {
+		Id        apid.ID
+		Namespace string
+		Name      common.ResourceName
+	}
+	type identityDetails struct {
+		ids         map[apid.ID]struct{}
+		hasNoId     bool
+		versions    map[uint64]int
+		unversioned map[string]int
+	}
+
+	byName := make(map[nameKey]*identityDetails)
+	byLogical := make(map[logicalKey]*identityDetails)
+	idNamespaces := make(map[apid.ID]map[string]struct{})
+	idNames := make(map[apid.ID]map[common.ResourceName]struct{})
+
+	for i, connector := range c.GetConnectors() {
+		if !connector.HasId() && !connector.HasName() {
+			result = multierror.Append(result, vc.NewErrorfForField(
+				"load_from_list",
+				"connector %d must specify name when id is omitted", i,
+			))
+			continue
 		}
 
-		// Create key from identifying label values
-		identifyingKey := serializeLabelValues(labelValues)
+		name := connector.Name
+		if name == "" {
+			name = common.ResourceName(connector.Id.String())
+		}
+		nk := nameKey{Namespace: connector.GetNamespace(), Name: name}
+		nameDetails := byName[nk]
+		if nameDetails == nil {
+			nameDetails = &identityDetails{ids: make(map[apid.ID]struct{}), versions: make(map[uint64]int)}
+			byName[nk] = nameDetails
+		}
+		if connector.HasId() {
+			nameDetails.ids[connector.Id] = struct{}{}
+		} else {
+			nameDetails.hasNoId = true
+		}
 
-		if connector.Id != apid.Nil {
-			uuidToCount[connector.Id]++
+		lk := logicalKey{Id: connector.Id}
+		if !connector.HasId() {
+			lk.Namespace = connector.GetNamespace()
+			lk.Name = name
+		}
+		logicalDetails := byLogical[lk]
+		if logicalDetails == nil {
+			logicalDetails = &identityDetails{versions: make(map[uint64]int), unversioned: make(map[string]int)}
+			byLogical[lk] = logicalDetails
+		}
+		if connector.HasVersion() {
+			logicalDetails.versions[connector.Version]++
+		} else {
+			state := connector.State
+			if state == "" {
+				state = "primary"
+			}
+			logicalDetails.unversioned[state]++
+		}
 
-			if connector.Version != 0 {
-				uuidHasVersionsCount[connector.Id]++
-				if uuidVersionCount[connector.Id] == nil {
-					uuidVersionCount[connector.Id] = make(map[uint64]int)
+		if connector.HasId() {
+			if idNamespaces[connector.Id] == nil {
+				idNamespaces[connector.Id] = make(map[string]struct{})
+			}
+			idNamespaces[connector.Id][connector.GetNamespace()] = struct{}{}
+			if connector.HasName() {
+				if idNames[connector.Id] == nil {
+					idNames[connector.Id] = make(map[common.ResourceName]struct{})
 				}
-				uuidVersionCount[connector.Id][connector.Version]++
+				idNames[connector.Id][connector.Name] = struct{}{}
 			}
 		}
+	}
 
-		if identifyingKey != "{}" {
-			identifyingLabelCounts[identifyingKey]++
+	for key, details := range byName {
+		if len(details.ids) > 1 {
+			result = multierror.Append(result, vc.NewErrorf("connector name %q in namespace %q is assigned to multiple ids", key.Name, key.Namespace))
+		}
+		if details.hasNoId && len(details.ids) > 0 {
+			result = multierror.Append(result, vc.NewErrorf("connector name %q in namespace %q mixes entries with and without ids", key.Name, key.Namespace))
+		}
+	}
 
-			if connector.Id != apid.Nil {
-				identifyingLabelHasUuidCount[identifyingKey]++
+	for id, namespaces := range idNamespaces {
+		if len(namespaces) > 1 {
+			result = multierror.Append(result, vc.NewErrorf("connector %s is assigned to multiple namespaces", id))
+		}
+	}
+	for id, names := range idNames {
+		if len(names) > 1 {
+			result = multierror.Append(result, vc.NewErrorf("connector %s is assigned multiple names", id))
+		}
+	}
+
+	for key, details := range byLogical {
+		if len(details.unversioned) > 0 && len(details.versions) > 0 {
+			if key.Id != apid.Nil {
+				result = multierror.Append(result, vc.NewErrorf("connector %s has multiple entries without differentiated versions", key.Id))
 			} else {
-				if connector.Version != 0 {
-					if identifyingLabelNoUuidVersionCount[identifyingKey] == nil {
-						identifyingLabelNoUuidVersionCount[identifyingKey] = make(map[uint64]int)
-					}
-					identifyingLabelNoUuidVersionCount[identifyingKey][connector.Version]++
+				result = multierror.Append(result, vc.NewErrorf("connector name %q in namespace %q has multiple entries without differentiated versions", key.Name, key.Namespace))
+			}
+		}
+		for state, count := range details.unversioned {
+			if count <= 1 {
+				continue
+			}
+			if key.Id != apid.Nil {
+				result = multierror.Append(result, vc.NewErrorf("connector %s has multiple unversioned entries for state %q", key.Id, state))
+			} else {
+				result = multierror.Append(result, vc.NewErrorf("connector name %q in namespace %q has multiple unversioned entries for state %q", key.Name, key.Namespace, state))
+			}
+		}
+		for version, count := range details.versions {
+			if count > 1 {
+				if key.Id != apid.Nil {
+					result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for id %s with version %d", key.Id, version))
+				} else {
+					result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for name %q in namespace %q with version %d", key.Name, key.Namespace, version))
 				}
-			}
-
-			if connector.Version != 0 {
-				identifyingLabelHasVersionCount[identifyingKey]++
-			}
-		}
-	}
-
-	for key, count := range identifyingLabelCounts {
-		if count > 1 && identifyingLabelHasUuidCount[key] < count && identifyingLabelHasVersionCount[key] < count {
-			result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for identifying labels %s without ids or versions specified to fully differentiate", key))
-		}
-	}
-
-	for id, count := range uuidToCount {
-		if count > 1 && count > uuidHasVersionsCount[id] {
-			result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for id %s without differentiated versions", id.String()))
-		}
-	}
-
-	for key, versionCounts := range identifyingLabelNoUuidVersionCount {
-		for version, count := range versionCounts {
-			if count > 1 {
-				result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for identifying labels %s with version %d", key, version))
-			}
-		}
-	}
-
-	for id, versionCounts := range uuidVersionCount {
-		for version, count := range versionCounts {
-			if count > 1 {
-				result = multierror.Append(result, vc.NewErrorf("duplicate connectors exist for id %s with version %d", id.String(), version))
 			}
 		}
 	}
 
 	return result.ErrorOrNil()
-}
-
-// serializeLabelValues serializes label values to a JSON string for use as a map key.
-func serializeLabelValues(labels map[string]string) string {
-	if len(labels) == 0 {
-		return "{}"
-	}
-	data, _ := json.Marshal(labels)
-	return string(data)
 }

--- a/internal/schema/resources/connectors/connectors_test.go
+++ b/internal/schema/resources/connectors/connectors_test.go
@@ -5,333 +5,154 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/stretchr/testify/assert"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
 )
 
-func TestConnectors_Validate(t *testing.T) {
-	// Helper function to create a basic connector
-	createConnector := func(id apid.ID, typ string, version uint64) Connector {
-		return Connector{
-			Id:          id,
-			Labels:      map[string]string{"type": typ},
-			Version:     version,
-			DisplayName: "Test Connector",
-			Description: "Test Description",
-		}
+func testConfiguredConnector(id apid.ID, namespace, name string, version uint64) Connector {
+	connector := Connector{
+		Id:          id,
+		Name:        common.ResourceName(name),
+		Version:     version,
+		DisplayName: "Test Connector",
+		Description: "Test Description",
+		Labels:      map[string]string{"type": "shared-label-value"},
 	}
+	if namespace != "" {
+		connector.Namespace = util.ToPtr(namespace)
+	}
+	return connector
+}
 
-	// Generate some UUIDs for testing
+func TestConnectorsValidateUsesNamesForIdentity(t *testing.T) {
 	id1 := apid.MustParse("cxr_test1111111111aa")
 	id2 := apid.MustParse("cxr_test2222222222aa")
 
 	tests := []struct {
 		name       string
-		connectors *Connectors
-		wantErr    bool
-		errMsg     string
+		connectors []Connector
+		errMessage string
 	}{
 		{
-			name: "Valid - Single connector",
-			connectors: FromList([]Connector{
-				createConnector(apid.Nil, "type1", 0),
-			}),
-			wantErr: false,
+			name: "name only",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "first", 0),
+			},
 		},
 		{
-			name: "Valid - Multiple connectors with different types",
-			connectors: FromList([]Connector{
-				createConnector(apid.Nil, "type1", 0),
-				createConnector(apid.Nil, "type2", 0),
-			}),
-			wantErr: false,
+			name: "id only defaults name later",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "", 0),
+			},
 		},
 		{
-			name: "Valid - Multiple connectors with same type but different IDs",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 0),
-				createConnector(id2, "type1", 0),
-			}),
-			wantErr: false,
+			name: "same labels do not identify connectors",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "first", 0),
+				testConfiguredConnector(apid.Nil, "root", "second", 0),
+			},
 		},
 		{
-			name: "Valid - Multiple connectors with same ID but different versions",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 1),
-				createConnector(id1, "type1", 2),
-			}),
-			wantErr: false,
+			name: "same name is valid in different namespaces",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root.first", "shared", 0),
+				testConfiguredConnector(apid.Nil, "root.second", "shared", 0),
+			},
 		},
 		{
-			name: "Valid - Multiple connectors with same type but different versions (no IDs)",
-			connectors: FromList([]Connector{
-				createConnector(apid.Nil, "type1", 1),
-				createConnector(apid.Nil, "type1", 2),
-			}),
-			wantErr: false,
+			name: "versions share a name",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "shared", 1),
+				testConfiguredConnector(apid.Nil, "root", "shared", 2),
+			},
 		},
 		{
-			name: "Invalid - Multiple connectors with same type, no IDs, no versions",
-			connectors: FromList([]Connector{
-				createConnector(apid.Nil, "type1", 0),
-				createConnector(apid.Nil, "type1", 0),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
+			name: "id versions may specify name once",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "shared", 1),
+				testConfiguredConnector(id1, "root", "", 2),
+			},
 		},
 		{
-			name: "Invalid - Multiple connectors with same ID, no versions",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 0),
-				createConnector(id1, "type1", 0),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa without differentiated versions",
+			name: "missing id and name",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "", 0),
+			},
+			errMessage: "must specify name when id is omitted",
 		},
 		{
-			name: "Invalid - Multiple connectors with same type and version (no IDs)",
-			connectors: FromList([]Connector{
-				createConnector(apid.Nil, "type1", 1),
-				createConnector(apid.Nil, "type1", 1),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
+			name: "invalid name",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "not valid", 0),
+			},
+			errMessage: "resource name must start and end",
 		},
 		{
-			name: "Invalid - Multiple connectors with same ID and version",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 1),
-				createConnector(id1, "type1", 1),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa with version 1",
+			name: "duplicate unversioned name",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "shared", 0),
+				testConfiguredConnector(apid.Nil, "root", "shared", 0),
+			},
+			errMessage: "multiple unversioned entries",
 		},
 		{
-			name: "Invalid - Mixed duplication scenarios",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 1),
-				createConnector(id1, "type1", 1), // Duplicate ID and version
-				createConnector(apid.Nil, "type2", 1),
-				createConnector(apid.Nil, "type2", 1), // Duplicate type and version (no ID)
-				createConnector(id2, "type3", 0),
-				createConnector(id2, "type3", 0), // Duplicate ID, no version
-			}),
-			wantErr: true,
-			// Multiple error messages will be returned
+			name: "duplicate name version",
+			connectors: []Connector{
+				testConfiguredConnector(apid.Nil, "root", "shared", 1),
+				testConfiguredConnector(apid.Nil, "root", "shared", 1),
+			},
+			errMessage: "duplicate connectors exist for name",
 		},
 		{
-			name: "Valid - Mixed valid scenarios",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 1),
-				createConnector(id1, "type1", 2), // Same ID, different version
-				createConnector(apid.Nil, "type2", 1),
-				createConnector(apid.Nil, "type2", 2), // Same type, different version (no ID)
-				createConnector(id2, "type1", 1),      // Same type as first, different ID
-			}),
-			wantErr: false,
+			name: "same name assigned different ids",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "shared", 1),
+				testConfiguredConnector(id2, "root", "shared", 2),
+			},
+			errMessage: "assigned to multiple ids",
 		},
 		{
-			name: "Invalid - Some connectors with same type have IDs, some don't",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 0),
-				createConnector(apid.Nil, "type1", 0),
-				createConnector(apid.Nil, "type1", 0),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
+			name: "same name mixes id and name lookup",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "shared", 1),
+				testConfiguredConnector(apid.Nil, "root", "shared", 2),
+			},
+			errMessage: "mixes entries with and without ids",
 		},
 		{
-			name: "Invalid - Some connectors with same type have IDs, some have versions",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 0),
-				createConnector(apid.Nil, "type1", 1),
-				createConnector(apid.Nil, "type1", 2),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
+			name: "same id assigned multiple names",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "first", 1),
+				testConfiguredConnector(id1, "root", "second", 2),
+			},
+			errMessage: "assigned multiple names",
 		},
 		{
-			name: "Invalid - Some connectors with same ID have versions, some don't",
-			connectors: FromList([]Connector{
-				createConnector(id1, "type1", 1),
-				createConnector(id1, "type1", 0),
-				createConnector(id1, "type1", 0),
-			}),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa without differentiated versions",
+			name: "same id assigned multiple namespaces",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root.first", "shared", 1),
+				testConfiguredConnector(id1, "root.second", "shared", 2),
+			},
+			errMessage: "assigned to multiple namespaces",
+		},
+		{
+			name: "duplicate id version",
+			connectors: []Connector{
+				testConfiguredConnector(id1, "root", "shared", 1),
+				testConfiguredConnector(id1, "root", "shared", 1),
+			},
+			errMessage: "duplicate connectors exist for id",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.connectors.Validate(&common.ValidationContext{})
-			if tt.wantErr {
-				assert.Error(t, err)
-				if tt.errMsg != "" {
-					assert.Contains(t, err.Error(), tt.errMsg)
-				}
-			} else {
-				assert.NoError(t, err)
+			err := FromList(tt.connectors).Validate(&common.ValidationContext{})
+			if tt.errMessage == "" {
+				require.NoError(t, err)
+				return
 			}
-		})
-	}
-}
-
-// TestConnectors_Validate_Exhaustive tests all possible combinations of type, ID, and version duplication
-func TestConnectors_Validate_Exhaustive(t *testing.T) {
-	// Helper function to create a basic connector
-	createConnector := func(id apid.ID, typ string, version uint64) Connector {
-		return Connector{
-			Id:          id,
-			Labels:      map[string]string{"type": typ},
-			Version:     version,
-			DisplayName: "Test Connector",
-			Description: "Test Description",
-		}
-	}
-
-	// Generate some UUIDs for testing
-	id1 := apid.MustParse("cxr_test1111111111aa")
-	id2 := apid.MustParse("cxr_test2222222222aa")
-
-	// Define all possible combinations for two connectors
-	tests := []struct {
-		name    string
-		conn1   Connector
-		conn2   Connector
-		wantErr bool
-		errMsg  string
-	}{
-		// Same type, different scenarios
-		{
-			name:    "Same type, no IDs, no versions",
-			conn1:   createConnector(apid.Nil, "type1", 0),
-			conn2:   createConnector(apid.Nil, "type1", 0),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
-		},
-		{
-			name:    "Same type, no IDs, different versions",
-			conn1:   createConnector(apid.Nil, "type1", 1),
-			conn2:   createConnector(apid.Nil, "type1", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Same type, no IDs, same versions",
-			conn1:   createConnector(apid.Nil, "type1", 1),
-			conn2:   createConnector(apid.Nil, "type1", 1),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for identifying labels",
-		},
-		{
-			name:    "Same type, different IDs, no versions",
-			conn1:   createConnector(id1, "type1", 0),
-			conn2:   createConnector(id2, "type1", 0),
-			wantErr: false,
-		},
-		{
-			name:    "Same type, different IDs, same versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id2, "type1", 1),
-			wantErr: false,
-		},
-		{
-			name:    "Same type, different IDs, different versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id2, "type1", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Same type, same IDs, no versions",
-			conn1:   createConnector(id1, "type1", 0),
-			conn2:   createConnector(id1, "type1", 0),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa without differentiated versions",
-		},
-		{
-			name:    "Same type, same IDs, different versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id1, "type1", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Same type, same IDs, same versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id1, "type1", 1),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa with version 1",
-		},
-
-		// Different type, same scenarios
-		{
-			name:    "Different type, no IDs, no versions",
-			conn1:   createConnector(apid.Nil, "type1", 0),
-			conn2:   createConnector(apid.Nil, "type2", 0),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, no IDs, different versions",
-			conn1:   createConnector(apid.Nil, "type1", 1),
-			conn2:   createConnector(apid.Nil, "type2", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, no IDs, same versions",
-			conn1:   createConnector(apid.Nil, "type1", 1),
-			conn2:   createConnector(apid.Nil, "type2", 1),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, different IDs, no versions",
-			conn1:   createConnector(id1, "type1", 0),
-			conn2:   createConnector(id2, "type2", 0),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, different IDs, same versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id2, "type2", 1),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, different IDs, different versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id2, "type2", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, same IDs, no versions",
-			conn1:   createConnector(id1, "type1", 0),
-			conn2:   createConnector(id1, "type2", 0),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa without differentiated versions",
-		},
-		{
-			name:    "Different type, same IDs, different versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id1, "type2", 2),
-			wantErr: false,
-		},
-		{
-			name:    "Different type, same IDs, same versions",
-			conn1:   createConnector(id1, "type1", 1),
-			conn2:   createConnector(id1, "type2", 1),
-			wantErr: true,
-			errMsg:  "duplicate connectors exist for id cxr_test1111111111aa with version 1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			connectors := FromList([]Connector{tt.conn1, tt.conn2})
-			err := connectors.Validate(&common.ValidationContext{})
-			if tt.wantErr {
-				assert.Error(t, err)
-				if tt.errMsg != "" {
-					assert.Contains(t, err.Error(), tt.errMsg)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
+			require.ErrorContains(t, err, tt.errMessage)
 		})
 	}
 }

--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -272,6 +272,9 @@
     "id": {
       "$ref": "../../common/schema.json#/$defs/UUID"
     },
+    "name": {
+      "$ref": "../../common/schema.json#/$defs/ResourceName"
+    },
     "namespace": {
       "$ref": "../namespace/schema.json#/$defs/NamespacePath"
     },


### PR DESCRIPTION
## Summary

- reconcile ID-less configured connectors by exact name within their namespace instead of identifying labels
- allow explicit-ID connector config to rename the logical connector without changing its definition hash or adding a version
- remove identifying-label configuration, database lookup methods, Helm values, and generated mocks
- update schemas, examples, tests, and existing documentation for name-based reconciliation

## Validation

- full Go suite with SQLite
- focused migration and database suites with PostgreSQL
- Helm lint and template rendering
- documentation build
- ./scripts/preflight.sh

Closes #780