### PR TITLE
Fix login redirect return URL parameter

### DIFF
--- a/cmd/cli/login_redirect.go
+++ b/cmd/cli/login_redirect.go
@@ -52,7 +52,7 @@ func httpServerForLoginRedirect(
 			return
 		}
 
-		returnTo := req.URL.Query().Get("returnTo")
+		returnTo := req.URL.Query().Get("returnToUrl")
 
 		if returnTo == "" {
 			log.Printf("[400] %s %s", req.Method, req.URL)
@@ -67,7 +67,7 @@ func httpServerForLoginRedirect(
 	</head>
 	<body>
 		<h1>No Return To Specified</h1>
-		<p>Request did not include the <tt>returnTo</tt> query parameter to specify path to return auth token.</p>
+		<p>Request did not include the <tt>returnToUrl</tt> query parameter to specify path to return auth token.</p>
 	</body>
 </html>
 `))


### PR DESCRIPTION
## Summary
- accept the camelCase returnToUrl query parameter in the local login-redirect handler
- align the missing-parameter page with the supported parameter name

## Validation
- scripts/preflight.sh passes.