### PR TITLE
Fix Redis shutdown race across services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This regenerates Swagger docs and checks the integration-tests module is consist
 
 ### Working with pull requests
 
+- **Open PRs; do not merge them.** Cut a pull request for completed changes, but never merge a PR unless the user's prompt explicitly instructs you to do so.
 - **Apply the issue's labels to the PR.** When opening a PR that closes a labelled issue, copy those labels onto the PR (e.g. `gh pr create --label "project:api-key"`). Keeps project-tracking views consistent and surfaces the PR in the same dashboards as the issue.
 - **Tag the PR with the local clone it came from.** Several clones of this repo coexist on the same machine (`~/src/authproxy1`, `~/src/authproxy2`, …) and it's useful to know which one produced a given PR. Take the current directory's basename — if it matches `authproxy<N>` (single-digit suffix `0-9`) — and apply a `clone:authproxy<N>` label. Create the label first if it doesn't exist (`gh label create clone:authproxy<N> --color BFD4F2`). If the basename doesn't match the `authproxy<N>` pattern (e.g. a fork, a feature-named worktree), skip this label.
 - **Respond to PR review comments after addressing them.** When you push a change that resolves a review comment, reply on the original comment thread describing what changed (link to the commit if useful). Don't leave the reviewer guessing whether their feedback landed.

--- a/internal/apredis/miniredis.go
+++ b/internal/apredis/miniredis.go
@@ -11,55 +11,48 @@ import (
 )
 
 var miniredisServer *miniredis.Miniredis
-var miniredisClient *redis.Client
 var miniredisMutex sync.Mutex
 var miniredisErr error
 
-// NewMiniredis creates a new redis connection to a miniredis instance.
+// NewMiniredis creates a Redis client connected to the shared miniredis
+// instance. Each caller receives its own client and is responsible for
+// closing it.
 //
 // Parameters:
