### PR TITLE
Document camelCase contract cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The final arg is the service to run: `admin-api`, `api`, `public`, `worker`, or 
 # JWT-signing reverse proxy to the AuthProxy server itself (dev tool).
 go run ./cmd/cli signing-proxy --enableLoginRedirect=true --proxyTo=api
 
-# Connection-scoped streaming reverse proxy through /_proxy_raw.
+# Connection-scoped streaming reverse proxy through /_proxyRaw.
 go run ./cmd/cli proxy --connection cxn_xxx --upstream-base https://api.openai.com
 
 # One-shot through curl or wget. Everything after `curl`/`wget` is

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sequenceDiagram
 
     User->>Host: Sign in and open integrations
     Host->>Host: Sign short-lived nonce JWT
-    Host-->>UI: Redirect with auth_token
+    Host-->>UI: Redirect with authToken
     UI->>AP: Exchange token for session
     AP-->>UI: Session established
 ```

--- a/docs/src/content/docs/concepts/core-model.md
+++ b/docs/src/content/docs/concepts/core-model.md
@@ -102,7 +102,7 @@ Connection lifecycle states are `setup`, `configured`, `disabled`,
 
 When a caller uses `POST /api/v1/connections/{id}/_proxy`, AuthProxy checks
 `connections:proxy` permission against the connection's namespace before it
-loads credentials. The raw streaming route, `/_proxy_raw`, uses the same
+loads credentials. The raw streaming route, `/_proxyRaw`, uses the same
 permission.
 
 ## OAuth connection flow
@@ -174,10 +174,10 @@ An **actor** represents a caller: an end user, application service, operator, or
 automation. Its host-facing identity is the pair:
 
 ```text
-(actor namespace, external_id)
+(actor namespace, externalId)
 ```
 
-`external_id` should be the host application's immutable user or service id,
+`externalId` should be the host application's immutable user or service id,
 not an email address. The same external id may exist in different actor
 namespaces.
 

--- a/docs/src/content/docs/concepts/labels-and-annotations.md
+++ b/docs/src/content/docs/concepts/labels-and-annotations.md
@@ -25,13 +25,13 @@ Content-Type: application/json
 List all connections in production for that tenant:
 
 ```http
-GET /api/v1/connections?label_selector=app.example.com/tenant-id=tenant-42,app.example.com/env=production
+GET /api/v1/connections?labelSelector=app.example.com/tenant-id=tenant-42,app.example.com/env=production
 ```
 
 Find every request log entry produced by that tenant:
 
 ```http
-GET /api/v1/metrics/request-events?label_selector=app.example.com/tenant-id=tenant-42
+GET /api/v1/metrics/request-events?labelSelector=app.example.com/tenant-id=tenant-42
 ```
 
 You did not have to write a separate "AuthProxy connection id → my tenant id" mapping table. The label travelled with the connection onto every request log entry automatically (see [Carry-forward](#carry-forward--how-labels-flow-through-the-hierarchy)).
@@ -180,7 +180,7 @@ the daily consistency checker.
 
 ## Per-request label snapshot
 
-When an application sends a request through the proxy, AuthProxy assembles a **label snapshot** for that request. This is what gets recorded on the request log entry and what label selectors evaluate against (e.g., the `label_selector` clause on a [rate limit](/operations/rate-limits/)).
+When an application sends a request through the proxy, AuthProxy assembles a **label snapshot** for that request. This is what gets recorded on the request log entry and what label selectors evaluate against (e.g., the `labelSelector` clause on a [rate limit](/operations/rate-limits/)).
 
 The snapshot is the union of:
 
@@ -196,7 +196,7 @@ may briefly remain at its pre-rename value while reconciliation runs.
 
 ## Label selectors
 
-Anywhere the API takes a `label_selector` query parameter, the syntax is Kubernetes-style:
+Anywhere the API takes a `labelSelector` query parameter, the syntax is Kubernetes-style:
 
 | Form | Matches |
 |---|---|

--- a/docs/src/content/docs/development/cli.md
+++ b/docs/src/content/docs/development/cli.md
@@ -23,32 +23,32 @@ The rest of this doc uses `ap <command>` for brevity.
 # Default actor signed onto outbound requests. If omitted, --actorId on
 # the command line is required (or `--admin` falls back to the current
 # OS username).
-admin_username: bobdole
+adminUsername: bobdole
 
 # Asymmetric signing key (RS256). Use this for the standard dev setup —
-# the public key lives in the server's system_auth.jwt_signing_key block.
-admin_private_key_path: /path/to/private/key
+# the public key lives in the server's systemAuth.jwtSigningKey block.
+adminPrivateKeyPath: /path/to/private/key
 
 # Optional alternative: HMAC shared secret (HS256). Mutually exclusive
-# with admin_private_key_path on a given invocation.
-# admin_shared_key_path: /path/to/shared.secret
+# with adminPrivateKeyPath on a given invocation.
+# adminSharedKeyPath: /path/to/shared.secret
 
 # Base URLs for each AuthProxy service. Only the services you call need
 # to be set — `api` is the most common for everyday CLI use.
 server:
   api: http://localhost:8081
-  admin_api: http://localhost:8082
+  adminApi: http://localhost:8082
   auth: http://localhost:8080
   marketplace: http://localhost:5173
-  admin_ui: http://localhost:5174
+  adminUi: http://localhost:5174
 
 # Defaults for `ap signing-proxy`. Useful when several AuthProxy clones
 # share one machine — each clone's signing-proxy needs its own port. The
-# `env_var` form lets one shared ~/.authproxy.yaml pick up the per-clone
+# `envVar` form lets one shared ~/.authproxy.yaml pick up the per-clone
 # value from the clone's .env (AUTHPROXY_SIGNING_PROXY_PORT).
-signing_proxy:
+signingProxy:
   port:
-    env_var: AUTHPROXY_SIGNING_PROXY_PORT
+    envVar: AUTHPROXY_SIGNING_PROXY_PORT
     default: "8888"
 ```
 
@@ -60,18 +60,18 @@ AuthProxy supports two JWT signing modes:
 
 | Mode | YAML field / flag | Server-side counterpart |
 |---|---|---|
-| RS256 (asymmetric) | `admin_private_key_path` / `--privateKeyPath` | `system_auth.jwt_signing_key.public_key.path` |
-| HS256 (shared secret) | `admin_shared_key_path` / `--secretKeyPath` | `system_auth.jwt_signing_key.private_key.path` (used as the shared secret) |
+| RS256 (asymmetric) | `adminPrivateKeyPath` / `--privateKeyPath` | `systemAuth.jwtSigningKey.publicKey.path` |
+| HS256 (shared secret) | `adminSharedKeyPath` / `--secretKeyPath` | `systemAuth.jwtSigningKey.privateKey.path` (used as the shared secret) |
 
