### PR TITLE
Add strict contract decoding foundation

### DIFF
--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -8169,7 +8169,7 @@ const docTemplateadmin_api = `{
         }
     },
     "definitions": {
-        "github_com_rmorlok_authproxy_internal_schema_api.ActorJson": {
+        "api.ActorJson": {
             "description": "Actor identity within a namespace",
             "type": "object",
             "properties": {
@@ -8209,7 +8209,7 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson": {
+        "api.ConnectorJson": {
             "description": "Connector API summary response",
             "type": "object",
             "properties": {
@@ -8277,7 +8277,7 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+        "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
             "properties": {
@@ -8310,7 +8310,7 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
+        "api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
             "properties": {
@@ -9086,7 +9086,7 @@ const docTemplateadmin_api = `{
                     "description": "List of actors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson"
+                        "$ref": "#/definitions/api.ActorJson"
                     }
                 }
             }
@@ -9131,7 +9131,7 @@ const docTemplateadmin_api = `{
                     "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson"
+                        "$ref": "#/definitions/api.ConnectorJson"
                     }
                 }
             }
@@ -9161,7 +9161,7 @@ const docTemplateadmin_api = `{
                     "description": "List of namespaces.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson"
+                        "$ref": "#/definitions/api.NamespaceJson"
                     }
                 }
             }
