### PR TITLE
Harden automatic migration locks

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
             'operations',
             'operations/load-testing',
             'operations/telemetry',
+            'operations/migrations',
             'operations/app-metrics',
             'operations/rate-limits',
             'operations/background-tasks',

--- a/docs/src/content/docs/operations/app-metrics.md
+++ b/docs/src/content/docs/operations/app-metrics.md
@@ -37,6 +37,9 @@ Key settings:
 
 The resource snapshot worker stores live resources at each interval. Deleted resources remain visible in historical time slices where they were sampled, but they are excluded from later snapshots.
 
+See [Automatic migrations](/operations/migrations/) for startup locking and
+lease-renewal behavior across SQLite, PostgreSQL, and ClickHouse.
+
 ## Request events
 
 List request-event metadata with `GET /api/v1/metrics/request-events`. Filters

--- a/docs/src/content/docs/operations/migrations.md
+++ b/docs/src/content/docs/operations/migrations.md
@@ -1,0 +1,80 @@
+---
+title: Automatic migrations
+description: Understand how AuthProxy coordinates schema migrations and startup reconciliation across service processes.
+---
+
+AuthProxy can apply database migrations automatically when a service starts.
+Every enabled service may start at the same time, so automatic migration uses
+Redis mutexes to ensure that only one process migrates each storage target.
+
+## Configure automatic migration
+
+The primary database and application-metrics store have independent switches
+and independent locks:
+
+~~~yaml
+database:
+  provider: postgres
+  autoMigrate: true
+  autoMigrationLockDuration: 2m
+  # ...
+
+app_metrics:
+  autoMigrate: true
+  database:
+    provider: clickhouse
+    autoMigrationLockDuration: 2m
+    # ...
+~~~
+
+The `autoMigrationLockDuration` value is the Redis lease duration.
+AuthProxy refreshes the lease while migration is running, so it is not a
+maximum migration runtime. Contending processes wait for a bounded period
+based on the same duration and then fail startup rather than continuing
+without exclusivity.
+
+## Lock targets and providers
+
+The primary relational schema and workflow schema share
+`db-migrate-lock` and run sequentially. The application-metrics
+schema uses the separate `app-metrics-migrate-lock`, because it may
+live in a different database and should not block an unrelated primary
+migration.
+
+The Redis contract is the same for SQLite, PostgreSQL, and ClickHouse:
+
+1. acquire the target mutex;
+2. refresh it every third of the lease duration;
+3. apply all migrations;
+4. release the mutex and report any release failure.
+
+If a refresh fails, AuthProxy cancels the migration context, asks the migration
+runner to stop at its next safe boundary, and fails startup. It never treats an
+expired or unconfirmed lease as successful migration ownership.
+
+PostgreSQL also retains the advisory lock supplied by its migration driver.
+That database-native lock provides defense in depth and interoperability with
+other processes that use the same migration driver. Redis supplies the
+provider-independent coordination needed by SQLite and ClickHouse.
+
+## Startup reconciliation
+
+Schema migration is followed by reconciliation of encryption keys, configured
+connectors, namespaces, and configured actors. These operations use distinct
+renewable Redis mutexes because they may include database cleanup or calls to
+external key providers. A key-sync sentinel additionally suppresses redundant
+work; the sentinel controls frequency, while the mutex prevents overlap.
+
+Failures acquiring, refreshing, or releasing these mutexes are surfaced as
+startup or task errors; automatic database migration logs also identify its
+lock key. Successful database migration, no-change outcomes, and original
+migration failures are logged separately.
+
+## Production rollout
+
+Automatic migration is convenient for local, demo, and controlled deployments.
+For a multi-replica production rollout, keep database backups current and
+ensure all replicas use the same Redis service. Prefer a deployment workflow
+that runs migration as an explicit pre-rollout step and starts application
+replicas only after it succeeds; dedicated migration-job packaging is tracked
+separately from the automatic startup path.

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -221,6 +221,7 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 	// and updates cfg.GetRoot().Database to point at the new isolated database.
 	cfg, _, rawDb := database.MustApplyBlankTestDbConfigRaw(t, cfg)
 	require.NoError(t, workflows.Migrate(
+		context.Background(),
 		cfg.GetRoot(),
 		cfg.GetRoot().GetRootLogger(),
 		workflows.WithPostgresMigrationDB(rawDb),

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -54,18 +54,17 @@ func (s *service) SyncConfiguredActorsExternalSource(ctx context.Context) error 
 			apredis.MutexOptionDetailedLockMetadata(),
 		)
 
-		if err := m.Lock(ctx); err != nil {
+		err := apredis.RunWithMutex(ctx, m, defaultSyncLockDuration, func(lockCtx context.Context) error {
+			return s.syncConfiguredActors(lockCtx, actors.All(), LabelValuePublicKeyDir)
+		})
+		if err != nil {
 			if apredis.MutexIsErrNotObtained(err) {
 				s.logger.Info("another sync is in progress, skipping this run")
 				return nil
 			}
-			return fmt.Errorf("failed to acquire sync lock: %w", err)
+			return fmt.Errorf("failed to run synchronized actor sync: %w", err)
 		}
-		defer func() {
-			if err := m.Unlock(ctx); err != nil {
-				s.logger.Warn("failed to release sync lock", "error", err)
-			}
-		}()
+		return nil
 	}
 
 	return s.syncConfiguredActors(ctx, actors.All(), LabelValuePublicKeyDir)

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -6,6 +6,10 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 )
 