-The dev stack ships a ready-to-use RSA keypair under [`dev_config/keys/admin/`](https://github.com/rmorlok/authproxy/tree/main/dev_config/keys/admin/) (`bobdole` + `bobdole.pub`) paired with the matching public key registered in `dev_config/default.yaml`. Point `admin_private_key_path` at `dev_config/keys/admin/bobdole` and you're signed in as `bobdole` against a fresh `docker compose up -d` server.
+The dev stack ships a ready-to-use RSA keypair under [`dev_config/keys/admin/`](https://github.com/rmorlok/authproxy/tree/main/dev_config/keys/admin/) (`bobdole` + `bobdole.pub`) paired with the matching public key registered in `dev_config/default.yaml`. Point `adminPrivateKeyPath` at `dev_config/keys/admin/bobdole` and you're signed in as `bobdole` against a fresh `docker compose up -d` server.
 
 ### Actor and scope
 
 Every signed token has an **actor** (who is making the call) and a **service-id allowlist** (which AuthProxy services the token is valid against).
 
-- Actor defaults: `--actorId` > YAML `admin_username` > current OS username (only when `--admin` is set).
+- Actor defaults: `--actorId` > YAML `adminUsername` > current OS username (only when `--admin` is set).
 - Service allowlist defaults to `all`. Override with `--apis admin-api,api` to scope a token down. Valid IDs: `admin-api`, `api`, `public`, `worker`.
-- `--admin` flips the token's permissions to match the `system_auth.actors.permissions` block on the server (full access in the dev config).
+- `--admin` flips the token's permissions to match the `systemAuth.actors.permissions` block on the server (full access in the dev config).
 
 ## Commands
 
@@ -133,7 +133,7 @@ ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs --no-ex
 
 Grafana presets use top-level JWT permissions. Those permissions only restrict the token; the backing actor still needs matching normal permissions.
 
-Permission namespaces in a permissions file support the same actor templates as normal actor permissions: `{{external_id}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. These render against the backing actor, and missing label or annotation values make the permission fail to match.
+Permission namespaces in a permissions file support the same actor templates as normal actor permissions: `{{externalId}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. These render against the backing actor, and missing label or annotation values make the permission fail to match.
 
 ### `ap verify-jwt`
 
@@ -152,13 +152,13 @@ ap signing-proxy --proxyTo=api --port 8888
 ap signing-proxy --proxyTo=admin-api --enableLoginRedirect=true
 ```
 
-`--proxyTo` accepts a service id (`api`, `admin-api`, `public`) or an absolute URL. `--enableLoginRedirect` adds a `/login-redirect` handler that simulates the host application's session-initiation flow — wire `host_application.initiate_session_url` (or `admin_api.ui.initiate_session_url`) at the printed URL.
+`--proxyTo` accepts a service id (`api`, `admin-api`, `public`) or an absolute URL. `--enableLoginRedirect` adds a `/login-redirect` handler that simulates the host application's session-initiation flow — wire `hostApplication.initiateSessionUrl` (or `adminApi.ui.initiateSessionUrl`) at the printed URL.
 
-`--port` defaults to `8888`. If the CLI config sets `signing_proxy.port`, that value is used instead when `--port` is not given on the command line. Multiple clones on one machine should set `AUTHPROXY_SIGNING_PROXY_PORT` per clone in their `.env` and reference it from a shared `~/.authproxy.yaml` via `signing_proxy.port.env_var`.
+`--port` defaults to `8888`. If the CLI config sets `signingProxy.port`, that value is used instead when `--port` is not given on the command line. Multiple clones on one machine should set `AUTHPROXY_SIGNING_PROXY_PORT` per clone in their `.env` and reference it from a shared `~/.authproxy.yaml` via `signingProxy.port.envVar`.
 
 ### `ap proxy` — connection-scoped streaming proxy
 
-Routes inbound requests through `POST /api/v1/connections/{id}/_proxy_raw` so the connection's credentials are applied and bodies stream end-to-end (chunked uploads, SSE responses).
+Routes inbound requests through `POST /api/v1/connections/{id}/_proxyRaw` so the connection's credentials are applied and bodies stream end-to-end (chunked uploads, SSE responses).
 
 **Long-running mode.** Boots a listener on `--port` (default 9999). Each inbound request derives its `X-AuthProxy-Upstream-URL` from `--upstream-base` (path + query appended) or the caller may set the header directly.
 
@@ -244,9 +244,9 @@ Each clone (`~/src/authproxy1`, `~/src/authproxy2`, …) needs its own port pool
 A single shared `~/.authproxy.yaml` picks up whichever clone you ran `ap` from by reading the env var loaded from that clone's `.env`:
 
 ```yaml
-signing_proxy:
+signingProxy:
   port:
-    env_var: AUTHPROXY_SIGNING_PROXY_PORT
+    envVar: AUTHPROXY_SIGNING_PROXY_PORT
     default: "8888"
 ```
 

--- a/docs/src/content/docs/development/design/key-model-migration.md
+++ b/docs/src/content/docs/development/design/key-model-migration.md
@@ -319,13 +319,13 @@ Provider notes:
 Use this workflow when the actual data-encryption key should change, such as a
 routine cryptoperiod rotation or a tenant isolation change.
 
-Configure policy under `system_auth.data_encryption_keys`:
+Configure policy under `systemAuth.dataEncryptionKeys`:
 
 ```yaml
-system_auth:
-  data_encryption_keys:
-    ensure_current: true
-    rotation_interval: 2160h # 90 days
+systemAuth:
+  dataEncryptionKeys:
+    ensureCurrent: true
+    rotationInterval: 2160h # 90 days
 ```
 
 Operational steps:

--- a/docs/src/content/docs/development/local-development.md
+++ b/docs/src/content/docs/development/local-development.md
@@ -63,14 +63,14 @@ development, the CLI signing proxy can stand in for that host.
 Create `~/.authproxy.yaml`:
 
 ```yaml
-admin_username: bobdole
-admin_private_key_path: /absolute/path/to/authproxy/dev_config/keys/admin/bobdole
+adminUsername: bobdole
+adminPrivateKeyPath: /absolute/path/to/authproxy/dev_config/keys/admin/bobdole
 server:
   api: http://localhost:8081
-  admin_api: https://localhost:8082
+  adminApi: https://localhost:8082
   auth: https://localhost:8080
   marketplace: http://localhost:5173
-  admin_ui: http://localhost:5174
+  adminUi: http://localhost:5174
 ```
 
 The corresponding development public key is already registered by

--- a/docs/src/content/docs/getting-started/demo.md
+++ b/docs/src/content/docs/getting-started/demo.md
@@ -29,7 +29,7 @@ sequenceDiagram
 
     User->>Shell: Choose actor and destination
     Shell->>Shell: Sign nonce JWT for actor
-    Shell-->>UI: Redirect with auth_token
+    Shell-->>UI: Redirect with authToken
     UI->>AP: POST /session/_initiate
     AP->>AP: Verify signer, nonce, actor, and scope
     AP-->>UI: Session cookie and UI configuration

--- a/docs/src/content/docs/integration/connector-predicates.md
+++ b/docs/src/content/docs/integration/connector-predicates.md
@@ -71,10 +71,10 @@ OAuth2 scopes support two predicate-related fields:
 ```yaml
 auth:
   type: OAuth2
-  client_id:
-    env_var: GOOGLE_CLIENT_ID
-  client_secret:
-    env_var: GOOGLE_CLIENT_SECRET
+  clientId:
+    envVar: GOOGLE_CLIENT_ID
+  clientSecret:
+    envVar: GOOGLE_CLIENT_SECRET
   authorization:
     endpoint: https://accounts.google.com/o/oauth2/v2/auth
   token:
@@ -107,7 +107,7 @@ AuthProxy uses the same effective scope set when building the OAuth authorizatio
 
 ### OAuth Timing
 
-OAuth scope predicates are evaluated before OAuth authorization for authorization-code connectors. Any `cfg` values they read must already exist before OAuth begins, usually from `setup_flow.preconnect` steps. Values collected in `setup_flow.configure` happen after OAuth and are too late to affect the initial authorization URL.
+OAuth scope predicates are evaluated before OAuth authorization for authorization-code connectors. Any `cfg` values they read must already exist before OAuth begins, usually from `setupFlow.preconnect` steps. Values collected in `setupFlow.configure` happen after OAuth and are too late to affect the initial authorization URL.
 
 For client-credentials connectors, scope predicates are evaluated before the token request. Any `cfg` values they read must be collected before that request is made.
 
@@ -121,7 +121,7 @@ Probes support `if.javascript` to decide whether the probe is enabled for a conn
 probes:
   - id: drive-health
     period: 1m
-    proxy_http:
+    proxyHttp:
       method: GET
       url: https://www.googleapis.com/drive/v3/about
 
@@ -129,7 +129,7 @@ probes:
     period: 30s
     if:
       javascript: cfg.has_calendar === true
-    proxy_http:
+    proxyHttp:
       method: GET
       url: https://www.googleapis.com/calendar/v3/users/me/calendarList
 ```

--- a/docs/src/content/docs/integration/connector-setup-flow.md
+++ b/docs/src/content/docs/integration/connector-setup-flow.md
@@ -7,7 +7,7 @@ Connector setup flows let a connector collect configuration before and after cre
 ## Phases
 
 ```yaml
-setup_flow:
+setupFlow:
   preconnect:
     steps: []
   configure:
@@ -16,7 +16,7 @@ setup_flow:
 
 `preconnect` steps run before the auth method establishes credentials. Use them for values needed by the auth flow itself, such as a tenant, region, or instance URL.
 
-`configure` steps run after credentials are available. Use them for connection-specific choices such as workspace selection, sync settings, or other post-auth options. Configure form steps can define `data_sources` because AuthProxy can call the upstream API through the authenticated proxy at that point.
+`configure` steps run after credentials are available. Use them for connection-specific choices such as workspace selection, sync settings, or other post-auth options. Configure form steps can define `dataSources` because AuthProxy can call the upstream API through the authenticated proxy at that point.
 
 Auth-method steps and AuthProxy pseudo-steps are inserted by the runtime. Connector YAML cannot conditionally hide or override them. In particular:
 
@@ -29,12 +29,12 @@ Auth-method steps and AuthProxy pseudo-steps are inserted by the runtime. Connec
 Form steps are the default step type. They use JSON Schema for submitted data and optional JSONForms UI Schema for layout.
 
 ```yaml
-setup_flow:
+setupFlow:
   preconnect:
     steps:
       - id: region
         title: Region
-        json_schema:
+        jsonSchema:
           type: object
           required:
             - region
@@ -46,14 +46,14 @@ setup_flow:
                 - eu
 ```
 
-When a form step is submitted, AuthProxy validates the payload against the step's `json_schema` and merges only top-level fields declared in `properties` into the connection configuration.
+When a form step is submitted, AuthProxy validates the payload against the step's `jsonSchema` and merges only top-level fields declared in `properties` into the connection configuration.
 
 ## Redirect Steps
 
 Redirect steps send the user to an off-platform URL before continuing setup. Set `type: redirect` and provide `redirect.url`.
 
 ```yaml
-setup_flow:
+setupFlow:
   preconnect:
     steps:
       - id: external_setup
@@ -68,7 +68,7 @@ Redirect URLs support `{{cfg.field_name}}` mustache references plus two runtime 
 - `{{RETURN_ADVANCE}}`: a signed one-time-use URL that advances the connection to the next step.
 - `{{RETURN_ABORT}}`: a signed one-time-use URL that aborts the in-flight setup.
 
-Redirect steps cannot define `json_schema`, `ui_schema`, or `data_sources`.
+Redirect steps cannot define `jsonSchema`, `uiSchema`, or `dataSources`.
 
 ## Conditional Steps
 
@@ -77,7 +77,7 @@ Connector-authored form and redirect steps can include an `if.javascript` condit
 Setup-step predicates share the same shape and runtime context as OAuth scope and probe predicates. See [Connector predicates](/integration/connector-predicates/) for the shared predicate contract and non-setup examples.
 
 ```yaml
-setup_flow:
+setupFlow:
   configure:
     steps:
       - id: advanced_options
@@ -85,7 +85,7 @@ setup_flow:
         if:
           javascript: |
             cfg.region === "eu" && labels["apxy/cxr/type"] === "salesforce"
-        json_schema:
+        jsonSchema:
           type: object
           properties:
             sync_mode:
@@ -105,12 +105,12 @@ The JavaScript runtime exposes these variables:
 Conditions are useful when a later step depends on an earlier answer, a connector label, or an operator-supplied annotation:
 
 ```yaml
-setup_flow:
+setupFlow:
   preconnect:
     steps:
       - id: region
         title: Region
-        json_schema:
+        jsonSchema:
           type: object
           required:
             - region
@@ -124,7 +124,7 @@ setup_flow:
     steps:
       - id: workspace
         title: Workspace
-        json_schema:
+        jsonSchema:
           type: object
           required:
             - workspace_id
@@ -132,9 +132,9 @@ setup_flow:
             workspace_id:
               type: string
               x-data-source: workspaces
-        data_sources:
+        dataSources:
           workspaces:
-            proxy_request:
+            proxyRequest:
               method: GET
               url: https://api.example.com/workspaces
             transform: data.map(w => ({ value: w.id, label: w.name }))
@@ -143,7 +143,7 @@ setup_flow:
         if:
           javascript: |
             cfg.region === "eu" && annotations["setup-mode"] === "advanced"
-        json_schema:
+        jsonSchema:
           type: object
           properties:
             sync_mode:
@@ -167,7 +167,7 @@ If all connector-authored steps in a phase are ineligible, the runtime skips tha
 
 ## Data Sources
 
-Configure form steps can define `data_sources` for controls that need upstream options. AuthProxy calls the `proxy_request` through the authenticated connection, exposes the JSON response as `data`, and evaluates `transform` JavaScript to produce options:
+Configure form steps can define `dataSources` for controls that need upstream options. AuthProxy calls the `proxyRequest` through the authenticated connection, exposes the JSON response as `data`, and evaluates `transform` JavaScript to produce options:
 
 ```yaml
 javascript: |
@@ -177,20 +177,20 @@ javascript: |
     });
   }
 
