### PR TITLE
Fix camelCase integration consumers

### DIFF
--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -129,7 +129,7 @@ func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []s
 
 	endpoint := h.PublicURL + "/api/v1/connectors?limit=100"
 	if labelSelector != "" {
-		endpoint += "&label_selector=" + url.QueryEscape(labelSelector)
+		endpoint += "&labelSelector=" + url.QueryEscape(labelSelector)
 	}
 
 	var list schemaapi.ListConnectorsResponseJson

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -285,7 +285,7 @@ func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID
 }
 
 // FollowOAuth2Redirect issues an in-process GET to the public service's
-// `/oauth2/redirect` endpoint with the same state_id and signed JWT the user's
+// `/oauth2/redirect` endpoint with the same stateId and signed JWT the user's
 // browser would carry, and returns the Location header — the URL of the OAuth
 // provider's authorize endpoint. The proxy generates the upstream URL from the
 // connector config, so callers can assert on its query parameters.
@@ -361,13 +361,13 @@ type OAuth2StateForTest struct {
 	Namespace              string                `json:"namespace"`
 	ActorId                apid.ID               `json:"actorId"`
 	ConnectorId            apid.ID               `json:"connectorId"`
-	ConnectorVersion       uint64                `json:"connector_version"`
+	ConnectorVersion       uint64                `json:"connectorVersion"`
 	ConnectionId           apid.ID               `json:"connectionId"`
 	ReturnToUrl            string                `json:"returnToUrl"`
-	CancelSessionAfterAuth bool                  `json:"cancel_session_after_auth"`
-	ExpiresAt              time.Time             `json:"expires_at"`
-	PKCECodeVerifier       string                `json:"pkce_code_verifier,omitempty"`
-	PKCEMethod             connectors.PKCEMethod `json:"pkce_method,omitempty"`
+	CancelSessionAfterAuth bool                  `json:"cancelSessionAfterAuth"`
+	ExpiresAt              time.Time             `json:"expiresAt"`
+	PKCECodeVerifier       string                `json:"pkceCodeVerifier,omitempty"`
+	PKCEMethod             connectors.PKCEMethod `json:"pkceMethod,omitempty"`
 }
 
 // WriteOAuth2StateForTest encrypts and stores a synthetic OAuth2 state

--- a/integration_tests/helpers/version_migration.go
+++ b/integration_tests/helpers/version_migration.go
@@ -228,7 +228,7 @@ func (env *IntegrationTestEnv) ListNotifications(
 		q.Set("state", string(state))
 	}
 	if includeViewed {
-		q.Set("include_viewed", "true")
+		q.Set("includeViewed", "true")
 	}
 	path := "/api/v1/notifications"
 	if encoded := q.Encode(); encoded != "" {

--- a/integration_tests/oauth2/callback_actor_mismatch_test.go
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.go
@@ -83,8 +83,8 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnTo, helpers.WithActor(attackerExternalID, sconfig.RootNamespace))
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed state_id in redirect URL: %s", redirectURL)
+	stateID := parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed stateId in redirect URL: %s", redirectURL)
 
 	// 2. Mint a code via the test provider's /test/authorize. The provider
 	//    doesn't care which proxy actor owns the state — it's validating

--- a/integration_tests/oauth2/callback_cross_namespace_test.go
+++ b/integration_tests/oauth2/callback_cross_namespace_test.go
@@ -98,8 +98,8 @@ func TestCallbackRejection_CrossNamespace(t *testing.T) {
 	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnTo, helpers.WithActor(sharedExternalID, tenantA))
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed state_id: %s", redirectURL)
+	stateID := parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2ConnectionAsActor should embed stateId: %s", redirectURL)
 
 	// 2. Mint a code via the test provider's /test/authorize. The provider
 	//    only validates against its own client/user records, so the

--- a/integration_tests/oauth2/callback_state_security_test.go
+++ b/integration_tests/oauth2/callback_state_security_test.go
@@ -106,14 +106,14 @@ func newCallbackStateSecurityRig(t *testing.T, name string) *callbackStateSecuri
 
 // initiateAndStateID kicks off a connection and returns the connection
 // ID plus the state UUID the proxy persisted in Redis. The state UUID
-// rides in the `state_id` query of the redirect URL.
+// rides in the `stateId` query of the redirect URL.
 func (r *callbackStateSecurityRig) initiateAndStateID(t *testing.T) (connectionID, stateID string) {
 	t.Helper()
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID = parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id in redirect URL: %s", redirectURL)
+	stateID = parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed stateId in redirect URL: %s", redirectURL)
 	return connID, stateID
 }
 

