### PR TITLE
Fix workflow worker Ctrl-C shutdown

### DIFF
--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	workflowworker "github.com/cschleiden/go-workflows/worker"
@@ -109,6 +112,12 @@ func Serve(cfg config.C) {
 	defer dm.GetEncryptService().Shutdown()
 	defer dm.ShutdownWorkflowRuntime()
 
+	// The workflow worker has no shutdown method; cancelling the context
+	// passed to Start stops its pollers so WaitForCompletion can drain and
+	// return. Keep its context separate from the Asynq BaseContext so Asynq
+	// can continue its own graceful in-flight task shutdown.
+	workflowCtx, stopWorkflow := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopWorkflow()
 	ctx := context.Background()
 
 	// Build the asynq telemetry surface (middleware + scheduler-sync
@@ -215,13 +224,9 @@ func Serve(cfg config.C) {
 	go func() {
 		defer wg.Done()
 		workflowRunning = true
-		if err := workflowWorker.Start(ctx); err != nil {
+		if err := runWorkflowWorker(workflowCtx, workflowWorker); err != nil {
 			workflowHasError = true
-			log.Fatalf("could not start workflow worker: %v", err)
-		}
-		if err := workflowWorker.WaitForCompletion(); err != nil {
-			workflowHasError = true
-			log.Fatalf("workflow worker failed while waiting for completion: %v", err)
+			log.Fatalf("workflow worker failed: %v", err)
 		}
 		workflowRunning = false
 		logger.Info("Workflow worker shutdown complete")
@@ -279,6 +284,21 @@ func Serve(cfg config.C) {
 	wg.Wait()
 	logger.Info("Worker shutting down")
 	defer logger.Info("Worker shutdown complete")
+}
+
+type workflowWorker interface {
+	Start(context.Context) error
+	WaitForCompletion() error
+}
+
+func runWorkflowWorker(ctx context.Context, worker workflowWorker) error {
+	if err := worker.Start(ctx); err != nil {
+		return fmt.Errorf("start workflow worker: %w", err)
+	}
+	if err := worker.WaitForCompletion(); err != nil {
+		return fmt.Errorf("wait for workflow worker completion: %w", err)
+	}
+	return nil
 }
 
 func workflowOptionsFromConfig(ctx context.Context, workerConfig *schemaConfig.ServiceWorker) *workflowworker.Options {

--- a/internal/service/worker/workflow_options_test.go
+++ b/internal/service/worker/workflow_options_test.go
@@ -35,3 +35,44 @@ func TestWorkflowOptionsFromConfigOverridesConfiguredValues(t *testing.T) {
 	require.Equal(t, 6, options.MaxParallelActivityTasks)
 	require.Equal(t, 7*time.Second, options.WorkflowHeartbeatInterval)
 }
+
+func TestRunWorkflowWorkerStopsWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	worker := &blockingWorkflowWorker{started: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		done <- runWorkflowWorker(ctx, worker)
+	}()
+
+	select {
+	case <-worker.started:
+	case <-time.After(time.Second):
+		t.Fatal("workflow worker did not start")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("workflow worker did not stop after context cancellation")
+	}
+}
+
+type blockingWorkflowWorker struct {
+	ctx     context.Context
+	started chan struct{}
+}
+
+func (w *blockingWorkflowWorker) Start(ctx context.Context) error {
+	w.ctx = ctx
+	close(w.started)
+	return nil
+}
+
+func (w *blockingWorkflowWorker) WaitForCompletion() error {
+	<-w.ctx.Done()
+	return nil
+}


### PR DESCRIPTION
## Summary

- cancel the go-workflows worker context when the process receives Ctrl-C or SIGTERM
- wait for its pollers to drain before completing worker shutdown
- cover workflow worker cancellation with a regression test

## Testing

- go test ./...
- ./scripts/preflight.sh
- local all-services server: SIGINT exit status 0 with every worker shutdown-completion log