-setup_flow:
+setupFlow:
   configure:
     steps:
       - id: workspace
         title: Workspace
-        json_schema:
+        jsonSchema:
           type: object
           properties:
             workspace_id:
               type: string
               x-data-source: workspaces
-        data_sources:
+        dataSources:
           workspaces:
-            proxy_request:
+            proxyRequest:
               method: GET
               url: https://api.example.com/workspaces
             transform: workspaceOptions(data.items)

--- a/docs/src/content/docs/integration/host-application.md
+++ b/docs/src/content/docs/integration/host-application.md
@@ -10,24 +10,24 @@ minimum metadata needed to authorize and operate third-party connections.
 
 | Host entity | AuthProxy representation | Guidance |
 |---|---|---|
-| User or service principal | Actor `external_id` | Use an immutable primary key, not email or display name. |
+| User or service principal | Actor `externalId` | Use an immutable primary key, not email or display name. |
 | Tenant or organization | Namespace | Derive a stable, namespace-safe segment and never rename it when the tenant's display name changes. |
 | Team | Optional child namespace | Create it only when it is an authorization boundary. Otherwise use a label. |
 | Integration installation | Connection | Store the immutable `cxn_...` ID in the host. Supply a human-readable name for display and exact-name discovery. |
 | Searchable host metadata | Labels | Keep values short and non-sensitive; labels appear in request-event dimensions. |
 | Descriptive metadata | Annotations | Use for non-selectable values such as a host record URL or description. |
 
-An actor is located by `(namespace, external_id)`, so keep both stable. A user
+An actor is located by `(namespace, externalId)`, so keep both stable. A user
 with host id `usr_7` in tenant `tnt_42` might map to:
 
 ```text
 actor namespace: root.tenants.tnt_42
-external_id:     usr_7
+externalId:     usr_7
 tenant namespace: root.tenants.tnt_42
 ```
 
 If the host id contains characters that cannot appear in a namespace segment,
-retain the original id as `external_id` and maintain a deterministic,
+retain the original id as `externalId` and maintain a deterministic,
 namespace-safe key separately.
 
 ## Choose a namespace model

--- a/docs/src/content/docs/integration/marketplace.md
+++ b/docs/src/content/docs/integration/marketplace.md
@@ -34,25 +34,25 @@ sequenceDiagram
     participant H as "Host application"
 
     User->>M: "Open Marketplace"
-    M->>P: "POST /api/v1/session/_initiate {return_to_url}"
+    M->>P: "POST /api/v1/session/_initiate {returnToUrl}"
     alt "Valid AuthProxy session already exists"
-        P-->>M: "200 {actor_id}"
+        P-->>M: "200 {actorId}"
     else "No valid session"
-        P-->>M: "401 {redirect_url}"
-        M->>H: "Navigate to initiate_session_url?return_to=..."
+        P-->>M: "401 {redirectUrl}"
+        M->>H: "Navigate to initiate_session_url?returnToUrl=..."
         H->>H: "Authenticate user and map actor"
         H->>H: "Sign JWT with expiration and nonce"
-        H-->>M: "302 return_to?auth_token=JWT"
+        H-->>M: "302 returnToUrl?authToken=JWT"
         M->>P: "POST /api/v1/session/_initiate + Bearer JWT"
         P->>P: "Verify actor, consume nonce, create session"
-        P-->>M: "200 {actor_id} + session cookie"
+        P-->>M: "200 {actorId} + session cookie"
     end
     M->>P: "List connectors and manage connections"
 ```
 
-The configured `host_application.initiate_session_url` receives a `return_to`
+The configured `hostApplication.initiateSessionUrl` receives a `returnToUrl`
 query parameter. After authenticating the user, the host redirects to that URL
-with an `auth_token` query parameter. The Marketplace moves the token into the
+with an `authToken` query parameter. The Marketplace moves the token into the
 `Authorization: Bearer` header when it calls the session endpoint.
 
 If authentication succeeds, the Public service consumes the nonce and creates
@@ -65,27 +65,27 @@ For a separately hosted Marketplace:
 
 ```yaml
 public:
-  base_url: https://authproxy.example.com
+  baseUrl: https://authproxy.example.com
   https: true
   cookie:
-    same_site: none
+    sameSite: none
 
-host_application:
-  initiate_session_url: https://app.example.com/auth/authproxy
+hostApplication:
+  initiateSessionUrl: https://app.example.com/auth/authproxy
 
 marketplace:
-  base_url: https://integrations.example.com
+  baseUrl: https://integrations.example.com
 ```
 
 The host endpoint follows this logic:
 
 ```text
 require an authenticated host session
-read return_to
-reject return_to unless it matches an exact Marketplace allowlist
+read returnToUrl
+reject returnToUrl unless it matches an exact Marketplace allowlist
 map the host user and tenant to an AuthProxy actor and namespace
 sign an AuthProxy JWT for the Public service with a short expiration and nonce
-redirect to return_to with auth_token=<jwt>
+redirect to returnToUrl with authToken=<jwt>
 ```
 
 The signing key remains in the host backend. Register its public key or trusted
@@ -118,7 +118,7 @@ ap login-redirect --port 8889
 ap sign-marketplace-login-url --actorId alice
 ```
 
-`login-redirect` implements the `return_to` handoff locally, while
+`login-redirect` implements the `returnToUrl` handoff locally, while
 `sign-marketplace-login-url` prints a Marketplace URL containing a one-time
 token. See the [CLI reference](/development/cli/#ap-login-redirect).
 

--- a/docs/src/content/docs/operations/app-metrics.md
+++ b/docs/src/content/docs/operations/app-metrics.md
@@ -2,26 +2,26 @@
 title: Application Metrics
 ---
 
-AuthProxy stores Admin UI-facing application metrics in the `app_metrics` store. This store includes request-event records, optional full request/response payloads, and periodic resource snapshots used for time-series dashboards.
+AuthProxy stores Admin UI-facing application metrics in the `appMetrics` store. This store includes request-event records, optional full request/response payloads, and periodic resource snapshots used for time-series dashboards.
 
 ## Configuration
 
-`app_metrics` is required because request-event listing and metrics queries are routed through it. In development the store can use the same SQLite or Postgres database as the primary application database; app_metrics tracks its migrations in `app_metrics_schema_migrations` so it does not conflict with the primary `schema_migrations` table. Deployed environments should prefer ClickHouse or a dedicated Postgres database when request volume is high.
+`appMetrics` is required because request-event listing and metrics queries are routed through it. In development the store can use the same SQLite or Postgres database as the primary application database; appMetrics tracks its migrations in `app_metrics_schema_migrations` so it does not conflict with the primary `schema_migrations` table. Deployed environments should prefer ClickHouse or a dedicated Postgres database when request volume is high.
 
 ```yaml
-app_metrics:
-  resource_snapshot_interval: 15m
+appMetrics:
+  resourceSnapshotInterval: 15m
   database:
     provider: clickhouse
-    auto_migrate: true
+    autoMigrate: true
     addresses:
       - localhost:8123
     database: authproxy
     user: authproxy
     password: authproxy
-  request_events:
-    full_request_recording: never
-  blob_storage:
+  requestEvents:
+    fullRequestRecording: never
+  blobStorage:
     provider: s3
     bucket: authproxy-request-logs
 ```
@@ -30,10 +30,10 @@ Key settings:
 
 | Setting | Purpose |
 |---|---|
-| `app_metrics.database` | Database for request events and resource sample tables; can be shared with the primary application database for development. |
-| `app_metrics.resource_snapshot_interval` | Cadence for the worker snapshot job. Defaults to `15m`. |
-| `app_metrics.request_events.full_request_recording` | `never` (default) or `always`; controls whether full request/response bodies are captured. |
-| `app_metrics.blob_storage` | Stores full request/response payloads when capture is enabled. |
+| `appMetrics.database` | Database for request events and resource sample tables; can be shared with the primary application database for development. |
+| `appMetrics.resourceSnapshotInterval` | Cadence for the worker snapshot job. Defaults to `15m`. |
+| `appMetrics.requestEvents.fullRequestRecording` | `never` (default) or `always`; controls whether full request/response bodies are captured. |
+| `appMetrics.blobStorage` | Stores full request/response payloads when capture is enabled. |
 
 The resource snapshot worker stores live resources at each interval. Deleted resources remain visible in historical time slices where they were sampled, but they are excluded from later snapshots.
 
@@ -45,7 +45,7 @@ source, rate-limit id, label selector, and timestamp range. Fetch one event at
 `GET /api/v1/metrics/request-events/{id}`.
 
 Full request and response payloads are separate encrypted blobs and exist only
-when `full_request_recording` is `always`. Keep recording at `never` unless the
+when `fullRequestRecording` is `always`. Keep recording at `never` unless the
 debugging or audit requirement justifies the additional sensitive data,
 storage, access control, and retention burden.
 
@@ -61,13 +61,13 @@ Use `POST /api/v1/metrics/query` with a time range, optional namespace matcher, 
     "step": "15m"
   },
   "namespace": "root.**",
