### PR TITLE
Fix setup schema property names

### DIFF
--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -284,7 +284,7 @@ connectors:
               required:
                 - calendar_id
               properties:
-                calendarId:
+                calendar_id:
                   type: string
                   title: Calendar
                   x-data-source: calendars
@@ -307,7 +307,7 @@ connectors:
             jsonSchema:
               type: object
               properties:
-                includeDeclined:
+                include_declined:
                   type: boolean
                   title: Include declined events
             uiSchema:

--- a/ui/marketplace/src/stories/Marketplace.stories.tsx
+++ b/ui/marketplace/src/stories/Marketplace.stories.tsx
@@ -162,7 +162,7 @@ const setupStep = {
     type: 'object',
     required: ['calendar_id'],
     properties: {
-      calendarId: {
+      calendar_id: {
         type: 'string',
         title: 'Calendar',
         enum: ['primary', 'product', 'support'],

--- a/ui/marketplace/src/tests/ConnectionList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectionList.test.tsx
@@ -247,7 +247,7 @@ describe('ConnectionList', () => {
                     jsonSchema: {
                         type: 'object',
                         properties: {
-                            calendarId: {
+                            calendar_id: {
                                 type: 'string',
                                 title: 'Calendar',
                                 enum: ['primary'],

--- a/ui/marketplace/src/tests/ConnectorList.test.tsx
+++ b/ui/marketplace/src/tests/ConnectorList.test.tsx
@@ -219,7 +219,7 @@ describe('ConnectorList', () => {
                     jsonSchema: {
                         type: 'object',
                         properties: {
-                            calendarId: {
+                            calendar_id: {
                                 type: 'string',
                                 title: 'Calendar',
                                 enum: ['primary'],


### PR DESCRIPTION
## Summary
- restore opaque JSON Schema property names in the Google Calendar development connector
- align Marketplace setup fixtures with those properties so JSON Forms resolves the controls

## Validation
- go test ./dev_config
- yarn workspace @authproxy/marketplace lint
- yarn workspace @authproxy/marketplace test
- yarn workspace @authproxy/marketplace typecheck
- yarn workspace @authproxy/marketplace build
- ./scripts/preflight.sh

## Screenshots
Unable to capture a new local screenshot: the available in-app browser cannot reach the host loopback server and no desktop browser extension is connected. The Marketplace test suite verifies the corrected form fixtures.