@@ -9215,7 +9215,7 @@ const docTemplateadmin_api = `{
                 "metrics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                        "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
                 }
             }

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -8163,7 +8163,7 @@
         }
     },
     "definitions": {
-        "github_com_rmorlok_authproxy_internal_schema_api.ActorJson": {
+        "api.ActorJson": {
             "description": "Actor identity within a namespace",
             "type": "object",
             "properties": {
@@ -8203,7 +8203,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson": {
+        "api.ConnectorJson": {
             "description": "Connector API summary response",
             "type": "object",
             "properties": {
@@ -8271,7 +8271,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+        "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
             "properties": {
@@ -8304,7 +8304,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
+        "api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
             "properties": {
@@ -9080,7 +9080,7 @@
                     "description": "List of actors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson"
+                        "$ref": "#/definitions/api.ActorJson"
                     }
                 }
             }
@@ -9125,7 +9125,7 @@
                     "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson"
+                        "$ref": "#/definitions/api.ConnectorJson"
                     }
                 }
             }
@@ -9155,7 +9155,7 @@
                     "description": "List of namespaces.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson"
+                        "$ref": "#/definitions/api.NamespaceJson"
                     }
                 }
             }
@@ -9209,7 +9209,7 @@
                 "metrics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                        "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
                 }
             }

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -1,6 +1,6 @@
 basePath: /api/v1
 definitions:
-  github_com_rmorlok_authproxy_internal_schema_api.ActorJson:
+  api.ActorJson:
     description: Actor identity within a namespace
     properties:
       annotations:
@@ -28,7 +28,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson:
+  api.ConnectorJson:
     description: Connector API summary response
     properties:
       annotations:
@@ -77,7 +77,7 @@ definitions:
         example: 1
         type: integer
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson:
+  api.MetricsSchemaMetricJson:
     description: Supported metric definition
     properties:
       aggregations:
@@ -100,7 +100,7 @@ definitions:
         example: request_events
         type: string
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
+  api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
       annotations:
@@ -660,7 +660,7 @@ definitions:
       items:
         description: List of actors.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson'
+          $ref: '#/definitions/api.ActorJson'
         type: array
     type: object
   routes.OpenAPIListConnectionResponseJson:
@@ -692,7 +692,7 @@ definitions:
       items:
         description: List of connectors.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson'
+          $ref: '#/definitions/api.ConnectorJson'
         type: array
     type: object
   routes.OpenAPIListKeysResponseJson:
@@ -713,7 +713,7 @@ definitions:
       items:
         description: List of namespaces.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson'
+          $ref: '#/definitions/api.NamespaceJson'
         type: array
     type: object
   routes.OpenAPIListNotificationsResponseJson:
@@ -750,7 +750,7 @@ definitions:
     properties:
       metrics:
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson'
+          $ref: '#/definitions/api.MetricsSchemaMetricJson'
         type: array
     type: object
   routes.OpenAPIMigrateConnectionVersionRequestJson:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -8169,7 +8169,7 @@ const docTemplateApi = `{
         }
     },
     "definitions": {
-        "github_com_rmorlok_authproxy_internal_schema_api.ActorJson": {
+        "api.ActorJson": {
             "description": "Actor identity within a namespace",
             "type": "object",
             "properties": {
@@ -8209,7 +8209,7 @@ const docTemplateApi = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson": {
+        "api.ConnectorJson": {
             "description": "Connector API summary response",
             "type": "object",
             "properties": {
@@ -8277,7 +8277,7 @@ const docTemplateApi = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+        "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
             "properties": {
@@ -8310,7 +8310,7 @@ const docTemplateApi = `{
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
+        "api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
             "properties": {
@@ -9086,7 +9086,7 @@ const docTemplateApi = `{
                     "description": "List of actors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson"
+                        "$ref": "#/definitions/api.ActorJson"
                     }
                 }
             }
@@ -9131,7 +9131,7 @@ const docTemplateApi = `{
                     "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson"
+                        "$ref": "#/definitions/api.ConnectorJson"
                     }
                 }
             }
@@ -9161,7 +9161,7 @@ const docTemplateApi = `{
                     "description": "List of namespaces.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson"
+                        "$ref": "#/definitions/api.NamespaceJson"
                     }
                 }
             }
@@ -9215,7 +9215,7 @@ const docTemplateApi = `{
                 "metrics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                        "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
                 }
             }

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -8163,7 +8163,7 @@
         }
     },
     "definitions": {
-        "github_com_rmorlok_authproxy_internal_schema_api.ActorJson": {
+        "api.ActorJson": {
             "description": "Actor identity within a namespace",
             "type": "object",
             "properties": {
@@ -8203,7 +8203,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson": {
+        "api.ConnectorJson": {
             "description": "Connector API summary response",
             "type": "object",
             "properties": {
@@ -8271,7 +8271,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson": {
+        "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
             "properties": {
@@ -8304,7 +8304,7 @@
                 }
             }
         },
-        "github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson": {
+        "api.NamespaceJson": {
             "description": "Namespace for organizing resources",
             "type": "object",
             "properties": {
@@ -9080,7 +9080,7 @@
                     "description": "List of actors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson"
+                        "$ref": "#/definitions/api.ActorJson"
                     }
                 }
             }
@@ -9125,7 +9125,7 @@
                     "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson"
+                        "$ref": "#/definitions/api.ConnectorJson"
                     }
                 }
             }
@@ -9155,7 +9155,7 @@
                     "description": "List of namespaces.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson"
+                        "$ref": "#/definitions/api.NamespaceJson"
                     }
                 }
             }
@@ -9209,7 +9209,7 @@
                 "metrics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson"
+                        "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
                 }
             }

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -1,6 +1,6 @@
 basePath: /api/v1
 definitions:
-  github_com_rmorlok_authproxy_internal_schema_api.ActorJson:
+  api.ActorJson:
     description: Actor identity within a namespace
     properties:
       annotations:
@@ -28,7 +28,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson:
+  api.ConnectorJson:
     description: Connector API summary response
     properties:
       annotations:
@@ -77,7 +77,7 @@ definitions:
         example: 1
         type: integer
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson:
+  api.MetricsSchemaMetricJson:
     description: Supported metric definition
     properties:
       aggregations:
@@ -100,7 +100,7 @@ definitions:
         example: request_events
         type: string
     type: object
-  github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson:
+  api.NamespaceJson:
     description: Namespace for organizing resources
     properties:
       annotations:
@@ -660,7 +660,7 @@ definitions:
       items:
         description: List of actors.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ActorJson'
+          $ref: '#/definitions/api.ActorJson'
         type: array
     type: object
   routes.OpenAPIListConnectionResponseJson:
@@ -692,7 +692,7 @@ definitions:
       items:
         description: List of connectors.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.ConnectorJson'
+          $ref: '#/definitions/api.ConnectorJson'
         type: array
     type: object
   routes.OpenAPIListKeysResponseJson:
@@ -713,7 +713,7 @@ definitions:
       items:
         description: List of namespaces.
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.NamespaceJson'
+          $ref: '#/definitions/api.NamespaceJson'
         type: array
     type: object
   routes.OpenAPIListNotificationsResponseJson:
@@ -750,7 +750,7 @@ definitions:
     properties:
       metrics:
         items:
-          $ref: '#/definitions/github_com_rmorlok_authproxy_internal_schema_api.MetricsSchemaMetricJson'
+          $ref: '#/definitions/api.MetricsSchemaMetricJson'
         type: array
     type: object
   routes.OpenAPIMigrateConnectionVersionRequestJson:

--- a/internal/util/strict_decode.go
+++ b/internal/util/strict_decode.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DecodeJSONStrict decodes exactly one JSON value and rejects fields that are
+// not declared by the destination struct. Callers that intentionally accept
+// arbitrary JSON should continue to use json.RawMessage or map[string]any.
+func DecodeJSONStrict(data []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected additional JSON value")
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DecodeYAMLStrict decodes exactly one YAML document and rejects fields that
+// are not declared by the destination struct.
+func DecodeYAMLStrict(data []byte, destination any) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected additional YAML document")
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DecodeYAMLNodeStrict applies DecodeYAMLStrict to a node used by a custom
+// yaml.Unmarshaler. It keeps union types from bypassing KnownFields.
+func DecodeYAMLNodeStrict(node *yaml.Node, destination any) error {
+	data, err := yaml.Marshal(node)
+	if err != nil {
+		return err
+	}
+	return DecodeYAMLStrict(data, destination)
+}

--- a/internal/util/strict_decode_test.go
+++ b/internal/util/strict_decode_test.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type strictDecodePayload struct {
+	CamelCase string `json:"camelCase" yaml:"camelCase"`
+}
+
+type strictInitialismPayload struct {
+	ConnectorID string `json:"connectorId" yaml:"connectorId"`
+	ReturnToURL string `json:"returnToUrl" yaml:"returnToUrl"`
+	BodyJSON    string `json:"bodyJson" yaml:"bodyJson"`
+	TLS         bool   `json:"tls" yaml:"tls"`
+	OAuth       bool   `json:"oauth" yaml:"oauth"`
+}
+
+func TestDecodeJSONStrict(t *testing.T) {
+	var payload strictDecodePayload
+	require.NoError(t, DecodeJSONStrict([]byte(`{"camelCase":"ok"}`), &payload))
+	require.Error(t, DecodeJSONStrict([]byte(`{"snake_case":"no"}`), &payload))
+	require.Error(t, DecodeJSONStrict([]byte(`{"camelCase":"ok"}{}`), &payload))
+}
+
+func TestDecodeYAMLStrict(t *testing.T) {
+	var payload strictDecodePayload
+	require.NoError(t, DecodeYAMLStrict([]byte("camelCase: ok\n"), &payload))
+	require.Error(t, DecodeYAMLStrict([]byte("snake_case: no\n"), &payload))
+	require.Error(t, DecodeYAMLStrict([]byte("camelCase: ok\n---\ncamelCase: again\n"), &payload))
+}
+
+func TestContractInitialismCasing(t *testing.T) {
+	payload := strictInitialismPayload{
+		ConnectorID: "cxr_1",
+		ReturnToURL: "https://example.com/return",
+		BodyJSON:    "{}",
+		TLS:         true,
+		OAuth:       true,
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"connectorId":"cxr_1","returnToUrl":"https://example.com/return","bodyJson":"{}","tls":true,"oauth":true}`, string(data))
+}

--- a/scripts/generate-swagger.sh
+++ b/scripts/generate-swagger.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SWAGGER_PARSE_DIRS="./internal/service/api/swagger,./internal/routes,./internal/schema/api,./internal/httperr"
+ADMIN_SWAGGER_PARSE_DIRS="./internal/service/admin_api/swagger,./internal/routes,./internal/schema/api,./internal/httperr"
 
 cd "$PROJECT_ROOT"
 
@@ -25,12 +27,12 @@ generate_api_swagger() {
     # --parseDependency: parse external dependencies
     # --parseInternal: parse internal packages
     go run github.com/swaggo/swag/cmd/swag init \
-        -g internal/service/api/swagger/definition.go \
+        -g definition.go \
         -o internal/service/api/swagger \
         --parseDependency \
         --parseInternal \
         --instanceName Api \
-        --dir ./
+        --dir "$SWAGGER_PARSE_DIRS"
 
     mv internal/service/api/swagger/Api_docs.go internal/service/api/swagger/docs.go
     mv internal/service/api/swagger/Api_swagger.json internal/service/api/swagger/docs.json
@@ -39,12 +41,12 @@ generate_api_swagger() {
 
 generate_admin_api_swagger() {
     go run github.com/swaggo/swag/cmd/swag init \
-        -g internal/service/admin_api/swagger/definition.go \
+        -g definition.go \
         -o internal/service/admin_api/swagger \
         --parseDependency \
         --parseInternal \
         --instanceName admin_api \
-        --dir ./
+        --dir "$ADMIN_SWAGGER_PARSE_DIRS"
 
     mv internal/service/admin_api/swagger/admin_api_docs.go internal/service/admin_api/swagger/docs.go
     mv internal/service/admin_api/swagger/admin_api_swagger.json internal/service/admin_api/swagger/docs.json


### PR DESCRIPTION
## Summary
- add reusable strict JSON and YAML decoding helpers
- cover lowerCamelCase initialisms and legacy snake_case rejection
- make Swagger generation locate the service, route, schema, and error packages explicitly

## Verification
- go test ./internal/util
- Swagger generation
- integration module consistency
- workflow, route-rendering, and schema-layout guardrails