### PR TITLE
Fix camelCase integration test configuration

### DIFF
--- a/integration_tests/config/integration.yaml
+++ b/integration_tests/config/integration.yaml
@@ -8,45 +8,45 @@ public:
 api:
   port: 0  # random port
 
-admin_api:
+adminApi:
   port: 0  # random port
 
 worker:
-  health_check_port: 0
-  cron_sync_interval: 1m
+  healthCheckPort: 0
+  cronSyncInterval: 1m
 
 tasks:
-  default_retention: 24h
+  defaultRetention: 24h
 
-host_application:
-  initiate_session_url: http://127.0.0.1:8888/login-redirect
+hostApplication:
+  initiateSessionUrl: http://127.0.0.1:8888/login-redirect
 
 marketplace:
-  base_url: http://localhost:5173
+  baseUrl: http://localhost:5173
 
-system_auth:
-  jwt_signing_key:
-    public_key:
+systemAuth:
+  jwtSigningKey:
+    publicKey:
       path: ./dev_config/keys/system.pub
-    private_key:
+    privateKey:
       path: ./dev_config/keys/system
   actors:
-    keys_path: ./dev_config/keys/admin
+    keysPath: ./dev_config/keys/admin
     permissions:
       - namespace: root.**
         resources:
           - "*"
         verbs:
           - "*"
-  global_aes_key:
+  globalAesKey:
     path: ./dev_config/keys/global_aes.key
 
-error_pages:
-  internal_error: https://example.com/500.html
+errorPages:
+  internalError: https://example.com/500.html
 
 database:
   provider: postgres
-  auto_migrate: true
+  autoMigrate: true
   host: localhost
   port: 5433
   user: postgres
@@ -58,28 +58,28 @@ logging:
   type: tint
   level: warn
 
-app_metrics:
-  resource_snapshot_interval: 15m
-  request_events:
-    full_request_recording: always
+appMetrics:
+  resourceSnapshotInterval: 15m
+  requestEvents:
+    fullRequestRecording: always
   database:
     provider: clickhouse
-    auto_migrate: true
+    autoMigrate: true
     user: authproxy
     password: authproxy
     addresses:
       - localhost:8124
     database: authproxy
-  blob_storage:
+  blobStorage:
     provider: s3
     endpoint: http://localhost:9003
     region: us-east-1
     bucket: authproxy-request-logs
     credentials:
       type: access_key
-      access_key_id: minioadmin
-      secret_access_key: minioadmin
-    force_path_style: true
+      accessKeyId: minioadmin
+      secretAccessKey: minioadmin
+    forcePathStyle: true
     prefix: "integration-test/"
 
 redis:
@@ -87,9 +87,9 @@ redis:
   address: localhost:6380
 
 oauth:
-  round_trip_ttl: 60m
+  roundTripTtl: 60m
 
 connectors:
-  auto_migrate: true
-  auto_migration_lock_duration: 30s
-  load_from_list: []
+  autoMigrate: true
+  autoMigrationLockDuration: 30s
+  loadFromList: []


### PR DESCRIPTION
## Summary
- Convert every AuthProxy-owned field in integration_tests/config/integration.yaml to lowerCamelCase.
- Preserve the access_key enum value unchanged.
- Restore integration config validation after the contract cutover.

## Validation
- cd integration_tests && go test ./config -count=1
- ./scripts/preflight.sh

The full local integration suite gets past configuration loading; it cannot complete in this checkout because Compose exposes ClickHouse at 8123 while the CI fixture correctly targets its 8124 service mapping.