### PR TITLE
Fix camelCase integration test fixtures

### DIFF
--- a/integration_tests/oauth2/provider_timeouts_test.go
+++ b/integration_tests/oauth2/provider_timeouts_test.go
@@ -165,7 +165,7 @@ func TestTokenRefreshTimeout_RetriesAndExhausts(t *testing.T) {
 	require.Lenf(t, failed, 1, "exhausted refresh timeout must emit exactly one refresh-failed event; got %d (%v)", len(failed), failed)
 	event := failed[0]
 	assert.Equal(t, "network_error", event["category"])
-	assert.Equal(t, connID, event["connectionId"])
+	assert.Equal(t, connID, event["connection_id"])
 	assert.Equalf(t, float64(tokenRefreshMaxAttempts), event["attempts"],
 		"failure event should record attempts=tokenRefreshMaxAttempts on exhaustion")
 	_, hasStatus := event["provider_status_code"]

--- a/integration_tests/oauth2/proxy_refresh_failure_test.go
+++ b/integration_tests/oauth2/proxy_refresh_failure_test.go
@@ -159,7 +159,7 @@ func TestProxyRefreshFailure_Scenarios(t *testing.T) {
 			require.Lenf(t, failed, 1, "expected exactly one refresh-failed event; got %d (%v)", len(failed), failed)
 			event := failed[0]
 			assert.Equal(t, tc.expectedCategory, event["category"], "failure category mismatch")
-			assert.Equal(t, connID, event["connectionId"])
+			assert.Equal(t, connID, event["connection_id"])
 			if tc.expectedStatusCode != 0 {
 				assert.Equal(t, float64(tc.expectedStatusCode), event["provider_status_code"],
 					"provider_status_code mismatch for %s", tc.name)

--- a/integration_tests/oauth2/proxy_refresh_retry_test.go
+++ b/integration_tests/oauth2/proxy_refresh_retry_test.go
@@ -114,7 +114,7 @@ func TestProxyRefresh_TransientRetrySucceeds(t *testing.T) {
 	// must stay clean on eventual success.
 	succeeded := rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage)
 	require.Lenf(t, succeeded, 1, "retried success must emit exactly one refresh-succeeded event; got %d", len(succeeded))
-	assert.Equal(t, connID, succeeded[0]["connectionId"])
+	assert.Equal(t, connID, succeeded[0]["connection_id"])
 	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
 		"retried success must not emit a refresh-failed event")
 
@@ -175,7 +175,7 @@ func TestProxyRefresh_TransientRetryExhausted(t *testing.T) {
 	require.Lenf(t, failed, 1, "exhausted retry must emit exactly one refresh-failed event; got %d (%v)", len(failed), failed)
 	event := failed[0]
 	assert.Equal(t, "provider_5xx", event["category"])
-	assert.Equal(t, connID, event["connectionId"])
+	assert.Equal(t, connID, event["connection_id"])
 	assert.Equal(t, float64(503), event["provider_status_code"])
 	assert.Equalf(t, float64(tokenRefreshMaxAttempts), event["attempts"],
 		"failure event should record attempts=tokenRefreshMaxAttempts on exhaustion")

--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -229,10 +229,10 @@ func TestProxyRefresh_ExpiredAccessTokenRefreshes(t *testing.T) {
 	assert.Equalf(t, 1, refreshCalls,
 		"expected exactly one grant_type=refresh_token call; got %d", refreshCalls)
 
-	// Structured success event with the right connectionId.
+	// Structured success event with the right connection_id log attribute.
 	succeeded := rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage)
 	require.Lenf(t, succeeded, 1, "expected exactly one refresh-succeeded event; got %d", len(succeeded))
-	assert.Equal(t, connID, succeeded[0]["connectionId"])
+	assert.Equal(t, connID, succeeded[0]["connection_id"])
 
 	// No refresh-failed event — even one would corrupt dashboards.
 	assert.Empty(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage),
@@ -319,7 +319,7 @@ func TestProxyRefresh_NoRefreshTokenFlipsUnhealthy(t *testing.T) {
 	failed := rig.logCapture.RecordsWithMessage(t, tokenRefreshFailureMessage)
 	require.Lenf(t, failed, 1, "expected exactly one refresh-failed event; got %d", len(failed))
 	assert.Equal(t, "no_refresh_token", failed[0]["category"])
-	assert.Equal(t, connID, failed[0]["connectionId"])
+	assert.Equal(t, connID, failed[0]["connection_id"])
 
 	// Health-state-changed event with reason=refresh_no_refresh_token.
 	// This is what dashboards correlate with the refresh-failure event.

--- a/integration_tests/oauth2/proxy_response_handling_test.go
+++ b/integration_tests/oauth2/proxy_response_handling_test.go
@@ -114,7 +114,7 @@ func TestProxyResponseHandling_401RefreshesAndRetriesOnce(t *testing.T) {
 
 	retryEvents := rig.logCapture.RecordsWithMessage(t, proxyUpstreamRetryAttemptedMessage)
 	require.Lenf(t, retryEvents, 1, "401 self-heal should emit exactly one retry-attempt event; got %d", len(retryEvents))
-	assert.Equal(t, connID, retryEvents[0]["connectionId"])
+	assert.Equal(t, connID, retryEvents[0]["connection_id"])
 	assert.Equal(t, float64(401), retryEvents[0]["provider_status_code"])
 	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
 		"401 self-heal should emit one refresh-succeeded event")
@@ -150,7 +150,7 @@ func TestProxyResponseHandling_Persistent401RefreshesOnceThenSurfaces(t *testing
 		"persistent 401 should emit exactly one retry-attempt event")
 	authFailures := rig.logCapture.RecordsWithMessage(t, proxyUpstreamAuthFailureMessage)
 	require.Lenf(t, authFailures, 1, "persistent final 401 should emit one auth-failure event; got %d", len(authFailures))
-	assert.Equal(t, connID, authFailures[0]["connectionId"])
+	assert.Equal(t, connID, authFailures[0]["connection_id"])
 	assert.Equal(t, float64(401), authFailures[0]["provider_status_code"])
 	require.Lenf(t, rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage), 1,
 		"persistent 401 still refreshes successfully once")
@@ -205,7 +205,7 @@ func TestProxyResponseHandling_429DoesNotRefresh(t *testing.T) {
 
 	rateLimitEvents := rig.logCapture.RecordsWithMessage(t, proxyUpstreamRateLimitedMessage)
 	require.Lenf(t, rateLimitEvents, 1, "429 should emit one rate-limit event; got %d", len(rateLimitEvents))
-	assert.Equal(t, connID, rateLimitEvents[0]["connectionId"])
+	assert.Equal(t, connID, rateLimitEvents[0]["connection_id"])
 	assert.Equal(t, float64(429), rateLimitEvents[0]["provider_status_code"])
 	assert.Equal(t, "7", rateLimitEvents[0]["retry_after"])
 	assert.Equal(t, float64(7), rateLimitEvents[0]["retry_after_seconds"])

--- a/integration_tests/oauth2/proxy_third_party_revocation_test.go
+++ b/integration_tests/oauth2/proxy_third_party_revocation_test.go
@@ -145,7 +145,7 @@ func TestProxyRevocation_UserRevocationFlipsUnhealthy(t *testing.T) {
 	// so we assert what the provider actually returns.
 	assert.Equal(t, "provider_4xx_other", failed[0]["category"],
 		"category reflects the test provider's non-RFC error string ('Refresh token revoked')")
-	assert.Equal(t, connID, failed[0]["connectionId"])
+	assert.Equal(t, connID, failed[0]["connection_id"])
 	assert.Equal(t, float64(400), failed[0]["provider_status_code"])
 	assert.Equal(t, "Refresh token revoked", failed[0]["provider_error"])
 
@@ -242,7 +242,7 @@ func TestProxyRevocation_AccessOnlyRevocationSelfHealsViaRefresh(t *testing.T) {
 	succeeded := rig.logCapture.RecordsWithMessage(t, tokenRefreshSuccessMessage)
 	require.Lenf(t, succeeded, 1,
 		"self-heal must emit exactly one refresh-succeeded event; got %d", len(succeeded))
-	assert.Equal(t, connID, succeeded[0]["connectionId"])
+	assert.Equal(t, connID, succeeded[0]["connection_id"])
 
 	// Exactly one refresh-token POST on the wire — the 401-retry
 	// path fires once and the replay succeeds, so no further refresh

--- a/integration_tests/terraform/connector_test.go
+++ b/integration_tests/terraform/connector_test.go
@@ -44,7 +44,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Test Connector"
+    displayName = "Test Connector"
     description  = "A test connector for integration tests"
     auth = {
       type = "no-auth"
@@ -72,7 +72,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Test Connector Updated"
+    displayName = "Test Connector Updated"
     description  = "An updated test connector"
     auth = {
       type = "no-auth"
@@ -108,7 +108,7 @@ resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   publish    = false
   definition = jsonencode({
-    display_name = "Draft Connector"
+    displayName = "Draft Connector"
     description  = "A draft connector"
     auth = {
       type = "no-auth"
@@ -146,7 +146,7 @@ resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   publish    = false
   definition = jsonencode({
-    display_name = "Transitioning Connector"
+    displayName = "Transitioning Connector"
     description  = "Will be promoted"
     auth = {
       type = "no-auth"
@@ -170,7 +170,7 @@ resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   publish    = true
   definition = jsonencode({
-    display_name = "Transitioning Connector"
+    displayName = "Transitioning Connector"
     description  = "Will be promoted"
     auth = {
       type = "no-auth"
@@ -205,7 +205,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Labeled Connector"
+    displayName = "Labeled Connector"
     description  = "Connector with labels"
     auth = {
       type = "no-auth"
@@ -230,7 +230,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Labeled Connector"
+    displayName = "Labeled Connector"
     description  = "Connector with labels"
     auth = {
       type = "no-auth"
@@ -271,7 +271,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Annotated Connector"
+    displayName = "Annotated Connector"
     description  = "Connector with annotations"
     auth = {
       type = "no-auth"
@@ -300,7 +300,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Annotated Connector"
+    displayName = "Annotated Connector"
     description  = "Connector with annotations"
     auth = {
       type = "no-auth"
@@ -328,7 +328,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Annotated Connector"
+    displayName = "Annotated Connector"
     description  = "Connector with annotations"
     auth = {
       type = "no-auth"
@@ -369,7 +369,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "Import Test Connector"
+    displayName = "Import Test Connector"
     description  = "For import testing"
     auth = {
       type = "no-auth"
@@ -403,7 +403,7 @@ resource "authproxy_namespace" "test" {
 resource "authproxy_connector" "test" {
   namespace  = authproxy_namespace.test.path
   definition = jsonencode({
-    display_name = "DataSource Test Connector"
+    displayName = "DataSource Test Connector"
     description  = "For data source testing"
     auth = {
       type = "no-auth"


### PR DESCRIPTION
## Summary
- emit displayName from every Terraform jsonencode connector definition
- retain connection_id for structured log assertions, which are intentionally excluded from the public camelCase wire contract

## Validation
- Affected OAuth and Terraform integration packages compile.
- Integration configuration test passes.
- scripts/preflight.sh passes.

The full integration workflow will rerun from the final feature PR after merge.