### PR TITLE
Fix demo deploy failure diagnostics

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -328,39 +328,6 @@ jobs:
               -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"demo.authproxy.net/image-revision\":\"${{ steps.tag.outputs.sha }}\"}}}}}"
           done
 
-      - name: Collect deploy diagnostics (on failure)
-        if: failure()
-        run: |
-          set +e
-          echo "## Applied resources"
-          kubectl -n "${RELEASE_NS}" get all,ingress,certificate,order,challenge -o wide
-          echo
-          echo "## Deployments"
-          for d in \
-            "${RELEASE_NAME}-authproxy" \
-            "${RELEASE_NAME}-demo-shell" \
-            "${RELEASE_NAME}-go-oauth2-server" \
-            "${RELEASE_NAME}-postgresql" \
-            "${RELEASE_NAME}-redis-master" \
-            "${RELEASE_NAME}-minio" \
-            "${RELEASE_NAME}-grafana" \
-            "${RELEASE_NAME}-otel-lgtm" \
-          ; do
-            kubectl -n "${RELEASE_NS}" describe "deployment/$d"
-            echo
-          done
-          echo "## Recent pod logs"
-          for selector in authproxy demo-shell go-oauth2-server grafana otel-lgtm; do
-            kubectl -n "${RELEASE_NS}" logs \
-              -l "app.kubernetes.io/name=${selector}" \
-              --all-containers --tail=120
-            echo
-          done
-          echo "## Recent events"
-          kubectl -n "${RELEASE_NS}" get events \
-            --sort-by='.lastTimestamp' \
-            | tail -n 100
-
       - name: Wait for workload rollouts
         timeout-minutes: 10
         run: |
@@ -452,6 +419,39 @@ jobs:
           cd integration_tests
           SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
             go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
+
+      - name: Collect deploy diagnostics (on failure)
+        if: failure()
+        run: |
+          set +e
+          echo "## Applied resources"
+          kubectl -n "${RELEASE_NS}" get all,ingress,certificate,order,challenge -o wide
+          echo
+          echo "## Deployments"
+          for d in \
+            "${RELEASE_NAME}-authproxy" \
+            "${RELEASE_NAME}-demo-shell" \
+            "${RELEASE_NAME}-go-oauth2-server" \
+            "${RELEASE_NAME}-postgresql" \
+            "${RELEASE_NAME}-redis-master" \
+            "${RELEASE_NAME}-minio" \
+            "${RELEASE_NAME}-grafana" \
+            "${RELEASE_NAME}-otel-lgtm" \
+          ; do
+            kubectl -n "${RELEASE_NS}" describe "deployment/$d"
+            echo
+          done
+          echo "## Recent pod logs"
+          for selector in authproxy demo-shell go-oauth2-server grafana otel-lgtm; do
+            kubectl -n "${RELEASE_NS}" logs \
+              -l "app.kubernetes.io/name=${selector}" \
+              --all-containers --tail=120
+            echo
+          done
+          echo "## Recent events"
+          kubectl -n "${RELEASE_NS}" get events \
+            --sort-by='.lastTimestamp' \
+            | tail -n 100
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary
- move the existing deploy diagnostics after all rollout, certificate, and smoke-test gates
- ensure failure() evaluates after the failure that needs diagnosis instead of before it
- preserve the current resource, deployment, pod-log, and event output

## Investigation
The latest Deploy Demo runs (31618343747 and 31632554748) authenticate to AWS through the gha-eks environment, configure kubeconfig, find the GHCR images, and apply the Kustomize manifest successfully. Both fail waiting for deployment/demo-authproxy because the deployment has exceeded its progress deadline.

The previous August 5 runs show the same deployment waiting ten minutes with an old replica pending termination. Issue #816 records the pod-level root error from that disposable demo reset: PostgreSQL was left at schema_migrations version 9 with dirty=true, and later restarts only exposed the dirty-state error. The one-time disposable-environment recovery is to reset that ephemeral PostgreSQL pod/data and restart AuthProxy, but that is intentionally not automated here because it destroys demo data.

The durable migration ownership and locking changes are already scoped in #816, #817, and #818. PR #813 was closed in favor of that explicit ticketed approach. This PR fixes the workflow defect that suppressed the evidence those changes need; it does not attempt a competing migration architecture.

## Verification
- ./scripts/preflight.sh
- git diff --check