--- a/integration_tests/oauth2/callback_token_exchange_failure_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_failure_test.go
@@ -109,8 +109,8 @@ func (r *tokenExchangeFailureRig) initiateAndMintCode(t *testing.T) (connectionI
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID = parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+	stateID = parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed stateId: %s", redirectURL)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{
 		ClientID:    r.clientKey,

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.go
@@ -95,8 +95,8 @@ func (r *tokenExchangeRetryRig) initiateAndMintCode(t *testing.T) (connectionID,
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID = parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+	stateID = parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed stateId: %s", redirectURL)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{
 		ClientID:    r.clientKey,

--- a/integration_tests/oauth2/connector_disconnect_all_test.go
+++ b/integration_tests/oauth2/connector_disconnect_all_test.go
@@ -115,7 +115,7 @@ func (r *connectorDisconnectAllRig) completeAuthFlow(t *testing.T, connector con
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, connector.id, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -99,7 +99,7 @@ func (r *disconnectRevocationRig) completeAuthFlow(t *testing.T) string {
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/incremental_authorization_test.go
+++ b/integration_tests/oauth2/incremental_authorization_test.go
@@ -166,8 +166,8 @@ func (r *incrementalAuthRig) approveOAuthRedirect(t *testing.T, redirectURL stri
 
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "redirect should embed state_id: %s", redirectURL)
+	stateID := parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "redirect should embed stateId: %s", redirectURL)
 
 	scope := "read_write"
 	if scopeOverride != nil {

--- a/integration_tests/oauth2/multiple_connections_test.go
+++ b/integration_tests/oauth2/multiple_connections_test.go
@@ -146,7 +146,7 @@ func completeAuthFlowWithRedirect(t *testing.T, r *proxyRefreshRig, connID, redi
 
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/pkce_test.go
+++ b/integration_tests/oauth2/pkce_test.go
@@ -331,13 +331,13 @@ func TestPKCE_TokenExchangeRejected(t *testing.T) {
 			// Step 1: initiate. The state record is written to Redis with a
 			// freshly generated verifier (because the connector has a PKCE
 			// block); the redirect URL points at /oauth2/redirect with the
-			// new state_id.
+			// new stateId.
 			connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnToURL)
 
 			redirectParsed, err := url.Parse(redirectURL)
 			require.NoError(t, err)
-			stateIDStr := redirectParsed.Query().Get("state_id")
-			require.NotEmpty(t, stateIDStr, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+			stateIDStr := redirectParsed.Query().Get("stateId")
+			require.NotEmpty(t, stateIDStr, "InitiateOAuth2Connection should embed stateId: %s", redirectURL)
 			stateID, err := apid.Parse(stateIDStr)
 			require.NoError(t, err)
 

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.go
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.go
@@ -111,7 +111,7 @@ func (r *authMethodCompatibilityRig) completeAuthFlow(t *testing.T, pkce bool) (
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsedRedirect, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsedRedirect.Query().Get("state_id")
+	stateID := parsedRedirect.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authReq := helpers.AuthorizeRequest{
@@ -231,7 +231,7 @@ func TestProviderAuthMethodCompatibility_InvalidMethodFailsClearly(t *testing.T)
 	connID, redirectURL := rig.env.InitiateOAuth2Connection(t, rig.connectorID, rig.returnToURL)
 	parsedRedirect, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsedRedirect.Query().Get("state_id")
+	stateID := parsedRedirect.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := rig.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -113,7 +113,7 @@ func (r *proxyRefreshRig) completeAuthFlow(t *testing.T) string {
 	connID, redirectURL := r.env.InitiateOAuth2Connection(t, r.connectorID, r.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := r.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/proxy_third_party_revocation_test.go
+++ b/integration_tests/oauth2/proxy_third_party_revocation_test.go
@@ -24,10 +24,10 @@ import (
 // succeeded) from 401 (refresh-then-replay failed, original upstream
 // 401 propagated).
 type proxyResponseBody struct {
-	StatusCode int                    `json:"status_code"`
+	StatusCode int                    `json:"statusCode"`
 	Headers    map[string]string      `json:"headers"`
-	BodyRaw    []byte                 `json:"body_raw"`
-	BodyJson   map[string]interface{} `json:"body_json"`
+	BodyRaw    []byte                 `json:"bodyRaw"`
+	BodyJson   map[string]interface{} `json:"bodyJson"`
 }
 
 func parseRevocationProxyResponse(t *testing.T, w *httptest.ResponseRecorder) proxyResponseBody {

--- a/integration_tests/oauth2/redaction_test.go
+++ b/integration_tests/oauth2/redaction_test.go
@@ -146,7 +146,7 @@ func TestRedaction_HappyPathFlowLeaksNoSecrets(t *testing.T) {
 	connID, redirectURL := rig.env.InitiateOAuth2Connection(t, rig.connectorID, rig.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := rig.provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/oauth2/scope_mismatch_test.go
+++ b/integration_tests/oauth2/scope_mismatch_test.go
@@ -114,8 +114,8 @@ func (s *scopeMismatchSetup) driveApprovalAndGetConnectionId(t *testing.T) strin
 	connID, redirectURL := s.env.InitiateOAuth2Connection(t, s.connectorID, s.returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed state_id: %s", redirectURL)
+	stateID := parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "InitiateOAuth2Connection should embed stateId: %s", redirectURL)
 
 	authResp := s.provider.Authorize(helpers.AuthorizeRequest{
 		ClientID:    s.clientKey,

--- a/integration_tests/probes/oauth2_probe_health_test.go
+++ b/integration_tests/probes/oauth2_probe_health_test.go
@@ -94,7 +94,7 @@ func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
 	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnToURL)
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
+	stateID := parsed.Query().Get("stateId")
 	require.NotEmpty(t, stateID)
 
 	authResp := provider.Authorize(helpers.AuthorizeRequest{

--- a/integration_tests/proxy/ratelimit_test.go
+++ b/integration_tests/proxy/ratelimit_test.go
@@ -20,10 +20,10 @@ import (
 
 // proxyResponse mirrors the JSON structure returned by the proxy endpoint.
 type proxyResponse struct {
-	StatusCode int               `json:"status_code"`
+	StatusCode int               `json:"statusCode"`
 	Headers    map[string]string `json:"headers"`
-	BodyRaw    []byte            `json:"body_raw"`
-	BodyJson   interface{}       `json:"body_json"`
+	BodyRaw    []byte            `json:"bodyRaw"`
+	BodyJson   interface{}       `json:"bodyJson"`
 }
 
 func parseProxyResponse(t *testing.T, w *httptest.ResponseRecorder) *proxyResponse {

--- a/integration_tests/terraform/connector_test.go
+++ b/integration_tests/terraform/connector_test.go
@@ -10,7 +10,7 @@ import (
 
 // minimalConnectorDefinition is a simple NoAuth connector definition for testing.
 const minimalConnectorDefinition = `{
-  "display_name": "Test Connector",
+  "displayName": "Test Connector",
   "description": "A test connector for integration tests",
   "auth": {
     "type": "no-auth"
@@ -18,7 +18,7 @@ const minimalConnectorDefinition = `{
 }`
 
 const updatedConnectorDefinition = `{
-  "display_name": "Test Connector Updated",
+  "displayName": "Test Connector Updated",
   "description": "An updated test connector",
   "auth": {
     "type": "no-auth"

--- a/integration_tests/version_migration/oauth_test.go
+++ b/integration_tests/version_migration/oauth_test.go
@@ -220,8 +220,8 @@ func (r *oauthMigrationRig) authorizeAndDeliverCallback(t *testing.T, redirectUR
 
 	parsed, err := url.Parse(redirectURL)
 	require.NoError(t, err)
-	stateID := parsed.Query().Get("state_id")
-	require.NotEmpty(t, stateID, "redirect should embed state_id: %s", redirectURL)
+	stateID := parsed.Query().Get("stateId")
+	require.NotEmpty(t, stateID, "redirect should embed stateId: %s", redirectURL)
 
 	authorize := r.provider.Authorize(helpers.AuthorizeRequest{
 		ClientID:    r.clientKey,


### PR DESCRIPTION
## Summary
- Consume camelCase AuthProxy query keys in integration helpers and OAuth tests.
- Decode camelCase proxy response envelopes and serialized OAuth state fixtures.
- Update Terraform test connector-definition JSON while preserving Terraform snake_case schema.

## Validation
- Affected Go integration packages compile.
- Integration config test passes.
- scripts/preflight.sh passes.

Full runtime integration coverage will run from the final feature PR after this is merged.