-  "label_selector": "env=prod",
+  "labelSelector": "env=prod",
   "queries": [
     {
-      "ref_id": "connections",
+      "refId": "connections",
       "metric": "resources.connections",
       "aggregation": "count",
-      "group_by": ["state", "health_state"]
+      "groupBy": ["state", "health_state"]
     }
   ]
 }
@@ -79,12 +79,12 @@ Responses are returned as labeled time series:
 {
   "series": [
     {
-      "ref_id": "connections",
+      "refId": "connections",
       "metric": "resources.connections",
       "aggregation": "count",
       "labels": {
         "state": "configured",
-        "health_state": "healthy"
+        "healthState": "healthy"
       },
       "points": [
         {"timestamp": "2026-05-25T12:00:00Z", "value": 4}

--- a/docs/src/content/docs/operations/connector-lifecycle.md
+++ b/docs/src/content/docs/operations/connector-lifecycle.md
@@ -4,10 +4,10 @@ title: Connector Lifecycle Operations
 
 AuthProxy exposes connector-wide lifecycle operations for administrative cleanup:
 
-- `POST /connectors/{id}/_disconnect_all`
+- `POST /connectors/{id}/_disconnectAll`
 - `POST /connectors/{id}/_archive`
 
-Both endpoints start go-workflows-backed background work and return a `task_id` that can be polled with `GET /tasks/{task_id}`. They run on the normal worker service, share the application database through the workflow backend, and use the same task polling contract as other long-running work.
+Both endpoints start go-workflows-backed background work and return a `taskId` that can be polled with `GET /tasks/{taskId}`. They run on the normal worker service, share the application database through the workflow backend, and use the same task polling contract as other long-running work.
 
 Admin lists display the connector name, but lifecycle URLs continue to use the
 immutable connector ID. Renaming a connector does not change an in-flight task,
@@ -27,11 +27,11 @@ Both endpoints accept an optional JSON body:
 
 ```json
 {
-  "timeout_seconds": 600
+  "timeoutSeconds": 600
 }
 ```
 
-`timeout_seconds` must be greater than zero. If omitted, AuthProxy uses the default connector lifecycle timeout of 600 seconds.
+`timeoutSeconds` must be greater than zero. If omitted, AuthProxy uses the default connector lifecycle timeout of 600 seconds.
 
 The caller needs `connectors:disconnect_all` permission for disconnect-all and `connectors:archive` permission for archive, scoped to the connector namespace and id.
 
@@ -41,15 +41,15 @@ The start response contains a secure task token:
 
 ```json
 {
-  "task_id": "encrypted-task-info",
-  "connector_id": "cxr_..."
+  "taskId": "encrypted-task-info",
+  "connectorId": "cxr_..."
 }
 ```
 
 Poll it with:
 
 ```http
-GET /tasks/{task_id}
+GET /tasks/{taskId}
 ```
 
 Workflow-backed connector lifecycle tasks usually report these states:
@@ -75,8 +75,8 @@ Archive uses the same disconnect-all workflow as a child. Its requested timeout 
 
 Connector lifecycle workflow instance ids are deterministic:
 
-- `core.connector.disconnect_all.v1:<connector_id>`
-- `core.connector.archive.v1:<connector_id>`
+- `core.connector.disconnect_all.v1:<connectorId>`
+- `core.connector.archive.v1:<connectorId>`
 
 This prevents duplicate disconnect-all or archive workflows from running for the same connector at the same time. After a workflow completes, AuthProxy can start a new execution with the same workflow instance id, which allows a connector to be disconnected again after new connections are created.
 

--- a/docs/src/content/docs/operations/connector-version-migrations.md
+++ b/docs/src/content/docs/operations/connector-version-migrations.md
@@ -126,7 +126,7 @@ return {
         level: "warning",
         title: "Connection needs review",
         message: "Review this connection before using the new connector version.",
-        action_url: "/connections/cxn_123?action=configure",
+        actionUrl: "/connections/cxn_123?action=configure",
         metadata: {
           reason: "workspace mapping changed"
         }
@@ -156,7 +156,7 @@ After hooks run, AuthProxy compares the source and target connector definitions
 and updates the migration candidate:
 
 - Target-only setup fields with JSON Schema defaults are filled automatically.
-- Missing required configure fields set `setup_step_id` so the actor can resume
+- Missing required configure fields set `setupStepId` so the actor can resume
   setup.
 - Missing required preconnect fields or required OAuth scope changes leave the
   connection configured but unhealthy, requiring re-authentication.
@@ -189,26 +189,26 @@ same deterministic key instead of creating a duplicate.
 The notification API is:
 
 ```http
-GET /api/v1/notifications?include_viewed=true
+GET /api/v1/notifications?includeViewed=true
 POST /api/v1/notifications/{id}/_viewed
 POST /api/v1/notifications/_viewed
 ```
 
 `GET /notifications` returns actor-filtered active notifications with `viewed`,
-`can_action`, and `action_url` when the actor is allowed to perform the action.
-Clients should only follow `action_url` when `can_action` is true.
+`canAction`, and `actionUrl` when the actor is allowed to perform the action.
+Clients should only follow `actionUrl` when `canAction` is true.
 
 ## API
 
 Start a single connection migration with:
 
 ```http
-POST /api/v1/connections/{id}/_migrate_version
+POST /api/v1/connections/{id}/_migrateVersion
 Content-Type: application/json
 
 {
-  "target_version": 3,
-  "timeout_seconds": 600
+  "targetVersion": 3,
+  "timeoutSeconds": 600
 }
 ```
 
@@ -216,10 +216,10 @@ The response binds the workflow task to the caller:
 
 ```json
 {
-  "task_id": "tsk_...",
-  "connection_id": "cxn_...",
-  "source_version": 1,
-  "target_version": 3
+  "taskId": "tsk_...",
+  "connectionId": "cxn_...",
+  "sourceVersion": 1,
+  "targetVersion": 3
 }
 ```
 

--- a/docs/src/content/docs/operations/rate-limits.md
+++ b/docs/src/content/docs/operations/rate-limits.md
@@ -14,7 +14,7 @@ Both can fire on the same request and both stamp the request log so you can tell
 | Need | Use |
 |---|---|
 | Stop hammering a 3rd party that just returned 429. | The reactive limiter — built in, no configuration required for the common case. |
-| Tune what counts as a "retryable" 429 and how aggressively to back off. | Configure `rate_limiting` on the connector definition. |
+| Tune what counts as a "retryable" 429 and how aggressively to back off. | Configure `rateLimiting` on the connector definition. |
 | Cap your own usage to stay below a known 3rd-party quota. | Define a rate-limit resource with `enforce` mode. |
 | Cap per-actor / per-team / per-cohort usage so noisy neighbours don't drain a shared quota. | Define a rate-limit resource with bucket dimensions. |
 | Roll out a new limit safely — see how many requests it *would have* rejected before turning it on. | Define a rate-limit resource with `observe` mode. |
@@ -40,9 +40,9 @@ Authorization: Bearer <admin token>
   "definition": {
     "mode": "enforce",
     "selector": {
-      "label_selector": "apxy/cxr/type=salesforce",
+      "labelSelector": "apxy/cxr/type=salesforce",
       "methods": ["POST", "PATCH", "PUT"],
-      "path_match": {
+      "pathMatch": {
         "kind": "prefix",
         "value": "/services/data/"
       }
@@ -51,7 +51,7 @@ Authorization: Bearer <admin token>
       "dimensions": ["actor", "labels/team"]
     },
     "algorithm": {
-      "token_bucket": { "capacity": 60, "refill_rate": 1.0 }
+      "tokenBucket": { "capacity": 60, "refillRate": 1.0 }
     }
   }
 }
@@ -59,7 +59,7 @@ Authorization: Bearer <admin token>
 
 The response carries the server-assigned id (e.g., `rl_AbcXyz…`), the materialised label set (including the implicit `apxy/rl/-/id` / `apxy/rl/-/ns` and any carried-forward namespace labels — see [Labels](/concepts/labels-and-annotations/)), and timestamps.
 
-Update with `PATCH /api/v1/rate-limits/{id}` (the request body can carry any of `definition`, `labels`, `annotations`; omit fields you don't want to change). Delete with `DELETE /api/v1/rate-limits/{id}`. List with `GET /api/v1/rate-limits` (supports `namespace`, `label_selector`, and pagination cursor params).
+Update with `PATCH /api/v1/rate-limits/{id}` (the request body can carry any of `definition`, `labels`, `annotations`; omit fields you don't want to change). Delete with `DELETE /api/v1/rate-limits/{id}`. List with `GET /api/v1/rate-limits` (supports `namespace`, `labelSelector`, and pagination cursor params).
 
 Labels and annotations also have sub-resource endpoints — see [Labels — API surface](/concepts/labels-and-annotations/#api-surface).
 
@@ -109,24 +109,24 @@ The `selector` block decides which requests the rule applies to. All clauses are
 
 | Clause | What it matches | Default if omitted |
 |---|---|---|
-| `label_selector` | Per-request label snapshot via [K8s-style selector syntax](/concepts/labels-and-annotations/#label-selectors). | Match any. |
+| `labelSelector` | Per-request label snapshot via [K8s-style selector syntax](/concepts/labels-and-annotations/#label-selectors). | Match any. |
 | `methods` | HTTP verb (exact, upper-case). | Match any. |
-| `path_match` | Final upstream URL path (after connector templating / rewriting). Three flavours: `prefix`, `glob` (`*` doesn't cross `/`), `regex`. | Match any. |
-| `request_types` | What kind of traffic — `proxy`, `probe`, `oauth2_token_exchange`, etc. | `[proxy, probe]`. |
+| `pathMatch` | Final upstream URL path (after connector templating / rewriting). Three flavours: `prefix`, `glob` (`*` doesn't cross `/`), `regex`. | Match any. |
+| `requestTypes` | What kind of traffic — `proxy`, `probe`, `oauth2_token_exchange`, etc. | `[proxy, probe]`. |
 
 ### Examples
 
 **By actor and tenant**, via the per-request label snapshot:
 ```json
 "selector": {
-  "label_selector": "apxy/act/-/id=act_AbcXyz,app.example.com/tenant-id=tenant-42"
+  "labelSelector": "apxy/act/-/id=act_AbcXyz,app.example.com/tenant-id=tenant-42"
 }
 ```
 
 **By connector type** — pin the rule to all Salesforce connections in the namespace:
 ```json
 "selector": {
-  "label_selector": "apxy/cxr/type=salesforce"
+  "labelSelector": "apxy/cxr/type=salesforce"
 }
 ```
 
@@ -136,14 +136,14 @@ The `selector` block decides which requests the rule applies to. All clauses are
 ```json
 "selector": {
   "methods": ["POST", "PATCH", "PUT"],
-  "path_match": { "kind": "prefix", "value": "/services/data/" }
+  "pathMatch": { "kind": "prefix", "value": "/services/data/" }
 }
 ```
 
 **By specific operation** — regex when prefix / glob aren't precise enough:
 ```json
 "selector": {
-  "path_match": {
+  "pathMatch": {
     "kind": "regex",
     "value": "^/v1/users/[0-9]+/permissions$"
   }
@@ -155,10 +155,10 @@ The `selector` block decides which requests the rule applies to. All clauses are
 Most rules govern user-driven `proxy` traffic and connector-defined `probe` traffic — that's the default. **OAuth2 token exchange / refresh / revocation are *not* governed by default** because rate-limiting your own auth flows is usually a self-inflicted outage. If you do need to throttle those (e.g., a 3rd party that throttles refresh aggressively), opt in explicitly:
 
 ```json
-"selector": { "request_types": ["oauth2_refresh"] }
+"selector": { "requestTypes": ["oauth2_refresh"] }
 ```
 
-An explicit empty `request_types: []` is rejected at validation — omit the field to use the default.
+An explicit empty `requestTypes: []` is rejected at validation — omit the field to use the default.
 
 ## Buckets — projecting requests into independent counters
 
@@ -190,45 +190,45 @@ A missing-but-referenced dimension resolves to `""`. So a rule that buckets by `
 
 Pick exactly one algorithm. Each makes a different tradeoff between accuracy, memory, and burst tolerance.
 
-### `fixed_window`
+### `fixedWindow`
 
 A counter that resets at boundaries derived from `floor(now / window)`.
 
 ```json
-{ "fixed_window": { "window": "1m", "limit": 100 } }
+{ "fixedWindow": { "window": "1m", "limit": 100 } }
 ```
 
 Simple and cheap. Susceptible to **boundary bursts** — a client can fire `limit` calls in the last 100 ms of one window and another `limit` in the first 100 ms of the next, getting `2 × limit` in a 200 ms interval.
 
-### `sliding_window` — `log` mode
+### `slidingWindow` — `log` mode
 
 A precise sliding window. Stores a timestamped log of recent allowed requests and removes entries older than `window` on each evaluation.
 
 ```json
-{ "sliding_window": { "window": "1m", "limit": 100, "mode": "log" } }
+{ "slidingWindow": { "window": "1m", "limit": 100, "mode": "log" } }
 ```
 
 Exactly `limit` requests permitted in any rolling `window` interval. Most accurate; most memory (a sorted set per bucket).
 
-### `sliding_window` — `counter` mode
+### `slidingWindow` — `counter` mode
 
 An approximation using two adjacent fixed-window counters, weighted by how far into the current window we are. Cheaper than `log` mode; accurate to a small constant factor.
 
 ```json
-{ "sliding_window": { "window": "1m", "limit": 100, "mode": "counter" } }
+{ "slidingWindow": { "window": "1m", "limit": 100, "mode": "counter" } }
 ```
 
 Use when you need sliding-window semantics without the per-request memory cost.
 
-### `token_bucket`
+### `tokenBucket`
 
 A bucket of tokens refilled at a constant rate. Each request consumes one token; if the bucket is empty, the request is rejected.
 
 ```json
-{ "token_bucket": { "capacity": 60, "refill_rate": 1.0 } }
+{ "tokenBucket": { "capacity": 60, "refillRate": 1.0 } }
 ```
 
-`capacity` is the burst — the max tokens the bucket can hold. `refill_rate` is tokens per second (may be fractional, e.g. `0.5` = one new token every two seconds). New buckets start full so first-time callers get the configured burst capacity rather than instantly hitting an empty pool.
+`capacity` is the burst — the max tokens the bucket can hold. `refillRate` is tokens per second (may be fractional, e.g. `0.5` = one new token every two seconds). New buckets start full so first-time callers get the configured burst capacity rather than instantly hitting an empty pool.
 
 ## `enforce` vs. `observe` mode
 
@@ -251,11 +251,11 @@ When an `enforce`-mode rule rejects a proxy request, AuthProxy returns:
 | `Retry-After` header | Seconds until the next request from this bucket would be permitted (window remainder for window algorithms; time-to-next-token for token bucket). |
 | `X-Authproxy-Ratelimited` header | `true` — distinguishes any AuthProxy synthetic 429 from a real upstream 429. |
 | `X-Authproxy-Ratelimit` header | The firing rule's id (e.g., `rl_AbcXyz…`). |
-| Body | JSON: `{ "error": "rate limited", "rate_limit_id": "<id>", "retry_after_seconds": <n> }` |
+| Body | JSON: `{ "error": "rate limited", "rateLimitId": "<id>", "retryAfterSeconds": <n> }` |
 
 Your application should treat 429 as a transient error and back off according to `Retry-After`. The `X-Authproxy-Ratelimit` header lets you correlate a 429 with the specific rule for support / debugging.
 
-The connector-level reactive limiter ([below](#connector-level-reactive-429-handling)) also produces a 429 with `X-Authproxy-Ratelimited: true` but **no** `X-Authproxy-Ratelimit` header (it has no rule id). Use the request log's `response_source` field (`upstream` / `connector_rate_limiter` / `rate_limit`) to disambiguate after the fact.
+The connector-level reactive limiter ([below](#connector-level-reactive-429-handling)) also produces a 429 with `X-Authproxy-Ratelimited: true` but **no** `X-Authproxy-Ratelimit` header (it has no rule id). Use the request log's `responseSource` field (`upstream` / `connector_rate_limiter` / `rate_limit`) to disambiguate after the fact.
 
 ## Multiple matching rules
 
@@ -263,7 +263,7 @@ A request can match several rules at once — e.g., one rule at the root namespa
 
 - **Most-restrictive wins.** If more than one `enforce`-mode rule rejects, the one with the longest `Retry-After` is the one whose id ends up in `X-Authproxy-Ratelimit` and in the response body. The caller sees a single 429 with the most pessimistic wait.
 - **Observe rules never reject** but still evaluate (and increment their counters). Their decisions are recorded in the request log so you can see what would have happened.
-- **The full match set lives on the log entry.** Every rule that matched — firing, observe, or didn't-reject — is recorded under `rate_limit_matched` on the request log entry. See [Request log attribution](#request-log-attribution).
+- **The full match set lives on the log entry.** Every rule that matched — firing, observe, or didn't-reject — is recorded under `rateLimitMatched` on the request log entry. See [Request log attribution](#request-log-attribution).
 
 Composition is "all apply" — there is no priority field, no specificity scoring, no first-match-wins. Layer org-wide caps at the root namespace with per-team caps at child namespaces and they stack cleanly.
 
@@ -279,20 +279,20 @@ Permission to create / read / update / delete a rate limit follows the standard 
 
 The reactive limiter is built into every connector. When a 3rd party returns 429, AuthProxy parses the response, blocks the connection for the suggested wait, and short-circuits subsequent requests on that connection with its own 429 until the cool-down expires. This prevents you from hammering an API that has already told you to slow down.
 
-Configuration lives on the connector definition under `rate_limiting`. Every field has a sensible default — you only need to set the ones you want to override.
+Configuration lives on the connector definition under `rateLimiting`. Every field has a sensible default — you only need to set the ones you want to override.
 
 ```yaml
 # In a connector definition YAML
-rate_limiting:
+rateLimiting:
   disabled: false                       # Set true to pass 429s through unchanged
-  retry_after_headers: ["Retry-After"]  # Headers to check, in priority order
-  max_retry_after: 15m                  # Cap on any wait
-  default_retry_after: 60s              # Fallback when no parseable header found
-  exponential_backoff:                  # Used on consecutive 429s without a header
-    initial_interval: 1s
+  retryAfterHeaders: ["Retry-After"]  # Headers to check, in priority order
+  maxRetryAfter: 15m                  # Cap on any wait
+  defaultRetryAfter: 60s              # Fallback when no parseable header found
+  exponentialBackoff:                  # Used on consecutive 429s without a header
+    initialInterval: 1s
     multiplier: 2.0
-    max_interval: 5m
-    jitter_fraction: 0.1
+    maxInterval: 5m
+    jitterFraction: 0.1
 ```
 
 | Field | Default | What it does |
@@ -306,13 +306,13 @@ rate_limiting:
 | `exponential_backoff.max_interval` | `5m` | Cap on the per-step backoff. |
 | `exponential_backoff.jitter_fraction` | `0.1` | Each computed backoff is uniformly sampled in `[(1−j)·t, (1+j)·t]`. Prevents thundering-herd retries. |
 
-When the reactive limiter short-circuits a request, the synthetic 429 carries `X-Authproxy-Ratelimited: true` and shows up in the request log with `response_source: connector_rate_limiter`. No `X-Authproxy-Ratelimit` header (there's no rule id — this is opportunistic, not a configured rule).
+When the reactive limiter short-circuits a request, the synthetic 429 carries `X-Authproxy-Ratelimited: true` and shows up in the request log with `responseSource: connector_rate_limiter`. No `X-Authproxy-Ratelimit` header (there's no rule id — this is opportunistic, not a configured rule).
 
 ## Request log attribution
 
-Every 429 — real upstream, connector-level reactive, or rate-limit resource — is recorded on the request log with a `response_source` field so you can tell them apart:
+Every 429 — real upstream, connector-level reactive, or rate-limit resource — is recorded on the request log with a `responseSource` field so you can tell them apart:
 
-| `response_source` | Means |
+| `responseSource` | Means |
 |---|---|
 | `upstream` (default) | The response (incl. any 429) came from the 3rd party. |
 | `connector_rate_limiter` | The connector-level reactive limiter short-circuited the request because the connection was in cool-down. No upstream call was made. |
@@ -322,18 +322,18 @@ When a rate-limit resource is involved (firing or in observe-mode), the request 
 
 | Field | When populated | Notes |
 |---|---|---|
-| `rate_limit_id` | Any time a rate-limit rule matched (incl. observe-only). | The most-restrictive firing rule, or the first observe match if none fired. |
-| `rate_limit_mode` | Same. | `enforce` or `observe`. |
-| `rate_limit_bucket` | Same. | The resolved dimension → value map for the matched rule. |
-| `rate_limit_matched` | Same. | Full list of every rule that matched: `[{id, mode, bucket}, …]` — observe rules included. |
+| `rateLimitId` | Any time a rate-limit rule matched (incl. observe-only). | The most-restrictive firing rule, or the first observe match if none fired. |
+| `rateLimitMode` | Same. | `enforce` or `observe`. |
+| `rateLimitBucket` | Same. | The resolved dimension → value map for the matched rule. |
+| `rateLimitMatched` | Same. | Full list of every rule that matched: `[{id, mode, bucket}, …]` — observe rules included. |
 
-The list endpoint accepts `response_source` and `rate_limit_id` filters so you can scope a request-log search to "every request rejected by `rl_AbcXyz`" or "every 429 that came from upstream".
+The list endpoint accepts `responseSource` and `rateLimitId` filters so you can scope a request-log search to "every request rejected by `rl_AbcXyz`" or "every 429 that came from upstream".
 
 ```http
-GET /api/v1/metrics/request-events?response_source=rate_limit&rate_limit_id=rl_AbcXyz
+GET /api/v1/metrics/request-events?responseSource=rate_limit&rateLimitId=rl_AbcXyz
 ```
 
-The admin UI surfaces `response_source` as a column (chip-rendered with a colour for synthetic-429 sources) and `rate_limit_id` as a hidden-by-default column with a link to the rate-limit detail page.
+The admin UI surfaces `responseSource` as a column (chip-rendered with a colour for synthetic-429 sources) and `rateLimitId` as a hidden-by-default column with a link to the rate-limit detail page.
 
 ## Implementation reference
 
@@ -421,9 +421,9 @@ Operationally:
 
 Both systems can fire on the same request. The order is determined by the middleware chain ([above](#architecture)):
 
-1. **Enforcer first.** If a proxy-side rule rejects, you get a 429 with `response_source: rate_limit` — the request never reaches the reactive limiter.
-2. **Reactive limiter second.** If the enforcer passed through but the connection is in cool-down from a prior real upstream 429, you get a 429 with `response_source: connector_rate_limiter`.
-3. **Upstream third.** If both passed through, the upstream call happens. A real upstream 429 returns with `response_source: upstream` and the reactive limiter records the cool-down for next time.
+1. **Enforcer first.** If a proxy-side rule rejects, you get a 429 with `responseSource: rate_limit` — the request never reaches the reactive limiter.
+2. **Reactive limiter second.** If the enforcer passed through but the connection is in cool-down from a prior real upstream 429, you get a 429 with `responseSource: connector_rate_limiter`.
+3. **Upstream third.** If both passed through, the upstream call happens. A real upstream 429 returns with `responseSource: upstream` and the reactive limiter records the cool-down for next time.
 
 This ordering means proxy-side rule rejections "win" over connector cool-down rejections. From an attribution standpoint that's the right call — operators configured the rule intentionally, while cool-down is opportunistic.
 

--- a/docs/src/content/docs/operations/telemetry.md
+++ b/docs/src/content/docs/operations/telemetry.md
@@ -12,7 +12,7 @@ telemetry:
   exporter:
     protocol: grpc
     endpoint:
-      env_var: AUTHPROXY_OTEL_ENDPOINT
+      envVar: AUTHPROXY_OTEL_ENDPOINT
       default: ""
     insecure: true
 ```
@@ -54,7 +54,7 @@ Toggling a signal off while telemetry is enabled keeps the corresponding provide
 | Asynq handlers + scheduler | `asynq.task {type}` and `asynq.scheduler.sync` | consumer / internal | `messaging.system=asynq`, `messaging.destination.name`, `messaging.message.id`, `authproxy.asynq.task_type`, `authproxy.asynq.retry_count`, `authproxy.asynq.max_retry` |
 | OAuth2 lifecycle | `oauth2.token_exchange`, `oauth2.refresh`, `oauth2.revoke` | client | `authproxy.connector_id`, `authproxy.oauth2.operation` |
 
-Health and readiness endpoints (`/ping`, `/healthz`) are excluded from spans and metrics by default — configurable via `telemetry.http.excluded_paths`. **Token contents, refresh payloads, and other secrets are never captured as span attributes.**
+Health and readiness endpoints (`/ping`, `/healthz`) are excluded from spans and metrics by default — configurable via `telemetry.http.excludedPaths`. **Token contents, refresh payloads, and other secrets are never captured as span attributes.**
 
 ## Metrics catalog
 
@@ -90,7 +90,7 @@ Standard `db.client.connections.*` and per-command histograms emitted by the red
 - `authproxy.oauth2.token_exchange.attempts.total{result}` — counter.
 - `authproxy.oauth2.token_exchange.failures.total{reason}` — counter.
 
-OAuth2 counters also receive any **allowlisted** connection-label dimensions from `telemetry.proxy.metric_dimension_labels` (e.g. `type=google_drive`, `env=prod`). The raw `authproxy.connector_id` is intentionally **not** emitted as a metric attribute — see the [label projection](#label-projection) section.
+OAuth2 counters also receive any **allowlisted** connection-label dimensions from `telemetry.proxy.metricDimensionLabels` (e.g. `type=google_drive`, `env=prod`). The raw `authproxy.connector_id` is intentionally **not** emitted as a metric attribute — see the [label projection](#label-projection) section.
 
 ## Configuration reference
 
@@ -102,17 +102,17 @@ telemetry:
 
   exporter:
     protocol: grpc                    # grpc (default) | http/protobuf
-    endpoint:                         # StringValue — supports env_var fallthrough
-      env_var: AUTHPROXY_OTEL_ENDPOINT
+    endpoint:                         # StringValue — supports envVar fallthrough
+      envVar: AUTHPROXY_OTEL_ENDPOINT
       default: ""                     # empty default → endpoint-gated soft-disable
-    headers:                          # map<string, StringValue> — env_var fallthrough on each value
+    headers:                          # map<string, StringValue> — envVar fallthrough on each value
       authorization:
-        env_var: OTEL_HEADER_AUTH
+        envVar: OTEL_HEADER_AUTH
         default: ""
     insecure: true                    # disable TLS on the OTLP connection
 
   resource:
-    service_name_prefix: authproxy    # prepended to service id (e.g. authproxy-api). Default "authproxy".
+    serviceNamePrefix: authproxy    # prepended to service id (e.g. authproxy-api). Default "authproxy".
     attributes:                       # static key/value resource attrs
       deployment.environment: prod
 
@@ -125,35 +125,35 @@ telemetry:
     logs: true
 
   http:
-    excluded_paths:                   # paths excluded from inbound HTTP spans + metrics
+    excludedPaths:                   # paths excluded from inbound HTTP spans + metrics
       - /ping
       - /healthz
 
   proxy:
-    span_attribute_labels:            # connection-label keys to project as proxy span attributes
+    spanAttributeLabels:            # connection-label keys to project as proxy span attributes
       - type
       - env
       - tenant_id
-    metric_dimension_labels:          # connection-label keys to project as metric attributes (proxy + oauth2)
+    metricDimensionLabels:          # connection-label keys to project as metric attributes (proxy + oauth2)
       - type
       - env
-    metric_dimension_value_cap: 50    # max distinct values per metric dim key; overflow collapses to "other"
+    metricDimensionValueCap: 50    # max distinct values per metric dim key; overflow collapses to "other"
 
   propagation:
-    inject_outbound_default: false    # global default for W3C traceparent injection on outbound calls
+    injectOutboundDefault: false    # global default for W3C traceparent injection on outbound calls
 ```
 
 Per-connector overrides for trace context propagation live on the connector definition:
 
 ```yaml
 connectors:
-  load_from_list:
+  loadFromList:
     - name: google-drive
       labels:
         type: google-drive
       auth: { type: OAuth2, ... }
       telemetry:
-        propagate_trace_context: true   # overrides telemetry.propagation.inject_outbound_default for this connector
+        propagateTraceContext: true   # overrides telemetry.propagation.injectOutboundDefault for this connector
 ```
 
 ## Standard `OTEL_*` env vars
@@ -164,7 +164,7 @@ The SDK honors the standard OpenTelemetry environment variables. YAML values tak
 - `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated `k=v` pairs (overridden by `telemetry.exporter.headers`).
 - `OTEL_EXPORTER_OTLP_PROTOCOL` — `grpc` or `http/protobuf` (overridden by `telemetry.exporter.protocol`).
 - `OTEL_RESOURCE_ATTRIBUTES` — comma-separated `k=v` pairs merged into the resource alongside `telemetry.resource.attributes`.
-- `OTEL_SERVICE_NAME` — overrides `resource.service_name_prefix + "-" + service_id` if set.
+- `OTEL_SERVICE_NAME` — overrides `resource.serviceNamePrefix + "-" + serviceId` if set.
 - `OTEL_METRIC_EXPORT_INTERVAL` — milliseconds. The SDK default is 60s; set to a smaller value for interactive dev (the dev sample uses `5000`).
 - `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` — `cumulative` (default — required for Prometheus exporters) or `delta`. The dev sample sets `cumulative` explicitly.
 
@@ -186,14 +186,14 @@ These are merged into `httpf.RequestInfo.Labels` via `ForConnection` (copies con
 
 Two separate keys in the config control projection:
 
-- **`telemetry.proxy.span_attribute_labels`** — keys whose values become **span attributes** on outbound proxy spans. Cheap; can tolerate higher cardinality.
-- **`telemetry.proxy.metric_dimension_labels`** — keys whose values become **metric dimensions** on outbound proxy metrics (also applied to OAuth2 lifecycle counters). Strictly bounded — every new value adds to the active series count in Prometheus.
+- **`telemetry.proxy.spanAttributeLabels`** — keys whose values become **span attributes** on outbound proxy spans. Cheap; can tolerate higher cardinality.
+- **`telemetry.proxy.metricDimensionLabels`** — keys whose values become **metric dimensions** on outbound proxy metrics (also applied to OAuth2 lifecycle counters). Strictly bounded — every new value adds to the active series count in Prometheus.
 
-A key in `span_attribute_labels` but not `metric_dimension_labels` shows up only on spans. Keys missing from both are dropped entirely. Keys not present in the effective set produce no attribute — they are absent, not empty strings.
+A key in `spanAttributeLabels` but not `metricDimensionLabels` shows up only on spans. Keys missing from both are dropped entirely. Keys not present in the effective set produce no attribute — they are absent, not empty strings.
 
 ### Value cap
 
-`telemetry.proxy.metric_dimension_value_cap` (off by default — set to a positive integer to enable) caps the number of **distinct values** per metric-dimension key. Once a key has admitted that many values, every new distinct value collapses to the literal string `"other"`. Previously-admitted values keep passing through verbatim. The cap is per-process and per-key — a multi-replica deployment caps independently on each replica.
+`telemetry.proxy.metricDimensionValueCap` (off by default — set to a positive integer to enable) caps the number of **distinct values** per metric-dimension key. Once a key has admitted that many values, every new distinct value collapses to the literal string `"other"`. Previously-admitted values keep passing through verbatim. The cap is per-process and per-key — a multi-replica deployment caps independently on each replica.
 
 This is the cardinality safety net for any allowlisted label whose value space might grow unboundedly (`tenant_id`, `customer_id`, etc.).
 
@@ -203,8 +203,8 @@ Outbound proxy requests **do not** inject W3C `traceparent` / `tracestate` by de
 
 Two knobs control this:
 
-- **Global default**: `telemetry.propagation.inject_outbound_default` (default `false`).
-- **Per-connector override**: `telemetry.propagate_trace_context` on the connector definition. Overrides the global default for outbound calls routed through that connector.
+- **Global default**: `telemetry.propagation.injectOutboundDefault` (default `false`).
+- **Per-connector override**: `telemetry.propagateTraceContext` on the connector definition. Overrides the global default for outbound calls routed through that connector.
 
 Inbound services accept incoming W3C headers via a parent-based sampler unconditionally — that's the normal OTel inbound contract and does not depend on this setting.
 
@@ -247,7 +247,7 @@ Each of the four services reports a distinct `service.name`:
 | `public` | `authproxy-public` |
 | `worker` | `authproxy-worker` |
 
-The prefix (`authproxy`) is configurable via `telemetry.resource.service_name_prefix`. Other resource attributes:
+The prefix (`authproxy`) is configurable via `telemetry.resource.serviceNamePrefix`. Other resource attributes:
 
 - `service.version` — from the build info (or empty in dev runs without an embedded version)
 - `service.instance.id` — random UUID per process start

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -13,6 +13,15 @@ Both publish generated Swagger 2.0 documentation when the service is running.
 The Admin URL uses the self-signed development certificate in a local checkout.
 Production URLs depend on deployment routing.
 
+:::caution[Breaking contract cutover]
+
+All AuthProxy-owned JSON fields, YAML fields, and URL query/path parameter names
+use lowerCamelCase. Snake_case input is rejected; there are no aliases or
+migration window. Reset persisted AuthProxy state before deploying this release
+instead of starting it against old serialized connector or configuration data.
+
+:::
+
 ## Which API to use
 
 - Use the **application API** for host-application resource access and
@@ -44,10 +53,10 @@ POST /api/v1/connections/_initiate
 Content-Type: application/json
 
 {
-  "connector_id": "cxr_01example",
-  "into_namespace": "root.acme",
+  "connectorId": "cxr_01example",
+  "intoNamespace": "root.acme",
   "name": "production-crm",
-  "return_to_url": "https://app.example.com/integrations/complete"
+  "returnToUrl": "https://app.example.com/integrations/complete"
 }
 ```
 
@@ -70,7 +79,7 @@ for reuse. The same name may appear on another resource type or in another
 namespace.
 
 A connector has one name shared by all definition versions. Rename it with
-`PATCH /api/v1/connectors/{connector_id}`. Version-specific create and update
+`PATCH /api/v1/connectors/{connectorId}`. Version-specific create and update
 requests do not accept a separate name. A namespace name is read-only and is
 derived from the final segment of its path.
 
@@ -91,7 +100,7 @@ The Admin cross-resource endpoint searches names directly and also searches
 user-label values:
 
 ```http
-GET /api/v1/search/resources?q=production&resource_type=connection
+GET /api/v1/search/resources?q=production&resourceType=connection
 ```
 
 Exact name matches rank before name prefixes, which rank before name

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -11,11 +11,11 @@ The development configuration demonstrates the full server shape at
 
 | Block | Purpose |
 |---|---|
-| `public`, `api`, `admin_api`, `worker` | Enabled services, ports, TLS, UI, and health behavior |
-| `host_application`, `marketplace` | Browser login handoff and Marketplace URL |
-| `system_auth` | JWT, actors, global encryption key, and DEK policy |
+| `public`, `api`, `adminApi`, `worker` | Enabled services, ports, TLS, UI, and health behavior |
+| `hostApplication`, `marketplace` | Browser login handoff and Marketplace URL |
+| `systemAuth` | JWT, actors, global encryption key, and DEK policy |
 | `database`, `redis` | Primary database and distributed state |
-| `app_metrics` | Request-event, resource-metric, and optional blob storage |
+| `appMetrics` | Request-event, resource-metric, and optional blob storage |
 | `connectors` | Connector loading and name-based reconciliation |
 | `tasks` | Task retention and worker behavior |
 | `telemetry` | OTLP exporter, signals, sampling, and label projection |
@@ -31,15 +31,15 @@ immutable `id`:
 
 ```yaml
 connectors:
-  auto_migrate: true
-  load_from_list:
+  autoMigrate: true
+  loadFromList:
     - name: google-drive
       namespace: root.integrations
       labels:
         type: google-drive
-      display_name: Google Drive
+      displayName: Google Drive
       logo:
-        public_url: https://example.com/google-drive.svg
+        publicUrl: https://example.com/google-drive.svg
       description: Connect to Google Drive.
       auth:
         type: no-auth
@@ -56,7 +56,7 @@ its ID fixed and change `name`. Changing the name of an ID-less entry describes
 a new connector, so the old config-managed connector enters the normal orphan
 cleanup flow.
 
-The former `connectors.identifying_labels` setting has been removed. Delete it
+The former `connectors.identifyingLabels` setting has been removed. Delete it
 from existing configuration and add a stable `name` to every connector entry
 that does not already specify `id`.
 

--- a/docs/src/content/docs/sdks/javascript.md
+++ b/docs/src/content/docs/sdks/javascript.md
@@ -138,7 +138,7 @@ const {data} = await client.post<ProxyResponse>(
   request,
 );
 
-console.log(data.status_code, data.body_json);
+console.log(data.statusCode, data.bodyJson);
 ```
 
 The wrapped endpoint buffers request and response bodies. For large files, chunked bodies, or server-sent events, use [`ap proxy`](/sdks/proxying/#use-ap-proxy) and the streaming raw endpoint instead.

--- a/docs/src/content/docs/sdks/proxying.md
+++ b/docs/src/content/docs/sdks/proxying.md
@@ -7,7 +7,7 @@ AuthProxy exposes two ways to send an HTTP request through a connection. Both au
 | Endpoint | Body handling | Response handling | Best for |
 |---|---|---|---|
 | `POST /api/v1/connections/{id}/_proxy` | JSON envelope; buffered | JSON envelope; buffered | Ordinary API calls and typed application code |
-| `ANY /api/v1/connections/{id}/_proxy_raw` | Original body streams through | Original response streams through | Large files, chunked bodies, and server-sent events |
+| `ANY /api/v1/connections/{id}/_proxyRaw` | Original body streams through | Original response streams through | Large files, chunked bodies, and server-sent events |
 
 In both cases, the `Authorization` credential presented to AuthProxy identifies the AuthProxy caller. AuthProxy does not forward that credential upstream; it applies authentication from the selected connection.
 
@@ -34,7 +34,7 @@ curl --request POST \
     "labels": {
       "app.example.com/tenant": "tenant-42"
     },
-    "body_json": {
+    "bodyJson": {
       "name": "example"
     }
   }'
@@ -48,29 +48,29 @@ The request fields are:
 | `method` | HTTP method such as `GET`, `POST`, or `PATCH` |
 | `headers` | Headers to send upstream, excluding provider credentials |
 | `labels` | Optional request labels used by rate limits, request events, and telemetry |
-| `body_json` | JSON request body |
-| `body_raw` | Base64-encoded request bytes; use instead of `body_json` |
+| `bodyJson` | JSON request body |
+| `bodyRaw` | Base64-encoded request bytes; use instead of `bodyJson` |
 
-`POST`, `PUT`, and `PATCH` requests require either `body_json` or `body_raw`. Do not set both.
+`POST`, `PUT`, and `PATCH` requests require either `bodyJson` or `bodyRaw`. Do not set both.
 
 AuthProxy returns the upstream result in a response envelope:
 
 ```json
 {
-  "status_code": 201,
+  "statusCode": 201,
   "headers": {
     "Content-Type": "application/json"
   },
-  "body_json": {
+  "bodyJson": {
     "id": "widget-123",
     "name": "example"
   }
 }
 ```
 
-The outer AuthProxy request returns `200` when an upstream response was received. Inspect `status_code` for the third-party status. AuthProxy authorization, validation, or transport failures use an error status on the outer request.
+The outer AuthProxy request returns `200` when an upstream response was received. Inspect `statusCode` for the third-party status. AuthProxy authorization, validation, or transport failures use an error status on the outer request.
 
-Responses with an `application/json` content type populate `body_json`. Other response bodies are returned as base64-encoded `body_raw`.
+Responses with an `application/json` content type populate `bodyJson`. Other response bodies are returned as base64-encoded `bodyRaw`.
 
 ### JavaScript
 
@@ -97,7 +97,7 @@ const request: ProxyRequest = {
   url: 'https://api.example.com/v1/widgets',
   method: 'POST',
   headers: {'Content-Type': 'application/json'},
-  body_json: {name: 'example'},
+  bodyJson: {name: 'example'},
 };
 
 const {data} = await client.post<ProxyResponse>(
@@ -105,8 +105,8 @@ const {data} = await client.post<ProxyResponse>(
   request,
 );
 
-if (data.status_code >= 400) {
-  throw new Error(`Upstream returned ${data.status_code}`);
+if (data.statusCode >= 400) {
+  throw new Error(`Upstream returned ${data.statusCode}`);
 }
 ```
 
@@ -118,7 +118,7 @@ The raw endpoint preserves streaming semantics in both directions. Send the upst
 
 ```bash
 curl --no-buffer \
-  "$AUTHPROXY_API_URL/api/v1/connections/$CONNECTION_ID/_proxy_raw" \
+  "$AUTHPROXY_API_URL/api/v1/connections/$CONNECTION_ID/_proxyRaw" \
   --header "Authorization: Bearer $TOKEN" \
   --header "X-AuthProxy-Upstream-URL: https://api.example.com/v1/events" \
   --header "Accept: text/event-stream" \

--- a/docs/src/content/docs/security/authentication-and-authorization.md
+++ b/docs/src/content/docs/security/authentication-and-authorization.md
@@ -16,7 +16,7 @@ recovery, or workforce/customer identity provider.
 
 ## Map Host Identities to Actors
 
-An actor represents a user or service principal. Its `external_id` should be a
+An actor represents a user or service principal. Its `externalId` should be a
 stable, non-reassignable identifier from the host system. Avoid mutable values
 such as email addresses when a durable user id is available.
 
@@ -25,7 +25,7 @@ For example:
 ```text
 Host tenant:    org_123
 Host principal: usr_456
-AuthProxy actor external_id: usr_456
+AuthProxy actor externalId: usr_456
 AuthProxy resource namespace: root.tenants.org_123
 ```
 
@@ -37,7 +37,7 @@ an email address, connection label, or other business metadata.
 | Path | Typical use | Security properties |
 |---|---|---|
 | Bearer JWT in `Authorization` | Host backend, CLI, automation | Signature and claims validated on each request; audience must include the receiving service |
-| One-time JWT in `auth_token` | Marketplace or Admin UI session handoff | Must include expiration and nonce; nonce is atomically marked used |
+| One-time JWT in `authToken` | Marketplace or Admin UI session handoff | Must include expiration and nonce; nonce is atomically marked used |
 | Browser session | Marketplace or Admin UI after handoff | Server-side state in Redis; encrypted session identifier in an `HttpOnly` cookie; XSRF token required for mutating session requests |
 | System-signed JWT | Internal AuthProxy handoffs and OAuth state | Minted and validated by AuthProxy services; protect internal signing material as production key material |
 
@@ -61,7 +61,7 @@ The embedded Marketplace and Admin UI use a delegated session flow:
 2. The host maps the user to an actor and decides what they may access.
 3. The host backend signs a short-lived JWT with the target AuthProxy service
    in `aud`, an expiration, and a one-time nonce.
-4. The host redirects to the AuthProxy UI with `auth_token=<jwt>`.
+4. The host redirects to the AuthProxy UI with `authToken=<jwt>`.
 5. The UI calls `POST /api/v1/session/_initiate`; AuthProxy validates the token, marks
    the nonce used, and establishes a server-side session.
 6. Later UI requests use the session cookie and an XSRF token for mutations.
@@ -72,9 +72,9 @@ Keep the handoff safe:
 - Keep the signing key in the backend and limit who can invoke the signing
   operation.
 - Use the shortest practical expiration and a fresh nonce for every handoff.
-- Allowlist `return_to` destinations. Do not turn the login endpoint into an
+- Allowlist `returnToUrl` destinations. Do not turn the login endpoint into an
   open redirect.
-- Avoid logging URLs that contain `auth_token`; scrub query strings at proxies,
+- Avoid logging URLs that contain `authToken`; scrub query strings at proxies,
   analytics tools, and error trackers.
 - Configure the external HTTPS URL correctly. Session cookies are `Secure` when
   AuthProxy is configured as HTTPS, so that setting must match ingress or proxy
@@ -99,7 +99,7 @@ permissions:
     verbs: [get, list, create, update]
   - namespace: root.tenants.org_123.**
     resources: [connections]
-    resource_ids: [cxn_example]
+    resourceIds: [cxn_example]
     verbs: [proxy]
 ```
 
@@ -132,7 +132,7 @@ while a task token can be limited to proxying through one connection:
 permissions:
   - namespace: root.tenants.org_123
     resources: [connections]
-    resource_ids: [cxn_salesforce]
+    resourceIds: [cxn_salesforce]
     verbs: [proxy]
 ```
 

--- a/docs/src/content/docs/security/encryption.md
+++ b/docs/src/content/docs/security/encryption.md
@@ -52,7 +52,7 @@ replace permission checks or datastore access controls.
 
 ```mermaid
 flowchart TD
-    Global["Global key<br/>system_auth.global_aes_key"]
+    Global["Global key<br/>systemAuth.globalAesKey"]
     Tenant["Logical key<br/>root.tenants.acme"]
     App["Logical key<br/>root.tenants.acme.billing"]
     GDEK["Current and retained DEKs"]
@@ -148,10 +148,10 @@ The default policy ensures every active data-encryption key has a current DEK
 and rotates it after 90 days:
 
 ```yaml
-system_auth:
-  data_encryption_keys:
-    ensure_current: true
-    rotation_interval: 2160h
+systemAuth:
+  dataEncryptionKeys:
+    ensureCurrent: true
+    rotationInterval: 2160h
 ```
 
 The normal worker schedule runs DEK generation and key sync every 15 minutes,
@@ -161,7 +161,7 @@ contains the detailed data model, migration history, and implementation checks.
 
 ## Operational Requirements
 
-- Configure a durable `system_auth.global_aes_key`; do not rely on an
+- Configure a durable `systemAuth.globalAesKey`; do not rely on an
   ephemeral startup key in production.
 - Keep fake encryption disabled. With `dev_settings.fake_encryption`, values
   labeled as encrypted are stored as plaintext.

--- a/docs/src/content/docs/security/index.md
+++ b/docs/src/content/docs/security/index.md
@@ -156,7 +156,7 @@ permissions. See [Application Metrics](/operations/app-metrics/).
 
 ### Keys and Storage
 
-- [ ] `system_auth.global_aes_key` uses durable, recoverable production key
+- [ ] `systemAuth.globalAesKey` uses durable, recoverable production key
   material; fake encryption, inline values, and ephemeral random keys are not
   used in production.
 - [ ] KMS/secret-manager identities have only the operations and keys they


### PR DESCRIPTION
## Summary
- replace AuthProxy-owned JSON, YAML, and URL examples with lowerCamelCase
- explicitly document the breaking cutover, snake_case rejection, no migration path, and demo reset/deploy workflow
- preserve documented opaque payload and non-contract naming examples

## Verification
- yarn docs:build