### PR TITLE
Fix signing proxy config guidance

### DIFF
--- a/cmd/cli/login_redirect.go
+++ b/cmd/cli/login_redirect.go
@@ -26,11 +26,11 @@ func httpServerForLoginRedirect(
 		if req.Method != "GET" || req.URL.Path != loginRedirectPath {
 			configProps := make([]string, 0)
 			if marketplaceUrl != "" {
-				configProps = append(configProps, "<tt>host_application.initiate_session_url</tt>")
+				configProps = append(configProps, "<tt>hostApplication.initiateSessionUrl</tt>")
 			}
 
 			if adminUiUrl != "" {
-				configProps = append(configProps, "<tt>admin_api.ui.initiate_session_url</tt>")
+				configProps = append(configProps, "<tt>adminApi.ui.initiateSessionUrl</tt>")
 			}
 
 			log.Printf("[404] %s %s", req.Method, req.URL)
@@ -147,11 +147,11 @@ func cmdMarketplaceLoginRedirect() *cobra.Command {
 
 			validRedirectUrl := fmt.Sprintf("%s://%s:%d%s", proto, ip, port, loginRedirectPath)
 			if marketplaceUrl != "" {
-				log.Printf("Configure host_application.initiate_session_url to %s", validRedirectUrl)
+				log.Printf("Configure hostApplication.initiateSessionUrl to %s", validRedirectUrl)
 			}
 
 			if adminUiUrl != "" {
-				log.Printf("Configure admin_api.ui.initiate_session_url to %s", validRedirectUrl)
+				log.Printf("Configure adminApi.ui.initiateSessionUrl to %s", validRedirectUrl)
 			}
 
 			server := &http.Server{

--- a/cmd/cli/signing_proxy.go
+++ b/cmd/cli/signing_proxy.go
@@ -164,11 +164,11 @@ func cmdSigningProxy() *cobra.Command {
 
 				validRedirectUrl := fmt.Sprintf("%s://%s:%d%s", proto, ip, port, loginRedirectPath)
 				if marketplaceUrl != "" {
-					log.Printf("Configure host_application.initiate_session_url to %s", validRedirectUrl)
+					log.Printf("Configure hostApplication.initiateSessionUrl to %s", validRedirectUrl)
 				}
 
 				if adminUiUrl != "" {
-					log.Printf("Configure admin_api.ui.initiate_session_url to %s", validRedirectUrl)
+					log.Printf("Configure adminApi.ui.initiateSessionUrl to %s", validRedirectUrl)
 				}
 
 				marketplaceRedirectHandler := httpServerForLoginRedirect(validRedirectUrl, marketplaceUrl, adminUiUrl, tb)


### PR DESCRIPTION
## Summary
- print camelCase hostApplication and adminApi configuration paths from signing-proxy
- align the standalone login-redirect command and its error page with the same paths

## Validation
- scripts/preflight.sh passes.