-// - redisConfig: the configuration for the miniredis instance
-// - opts: optional functional options (e.g. WithTelemetry) for instrumenting
-//   the client with OTel tracing and / or metrics
+//   - redisConfig: the configuration for the miniredis instance
+//   - opts: optional functional options (e.g. WithTelemetry) for instrumenting
+//     the client with OTel tracing and / or metrics
 func NewMiniredis(redisConfig *config.RedisMiniredis, opts ...Option) (Client, error) {
 	resolved := resolveOpts(opts)
+	miniredisMutex.Lock()
 	if miniredisServer == nil {
-		miniredisMutex.Lock()
-		defer miniredisMutex.Unlock()
-
-		// Check again now that we are the primary
-		if miniredisServer == nil {
-			var err error
-			// Create a new instance of miniredis for testing purposes
-			miniredisServer, err = miniredis.Run()
-			if err != nil {
-				miniredisErr = fmt.Errorf("failed to start miniredis server: %w", err)
-			}
-
-			// Configure the Redis client to use the miniredis instance
-			miniredisClient = redis.NewClient(&redis.Options{
-				Addr:     miniredisServer.Addr(),
-				Protocol: 2, // Needed because RESP3 is unstable for Redis Search
-			})
-
-			if err := instrumentClient(miniredisClient, resolved); err != nil {
-				miniredisServer.Close()
-				miniredisErr = err
-				return nil, miniredisErr
-			}
-
-			// Test the connection to ensure it's working
-			_, err = miniredisClient.Ping(context.Background()).Result()
-			if err != nil {
-				miniredisServer.Close()
-				miniredisErr = fmt.Errorf("failed to connect to miniredis client: %w", err)
-			}
+		var err error
+		miniredisServer, err = miniredis.Run()
+		if err != nil {
+			miniredisErr = fmt.Errorf("failed to start miniredis server: %w", err)
 		}
 	}
+	server := miniredisServer
+	err := miniredisErr
+	miniredisMutex.Unlock()
 
-	if miniredisErr != nil {
-		return nil, miniredisErr
+	if err != nil {
+		return nil, err
 	}
 
-	return miniredisClient, nil
+	client := redis.NewClient(&redis.Options{
+		Addr:     server.Addr(),
+		Protocol: 2, // Needed because RESP3 is unstable for Redis Search
+	})
+	if err := instrumentClient(client, resolved); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	if _, err := client.Ping(context.Background()).Result(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("failed to connect to miniredis client: %w", err)
+	}
+
+	return client, nil
 }

--- a/internal/apredis/redis.go
+++ b/internal/apredis/redis.go
@@ -3,54 +3,37 @@ package apredis
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
-var redisClient *redis.Client
-var redisOnce sync.Once
-var redisErr error
-
-// NewRedis creates a new redis connection to a real redis instance.
+// NewRedis creates a Redis client for a real Redis instance.
 //
 // Parameters:
-// - redisConfig: the configuration for the Redis instance
-// - opts: optional functional options (e.g. WithTelemetry) for instrumenting
-//   the client with OTel tracing and / or metrics
+//   - redisConfig: the configuration for the Redis instance
+//   - opts: optional functional options (e.g. WithTelemetry) for instrumenting
+//     the client with OTel tracing and / or metrics
 func NewRedis(ctx context.Context, redisConfig *config.RedisReal, opts ...Option) (Client, error) {
 	resolved := resolveOpts(opts)
-	if redisClient == nil {
-		redisOnce.Do(func() {
-			var err error
-
-			cfg, err := redisConfig.ToRedisOptions(ctx)
-			if err != nil {
-				redisErr = fmt.Errorf("failed to convert redis config to redis options: %w", err)
-				return
-			}
-
-			// Configure the Redis client with the provided configuration
-			redisClient = redis.NewClient(cfg)
-
-			if err := instrumentClient(redisClient, resolved); err != nil {
-				redisErr = err
-				return
-			}
-
-			// Test the connection to ensure it's working
-			_, err = redisClient.Ping(context.Background()).Result()
-			if err != nil {
-				redisErr = fmt.Errorf("failed to connect to real Redis server: %w", err)
-				return
-			}
-		})
+	cfg, err := redisConfig.ToRedisOptions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert redis config to redis options: %w", err)
 	}
 
-	if redisErr != nil {
-		return nil, redisErr
+	client := redis.NewClient(cfg)
+	if err := instrumentClient(client, resolved); err != nil {
+		_ = client.Close()
+		return nil, err
 	}
 
-	return redisClient, nil
+	// Test the connection to ensure it's working before handing ownership to
+	// the caller. Each dependency manager owns this client and can close it
+	// without interrupting sibling services in an all-in-one server process.
+	if _, err := client.Ping(context.Background()).Result(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("failed to connect to real Redis server: %w", err)
+	}
+
+	return client, nil
 }

--- a/internal/apredis/redis_test.go
+++ b/internal/apredis/redis_test.go
@@ -1,0 +1,47 @@
+package apredis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRedis_ClientsHaveIndependentLifecycles(t *testing.T) {
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(server.Close)
+
+	redisConfig := &config.RedisReal{
+		Provider: config.RedisProviderRedis,
+		Address:  server.Addr(),
+	}
+
+	first, err := NewRedis(context.Background(), redisConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := NewRedis(context.Background(), redisConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	require.NotSame(t, first, second)
+	require.NoError(t, first.Close())
+	require.NoError(t, second.Ping(context.Background()).Err())
+}
+
+func TestNewMiniredis_ClientsHaveIndependentLifecycles(t *testing.T) {
+	first, err := NewMiniredis(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := NewMiniredis(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	require.NotSame(t, first, second)
+	require.NoError(t, first.Close())
+	require.NoError(t, second.Ping(context.Background()).Err())
+}

--- a/internal/apredis/test_config.go
+++ b/internal/apredis/test_config.go
@@ -10,15 +10,12 @@ import (
 func mustApplyTestConfigInternal(cfg config.C) (config.C, Client, *miniredis.Miniredis) {
 	// Avoid shared singletons for test cases, while still going through wireup logic
 	miniredisServerPrevious := miniredisServer
-	miniredisClientPrevious := miniredisClient
 	miniredisErrPrevious := miniredisErr
 	defer func() {
 		miniredisServer = miniredisServerPrevious
-		miniredisClient = miniredisClientPrevious
 		miniredisErr = miniredisErrPrevious
 	}()
 	miniredisServer = nil
-	miniredisClient = nil
 	miniredisErr = nil
 
 	if cfg == nil {

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -39,6 +39,11 @@ func Serve(cfg config.C) {
 	dm.GetTelemetry()
 	defer dm.ShutdownTelemetry()
 
+	// The Asynq server shares this client's connection pool. Register this
+	// before starting it so the pool is closed only after its shutdown has
+	// completed.
+	defer dm.GetRedisClient().Close()
+
 	workerConfig := cfg.GetRoot().Worker
 	router := apgin.ForService(
 		&workerConfig,


### PR DESCRIPTION
## Summary
- give each dependency manager its own Redis client, preventing one service from closing another service’s client pool
- close the worker Redis client only after Asynq has fully stopped
- cover independent lifecycle behavior for real Redis and miniredis clients

## Tests
- go test ./...
- ./scripts/preflight.sh