+// MigrateMutexKeyName coordinates automatic app-metrics migrations across
+// service processes, regardless of the configured database provider.
+const MigrateMutexKeyName = "app-metrics-migrate-lock"
+
 // RecordStore handles persisting LogRecord metadata to a storage backend.
 type RecordStore interface {
 	// StoreRecord persists a LogRecord to the storage backend.

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/sqlh"
+	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -125,9 +126,15 @@ func (s *clickhouseRecordStore) StoreRecord(ctx context.Context, record *LogReco
 	return s.StoreRecords(ctx, []*LogRecord{record})
 }
 
-func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
+func (s *clickhouseRecordStore) Migrate(ctx context.Context) (resultErr error) {
 	s.logger.Info("running clickhouse app metrics migrations")
-	defer s.logger.Info("clickhouse app metrics migrations complete")
+	defer func() {
+		if resultErr != nil {
+			s.logger.Error("clickhouse app metrics migrations failed", "error", resultErr)
+			return
+		}
+		s.logger.Info("clickhouse app metrics migrations complete")
+	}()
 
 	src, err := iofs.New(appMetricsMigrationsFs, "migrations/clickhouse")
 	if err != nil {
@@ -173,7 +180,7 @@ func (s *clickhouseRecordStore) Migrate(ctx context.Context) error {
 		}
 	}()
 
-	if err := m.Up(); err != nil {
+	if err := util.RunMigrationsUp(ctx, m); err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
 			s.logger.Info("no clickhouse app metrics migrations required")
 			return nil

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -171,10 +171,16 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 	return nil
 }
 
-func (s *sqlRecordStore) Migrate(ctx context.Context) error {
+func (s *sqlRecordStore) Migrate(ctx context.Context) (resultErr error) {
 	provider := string(s.cfg.GetProvider())
 	s.logger.Info("running app metrics database migrations", "provider", provider)
-	defer s.logger.Info("app metrics database migrations complete")
+	defer func() {
+		if resultErr != nil {
+			s.logger.Error("app metrics database migrations failed", "provider", provider, "error", resultErr)
+			return
+		}
+		s.logger.Info("app metrics database migrations complete", "provider", provider)
+	}()
 
 	d, err := iofs.New(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
 	if err != nil {
@@ -198,7 +204,7 @@ func (s *sqlRecordStore) Migrate(ctx context.Context) error {
 		}
 	}()
 
-	err = m.Up()
+	err = util.RunMigrationsUp(ctx, m)
 	if err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
 			s.logger.Info("no app metrics migrations required")

--- a/internal/apredis/mutex.go
+++ b/internal/apredis/mutex.go
@@ -2,6 +2,7 @@ package apredis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +15,16 @@ type Mutex interface {
 	Extend(context.Context, time.Duration) error
 	Unlock(context.Context) error
 }
+
+var (
+	// ErrMutexNotLocked is returned when an operation requires an acquired mutex.
+	ErrMutexNotLocked = errors.New("mutex not locked")
+	// ErrMutexLeaseLost indicates that a mutex could not be refreshed and its
+	// exclusive ownership can no longer be guaranteed.
+	ErrMutexLeaseLost = errors.New("mutex lease lost")
+)
+
+const mutexCleanupTimeout = 5 * time.Second
 
 type MutexOption func(m *mutex)
 
@@ -99,14 +110,7 @@ func MutexOptionNoRetry() MutexOption {
 func MutexOptionRetryFor(d time.Duration) MutexOption {
 	return func(m *mutex) {
 		m.lockContextCancellation = func(ctx context.Context) (context.Context, context.CancelFunc) {
-			// Check if the context currently has a more aggressive deadline, and if so, respect that
-			if currentDeadline, ok := ctx.Deadline(); !ok {
-				desiredDeadline := apctx.GetClock(ctx).Now().Add(d)
-				if desiredDeadline.After(currentDeadline) {
-					return ctx, func() {}
-				}
-			}
-
+			// context.WithTimeout automatically preserves an earlier parent deadline.
 			return context.WithTimeout(ctx, d)
 		}
 	}
@@ -129,7 +133,7 @@ func NewMutex(r Client, key string, options ...MutexOption) Mutex {
 }
 
 func MutexIsErrNotObtained(err error) bool {
-	return err == redislock.ErrNotObtained
+	return errors.Is(err, redislock.ErrNotObtained)
 }
 
 type mutex struct {
@@ -172,12 +176,14 @@ func (m *mutex) Lock(ctx context.Context) error {
 
 func (m *mutex) Extend(ctx context.Context, d time.Duration) error {
 	if m.lock == nil {
-		return fmt.Errorf("mutex '%s' not locked", m.key)
+		return fmt.Errorf("mutex '%s': %w", m.key, ErrMutexNotLocked)
 	}
 
 	err := m.lock.Refresh(ctx, d, m.opts())
-	if err != nil {
-		// We no longer hold the lock
+	if errors.Is(err, redislock.ErrNotObtained) {
+		// Redis confirmed that this token no longer owns the lock. Preserve the
+		// handle for transient transport errors so a later release can still be
+		// attempted safely with the same token.
 		m.lock = nil
 	}
 
@@ -186,8 +192,113 @@ func (m *mutex) Extend(ctx context.Context, d time.Duration) error {
 
 func (m *mutex) Unlock(ctx context.Context) error {
 	if m.lock == nil {
-		return fmt.Errorf("mutex '%s' not locked", m.key)
+		return fmt.Errorf("mutex '%s': %w", m.key, ErrMutexNotLocked)
 	}
 
-	return m.lock.Release(ctx)
+	err := m.lock.Release(ctx)
+	if err == nil || errors.Is(err, redislock.ErrLockNotHeld) {
+		m.lock = nil
+	}
+	return err
+}
+
+// RunWithMutex executes operation while continuously refreshing an acquired
+// Redis mutex. If the lease can no longer be refreshed, the operation context
+// is cancelled and ErrMutexLeaseLost is returned. Renewal is decoupled from
+// parent cancellation and remains active until the operation returns, giving
+// the operation time to stop without silently outliving the lease.
+func RunWithMutex(
+	ctx context.Context,
+	m Mutex,
+	leaseDuration time.Duration,
+	operation func(context.Context) error,
+) (resultErr error) {
+	if m == nil {
+		return errors.New("mutex is required")
+	}
+	if leaseDuration <= 0 {
+		return fmt.Errorf("mutex lease duration must be greater than zero: %s", leaseDuration)
+	}
+	if operation == nil {
+		return errors.New("mutex operation is required")
+	}
+
+	if err := m.Lock(ctx); err != nil {
+		return fmt.Errorf("failed to acquire mutex: %w", err)
+	}
+
+	operationCtx, cancelOperation := context.WithCancelCause(ctx)
+	renewCtx, stopRenewal := context.WithCancel(context.WithoutCancel(ctx))
+	renewalDone := make(chan error, 1)
+	renewalReady := make(chan struct{})
+	go func() {
+		renewalDone <- renewMutex(renewCtx, m, leaseDuration, cancelOperation, renewalReady)
+	}()
+	<-renewalReady
+
+	defer func() {
+		panicValue := recover()
+
+		stopRenewal()
+		renewalErr := <-renewalDone
+		cancelOperation(context.Canceled)
+
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), mutexCleanupTimeout)
+		unlockErr := m.Unlock(cleanupCtx)
+		cancelCleanup()
+
+		// A confirmed lease loss clears the mutex handle. The resulting
+		// ErrMutexNotLocked does not add information beyond ErrMutexLeaseLost.
+		if errors.Is(renewalErr, ErrMutexLeaseLost) && errors.Is(unlockErr, ErrMutexNotLocked) {
+			unlockErr = nil
+		}
+
+		if renewalErr != nil {
+			resultErr = errors.Join(resultErr, renewalErr)
+		}
+		if unlockErr != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("failed to release mutex: %w", unlockErr))
+		}
+
+		if panicValue != nil {
+			panic(panicValue)
+		}
+	}()
+
+	resultErr = operation(operationCtx)
+	return resultErr
+}
+
+func renewMutex(
+	ctx context.Context,
+	m Mutex,
+	leaseDuration time.Duration,
+	cancelOperation context.CancelCauseFunc,
+	ready chan<- struct{},
+) error {
+	refreshInterval := leaseDuration / 3
+	if refreshInterval <= 0 {
+		refreshInterval = leaseDuration
+	}
+
+	timer := apctx.GetClock(ctx).NewTimer(refreshInterval)
+	defer timer.Stop()
+	close(ready)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-timer.C():
+			refreshCtx, cancelRefresh := context.WithTimeout(ctx, refreshInterval)
+			err := m.Extend(refreshCtx, leaseDuration)
+			cancelRefresh()
+			if err != nil {
+				leaseErr := fmt.Errorf("%w: failed to refresh mutex: %w", ErrMutexLeaseLost, err)
+				cancelOperation(leaseErr)
+				return leaseErr
+			}
+			timer.Reset(refreshInterval)
+		}
+	}
 }

--- a/internal/apredis/mutex_test.go
+++ b/internal/apredis/mutex_test.go
@@ -163,6 +163,8 @@ func TestRunWithMutexRenewsRedisLeaseBeyondInitialDuration(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return miniredisServer.TTL(key) > 80*time.Second
 		}, time.Second, time.Millisecond)
+		require.Eventually(t, fakeClock.HasWaiters, time.Second, time.Millisecond,
+			"renewal timer was not reset after refreshing the lease")
 	}
 
 	competitor := NewMutex(r, key, MutexOptionLockFor(leaseDuration), MutexOptionNoRetry())

--- a/internal/apredis/mutex_test.go
+++ b/internal/apredis/mutex_test.go
@@ -2,10 +2,15 @@ package apredis
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/bsm/redislock"
+	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 func TestMutex(t *testing.T) {
@@ -40,4 +45,289 @@ func TestMutex(t *testing.T) {
 
 	err = m2.Lock(ctx)
 	require.NoError(t, err)
+	require.NoError(t, m2.Unlock(ctx))
+
+	// A successfully released mutex can be reused.
+	require.NoError(t, m1.Lock(ctx))
+	require.NoError(t, m1.Unlock(ctx))
+}
+
+func TestMutexOptionRetryForDeadline(t *testing.T) {
+	const retryFor = 200 * time.Millisecond
+
+	t.Run("no deadline", func(t *testing.T) {
+		m := &mutex{}
+		MutexOptionRetryFor(retryFor)(m)
+
+		started := time.Now()
+		ctx, cancel := m.lockContextCancellation(context.Background())
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, started.Add(retryFor), deadline, 25*time.Millisecond)
+	})
+
+	t.Run("earlier deadline", func(t *testing.T) {
+		m := &mutex{}
+		MutexOptionRetryFor(retryFor)(m)
+
+		parentDeadline := time.Now().Add(50 * time.Millisecond)
+		parent, cancelParent := context.WithDeadline(context.Background(), parentDeadline)
+		defer cancelParent()
+		ctx, cancel := m.lockContextCancellation(parent)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, parentDeadline, deadline)
+	})
+
+	t.Run("later deadline", func(t *testing.T) {
+		m := &mutex{}
+		MutexOptionRetryFor(retryFor)(m)
+
+		started := time.Now()
+		parent, cancelParent := context.WithDeadline(context.Background(), started.Add(time.Second))
+		defer cancelParent()
+		ctx, cancel := m.lockContextCancellation(parent)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, started.Add(retryFor), deadline, 25*time.Millisecond)
+	})
+}
+
+func TestRunWithMutexRenewsAndReleases(t *testing.T) {
+	fakeClock := clocktesting.NewFakeClock(time.Now())
+	ctx := apctx.WithClock(context.Background(), fakeClock)
+	m := newTestMutex()
+	operationStarted := make(chan struct{})
+	finishOperation := make(chan struct{})
+	var finishOnce sync.Once
+	t.Cleanup(func() { finishOnce.Do(func() { close(finishOperation) }) })
+	result := make(chan error, 1)
+
+	go func() {
+		result <- RunWithMutex(ctx, m, 90*time.Second, func(context.Context) error {
+			close(operationStarted)
+			<-finishOperation
+			return nil
+		})
+	}()
+
+	<-operationStarted
+	fakeClock.Step(30 * time.Second)
+	require.Eventually(t, func() bool { return m.extendCallCount() == 1 }, time.Second, time.Millisecond)
+	fakeClock.Step(30 * time.Second)
+	require.Eventually(t, func() bool { return m.extendCallCount() == 2 }, time.Second, time.Millisecond)
+
+	finishOnce.Do(func() { close(finishOperation) })
+	require.NoError(t, <-result)
+	require.Equal(t, 1, m.lockCallCount())
+	require.Equal(t, 1, m.unlockCallCount())
+}
+
+func TestRunWithMutexRenewsRedisLeaseBeyondInitialDuration(t *testing.T) {
+	r, err := NewMiniredis(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	const (
+		key           = "renewing-mutex-integration"
+		leaseDuration = 90 * time.Second
+	)
+	require.NoError(t, r.Del(context.Background(), key).Err())
+
+	fakeClock := clocktesting.NewFakeClock(time.Now())
+	ctx := apctx.WithClock(context.Background(), fakeClock)
+	m := NewMutex(r, key, MutexOptionLockFor(leaseDuration), MutexOptionNoRetry())
+	operationStarted := make(chan struct{})
+	finishOperation := make(chan struct{})
+	var finishOnce sync.Once
+	t.Cleanup(func() { finishOnce.Do(func() { close(finishOperation) }) })
+	result := make(chan error, 1)
+	go func() {
+		result <- RunWithMutex(ctx, m, leaseDuration, func(context.Context) error {
+			close(operationStarted)
+			<-finishOperation
+			return nil
+		})
+	}()
+
+	<-operationStarted
+	for range 3 {
+		miniredisServer.FastForward(40 * time.Second)
+		fakeClock.Step(30 * time.Second)
+		require.Eventually(t, func() bool {
+			return miniredisServer.TTL(key) > 80*time.Second
+		}, time.Second, time.Millisecond)
+	}
+
+	competitor := NewMutex(r, key, MutexOptionLockFor(leaseDuration), MutexOptionNoRetry())
+	require.ErrorIs(t, competitor.Lock(context.Background()), redislock.ErrNotObtained)
+
+	finishOnce.Do(func() { close(finishOperation) })
+	require.NoError(t, <-result)
+	require.False(t, miniredisServer.Exists(key))
+}
+
+func TestRunWithMutexSerializesConcurrentOperations(t *testing.T) {
+	r, err := NewMiniredis(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	const key = "serializing-mutex-integration"
+	require.NoError(t, r.Del(context.Background(), key).Err())
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseFirst) }) })
+	secondStarted := make(chan struct{})
+	firstResult := make(chan error, 1)
+	secondResult := make(chan error, 1)
+
+	go func() {
+		m := NewMutex(r, key, MutexOptionLockFor(time.Second), MutexOptionNoRetry())
+		firstResult <- RunWithMutex(context.Background(), m, time.Second, func(context.Context) error {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	<-firstStarted
+
+	go func() {
+		m := NewMutex(
+			r,
+			key,
+			MutexOptionLockFor(time.Second),
+			MutexOptionRetryFor(time.Second),
+			MutexOptionRetryLinearBackoff(time.Millisecond),
+		)
+		secondResult <- RunWithMutex(context.Background(), m, time.Second, func(context.Context) error {
+			close(secondStarted)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second operation entered before the first released the mutex")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	releaseOnce.Do(func() { close(releaseFirst) })
+	require.NoError(t, <-firstResult)
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second operation did not enter after the first released the mutex")
+	}
+	require.NoError(t, <-secondResult)
+}
+
+func TestRunWithMutexCancelsOperationWhenLeaseIsLost(t *testing.T) {
+	fakeClock := clocktesting.NewFakeClock(time.Now())
+	ctx := apctx.WithClock(context.Background(), fakeClock)
+	refreshErr := errors.New("refresh rejected")
+	m := newTestMutex()
+	m.extendErr = refreshErr
+	operationStarted := make(chan struct{})
+	result := make(chan error, 1)
+
+	go func() {
+		result <- RunWithMutex(ctx, m, 90*time.Second, func(ctx context.Context) error {
+			close(operationStarted)
+			<-ctx.Done()
+			return context.Cause(ctx)
+		})
+	}()
+
+	<-operationStarted
+	fakeClock.Step(30 * time.Second)
+	err := <-result
+	require.ErrorIs(t, err, ErrMutexLeaseLost)
+	require.ErrorIs(t, err, refreshErr)
+	require.Equal(t, 1, m.unlockCallCount())
+}
+
+func TestRunWithMutexReturnsOperationAndUnlockErrors(t *testing.T) {
+	operationErr := errors.New("operation failed")
+	unlockErr := errors.New("unlock failed")
+	m := newTestMutex()
+	m.unlockErr = unlockErr
+
+	err := RunWithMutex(context.Background(), m, time.Minute, func(context.Context) error {
+		return operationErr
+	})
+
+	require.ErrorIs(t, err, operationErr)
+	require.ErrorIs(t, err, unlockErr)
+}
+
+func TestRunWithMutexReleasesBeforeRepanicking(t *testing.T) {
+	m := newTestMutex()
+
+	require.PanicsWithValue(t, "boom", func() {
+		_ = RunWithMutex(context.Background(), m, time.Minute, func(context.Context) error {
+			panic("boom")
+		})
+	})
+	require.Equal(t, 1, m.unlockCallCount())
+}
+
+type testMutex struct {
+	mu          sync.Mutex
+	lockCalls   int
+	extendCalls int
+	unlockCalls int
+	lockErr     error
+	extendErr   error
+	unlockErr   error
+}
+
+func newTestMutex() *testMutex {
+	return &testMutex{}
+}
+
+func (m *testMutex) Lock(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lockCalls++
+	return m.lockErr
+}
+
+func (m *testMutex) Extend(context.Context, time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.extendCalls++
+	return m.extendErr
+}
+
+func (m *testMutex) Unlock(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unlockCalls++
+	return m.unlockErr
+}
+
+func (m *testMutex) lockCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lockCalls
+}
+
+func (m *testMutex) extendCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.extendCalls
+}
+
+func (m *testMutex) unlockCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.unlockCalls
 }

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -89,7 +89,7 @@ func (s *service) MigrateNamespaces(ctx context.Context) error {
 
 	for _, nsPath := range toCreatePaths {
 		s.logger.Info("migrating namespace", "namespace", nsPath)
-		err := s.db.CreateNamespace(context.Background(), &database.Namespace{
+		err := s.db.CreateNamespace(ctx, &database.Namespace{
 			Path:   nsPath,
 			State:  database.NamespaceStateActive,
 			Labels: make(database.Labels),

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 //go:embed migrations/**/*.sql
@@ -18,9 +19,15 @@ var migrationsFs embed.FS
 // MigrateMutexKeyName is the key that can be used when locking to perform a migration in redis.
 const MigrateMutexKeyName = "db-migrate-lock"
 
-func (s *service) Migrate(ctx context.Context) error {
+func (s *service) Migrate(ctx context.Context) (resultErr error) {
 	s.logger.Info("running database migrations", "provider", s.cfg.GetProvider())
-	defer s.logger.Info("database migrations complete")
+	defer func() {
+		if resultErr != nil {
+			s.logger.Error("database migrations failed", "provider", s.cfg.GetProvider(), "error", resultErr)
+			return
+		}
+		s.logger.Info("database migrations complete", "provider", s.cfg.GetProvider())
+	}()
 
 	d, err := iofs.New(migrationsFs, fmt.Sprintf("migrations/%s", s.cfg.GetProvider()))
 	if err != nil {
@@ -38,7 +45,7 @@ func (s *service) Migrate(ctx context.Context) error {
 		}
 	}()
 
-	err = m.Up()
+	err = util.RunMigrationsUp(ctx, m)
 	if err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
 			s.logger.Info("no migrations required")

--- a/internal/encrypt/task_generate_data_encryption_keys.go
+++ b/internal/encrypt/task_generate_data_encryption_keys.go
@@ -129,25 +129,24 @@ func generateDataEncryptionKeysToDatabase(
 	redis apredis.Client,
 	opts ...GenerateDataEncryptionKeysOption,
 ) error {
-	logger.Info("generating data encryption keys")
-	defer logger.Info("generating data encryption keys complete")
-	options := newGenerateDataEncryptionKeysOptions(opts)
-
 	if redis != nil {
+		const lockDuration = 30 * time.Second
 		m := apredis.NewMutex(
 			redis,
 			"encrypt:generate_deks",
-			apredis.MutexOptionLockFor(30*time.Second),
-			apredis.MutexOptionRetryFor(31*time.Second),
+			apredis.MutexOptionLockFor(lockDuration),
+			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
 			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
 			apredis.MutexOptionDetailedLockMetadata(),
 		)
-		err := m.Lock(context.Background())
-		if err != nil {
-			return errors.Wrap(err, "failed to establish lock for data encryption key generation")
-		}
-		defer m.Unlock(context.Background())
+		return apredis.RunWithMutex(ctx, m, lockDuration, func(lockCtx context.Context) error {
+			return generateDataEncryptionKeysToDatabase(lockCtx, cfg, db, logger, nil, opts...)
+		})
 	}
+
+	logger.Info("generating data encryption keys")
+	defer logger.Info("generating data encryption keys complete")
+	options := newGenerateDataEncryptionKeysOptions(opts)
 
 	if cfg == nil || cfg.GetRoot() == nil {
 		return errors.New("no configuration available")

--- a/internal/encrypt/task_sync_keys_to_database.go
+++ b/internal/encrypt/task_sync_keys_to_database.go
@@ -277,36 +277,50 @@ func syncKeysToDatabase(
 	redis apredis.Client,
 	opts ...SyncKeysOption,
 ) error {
-	logger.Info("syncing data encryption key wrapping to database")
-	defer logger.Info("syncing data encryption key wrapping to database complete")
-	options := newSyncKeysOptions(opts)
-
-	if err := ensureRootNamespaceHasKeySet(ctx, db); err != nil {
-		return errors.Wrap(err, "failed to ensure root namespace uses global key")
-	}
-
 	if redis != nil {
-		// Redis can be skipped in test cases
+		// Redis can be skipped in test cases. The sentinel avoids redundant
+		// work; the renewable mutex prevents overlapping work.
 		val, err := redis.Get(ctx, sentinelKey).Result()
 		if err == nil && val != "" {
 			logger.Info("skipping key sync: recently synced")
 			return nil
 		}
 
+		const lockDuration = 30 * time.Second
 		m := apredis.NewMutex(
 			redis,
 			"encrypt:sync_keys",
-			apredis.MutexOptionLockFor(30*time.Second),
-			apredis.MutexOptionRetryFor(31*time.Second),
+			apredis.MutexOptionLockFor(lockDuration),
+			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
 			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
 			apredis.MutexOptionDetailedLockMetadata(),
 		)
-		err = m.Lock(context.Background())
-		if err != nil {
-			logger.Info("failed to establish redis lock")
-			return errors.Wrap(err, "failed to establish lock for data encryption key wrapping sync")
-		}
-		defer m.Unlock(context.Background())
+		return apredis.RunWithMutex(ctx, m, lockDuration, func(lockCtx context.Context) error {
+			// Another owner may have completed while this caller waited.
+			val, getErr := redis.Get(lockCtx, sentinelKey).Result()
+			if getErr == nil && val != "" {
+				logger.Info("skipping key sync: recently synced")
+				return nil
+			}
+
+			if syncErr := syncKeysToDatabase(lockCtx, cfg, db, logger, nil, opts...); syncErr != nil {
+				return syncErr
+			}
+
+			now := apctx.GetClock(lockCtx).Now()
+			if setErr := redis.Set(lockCtx, sentinelKey, fmt.Sprintf("%d", now.Unix()), sentinelTTL).Err(); setErr != nil {
+				logger.Warn("failed to set key sync sentinel", "error", setErr)
+			}
+			return nil
+		})
+	}
+
+	logger.Info("syncing data encryption key wrapping to database")
+	defer logger.Info("syncing data encryption key wrapping to database complete")
+	options := newSyncKeysOptions(opts)
+
+	if err := ensureRootNamespaceHasKeySet(ctx, db); err != nil {
+		return errors.Wrap(err, "failed to ensure root namespace uses global key")
 	}
 
 	if cfg == nil || cfg.GetRoot() == nil {
@@ -428,14 +442,6 @@ func syncKeysToDatabase(
 	err = reconcileNamespaceEncryptionTargets(ctx, db, logger)
 	if err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to update namespace target data encryption keys"))
-	}
-
-	// Set sentinel after successful sync
-	if redis != nil {
-		now := apctx.GetClock(ctx).Now()
-		if setErr := redis.Set(ctx, sentinelKey, fmt.Sprintf("%d", now.Unix()), sentinelTTL).Err(); setErr != nil {
-			logger.Warn("failed to set key sync sentinel", "error", setErr)
-		}
 	}
 
 	return result.ErrorOrNil()

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -381,10 +381,10 @@ func (dm *DependencyManager) AutoMigrateDatabase() {
 			}
 
 			if err := workflows.Migrate(
+				ctx,
 				dm.GetConfigRoot(),
 				dm.GetLogBuilder().WithComponent("workflows").Build(),
 				workflows.WithPostgresMigrationDB(dm.GetSQLDB()),
-				workflows.WithMigrationContext(ctx),
 			); err != nil {
 				return fmt.Errorf("failed to migrate workflow database: %w", err)
 			}

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -366,33 +366,34 @@ func (dm *DependencyManager) ShutdownDatabase() {
 // AutoMigrateDatabase will attempt to migrate the database if the root config has auto migrate enabled.
 func (dm *DependencyManager) AutoMigrateDatabase() {
 	if dm.GetConfigRoot().Database.GetAutoMigrate() {
-		func() {
-			m := apredis.NewMutex(
-				dm.GetRedisClient(),
-				database.MigrateMutexKeyName,
-				apredis.MutexOptionLockFor(dm.GetConfigRoot().Database.GetAutoMigrationLockDuration()),
-				apredis.MutexOptionRetryFor(dm.GetConfigRoot().Database.GetAutoMigrationLockDuration()+1*time.Second),
-				apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-				apredis.MutexOptionDetailedLockMetadata(),
-			)
-			err := m.Lock(context.Background())
-			if err != nil {
-				panic(fmt.Errorf("failed to establish lock for database migration: %w", err))
-			}
-			defer m.Unlock(context.Background())
-
-			if err := dm.GetDatabase().Migrate(context.Background()); err != nil {
-				panic(err)
+		lockDuration := dm.GetConfigRoot().Database.GetAutoMigrationLockDuration()
+		m := apredis.NewMutex(
+			dm.GetRedisClient(),
+			database.MigrateMutexKeyName,
+			apredis.MutexOptionLockFor(lockDuration),
+			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
+			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+			apredis.MutexOptionDetailedLockMetadata(),
+		)
+		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
+			if err := dm.GetDatabase().Migrate(ctx); err != nil {
+				return err
 			}
 
 			if err := workflows.Migrate(
 				dm.GetConfigRoot(),
 				dm.GetLogBuilder().WithComponent("workflows").Build(),
 				workflows.WithPostgresMigrationDB(dm.GetSQLDB()),
+				workflows.WithMigrationContext(ctx),
 			); err != nil {
-				panic(fmt.Errorf("failed to migrate workflow database: %w", err))
+				return fmt.Errorf("failed to migrate workflow database: %w", err)
 			}
-		}()
+			return nil
+		})
+		if err != nil {
+			dm.GetLogger().Error("automatic database migration failed", "lock_key", database.MigrateMutexKeyName, "error", err)
+			panic(fmt.Errorf("failed to automatically migrate database: %w", err))
+		}
 	}
 }
 
@@ -479,10 +480,25 @@ func (dm *DependencyManager) GetHttpf() httpf.F {
 
 func (dm *DependencyManager) AutoMigrateAppMetricsService() {
 	if dm.GetConfigRoot().AppMetrics.GetAutoMigrate() {
-		store := dm.GetAppMetricsService()
-		err := store.Migrate(context.Background())
+		var dbConfig *sconfig.Database
+		if dm.GetConfigRoot().AppMetrics != nil {
+			dbConfig = dm.GetConfigRoot().AppMetrics.Database
+		}
+		lockDuration := dbConfig.GetAutoMigrationLockDuration()
+		m := apredis.NewMutex(
+			dm.GetRedisClient(),
+			app_metrics.MigrateMutexKeyName,
+			apredis.MutexOptionLockFor(lockDuration),
+			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
+			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+			apredis.MutexOptionDetailedLockMetadata(),
+		)
+		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
+			return dm.GetAppMetricsService().Migrate(ctx)
+		})
 		if err != nil {
-			panic(err)
+			dm.GetLogger().Error("automatic app metrics migration failed", "lock_key", app_metrics.MigrateMutexKeyName, "error", err)
+			panic(fmt.Errorf("failed to automatically migrate app metrics: %w", err))
 		}
 	}
 }
@@ -679,25 +695,21 @@ func (dm *DependencyManager) StartRateLimitRefresher(ctx context.Context) (stop 
 // TODO: this automigrate should not be specific to the connectors config
 func (dm *DependencyManager) AutoMigrateCore() {
 	if dm.GetConfigRoot().Connectors.GetAutoMigrate() {
-		func() {
-			m := apredis.NewMutex(
-				dm.GetRedisClient(),
-				core.MigrateMutexKeyName,
-				apredis.MutexOptionLockFor(dm.GetConfigRoot().Connectors.GetAutoMigrationLockDurationOrDefault()),
-				apredis.MutexOptionRetryFor(dm.GetConfigRoot().Connectors.GetAutoMigrationLockDurationOrDefault()+1*time.Second),
-				apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-				apredis.MutexOptionDetailedLockMetadata(),
-			)
-			err := m.Lock(context.Background())
-			if err != nil {
-				panic(err)
-			}
-			defer m.Unlock(context.Background())
-
-			if err := dm.GetCoreService().Migrate(context.Background()); err != nil {
-				panic(err)
-			}
-		}()
+		lockDuration := dm.GetConfigRoot().Connectors.GetAutoMigrationLockDurationOrDefault()
+		m := apredis.NewMutex(
+			dm.GetRedisClient(),
+			core.MigrateMutexKeyName,
+			apredis.MutexOptionLockFor(lockDuration),
+			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
+			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+			apredis.MutexOptionDetailedLockMetadata(),
+		)
+		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
+			return dm.GetCoreService().Migrate(ctx)
+		})
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 
@@ -726,21 +738,16 @@ func (dm *DependencyManager) AutoMigratePredefinedActors() {
 		return
 	}
 
-	func() {
-		m := apredis.NewMutex(
-			dm.GetRedisClient(),
-			"actor_sync:migrate",
-			apredis.MutexOptionLockFor(30*time.Second),
-			apredis.MutexOptionRetryFor(31*time.Second),
-			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-			apredis.MutexOptionDetailedLockMetadata(),
-		)
-		err := m.Lock(context.Background())
-		if err != nil {
-			panic(fmt.Errorf("failed to establish lock for admin users migration: %w", err))
-		}
-		defer m.Unlock(context.Background())
-
+	const lockDuration = 30 * time.Second
+	m := apredis.NewMutex(
+		dm.GetRedisClient(),
+		"actor_sync:migrate",
+		apredis.MutexOptionLockFor(lockDuration),
+		apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
+		apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+		apredis.MutexOptionDetailedLockMetadata(),
+	)
+	err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
 		svc := tasks.NewService(
 			dm.GetConfig(),
 			dm.GetDatabase(),
@@ -748,11 +755,11 @@ func (dm *DependencyManager) AutoMigratePredefinedActors() {
 			dm.GetEncryptService(),
 			dm.GetLogger(),
 		)
-
-		if err := svc.SyncActorList(context.Background()); err != nil {
-			panic(fmt.Errorf("failed to sync actors from config list: %w", err))
-		}
-	}()
+		return svc.SyncActorList(ctx)
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to sync actors from config list: %w", err))
+	}
 }
 
 // AutoMigrateGenerateDataEncryptionKeys ensures current DEKs exist before any

--- a/internal/util/migrate.go
+++ b/internal/util/migrate.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"context"
+
+	"github.com/golang-migrate/migrate/v4"
+)
+
+// RunMigrationsUp runs all pending migrations and asks golang-migrate to stop
+// at its next safe boundary if ctx is cancelled. golang-migrate does not accept
+// a context directly, so callers must bridge cancellation through GracefulStop.
+func RunMigrationsUp(ctx context.Context, migrator *migrate.Migrate) error {
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			select {
+			case migrator.GracefulStop <- true:
+			case <-done:
+			}
+		case <-done:
+		}
+	}()
+
+	return migrator.Up()
+}

--- a/internal/util/migrate_test.go
+++ b/internal/util/migrate_test.go
@@ -1,0 +1,124 @@
+package util
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	dbstub "github.com/golang-migrate/migrate/v4/database/stub"
+	"github.com/golang-migrate/migrate/v4/source"
+	sourcestub "github.com/golang-migrate/migrate/v4/source/stub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMigrationsUpStopsAfterCurrentMigrationWhenContextCancelled(t *testing.T) {
+	sourceDriver, err := sourcestub.WithInstance(struct{}{}, &sourcestub.Config{})
+	require.NoError(t, err)
+	sourceBase := sourceDriver.(*sourcestub.Stub)
+	require.True(t, sourceBase.Migrations.Append(&source.Migration{
+		Version:    1,
+		Direction:  source.Up,
+		Identifier: "CREATE 1",
+	}))
+	require.True(t, sourceBase.Migrations.Append(&source.Migration{
+		Version:    2,
+		Direction:  source.Up,
+		Identifier: "CREATE 2",
+	}))
+
+	databaseDriver, err := dbstub.WithInstance(struct{}{}, &dbstub.Config{})
+	require.NoError(t, err)
+	databaseBase := databaseDriver.(*dbstub.Stub)
+
+	continueSource := make(chan struct{})
+	continueMigration := make(chan struct{})
+	var continueSourceOnce sync.Once
+	var continueMigrationOnce sync.Once
+	t.Cleanup(func() {
+		continueSourceOnce.Do(func() { close(continueSource) })
+		continueMigrationOnce.Do(func() { close(continueMigration) })
+	})
+
+	blockingSource := &blockingMigrationSource{
+		Stub:         sourceBase,
+		nextStarted:  make(chan struct{}),
+		continueNext: continueSource,
+	}
+	blockingDatabase := &blockingMigrationDatabase{
+		Stub:             databaseBase,
+		firstRunStarted:  make(chan struct{}),
+		continueFirstRun: continueMigration,
+	}
+
+	migrator, err := migrate.NewWithInstance("test-source", blockingSource, "test-database", blockingDatabase)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = migrator.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- RunMigrationsUp(ctx, migrator)
+	}()
+
+	requireSignal(t, blockingDatabase.firstRunStarted, "first migration to start")
+	requireSignal(t, blockingSource.nextStarted, "second migration to be discovered")
+	cancel()
+	require.Eventually(t, func() bool {
+		return len(migrator.GracefulStop) == 1
+	}, time.Second, time.Millisecond, "context cancellation was not bridged to GracefulStop")
+
+	continueSourceOnce.Do(func() { close(continueSource) })
+	continueMigrationOnce.Do(func() { close(continueMigration) })
+
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("migration did not stop after context cancellation")
+	}
+	require.Equal(t, []string{"CREATE 1"}, databaseBase.MigrationSequence)
+}
+
+type blockingMigrationSource struct {
+	*sourcestub.Stub
+	nextStarted  chan struct{}
+	continueNext chan struct{}
+	blockOnce    sync.Once
+}
+
+func (s *blockingMigrationSource) Next(version uint) (uint, error) {
+	s.blockOnce.Do(func() {
+		close(s.nextStarted)
+		<-s.continueNext
+	})
+	return s.Stub.Next(version)
+}
+
+type blockingMigrationDatabase struct {
+	*dbstub.Stub
+	firstRunStarted  chan struct{}
+	continueFirstRun chan struct{}
+	blockOnce        sync.Once
+}
+
+func (d *blockingMigrationDatabase) Run(migration io.Reader) error {
+	d.blockOnce.Do(func() {
+		close(d.firstRunStarted)
+		<-d.continueFirstRun
+	})
+	return d.Stub.Run(migration)
+}
+
+func requireSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -126,7 +126,6 @@ type MigrateOption func(*migrateOptions)
 
 type migrateOptions struct {
 	postgresDB *sql.DB
-	ctx        context.Context
 }
 
 func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
@@ -135,13 +134,7 @@ func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
 	}
 }
 
-func WithMigrationContext(ctx context.Context) MigrateOption {
-	return func(o *migrateOptions) {
-		o.ctx = ctx
-	}
-}
-
-func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) error {
+func Migrate(ctx context.Context, root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) error {
 	if root == nil || root.Database == nil {
 		return fmt.Errorf("database configuration is required")
 	}
@@ -149,9 +142,6 @@ func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) err
 	migrateOpts := &migrateOptions{}
 	for _, opt := range opts {
 		opt(migrateOpts)
-	}
-	if migrateOpts.ctx == nil {
-		migrateOpts.ctx = context.Background()
 	}
 
 	switch cfg := root.Database.InnerVal.(type) {
@@ -161,14 +151,14 @@ func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) err
 			return fmt.Errorf("open workflow sqlite database: %w", err)
 		}
 		defer db.Close()
-		return migrateDB(migrateOpts.ctx, db, "sqlite", "migrations/sqlite")
+		return migrateDB(ctx, db, "sqlite", "migrations/sqlite")
 	case *sconfig.DatabasePostgres:
 		db := migrateOpts.postgresDB
 		if db == nil {
 			return fmt.Errorf("workflow postgres database handle is required")
 		}
 
-		return migrateDB(migrateOpts.ctx, db, "postgres", "migrations/postgres")
+		return migrateDB(ctx, db, "postgres", "migrations/postgres")
 	default:
 		return fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
 	}

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 const (
@@ -125,11 +126,18 @@ type MigrateOption func(*migrateOptions)
 
 type migrateOptions struct {
 	postgresDB *sql.DB
+	ctx        context.Context
 }
 
 func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
 	return func(o *migrateOptions) {
 		o.postgresDB = db
+	}
+}
+
+func WithMigrationContext(ctx context.Context) MigrateOption {
+	return func(o *migrateOptions) {
+		o.ctx = ctx
 	}
 }
 
@@ -142,6 +150,9 @@ func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) err
 	for _, opt := range opts {
 		opt(migrateOpts)
 	}
+	if migrateOpts.ctx == nil {
+		migrateOpts.ctx = context.Background()
+	}
 
 	switch cfg := root.Database.InnerVal.(type) {
 	case *sconfig.DatabaseSqlite:
@@ -150,20 +161,20 @@ func Migrate(root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) err
 			return fmt.Errorf("open workflow sqlite database: %w", err)
 		}
 		defer db.Close()
-		return migrateDB(db, "sqlite", "migrations/sqlite")
+		return migrateDB(migrateOpts.ctx, db, "sqlite", "migrations/sqlite")
 	case *sconfig.DatabasePostgres:
 		db := migrateOpts.postgresDB
 		if db == nil {
 			return fmt.Errorf("workflow postgres database handle is required")
 		}
 
-		return migrateDB(db, "postgres", "migrations/postgres")
+		return migrateDB(migrateOpts.ctx, db, "postgres", "migrations/postgres")
 	default:
 		return fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
 	}
 }
 
