### PR TITLE
Update first-party clients for camelCase contracts

### DIFF
--- a/cmd/cli/list_connections.go
+++ b/cmd/cli/list_connections.go
@@ -102,7 +102,7 @@ func setConnectionListQuery(req *resty.Request, name, state, order, cursor strin
 		req.SetQueryParam("state", state)
 	}
 	if order != "" {
-		req.SetQueryParam("order_by", order)
+		req.SetQueryParam("orderBy", order)
 	}
 	if cursor != "" {
 		req.SetQueryParam("cursor", cursor)

--- a/cmd/cli/list_connectors.go
+++ b/cmd/cli/list_connectors.go
@@ -107,7 +107,7 @@ func setConnectorListQuery(req *resty.Request, name, state, typ, order, cursor s
 		req.SetQueryParam("state", state)
 	}
 	if order != "" {
-		req.SetQueryParam("order_by", order)
+		req.SetQueryParam("orderBy", order)
 	}
 	if cursor != "" {
 		req.SetQueryParam("cursor", cursor)

--- a/cmd/cli/login_redirect.go
+++ b/cmd/cli/login_redirect.go
@@ -52,7 +52,7 @@ func httpServerForLoginRedirect(
 			return
 		}
 
-		returnTo := req.URL.Query().Get("return_to")
+		returnTo := req.URL.Query().Get("returnTo")
 
 		if returnTo == "" {
 			log.Printf("[400] %s %s", req.Method, req.URL)
@@ -67,7 +67,7 @@ func httpServerForLoginRedirect(
 	</head>
 	<body>
 		<h1>No Return To Specified</h1>
-		<p>Request did not include the <tt>return_to</tt> query parameter to specify path to return auth token.</p>
+		<p>Request did not include the <tt>returnTo</tt> query parameter to specify path to return auth token.</p>
 	</body>
 </html>
 `))

--- a/cmd/cli/proxy.go
+++ b/cmd/cli/proxy.go
@@ -22,7 +22,7 @@ import (
 )
 
 // rawProxyEnvelopeHeader is the upstream-URL header consumed by
-// /_proxy_raw. Spelled in the API's display form; net/http canonicalises
+	// /_proxyRaw. Spelled in the API's display form; net/http canonicalises
 // on read.
 const rawProxyEnvelopeHeader = "X-AuthProxy-Upstream-URL"
 
@@ -40,14 +40,14 @@ var hopByHopHeaders = map[string]struct{}{
 }
 
 // rawProxyHandler returns an http.Handler that forwards each inbound
-// request through {apiBaseURL}/api/v1/connections/{connectionID}/_proxy_raw
+	// request through {apiBaseURL}/api/v1/connections/{connectionID}/_proxyRaw
 // with the JWT signer attached and bodies streamed both directions.
 //
 // If upstreamBase is non-nil, the inbound path+query is appended to it
 // to derive X-AuthProxy-Upstream-URL automatically. Otherwise the
 // caller must set the header on the inbound request.
 func rawProxyHandler(apiBaseURL string, connectionID string, upstreamBase *url.URL, signer jwt.Signer) http.HandlerFunc {
-	rawProxyURL := strings.TrimRight(apiBaseURL, "/") + "/api/v1/connections/" + connectionID + "/_proxy_raw"
+	rawProxyURL := strings.TrimRight(apiBaseURL, "/") + "/api/v1/connections/" + connectionID + "/_proxyRaw"
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		upstream := req.Header.Get(rawProxyEnvelopeHeader)
@@ -168,8 +168,8 @@ func cmdProxy() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "proxy --connection <id> [--upstream-base <url>] [curl|wget <args>]",
-		Short: "Reverse proxy that forwards requests through a connection's /_proxy_raw endpoint",
-		Long: `Boots a streaming reverse-proxy through the connection's /_proxy_raw
+		Short: "Reverse proxy that forwards requests through a connection's /_proxyRaw endpoint",
+		Long: `Boots a streaming reverse-proxy through the connection's /_proxyRaw
 endpoint. Bodies stream both directions so chunked uploads and SSE
 responses pass through without buffering.
 
@@ -258,7 +258,7 @@ func parseUpstreamBase(s string) (*url.URL, error) {
 func runProxyListener(apiURL, connectionID string, base *url.URL, signer jwt.Signer, ip string, port int) error {
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	log.Printf("ap proxy listening on %s", addr)
-	log.Printf("forwarding through %s/api/v1/connections/%s/_proxy_raw", strings.TrimRight(apiURL, "/"), connectionID)
+	log.Printf("forwarding through %s/api/v1/connections/%s/_proxyRaw", strings.TrimRight(apiURL, "/"), connectionID)
 	if base != nil {
 		log.Printf("upstream-base: %s", base.String())
 	} else {

--- a/cmd/cli/proxy_test.go
+++ b/cmd/cli/proxy_test.go
@@ -104,10 +104,10 @@ func TestProxyCmd_NoPositional_RunsListenerMode(t *testing.T) {
 // sets X-AuthProxy-Upstream-URL to https://upstream/v1/foo and signs
 // the outbound request before forwarding to the AuthProxy server.
 func TestRawProxyHandler_DerivesUpstreamFromBase(t *testing.T) {
-	// Fake AuthProxy /_proxy_raw server. The handler's outbound request
+	// Fake AuthProxy /_proxyRaw server. The handler's outbound request
 	// lands here; we assert the envelope and echo a small body back.
 	authproxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/connections/cxn_test/_proxy_raw", r.URL.Path)
+		assert.Equal(t, "/api/v1/connections/cxn_test/_proxyRaw", r.URL.Path)
 		assert.Equal(t, "https://upstream.example.com/v1/foo?q=1", r.Header.Get("X-AuthProxy-Upstream-URL"))
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		assert.Equal(t, "ap-curl-test", r.Header.Get("X-Caller"))

--- a/cmd/cli/sign_marketplace_login_url.go
+++ b/cmd/cli/sign_marketplace_login_url.go
@@ -51,7 +51,7 @@ to access the marketplace SPA. This marketplace URL will be used by the SPA to e
 			}
 
 			query := parsedUrl.Query()
-			query.Set("auth_token", tok)
+			query.Set("authToken", tok)
 			parsedUrl.RawQuery = query.Encode()
 
 			fmt.Print(parsedUrl.String())

--- a/cmd/loadtest/background.go
+++ b/cmd/loadtest/background.go
@@ -34,37 +34,37 @@ const (
 )
 
 type loadtestBackgroundSummary struct {
-	ProfileName             string                 `json:"profile_name,omitempty"`
+	ProfileName             string                 `json:"profileName,omitempty"`
 	Scenario                string                 `json:"scenario"`
 	Queue                   string                 `json:"queue,omitempty"`
 	Percent                 *int                   `json:"percent,omitempty"`
-	TaskType                string                 `json:"task_type,omitempty"`
-	TaskID                  string                 `json:"task_id,omitempty"`
-	TaskQueue               string                 `json:"task_queue,omitempty"`
-	ExpectedExpiringTokens  int                    `json:"expected_expiring_tokens,omitempty"`
-	SchedulerTaskConfigs    int                    `json:"scheduler_task_configs,omitempty"`
-	SchedulerProbeTasks     int                    `json:"scheduler_probe_tasks,omitempty"`
-	StartedAt               time.Time              `json:"started_at"`
-	FinishedAt              time.Time              `json:"finished_at"`
-	DurationSeconds         float64                `json:"duration_seconds"`
-	EnqueueDurationSeconds  float64                `json:"enqueue_duration_seconds,omitempty"`
-	WaitDurationSeconds     float64                `json:"wait_duration_seconds,omitempty"`
-	ProcessedDelta          int                    `json:"processed_delta,omitempty"`
-	FailedDelta             int                    `json:"failed_delta,omitempty"`
-	ProcessedRatePerSecond  float64                `json:"processed_rate_per_second,omitempty"`
+	TaskType                string                 `json:"taskType,omitempty"`
+	TaskID                  string                 `json:"taskId,omitempty"`
+	TaskQueue               string                 `json:"taskQueue,omitempty"`
+	ExpectedExpiringTokens  int                    `json:"expectedExpiringTokens,omitempty"`
+	SchedulerTaskConfigs    int                    `json:"schedulerTaskConfigs,omitempty"`
+	SchedulerProbeTasks     int                    `json:"schedulerProbeTasks,omitempty"`
+	StartedAt               time.Time              `json:"startedAt"`
+	FinishedAt              time.Time              `json:"finishedAt"`
+	DurationSeconds         float64                `json:"durationSeconds"`
+	EnqueueDurationSeconds  float64                `json:"enqueueDurationSeconds,omitempty"`
+	WaitDurationSeconds     float64                `json:"waitDurationSeconds,omitempty"`
+	ProcessedDelta          int                    `json:"processedDelta,omitempty"`
+	FailedDelta             int                    `json:"failedDelta,omitempty"`
+	ProcessedRatePerSecond  float64                `json:"processedRatePerSecond,omitempty"`
 	Before                  *loadtestQueueSnapshot `json:"before,omitempty"`
 	After                   *loadtestQueueSnapshot `json:"after,omitempty"`
-	MaxObserved             *loadtestQueueSnapshot `json:"max_observed,omitempty"`
-	MemoryBefore            loadtestMemorySnapshot `json:"memory_before"`
-	MemoryAfter             loadtestMemorySnapshot `json:"memory_after"`
-	MemoryDeltaAllocBytes   int64                  `json:"memory_delta_alloc_bytes"`
-	MemoryDeltaSysBytes     int64                  `json:"memory_delta_sys_bytes"`
-	SchedulerTaskTypeCounts map[string]int         `json:"scheduler_task_type_counts,omitempty"`
+	MaxObserved             *loadtestQueueSnapshot `json:"maxObserved,omitempty"`
+	MemoryBefore            loadtestMemorySnapshot `json:"memoryBefore"`
+	MemoryAfter             loadtestMemorySnapshot `json:"memoryAfter"`
+	MemoryDeltaAllocBytes   int64                  `json:"memoryDeltaAllocBytes"`
+	MemoryDeltaSysBytes     int64                  `json:"memoryDeltaSysBytes"`
+	SchedulerTaskTypeCounts map[string]int         `json:"schedulerTaskTypeCounts,omitempty"`
 	Artifacts               map[string]string      `json:"artifacts,omitempty"`
 }
 
 type loadtestQueueSnapshot struct {
-	CapturedAt       time.Time `json:"captured_at"`
+	CapturedAt       time.Time `json:"capturedAt"`
 	Queue            string    `json:"queue"`
 	Size             int       `json:"size"`
 	Pending          int       `json:"pending"`
@@ -76,20 +76,20 @@ type loadtestQueueSnapshot struct {
 	Aggregating      int       `json:"aggregating"`
 	Processed        int       `json:"processed"`
 	Failed           int       `json:"failed"`
-	ProcessedTotal   int       `json:"processed_total"`
-	FailedTotal      int       `json:"failed_total"`
-	MemoryUsage      int64     `json:"memory_usage"`
-	LatencySeconds   float64   `json:"latency_seconds"`
-	InFlightAndRetry int       `json:"in_flight_and_retry"`
+	ProcessedTotal   int       `json:"processedTotal"`
+	FailedTotal      int       `json:"failedTotal"`
+	MemoryUsage      int64     `json:"memoryUsage"`
+	LatencySeconds   float64   `json:"latencySeconds"`
+	InFlightAndRetry int       `json:"inFlightAndRetry"`
 }
 
 type loadtestMemorySnapshot struct {
-	AllocBytes      uint64 `json:"alloc_bytes"`
-	TotalAllocBytes uint64 `json:"total_alloc_bytes"`
-	SysBytes        uint64 `json:"sys_bytes"`
-	HeapAllocBytes  uint64 `json:"heap_alloc_bytes"`
-	HeapSysBytes    uint64 `json:"heap_sys_bytes"`
-	NumGC           uint32 `json:"num_gc"`
+	AllocBytes      uint64 `json:"allocBytes"`
+	TotalAllocBytes uint64 `json:"totalAllocBytes"`
+	SysBytes        uint64 `json:"sysBytes"`
+	HeapAllocBytes  uint64 `json:"heapAllocBytes"`
+	HeapSysBytes    uint64 `json:"heapSysBytes"`
+	NumGC           uint32 `json:"numGc"`
 }
 
 func cmdBackground() *cobra.Command {

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -26,22 +26,21 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
-	"gopkg.in/yaml.v3"
-
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
 	"github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // SeedConfig is the YAML shape the binary consumes.
 type SeedConfig struct {
 	Actors             []ActorSeed             `yaml:"actors"`
-	OAuth2TestProvider *OAuth2TestProviderSeed `yaml:"oauth2_test_provider"`
+	OAuth2TestProvider *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
 	Connectors         []ConnectorSeed         `yaml:"connectors"`
 }
 
 type ActorSeed struct {
-	ExternalId  string            `yaml:"external_id"`
+	ExternalId  string            `yaml:"externalId"`
 	Namespace   string            `yaml:"namespace,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
@@ -59,19 +58,19 @@ type ConnectorSeed struct {
 }
 
 type OAuth2TestProviderSeed struct {
-	BaseUrl                string                     `yaml:"base_url"`
+	BaseUrl                string                     `yaml:"baseUrl"`
 	Clients                []OAuth2TestProviderClient `yaml:"clients,omitempty"`
 	Users                  []OAuth2TestProviderUser   `yaml:"users,omitempty"`
-	ResourcePolicies       []OAuth2ResourcePolicy     `yaml:"resource_policies,omitempty"`
-	APIKeyResourcePolicies []APIKeyResourcePolicy     `yaml:"api_key_resource_policies,omitempty"`
+	ResourcePolicies       []OAuth2ResourcePolicy     `yaml:"resourcePolicies,omitempty"`
+	APIKeyResourcePolicies []APIKeyResourcePolicy     `yaml:"apiKeyResourcePolicies,omitempty"`
 }
 
 type OAuth2TestProviderClient struct {
 	Key                     string `json:"key" yaml:"key"`
 	Secret                  string `json:"secret,omitempty" yaml:"secret,omitempty"`
-	RedirectURI             string `json:"redirect_uri,omitempty" yaml:"redirect_uri,omitempty"`
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
-	RequirePKCE             bool   `json:"require_pkce,omitempty" yaml:"require_pkce,omitempty"`
+	RedirectURI             string `json:"redirectUri,omitempty" yaml:"redirectUri,omitempty"`
+	TokenEndpointAuthMethod string `json:"tokenEndpointAuthMethod,omitempty" yaml:"tokenEndpointAuthMethod,omitempty"`
+	RequirePKCE             bool   `json:"requirePkce,omitempty" yaml:"requirePkce,omitempty"`
 	Scope                   string `json:"scope,omitempty" yaml:"scope,omitempty"`
 }
 
@@ -80,20 +79,20 @@ type OAuth2TestProviderUser struct {
 	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
 	Role        string `json:"role,omitempty" yaml:"role,omitempty"`
 	Email       string `json:"email,omitempty" yaml:"email,omitempty"`
-	DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Sub         string `json:"sub,omitempty" yaml:"sub,omitempty"`
 }
 
 type OAuth2ResourcePolicy struct {
 	Path          string `json:"path" yaml:"path"`
-	RequiredScope string `json:"required_scope" yaml:"required_scope"`
+	RequiredScope string `json:"requiredScope" yaml:"requiredScope"`
 }
 
 type APIKeyResourcePolicy struct {
 	Path       string `json:"path" yaml:"path"`
 	Key        string `json:"key" yaml:"key"`
 	Placement  string `json:"placement,omitempty" yaml:"placement,omitempty"`
-	HeaderName string `json:"header_name,omitempty" yaml:"header_name,omitempty"`
+	HeaderName string `json:"headerName,omitempty" yaml:"headerName,omitempty"`
 	Prefix     string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 }
 
@@ -142,7 +141,7 @@ func loadConfig(path string) (*SeedConfig, error) {
 		return nil, fmt.Errorf("read seed config %q: %w", path, err)
 	}
 	var c SeedConfig
-	if err := yaml.Unmarshal(data, &c); err != nil {
+	if err := util.DecodeYAMLStrict(data, &c); err != nil {
 		return nil, fmt.Errorf("parse seed config %q: %w", path, err)
 	}
 	return &c, nil
@@ -363,7 +362,7 @@ func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*
 	resp, err := c.R().
 		SetHeader("Accept", "application/json").
 		SetQueryParam("namespace", connectorNamespace(seed)).
-		SetQueryParam("label_selector", fmt.Sprintf("%s=%s", seedLabelKey, seed.Key)).
+		SetQueryParam("labelSelector", fmt.Sprintf("%s=%s", seedLabelKey, seed.Key)).
 		SetQueryParam("limit", "1").
 		SetResult(&list).
 		Get(fmt.Sprintf("%s/api/v1/connectors", baseUrl))
@@ -442,7 +441,7 @@ func forceConnectorPrimary(c *resty.Client, baseUrl string, version api.Connecto
 	resp, err := c.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(api.ForceConnectorVersionStateRequestJson{State: string(api.ConnectorVersionStatePrimary)}).
-		Put(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_force_state", baseUrl, version.Id, version.Version))
+		Put(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_forceState", baseUrl, version.Id, version.Version))
 	if err != nil {
 		return fmt.Errorf("PUT connector seed %s:%d primary: %w", version.Id, version.Version, err)
 	}

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -34,7 +34,7 @@ func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
 		switch r.Method + " " + r.URL.Path {
 		case "GET /api/v1/connectors":
 			require.Equal(t, defaultNamespace, r.URL.Query().Get("namespace"))
-			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("label_selector"))
+			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("labelSelector"))
 			writeJSON(t, w, api.ListConnectorsResponseJson{})
 		case "POST /api/v1/connectors":
 			var req api.CreateConnectorRequestJson
@@ -44,7 +44,7 @@ func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
 			require.Equal(t, "demo-noauth", req.Labels[seedLabelKey])
 			require.Equal(t, "true", req.Labels["demo"])
 			writeJSON(t, w, connectorVersion(req.Definition, req.Labels, api.ConnectorVersionStateDraft, 1))
-		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/1/_force_state":
+		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/1/_forceState":
 			forcedPrimary = true
 			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
 		default:
@@ -111,7 +111,7 @@ func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
 			require.NotNil(t, req.Labels)
 			require.Equal(t, "demo-noauth", (*req.Labels)[seedLabelKey])
 			writeJSON(t, w, connectorVersion(*req.Definition, *req.Labels, api.ConnectorVersionStateDraft, 2))
-		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/2/_force_state":
+		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/2/_forceState":
 			forcedPrimary = true
 			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 2))
 		default:
@@ -213,13 +213,13 @@ func TestPostOAuth2TestProviderTreatsDuplicateAsAlreadyPresent(t *testing.T) {
 
 func TestSeedConfigParsesOAuthConnectorSetupVariants(t *testing.T) {
 	data := []byte(`
-oauth2_test_provider:
-  base_url: http://go-oauth2-server
+oauth2TestProvider:
+  baseUrl: http://go-oauth2-server
   clients:
     - key: demo-oauth-simple
       secret: demo-oauth-simple-secret
-      redirect_uri: https://marketplace.example.test/oauth2/callback
-      token_endpoint_auth_method: client_secret_post
+      redirectUri: https://marketplace.example.test/oauth2/callback
+      tokenEndpointAuthMethod: client_secret_post
       scope: read profile resources
   users:
     - username: demo-oauth-user@example.test
@@ -228,36 +228,36 @@ connectors:
   - key: demo-oauth-tenant
     namespace: root
     definition:
-      display_name: Demo OAuth Tenant
+      displayName: Demo OAuth Tenant
       description: Demo OAuth connector with pre-connect config
       labels:
         type: demo-oauth-tenant
       auth:
         type: OAuth2
-        client_id: demo-oauth-tenant
-        client_secret: demo-oauth-tenant-secret
+        clientId: demo-oauth-tenant
+        clientSecret: demo-oauth-tenant-secret
         authorization:
           endpoint: https://example.test/oauth2/web/authorize
-          query_overrides:
+          queryOverrides:
             tenant: "{{cfg.tenant}}"
         token:
           endpoint: http://go-oauth2-server/v1/oauth/tokens
         scopes:
           - id: read
             reason: Read demo data
-      setup_flow:
+      setupFlow:
         preconnect:
           steps:
             - id: tenant
               title: Choose tenant
-              json_schema:
+              jsonSchema:
                 type: object
                 required:
                   - tenant
                 properties:
                   tenant:
                     type: string
-              ui_schema:
+              uiSchema:
                 type: VerticalLayout
                 elements:
                   - type: Control
@@ -274,9 +274,9 @@ connectors:
 
 func TestSeedConfigParsesAPIKeyConnector(t *testing.T) {
 	data := []byte(`
-oauth2_test_provider:
-  base_url: http://go-oauth2-server
-  api_key_resource_policies:
+oauth2TestProvider:
+  baseUrl: http://go-oauth2-server
+  apiKeyResourcePolicies:
     - path: /test/api-key-resource/demo-api-key
       key: demo-api-key
       placement: bearer
@@ -284,7 +284,7 @@ connectors:
   - key: demo-api-key
     namespace: root
     definition:
-      display_name: Demo API Key
+      displayName: Demo API Key
       description: Demo API key connector
       labels:
         type: demo-api-key
@@ -294,7 +294,7 @@ connectors:
           type: bearer
       probes:
         - id: verify-api-key
-          proxy_http:
+          proxyHttp:
             method: GET
             url: http://go-oauth2-server/test/api-key-resource/demo-api-key
 `)
@@ -310,7 +310,7 @@ func mustConnector(t *testing.T, displayName string) config.Connector {
 	t.Helper()
 
 	data := []byte(`
-display_name: "` + displayName + `"
+displayName: "` + displayName + `"
 description: "Seeded test connector"
 labels:
   type: demo-noauth

--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -20,12 +20,12 @@ marketplace or admin UI.
                                                                 ▼
                             ┌──────────────────────────────────────────────────┐
                             │  Marketplace or Admin UI                          │
-                            │  picks up ?auth_token=… → establishes session     │
+                            │  picks up ?authToken=… → establishes session     │
                             └──────────────────────────────────────────────────┘
 ```
 
 The backend holds **one** admin private key. AuthProxy's auth model
-trusts an admin-signed JWT to bear any `actor_external_id` claim — so
+trusts an admin-signed JWT to represent any actor `externalId` — so
 one key is enough to "be" any of the three demo identities.
 
 ## Running locally
@@ -46,11 +46,11 @@ openssl rsa -in demos/shell/dev_keys/demo-shell -pubout -out demos/shell/dev_key
 Add the public key as an admin actor in `dev_config/default.yaml`:
 
 ```yaml
-system_auth:
+systemAuth:
   actors:
-    - external_id: demo-shell
+    - externalId: demo-shell
       key:
-        public_key:
+        publicKey:
           path: ./demos/shell/dev_keys/demo-shell.pub
       permissions:
         - namespace: "root.**"
@@ -122,7 +122,7 @@ The backend reads the following env vars:
 
 | Var                       | Required | Notes                                                                       |
 |---------------------------|----------|-----------------------------------------------------------------------------|
-| `ADMIN_USERNAME`          | ✅        | external_id of the admin actor whose key is mounted at `ADMIN_PRIVATE_KEY_PATH` |
+| `ADMIN_USERNAME`          | ✅        | externalId of the admin actor whose key is mounted at `ADMIN_PRIVATE_KEY_PATH` |
 | `ADMIN_PRIVATE_KEY_PATH`  | ✅        | File path; PEM RSA or EC                                                    |
 | `AUTHPROXY_ADMIN_UI_URL`  | ✅        | Base URL of the admin SPA                                                   |
 | `AUTHPROXY_MARKETPLACE_URL` | ✅      | Base URL of the marketplace SPA                                             |
@@ -144,8 +144,8 @@ dev mode, `/config.json` and `/sso` are proxied to the backend; override
 
 It's tempting to give the demo shell one keypair per demo identity. The
 existing AuthProxy auth model already covers the multi-identity case via
-admin-actor vouching: an admin's JWT can bear any `actor_external_id`
-claim and AuthProxy will trust the user assignment. That's the same
+admin-actor vouching: an admin's JWT can represent any actor `externalId`
+and AuthProxy will trust the user assignment. That's the same
 pattern `cmd/cli/sign-marketplace-login-url` uses, so the demo shell
 mirrors it.
 

--- a/demos/shell/backend/main.go
+++ b/demos/shell/backend/main.go
@@ -197,7 +197,7 @@ func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
 			return
 		}
 		q := parsed.Query()
-		q.Set("auth_token", token)
+		q.Set("authToken", token)
 		parsed.RawQuery = q.Encode()
 
 		logger.Info("signed token, redirecting", "actor", actor, "destination", destination)

--- a/internal/loadtest/seeder/profile.go
+++ b/internal/loadtest/seeder/profile.go
@@ -4,24 +4,75 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rmorlok/authproxy/internal/util"
 	"gopkg.in/yaml.v3"
 )
 
 type Profile struct {
-	Name        string         `yaml:"name" json:"name"`
-	Namespace   string         `yaml:"namespace" json:"namespace"`
-	Description string         `yaml:"description" json:"description"`
-	Objects     ProfileObjects `yaml:"objects" json:"objects"`
+	Name        string            `yaml:"name" json:"name"`
+	Namespace   string            `yaml:"namespace" json:"namespace"`
+	Description string            `yaml:"description" json:"description"`
+	Cluster     ProfileCluster    `yaml:"cluster" json:"cluster"`
+	Objects     ProfileObjects    `yaml:"objects" json:"objects"`
+	AuthProxy   ProfileAuthProxy  `yaml:"authproxy" json:"authproxy"`
+	K6          ProfileK6         `yaml:"k6" json:"k6"`
+	Acceptance  ProfileAcceptance `yaml:"acceptance" json:"acceptance"`
+}
+
+type ProfileCluster struct {
+	Target string `yaml:"target" json:"target"`
 }
 
 type ProfileObjects struct {
 	Namespaces             int         `yaml:"namespaces" json:"namespaces,omitempty"`
-	NamespacesMin          int         `yaml:"namespaces_min" json:"namespaces_min,omitempty"`
-	NamespacesMax          int         `yaml:"namespaces_max" json:"namespaces_max,omitempty"`
+	NamespacesMin          int         `yaml:"namespacesMin" json:"namespacesMin,omitempty"`
+	NamespacesMax          int         `yaml:"namespacesMax" json:"namespacesMax,omitempty"`
 	Connections            int         `yaml:"connections" json:"connections"`
-	StaleSetupConnections  int         `yaml:"stale_setup_connections" json:"stale_setup_connections,omitempty"`
-	OAuthTokensExpiringPct PercentList `yaml:"oauth_tokens_expiring_percent" json:"oauth_tokens_expiring_percent,omitempty"`
-	PeriodicProbePct       PercentList `yaml:"periodic_probe_percent" json:"periodic_probe_percent,omitempty"`
+	StaleSetupConnections  int         `yaml:"staleSetupConnections" json:"staleSetupConnections,omitempty"`
+	OAuthTokensExpiringPct PercentList `yaml:"oauthTokensExpiringPercent" json:"oauthTokensExpiringPercent,omitempty"`
+	PeriodicProbePct       PercentList `yaml:"periodicProbePercent" json:"periodicProbePercent,omitempty"`
+}
+
+type ProfileAuthProxy struct {
+	ApiReplicas      int `yaml:"apiReplicas" json:"apiReplicas"`
+	WorkerReplicas   int `yaml:"workerReplicas" json:"workerReplicas"`
+	PublicReplicas   int `yaml:"publicReplicas" json:"publicReplicas"`
+	AdminApiReplicas int `yaml:"adminApiReplicas" json:"adminApiReplicas"`
+}
+
+type ProfileK6 struct {
+	Mode                 string  `yaml:"mode" json:"mode"`
+	Scenario             string  `yaml:"scenario" json:"scenario"`
+	Rate                 int     `yaml:"rate" json:"rate"`
+	Duration             string  `yaml:"duration" json:"duration"`
+	TimeUnit             string  `yaml:"timeUnit" json:"timeUnit"`
+	ConnectionRows       int     `yaml:"connectionRows" json:"connectionRows"`
+	Parallelism          int     `yaml:"parallelism" json:"parallelism"`
+	PreAllocatedVus      int     `yaml:"preAllocatedVus" json:"preAllocatedVus"`
+	MaxVus               int     `yaml:"maxVus" json:"maxVus"`
+	RequestTimeout       string  `yaml:"requestTimeout" json:"requestTimeout"`
+	P95LatencyMs         int     `yaml:"p95LatencyMs" json:"p95LatencyMs"`
+	MaxFailedRate        float64 `yaml:"maxFailedRate" json:"maxFailedRate"`
+	UpstreamStatus       int     `yaml:"upstreamStatus" json:"upstreamStatus"`
+	UpstreamBytes        int     `yaml:"upstreamBytes" json:"upstreamBytes"`
+	UpstreamDelayMs      int     `yaml:"upstreamDelayMs" json:"upstreamDelayMs"`
+	UpstreamJitterMs     int     `yaml:"upstreamJitterMs" json:"upstreamJitterMs"`
+	UpstreamBearerPrefix string  `yaml:"upstreamBearerPrefix" json:"upstreamBearerPrefix"`
+	UpstreamPathPrefix   string  `yaml:"upstreamPathPrefix" json:"upstreamPathPrefix"`
+	SoakDuration         string  `yaml:"soakDuration" json:"soakDuration"`
+	SpikeBaseRate        int     `yaml:"spikeBaseRate" json:"spikeBaseRate"`
+	SpikeRate            int     `yaml:"spikeRate" json:"spikeRate"`
+	SpikeRampUp          string  `yaml:"spikeRampUp" json:"spikeRampUp"`
+	SpikeHold            string  `yaml:"spikeHold" json:"spikeHold"`
+	SpikeRampDown        string  `yaml:"spikeRampDown" json:"spikeRampDown"`
+	SpikeRecovery        string  `yaml:"spikeRecovery" json:"spikeRecovery"`
+	ScaleReplicas        []int   `yaml:"scaleReplicas" json:"scaleReplicas"`
+}
+
+type ProfileAcceptance struct {
+	Max5xxRate                          float64 `yaml:"max5xxRate" json:"max5xxRate"`
+	P95LatencyTarget                    string  `yaml:"p95LatencyTarget" json:"p95LatencyTarget"`
+	RefreshSweepMustDrainBeforeNextCron bool    `yaml:"refreshSweepMustDrainBeforeNextCron" json:"refreshSweepMustDrainBeforeNextCron"`
 }
 
 type PercentList []int
@@ -54,7 +105,7 @@ func LoadProfile(path string) (Profile, error) {
 	}
 
 	var profile Profile
-	if err := yaml.Unmarshal(content, &profile); err != nil {
+	if err := util.DecodeYAMLStrict(content, &profile); err != nil {
 		return Profile{}, err
 	}
 	if profile.Name == "" {

--- a/internal/loadtest/seeder/provider_client.go
+++ b/internal/loadtest/seeder/provider_client.go
@@ -27,7 +27,7 @@ type providerClientRequest struct {
 	Key                     string `json:"key"`
 	Secret                  string `json:"secret"`
 	Scope                   string `json:"scope"`
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+	TokenEndpointAuthMethod string `json:"tokenEndpointAuthMethod"`
 }
 
 func ensureProviderLoadtestClient(ctx context.Context, client HTTPClient, providerBaseURL string) error {

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -43,31 +43,31 @@ type Options struct {
 }
 
 type Result struct {
-	ProfileName               string             `json:"profile_name"`
-	ProviderBaseURL           string             `json:"provider_base_url"`
-	BaseNamespace             string             `json:"base_namespace"`
-	ConnectorID               apid.ID            `json:"connector_id"`
-	ConnectorVersion          uint64             `json:"connector_version"`
-	RequestedTenantNamespaces int                `json:"requested_tenant_namespaces"`
-	RequestedConnections      int                `json:"requested_connections"`
-	RequestedStaleSetups      int                `json:"requested_stale_setup_connections"`
-	OAuthExpiringPercent      int                `json:"oauth_expiring_percent"`
-	PeriodicProbePercent      int                `json:"periodic_probe_percent"`
-	StartedAt                 time.Time          `json:"started_at"`
-	FinishedAt                time.Time          `json:"finished_at"`
-	CreatedNamespaces         int                `json:"created_namespaces"`
-	UpsertedActors            int                `json:"upserted_actors"`
-	CreatedConnections        int                `json:"created_connections"`
-	ExistingConnections       int                `json:"existing_connections"`
-	CreatedStaleSetups        int                `json:"created_stale_setup_connections"`
-	ExistingStaleSetups       int                `json:"existing_stale_setup_connections"`
-	UpsertedOAuthTokens       int                `json:"upserted_oauth_tokens"`
-	ProbeEnabledConnections   int                `json:"probe_enabled_connections"`
-	VerifiedSamples           []VerifiedSample   `json:"verified_samples"`
+	ProfileName               string             `json:"profileName"`
+	ProviderBaseURL           string             `json:"providerBaseUrl"`
+	BaseNamespace             string             `json:"baseNamespace"`
+	ConnectorID               apid.ID            `json:"connectorId"`
+	ConnectorVersion          uint64             `json:"connectorVersion"`
+	RequestedTenantNamespaces int                `json:"requestedTenantNamespaces"`
+	RequestedConnections      int                `json:"requestedConnections"`
+	RequestedStaleSetups      int                `json:"requestedStaleSetupConnections"`
+	OAuthExpiringPercent      int                `json:"oauthExpiringPercent"`
+	PeriodicProbePercent      int                `json:"periodicProbePercent"`
+	StartedAt                 time.Time          `json:"startedAt"`
+	FinishedAt                time.Time          `json:"finishedAt"`
+	CreatedNamespaces         int                `json:"createdNamespaces"`
+	UpsertedActors            int                `json:"upsertedActors"`
+	CreatedConnections        int                `json:"createdConnections"`
+	ExistingConnections       int                `json:"existingConnections"`
+	CreatedStaleSetups        int                `json:"createdStaleSetupConnections"`
+	ExistingStaleSetups       int                `json:"existingStaleSetupConnections"`
+	UpsertedOAuthTokens       int                `json:"upsertedOauthTokens"`
+	ProbeEnabledConnections   int                `json:"probeEnabledConnections"`
+	VerifiedSamples           []VerifiedSample   `json:"verifiedSamples"`
 	Namespaces                []NamespaceRecord  `json:"namespaces"`
 	Actors                    []ActorRecord      `json:"actors"`
 	Connections               []ConnectionRecord `json:"connections"`
-	StaleSetups               []ConnectionRecord `json:"stale_setup_connections"`
+	StaleSetups               []ConnectionRecord `json:"staleSetupConnections"`
 }
 
 type NamespaceRecord struct {
@@ -75,29 +75,29 @@ type NamespaceRecord struct {
 }
 
 type ActorRecord struct {
-	ActorID    apid.ID `json:"actor_id"`
+	ActorID    apid.ID `json:"actorId"`
 	Namespace  string  `json:"namespace"`
-	ExternalID string  `json:"external_id"`
+	ExternalID string  `json:"externalId"`
 }
 
 type ConnectionRecord struct {
-	ConnectionID         apid.ID   `json:"connection_id"`
+	ConnectionID         apid.ID   `json:"connectionId"`
 	Namespace            string    `json:"namespace"`
-	ActorID              apid.ID   `json:"actor_id"`
-	ConnectorID          apid.ID   `json:"connector_id"`
-	ConnectorVersion     uint64    `json:"connector_version"`
-	RefreshToken         string    `json:"refresh_token"`
-	AccessToken          string    `json:"access_token"`
-	AccessTokenExpiresAt time.Time `json:"access_token_expires_at"`
-	ProbeEnabled         bool      `json:"probe_enabled"`
-	OAuthTokenID         *apid.ID  `json:"oauth_token_id,omitempty"`
+	ActorID              apid.ID   `json:"actorId"`
+	ConnectorID          apid.ID   `json:"connectorId"`
+	ConnectorVersion     uint64    `json:"connectorVersion"`
+	RefreshToken         string    `json:"refreshToken"`
+	AccessToken          string    `json:"accessToken"`
+	AccessTokenExpiresAt time.Time `json:"accessTokenExpiresAt"`
+	ProbeEnabled         bool      `json:"probeEnabled"`
+	OAuthTokenID         *apid.ID  `json:"oauthTokenId,omitempty"`
 }
 
 type VerifiedSample struct {
-	ConnectionID apid.ID `json:"connection_id"`
+	ConnectionID apid.ID `json:"connectionId"`
 	Namespace    string  `json:"namespace"`
-	ActorID      apid.ID `json:"actor_id"`
-	OAuthTokenID apid.ID `json:"oauth_token_id"`
+	ActorID      apid.ID `json:"actorId"`
+	OAuthTokenID apid.ID `json:"oauthTokenId"`
 }
 
 func Seed(ctx context.Context, opts Options) (*Result, error) {

--- a/internal/loadtest/seeder/seed_test.go
+++ b/internal/loadtest/seeder/seed_test.go
@@ -146,8 +146,8 @@ func TestSeedWritesArtifactsAndIsConnectionIdempotent(t *testing.T) {
 
 	summary, err := os.ReadFile(filepath.Join(runDir, "seed-summary.json"))
 	require.NoError(t, err)
-	assert.Contains(t, string(summary), `"existing_connections": 2`)
-	assert.Contains(t, string(summary), `"existing_stale_setup_connections": 1`)
+	assert.Contains(t, string(summary), `"existingConnections": 2`)
+	assert.Contains(t, string(summary), `"existingStaleSetupConnections": 1`)
 
 	plan, err := os.ReadFile(filepath.Join(runDir, "seed-plan.txt"))
 	require.NoError(t, err)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -88,12 +88,12 @@ and scale runs.
 
 - `all`: refresh sweeps, scheduler sync, resource snapshot, and stale setup
   cleanup.
-- `refresh-sweep`: seeds each `objects.oauth_tokens_expiring_percent` value
+- `refresh-sweep`: seeds each `objects.oauthTokensExpiringPercent` value
   and enqueues the OAuth refresh sweep task.
-- `scheduler-sync`: seeds each `objects.periodic_probe_percent` value and
+- `scheduler-sync`: seeds each `objects.periodicProbePercent` value and
   measures the periodic scheduler's connection walk without needing a worker.
 - `resource-snapshot`: enqueues the app-metrics resource snapshot task.
-- `stale-setup-cleanup`: seeds `objects.stale_setup_connections`, waits for the
+- `stale-setup-cleanup`: seeds `objects.staleSetupConnections`, waits for the
   load-test setup TTL, then enqueues stale setup cleanup.
 - `probe-outcome-cleanup`: optional cleanup-task walk over probe-enabled
   connections.
@@ -111,17 +111,17 @@ record enqueue/queue state without waiting for worker processing.
 
 - `smoke`: low-rate health checks for the deployed services.
 - `proxy-raw`: constant-arrival-rate traffic against
-  `/api/v1/connections/{id}/_proxy_raw`.
+  `/api/v1/connections/{id}/_proxyRaw`.
 - `proxy-wrapped`: constant-arrival-rate comparison traffic against
   `/api/v1/connections/{id}/_proxy`.
 - `proxy-scale`: sequentially fixes `authproxy-api` replicas to the profile's
-  `k6.scale_replicas` entries and runs `LOADTEST_PROXY_SCALE_SCENARIO`
+  `k6.scaleReplicas` entries and runs `LOADTEST_PROXY_SCALE_SCENARIO`
   (`proxy-raw` by default) at each size.
-- `proxy-soak`: long constant-arrival-rate run using `k6.soak_duration`.
+- `proxy-soak`: long constant-arrival-rate run using `k6.soakDuration`.
 - `proxy-spike`: ramping-arrival-rate run using the profile's spike knobs.
 
 The proxy script calls the go-oauth2-server load sink under
-`/test/load/resource/proxy/{connection_id}` and expects the provider to accept
+`/test/load/resource/proxy/{connectionId}` and expects the provider to accept
 seeded bearer tokens with the `at_` prefix. Override the sink behavior with
 `K6_UPSTREAM_STATUS`, `K6_UPSTREAM_BYTES`, `K6_UPSTREAM_DELAY_MS`,
 `K6_UPSTREAM_JITTER_MS`, and `K6_UPSTREAM_BEARER_PREFIX`.
@@ -139,7 +139,7 @@ k6 thresholds fail runs when:
 
 ConfigMap-backed k6 Operator scripts have a Kubernetes size ceiling, so the
 runner defaults to a compact sample of 10,000 seeded connections. Tune that with
-`LOADTEST_K6_CONNECTION_ROWS` or `k6.connection_rows`; use `all` only when the
+`LOADTEST_K6_CONNECTION_ROWS` or `k6.connectionRows`; use `all` only when the
 generated ConfigMap remains below `LOADTEST_K6_CONFIGMAP_MAX_BYTES`. Grafana's
 k6 Operator docs recommend a PVC or local-file based runner image for larger
 multi-file suites:

--- a/loadtest/helm-values/common.yaml
+++ b/loadtest/helm-values/common.yaml
@@ -83,14 +83,14 @@ appMetrics:
     database: authproxy_app_metrics
     user: authproxy
     password:
-      env_var: CLICKHOUSE_PASSWORD
+      envVar: CLICKHOUSE_PASSWORD
   fullRequestRecording: never
 
 config:
   connections:
-    setup_ttl: 1s
+    setupTtl: 1s
   tasks:
-    default_retention: 24h
+    defaultRetention: 24h
   telemetry:
     enabled: true
     exporter:
@@ -98,7 +98,7 @@ config:
       endpoint: http://otel-lgtm:4317
       insecure: true
     resource:
-      service_name_prefix: authproxy-load
+      serviceNamePrefix: authproxy-load
       attributes:
         deployment.environment: loadtest
     sampling:
@@ -108,12 +108,12 @@ config:
       metrics: true
       logs: true
     http:
-      excluded_paths:
+      excludedPaths:
         - /ping
         - /healthz
     proxy:
-      span_attribute_labels:
+      spanAttributeLabels:
         - loadtest
-      metric_dimension_labels:
+      metricDimensionLabels:
         - loadtest
-      metric_dimension_value_cap: 25
+      metricDimensionValueCap: 25

--- a/loadtest/k6/proxy.js
+++ b/loadtest/k6/proxy.js
@@ -93,7 +93,7 @@ export default function () {
 }
 
 function rawProxy(connection, upstreamUrl) {
-  const url = `${apiUrl}/api/v1/connections/${encodeURIComponent(connection.connection_id)}/_proxy_raw`;
+  const url = `${apiUrl}/api/v1/connections/${encodeURIComponent(connection.connection_id)}/_proxyRaw`;
   return http.request(proxyMethod, url, null, {
     timeout: requestTimeout,
     headers: {

--- a/loadtest/profiles/100k.yaml
+++ b/loadtest/profiles/100k.yaml
@@ -4,56 +4,56 @@ description: Baseline high-cardinality target profile.
 cluster:
   target: real-cluster
 objects:
-  namespaces_min: 50000
-  namespaces_max: 100000
+  namespacesMin: 50000
+  namespacesMax: 100000
   connections: 100000
-  stale_setup_connections: 1000
-  oauth_tokens_expiring_percent:
+  staleSetupConnections: 1000
+  oauthTokensExpiringPercent:
     - 10
     - 50
     - 100
-  periodic_probe_percent:
+  periodicProbePercent:
     - 1
     - 10
     - 100
 authproxy:
-  api_replicas: 2
-  worker_replicas: 2
+  apiReplicas: 2
+  workerReplicas: 2
   # Public OAuth callbacks are not exercised by this proxy/cardinality profile.
-  public_replicas: 0
-  admin_api_replicas: 1
+  publicReplicas: 0
+  adminApiReplicas: 1
 k6:
   mode: operator
   scenario: proxy-raw
   rate: 500
   duration: 10m
-  time_unit: 1s
-  connection_rows: 10000
+  timeUnit: 1s
+  connectionRows: 10000
   parallelism: 4
-  pre_allocated_vus: 250
-  max_vus: 2000
-  request_timeout: 30s
-  p95_latency_ms: 1000
-  max_failed_rate: 0.001
-  upstream_status: 200
-  upstream_bytes: 256
-  upstream_delay_ms: 0
-  upstream_jitter_ms: 0
-  upstream_bearer_prefix: at_
-  upstream_path_prefix: /test/load/resource/proxy
-  soak_duration: 2h
-  spike_base_rate: 500
-  spike_rate: 1500
-  spike_ramp_up: 2m
-  spike_hold: 5m
-  spike_ramp_down: 2m
-  spike_recovery: 5m
-  scale_replicas:
+  preAllocatedVus: 250
+  maxVus: 2000
+  requestTimeout: 30s
+  p95LatencyMs: 1000
+  maxFailedRate: 0.001
+  upstreamStatus: 200
+  upstreamBytes: 256
+  upstreamDelayMs: 0
+  upstreamJitterMs: 0
+  upstreamBearerPrefix: at_
+  upstreamPathPrefix: /test/load/resource/proxy
+  soakDuration: 2h
+  spikeBaseRate: 500
+  spikeRate: 1500
+  spikeRampUp: 2m
+  spikeHold: 5m
+  spikeRampDown: 2m
+  spikeRecovery: 5m
+  scaleReplicas:
     - 2
     - 4
     - 8
     - 16
 acceptance:
-  max_5xx_rate: 0.001
-  p95_latency_target: profile-configured
-  refresh_sweep_must_drain_before_next_cron: true
+  max5xxRate: 0.001
+  p95LatencyTarget: profile-configured
+  refreshSweepMustDrainBeforeNextCron: true

--- a/loadtest/profiles/250k.yaml
+++ b/loadtest/profiles/250k.yaml
@@ -4,54 +4,54 @@ description: Larger cardinality target profile for database, scheduler, and work
 cluster:
   target: real-cluster
 objects:
-  namespaces_min: 100000
+  namespacesMin: 100000
   connections: 250000
-  stale_setup_connections: 2500
-  oauth_tokens_expiring_percent:
+  staleSetupConnections: 2500
+  oauthTokensExpiringPercent:
     - 10
     - 50
     - 100
-  periodic_probe_percent:
+  periodicProbePercent:
     - 1
     - 10
     - 100
 authproxy:
-  api_replicas: 4
-  worker_replicas: 4
+  apiReplicas: 4
+  workerReplicas: 4
   # Public OAuth callbacks are not exercised by this proxy/cardinality profile.
-  public_replicas: 0
-  admin_api_replicas: 1
+  publicReplicas: 0
+  adminApiReplicas: 1
 k6:
   mode: operator
   scenario: proxy-raw
   rate: 1000
   duration: 10m
-  time_unit: 1s
-  connection_rows: 10000
+  timeUnit: 1s
+  connectionRows: 10000
   parallelism: 8
-  pre_allocated_vus: 500
-  max_vus: 4000
-  request_timeout: 30s
-  p95_latency_ms: 1000
-  max_failed_rate: 0.001
-  upstream_status: 200
-  upstream_bytes: 256
-  upstream_delay_ms: 0
-  upstream_jitter_ms: 0
-  upstream_bearer_prefix: at_
-  upstream_path_prefix: /test/load/resource/proxy
-  soak_duration: 2h
-  spike_base_rate: 1000
-  spike_rate: 3000
-  spike_ramp_up: 2m
-  spike_hold: 5m
-  spike_ramp_down: 2m
-  spike_recovery: 5m
-  scale_replicas:
+  preAllocatedVus: 500
+  maxVus: 4000
+  requestTimeout: 30s
+  p95LatencyMs: 1000
+  maxFailedRate: 0.001
+  upstreamStatus: 200
+  upstreamBytes: 256
+  upstreamDelayMs: 0
+  upstreamJitterMs: 0
+  upstreamBearerPrefix: at_
+  upstreamPathPrefix: /test/load/resource/proxy
+  soakDuration: 2h
+  spikeBaseRate: 1000
+  spikeRate: 3000
+  spikeRampUp: 2m
+  spikeHold: 5m
+  spikeRampDown: 2m
+  spikeRecovery: 5m
+  scaleReplicas:
     - 4
     - 8
     - 16
 acceptance:
-  max_5xx_rate: 0.001
-  p95_latency_target: profile-configured
-  refresh_sweep_must_drain_before_next_cron: true
+  max5xxRate: 0.001
+  p95LatencyTarget: profile-configured
+  refreshSweepMustDrainBeforeNextCron: true

--- a/loadtest/profiles/500k.yaml
+++ b/loadtest/profiles/500k.yaml
@@ -4,53 +4,53 @@ description: Stretch target profile for upper-bound capacity exploration.
 cluster:
   target: real-cluster
 objects:
-  namespaces_min: 200000
+  namespacesMin: 200000
   connections: 500000
-  stale_setup_connections: 5000
-  oauth_tokens_expiring_percent:
+  staleSetupConnections: 5000
+  oauthTokensExpiringPercent:
     - 10
     - 50
     - 100
-  periodic_probe_percent:
+  periodicProbePercent:
     - 1
     - 10
     - 100
 authproxy:
-  api_replicas: 8
-  worker_replicas: 8
+  apiReplicas: 8
+  workerReplicas: 8
   # Public OAuth callbacks are not exercised by this proxy/cardinality profile.
-  public_replicas: 0
-  admin_api_replicas: 1
+  publicReplicas: 0
+  adminApiReplicas: 1
 k6:
   mode: operator
   scenario: proxy-raw
   rate: 1500
   duration: 10m
-  time_unit: 1s
-  connection_rows: 10000
+  timeUnit: 1s
+  connectionRows: 10000
   parallelism: 12
-  pre_allocated_vus: 750
-  max_vus: 6000
-  request_timeout: 30s
-  p95_latency_ms: 1000
-  max_failed_rate: 0.001
-  upstream_status: 200
-  upstream_bytes: 256
-  upstream_delay_ms: 0
-  upstream_jitter_ms: 0
-  upstream_bearer_prefix: at_
-  upstream_path_prefix: /test/load/resource/proxy
-  soak_duration: 2h
-  spike_base_rate: 1500
-  spike_rate: 4500
-  spike_ramp_up: 2m
-  spike_hold: 5m
-  spike_ramp_down: 2m
-  spike_recovery: 5m
-  scale_replicas:
+  preAllocatedVus: 750
+  maxVus: 6000
+  requestTimeout: 30s
+  p95LatencyMs: 1000
+  maxFailedRate: 0.001
+  upstreamStatus: 200
+  upstreamBytes: 256
+  upstreamDelayMs: 0
+  upstreamJitterMs: 0
+  upstreamBearerPrefix: at_
+  upstreamPathPrefix: /test/load/resource/proxy
+  soakDuration: 2h
+  spikeBaseRate: 1500
+  spikeRate: 4500
+  spikeRampUp: 2m
+  spikeHold: 5m
+  spikeRampDown: 2m
+  spikeRecovery: 5m
+  scaleReplicas:
     - 8
     - 16
 acceptance:
-  max_5xx_rate: 0.001
-  p95_latency_target: profile-configured
-  refresh_sweep_must_drain_before_next_cron: true
+  max5xxRate: 0.001
+  p95LatencyTarget: profile-configured
+  refreshSweepMustDrainBeforeNextCron: true

--- a/loadtest/profiles/smoke.yaml
+++ b/loadtest/profiles/smoke.yaml
@@ -6,22 +6,22 @@ cluster:
 objects:
   namespaces: 10
   connections: 10
-  stale_setup_connections: 2
-  oauth_tokens_expiring_percent: 0
-  periodic_probe_percent: 0
+  staleSetupConnections: 2
+  oauthTokensExpiringPercent: 0
+  periodicProbePercent: 0
 authproxy:
-  api_replicas: 2
-  worker_replicas: 1
-  public_replicas: 1
-  admin_api_replicas: 1
+  apiReplicas: 2
+  workerReplicas: 1
+  publicReplicas: 1
+  adminApiReplicas: 1
 k6:
   mode: job
   scenario: smoke
   rate: 2
   duration: 30s
-  connection_rows: 10
-  pre_allocated_vus: 4
-  max_vus: 16
+  connectionRows: 10
+  preAllocatedVus: 4
+  maxVus: 16
 acceptance:
-  max_5xx_rate: 0.001
-  p95_latency_target: 500ms
+  max5xxRate: 0.001
+  p95LatencyTarget: 500ms

--- a/loadtest/scripts/background
+++ b/loadtest/scripts/background
@@ -40,46 +40,46 @@ generate_local_config() {
 
   loadtest_log "generating local SQLite/miniredis background config: $path"
   cat > "$path" <<EOF
-host_application:
-  initiate_session_url: http://placeholder.invalid/login
+hostApplication:
+  initiateSessionUrl: http://placeholder.invalid/login
 
 connections:
-  setup_ttl: 1s
+  setupTtl: 1s
 
 tasks:
-  default_retention: 24h
+  defaultRetention: 24h
 
 database:
   provider: sqlite
-  auto_migrate: true
+  autoMigrate: true
   path: $sqlite_path
 
 redis:
   provider: miniredis
 
-system_auth:
-  jwt_signing_key:
-    public_key:
+systemAuth:
+  jwtSigningKey:
+    publicKey:
       path: $REPO_ROOT/dev_config/system.pub
-    private_key:
+    privateKey:
       path: $REPO_ROOT/dev_config/system
   actors:
-    keys_path: $REPO_ROOT/dev_config/keys/admin
+    keysPath: $REPO_ROOT/dev_config/keys/admin
     permissions:
       - namespace: root.**
         resources:
           - "*"
         verbs:
           - "*"
-  global_aes_key:
+  globalAesKey:
     path: $REPO_ROOT/dev_config/keys/global_aes.key
 
 connectors:
-  auto_migrate: false
-  load_from_list: []
+  autoMigrate: false
+  loadFromList: []
 
-app_metrics:
-  auto_migrate: false
+appMetrics:
+  autoMigrate: false
   database:
     provider: sqlite
     path: $sqlite_path
@@ -212,7 +212,7 @@ run_refresh_sweep() {
       --periodic-probe-percent 0 \
       --stale-setup-connections 0
     run_background_scenario "$variant" refresh-sweep "$pct"
-  done < <(profile_percent_values oauth_tokens_expiring_percent)
+  done < <(profile_percent_values oauthTokensExpiringPercent)
 }
 
 run_scheduler_sync() {
@@ -225,7 +225,7 @@ run_scheduler_sync() {
       --periodic-probe-percent "$pct" \
       --stale-setup-connections 0
     run_background_scenario "$variant" scheduler-sync "$pct"
-  done < <(profile_percent_values periodic_probe_percent)
+  done < <(profile_percent_values periodicProbePercent)
 }
 
 run_resource_snapshot() {

--- a/loadtest/scripts/lib/loadtest.sh
+++ b/loadtest/scripts/lib/loadtest.sh
@@ -256,9 +256,9 @@ loadtest_init_run_dir() {
 loadtest_profile_p95_seconds() {
   local profile_file=$1
   local value
-  value=$(loadtest_yaml_section_value "$profile_file" k6 p95_latency_ms)
+  value=$(loadtest_yaml_section_value "$profile_file" k6 p95LatencyMs)
   if [[ -z "$value" ]]; then
-    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95_latency_target)
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95LatencyTarget)
   fi
 
   case "$value" in

--- a/loadtest/scripts/run
+++ b/loadtest/scripts/run
@@ -45,10 +45,10 @@ k6_env_or_profile() {
 k6_p95_threshold_ms() {
   local value=${LOADTEST_K6_P95_THRESHOLD_MS:-}
   if [[ -z "$value" ]]; then
-    value=$(loadtest_yaml_section_value "$profile_file" k6 p95_latency_ms)
+    value=$(loadtest_yaml_section_value "$profile_file" k6 p95LatencyMs)
   fi
   if [[ -z "$value" ]]; then
-    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95_latency_target)
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance p95LatencyTarget)
   fi
 
   case "$value" in
@@ -100,7 +100,7 @@ shape_for_scenario() {
 duration_for_scenario() {
   case "$1" in
     proxy-soak)
-      k6_env_or_profile LOADTEST_K6_SOAK_DURATION soak_duration 2h
+      k6_env_or_profile LOADTEST_K6_SOAK_DURATION soakDuration 2h
       ;;
     *)
       k6_env_or_profile LOADTEST_K6_DURATION duration 5m
@@ -108,10 +108,10 @@ duration_for_scenario() {
   esac
 }
 
-max_5xx_rate() {
+max5xxRate() {
   local value=${LOADTEST_K6_MAX_5XX_RATE:-}
   if [[ -z "$value" ]]; then
-    value=$(loadtest_yaml_section_value "$profile_file" acceptance max_5xx_rate)
+    value=$(loadtest_yaml_section_value "$profile_file" acceptance max5xxRate)
   fi
   printf "%s\n" "${value:-0.001}"
 }
@@ -125,7 +125,7 @@ prepare_connections_dataset() {
   [[ -f "$source" ]] || loadtest_die "connections dataset does not exist: $source"
 
   local rows
-  rows=$(k6_env_or_profile LOADTEST_K6_CONNECTION_ROWS connection_rows 10000)
+  rows=$(k6_env_or_profile LOADTEST_K6_CONNECTION_ROWS connectionRows 10000)
   if [[ "$rows" != "all" && ! "$rows" =~ ^[0-9]+$ ]]; then
     loadtest_die "LOADTEST_K6_CONNECTION_ROWS must be numeric or all"
   fi
@@ -247,26 +247,26 @@ apply_k6_env_configmap() {
     printf "LOADTEST_K6_API_REPLICAS=%s\n" "$api_replicas"
     printf "LOADTEST_K6_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_RATE rate 100)"
     printf "LOADTEST_K6_DURATION=%s\n" "$(duration_for_scenario "$scenario_name")"
-    printf "LOADTEST_K6_TIME_UNIT=%s\n" "$(k6_env_or_profile LOADTEST_K6_TIME_UNIT time_unit 1s)"
-    printf "LOADTEST_K6_PRE_ALLOCATED_VUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_PRE_ALLOCATED_VUS pre_allocated_vus 100)"
-    printf "LOADTEST_K6_MAX_VUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_MAX_VUS max_vus 1000)"
-    printf "LOADTEST_K6_REQUEST_TIMEOUT=%s\n" "$(k6_env_or_profile LOADTEST_K6_REQUEST_TIMEOUT request_timeout 30s)"
+    printf "LOADTEST_K6_TIME_UNIT=%s\n" "$(k6_env_or_profile LOADTEST_K6_TIME_UNIT timeUnit 1s)"
+    printf "LOADTEST_K6_PRE_ALLOCATED_VUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_PRE_ALLOCATED_VUS preAllocatedVus 100)"
+    printf "LOADTEST_K6_MAX_VUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_MAX_VUS maxVus 1000)"
+    printf "LOADTEST_K6_REQUEST_TIMEOUT=%s\n" "$(k6_env_or_profile LOADTEST_K6_REQUEST_TIMEOUT requestTimeout 30s)"
     printf "LOADTEST_K6_P95_THRESHOLD_MS=%s\n" "$(k6_p95_threshold_ms)"
-    printf "LOADTEST_K6_MAX_FAILED_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_MAX_FAILED_RATE max_failed_rate "$(max_5xx_rate)")"
-    printf "LOADTEST_K6_MAX_5XX_RATE=%s\n" "$(max_5xx_rate)"
-    printf "LOADTEST_K6_UPSTREAM_STATUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_STATUS upstream_status 200)"
-    printf "LOADTEST_K6_UPSTREAM_BYTES=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_BYTES upstream_bytes 256)"
-    printf "LOADTEST_K6_UPSTREAM_DELAY_MS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_DELAY_MS upstream_delay_ms 0)"
-    printf "LOADTEST_K6_UPSTREAM_JITTER_MS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_JITTER_MS upstream_jitter_ms 0)"
-    printf "LOADTEST_K6_UPSTREAM_BEARER_PREFIX=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_BEARER_PREFIX upstream_bearer_prefix at_)"
-    printf "LOADTEST_K6_UPSTREAM_PATH_PREFIX=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_PATH_PREFIX upstream_path_prefix /test/load/resource/proxy)"
-    printf "LOADTEST_K6_PROXY_METHOD=%s\n" "$(k6_env_or_profile LOADTEST_K6_PROXY_METHOD proxy_method GET)"
-    printf "LOADTEST_K6_SPIKE_BASE_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_BASE_RATE spike_base_rate "$(k6_env_or_profile LOADTEST_K6_RATE rate 100)")"
-    printf "LOADTEST_K6_SPIKE_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RATE spike_rate 300)"
-    printf "LOADTEST_K6_SPIKE_RAMP_UP=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RAMP_UP spike_ramp_up 1m)"
-    printf "LOADTEST_K6_SPIKE_HOLD=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_HOLD spike_hold 3m)"
-    printf "LOADTEST_K6_SPIKE_RAMP_DOWN=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RAMP_DOWN spike_ramp_down 1m)"
-    printf "LOADTEST_K6_SPIKE_RECOVERY=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RECOVERY spike_recovery 3m)"
+    printf "LOADTEST_K6_MAX_FAILED_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_MAX_FAILED_RATE maxFailedRate "$(max5xxRate)")"
+    printf "LOADTEST_K6_MAX_5XX_RATE=%s\n" "$(max5xxRate)"
+    printf "LOADTEST_K6_UPSTREAM_STATUS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_STATUS upstreamStatus 200)"
+    printf "LOADTEST_K6_UPSTREAM_BYTES=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_BYTES upstreamBytes 256)"
+    printf "LOADTEST_K6_UPSTREAM_DELAY_MS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_DELAY_MS upstreamDelayMs 0)"
+    printf "LOADTEST_K6_UPSTREAM_JITTER_MS=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_JITTER_MS upstreamJitterMs 0)"
+    printf "LOADTEST_K6_UPSTREAM_BEARER_PREFIX=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_BEARER_PREFIX upstreamBearerPrefix at_)"
+    printf "LOADTEST_K6_UPSTREAM_PATH_PREFIX=%s\n" "$(k6_env_or_profile LOADTEST_K6_UPSTREAM_PATH_PREFIX upstreamPathPrefix /test/load/resource/proxy)"
+    printf "LOADTEST_K6_PROXY_METHOD=%s\n" "$(k6_env_or_profile LOADTEST_K6_PROXY_METHOD proxyMethod GET)"
+    printf "LOADTEST_K6_SPIKE_BASE_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_BASE_RATE spikeBaseRate "$(k6_env_or_profile LOADTEST_K6_RATE rate 100)")"
+    printf "LOADTEST_K6_SPIKE_RATE=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RATE spikeRate 300)"
+    printf "LOADTEST_K6_SPIKE_RAMP_UP=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RAMP_UP spikeRampUp 1m)"
+    printf "LOADTEST_K6_SPIKE_HOLD=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_HOLD spikeHold 3m)"
+    printf "LOADTEST_K6_SPIKE_RAMP_DOWN=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RAMP_DOWN spikeRampDown 1m)"
+    printf "LOADTEST_K6_SPIKE_RECOVERY=%s\n" "$(k6_env_or_profile LOADTEST_K6_SPIKE_RECOVERY spikeRecovery 3m)"
   } > "$env_file"
 
   kubectl -n "$namespace" create configmap "$configmap_name" \
@@ -434,7 +434,7 @@ record_scale_result() {
   local results_file="$run_dir/k6/scale-results.tsv"
 
   if [[ ! -f "$results_file" ]]; then
-    printf "api_replicas\tscenario\titerations_per_second\thttp_req_duration_p95_ms\thttp_req_failed_rate\tdropped_iterations\tmax_vus\tlog_file\tsummary_file\n" > "$results_file"
+    printf "api_replicas\tscenario\titerations_per_second\thttp_req_duration_p95_ms\thttp_req_failed_rate\tdropped_iterations\tmaxVus\tlog_file\tsummary_file\n" > "$results_file"
   fi
 
   if command -v jq >/dev/null 2>&1 && [[ -f "$summary_file" ]]; then
@@ -492,9 +492,9 @@ run_proxy_suite() {
       local replica_count
       while IFS= read -r replica_count; do
         [[ -n "$replica_count" ]] && replicas+=("$replica_count")
-      done < <(loadtest_yaml_section_list "$profile_file" k6 scale_replicas)
+      done < <(loadtest_yaml_section_list "$profile_file" k6 scaleReplicas)
       if [[ "${#replicas[@]}" -eq 0 ]]; then
-        loadtest_die "profile $profile_name has no k6.scale_replicas entries"
+        loadtest_die "profile $profile_name has no k6.scaleReplicas entries"
       fi
       if [[ "$k6_mode" == "operator" && -z "${LOADTEST_K6_WAIT:-}" ]]; then
         export LOADTEST_K6_WAIT=true

--- a/loadtest/scripts/seed
+++ b/loadtest/scripts/seed
@@ -19,46 +19,46 @@ if [[ -z "$config_file" ]]; then
   sqlite_path="$run_dir/authproxy-seed.sqlite3"
   loadtest_log "generating local SQLite/miniredis seed config: $config_file"
   cat > "$config_file" <<EOF
-host_application:
-  initiate_session_url: http://placeholder.invalid/login
+hostApplication:
+  initiateSessionUrl: http://placeholder.invalid/login
 
 connections:
-  setup_ttl: 1s
+  setupTtl: 1s
 
 tasks:
-  default_retention: 24h
+  defaultRetention: 24h
 
 database:
   provider: sqlite
-  auto_migrate: true
+  autoMigrate: true
   path: $sqlite_path
 
 redis:
   provider: miniredis
 
-system_auth:
-  jwt_signing_key:
-    public_key:
+systemAuth:
+  jwtSigningKey:
+    publicKey:
       path: $REPO_ROOT/dev_config/system.pub
-    private_key:
+    privateKey:
       path: $REPO_ROOT/dev_config/system
   actors:
-    keys_path: $REPO_ROOT/dev_config/keys/admin
+    keysPath: $REPO_ROOT/dev_config/keys/admin
     permissions:
       - namespace: root.**
         resources:
           - "*"
         verbs:
           - "*"
-  global_aes_key:
+  globalAesKey:
     path: $REPO_ROOT/dev_config/keys/global_aes.key
 
 connectors:
-  auto_migrate: false
-  load_from_list: []
+  autoMigrate: false
+  loadFromList: []
 
-app_metrics:
-  auto_migrate: false
+appMetrics:
+  autoMigrate: false
   database:
     provider: sqlite
     path: $sqlite_path

--- a/loadtest/scripts/up
+++ b/loadtest/scripts/up
@@ -88,10 +88,10 @@ profile_values_dir="$run_dir/helm-values/profile-overrides"
 mkdir -p "$profile_values_dir"
 
 profile_replica_count() {
-  local service=$1
-  local value
-  value=$(loadtest_yaml_section_value "$profile_file" authproxy "${service}_replicas")
-  [[ "$value" =~ ^[0-9]+$ ]] || loadtest_die "authproxy.${service}_replicas must be a non-negative integer"
+	local field=$1
+	local value
+	value=$(loadtest_yaml_section_value "$profile_file" authproxy "$field")
+	[[ "$value" =~ ^[0-9]+$ ]] || loadtest_die "authproxy.${field} must be a non-negative integer"
   printf "%s\n" "$value"
 }
 
@@ -112,7 +112,7 @@ write_profile_values() {
   printf "%s\n" "$output"
 }
 
-admin_api_profile_values=$(write_profile_values admin_api "$(profile_replica_count admin_api)" false)
+admin_api_profile_values=$(write_profile_values admin_api "$(profile_replica_count adminApi)" false)
 api_profile_values=$(write_profile_values api "$(profile_replica_count api)" true)
 public_replicas=$(profile_replica_count public)
 public_profile_values=$(write_profile_values public "$public_replicas" false)

--- a/plugins/grafana/authproxy-datasource/pkg/plugin/client.go
+++ b/plugins/grafana/authproxy-datasource/pkg/plugin/client.go
@@ -108,22 +108,22 @@ func (c *authProxyClient) queryMetrics(ctx context.Context, req metricsQueryRequ
 func (c *authProxyClient) listRequestEvents(ctx context.Context, filters requestEventFilters) ([]requestEvent, error) {
 	q := url.Values{}
 	addString(q, "namespace", filters.Namespace)
-	addString(q, "request_type", filters.RequestType)
-	addString(q, "correlation_id", filters.CorrelationID)
-	addString(q, "connection_id", filters.ConnectionID)
-	addString(q, "connector_type", filters.ConnectorType)
-	addString(q, "connector_id", filters.ConnectorID)
+	addString(q, "requestType", filters.RequestType)
+	addString(q, "correlationId", filters.CorrelationID)
+	addString(q, "connectionId", filters.ConnectionID)
+	addString(q, "connectorType", filters.ConnectorType)
+	addString(q, "connectorId", filters.ConnectorID)
 	addString(q, "method", filters.Method)
 	if filters.StatusCode != 0 {
-		q.Set("status_code", strconv.Itoa(filters.StatusCode))
+		q.Set("statusCode", strconv.Itoa(filters.StatusCode))
 	}
-	addString(q, "status_code_range", filters.StatusCodeRange)
-	addString(q, "timestamp_range", filters.TimestampRange)
+	addString(q, "statusCodeRange", filters.StatusCodeRange)
+	addString(q, "timestampRange", filters.TimestampRange)
 	addString(q, "path", filters.Path)
-	addString(q, "path_regex", filters.PathRegex)
-	addString(q, "label_selector", filters.LabelSelector)
-	addString(q, "response_source", filters.ResponseSource)
-	addString(q, "rate_limit_id", filters.RateLimitID)
+	addString(q, "pathRegex", filters.PathRegex)
+	addString(q, "labelSelector", filters.LabelSelector)
+	addString(q, "responseSource", filters.ResponseSource)
+	addString(q, "rateLimitId", filters.RateLimitID)
 	q.Set("limit", "500")
 
 	var out listResponse[requestEvent]
@@ -137,7 +137,7 @@ func (c *authProxyClient) variableValues(ctx context.Context, opts variableQuery
 	q := url.Values{}
 	q.Set("limit", "500")
 	addString(q, "namespace", opts.Namespace)
-	addString(q, "label_selector", opts.LabelSelector)
+	addString(q, "labelSelector", opts.LabelSelector)
 
 	apiPath := ""
 	switch opts.Type {
@@ -147,7 +147,7 @@ func (c *authProxyClient) variableValues(ctx context.Context, opts variableQuery
 		apiPath = "/connectors"
 	case "connections":
 		apiPath = "/connections"
-		addString(q, "connector_id", opts.ConnectorID)
+		addString(q, "connectorId", opts.ConnectorID)
 	case "actors":
 		apiPath = "/actors"
 	case "rate_limits":

--- a/plugins/grafana/authproxy-datasource/pkg/plugin/datasource_test.go
+++ b/plugins/grafana/authproxy-datasource/pkg/plugin/datasource_test.go
@@ -95,8 +95,8 @@ func TestQueryDataRequestEvents(t *testing.T) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/api/v1/metrics/request-events", r.URL.Path)
 		require.Equal(t, "root/demo", r.URL.Query().Get("namespace"))
-		require.Equal(t, "5xx", r.URL.Query().Get("status_code_range"))
-		require.Equal(t, "env=demo", r.URL.Query().Get("label_selector"))
+		require.Equal(t, "5xx", r.URL.Query().Get("statusCodeRange"))
+		require.Equal(t, "env=demo", r.URL.Query().Get("labelSelector"))
 		require.Equal(t, "500", r.URL.Query().Get("limit"))
 
 		writeJSON(t, w, listResponse[requestEvent]{Items: []requestEvent{{
@@ -193,7 +193,7 @@ func TestQueryDataVariables(t *testing.T) {
 				require.Equal(t, http.MethodGet, r.Method)
 				require.Equal(t, tt.wantPath, r.URL.Path)
 				require.Equal(t, "500", r.URL.Query().Get("limit"))
-				require.Equal(t, tt.wantConnector, r.URL.Query().Get("connector_id"))
+				require.Equal(t, tt.wantConnector, r.URL.Query().Get("connectorId"))
 				writeJSON(t, w, tt.response)
 			})
 			defer server.Close()

--- a/plugins/grafana/authproxy-datasource/pkg/plugin/models.go
+++ b/plugins/grafana/authproxy-datasource/pkg/plugin/models.go
@@ -45,7 +45,7 @@ type variableQueryOptions struct {
 type metricsQueryRequest struct {
 	Range         metricsRange      `json:"range"`
 	Namespace     *string           `json:"namespace,omitempty"`
-	LabelSelector *string           `json:"label_selector,omitempty"`
+	LabelSelector *string           `json:"labelSelector,omitempty"`
 	Queries       []metricsQueryRef `json:"queries"`
 }
 
@@ -56,10 +56,10 @@ type metricsRange struct {
 }
 
 type metricsQueryRef struct {
-	RefID       string   `json:"ref_id"`
+	RefID       string   `json:"refId"`
 	Metric      string   `json:"metric"`
 	Aggregation string   `json:"aggregation"`
-	GroupBy     []string `json:"group_by,omitempty"`
+	GroupBy     []string `json:"groupBy,omitempty"`
 }
 
 type metricsQueryResponse struct {
@@ -67,7 +67,7 @@ type metricsQueryResponse struct {
 }
 
 type metricsSeries struct {
-	RefID       string            `json:"ref_id"`
+	RefID       string            `json:"refId"`
 	Metric      string            `json:"metric"`
 	Aggregation string            `json:"aggregation"`
 	Labels      map[string]string `json:"labels,omitempty"`
@@ -88,8 +88,8 @@ type listResponse[T any] struct {
 type namedResource struct {
 	ID          string            `json:"id"`
 	Path        string            `json:"path"`
-	ExternalID  string            `json:"external_id"`
-	DisplayName string            `json:"display_name"`
+	ExternalID  string            `json:"externalId"`
+	DisplayName string            `json:"displayName"`
 	Name        string            `json:"name"`
 	Namespace   string            `json:"namespace"`
 	Labels      map[string]string `json:"labels,omitempty"`
@@ -99,33 +99,33 @@ type namedResource struct {
 type requestEvent struct {
 	Namespace           string            `json:"namespace"`
 	Type                string            `json:"type"`
-	RequestID           string            `json:"request_id"`
-	CorrelationID       string            `json:"correlation_id"`
+	RequestID           string            `json:"requestId"`
+	CorrelationID       string            `json:"correlationId"`
 	Timestamp           time.Time         `json:"timestamp"`
 	MillisecondDuration int64             `json:"duration"`
-	ConnectionID        string            `json:"connection_id"`
-	ConnectorID         string            `json:"connector_id"`
-	ConnectorVersion    uint64            `json:"connector_version"`
+	ConnectionID        string            `json:"connectionId"`
+	ConnectorID         string            `json:"connectorId"`
+	ConnectorVersion    uint64            `json:"connectorVersion"`
 	Method              string            `json:"method"`
 	Host                string            `json:"host"`
 	Scheme              string            `json:"scheme"`
 	Path                string            `json:"path"`
-	RequestSizeBytes    int64             `json:"request_size_bytes"`
-	ResponseStatusCode  int               `json:"response_status_code"`
-	ResponseError       string            `json:"response_error"`
-	ResponseSizeBytes   int64             `json:"response_size_bytes"`
-	InternalTimeout     bool              `json:"internal_timeout"`
-	RequestCancelled    bool              `json:"request_cancelled"`
+	RequestSizeBytes    int64             `json:"requestSizeBytes"`
+	ResponseStatusCode  int               `json:"responseStatusCode"`
+	ResponseError       string            `json:"responseError"`
+	ResponseSizeBytes   int64             `json:"responseSizeBytes"`
+	InternalTimeout     bool              `json:"internalTimeout"`
+	RequestCancelled    bool              `json:"requestCancelled"`
 	Labels              map[string]string `json:"labels,omitempty"`
-	ResponseSource      string            `json:"response_source"`
-	RateLimitID         string            `json:"rate_limit_id"`
-	RateLimitMode       string            `json:"rate_limit_mode"`
-	RateLimitBucket     map[string]string `json:"rate_limit_bucket,omitempty"`
-	FullRequestRecorded bool              `json:"full_request_recorded"`
-	RequestBodySkipped  string            `json:"request_body_skipped"`
-	ResponseBodySkipped string            `json:"response_body_skipped"`
-	RequestHTTPVersion  string            `json:"request_http_version"`
-	ResponseHTTPVersion string            `json:"response_http_version"`
-	RequestMimeType     string            `json:"request_mime_type"`
-	ResponseMimeType    string            `json:"response_mime_type"`
+	ResponseSource      string            `json:"responseSource"`
+	RateLimitID         string            `json:"rateLimitId"`
+	RateLimitMode       string            `json:"rateLimitMode"`
+	RateLimitBucket     map[string]string `json:"rateLimitBucket,omitempty"`
+	FullRequestRecorded bool              `json:"fullRequestRecorded"`
+	RequestBodySkipped  string            `json:"requestBodySkipped"`
+	ResponseBodySkipped string            `json:"responseBodySkipped"`
+	RequestHTTPVersion  string            `json:"requestHttpVersion"`
+	ResponseHTTPVersion string            `json:"responseHttpVersion"`
+	RequestMimeType     string            `json:"requestMimeType"`
+	ResponseMimeType    string            `json:"responseMimeType"`
 }

--- a/sdks/js/src/actors.ts
+++ b/sdks/js/src/actors.ts
@@ -33,15 +33,15 @@ export interface Actor {
   namespace: string;
   labels?: Record<string, string>;
   annotations?: Record<string, string>;
-  external_id: string;
-  created_at: string;
-  updated_at: string;
+  externalId: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface CreateActorRequest {
     namespace: string;
     name?: string;
-    external_id: string;
+    externalId: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
 }
@@ -51,12 +51,12 @@ export interface CreateActorRequest {
  */
 export interface ListActorsParams {
   name?: string;
-  external_id?: string;
+  externalId?: string;
   namespace?: string;
-  label_selector?: string;
+  labelSelector?: string;
   cursor?: string;
   limit?: number;
-  order_by?: string;
+  orderBy?: string;
 }
 
 /**

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -54,13 +54,13 @@ export interface Connection {
     namespace: string;
     connector: Connector;
     state: ConnectionState;
-    health_state: ConnectionHealthState;
-    setup_step_id?: string;
-    setup_error?: string;
+    healthState: ConnectionHealthState;
+    setupStepId?: string;
+    setupError?: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
-    created_at: string;
-    updated_at: string;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export function canBeDisconnected(connection: Connection): boolean {
@@ -72,9 +72,9 @@ export function canBeDisconnected(connection: Connection): boolean {
 
 // Request models
 export interface InitiateConnectionRequest {
-    connector_id: string;
+    connectorId: string;
     name?: string;
-    return_to_url: string;
+    returnToUrl: string;
     labels?: Record<string, string>;
 }
 
@@ -93,16 +93,16 @@ export interface ConnectionSetupResponse {
 
 export interface ConnectionSetupRedirectResponse extends ConnectionSetupResponse {
     type: ConnectionSetupResponseType.REDIRECT;
-    redirect_url: string;
+    redirectUrl: string;
 }
 
 export interface ConnectionSetupFormResponse extends ConnectionSetupResponse {
     type: ConnectionSetupResponseType.FORM;
-    step_id: string;
-    step_title?: string;
-    step_description?: string;
-    json_schema: Record<string, unknown>;
-    ui_schema: Record<string, unknown>;
+    stepId: string;
+    stepTitle?: string;
+    stepDescription?: string;
+    jsonSchema: Record<string, unknown>;
+    uiSchema: Record<string, unknown>;
 }
 
 export interface ConnectionSetupCompleteResponse extends ConnectionSetupResponse {
@@ -116,7 +116,7 @@ export interface ConnectionSetupVerifyingResponse extends ConnectionSetupRespons
 export interface ConnectionSetupErrorResponse extends ConnectionSetupResponse {
     type: ConnectionSetupResponseType.ERROR;
     error: string;
-    can_retry: boolean;
+    canRetry: boolean;
 }
 
 export function isRedirectResponse(response: ConnectionSetupResponse): response is ConnectionSetupRedirectResponse {
@@ -140,17 +140,17 @@ export function isErrorResponse(response: ConnectionSetupResponse): response is 
 }
 
 export interface SubmitConnectionRequest {
-    step_id: string;
+    stepId: string;
     data: unknown;
-    return_to_url?: string;
+    returnToUrl?: string;
 }
 
 export interface RetryConnectionRequest {
-    return_to_url?: string;
+    returnToUrl?: string;
 }
 
 export interface ReauthConnectionRequest {
-    return_to_url?: string;
+    returnToUrl?: string;
 }
 
 export interface DataSourceOption {
@@ -160,24 +160,24 @@ export interface DataSourceOption {
 
 // Disconnect models
 export interface DisconnectConnectionRequest {
-    timeout_seconds?: number;
+    timeoutSeconds?: number;
 }
 
 export interface DisconnectResponseJson {
-    task_id: string;
+    taskId: string;
     connection: Connection;
 }
 
 export interface MigrateConnectionVersionRequest {
-    target_version: number;
-    timeout_seconds?: number;
+    targetVersion: number;
+    timeoutSeconds?: number;
 }
 
 export interface MigrateConnectionVersionResponseJson {
-    task_id: string;
-    connection_id: string;
-    source_version: number;
-    target_version: number;
+    taskId: string;
+    connectionId: string;
+    sourceVersion: number;
+    targetVersion: number;
 }
 
 export interface ForceConnectionStateRequest {
@@ -193,10 +193,10 @@ export interface ListConnectionsParams {
     name?: string;
     state?: ConnectionState;
     namespace?: string;
-    label_selector?: string;
+    labelSelector?: string;
     cursor?: string;
     limit?: number;
-    order_by?: string;
+    orderBy?: string;
 }
 
 /**
@@ -223,9 +223,9 @@ export const initiateConnection = (
     name?: string,
 ) => {
     const request: InitiateConnectionRequest = {
-        connector_id: connectorId,
+        connectorId: connectorId,
         name,
-        return_to_url: returnToUrl,
+        returnToUrl: returnToUrl,
         labels,
     };
 
@@ -245,9 +245,9 @@ export const submitConnection = (
     returnToUrl?: string
 ) => {
     const request: SubmitConnectionRequest = {
-        step_id: stepId,
+        stepId: stepId,
         data,
-        return_to_url: returnToUrl,
+        returnToUrl: returnToUrl,
     };
 
     return client.post<ConnectionSetupResponse>(
@@ -271,7 +271,7 @@ export const disconnectConnection = (id: string, request?: DisconnectConnectionR
  */
 export const migrateConnectionVersion = (id: string, request: MigrateConnectionVersionRequest) => {
     return client.post<MigrateConnectionVersionResponseJson>(
-        `/api/v1/connections/${id}/_migrate_version`,
+        `/api/v1/connections/${id}/_migrateVersion`,
         request
     );
 };
@@ -284,7 +284,7 @@ export const forceConnectionState = (id: string, state: ConnectionState) => {
         state: state,
     };
     return client.put<ForceConnectionStateResponse>(
-        `/api/v1/connections/${id}/_force_state`,
+        `/api/v1/connections/${id}/_forceState`,
         request
     );
 };
@@ -364,8 +364,8 @@ export const abortConnection = (id: string) => {
  */
 export const getSetupStep = (connectionId: string, returnToUrl?: string) => {
     return client.get<ConnectionSetupResponse>(
-        `/api/v1/connections/${connectionId}/_setup_step`,
-        returnToUrl ? {params: {return_to_url: returnToUrl}} : undefined
+        `/api/v1/connections/${connectionId}/_setupStep`,
+        returnToUrl ? {params: {returnToUrl: returnToUrl}} : undefined
     );
 };
 
@@ -373,7 +373,7 @@ export const getSetupStep = (connectionId: string, returnToUrl?: string) => {
  * Get data source options for a connection setup step
  */
 export const getDataSource = (connectionId: string, sourceId: string) => {
-    return client.get<DataSourceOption[]>(`/api/v1/connections/${connectionId}/_data_source/${sourceId}`);
+    return client.get<DataSourceOption[]>(`/api/v1/connections/${connectionId}/_dataSource/${sourceId}`);
 };
 
 /**
@@ -388,17 +388,17 @@ export const reconfigureConnection = (id: string) => {
  * The connection remains ready and its previously stored configuration continues to apply.
  */
 export const cancelSetupConnection = (id: string) => {
-    return client.post<void>(`/api/v1/connections/${id}/_cancel_setup`);
+    return client.post<void>(`/api/v1/connections/${id}/_cancelSetup`);
 };
 
 /**
  * Retry a connection that failed during setup, including auth-phase failures and probe
  * verification failures. For connectors with preconnect steps, returns to preconnect:0 so the
  * user can correct inputs. For connectors without preconnect steps, re-initiates OAuth
- * (return_to_url is required in that case).
+ * (returnToUrl is required in that case).
  */
 export const retryConnection = (id: string, returnToUrl?: string) => {
-    const request: RetryConnectionRequest = { return_to_url: returnToUrl };
+    const request: RetryConnectionRequest = { returnToUrl: returnToUrl };
     return client.post<ConnectionSetupResponse>(
         `/api/v1/connections/${id}/_retry`,
         request
@@ -410,10 +410,10 @@ export const retryConnection = (id: string, returnToUrl?: string) => {
  * recovery action when a connection has flipped to unhealthy. For api-key connectors, returns the
  * credentials form (no prior values pre-filled); on submit the existing credential is rotated
  * atomically. For OAuth2 connectors, restarts at preconnect:0 if defined, otherwise re-initiates
- * the OAuth redirect (return_to_url is required in that case).
+ * the OAuth redirect (returnToUrl is required in that case).
  */
 export const reauthConnection = (id: string, returnToUrl?: string) => {
-    const request: ReauthConnectionRequest = { return_to_url: returnToUrl };
+    const request: ReauthConnectionRequest = { returnToUrl: returnToUrl };
     return client.post<ConnectionSetupResponse>(
         `/api/v1/connections/${id}/_reauth`,
         request
@@ -428,7 +428,7 @@ export const connections = {
     disconnect: disconnectConnection,
     migrateVersion: migrateConnectionVersion,
     abort: abortConnection,
-    force_state: forceConnectionState,
+    forceState: forceConnectionState,
     update: updateConnection,
     getSetupStep: getSetupStep,
     getDataSource: getDataSource,

--- a/sdks/js/src/connectors.ts
+++ b/sdks/js/src/connectors.ts
@@ -11,8 +11,8 @@ export interface ConnectorVersion {
     definition: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
-    created_at: string;
-    updated_at: string;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface Connector {
@@ -21,16 +21,16 @@ export interface Connector {
     version: number;
     namespace: string;
     state: ConnectorVersionState;
-    display_name: string;
+    displayName: string;
     description: string;
     highlight?: string;
-    status_page_url?: string;
+    statusPageUrl?: string;
     logo: string;
-    has_configure: boolean;
+    hasConfigure: boolean;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
-    created_at: string;
-    updated_at: string;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface PutConnectorAnnotationRequest {
@@ -53,19 +53,19 @@ export interface ListConnectorsParams {
     name?: string;
     state?: ConnectorVersionState;
     namespace?: string;
-    label_selector?: string;
+    labelSelector?: string;
     cursor?: string;
     limit?: number;
-    order_by?: string;
+    orderBy?: string;
 }
 
 export interface ListConnectorVersionsParams {
     state?: ConnectorVersionState;
     namespace?: string;
-    label_selector?: string;
+    labelSelector?: string;
     cursor?: string;
     limit?: number;
-    order_by?: string;
+    orderBy?: string;
 }
 
 export interface UpdateConnectorRequest {
@@ -73,12 +73,12 @@ export interface UpdateConnectorRequest {
 }
 
 export interface ConnectorLifecycleRequest {
-    timeout_seconds?: number;
+    timeoutSeconds?: number;
 }
 
 export interface ConnectorLifecycleResponse {
-    task_id: string;
-    connector_id: string;
+    taskId: string;
+    connectorId: string;
 }
 
 /**
@@ -134,7 +134,7 @@ export type ForceConnectorVersionStateResponse = ConnectorVersion;
 export const forceConnectorVersionState = (id: string, version: number, state: ConnectorVersionState) => {
     const request: ForceConnectorVersionStateRequest = { state };
     return client.put<ForceConnectorVersionStateResponse>(
-        `/api/v1/connectors/${id}/versions/${version}/_force_state`,
+        `/api/v1/connectors/${id}/versions/${version}/_forceState`,
         request
     );
 };
@@ -144,7 +144,7 @@ export const forceConnectorVersionState = (id: string, version: number, state: C
  */
 export const disconnectAllConnectorConnections = (id: string, request?: ConnectorLifecycleRequest) => {
     return client.post<ConnectorLifecycleResponse>(
-        `/api/v1/connectors/${id}/_disconnect_all`,
+        `/api/v1/connectors/${id}/_disconnectAll`,
         request
     );
 };
@@ -221,7 +221,7 @@ export const connectors = {
     update: updateConnector,
     listVersions: listConnectorVersions,
     getVersion: getConnectorVersion,
-    force_version_state: forceConnectorVersionState,
+    forceVersionState: forceConnectorVersionState,
     disconnectAll: disconnectAllConnectorConnections,
     archive: archiveConnector,
     getAnnotations: getConnectorAnnotations,

--- a/sdks/js/src/keys.ts
+++ b/sdks/js/src/keys.ts
@@ -13,11 +13,11 @@ export interface Key {
   name: string;
   namespace: string;
   state: KeyState;
-  key_data?: KeyData;
+  keyData?: KeyData;
   labels?: Record<string, string>;
   annotations?: Record<string, string>;
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export type KeyData = Record<string, unknown>;
@@ -25,7 +25,7 @@ export type KeyData = Record<string, unknown>;
 export interface CreateKeyRequest {
     namespace: string;
     name?: string;
-    key_data?: KeyData;
+    keyData?: KeyData;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
 }
@@ -33,7 +33,7 @@ export interface CreateKeyRequest {
 export interface UpdateKeyRequest {
     name?: string;
     state?: KeyState;
-    key_data?: KeyData;
+    keyData?: KeyData;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
 }
@@ -44,8 +44,8 @@ export interface ListKeysParams {
   limit?: number;
   state?: KeyState;
   namespace?: string;
-  label_selector?: string;
-  order_by?: string;
+  labelSelector?: string;
+  orderBy?: string;
 }
 
 export interface KeyLabel {

--- a/sdks/js/src/metrics.ts
+++ b/sdks/js/src/metrics.ts
@@ -34,16 +34,16 @@ export interface MetricsRange {
 }
 
 export interface MetricsQueryRef {
-    ref_id: string;
+    refId: string;
     metric: MetricsMetric;
     aggregation: MetricsAggregation;
-    group_by?: MetricsGroupBy[];
+    groupBy?: MetricsGroupBy[];
 }
 
 export interface MetricsQueryRequest {
     range: MetricsRange;
     namespace?: string;
-    label_selector?: string;
+    labelSelector?: string;
     queries: MetricsQueryRef[];
 }
 
@@ -53,7 +53,7 @@ export interface MetricsPoint {
 }
 
 export interface MetricsSeries {
-    ref_id: string;
+    refId: string;
     metric: string;
     aggregation: string;
     labels?: Record<string, string>;

--- a/sdks/js/src/namespaces.ts
+++ b/sdks/js/src/namespaces.ts
@@ -40,19 +40,19 @@ export interface Namespace {
   path: string;
   name: string;
   state: NamespaceState;
-  key_id?: string;
+  keyId?: string;
   labels?: Record<string, string>;
   annotations?: Record<string, string>;
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface NamespaceKeyResponse {
-  key_id: string;
+  keyId: string;
 }
 
 export interface SetNamespaceKeyRequest {
-  key_id: string;
+  keyId: string;
 }
 
 export interface CreateNamespaceRequest {
@@ -68,11 +68,11 @@ export interface ListNamespaceParams {
   name?: string;
   state?: NamespaceState;
   namespace?: string;
-  label_selector?: string;
+  labelSelector?: string;
   cursor?: string;
   limit?: number;
-  order_by?: string;
-  children_of?: string;
+  orderBy?: string;
+  childrenOf?: string;
 }
 
 /**
@@ -160,7 +160,7 @@ export const getNamespaceKey = (path: string) => {
  * Set the key for a namespace
  */
 export const setNamespaceKey = (path: string, keyId: string) => {
-  const request: SetNamespaceKeyRequest = { key_id: keyId };
+  const request: SetNamespaceKeyRequest = { keyId: keyId };
   return client.put<Namespace>(`/api/v1/namespaces/${path}/key`, request);
 };
 

--- a/sdks/js/src/notifications.ts
+++ b/sdks/js/src/notifications.ts
@@ -17,26 +17,26 @@ export interface Notification {
     key: string;
     level: NotificationLevel;
     state: NotificationState;
-    resource_type: string;
-    resource_id: string;
+    resourceType: string;
+    resourceId: string;
     namespace: string;
     title: string;
     message: string;
-    action_url?: string;
-    can_action: boolean;
+    actionUrl?: string;
+    canAction: boolean;
     viewed: boolean;
     metadata?: Record<string, unknown>;
-    created_at: string;
-    updated_at: string;
-    resolved_at?: string;
+    createdAt: string;
+    updatedAt: string;
+    resolvedAt?: string;
 }
 
 export interface ListNotificationsParams {
     limit?: number;
-    include_viewed?: boolean;
+    includeViewed?: boolean;
     state?: NotificationState;
     namespace?: string;
-    label_selector?: string;
+    labelSelector?: string;
 }
 
 export interface MarkNotificationsViewedRequest {

--- a/sdks/js/src/proxy.ts
+++ b/sdks/js/src/proxy.ts
@@ -18,18 +18,18 @@ export interface ProxyRequest {
     labels?: Record<string, string>;
     /**
      * Raw body bytes, base64-encoded for transport. Exactly one of
-     * body_raw / body_json may be set; for GET/HEAD/etc., neither.
+     * bodyRaw / bodyJson may be set; for GET/HEAD/etc., neither.
      */
-    body_raw?: string;
-    /** JSON body. Alternative to body_raw. */
-    body_json?: unknown;
+    bodyRaw?: string;
+    /** JSON body. Alternative to bodyRaw. */
+    bodyJson?: unknown;
 }
 
 export interface ProxyResponse {
-    status_code: number;
+    statusCode: number;
     headers: Record<string, string>;
-    body_raw?: string;
-    body_json?: unknown;
+    bodyRaw?: string;
+    bodyJson?: unknown;
 }
 
 // Valid HTTP methods accepted by the proxy. Mirrors the server's

--- a/sdks/js/src/rateLimits.ts
+++ b/sdks/js/src/rateLimits.ts
@@ -28,14 +28,14 @@ export interface RateLimitPathMatch {
 }
 
 export interface RateLimitSelector {
-    label_selector?: string;
+    labelSelector?: string;
     methods?: string[];
-    path_match?: RateLimitPathMatch;
+    pathMatch?: RateLimitPathMatch;
     /**
      * When omitted, defaults to ['proxy', 'probe']. An explicit empty list is
      * rejected at validation.
      */
-    request_types?: string[];
+    requestTypes?: string[];
 }
 
 export interface RateLimitBucket {
@@ -62,7 +62,7 @@ export interface RateLimitSlidingWindow {
 export interface RateLimitTokenBucket {
     capacity: number;
     /** Tokens per second; may be fractional (e.g. 0.5). */
-    refill_rate: number;
+    refillRate: number;
 }
 
 /**
@@ -70,9 +70,9 @@ export interface RateLimitTokenBucket {
  * Terraform provider) validate this at write time.
  */
 export interface RateLimitAlgorithm {
-    fixed_window?: RateLimitFixedWindow;
-    sliding_window?: RateLimitSlidingWindow;
-    token_bucket?: RateLimitTokenBucket;
+    fixedWindow?: RateLimitFixedWindow;
+    slidingWindow?: RateLimitSlidingWindow;
+    tokenBucket?: RateLimitTokenBucket;
 }
 
 export interface RateLimitDefinition {
@@ -89,8 +89,8 @@ export interface RateLimit {
     definition: RateLimitDefinition;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
-    created_at: string;
-    updated_at: string;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface CreateRateLimitRequest {
@@ -113,8 +113,8 @@ export interface ListRateLimitsParams {
     cursor?: string;
     limit?: number;
     namespace?: string;
-    label_selector?: string;
-    order_by?: string;
+    labelSelector?: string;
+    orderBy?: string;
 }
 
 /**
@@ -162,42 +162,42 @@ export const deleteRateLimit = (id: string) => {
  */
 export interface DryRunRateLimitRequest {
     request: ProxyRequest;
-    request_type: string;
+    requestType: string;
     context: {
-        connection_id?: string;
-        actor_id?: string;
+        connectionId?: string;
+        actorId?: string;
         namespace?: string;
     };
 }
 
 export interface DryRunRateLimitMatch {
-    rate_limit_id: string;
+    rateLimitId: string;
     namespace: string;
-    effective_mode: string;
-    bucket_key: string;
-    algorithm_summary: string;
-    would_allow: boolean;
+    effectiveMode: string;
+    bucketKey: string;
+    algorithmSummary: string;
+    wouldAllow: boolean;
     remaining: number;
-    retry_after_ms: number;
+    retryAfterMs: number;
     /**
      * True when the runtime fail-opened on a Redis error during Peek.
      * The UI should surface this as "couldn't read counter; runtime
      * would fail-open" so operators know the would_allow isn't
      * trustworthy.
      */
-    peek_failed: boolean;
+    peekFailed: boolean;
 }
 
 export interface DryRunRateLimitNotMatched {
-    rate_limit_id: string;
+    rateLimitId: string;
     namespace: string;
     reason: string;
 }
 
 export interface DryRunRateLimitResponse {
-    request_label_snapshot: Record<string, string>;
+    requestLabelSnapshot: Record<string, string>;
     matched: DryRunRateLimitMatch[];
-    not_matched: DryRunRateLimitNotMatched[];
+    notMatched: DryRunRateLimitNotMatched[];
 }
 
 /**
@@ -208,7 +208,7 @@ export interface DryRunRateLimitResponse {
  * traffic.
  */
 export const dryRunRateLimit = (req: DryRunRateLimitRequest) => {
-    return client.post<DryRunRateLimitResponse>('/api/v1/rate-limits/_dry_run', req);
+    return client.post<DryRunRateLimitResponse>('/api/v1/rate-limits/_dryRun', req);
 };
 
 // --- Label & annotation sub-resources, identical shape to keys. ---

--- a/sdks/js/src/requestEvents.ts
+++ b/sdks/js/src/requestEvents.ts
@@ -23,7 +23,7 @@ export enum ResponseSource {
 }
 
 // A single rate-limit rule that matched a request. The full set of
-// matches is stored on RequestEventRecord.rate_limit_matched so observers
+// matches is stored on RequestEventRecord.rateLimitMatched so observers
 // can see every rule that contributed to the decision, not just the one
 // that ultimately rejected the request.
 export interface RateLimitMatch {
@@ -37,28 +37,28 @@ export interface RateLimitMatch {
 export interface RequestEventRecord {
     namespace: string; // The namespace of the request
     type: RequestType; // The type of request (global, proxy, oauth, public)
-    request_id: string; // The ID of the request (randomly generated UUID)
-    correlation_id: string; // Correlation ID for the request as supplied by the proxy caller
+    requestId: string; // The ID of the request (randomly generated UUID)
+    correlationId: string; // Correlation ID for the request as supplied by the proxy caller
     timestamp: string; // Timestamp of the request
     duration: number; // Duration of the request in milliseconds
-    connection_id: string; // The ID of the connection that handled the request, if applicable
-    connector_id: string; // The ID of the connector that handled the request, if applicable
-    connector_version: number; // The version of the connector that handled the request, if applicable
+    connectionId: string; // The ID of the connection that handled the request, if applicable
+    connectorId: string; // The ID of the connector that handled the request, if applicable
+    connectorVersion: number; // The version of the connector that handled the request, if applicable
     method: string; // The HTTP method of the request
     host: string; // The host of the request
     scheme: string; // The scheme of the request (http, https)
     path: string; // The path of the request
-    request_http_version?: string; // The HTTP version of the request
-    request_size_bytes?: number; // The size of the request in bytes
-    request_mime_type?: string; // The MIME type of the request
-    response_status_code?: number; // The HTTP status code of the response
-    response_error?: string; // The error message if the response was an error (could not make HTTP call)
-    response_http_version?: string; // The HTTP version of the response
-    response_size_bytes?: number; // The size of the response in bytes
-    response_mime_type?: string; // The MIME type of the response
-    internal_timeout?: boolean; // If there was an internal timeout while capture full response size/body
-    request_cancelled?: boolean; // If the caller cancelled the request before the full body was consumed
-    full_request_recorded?: boolean; // If the full request body was recorded; This means you may be able to get the full request
+    requestHttpVersion?: string; // The HTTP version of the request
+    requestSizeBytes?: number; // The size of the request in bytes
+    requestMimeType?: string; // The MIME type of the request
+    responseStatusCode?: number; // The HTTP status code of the response
+    responseError?: string; // The error message if the response was an error (could not make HTTP call)
+    responseHttpVersion?: string; // The HTTP version of the response
+    responseSizeBytes?: number; // The size of the response in bytes
+    responseMimeType?: string; // The MIME type of the response
+    internalTimeout?: boolean; // If there was an internal timeout while capture full response size/body
+    requestCancelled?: boolean; // If the caller cancelled the request before the full body was consumed
+    fullRequestRecorded?: boolean; // If the full request body was recorded; This means you may be able to get the full request
     labels?: Record<string, string>; // Labels associated with the request (merged from connection and per-request labels)
 
     // Rate-limit attribution. Defaults to ResponseSource.UPSTREAM for any
@@ -66,11 +66,11 @@ export interface RequestEventRecord {
     // rate_limit_* fields are populated when a proxy-side RateLimit
     // resource matched the request — they remain empty for upstream and
     // connector_rate_limiter responses.
-    response_source?: ResponseSource;
-    rate_limit_id?: string; // ID of the RateLimit resource that fired (when response_source = rate_limit)
-    rate_limit_mode?: string; // 'enforce' or 'observe' (when response_source = rate_limit)
-    rate_limit_bucket?: Record<string, string>; // Resolved bucket dimensions for the firing rule
-    rate_limit_matched?: RateLimitMatch[]; // Full set of rate-limit rules that matched this request
+    responseSource?: ResponseSource;
+    rateLimitId?: string; // ID of the RateLimit resource that fired (when response_source = rate_limit)
+    rateLimitMode?: string; // 'enforce' or 'observe' (when response_source = rate_limit)
+    rateLimitBucket?: Record<string, string>; // Resolved bucket dimensions for the firing rule
+    rateLimitMatched?: RateLimitMatch[]; // Full set of rate-limit rules that matched this request
 }
 
 // RequestEvent is the full data for a single request event. It contains header and body data.
@@ -107,28 +107,28 @@ export interface RequestEvent {
 export interface ListRequestEventsParams {
     cursor?: string;
     limit?: number;
-    order_by?: string;
+    orderBy?: string;
 
     /*
      * Filters
      */
 
     namespace?: string;
-    request_type?: RequestType;
-    label_selector?: string;
-    correlation_id?: string;
-    connection_id?: string;
-    connector_type?: string;
-    connector_id?: string;
-    connector_version?: number;
+    requestType?: RequestType;
+    labelSelector?: string;
+    correlationId?: string;
+    connectionId?: string;
+    connectorType?: string;
+    connectorId?: string;
+    connectorVersion?: number;
     method?: string;
-    status_code?: number;
-    status_code_range?: string; // Changed to string to match Go's format (e.g., "200-299")
-    timestamp_range?: string;
+    statusCode?: number;
+    statusCodeRange?: string; // Changed to string to match Go's format (e.g., "200-299")
+    timestampRange?: string;
     path?: string;
-    path_regex?: string; // Changed to string to match Go's format
-    response_source?: ResponseSource; // Filter by who produced the response
-    rate_limit_id?: string; // Filter for entries that fired a specific RateLimit resource
+    pathRegex?: string; // Changed to string to match Go's format
+    responseSource?: ResponseSource; // Filter by who produced the response
+    rateLimitId?: string; // Filter for entries that fired a specific RateLimit resource
 }
 
 /**

--- a/sdks/js/src/resourceNames.test.ts
+++ b/sdks/js/src/resourceNames.test.ts
@@ -23,7 +23,7 @@ describe('resource name contracts', () => {
     });
 
     it('sends optional names on create requests', () => {
-        createActor({namespace: 'root', external_id: 'customer-1', name: 'customer'});
+        createActor({namespace: 'root', externalId: 'customer-1', name: 'customer'});
         initiateConnection('cxr_test', '/return', {env: 'prod'}, 'production-crm');
         createKey({namespace: 'root', name: 'primary-key'});
         createRateLimit({
@@ -33,7 +33,7 @@ describe('resource name contracts', () => {
                 mode: RateLimitMode.ENFORCE,
                 selector: {},
                 bucket: {},
-                algorithm: {fixed_window: {window: '1m', limit: 10}},
+                algorithm: {fixedWindow: {window: '1m', limit: 10}},
             },
         });
 

--- a/sdks/js/src/search.test.ts
+++ b/sdks/js/src/search.test.ts
@@ -15,7 +15,7 @@ describe('searchResources', () => {
         const controller = new AbortController();
         searchResources({
             mode: 'query',
-            resource_type: ['connection', 'namespace'],
+            resourceType: ['connection', 'namespace'],
             q: 'payments',
         }, {signal: controller.signal});
 
@@ -23,7 +23,7 @@ describe('searchResources', () => {
             signal: controller.signal,
             params: {
                 mode: 'query',
-                resource_type: ['connection', 'namespace'],
+                resourceType: ['connection', 'namespace'],
                 q: 'payments',
             },
             paramsSerializer: {indexes: null},
@@ -31,8 +31,8 @@ describe('searchResources', () => {
     });
 
     it('preserves a caller-provided params serializer', () => {
-        const paramsSerializer = vi.fn(() => 'resource_type=connection');
-        searchResources({resource_type: ['connection']}, {paramsSerializer});
+        const paramsSerializer = vi.fn(() => 'resourceType=connection');
+        searchResources({resourceType: ['connection']}, {paramsSerializer});
 
         expect(getMock).toHaveBeenCalledWith('/api/v1/search/resources', expect.objectContaining({
             paramsSerializer,

--- a/sdks/js/src/search.ts
+++ b/sdks/js/src/search.ts
@@ -17,26 +17,26 @@ export interface SearchLabelMatch {
 }
 
 export interface SearchResourceSummary {
-    resource_type: SearchResourceType;
-    resource_id: string;
+    resourceType: SearchResourceType;
+    resourceId: string;
     name: string;
     namespace: string;
     labels: Record<string, string>;
-    matched_labels: SearchLabelMatch[];
-    updated_at: string;
+    matchedLabels: SearchLabelMatch[];
+    updatedAt: string;
 }
 
 export interface SearchResourcesResponse {
     items: SearchResourceSummary[];
-    truncated_types: SearchResourceType[];
-    incomplete_types: SearchResourceType[];
+    truncatedTypes: SearchResourceType[];
+    incompleteTypes: SearchResourceType[];
 }
 
 export interface SearchResourcesParams {
     mode?: SearchMode;
-    resource_type?: SearchResourceType[];
+    resourceType?: SearchResourceType[];
     q?: string;
-    label_selector?: string;
+    labelSelector?: string;
     namespace?: string;
     limit?: number;
 }

--- a/sdks/js/src/session.ts
+++ b/sdks/js/src/session.ts
@@ -1,16 +1,16 @@
 import { client } from './client';
 
 type ApiSessionInitiateRequest = {
-  auth_token?: string;
-  return_to_url: string;
+  authToken?: string;
+  returnToUrl: string;
 };
 
 type ApiSessionInitiateSuccessResponse = {
-  actor_id: string;
+  actorId: string;
 };
 
 type ApiSessionInitiateFailureResponse = {
-  redirect_url: string;
+  redirectUrl: string;
 };
 
 type ApiSessionInitiateResponse =
@@ -20,7 +20,7 @@ type ApiSessionInitiateResponse =
 function isInitiateSessionSuccessResponse(
   response: ApiSessionInitiateResponse
 ): response is ApiSessionInitiateSuccessResponse {
-  return 'actor_id' in response;
+  return 'actorId' in response;
 }
 
 
@@ -28,13 +28,13 @@ type ApiSessionTerminateResponse = Record<string, never>;
 
 const initiate = (params: ApiSessionInitiateRequest) => {
   const headers: { Authorization?: string } = {};
-  if (params.auth_token) {
-    headers.Authorization = `Bearer ${params.auth_token}`;
+  if (params.authToken) {
+    headers.Authorization = `Bearer ${params.authToken}`;
   }
   return client.post<ApiSessionInitiateResponse>(
     '/api/v1/session/_initiate',
     {
-      return_to_url: params.return_to_url,
+      returnToUrl: params.returnToUrl,
     },
     {
       headers: headers,

--- a/sdks/js/src/taskMonitoring.ts
+++ b/sdks/js/src/taskMonitoring.ts
@@ -4,8 +4,8 @@ import { ListResponse } from './common';
 // Queue info
 export interface QueueInfo {
   queue: string;
-  memory_usage: number;
-  latency_seconds: number;
+  memoryUsage: number;
+  latencySeconds: number;
   size: number;
   groups: number;
   pending: number;
@@ -17,8 +17,8 @@ export interface QueueInfo {
   aggregating: number;
   processed: number;
   failed: number;
-  processed_total: number;
-  failed_total: number;
+  processedTotal: number;
+  failedTotal: number;
   paused: boolean;
   timestamp: string;
 }
@@ -30,13 +30,13 @@ export interface MonitoringTaskInfo {
   type: string;
   payload: string;
   state: string;
-  max_retry: number;
+  maxRetry: number;
   retried: number;
-  last_err?: string;
-  last_failed_at?: string;
-  next_process_at?: string;
-  completed_at?: string;
-  is_orphaned?: boolean;
+  lastErr?: string;
+  lastFailedAt?: string;
+  nextProcessAt?: string;
+  completedAt?: string;
+  isOrphaned?: boolean;
   group?: string;
 }
 
@@ -50,8 +50,8 @@ export interface DailyStats {
 
 // Worker info
 export interface WorkerInfo {
-  task_id: string;
-  task_type: string;
+  taskId: string;
+  taskType: string;
   queue: string;
   started: string;
   deadline: string;
@@ -64,24 +64,24 @@ export interface ServerInfo {
   pid: number;
   concurrency: number;
   queues: Record<string, number>;
-  strict_priority: boolean;
+  strictPriority: boolean;
   started: string;
   status: string;
-  active_workers: WorkerInfo[];
+  activeWorkers: WorkerInfo[];
 }
 
 // Scheduler entry
 export interface SchedulerEntry {
   id: string;
   spec: string;
-  task_type: string;
+  taskType: string;
   next: string;
   prev?: string;
 }
 
 // Bulk action response
 export interface BulkActionResponse {
-  affected_count: number;
+  affectedCount: number;
 }
 
 // Query params
@@ -216,7 +216,7 @@ export const unpauseQueue = (queue: string) => {
  */
 export const runAllArchivedTasks = (queue: string) => {
   return client.post<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/archived/_run-all`
+    `/api/v1/task-monitoring/queues/${queue}/archived/_runAll`
   );
 };
 
@@ -225,7 +225,7 @@ export const runAllArchivedTasks = (queue: string) => {
  */
 export const runAllRetryTasks = (queue: string) => {
   return client.post<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/retry/_run-all`
+    `/api/v1/task-monitoring/queues/${queue}/retry/_runAll`
   );
 };
 

--- a/sdks/js/src/tasks.ts
+++ b/sdks/js/src/tasks.ts
@@ -16,7 +16,7 @@ export interface TaskInfoJson {
   id: string;
   type: string;
   state: TaskState;
-  updated_at?: string;
+  updatedAt?: string;
 }
 
 /**

--- a/sdks/js/src/workflowMonitoring.ts
+++ b/sdks/js/src/workflowMonitoring.ts
@@ -2,8 +2,8 @@ import { AxiosRequestConfig } from 'axios';
 import { client } from './client';
 
 export interface WorkflowInstance {
-  instance_id: string;
-  execution_id: string;
+  instanceId: string;
+  executionId: string;
   parent?: WorkflowInstance;
 }
 
@@ -11,20 +11,20 @@ export type WorkflowInstanceState = 'active' | 'continued_as_new' | 'finished' |
 
 export interface WorkflowInstanceRef {
   instance?: WorkflowInstance;
-  created_at?: string;
-  completed_at?: string;
+  createdAt?: string;
+  completedAt?: string;
   state: WorkflowInstanceState;
   queue: string;
 }
 
 export interface WorkflowHistoryEvent {
   id?: string;
-  sequence_id?: number;
+  sequenceId?: number;
   type?: string;
   timestamp?: string;
-  schedule_event_id?: number;
+  scheduleEventId?: number;
   attributes?: unknown;
-  visible_at?: string;
+  visibleAt?: string;
 }
 
 export interface WorkflowInstanceInfo extends WorkflowInstanceRef {
@@ -32,7 +32,7 @@ export interface WorkflowInstanceInfo extends WorkflowInstanceRef {
 }
 
 export interface WorkflowInstanceTree extends WorkflowInstanceRef {
-  workflow_name?: string;
+  workflowName?: string;
   error?: boolean;
   children?: WorkflowInstanceTree[];
 }

--- a/terraform/provider/internal/client/actors.go
+++ b/terraform/provider/internal/client/actors.go
@@ -9,15 +9,15 @@ import (
 type Actor struct {
 	Id          string            `json:"id"`
 	Namespace   string            `json:"namespace"`
-	ExternalId  string            `json:"external_id"`
+	ExternalId  string            `json:"externalId"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
 }
 
 type CreateActorRequest struct {
-	ExternalId  string            `json:"external_id"`
+	ExternalId  string            `json:"externalId"`
 	Namespace   string            `json:"namespace"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/terraform/provider/internal/client/auth.go
+++ b/terraform/provider/internal/client/auth.go
@@ -36,8 +36,8 @@ func signJWT(privateKeyPath, username string) (string, error) {
 		"iat":           now.Unix(),
 		"exp":           now.Add(1 * time.Hour).Unix(),
 		"namespace":     "root",
-		"actor_signed":  true,
-		"system_signed": false,
+		"actorSigned":  true,
+		"systemSigned": false,
 	}
 
 	token := jwt.NewWithClaims(method, claims)

--- a/terraform/provider/internal/client/connectors.go
+++ b/terraform/provider/internal/client/connectors.go
@@ -12,14 +12,14 @@ type Connector struct {
 	Version     uint64            `json:"version"`
 	Namespace   string            `json:"namespace"`
 	State       string            `json:"state"`
-	DisplayName string            `json:"display_name"`
+	DisplayName string            `json:"displayName"`
 	Highlight   string            `json:"highlight,omitempty"`
 	Description string            `json:"description"`
 	Logo        string            `json:"logo"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
 	Versions    int64             `json:"versions,omitempty"`
 }
 
@@ -31,8 +31,8 @@ type ConnectorVersion struct {
 	Definition  json.RawMessage   `json:"definition"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
 }
 
 type CreateConnectorRequest struct {
@@ -100,7 +100,7 @@ func (c *Client) CreateConnectorVersion(ctx context.Context, id string, req Crea
 }
 
 func (c *Client) ForceConnectorVersionState(ctx context.Context, id string, version uint64, state string) error {
-	return c.put(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions/%d/_force_state", id, version), ForceStateRequest{State: state}, nil)
+	return c.put(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions/%d/_forceState", id, version), ForceStateRequest{State: state}, nil)
 }
 
 func (c *Client) ListConnectorVersions(ctx context.Context, id string) (*ListConnectorVersionsResponse, error) {

--- a/terraform/provider/internal/client/keys.go
+++ b/terraform/provider/internal/client/keys.go
@@ -12,15 +12,15 @@ type Key struct {
 	State       string            `json:"state"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
 }
 
 type CreateKeyRequest struct {
 	Namespace   string                 `json:"namespace"`
 	Labels      map[string]string      `json:"labels,omitempty"`
 	Annotations map[string]string      `json:"annotations,omitempty"`
-	KeyData     map[string]interface{} `json:"key_data"`
+	KeyData     map[string]interface{} `json:"keyData"`
 }
 
 type UpdateKeyRequest struct {

--- a/terraform/provider/internal/client/namespaces.go
+++ b/terraform/provider/internal/client/namespaces.go
@@ -9,11 +9,11 @@ import (
 type Namespace struct {
 	Path        string            `json:"path"`
 	State       string            `json:"state"`
-	KeyId       *string           `json:"key_id,omitempty"`
+	KeyId       *string           `json:"keyId,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
 }
 
 type CreateNamespaceRequest struct {

--- a/terraform/provider/internal/client/rate_limits.go
+++ b/terraform/provider/internal/client/rate_limits.go
@@ -17,10 +17,10 @@ type RateLimitPathMatch struct {
 }
 
 type RateLimitSelector struct {
-	LabelSelector string              `json:"label_selector,omitempty"`
+	LabelSelector string              `json:"labelSelector,omitempty"`
 	Methods       []string            `json:"methods,omitempty"`
-	PathMatch     *RateLimitPathMatch `json:"path_match,omitempty"`
-	RequestTypes  []string            `json:"request_types,omitempty"`
+	PathMatch     *RateLimitPathMatch `json:"pathMatch,omitempty"`
+	RequestTypes  []string            `json:"requestTypes,omitempty"`
 }
 
 type RateLimitBucket struct {
@@ -40,7 +40,7 @@ type RateLimitSlidingWindow struct {
 
 type RateLimitTokenBucket struct {
 	Capacity   int     `json:"capacity"`
-	RefillRate float64 `json:"refill_rate"`
+	RefillRate float64 `json:"refillRate"`
 }
 
 // RateLimitAlgorithm is a tagged union: exactly one variant is set per
@@ -48,9 +48,9 @@ type RateLimitTokenBucket struct {
 // provider-side ConfigValidator on the resource enforces it at plan time
 // so authors see the error before \`terraform apply\`.
 type RateLimitAlgorithm struct {
-	FixedWindow   *RateLimitFixedWindow   `json:"fixed_window,omitempty"`
-	SlidingWindow *RateLimitSlidingWindow `json:"sliding_window,omitempty"`
-	TokenBucket   *RateLimitTokenBucket   `json:"token_bucket,omitempty"`
+	FixedWindow   *RateLimitFixedWindow   `json:"fixedWindow,omitempty"`
+	SlidingWindow *RateLimitSlidingWindow `json:"slidingWindow,omitempty"`
+	TokenBucket   *RateLimitTokenBucket   `json:"tokenBucket,omitempty"`
 }
 
 // RateLimitDefinition is the JSON-serialised "definition" payload of a
@@ -69,8 +69,8 @@ type RateLimit struct {
 	Definition  RateLimitDefinition `json:"definition"`
 	Labels      map[string]string   `json:"labels,omitempty"`
 	Annotations map[string]string   `json:"annotations,omitempty"`
-	CreatedAt   time.Time           `json:"created_at"`
-	UpdatedAt   time.Time           `json:"updated_at"`
+	CreatedAt   time.Time           `json:"createdAt"`
+	UpdatedAt   time.Time           `json:"updatedAt"`
 }
 
 type CreateRateLimitRequest struct {

--- a/terraform/provider/internal/resources/connector.go
+++ b/terraform/provider/internal/resources/connector.go
@@ -324,7 +324,7 @@ func (r *ConnectorResource) ImportState(ctx context.Context, req resource.Import
 // before storing the definition in state to avoid "inconsistent result" errors.
 var connectorMetadataFields = []string{
 	"id", "version", "namespace", "state", "logo",
-	"labels", "annotations", "created_at", "updated_at",
+	"labels", "annotations", "createdAt", "updatedAt",
 }
 
 func setConnectorState(model *ConnectorResourceModel, cv *client.ConnectorVersion) {
@@ -357,7 +357,7 @@ func setConnectorState(model *ConnectorResourceModel, cv *client.ConnectorVersio
 
 	// Extract display_name from definition
 	var def struct {
-		DisplayName string `json:"display_name"`
+		DisplayName string `json:"displayName"`
 	}
 	if cv.Definition != nil {
 		if err := json.Unmarshal(cv.Definition, &def); err == nil {

--- a/terraform/provider/internal/resources/key.go
+++ b/terraform/provider/internal/resources/key.go
@@ -105,7 +105,7 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		Namespace:   plan.Namespace.ValueString(),
 		Labels:      labels,
 		Annotations: annotations,
-		KeyData:     map[string]interface{}{"num_bytes": 32},
+		KeyData:     map[string]interface{}{"numBytes": 32},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create key", err.Error())


### PR DESCRIPTION
## Summary
- update the JavaScript SDK, CLI API calls, Terraform provider, Grafana datasource, demos, and load-test clients for lowerCamelCase wire contracts
- update endpoint action suffixes, query serialization, and typed field access

## Verification
- go test ./cmd/cli ./cmd/loadtest ./demos/seed/backend ./demos/shell/backend ./internal/loadtest/seeder
- cd terraform/provider && go test ./...
- cd plugins/grafana/authproxy-datasource && npm run validate
- yarn workspace @authproxy/api typecheck && yarn workspace @authproxy/api test
- bash -n loadtest/scripts/background loadtest/scripts/lib/loadtest.sh loadtest/scripts/run loadtest/scripts/seed loadtest/scripts/up
- helm template authproxy-loadtest deploy/charts/authproxy -f loadtest/helm-values/common.yaml --set services.api.enabled=true