### PR TITLE
Fix demo shell image workspace inputs

### DIFF
--- a/demos/shell/Dockerfile
+++ b/demos/shell/Dockerfile
@@ -22,6 +22,7 @@ RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
 # All declared workspaces must exist on disk for `yarn install --immutable`
 # to succeed — copy them all even though we only build one here.
+COPY blog/package.json blog/package.json
 COPY docs/package.json docs/package.json
 COPY ui ui
 COPY sdks sdks


### PR DESCRIPTION
## Summary
- include the Blog workspace manifest in the demo shell Docker build context before immutable Yarn installation
- restore reproducible demo-shell image builds after the Blog workspace was added

## Validation
- `yarn install --immutable`
- `./scripts/preflight.sh`