-func migrateDB(db *sql.DB, driverName string, sourcePath string) error {
+func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath string) error {
 	var (
 		driver migratedatabase.Driver
 		err    error
@@ -193,7 +204,7 @@ func migrateDB(db *sql.DB, driverName string, sourcePath string) error {
 	if err != nil {
 		return fmt.Errorf("creating workflow migration: %w", err)
 	}
-	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+	if err := util.RunMigrationsUp(ctx, m); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("running workflow migrations: %w", err)
 	}
 

--- a/internal/workflows/runtime_test.go
+++ b/internal/workflows/runtime_test.go
@@ -25,7 +25,7 @@ func TestMigrateSqliteAndRuntimePing(t *testing.T) {
 	}
 	logger := slog.New(slog.DiscardHandler)
 
-	require.NoError(t, Migrate(root, logger))
+	require.NoError(t, Migrate(context.Background(), root, logger))
 
 	db, err := sql.Open("sqlite", "file:"+dbPath)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- extend the shared `apredis.Mutex` support with a renewable `RunWithMutex` helper, cancellation on lease loss, reliable cleanup, and correct bounded-retry deadlines
- use the same Redis coordination contract for primary SQLite/PostgreSQL migrations, workflow migrations, and SQLite/PostgreSQL/ClickHouse app-metrics migrations
- move the other startup/task reconcilers onto the renewable helper and make golang-migrate respond to context cancellation at safe boundaries
- document the lock targets, lease behavior, provider coverage, and production rollout guidance

## Locking interface

Callers continue to construct an `apredis.Mutex` with the existing options, then run protected work through:

```go
err := apredis.RunWithMutex(ctx, mutex, leaseDuration, func(lockCtx context.Context) error {
    return migrate(lockCtx)
})
```

The helper acquires the lock, refreshes it every third of the lease, cancels `lockCtx` and returns `ErrMutexLeaseLost` if renewal fails, and always attempts release on success, error, or panic. This stays provider-independent because Redis is the common coordinator; PostgreSQL's migrate-driver advisory lock remains as defense in depth.

The primary and workflow schemas share `db-migrate-lock`. App metrics uses `app-metrics-migrate-lock`, allowing its separately configured database to migrate independently.

## Verification

- `go test -count=1 -timeout=20m ./...`
- SQLite affected-package suites
- PostgreSQL affected-package suites
- ClickHouse `internal/app_metrics` suite
- `yarn docs:build`
- `./scripts/preflight.sh`

Closes #816
