### PR TITLE
Add explicit database migration workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -287,6 +287,8 @@ jobs:
           echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
 
           grep -Fq "image: ghcr.io/rmorlok/authproxy:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "name: ${RELEASE_NAME}-authproxy-migrate" "${manifest}"
+          grep -Fq -- "- migrate" "${manifest}"
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-shell:${IMAGE_TAG}" "${manifest}"
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-grafana:${IMAGE_TAG}" "${manifest}"
           grep -Fq "image: docker.io/grafana/otel-lgtm:0.8.6" "${manifest}"
@@ -306,17 +308,23 @@ jobs:
           grep -Fq "uid: tempo" "${manifest}"
           grep -Fq "uid: loki" "${manifest}"
 
-      - name: Apply Kustomize manifest
+      - name: Apply migration prerequisites
         run: |
           set -euo pipefail
           manifest="${{ steps.render.outputs.manifest }}"
 
           kubectl create namespace "${RELEASE_NS}" --dry-run=client -o yaml \
             | kubectl apply -f -
-          kubectl -n "${RELEASE_NS}" apply -f "${manifest}"
+          kubectl -n "${RELEASE_NS}" delete job "${RELEASE_NAME}-authproxy-migrate" \
+            --ignore-not-found --wait=true
+
+          # Keep the new AuthProxy workload and migration Job out of this
+          # apply. Existing AuthProxy pods continue running until the new
+          # schema has migrated successfully.
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}" \
+            -l 'app.kubernetes.io/component notin (authproxy,migration)'
 
           deployments=(
-            "${RELEASE_NAME}-authproxy"
             "${RELEASE_NAME}-demo-shell"
             "${RELEASE_NAME}-grafana"
             "${RELEASE_NAME}-otel-lgtm"
@@ -328,7 +336,7 @@ jobs:
               -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"demo.authproxy.net/image-revision\":\"${{ steps.tag.outputs.sha }}\"}}}}}"
           done
 
-      - name: Wait for workload rollouts
+      - name: Wait for migration prerequisites
         timeout-minutes: 10
         run: |
           set -euo pipefail
@@ -337,6 +345,54 @@ jobs:
             "${RELEASE_NAME}-redis-master" \
             "${RELEASE_NAME}-minio" \
             "${RELEASE_NAME}-otel-lgtm" \
+          ; do
+            echo "Waiting for $d..."
+            kubectl -n "${RELEASE_NS}" rollout status "deployment/$d" --timeout=10m
+          done
+
+      - name: Wait for database migration
+        timeout-minutes: 16
+        run: |
+          set -euo pipefail
+          manifest="${{ steps.render.outputs.manifest }}"
+          job="${RELEASE_NAME}-authproxy-migrate"
+
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}" \
+            -l 'app.kubernetes.io/component=migration'
+          kubectl -n "${RELEASE_NS}" patch "job/${job}" --type merge -p '{"spec":{"suspend":false}}'
+          deadline=$((SECONDS + 900))
+          while (( SECONDS < deadline )); do
+            conditions="$(kubectl -n "${RELEASE_NS}" get "job/${job}" -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}')"
+            if grep -Fq 'Complete=True' <<<"${conditions}"; then
+              kubectl -n "${RELEASE_NS}" logs "job/${job}"
+              exit 0
+            fi
+            if grep -Fq 'Failed=True' <<<"${conditions}"; then
+              echo "Migration Job failed" >&2
+              break
+            fi
+            sleep 5
+          done
+          kubectl -n "${RELEASE_NS}" logs "job/${job}" --all-containers=true || true
+          kubectl -n "${RELEASE_NS}" describe "job/${job}" || true
+          exit 1
+
+      - name: Apply AuthProxy workload
+        run: |
+          set -euo pipefail
+          manifest="${{ steps.render.outputs.manifest }}"
+
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}" \
+            -l 'app.kubernetes.io/component=authproxy'
+          kubectl -n "${RELEASE_NS}" patch "deployment/${RELEASE_NAME}-authproxy" \
+            --type merge \
+            -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"demo.authproxy.net/image-revision\":\"${{ steps.tag.outputs.sha }}\"}}}}}"
+
+      - name: Wait for workload rollouts
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          for d in \
             "${RELEASE_NAME}-authproxy" \
             "${RELEASE_NAME}-demo-shell" \
             "${RELEASE_NAME}-go-oauth2-server" \

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -86,7 +86,7 @@ jobs:
           keda_manifest="$(mktemp)"
 
           helm template authproxy deploy/charts/authproxy \
-            -f deploy/charts/authproxy/ci/sqlite-redis-values.yaml \
+            -f deploy/charts/authproxy/ci/postgres-redis-values.yaml \
             >"${disabled_manifest}"
           if grep -q "kind: HorizontalPodAutoscaler" "${disabled_manifest}"; then
             echo "HPA rendered even though autoscaling.enabled is false" >&2
@@ -96,9 +96,16 @@ jobs:
             echo "KEDA rendered even though keda.enabled is false" >&2
             exit 1
           fi
+          grep -q "name: authproxy-migrate-1" "${disabled_manifest}"
+          grep -q -- "- migrate" "${disabled_manifest}"
+          grep -q -- "- all" "${disabled_manifest}"
+          if grep -q "autoMigrate" "${disabled_manifest}"; then
+            echo "Removed autoMigrate configuration rendered by Helm" >&2
+            exit 1
+          fi
 
           helm template authproxy deploy/charts/authproxy \
-            -f deploy/charts/authproxy/ci/sqlite-redis-values.yaml \
+            -f deploy/charts/authproxy/ci/postgres-redis-values.yaml \
             --set keda.enabled=true \
             >"${keda_controller_manifest}"
           grep -q "kind: CustomResourceDefinition" "${keda_controller_manifest}"
@@ -107,7 +114,7 @@ jobs:
           grep -q "name: keda-operator" "${keda_controller_manifest}"
 
           helm template authproxy deploy/charts/authproxy \
-            -f deploy/charts/authproxy/ci/sqlite-redis-values.yaml \
+            -f deploy/charts/authproxy/ci/postgres-redis-values.yaml \
             --set keda.enabled=false \
             --set autoscaling.enabled=true \
             --set autoscaling.minReplicas=2 \
@@ -117,7 +124,7 @@ jobs:
           grep -q "kind: HorizontalPodAutoscaler" "${native_hpa_manifest}"
 
           helm template authproxy deploy/charts/authproxy \
-            -f deploy/charts/authproxy/ci/sqlite-redis-values.yaml \
+            -f deploy/charts/authproxy/ci/postgres-redis-values.yaml \
             -f deploy/charts/authproxy/ci/autoscaling-render.yaml \
             >"${keda_manifest}"
           grep -q "apiVersion: keda.sh/v1alpha1" "${keda_manifest}"
@@ -156,10 +163,17 @@ jobs:
           grep -q "host: demo-postgresql" "${demo_manifest}"
           grep -q "address: demo-redis-master:6379" "${demo_manifest}"
           grep -q "secretName: demo-jwt" "${demo_manifest}"
+          grep -q "name: demo-authproxy-migrate" "${demo_manifest}"
+          grep -q "suspend: true" "${demo_manifest}"
 
           grep -q "name: dev-authproxy" "${dev_manifest}"
           grep -q "provider: miniredis" "${dev_manifest}"
           grep -q "provider: filesystem" "${dev_manifest}"
+          grep -q -- "- --auto-migrate" "${dev_manifest}"
+          if grep -q "authproxy-migrate" "${dev_manifest}"; then
+            echo "Kustomize dev render included a cross-pod SQLite migration Job" >&2
+            exit 1
+          fi
 
           if grep -Eq "name: dev-(postgresql|redis-master|minio)$" "${dev_manifest}"; then
             echo "Kustomize dev render leaked backing service workloads" >&2
@@ -241,11 +255,11 @@ jobs:
         if: steps.changed.outputs.found == 'true'
         run: kubectl create namespace authproxy-ct
 
-      - name: Deploy in-cluster Redis sidecar
+      - name: Deploy in-cluster database dependencies
         if: steps.changed.outputs.found == 'true'
         run: |
           # Deployed into the same namespace as `ct install` so the chart's
-          # `redis:6379` short-name resolves via in-namespace DNS.
+          # short service names resolve via in-namespace DNS.
           kubectl apply -n authproxy-ct -f - <<'EOF'
           apiVersion: apps/v1
           kind: Deployment
@@ -277,8 +291,43 @@ jobs:
               - port: 6379
                 targetPort: redis
                 name: redis
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: postgres
+            labels: { app: postgres }
+          spec:
+            replicas: 1
+            selector: { matchLabels: { app: postgres } }
+            template:
+              metadata: { labels: { app: postgres } }
+              spec:
+                containers:
+                  - name: postgres
+                    image: postgres:16-alpine
+                    env:
+                      - { name: POSTGRES_DB, value: authproxy }
+                      - { name: POSTGRES_USER, value: authproxy }
+                      - { name: POSTGRES_PASSWORD, value: authproxy }
+                    ports: [{ name: postgres, containerPort: 5432 }]
+                    readinessProbe:
+                      exec: { command: ["pg_isready", "-U", "authproxy", "-d", "authproxy"] }
+                      periodSeconds: 2
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: postgres
+          spec:
+            selector: { app: postgres }
+            ports:
+              - port: 5432
+                targetPort: postgres
+                name: postgres
           EOF
           kubectl -n authproxy-ct rollout status deployment/redis --timeout=60s
+          kubectl -n authproxy-ct rollout status deployment/postgres --timeout=60s
 
       - name: Generate crypto material + apply as K8s Secrets
         if: steps.changed.outputs.found == 'true'
@@ -304,6 +353,8 @@ jobs:
             --from-file=system.pub="$workdir/system.pub"
           kubectl -n authproxy-ct create secret generic authproxy-encryption \
             --from-file=global_aes.key="$workdir/global_aes.key"
+          kubectl -n authproxy-ct create secret generic authproxy-db \
+            --from-literal=AUTHPROXY_DB_PASSWORD=authproxy
           # Actor keypair files mount as <actors.mountPath>/<key>; key names
           # carry no slashes (K8s Secret data keys can't), so files like
           # `ci` and `ci.pub` are how the actors loader reads pairs.
@@ -322,4 +373,4 @@ jobs:
             --config .github/ct.yaml \
             --target-branch main \
             --namespace authproxy-ct \
-            --helm-extra-args "--timeout=5m"
+            --helm-extra-args "--timeout=5m --wait-for-jobs"

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -365,12 +365,14 @@ jobs:
       - name: ct install
         if: steps.changed.outputs.found == 'true'
         # chart-testing auto-installs each chart once per
-        # <chart>/ci/*-values.yaml file. AuthProxy's sqlite/redis CI
+        # <chart>/ci/*-values.yaml file. AuthProxy's Postgres/Redis CI
         # values point at the local image loaded above and provide the
-        # minimum config needed for the runtime validator.
+        # minimum config needed for the runtime validator. Keep install-only
+        # flags out of helm-extra-args because ct also forwards these arguments
+        # to helm test and helm uninstall.
         run: |
           ct install \
             --config .github/ct.yaml \
             --target-branch main \
             --namespace authproxy-ct \
-            --helm-extra-args "--timeout=5m --wait-for-jobs"
+            --helm-extra-args "--timeout=5m"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ docker compose --profile server up -d
 ### Run the server
 
 ```bash
-go run ./cmd/server serve --config=./dev_config/default.yaml all
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
 ```
 
 The final arg is the service to run: `admin-api`, `api`, `public`, `worker`, or `all`.

--- a/cmd/loadtest/seed.go
+++ b/cmd/loadtest/seed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rmorlok/authproxy/internal/database"
 	encryptpkg "github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/loadtest/seeder"
 	"github.com/rmorlok/authproxy/internal/migration"
@@ -54,7 +55,13 @@ func cmdSeed() *cobra.Command {
 						return err
 					}
 				} else {
-					if err := dm.GetDatabase().Migrate(ctx); err != nil {
+					if err := database.RunMigrations(
+						ctx,
+						dm.GetConfigRoot().Database,
+						dm.GetLogger(),
+						migration.DirectionUp,
+						nil,
+					); err != nil {
 						return fmt.Errorf("failed to migrate database: %w", err)
 					}
 					if err := dm.GetDatabase().EnsureNamespaceByPath(ctx, namespace.Root); err != nil {

--- a/cmd/loadtest/seed.go
+++ b/cmd/loadtest/seed.go
@@ -7,6 +7,8 @@ import (
 
 	encryptpkg "github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/loadtest/seeder"
+	"github.com/rmorlok/authproxy/internal/migration"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/service"
 	"github.com/spf13/cobra"
 )
@@ -48,12 +50,15 @@ func cmdSeed() *cobra.Command {
 
 			if migrate {
 				if distributedMigrationLocks {
-					dm.AutoMigrateDatabase()
-					dm.AutoMigrateGenerateDataEncryptionKeys()
-					dm.AutoMigrateSyncKeysToDatabase()
+					if err := dm.RunProductionMigration(ctx, migration.TargetMainDatabase, migration.DirectionUp, nil); err != nil {
+						return err
+					}
 				} else {
 					if err := dm.GetDatabase().Migrate(ctx); err != nil {
 						return fmt.Errorf("failed to migrate database: %w", err)
+					}
+					if err := dm.GetDatabase().EnsureNamespaceByPath(ctx, namespace.Root); err != nil {
+						return fmt.Errorf("failed to ensure root namespace: %w", err)
 					}
 					if err := encryptpkg.GenerateDataEncryptionKeysToDatabase(ctx, cfg, dm.GetDatabase(), dm.GetLogger(), nil); err != nil {
 						return fmt.Errorf("failed to generate data encryption keys: %w", err)

--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -5,12 +5,21 @@ This is the CLI that starts the services on the server.
 Start all services with:
 
 ```bash
-go run ./cmd/server serve --config=./dev_config/default.yaml all
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
 ```
 
 Or start individual services:
 ```bash
-go run ./cmd/server serve --config=./dev_config/default.yaml worker
-go run ./cmd/server serve --config=./dev_config/default.yaml api
-go run ./cmd/server serve --config=./dev_config/default.yaml admin-api
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml worker
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml api
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml admin-api
+```
+
+Production-style startup omits `--auto-migrate`. Inspect and migrate schemas
+explicitly before starting services:
+
+```bash
+go run ./cmd/server migrate status --config=./dev_config/default.yaml
+go run ./cmd/server migrate all --config=./dev_config/default.yaml
+go run ./cmd/server serve --config=./dev_config/default.yaml all
 ```

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
+	"text/tabwriter"
 
 	"github.com/fatih/color"
 	"github.com/gin-gonic/gin"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/service"
 	"github.com/rmorlok/authproxy/internal/service/admin_api"
 	api "github.com/rmorlok/authproxy/internal/service/api"
@@ -23,6 +28,20 @@ import (
 
 var cfgFile string
 var cfg config.C
+
+type migrationManager interface {
+	RunDevelopmentMigration(context.Context) error
+	VerifyMigrations(context.Context) error
+	RunProductionMigration(context.Context, migration.Target, migration.Direction, *uint) error
+	MigrationStatuses(context.Context, migration.Target) []migration.Status
+	ShutdownMigrationResources()
+}
+
+var newMigrationManager = func(serviceID string, cfg config.C) migrationManager {
+	return service.NewDependencyManager(serviceID, cfg)
+}
+
+var startServices = runServices
 
 func loadConfig() error {
 	if cfgFile == "" {
@@ -48,27 +67,9 @@ func loadConfig() error {
 }
 
 func runServices(noBanner bool, servicesList string) error {
-	services := strings.Split(servicesList, ",")
-	servers := make([]func(cfg config.C), 0, len(services))
-
-	if len(services) == 0 {
-		return errors.New("no services provided")
-	}
-	for _, service := range services {
-		switch service {
-		case "admin-api":
-			servers = append(servers, admin_api.Serve)
-		case "api":
-			servers = append(servers, api.Serve)
-		case "public":
-			servers = append(servers, public.Serve)
-		case "worker":
-			servers = append(servers, worker.Serve)
-		case "all":
-			servers = append(servers, admin_api.Serve, api.Serve, public.Serve, worker.Serve)
-		default:
-			return errors.New("unknown service: " + service)
-		}
+	servers, err := resolveServices(servicesList)
+	if err != nil {
+		return err
 	}
 
 	if !noBanner {
@@ -87,6 +88,33 @@ func runServices(noBanner bool, servicesList string) error {
 	wg.Wait()
 
 	return nil
+}
+
+func resolveServices(servicesList string) ([]func(cfg config.C), error) {
+	services := strings.Split(servicesList, ",")
+	servers := make([]func(cfg config.C), 0, len(services))
+
+	if len(services) == 0 {
+		return nil, errors.New("no services provided")
+	}
+	for _, service := range services {
+		switch service {
+		case "admin-api":
+			servers = append(servers, admin_api.Serve)
+		case "api":
+			servers = append(servers, api.Serve)
+		case "public":
+			servers = append(servers, public.Serve)
+		case "worker":
+			servers = append(servers, worker.Serve)
+		case "all":
+			servers = append(servers, admin_api.Serve, api.Serve, public.Serve, worker.Serve)
+		default:
+			return nil, errors.New("unknown service: " + service)
+		}
+	}
+
+	return servers, nil
 }
 
 func banner() {
@@ -123,19 +151,132 @@ func cmdRoutes() *cobra.Command {
 
 func cmdServe() *cobra.Command {
 	var noBanner bool
+	var autoMigrate bool
 
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start services",
 		Args:  cobra.ExactArgs(1), // Expect exactly one argument
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runServices(noBanner, args[0])
+			if _, err := resolveServices(args[0]); err != nil {
+				return err
+			}
+			if err := prepareServe(cmd.Context(), autoMigrate, cmd.ErrOrStderr()); err != nil {
+				return err
+			}
+			return startServices(noBanner, args[0])
 		},
 	}
 
 	cmd.Flags().BoolVar(&noBanner, "no-banner", false, "Don't show banner")
+	cmd.Flags().BoolVar(&autoMigrate, "auto-migrate", false, "Automatically migrate and reconcile a local/disposable development environment (unsafe for production)")
 
 	return cmd
+}
+
+func prepareServe(ctx context.Context, autoMigrate bool, warningOutput io.Writer) error {
+	dm := newMigrationManager("startup-migrations", cfg)
+	defer dm.ShutdownMigrationResources()
+	if autoMigrate {
+		fmt.Fprintln(warningOutput, "WARNING: --auto-migrate is intended only for local/disposable development environments. Use 'authproxy migrate' before production deployment.")
+		if err := dm.RunDevelopmentMigration(ctx); err != nil {
+			return fmt.Errorf("automatic development migration failed: %w", err)
+		}
+		return nil
+	}
+	return dm.VerifyMigrations(ctx)
+}
+
+func cmdMigrate() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate <database> [up|down] [version]",
+		Short: "Migrate AuthProxy database schemas",
+		Long:  "Migrate one AuthProxy schema target or all targets sequentially. Databases: " + migration.FormatTargets(),
+		Args:  cobra.RangeArgs(1, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, direction, version, err := parseMigrateArgs(args)
+			if err != nil {
+				return err
+			}
+			dm := newMigrationManager("migrate", cfg)
+			defer dm.ShutdownMigrationResources()
+			return dm.RunProductionMigration(cmd.Context(), target, direction, version)
+		},
+	}
+	cmd.AddCommand(cmdMigrateStatus())
+	return cmd
+}
+
+func parseMigrateArgs(args []string) (migration.Target, migration.Direction, *uint, error) {
+	target, err := migration.ParseTarget(args[0], true)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("%w; expected one of: %s", err, migration.FormatTargets())
+	}
+	direction := migration.DirectionUp
+	if len(args) >= 2 {
+		direction, err = migration.ParseDirection(args[1])
+		if err != nil {
+			return "", "", nil, err
+		}
+	}
+	var version *uint
+	if len(args) == 3 {
+		parsed, err := strconv.ParseUint(args[2], 10, 32)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("invalid schema version %q: %w", args[2], err)
+		}
+		if parsed == 0 {
+			return "", "", nil, errors.New("schema version must be greater than zero")
+		}
+		value := uint(parsed)
+		version = &value
+	}
+	return target, direction, version, nil
+}
+
+func cmdMigrateStatus() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status [database]",
+		Short: "Report database schema migration status without making changes",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := migration.TargetAll
+			if len(args) == 1 {
+				var err error
+				target, err = migration.ParseTarget(args[0], true)
+				if err != nil {
+					return fmt.Errorf("%w; expected one of: %s", err, migration.FormatTargets())
+				}
+			}
+			dm := newMigrationManager("migrate-status", cfg)
+			defer dm.ShutdownMigrationResources()
+			statuses := dm.MigrationStatuses(cmd.Context(), target)
+			printMigrationStatuses(cmd.OutOrStdout(), statuses)
+			var result error
+			for _, status := range statuses {
+				result = errors.Join(result, migration.IncompatibleError(status))
+			}
+			return result
+		},
+	}
+}
+
+func printMigrationStatuses(output io.Writer, statuses []migration.Status) {
+	w := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "DATABASE\tPROVIDER\tCURRENT\tAVAILABLE\tDIRTY\tSTATUS")
+	for _, status := range statuses {
+		fmt.Fprintf(
+			w,
+			"%s\t%s\t%s\t%d\t%t\t%s\n",
+			status.Target,
+			status.Provider,
+			status.CurrentVersionString(),
+			status.AvailableVersion,
+			status.Dirty,
+			status.State,
+		)
+	}
+	_ = w.Flush()
 }
 
 func cmdReencrypt() *cobra.Command {
@@ -155,13 +296,14 @@ func cmdReencrypt() *cobra.Command {
 	}
 }
 
-func main() {
+func newRootCommand() *cobra.Command {
 	// Optionally load environment variables from .env files walking up
 	// from the current working directory.
 	util.LoadDotEnv()
 
-	var rootCmd = &cobra.Command{
-		Use: "authproxy",
+	rootCmd := &cobra.Command{
+		Use:          "authproxy",
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return loadConfig()
 		},
@@ -171,6 +313,13 @@ func main() {
 
 	rootCmd.AddCommand(cmdRoutes())
 	rootCmd.AddCommand(cmdServe())
+	rootCmd.AddCommand(cmdMigrate())
 	rootCmd.AddCommand(cmdReencrypt())
-	rootCmd.Execute()
+	return rootCmd
+}
+
+func main() {
+	if err := newRootCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/migration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMigrateArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		target    migration.Target
+		direction migration.Direction
+		version   *uint
+		wantErr   bool
+	}{
+		{name: "defaults up", args: []string{"all"}, target: migration.TargetAll, direction: migration.DirectionUp},
+		{name: "down one", args: []string{"workflows", "down"}, target: migration.TargetWorkflows, direction: migration.DirectionDown},
+		{name: "exact version", args: []string{"main-database", "up", "12"}, target: migration.TargetMainDatabase, direction: migration.DirectionUp, version: uintPtr(12)},
+		{name: "bad target", args: []string{"main"}, wantErr: true},
+		{name: "bad direction", args: []string{"workflows", "sideways"}, wantErr: true},
+		{name: "bad version", args: []string{"app-metrics", "up", "latest"}, wantErr: true},
+		{name: "zero version", args: []string{"main-database", "down", "0"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, direction, version, err := parseMigrateArgs(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.target, target)
+			require.Equal(t, tt.direction, direction)
+			require.Equal(t, tt.version, version)
+		})
+	}
+}
+
+func TestPrepareServeRunsDevelopmentPlanOnce(t *testing.T) {
+	fake := &fakeMigrationManager{}
+	restoreMigrationManager(t, fake)
+	var warnings bytes.Buffer
+
+	require.NoError(t, prepareServe(context.Background(), true, &warnings))
+	require.Equal(t, 1, fake.developmentCalls)
+	require.Zero(t, fake.verifyCalls)
+	require.Equal(t, 1, fake.shutdownCalls)
+	require.Contains(t, warnings.String(), "WARNING")
+}
+
+func TestPrepareServeWithoutFlagOnlyVerifies(t *testing.T) {
+	fake := &fakeMigrationManager{}
+	restoreMigrationManager(t, fake)
+
+	require.NoError(t, prepareServe(context.Background(), false, &bytes.Buffer{}))
+	require.Zero(t, fake.developmentCalls)
+	require.Equal(t, 1, fake.verifyCalls)
+	require.Equal(t, 1, fake.shutdownCalls)
+}
+
+func TestResolveServicesAll(t *testing.T) {
+	servers, err := resolveServices("all")
+	require.NoError(t, err)
+	require.Len(t, servers, 4)
+}
+
+func TestServeDoesNotStartServicesWhenVerificationFails(t *testing.T) {
+	for _, failure := range []string{"stale schema", "dirty schema"} {
+		t.Run(failure, func(t *testing.T) {
+			fake := &fakeMigrationManager{verifyErr: errors.New(failure)}
+			restoreMigrationManager(t, fake)
+			originalStartServices := startServices
+			started := 0
+			startServices = func(bool, string) error {
+				started++
+				return nil
+			}
+			t.Cleanup(func() { startServices = originalStartServices })
+
+			cmd := cmdServe()
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.RunE(cmd, []string{"all"})
+			require.ErrorContains(t, err, failure)
+			require.Zero(t, started)
+		})
+	}
+}
+
+func restoreMigrationManager(t *testing.T, fake migrationManager) {
+	t.Helper()
+	original := newMigrationManager
+	newMigrationManager = func(string, config.C) migrationManager { return fake }
+	t.Cleanup(func() { newMigrationManager = original })
+}
+
+func uintPtr(value uint) *uint { return &value }
+
+type fakeMigrationManager struct {
+	developmentCalls int
+	verifyCalls      int
+	shutdownCalls    int
+	verifyErr        error
+}
+
+func (f *fakeMigrationManager) RunDevelopmentMigration(context.Context) error {
+	f.developmentCalls++
+	return nil
+}
+
+func (f *fakeMigrationManager) VerifyMigrations(context.Context) error {
+	f.verifyCalls++
+	return f.verifyErr
+}
+
+func (f *fakeMigrationManager) RunProductionMigration(context.Context, migration.Target, migration.Direction, *uint) error {
+	return nil
+}
+
+func (f *fakeMigrationManager) MigrationStatuses(context.Context, migration.Target) []migration.Status {
+	return nil
+}
+
+func (f *fakeMigrationManager) ShutdownMigrationResources() { f.shutdownCalls++ }

--- a/deploy/charts/authproxy/Chart.yaml
+++ b/deploy/charts/authproxy/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # Chart version follows its own semver, independent of the application image
 # version below. Bumped on every chart change.
-version: 0.1.2
+version: 0.1.3
 
 # Application version this chart was last validated against. Pinned to a
 # specific image tag here; downstream values can override `image.tag`.

--- a/deploy/charts/authproxy/README.md
+++ b/deploy/charts/authproxy/README.md
@@ -23,6 +23,7 @@ kubectl create secret generic authproxy-encryption \
 # 2. Install from the GHCR OCI registry.
 helm install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
   --version <chart-version> \
+  --wait --wait-for-jobs \
   --set database.provider=postgres \
   --set database.host=postgres.example.com \
   --set database.existingSecret=authproxy-db \
@@ -40,14 +41,14 @@ application version (`image.tag`).
 
 ```bash
 # Inspect available versions:
-helm show chart oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.2
+helm show chart oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.3
 
 # Pull a tarball locally:
-helm pull oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.2
+helm pull oci://ghcr.io/rmorlok/charts/authproxy --version 0.1.3
 
 # Install:
 helm install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
-  --version 0.1.2 \
+  --version 0.1.3 \
   -f my-values.yaml
 ```
 
@@ -59,6 +60,7 @@ The chart exposes typed values for the common connectivity blocks. See
 | Section          | Purpose                                                              |
 |------------------|----------------------------------------------------------------------|
 | `image`          | Container image repository, tag, pull policy                         |
+| `migrationJob`   | Explicit per-release schema migration Job controls                    |
 | `services.*`     | Per-service enable toggles (`api`, `adminApi`, `public`, `worker`)   |
 | `autoscaling`    | Optional native autoscaling/v2 HPA for the chart release             |
 | `keda`           | Optional KEDA controller dependency; disabled by default              |
@@ -95,11 +97,32 @@ For disposable environments, set `blobStorage.provider=filesystem`; the chart
 mounts an `emptyDir` at `blobStorage.filesystem.path` by default. Persistent
 deployments should continue to use S3-compatible storage.
 
+### Database migration Job
+
+Every release revision renders a dedicated Job that runs `authproxy migrate
+all` with the same image, ConfigMap, credentials, service account, and key
+mounts as the application Deployment. Install and upgrade with
+`--wait --wait-for-jobs` so a failed migration blocks the release:
+
+```bash
+helm upgrade --install authproxy oci://ghcr.io/rmorlok/charts/authproxy \
+  -f my-values.yaml \
+  --wait --wait-for-jobs
+```
+
+Inspect a failure with `kubectl logs job/<release>-authproxy-migrate-<revision>`.
+The Job does not force dirty versions. Disable `migrationJob.enabled` only when
+an external release process runs the same explicit migration command first.
+
 ## Independent Service Scaling
 
 The chart renders one Deployment for the enabled service set. For production or
 load-test environments that need independent scale curves, install the chart
 multiple times with different `services` toggles:
+
+Choose one release as the migration owner (`migrationJob.enabled=true`) and set
+`migrationJob.enabled=false` on every other role release. Install or upgrade
+the owner first and wait for its Job before updating the remaining roles.
 
 ```bash
 helm upgrade --install authproxy-api oci://ghcr.io/rmorlok/charts/authproxy \

--- a/deploy/charts/authproxy/ci/postgres-redis-values.yaml
+++ b/deploy/charts/authproxy/ci/postgres-redis-values.yaml
@@ -1,7 +1,7 @@
 # chart-testing values for the helm-chart-ci workflow.
 #
 # Minimum-deps profile per A5 (#287):
-#   - SQLite database (no external DB)
+#   - PostgreSQL so the migration Job and Deployment share durable schema state
 #   - real Redis as a tiny in-cluster Deployment (applied by the workflow
 #     before `ct install`, addressable at `redis:6379` in the test namespace)
 #   - JWT + encryption key Secrets are generated and applied by the workflow
@@ -19,8 +19,13 @@ image:
   pullPolicy: Never
 
 database:
-  provider: sqlite
-  path: /tmp/authproxy.db
+  provider: postgres
+  host: postgres
+  port: 5432
+  database: authproxy
+  user: authproxy
+  sslmode: disable
+  existingSecret: authproxy-db
 
 redis:
   address: redis:6379
@@ -40,7 +45,6 @@ hostApplication:
   initiateSessionUrl: http://placeholder.invalid/login
 
 connectors:
-  autoMigrate: true
   loadFromList: []
 
 # Faster probes so the helm test pod's rollout wait doesn't stall.

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -83,7 +83,7 @@ template syntax.
 */}}
 
 {{/* --- database --- */}}
-{{- $db := dict "provider" .Values.database.provider "autoMigrate" .Values.database.autoMigrate -}}
+{{- $db := dict "provider" .Values.database.provider -}}
 {{- if eq .Values.database.provider "postgres" -}}
 {{-   $_ := set $db "host" (tpl .Values.database.host $) -}}
 {{-   $_ := set $db "port" .Values.database.port -}}
@@ -119,7 +119,7 @@ template syntax.
 {{- end -}}
 
 {{/* --- connectors block (required by validator; empty list is acceptable) --- */}}
-{{- $connectors := dict "autoMigrate" .Values.connectors.autoMigrate "loadFromList" .Values.connectors.loadFromList -}}
+{{- $connectors := dict "loadFromList" .Values.connectors.loadFromList -}}
 {{- $_ := set $cfg "connectors" $connectors -}}
 
 {{/* --- appMetrics (server unconditionally wires up the metrics store) --- */}}
@@ -152,7 +152,6 @@ template syntax.
 {{- end -}}
 
 {{- $appMetrics := dict
-      "autoMigrate" .Values.appMetrics.autoMigrate
       "database" $metricsDb
       "requestEvents" (dict
         "fullRequestRecording" .Values.appMetrics.fullRequestRecording) -}}

--- a/deploy/charts/authproxy/templates/migration-job.yaml
+++ b/deploy/charts/authproxy/templates/migration-job.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "authproxy.fullname" . }}-migrate-{{ .Release.Revision }}
+  labels:
+    {{- include "authproxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+spec:
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ printf "%s-migration" (include "authproxy.name" .) | trunc 63 | trimSuffix "-" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "authproxy.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ include "authproxy.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - migrate
+            - --config=/etc/authproxy/config.yaml
+            - all
+          {{- if or .Values.database.existingSecret .Values.redis.existingSecret .Values.appMetrics.existingSecret .Values.s3.existingSecret }}
+          envFrom:
+            {{- with .Values.database.existingSecret }}
+            - secretRef:
+                name: {{ tpl . $ }}
+            {{- end }}
+            {{- with .Values.redis.existingSecret }}
+            - secretRef:
+                name: {{ tpl . $ }}
+            {{- end }}
+            {{- with .Values.appMetrics.existingSecret }}
+            - secretRef:
+                name: {{ tpl . $ }}
+            {{- end }}
+            {{- with .Values.s3.existingSecret }}
+            - secretRef:
+                name: {{ tpl . $ }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/authproxy/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- with .Values.jwt.existingSecret }}
+            - name: jwt-keys
+              mountPath: {{ $.Values.jwt.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.encryptionKeys.existingSecret }}
+            - name: encryption-keys
+              mountPath: {{ $.Values.encryptionKeys.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.actors.existingSecret }}
+            - name: actors-keys
+              mountPath: {{ $.Values.actors.mountPath }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "authproxy.fullname" . }}-config
+        {{- with .Values.jwt.existingSecret }}
+        - name: jwt-keys
+          secret:
+            secretName: {{ tpl . $ }}
+        {{- end }}
+        {{- with .Values.encryptionKeys.existingSecret }}
+        - name: encryption-keys
+          secret:
+            secretName: {{ tpl . $ }}
+        {{- end }}
+        {{- with .Values.actors.existingSecret }}
+        - name: actors-keys
+          secret:
+            secretName: {{ tpl . $ }}
+        {{- end }}
+{{- end }}

--- a/deploy/charts/authproxy/values.schema.json
+++ b/deploy/charts/authproxy/values.schema.json
@@ -4,6 +4,15 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "migrationJob": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":               { "type": "boolean" },
+        "backoffLimit":          { "type": "integer", "minimum": 0 },
+        "activeDeadlineSeconds": { "type": "integer", "minimum": 1 }
+      }
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,
@@ -195,7 +204,6 @@
         "database":       { "type": "string" },
         "user":           { "type": "string" },
         "sslmode":        { "type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] },
-        "autoMigrate":    { "type": "boolean" },
         "existingSecret": { "type": "string" },
         "path":           { "type": "string" }
       },
@@ -297,7 +305,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "autoMigrate":  { "type": "boolean" },
         "loadFromList": { "type": "array" }
       }
     },
@@ -307,7 +314,6 @@
       "additionalProperties": false,
       "properties": {
         "shareMainDatabase":    { "type": "boolean" },
-        "autoMigrate":          { "type": "boolean" },
         "database":             { "type": "object" },
         "existingSecret":       { "type": "string" },
         "fullRequestRecording": { "type": "string", "enum": ["never", "always"] }

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -41,6 +41,13 @@ serviceAccount:
 # different `services` blocks (see chart README for examples).
 replicaCount: 1
 
+# -- Dedicated schema migration Job. The Job uses the release image and
+# configuration and must succeed before the application rollout is promoted.
+migrationJob:
+  enabled: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 900
+
 # -- HorizontalPodAutoscaler configuration. Disabled by default so existing
 # installs keep using `replicaCount`. When enabled, the Deployment omits
 # `spec.replicas` and the HPA owns the desired replica count. Install this
@@ -216,8 +223,6 @@ database:
   user: authproxy
   # -- Postgres SSL mode (`disable`, `require`, `verify-ca`, `verify-full`).
   sslmode: require
-  # -- Run schema migrations at startup.
-  autoMigrate: true
   # -- Secret holding the database password. Must contain a key named
   # `AUTHPROXY_DB_PASSWORD` (the env var the rendered config references).
   # The chart wires it via `envFrom`; the password never appears in the
@@ -328,8 +333,6 @@ appMetrics:
   # main database section into `appMetrics.database`. Set to false to
   # configure a dedicated `database:` block below.
   shareMainDatabase: true
-  # -- Run appMetrics schema migrations at startup.
-  autoMigrate: true
   # -- Dedicated database block for appMetrics. Only consulted when
   # `shareMainDatabase` is false. Same field shape as the top-level
   # `database` block (provider, host, port, etc.).
@@ -347,8 +350,6 @@ appMetrics:
 # block — supply at least an empty `loadFromList` even when you intend to
 # manage connectors through the admin API at runtime.
 connectors:
-  # -- Run connector schema migrations at startup.
-  autoMigrate: true
   # -- Inline connector definitions loaded at boot. See the AuthProxy
   # connector schema docs for the format. Leave empty to manage connectors
   # exclusively through the admin API.

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -10,7 +10,9 @@ workloads. Overlays choose backing services and public hostnames:
 - `overlays/demo` targets `demo.authproxy.net` and includes Postgres, Redis,
   and MinIO backing workloads.
 - `overlays/dev` targets an example per-branch namespace and keeps the slim
-  dev profile: SQLite, embedded miniredis, and filesystem blob storage.
+  dev profile: SQLite, embedded miniredis, and filesystem blob storage. Its
+  disposable pod-local database uses `serve --auto-migrate`; it removes the
+  dedicated Job because a separate pod cannot migrate that SQLite file.
 
 Render locally:
 
@@ -27,6 +29,13 @@ Prometheus, Tempo, and Loki datasources, and sample app metrics dashboard
 provisioned from Kustomize ConfigMaps. Prometheus, Tempo, Loki, and the OTel
 Collector are provided by the internal `otel-lgtm` workload; AuthProxy exports
 OTLP/gRPC telemetry to `demo-otel-lgtm:4317`.
+
+The demo manifest also includes `<env>-authproxy-migrate`. Deployment workflows
+delete the completed Job from the previous release, apply only the release
+prerequisites, wait for PostgreSQL and Redis, apply and unsuspend the migration
+Job, then require it to complete before applying the new AuthProxy workload.
+When applying the rendered demo manifest manually, patch `spec.suspend=false` on
+`<env>-authproxy-migrate` only after those dependencies are ready.
 
 During the Helm-to-Kustomize cutover, `Deploy Demo` preserves the operator
 Secrets listed below, uninstalls any legacy `demo` / `authproxy-demo` Helm

--- a/deploy/kustomize/authproxy-demo/base/authproxy-migration-job.yaml
+++ b/deploy/kustomize/authproxy-demo/base/authproxy-migration-job.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authproxy-migrate
+  labels:
+    app.kubernetes.io/name: authproxy
+    app.kubernetes.io/component: migration
+spec:
+  suspend: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authproxy
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      serviceAccountName: authproxy
+      containers:
+        - name: migrate
+          image: ghcr.io/rmorlok/authproxy:main
+          imagePullPolicy: Always
+          args:
+            - migrate
+            - --config=/etc/authproxy/config.yaml
+            - all
+          envFrom:
+            - secretRef:
+                name: db
+                optional: true
+            - secretRef:
+                name: redis-creds
+                optional: true
+            - secretRef:
+                name: minio-creds
+                optional: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/authproxy/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: jwt-keys
+              mountPath: /etc/authproxy/keys/jwt
+              readOnly: true
+            - name: encryption-keys
+              mountPath: /etc/authproxy/keys/encryption
+              readOnly: true
+            - name: actors-keys
+              mountPath: /etc/authproxy/keys/actors
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: authproxy-config
+        - name: jwt-keys
+          secret:
+            secretName: authproxy-jwt-placeholder
+        - name: encryption-keys
+          secret:
+            secretName: authproxy-encryption-placeholder
+        - name: actors-keys
+          secret:
+            secretName: authproxy-actors-placeholder

--- a/deploy/kustomize/authproxy-demo/base/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - authproxy.yaml
+  - authproxy-migration-job.yaml
   - demo-shell.yaml
   - go-oauth2-server.yaml
 

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -16,7 +16,6 @@ worker:
   healthCheckPort: 8083
 database:
   provider: postgres
-  autoMigrate: true
   host: demo-postgresql
   port: 5432
   user: authproxy
@@ -33,13 +32,17 @@ redis:
 hostApplication:
   initiateSessionUrl: https://demo.authproxy.net/
 connectors:
-  autoMigrate: true
   loadFromList: []
 appMetrics:
-  autoMigrate: true
   database:
-    provider: sqlite
-    path: /tmp/authproxy-app-metrics.db
+    provider: postgres
+    host: demo-postgresql
+    port: 5432
+    user: authproxy
+    database: authproxy
+    sslmode: disable
+    password:
+      envVar: AUTHPROXY_DB_PASSWORD
   blobStorage:
     provider: s3
     endpoint: http://demo-minio:9000

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
@@ -33,3 +33,33 @@ spec:
         - name: actors-keys
           secret:
             secretName: demo-actors
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authproxy-migrate
+spec:
+  template:
+    spec:
+      containers:
+        - name: migrate
+          envFrom:
+            - secretRef:
+                name: demo-db
+                optional: true
+            - secretRef:
+                name: demo-redis-creds
+                optional: true
+            - secretRef:
+                name: demo-minio-creds
+                optional: true
+      volumes:
+        - name: jwt-keys
+          secret:
+            secretName: demo-jwt
+        - name: encryption-keys
+          secret:
+            secretName: demo-encryption
+        - name: actors-keys
+          secret:
+            secretName: demo-actors

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -16,17 +16,14 @@ worker:
   healthCheckPort: 8083
 database:
   provider: sqlite
-  autoMigrate: true
   path: /tmp/authproxy-dev.db
 redis:
   provider: miniredis
 hostApplication:
   initiateSessionUrl: https://branch.dev.authproxy.net/
 connectors:
-  autoMigrate: true
   loadFromList: []
 appMetrics:
-  autoMigrate: true
   database:
     provider: sqlite
     path: /tmp/authproxy-dev.db.app-metrics

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-development.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-development.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: authproxy
+          args:
+            - serve
+            - --auto-migrate
+            - --config=/etc/authproxy/config.yaml
+            - admin-api,api,public,worker
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authproxy-migrate
+$patch: delete

--- a/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/kustomization.yaml
@@ -23,5 +23,6 @@ images:
     newTag: main
 
 patches:
+  - path: authproxy-development.yaml
   - path: authproxy-secrets.yaml
   - path: demo-shell-env.yaml

--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -72,7 +72,6 @@ errorPages:
 
 database:
   provider: postgres
-  autoMigrate: true
   host: localhost
   port: 5432
   user: postgres
@@ -91,11 +90,9 @@ appMetrics:
   # fullRequestRecording: never
   #  database:
   #    provider: sqlite
-  #    autoMigrate: true
   #    path: ./dev_config/app_metrics.db
   database:
     provider: clickhouse
-    autoMigrate: true
     user: authproxy
     password: authproxy
     addresses:
@@ -174,7 +171,6 @@ telemetry:
     injectOutboundDefault: false
 
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList:
   #

--- a/dev_config/docker.yaml
+++ b/dev_config/docker.yaml
@@ -61,7 +61,6 @@ errorPages:
 
 database:
   provider: postgres
-  autoMigrate: true
   host: postgres
   port: 5432
   user: postgres
@@ -79,7 +78,6 @@ appMetrics:
     fullRequestRecording: always
   database:
     provider: clickhouse
-    autoMigrate: true
     user: authproxy
     password: authproxy
     addresses:
@@ -105,7 +103,6 @@ oauth:
   roundTripTtl: 60m
 
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList:
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
 
   server:
     build: .
+    command: ["serve", "--auto-migrate", "--config=/app/dev_config/docker.yaml", "all"]
     ports:
       - "8080:8080"
       - "8081:8081"

--- a/docs/src/content/docs/deployment/container-images.md
+++ b/docs/src/content/docs/deployment/container-images.md
@@ -12,7 +12,9 @@ ghcr.io/rmorlok/authproxy:<tag>
 
 The image contains the Go server and embedded Marketplace and Admin UI assets.
 Its default command starts all services with `dev_config/docker.yaml`; a real
-deployment should mount or generate its own configuration and Secrets.
+deployment should mount or generate its own configuration and Secrets. The
+default command performs read-only schema verification; it never migrates a
+database unless the operator explicitly supplies `serve --auto-migrate`.
 
 Published tag forms include:
 

--- a/docs/src/content/docs/development/local-development.md
+++ b/docs/src/content/docs/development/local-development.md
@@ -43,7 +43,7 @@ credentials.
 Start all four services:
 
 ```bash
-go run ./cmd/server serve --config=./dev_config/default.yaml all
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
 ```
 
 The final argument can instead be `public`, `api`, `admin-api`, or `worker`.

--- a/docs/src/content/docs/operations/app-metrics.md
+++ b/docs/src/content/docs/operations/app-metrics.md
@@ -13,7 +13,6 @@ appMetrics:
   resourceSnapshotInterval: 15m
   database:
     provider: clickhouse
-    autoMigrate: true
     addresses:
       - localhost:8123
     database: authproxy
@@ -37,8 +36,9 @@ Key settings:
 
 The resource snapshot worker stores live resources at each interval. Deleted resources remain visible in historical time slices where they were sampled, but they are excluded from later snapshots.
 
-See [Automatic migrations](/operations/migrations/) for startup locking and
-lease-renewal behavior across SQLite, PostgreSQL, and ClickHouse.
+See [Database migrations](/operations/migrations/) for status inspection,
+explicit migration commands, and locking behavior across SQLite, PostgreSQL,
+and ClickHouse.
 
 ## Request events
 

--- a/docs/src/content/docs/operations/migrations.md
+++ b/docs/src/content/docs/operations/migrations.md
@@ -1,80 +1,104 @@
 ---
-title: Automatic migrations
-description: Understand how AuthProxy coordinates schema migrations and startup reconciliation across service processes.
+title: Database migrations
+description: Inspect and migrate AuthProxy schemas safely before starting production services.
 ---
 
-AuthProxy can apply database migrations automatically when a service starts.
-Every enabled service may start at the same time, so automatic migration uses
-Redis mutexes to ensure that only one process migrates each storage target.
+AuthProxy verifies every configured schema before opening a listener or starting
+a worker. Normal `serve` processes never change schemas. Run migrations as an
+explicit deployment step before starting or updating production workloads.
 
-## Configure automatic migration
+## Inspect schema status
 
-The primary database and application-metrics store have independent switches
-and independent locks:
+Report every migration target without changing a database:
 
-~~~yaml
-database:
-  provider: postgres
-  autoMigrate: true
-  autoMigrationLockDuration: 2m
-  # ...
+```sh
+authproxy migrate status --config=/etc/authproxy/config.yaml
+```
 
-app_metrics:
-  autoMigrate: true
-  database:
-    provider: clickhouse
-    autoMigrationLockDuration: 2m
-    # ...
-~~~
+Limit the report to one target by adding `main-database`, `workflows`, or
+`app-metrics`:
 
-The `autoMigrationLockDuration` value is the Redis lease duration.
-AuthProxy refreshes the lease while migration is running, so it is not a
-maximum migration runtime. Contending processes wait for a bounded period
-based on the same duration and then fail startup rather than continuing
-without exclusivity.
+```sh
+authproxy migrate status app-metrics --config=/etc/authproxy/config.yaml
+```
 
-## Lock targets and providers
+The report includes the provider, current version, highest version available in
+the AuthProxy binary, dirty flag, and compatibility state. The command exits
+non-zero when a requested target is missing, behind, ahead, dirty, or
+unavailable. Inspection is read-only and does not create a missing SQLite file
+or migration table.
 
-The primary relational schema and workflow schema share
-`db-migrate-lock` and run sequentially. The application-metrics
-schema uses the separate `app-metrics-migrate-lock`, because it may
-live in a different database and should not block an unrelated primary
-migration.
+## Apply migrations
 
-The Redis contract is the same for SQLite, PostgreSQL, and ClickHouse:
+Upgrade every target to its latest version in dependency order:
 
-1. acquire the target mutex;
-2. refresh it every third of the lease duration;
-3. apply all migrations;
-4. release the mutex and report any release failure.
+```sh
+authproxy migrate all --config=/etc/authproxy/config.yaml
+```
 
-If a refresh fails, AuthProxy cancels the migration context, asks the migration
-runner to stop at its next safe boundary, and fails startup. It never treats an
-expired or unconfirmed lease as successful migration ownership.
+The order is `main-database`, `workflows`, then `app-metrics`. Processing stops
+at the first failure. Earlier targets remain migrated because independent
+databases cannot share a transaction.
 
-PostgreSQL also retains the advisory lock supplied by its migration driver.
-That database-native lock provides defense in depth and interoperability with
-other processes that use the same migration driver. Redis supplies the
-provider-independent coordination needed by SQLite and ClickHouse.
+Target one schema or an exact version when needed:
 
-## Startup reconciliation
+```sh
+authproxy migrate main-database
+authproxy migrate main-database up 16
+authproxy migrate workflows down
+authproxy migrate workflows down 2
+```
 
-Schema migration is followed by reconciliation of encryption keys, configured
-connectors, namespaces, and configured actors. These operations use distinct
-renewable Redis mutexes because they may include database cleanup or calls to
-external key providers. A key-sync sentinel additionally suppresses redundant
-work; the sentinel controls frequency, while the mutex prevents overlap.
+`up` is the default direction. Without a version, `up` selects the latest
+available version and `down` rolls back one version. A supplied version is an
+absolute target version. Exact versions are not accepted with `all`, because
+the three targets have independent version sequences. `all down` rolls back
+one version in reverse dependency order: app metrics, workflows, then the main
+database.
 
-Failures acquiring, refreshing, or releasing these mutexes are surfaced as
-startup or task errors; automatic database migration logs also identify its
-lock key. Successful database migration, no-change outcomes, and original
-migration failures are logged separately.
+AuthProxy does not automatically force or repair a dirty schema. Diagnose the
+failed migration and restore or repair the database deliberately before
+retrying.
 
-## Production rollout
+## Local automatic migration
 
-Automatic migration is convenient for local, demo, and controlled deployments.
-For a multi-replica production rollout, keep database backups current and
-ensure all replicas use the same Redis service. Prefer a deployment workflow
-that runs migration as an explicit pre-rollout step and starts application
-replicas only after it succeeds; dedicated migration-job packaging is tracked
-separately from the automatic startup path.
+For a disposable development environment, migration and configuration
+reconciliation can run once before service fan-out:
+
+```sh
+go run ./cmd/server serve --auto-migrate \
+  --config=./dev_config/default.yaml all
+```
+
+`--auto-migrate` is intentionally a CLI-only option and is unsafe for
+production. It upgrades all schemas, initializes required encryption-key
+state, reconciles configured connectors and actors, verifies compatibility,
+and only then starts the requested services. Omitting it performs read-only
+verification only.
+
+## Locks and concurrency
+
+The main and workflow schemas share the renewable Redis lock
+`db-migrate-lock`; app metrics uses `app-metrics-migrate-lock`. The lock lease
+is refreshed every third of its configured duration. PostgreSQL migration
+drivers also retain their native advisory lock. Concurrent migration processes
+therefore serialize across SQLite, PostgreSQL, and ClickHouse while retaining
+the database-native protection available in PostgreSQL.
+
+`database.autoMigrationLockDuration`,
+`appMetrics.database.autoMigrationLockDuration`, and
+`connectors.autoMigrationLockDuration` tune lock leases. They do not enable
+automatic migration.
+
+## Kubernetes deployments
+
+The Helm chart and demo Kustomize manifests include a dedicated migration Job
+that uses the same image, configuration, credentials, and mounted key material
+as the AuthProxy workload. Wait for that Job to succeed before waiting for or
+promoting the AuthProxy Deployment. A failed Job stops the rollout and its pod
+logs contain the target-specific migration error.
+
+For Helm, use `--wait --wait-for-jobs`; every release revision renders a new
+migration Job. Application pods may be scheduled concurrently, but mandatory
+startup verification prevents them from opening listeners or starting workers
+until the Job has made every schema current.

--- a/docs/src/content/docs/operations/telemetry.md
+++ b/docs/src/content/docs/operations/telemetry.md
@@ -260,7 +260,7 @@ A one-command local observability stack ships under a new `observability` compos
 ```bash
 docker compose --profile observability up -d
 export AUTHPROXY_OTEL_ENDPOINT=http://localhost:4317
-go run ./cmd/server serve --config=./dev_config/default.yaml all
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
 ```
 
 Grafana is at <http://localhost:3000> — no login required. A pre-provisioned dashboard (**AuthProxy — Proxy RED + Inbound HTTP**) lives under the `AuthProxy` folder. The full operator runbook with query examples, persistence notes, and limitations is in [`dev_config/observability/README.md`](https://github.com/rmorlok/authproxy/blob/main/dev_config/observability/README.md).

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -31,7 +31,6 @@ immutable `id`:
 
 ```yaml
 connectors:
-  autoMigrate: true
   loadFromList:
     - name: google-drive
       namespace: root.integrations
@@ -45,7 +44,8 @@ connectors:
         type: no-auth
 ```
 
-At startup, AuthProxy reconciles this entry to the live connector whose exact
+With the development-only `serve --auto-migrate` option, AuthProxy reconciles
+this entry to the live connector whose exact
 name is `google-drive` in `root.integrations`. Labels are ordinary selectable
 metadata and do not participate in identity. Multiple configured versions use
 the same name and namespace.

--- a/integration_tests/config/integration.yaml
+++ b/integration_tests/config/integration.yaml
@@ -46,7 +46,6 @@ errorPages:
 
 database:
   provider: postgres
-  autoMigrate: true
   host: localhost
   port: 5433
   user: postgres
@@ -64,7 +63,6 @@ appMetrics:
     fullRequestRecording: always
   database:
     provider: clickhouse
-    autoMigrate: true
     user: authproxy
     password: authproxy
     addresses:
@@ -90,6 +88,5 @@ oauth:
   roundTripTtl: 60m
 
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList: []

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -22,6 +22,7 @@ import (
 	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/migration"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -286,22 +287,17 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 	serviceId := string(opts.Service)
 	dm := service.NewDependencyManager(serviceId, cfg)
 
-	dm.AutoMigrateDatabase()
+	require.NoError(t, dm.MigrateSchemas(context.Background(), migration.TargetAll, migration.DirectionUp, nil))
 
 	// Each test gets an isolated database via pgtestdb but shares the same Redis.
 	// Passing nil for Redis bypasses shared locks/sentinels so this test's
 	// database is always seeded with a current DEK and then synced, regardless of
 	// what other packages are doing concurrently.
 	//
-	// This must happen before AutoMigrateAppMetricsService because that call
-	// can trigger GetEncryptService(), which starts the syncLoop goroutine that
-	// immediately tries to read the current global DEK from the database.
 	require.NoError(t, encrypt.GenerateDataEncryptionKeysToDatabase(context.Background(), cfg, dm.GetDatabase(), dm.GetLogger(), nil))
 	require.NoError(t, encrypt.SyncKeysToDatabase(context.Background(), cfg, dm.GetDatabase(), dm.GetLogger(), nil))
 
-	dm.AutoMigrateAppMetricsService()
-	dm.AutoMigrateCore()
-	dm.AutoMigratePredefinedActors()
+	require.NoError(t, dm.ReconcileDevelopmentData(context.Background()))
 
 	// Get the appropriate server
 	var httpServer *http.Server

--- a/integration_tests/helpers/setup.go
+++ b/integration_tests/helpers/setup.go
@@ -221,10 +221,12 @@ func Setup(t *testing.T, opts SetupOptions) *IntegrationTestEnv {
 	// MustApplyBlankTestDbConfig reads connection info from POSTGRES_TEST_* env vars
 	// and updates cfg.GetRoot().Database to point at the new isolated database.
 	cfg, _, rawDb := database.MustApplyBlankTestDbConfigRaw(t, cfg)
-	require.NoError(t, workflows.Migrate(
+	require.NoError(t, workflows.RunMigrations(
 		context.Background(),
 		cfg.GetRoot(),
 		cfg.GetRoot().GetRootLogger(),
+		migration.DirectionUp,
+		nil,
 		workflows.WithPostgresMigrationDB(rawDb),
 	))
 

--- a/internal/app_metrics/migrate.go
+++ b/internal/app_metrics/migrate.go
@@ -104,7 +104,11 @@ func RunMigrations(
 	defer func() {
 		sourceErr, dbErr := migrator.Close()
 		if sourceErr != nil || dbErr != nil {
-			logger.Warn("failed to close app metrics migrator", "source_err", sourceErr, "db_err", dbErr)
+			logger.Warn(
+				"failed to close app metrics migrator",
+				"source_err", sourceErr,
+				"db_err", dbErr,
+			)
 		}
 	}()
 
@@ -130,7 +134,12 @@ func newMigrationDriver(
 		if err != nil {
 			return nil, "", err
 		}
-		driver, err := postgres.WithInstance(db, &postgres.Config{MigrationsTable: appMetricsMigrationsTable})
+		driver, err := postgres.WithInstance(
+			db,
+			&postgres.Config{
+				MigrationsTable: appMetricsMigrationsTable,
+			},
+		)
 		if err != nil {
 			_ = db.Close()
 		}
@@ -141,7 +150,12 @@ func newMigrationDriver(
 		if err != nil {
 			return nil, "", err
 		}
-		driver, err := sqlite3.WithInstance(db, &sqlite3.Config{MigrationsTable: appMetricsMigrationsTable})
+		driver, err := sqlite3.WithInstance(
+			db,
+			&sqlite3.Config{
+				MigrationsTable: appMetricsMigrationsTable,
+			},
+		)
 		if err != nil {
 			_ = db.Close()
 		}

--- a/internal/app_metrics/migrate.go
+++ b/internal/app_metrics/migrate.go
@@ -17,16 +17,33 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
+// MigrationStatus returns the migration status for the app metrics database.
 func MigrationStatus(ctx context.Context, cfg *config.Database) migration.Status {
 	if cfg == nil || cfg.InnerVal == nil {
-		return migration.UnavailableStatus(migration.TargetAppMetrics, "", 0, fmt.Errorf("app metrics database configuration is required"))
+		return migration.UnavailableStatus(
+			migration.TargetAppMetrics,
+			"",
+			0,
+			fmt.Errorf("app metrics database configuration is required"),
+		)
 	}
+
 	provider := cfg.GetProvider()
-	latest, err := migration.LatestVersion(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
+	latest, err := migration.LatestVersion(
+		appMetricsMigrationsFs,
+		fmt.Sprintf("migrations/%s", provider),
+	)
 	if err != nil {
 		return migration.UnavailableStatus(migration.TargetAppMetrics, provider, 0, err)
 	}
-	return migration.Inspect(ctx, migration.TargetAppMetrics, cfg, appMetricsMigrationsTable, latest)
+
+	return migration.Inspect(
+		ctx,
+		migration.TargetAppMetrics,
+		cfg,
+		appMetricsMigrationsTable,
+		latest,
+	)
 }
 
 func RunMigrations(
@@ -39,29 +56,48 @@ func RunMigrations(
 	if cfg == nil || cfg.InnerVal == nil {
 		return fmt.Errorf("app metrics database configuration is required")
 	}
+
 	provider := cfg.GetProvider()
-	logger.Info("running app metrics database migrations", "provider", provider, "direction", direction, "version", version)
+	logger.Info(
+		"running app metrics database migrations",
+		"provider", provider,
+		"direction", direction,
+		"version", version,
+	)
+
+	// Deferred logging based on error status
 	defer func() {
 		if resultErr != nil {
-			logger.Error("app metrics database migrations failed", "provider", provider, "error", resultErr)
+			logger.Error(
+				"app metrics database migrations failed",
+				"provider", provider,
+				"error", resultErr,
+			)
 			return
 		}
 		logger.Info("app metrics database migrations complete", "provider", provider)
 	}()
 
+	// Migrations are read from the embedded filesystem
 	source, err := iofs.New(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
 	if err != nil {
 		return fmt.Errorf("load app metrics migrations for %q: %w", provider, err)
 	}
+
+	// Get a go-migrate driver that is provider specific
 	driver, driverName, err := newMigrationDriver(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("setup app metrics migration driver: %w", err)
 	}
+
+	// Initialize a migrator that pulls from the embedded fs
 	migrator, err := migrate.NewWithInstance("iofs", source, driverName, driver)
 	if err != nil {
 		_ = driver.Close()
 		return fmt.Errorf("setup app metrics migrator: %w", err)
 	}
+
+	// Defer cleanup and logging
 	defer func() {
 		sourceErr, dbErr := migrator.Close()
 		if sourceErr != nil || dbErr != nil {
@@ -69,14 +105,23 @@ func RunMigrations(
 		}
 	}()
 
+	// Run the migration.
 	if err := migration.Apply(ctx, migrator, direction, version); err != nil {
 		return fmt.Errorf("run app metrics migrations: %w", err)
 	}
+
 	return nil
 }
 
-func newMigrationDriver(ctx context.Context, cfg *config.Database) (migratedb.Driver, string, error) {
+// newMigrationDriver creates a new migration driver based on the provided
+// configuration. This is mapping cfg options to the options passed to the
+// go-migrate driver and returning an initialized object.
+func newMigrationDriver(
+	ctx context.Context,
+	cfg *config.Database,
+) (migratedb.Driver, string, error) {
 	switch concrete := cfg.InnerVal.(type) {
+
 	case *config.DatabasePostgres:
 		db, err := sql.Open(concrete.GetDriver(), concrete.GetDsn())
 		if err != nil {
@@ -87,6 +132,7 @@ func newMigrationDriver(ctx context.Context, cfg *config.Database) (migratedb.Dr
 			_ = db.Close()
 		}
 		return driver, "postgres", err
+
 	case *config.DatabaseSqlite:
 		db, err := sql.Open(concrete.GetDriver(), concrete.GetDsn())
 		if err != nil {
@@ -97,6 +143,7 @@ func newMigrationDriver(ctx context.Context, cfg *config.Database) (migratedb.Dr
 			_ = db.Close()
 		}
 		return driver, "sqlite", err
+
 	case *config.DatabaseClickhouse:
 		opts, err := concrete.ToClickhouseOptions()
 		if err != nil {
@@ -119,6 +166,7 @@ func newMigrationDriver(ctx context.Context, cfg *config.Database) (migratedb.Dr
 			_ = db.Close()
 		}
 		return driver, "clickhouse", err
+
 	default:
 		return nil, "", fmt.Errorf("unsupported app metrics provider %q", cfg.GetProvider())
 	}

--- a/internal/app_metrics/migrate.go
+++ b/internal/app_metrics/migrate.go
@@ -46,6 +46,9 @@ func MigrationStatus(ctx context.Context, cfg *config.Database) migration.Status
 	)
 }
 
+// RunMigrations runs any necessary schema migrations for the app metrics
+// database. This will run on clickhouse, postgres, or sqlite depending on
+// the provider in the configuration.
 func RunMigrations(
 	ctx context.Context,
 	cfg *config.Database,

--- a/internal/app_metrics/migrate.go
+++ b/internal/app_metrics/migrate.go
@@ -1,0 +1,125 @@
+package app_metrics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/golang-migrate/migrate/v4"
+	migratedb "github.com/golang-migrate/migrate/v4/database"
+	chmigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/database/sqlite3"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/rmorlok/authproxy/internal/migration"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+func MigrationStatus(ctx context.Context, cfg *config.Database) migration.Status {
+	if cfg == nil || cfg.InnerVal == nil {
+		return migration.UnavailableStatus(migration.TargetAppMetrics, "", 0, fmt.Errorf("app metrics database configuration is required"))
+	}
+	provider := cfg.GetProvider()
+	latest, err := migration.LatestVersion(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
+	if err != nil {
+		return migration.UnavailableStatus(migration.TargetAppMetrics, provider, 0, err)
+	}
+	return migration.Inspect(ctx, migration.TargetAppMetrics, cfg, appMetricsMigrationsTable, latest)
+}
+
+func RunMigrations(
+	ctx context.Context,
+	cfg *config.Database,
+	logger *slog.Logger,
+	direction migration.Direction,
+	version *uint,
+) (resultErr error) {
+	if cfg == nil || cfg.InnerVal == nil {
+		return fmt.Errorf("app metrics database configuration is required")
+	}
+	provider := cfg.GetProvider()
+	logger.Info("running app metrics database migrations", "provider", provider, "direction", direction, "version", version)
+	defer func() {
+		if resultErr != nil {
+			logger.Error("app metrics database migrations failed", "provider", provider, "error", resultErr)
+			return
+		}
+		logger.Info("app metrics database migrations complete", "provider", provider)
+	}()
+
+	source, err := iofs.New(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
+	if err != nil {
+		return fmt.Errorf("load app metrics migrations for %q: %w", provider, err)
+	}
+	driver, driverName, err := newMigrationDriver(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("setup app metrics migration driver: %w", err)
+	}
+	migrator, err := migrate.NewWithInstance("iofs", source, driverName, driver)
+	if err != nil {
+		_ = driver.Close()
+		return fmt.Errorf("setup app metrics migrator: %w", err)
+	}
+	defer func() {
+		sourceErr, dbErr := migrator.Close()
+		if sourceErr != nil || dbErr != nil {
+			logger.Warn("failed to close app metrics migrator", "source_err", sourceErr, "db_err", dbErr)
+		}
+	}()
+
+	if err := migration.Apply(ctx, migrator, direction, version); err != nil {
+		return fmt.Errorf("run app metrics migrations: %w", err)
+	}
+	return nil
+}
+
+func newMigrationDriver(ctx context.Context, cfg *config.Database) (migratedb.Driver, string, error) {
+	switch concrete := cfg.InnerVal.(type) {
+	case *config.DatabasePostgres:
+		db, err := sql.Open(concrete.GetDriver(), concrete.GetDsn())
+		if err != nil {
+			return nil, "", err
+		}
+		driver, err := postgres.WithInstance(db, &postgres.Config{MigrationsTable: appMetricsMigrationsTable})
+		if err != nil {
+			_ = db.Close()
+		}
+		return driver, "postgres", err
+	case *config.DatabaseSqlite:
+		db, err := sql.Open(concrete.GetDriver(), concrete.GetDsn())
+		if err != nil {
+			return nil, "", err
+		}
+		driver, err := sqlite3.WithInstance(db, &sqlite3.Config{MigrationsTable: appMetricsMigrationsTable})
+		if err != nil {
+			_ = db.Close()
+		}
+		return driver, "sqlite", err
+	case *config.DatabaseClickhouse:
+		opts, err := concrete.ToClickhouseOptions()
+		if err != nil {
+			return nil, "", err
+		}
+		dbName := ""
+		if concrete.Database != nil {
+			dbName, err = concrete.Database.GetValue(ctx)
+			if err != nil {
+				return nil, "", err
+			}
+		}
+		db := sql.OpenDB(clickhouse.Connector(opts))
+		driver, err := chmigrate.WithInstance(db, &chmigrate.Config{
+			DatabaseName:          dbName,
+			MigrationsTable:       appMetricsMigrationsTable,
+			MultiStatementEnabled: true,
+		})
+		if err != nil {
+			_ = db.Close()
+		}
+		return driver, "clickhouse", err
+	default:
+		return nil, "", fmt.Errorf("unsupported app metrics provider %q", cfg.GetProvider())
+	}
+}

--- a/internal/app_metrics/provider.go
+++ b/internal/app_metrics/provider.go
@@ -6,8 +6,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 )
 
-// MigrateMutexKeyName coordinates automatic app-metrics migrations across
-// service processes, regardless of the configured database provider.
+// MigrateMutexKeyName coordinates app-metrics migrations across service
+// processes, regardless of the configured database provider.
 const MigrateMutexKeyName = "app-metrics-migrate-lock"
 
 // RecordStore handles persisting LogRecord metadata to a storage backend.
@@ -27,11 +27,6 @@ type ResourceSampleStore interface {
 	StoreConnectorVersionResourceSamples(ctx context.Context, samples []*ConnectorVersionResourceSample) error
 	StoreNamespaceResourceSamples(ctx context.Context, samples []*NamespaceResourceSample) error
 	StoreRateLimitResourceSamples(ctx context.Context, samples []*RateLimitResourceSample) error
-}
-
-type migratable interface {
-	// Migrate runs any necessary schema migrations for the storage backend.
-	Migrate(ctx context.Context) error
 }
 
 type pingable interface {

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -13,7 +13,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -121,16 +120,6 @@ func (s *clickhouseRecordStore) StoreRecords(ctx context.Context, records []*Log
 
 func (s *clickhouseRecordStore) StoreRecord(ctx context.Context, record *LogRecord) error {
 	return s.StoreRecords(ctx, []*LogRecord{record})
-}
-
-func (s *clickhouseRecordStore) Migrate(ctx context.Context) (resultErr error) {
-	return RunMigrations(
-		ctx,
-		&config.Database{InnerVal: s.cfg},
-		s.logger,
-		migration.DirectionUp,
-		nil,
-	)
 }
 
 func (s *clickhouseRecordStore) Ping(ctx context.Context) bool {

--- a/internal/app_metrics/provider_clickhouse.go
+++ b/internal/app_metrics/provider_clickhouse.go
@@ -11,14 +11,11 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	sq "github.com/Masterminds/squirrel"
-	"github.com/golang-migrate/migrate/v4"
-	chmigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
-	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/sqlh"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -127,68 +124,13 @@ func (s *clickhouseRecordStore) StoreRecord(ctx context.Context, record *LogReco
 }
 
 func (s *clickhouseRecordStore) Migrate(ctx context.Context) (resultErr error) {
-	s.logger.Info("running clickhouse app metrics migrations")
-	defer func() {
-		if resultErr != nil {
-			s.logger.Error("clickhouse app metrics migrations failed", "error", resultErr)
-			return
-		}
-		s.logger.Info("clickhouse app metrics migrations complete")
-	}()
-
-	src, err := iofs.New(appMetricsMigrationsFs, "migrations/clickhouse")
-	if err != nil {
-		return fmt.Errorf("failed to load clickhouse app metrics migrations: %w", err)
-	}
-
-	var dbName string
-	if s.cfg.Database != nil {
-		dbName, err = s.cfg.Database.GetValue(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to resolve clickhouse database name: %w", err)
-		}
-	}
-
-	// The clickhouse migrate driver takes ownership of the *sql.DB it's given
-	// and closes it when the migrator does — so we must hand it a dedicated
-	// connection rather than the long-lived store handle.
-	chOpts, err := s.cfg.ToClickhouseOptions()
-	if err != nil {
-		return fmt.Errorf("failed to derive clickhouse options for migration: %w", err)
-	}
-	migrationConn := sql.OpenDB(clickhouse.Connector(chOpts))
-
-	driver, err := chmigrate.WithInstance(migrationConn, &chmigrate.Config{
-		DatabaseName:          dbName,
-		MigrationsTable:       appMetricsMigrationsTable,
-		MultiStatementEnabled: true,
-	})
-	if err != nil {
-		_ = migrationConn.Close()
-		return fmt.Errorf("failed to setup clickhouse app metrics migration driver: %w", err)
-	}
-
-	m, err := migrate.NewWithInstance("iofs", src, "clickhouse", driver)
-	if err != nil {
-		_ = migrationConn.Close()
-		return fmt.Errorf("failed to setup clickhouse app metrics migrator: %w", err)
-	}
-	defer func() {
-		sourceErr, dbErr := m.Close()
-		if sourceErr != nil || dbErr != nil {
-			s.logger.Warn("failed to close clickhouse migrator", "source_err", sourceErr, "db_err", dbErr)
-		}
-	}()
-
-	if err := util.RunMigrationsUp(ctx, m); err != nil {
-		if errors.Is(err, migrate.ErrNoChange) {
-			s.logger.Info("no clickhouse app metrics migrations required")
-			return nil
-		}
-		return fmt.Errorf("failed to migrate clickhouse app metrics database: %w", err)
-	}
-
-	return nil
+	return RunMigrations(
+		ctx,
+		&config.Database{InnerVal: s.cfg},
+		s.logger,
+		migration.DirectionUp,
+		nil,
+	)
 }
 
 func (s *clickhouseRecordStore) Ping(ctx context.Context) bool {

--- a/internal/app_metrics/provider_migration_test.go
+++ b/internal/app_metrics/provider_migration_test.go
@@ -25,8 +25,13 @@ func TestSQLMigrateUsesAppMetricsSchemaMigrationsTable(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	store, _, _ := buildSqlStorePairNoMigrate(t, cfg)
-	require.NoError(t, store.(*sqlRecordStore).Migrate(context.Background()))
+	require.NoError(t, RunMigrations(
+		context.Background(),
+		cfg,
+		newTestHarnessLogger(),
+		migration.DirectionUp,
+		nil,
+	))
 
 	var mainVersion int
 	require.NoError(t, db.QueryRow("SELECT version FROM schema_migrations").Scan(&mainVersion))

--- a/internal/app_metrics/provider_migration_test.go
+++ b/internal/app_metrics/provider_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/rmorlok/authproxy/internal/migration"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +35,27 @@ func TestSQLMigrateUsesAppMetricsSchemaMigrationsTable(t *testing.T) {
 	var appMetricsVersion int
 	require.NoError(t, db.QueryRow("SELECT version FROM app_metrics_schema_migrations").Scan(&appMetricsVersion))
 	require.Greater(t, appMetricsVersion, 0)
+
+	status := MigrationStatus(context.Background(), cfg)
+	require.Equal(t, migration.StateCurrent, status.State)
+	require.Equal(t, uint(5), status.AvailableVersion)
+	require.Equal(t, uint(5), *status.CurrentVersion)
+}
+
+func TestMigrationStatusCurrentForConfiguredProvider(t *testing.T) {
+	store, _, _ := MustNewBlankRequestEventsStore(t)
+	var cfg *sconfig.Database
+	switch concrete := store.(type) {
+	case *sqlRecordStore:
+		cfg = concrete.cfg
+	case *clickhouseRecordStore:
+		cfg = &sconfig.Database{InnerVal: concrete.cfg}
+	default:
+		t.Fatalf("unexpected record store type %T", store)
+	}
+
+	status := MigrationStatus(context.Background(), cfg)
+	require.NoError(t, status.Err)
+	require.True(t, status.Compatible())
+	require.Equal(t, status.AvailableVersion, *status.CurrentVersion)
 }

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
-	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -165,10 +164,6 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 	}
 
 	return nil
-}
-
-func (s *sqlRecordStore) Migrate(ctx context.Context) (resultErr error) {
-	return RunMigrations(ctx, s.cfg, s.logger, migration.DirectionUp, nil)
 }
 
 func (s *sqlRecordStore) Ping(ctx context.Context) bool {

--- a/internal/app_metrics/provider_sql.go
+++ b/internal/app_metrics/provider_sql.go
@@ -12,14 +12,10 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/golang-migrate/migrate/v4"
-	migratedb "github.com/golang-migrate/migrate/v4/database"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
-	"github.com/golang-migrate/migrate/v4/database/sqlite3"
-	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
+	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -172,77 +168,7 @@ func (s *sqlRecordStore) StoreRecords(ctx context.Context, records []*LogRecord)
 }
 
 func (s *sqlRecordStore) Migrate(ctx context.Context) (resultErr error) {
-	provider := string(s.cfg.GetProvider())
-	s.logger.Info("running app metrics database migrations", "provider", provider)
-	defer func() {
-		if resultErr != nil {
-			s.logger.Error("app metrics database migrations failed", "provider", provider, "error", resultErr)
-			return
-		}
-		s.logger.Info("app metrics database migrations complete", "provider", provider)
-	}()
-
-	d, err := iofs.New(appMetricsMigrationsFs, fmt.Sprintf("migrations/%s", provider))
-	if err != nil {
-		return fmt.Errorf("failed to load app metrics migrations for '%s': %w", provider, err)
-	}
-
-	driver, err := s.newMigrationDriver()
-	if err != nil {
-		return fmt.Errorf("failed to setup app metrics migration driver: %w", err)
-	}
-
-	m, err := migrate.NewWithInstance("iofs", d, provider, driver)
-	if err != nil {
-		_ = driver.Close()
-		return fmt.Errorf("failed to setup app metrics migrations: %w", err)
-	}
-	defer func() {
-		sourceErr, dbErr := m.Close()
-		if sourceErr != nil || dbErr != nil {
-			s.logger.Warn("failed to close migrator", "source_err", sourceErr, "db_err", dbErr)
-		}
-	}()
-
-	err = util.RunMigrationsUp(ctx, m)
-	if err != nil {
-		if errors.Is(err, migrate.ErrNoChange) {
-			s.logger.Info("no app metrics migrations required")
-			return nil
-		}
-		return fmt.Errorf("failed to migrate app metrics database: %w", err)
-	}
-
-	return nil
-}
-
-func (s *sqlRecordStore) newMigrationDriver() (migratedb.Driver, error) {
-	migrationConn, err := sql.Open(s.cfg.GetDriver(), s.cfg.GetDsn())
-	if err != nil {
-		return nil, err
-	}
-
-	switch s.cfg.GetProvider() {
-	case config.DatabaseProviderPostgres:
-		driver, err := postgres.WithInstance(migrationConn, &postgres.Config{
-			MigrationsTable: appMetricsMigrationsTable,
-		})
-		if err != nil {
-			_ = migrationConn.Close()
-		}
-		return driver, err
-	case config.DatabaseProviderSqlite:
-		driver, err := sqlite3.WithInstance(migrationConn, &sqlite3.Config{
-			MigrationsTable: appMetricsMigrationsTable,
-		})
-		if err != nil {
-			_ = migrationConn.Close()
-		}
-		return driver, err
-	default:
-		_ = migrationConn.Close()
-		return nil, fmt.Errorf("unsupported SQL app metrics provider %q", s.cfg.GetProvider())
-	}
+	return RunMigrations(ctx, s.cfg, s.logger, migration.DirectionUp, nil)
 }
 
 func (s *sqlRecordStore) Ping(ctx context.Context) bool {

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -144,30 +144,6 @@ func (ss *StorageService) Ping(ctx context.Context) bool {
 	return true
 }
 
-// Migrate runs any necessary schema migrations for the storage backend.
-func (ss *StorageService) Migrate(ctx context.Context) error {
-	ss.logger.Info("running app metrics migrations")
-	defer ss.logger.Info("app metrics migrations complete")
-
-	if m, ok := ss.store.(migratable); ok {
-		ss.logger.Info("running store migrations")
-		if err := m.Migrate(ctx); err != nil {
-			return err
-		}
-	}
-
-	if util.SameInstance(ss.store, ss.fullStore) {
-		return nil
-	}
-
-	if m, ok := ss.fullStore.(migratable); ok {
-		ss.logger.Info("running full store migrations")
-		return m.Migrate(ctx)
-	}
-
-	return nil
-}
-
 // NewStorageService that will store app metrics records and full request/response details.
 // dbOpts are forwarded to the underlying DB constructors — pass
 // sqlh.WithTelemetry(...) to instrument the request-events database tier.

--- a/internal/app_metrics/test_store.go
+++ b/internal/app_metrics/test_store.go
@@ -77,6 +77,34 @@ func newTestHarnessLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
+// postgresAppMetricsMigrator configures pgtestdb's golang-migrate adapter to
+// create the same migrations table used by the production app-metrics path.
+type postgresAppMetricsMigrator struct {
+	*golangmigrator.GolangMigrator
+}
+
+func (m *postgresAppMetricsMigrator) Hash() (string, error) {
+	hash, err := m.GolangMigrator.Hash()
+	if err != nil {
+		return "", err
+	}
+	return hash + ":" + appMetricsMigrationsTable, nil
+}
+
+func (m *postgresAppMetricsMigrator) Migrate(
+	ctx context.Context,
+	db *sql.DB,
+	templateConfig pgtestdb.Config,
+) error {
+	options, err := url.ParseQuery(templateConfig.Options)
+	if err != nil {
+		return fmt.Errorf("parse postgres test database options: %w", err)
+	}
+	options.Set("x-migrations-table", appMetricsMigrationsTable)
+	templateConfig.Options = options.Encode()
+	return m.GolangMigrator.Migrate(ctx, db, templateConfig)
+}
+
 func mustNewBlankSqliteRequestEventsStore(t testing.TB) (RecordStore, RecordRetriever, *sql.DB) {
 	t.Helper()
 
@@ -117,10 +145,12 @@ func mustNewBlankPostgresRequestEventsStore(t testing.TB) (RecordStore, RecordRe
 		ForceTerminateConnections: true,
 	}
 
-	migrator := golangmigrator.New(
-		"migrations/postgres",
-		golangmigrator.WithFS(appMetricsMigrationsFs),
-	)
+	migrator := &postgresAppMetricsMigrator{
+		GolangMigrator: golangmigrator.New(
+			"migrations/postgres",
+			golangmigrator.WithFS(appMetricsMigrationsFs),
+		),
+	}
 
 	testDbConfig := pgtestdb.Custom(t, adminConfig, migrator)
 
@@ -156,21 +186,6 @@ func mustNewBlankPostgresRequestEventsStore(t testing.TB) (RecordStore, RecordRe
 		SSLMode:  scommon.NewStringValueDirectInline(sslMode),
 		Params:   params,
 	}}
-
-	// pgtestdb's golang-migrate adapter always uses schema_migrations. Production
-	// app-metrics migrations use their own table so they can share a database
-	// with the main schema; align the cloned test database with that layout.
-	setupDB, err := sql.Open(cfg.GetDriver(), cfg.GetDsn())
-	if err != nil {
-		t.Fatalf("failed to open postgres app_metrics test database: %v", err)
-	}
-	if _, err := setupDB.Exec(`ALTER TABLE schema_migrations RENAME TO app_metrics_schema_migrations`); err != nil {
-		_ = setupDB.Close()
-		t.Fatalf("failed to rename postgres app_metrics migration table: %v", err)
-	}
-	if err := setupDB.Close(); err != nil {
-		t.Fatalf("failed to close postgres app_metrics setup database: %v", err)
-	}
 
 	// pgtestdb already ran the migrator against the per-test database, so the
 	// SQL store can be built without re-migrating.

--- a/internal/app_metrics/test_store.go
+++ b/internal/app_metrics/test_store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/peterldowns/pgtestdb"
 	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
+	"github.com/rmorlok/authproxy/internal/migration"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -238,7 +239,7 @@ func mustNewBlankClickhouseRequestEventsStore(t testing.TB) (RecordStore, Record
 	logger := newTestHarnessLogger()
 	store := NewClickhouseRecordStore(cfg, logger).(*clickhouseRecordStore)
 	t.Cleanup(func() { _ = store.db.Close() })
-	if err := store.Migrate(context.Background()); err != nil {
+	if err := RunMigrations(context.Background(), cfg, logger, migration.DirectionUp, nil); err != nil {
 		t.Fatalf("failed to migrate clickhouse app_metrics test database: %v", err)
 	}
 
@@ -255,7 +256,7 @@ func mustBuildSqlStorePair(t testing.TB, cfg *sconfig.Database) (RecordStore, Re
 	t.Helper()
 
 	store, retriever, rawDb := buildSqlStorePairNoMigrate(t, cfg)
-	if err := store.(*sqlRecordStore).Migrate(context.Background()); err != nil {
+	if err := RunMigrations(context.Background(), cfg, newTestHarnessLogger(), migration.DirectionUp, nil); err != nil {
 		t.Fatalf("failed to migrate app_metrics test database: %v", err)
 	}
 	return store, retriever, rawDb

--- a/internal/app_metrics/test_store.go
+++ b/internal/app_metrics/test_store.go
@@ -156,6 +156,21 @@ func mustNewBlankPostgresRequestEventsStore(t testing.TB) (RecordStore, RecordRe
 		Params:   params,
 	}}
 
+	// pgtestdb's golang-migrate adapter always uses schema_migrations. Production
+	// app-metrics migrations use their own table so they can share a database
+	// with the main schema; align the cloned test database with that layout.
+	setupDB, err := sql.Open(cfg.GetDriver(), cfg.GetDsn())
+	if err != nil {
+		t.Fatalf("failed to open postgres app_metrics test database: %v", err)
+	}
+	if _, err := setupDB.Exec(`ALTER TABLE schema_migrations RENAME TO app_metrics_schema_migrations`); err != nil {
+		_ = setupDB.Close()
+		t.Fatalf("failed to rename postgres app_metrics migration table: %v", err)
+	}
+	if err := setupDB.Close(); err != nil {
+		t.Fatalf("failed to close postgres app_metrics setup database: %v", err)
+	}
+
 	// pgtestdb already ran the migrator against the per-test database, so the
 	// SQL store can be built without re-migrating.
 	return buildSqlStorePairNoMigrate(t, cfg)

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -47,7 +47,6 @@ type IActorDataExtended interface {
 //go:generate mockgen -source=./interface.go -destination=./mock/db.go -package=mock
 type DB interface {
 	SetCursorEncryptor(e pagination.CursorEncryptor)
-	Migrate(ctx context.Context) error
 	Ping(ctx context.Context) bool
 	SearchResources(ctx context.Context, params SearchResourcesParams) (SearchResourcesResult, error)
 

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -22,21 +22,39 @@ const MigrateMutexKeyName = "db-migrate-lock"
 
 const migrationsTable = "schema_migrations"
 
-func MigrationStatus(ctx context.Context, cfg *config.Database) migration.Status {
+// MigrationStatus returns the status of the database migrations for the main
+// application database.
+func MigrationStatus(
+	ctx context.Context,
+	cfg *config.Database,
+) migration.Status {
 	if cfg == nil || cfg.InnerVal == nil {
-		return migration.UnavailableStatus(migration.TargetMainDatabase, "", 0, fmt.Errorf("database configuration is required"))
+		return migration.UnavailableStatus(
+			migration.TargetMainDatabase,
+			"", // provider
+			0,  // available version
+			fmt.Errorf("database configuration is required"),
+		)
 	}
-	latest, err := migration.LatestVersion(migrationsFs, fmt.Sprintf("migrations/%s", cfg.GetProvider()))
+
+	latest, err := migration.LatestVersion(
+		migrationsFs,
+		fmt.Sprintf("migrations/%s", cfg.GetProvider()),
+	)
 	if err != nil {
 		return migration.UnavailableStatus(migration.TargetMainDatabase, cfg.GetProvider(), 0, err)
 	}
-	return migration.Inspect(ctx, migration.TargetMainDatabase, cfg, migrationsTable, latest)
+
+	return migration.Inspect(
+		ctx,
+		migration.TargetMainDatabase,
+		cfg,
+		migrationsTable,
+		latest,
+	)
 }
 
-func (s *service) Migrate(ctx context.Context) (resultErr error) {
-	return RunMigrations(ctx, &config.Database{InnerVal: s.cfg}, s.logger, migration.DirectionUp, nil)
-}
-
+// RunMigrations runs database migrations for the main application database.
 func RunMigrations(
 	ctx context.Context,
 	cfg *config.Database,
@@ -44,16 +62,31 @@ func RunMigrations(
 	direction migration.Direction,
 	version *uint,
 ) (resultErr error) {
-	logger.Info("running database migrations", "provider", cfg.GetProvider(), "direction", direction, "version", version)
+	logger.Info(
+		"running database migrations",
+		"provider", cfg.GetProvider(),
+		"direction", direction,
+		"version", version,
+	)
 	defer func() {
 		if resultErr != nil {
-			logger.Error("database migrations failed", "provider", cfg.GetProvider(), "error", resultErr)
+			logger.Error(
+				"database migrations failed",
+				"provider", cfg.GetProvider(),
+				"error", resultErr,
+			)
 			return
 		}
-		logger.Info("database migrations complete", "provider", cfg.GetProvider())
+		logger.Info(
+			"database migrations complete",
+			"provider", cfg.GetProvider(),
+		)
 	}()
 
-	d, err := iofs.New(migrationsFs, fmt.Sprintf("migrations/%s", cfg.GetProvider()))
+	d, err := iofs.New(
+		migrationsFs,
+		fmt.Sprintf("migrations/%s", cfg.GetProvider()),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to load database migrations for '%s': %w", cfg.GetProvider(), err)
 	}
@@ -65,7 +98,11 @@ func RunMigrations(
 	defer func() {
 		sourceErr, dbErr := m.Close()
 		if sourceErr != nil || dbErr != nil {
-			logger.Warn("failed to close migrator", "source_err", sourceErr, "db_err", dbErr)
+			logger.Warn(
+				"failed to close migrator",
+				"source_err", sourceErr,
+				"db_err", dbErr,
+			)
 		}
 	}()
 

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -3,14 +3,15 @@ package database
 import (
 	"context"
 	"embed"
-	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
-	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/rmorlok/authproxy/internal/migration"
+	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
 //go:embed migrations/**/*.sql
@@ -19,39 +20,57 @@ var migrationsFs embed.FS
 // MigrateMutexKeyName is the key that can be used when locking to perform a migration in redis.
 const MigrateMutexKeyName = "db-migrate-lock"
 
+const migrationsTable = "schema_migrations"
+
+func MigrationStatus(ctx context.Context, cfg *config.Database) migration.Status {
+	if cfg == nil || cfg.InnerVal == nil {
+		return migration.UnavailableStatus(migration.TargetMainDatabase, "", 0, fmt.Errorf("database configuration is required"))
+	}
+	latest, err := migration.LatestVersion(migrationsFs, fmt.Sprintf("migrations/%s", cfg.GetProvider()))
+	if err != nil {
+		return migration.UnavailableStatus(migration.TargetMainDatabase, cfg.GetProvider(), 0, err)
+	}
+	return migration.Inspect(ctx, migration.TargetMainDatabase, cfg, migrationsTable, latest)
+}
+
 func (s *service) Migrate(ctx context.Context) (resultErr error) {
-	s.logger.Info("running database migrations", "provider", s.cfg.GetProvider())
+	return RunMigrations(ctx, &config.Database{InnerVal: s.cfg}, s.logger, migration.DirectionUp, nil)
+}
+
+func RunMigrations(
+	ctx context.Context,
+	cfg *config.Database,
+	logger *slog.Logger,
+	direction migration.Direction,
+	version *uint,
+) (resultErr error) {
+	logger.Info("running database migrations", "provider", cfg.GetProvider(), "direction", direction, "version", version)
 	defer func() {
 		if resultErr != nil {
-			s.logger.Error("database migrations failed", "provider", s.cfg.GetProvider(), "error", resultErr)
+			logger.Error("database migrations failed", "provider", cfg.GetProvider(), "error", resultErr)
 			return
 		}
-		s.logger.Info("database migrations complete", "provider", s.cfg.GetProvider())
+		logger.Info("database migrations complete", "provider", cfg.GetProvider())
 	}()
 
-	d, err := iofs.New(migrationsFs, fmt.Sprintf("migrations/%s", s.cfg.GetProvider()))
+	d, err := iofs.New(migrationsFs, fmt.Sprintf("migrations/%s", cfg.GetProvider()))
 	if err != nil {
-		return fmt.Errorf("failed to load database migrations for '%s': %w", s.cfg.GetProvider(), err)
+		return fmt.Errorf("failed to load database migrations for '%s': %w", cfg.GetProvider(), err)
 	}
 
-	m, err := migrate.NewWithSourceInstance("iofs", d, s.cfg.GetUri())
+	m, err := migrate.NewWithSourceInstance("iofs", d, cfg.GetUri())
 	if err != nil {
 		return fmt.Errorf("failed setup database migrations: %w", err)
 	}
 	defer func() {
 		sourceErr, dbErr := m.Close()
 		if sourceErr != nil || dbErr != nil {
-			s.logger.Warn("failed to close migrator", "source_err", sourceErr, "db_err", dbErr)
+			logger.Warn("failed to close migrator", "source_err", sourceErr, "db_err", dbErr)
 		}
 	}()
 
-	err = util.RunMigrationsUp(ctx, m)
+	err = migration.Apply(ctx, m, direction, version)
 	if err != nil {
-		if errors.Is(err, migrate.ErrNoChange) {
-			s.logger.Info("no migrations required")
-			return nil
-		}
-
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}
 

--- a/internal/database/migrate_status_test.go
+++ b/internal/database/migrate_status_test.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/migration"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationStatusAndDirectionsSQLite(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.Database{InnerVal: &config.DatabaseSqlite{
+		Provider: config.DatabaseProviderSqlite,
+		Path:     filepath.Join(t.TempDir(), "database.sqlite"),
+	}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	missing := MigrationStatus(ctx, cfg)
+	require.Equal(t, migration.StateMissing, missing.State)
+	require.Equal(t, uint(16), missing.AvailableVersion)
+
+	require.NoError(t, RunMigrations(ctx, cfg, logger, migration.DirectionUp, nil))
+	current := MigrationStatus(ctx, cfg)
+	require.True(t, current.Compatible())
+	require.Equal(t, uint(16), *current.CurrentVersion)
+
+	target := uint(15)
+	require.NoError(t, RunMigrations(ctx, cfg, logger, migration.DirectionDown, &target))
+	behind := MigrationStatus(ctx, cfg)
+	require.Equal(t, migration.StateBehind, behind.State)
+	require.Equal(t, target, *behind.CurrentVersion)
+
+	require.NoError(t, RunMigrations(ctx, cfg, logger, migration.DirectionUp, nil))
+	require.True(t, MigrationStatus(ctx, cfg).Compatible())
+}
+
+func TestMigrationStatusCurrentForConfiguredProvider(t *testing.T) {
+	cfg, _, _ := MustApplyBlankTestDbConfigRaw(t, nil)
+	status := MigrationStatus(context.Background(), cfg.GetRoot().Database)
+	require.NoError(t, status.Err)
+	require.True(t, status.Compatible())
+	require.Equal(t, status.AvailableVersion, *status.CurrentVersion)
+}

--- a/internal/database/mock/db.go
+++ b/internal/database/mock/db.go
@@ -1365,20 +1365,6 @@ func (mr *MockDBMockRecorder) MarkNotificationsViewed(ctx, notificationIDs, acto
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkNotificationsViewed", reflect.TypeOf((*MockDB)(nil).MarkNotificationsViewed), ctx, notificationIDs, actorID)
 }
 
-// Migrate mocks base method.
-func (m *MockDB) Migrate(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Migrate", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Migrate indicates an expected call of Migrate.
-func (mr *MockDBMockRecorder) Migrate(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockDB)(nil).Migrate), ctx)
-}
-
 // NewestConnectorDefinitionVersionForId mocks base method.
 func (m *MockDB) NewestConnectorDefinitionVersionForId(ctx context.Context, id apid.ID) (*database.ConnectorWithDefinition, error) {
 	m.ctrl.T.Helper()

--- a/internal/database/oauth2_token_test.go
+++ b/internal/database/oauth2_token_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/sqlh"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -646,8 +647,14 @@ func TestEnumerateOAuth2TokensExpiringWithin(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				_, db := MustApplyBlankTestDbConfig(t, nil)
-				err := db.Migrate(ctx)
+				cfg, db := MustApplyBlankTestDbConfig(t, nil)
+				err := RunMigrations(
+					ctx,
+					cfg.GetRoot().Database,
+					cfg.GetRoot().GetRootLogger(),
+					migration.DirectionUp,
+					nil,
+				)
 				require.NoError(t, err)
 
 				dbRaw := db.(*service)

--- a/internal/database/test_db.go
+++ b/internal/database/test_db.go
@@ -19,6 +19,7 @@ import (
 	"github.com/peterldowns/pgtestdb"
 	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"github.com/rmorlok/authproxy/internal/config"
+	"github.com/rmorlok/authproxy/internal/migration"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -133,7 +134,13 @@ func mustApplyBlankSqliteTestDbConfig(t testing.TB, cfg config.C) (config.C, DB,
 		t.Fatalf("failed to construct sqlite test database: %v", err)
 	}
 
-	if err := db.Migrate(context.Background()); err != nil {
+	if err := RunMigrations(
+		context.Background(),
+		root.Database,
+		root.GetRootLogger(),
+		migration.DirectionUp,
+		nil,
+	); err != nil {
 		t.Fatalf("failed to migrate sqlite test database: %v", err)
 	}
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -28,8 +28,14 @@ const (
 	TargetAll          Target = "all"
 )
 
-var OrderedTargets = []Target{TargetMainDatabase, TargetWorkflows, TargetAppMetrics}
+var OrderedTargets = []Target{
+	TargetMainDatabase,
+	TargetWorkflows,
+	TargetAppMetrics,
+}
 
+// ParseTarget parses a string value into a Target. If the target is not valid,
+// an error is returned.
 func ParseTarget(value string, allowAll bool) (Target, error) {
 	target := Target(value)
 	for _, valid := range OrderedTargets {
@@ -37,9 +43,11 @@ func ParseTarget(value string, allowAll bool) (Target, error) {
 			return target, nil
 		}
 	}
+
 	if allowAll && target == TargetAll {
 		return target, nil
 	}
+
 	return "", fmt.Errorf("unknown migration database %q", value)
 }
 
@@ -54,10 +62,12 @@ func ParseDirection(value string) (Direction, error) {
 	if value == "" {
 		return DirectionUp, nil
 	}
+
 	direction := Direction(value)
 	if direction != DirectionUp && direction != DirectionDown {
 		return "", fmt.Errorf("unknown migration direction %q; expected up or down", value)
 	}
+
 	return direction, nil
 }
 
@@ -93,7 +103,15 @@ func (s Status) CurrentVersionString() string {
 	return strconv.FormatUint(uint64(*s.CurrentVersion), 10)
 }
 
-func NewStatus(target Target, provider config.DatabaseProvider, current *uint, available uint, dirty bool) Status {
+// NewStatus returns a new Status computing state based on the information
+// provided.
+func NewStatus(
+	target Target,
+	provider config.DatabaseProvider,
+	current *uint,
+	available uint,
+	dirty bool,
+) Status {
 	state := StateCurrent
 	switch {
 	case dirty:
@@ -105,6 +123,7 @@ func NewStatus(target Target, provider config.DatabaseProvider, current *uint, a
 	case *current > available:
 		state = StateAhead
 	}
+
 	return Status{
 		Target:           target,
 		Provider:         provider,
@@ -115,7 +134,12 @@ func NewStatus(target Target, provider config.DatabaseProvider, current *uint, a
 	}
 }
 
-func UnavailableStatus(target Target, provider config.DatabaseProvider, available uint, err error) Status {
+func UnavailableStatus(
+	target Target,
+	provider config.DatabaseProvider,
+	available uint,
+	err error,
+) Status {
 	return Status{
 		Target:           target,
 		Provider:         provider,
@@ -127,46 +151,77 @@ func UnavailableStatus(target Target, provider config.DatabaseProvider, availabl
 
 var migrationFilename = regexp.MustCompile(`^(\d+).+\.up\.sql$`)
 
+// LatestVersion returns the latest available migration version by walking the
+// migrations in the specified directory of the filesystem. In practice this
+// will be applied to an embedded filesystem that contains the database
+// migration SQL files.
 func LatestVersion(fsys fs.FS, directory string) (uint, error) {
 	entries, err := fs.ReadDir(fsys, directory)
 	if err != nil {
 		return 0, err
 	}
+
 	var latest uint64
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
+
 		matches := migrationFilename.FindStringSubmatch(entry.Name())
 		if len(matches) != 2 {
 			continue
 		}
+
 		version, err := strconv.ParseUint(matches[1], 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("parse migration version from %q: %w", entry.Name(), err)
+			return 0, fmt.Errorf(
+				"parse migration version from %q: %w",
+				entry.Name(), err,
+			)
 		}
+
 		if version > latest {
 			latest = version
 		}
 	}
+
 	if latest == 0 {
 		return 0, fmt.Errorf("no up migrations found in %q", directory)
 	}
+
 	return uint(latest), nil
 }
 
-func Inspect(ctx context.Context, target Target, cfg *config.Database, table string, available uint) Status {
+func Inspect(
+	ctx context.Context,
+	target Target,
+	cfg *config.Database,
+	table string,
+	available uint,
+) Status {
 	if cfg == nil || cfg.InnerVal == nil {
-		return UnavailableStatus(target, "", available, errors.New("database configuration is required"))
+		return UnavailableStatus(
+			target,
+			"", // provider
+			available,
+			errors.New("database configuration is required"),
+		)
 	}
+
 	if !validIdentifier(table) {
-		return UnavailableStatus(target, cfg.GetProvider(), available, fmt.Errorf("invalid migration table %q", table))
+		return UnavailableStatus(
+			target,
+			cfg.GetProvider(),
+			available,
+			fmt.Errorf("invalid migration table %q", table),
+		)
 	}
 
 	current, dirty, err := inspect(ctx, cfg, table)
 	if err != nil {
 		return UnavailableStatus(target, cfg.GetProvider(), available, err)
 	}
+
 	return NewStatus(target, cfg.GetProvider(), current, available, dirty)
 }
 
@@ -176,7 +231,16 @@ func validIdentifier(value string) bool {
 	return identifier.MatchString(value)
 }
 
-func inspect(ctx context.Context, cfg *config.Database, table string) (*uint, bool, error) {
+// inspect opens a connection to the database and runs a query to determine
+// the current migration version and whether there are any pending migrations.
+//
+// This method delegates to the appropriate provider version to accomplish the
+// task.
+func inspect(
+	ctx context.Context,
+	cfg *config.Database,
+	table string, // the table name of the migration table
+) (version *uint, dirty bool, err error) {
 	switch concrete := cfg.InnerVal.(type) {
 	case *config.DatabaseSqlite:
 		return inspectSQLite(ctx, concrete, table)
@@ -189,11 +253,16 @@ func inspect(ctx context.Context, cfg *config.Database, table string) (*uint, bo
 	}
 }
 
-func inspectSQLite(ctx context.Context, cfg *config.DatabaseSqlite, table string) (*uint, bool, error) {
+func inspectSQLite(
+	ctx context.Context,
+	cfg *config.DatabaseSqlite,
+	table string,
+) (version *uint, dirty bool, err error) {
 	path, err := homedir.Expand(cfg.Path)
 	if err != nil {
 		return nil, false, fmt.Errorf("expand sqlite database path: %w", err)
 	}
+
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			return nil, false, nil
@@ -205,88 +274,156 @@ func inspectSQLite(ctx context.Context, cfg *config.DatabaseSqlite, table string
 	if err != nil {
 		return nil, false, fmt.Errorf("open sqlite database read-only: %w", err)
 	}
+
 	defer db.Close()
+
 	if err := db.PingContext(ctx); err != nil {
 		return nil, false, fmt.Errorf("ping sqlite database read-only: %w", err)
 	}
 
 	var exists int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&exists); err != nil {
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		table,
+	).Scan(&exists); err != nil {
 		return nil, false, fmt.Errorf("inspect sqlite migration table: %w", err)
 	}
+
 	if exists == 0 {
 		return nil, false, nil
 	}
-	return readVersion(ctx, db, fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table))
+
+	return readVersion(
+		ctx,
+		db,
+		fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table),
+	)
 }
 
-func inspectPostgres(ctx context.Context, cfg *config.DatabasePostgres, table string) (*uint, bool, error) {
+func inspectPostgres(
+	ctx context.Context,
+	cfg *config.DatabasePostgres,
+	table string,
+) (version *uint, dirty bool, err error) {
 	db, err := sql.Open("pgx", cfg.GetDsn())
 	if err != nil {
 		return nil, false, fmt.Errorf("open postgres database read-only inspection: %w", err)
 	}
+
 	defer db.Close()
+
 	if err := db.PingContext(ctx); err != nil {
 		return nil, false, fmt.Errorf("ping postgres database: %w", err)
 	}
 
 	var exists bool
-	if err := db.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, table).Scan(&exists); err != nil {
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT to_regclass($1) IS NOT NULL`,
+		table,
+	).Scan(&exists); err != nil {
 		return nil, false, fmt.Errorf("inspect postgres migration table: %w", err)
 	}
+
 	if !exists {
 		return nil, false, nil
 	}
-	return readVersion(ctx, db, fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table))
+
+	return readVersion(
+		ctx,
+		db,
+		fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table),
+	)
 }
 
-func inspectClickHouse(ctx context.Context, cfg *config.DatabaseClickhouse, table string) (*uint, bool, error) {
+func inspectClickHouse(
+	ctx context.Context,
+	cfg *config.DatabaseClickhouse,
+	table string,
+) (*uint, bool, error) {
 	opts, err := cfg.ToClickhouseOptions()
 	if err != nil {
 		return nil, false, fmt.Errorf("resolve clickhouse configuration: %w", err)
 	}
+
 	db := sql.OpenDB(clickhouse.Connector(opts))
+
 	defer db.Close()
+
 	if err := db.PingContext(ctx); err != nil {
 		return nil, false, fmt.Errorf("ping clickhouse database: %w", err)
 	}
 
 	databaseName := opts.Auth.Database
+
 	var exists uint8
-	if err := db.QueryRowContext(ctx, `SELECT count() > 0 FROM system.tables WHERE database = ? AND name = ?`, databaseName, table).Scan(&exists); err != nil {
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT count() > 0 FROM system.tables WHERE database = ? AND name = ?`,
+		databaseName,
+		table,
+	).Scan(&exists); err != nil {
 		return nil, false, fmt.Errorf("inspect clickhouse migration table: %w", err)
 	}
+
 	if exists == 0 {
 		return nil, false, nil
 	}
+
 	var version uint
 	var dirty uint8
-	err = db.QueryRowContext(ctx, fmt.Sprintf("SELECT version, dirty FROM `%s` ORDER BY sequence DESC LIMIT 1", table)).Scan(&version, &dirty)
+	err = db.QueryRowContext(
+		ctx,
+		fmt.Sprintf("SELECT version, dirty FROM `%s` ORDER BY sequence DESC LIMIT 1", table),
+	).Scan(&version, &dirty)
+
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, false, nil
 	}
+
 	if err != nil {
 		return nil, false, fmt.Errorf("read clickhouse migration version: %w", err)
 	}
+
 	return &version, dirty == 1, nil
 }
 
-func readVersion(ctx context.Context, db *sql.DB, query string) (*uint, bool, error) {
+// readVersion runs a query that returns version, dirty as the result. Handles
+// error cases such as when there are no rows returned.
+func readVersion(
+	ctx context.Context,
+	db *sql.DB,
+	query string,
+) (ver *uint, drty bool, e error) {
 	var version uint
 	var dirty bool
 	err := db.QueryRowContext(ctx, query).Scan(&version, &dirty)
+
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, false, nil
 	}
+
 	if err != nil {
 		return nil, false, fmt.Errorf("read migration version: %w", err)
 	}
+
 	return &version, dirty, nil
 }
 
-func Apply(ctx context.Context, migrator *migrate.Migrate, direction Direction, version *uint) error {
+// Apply runs a migration in the specified direction. If version is specified
+// it migrates to the specified version. If it is not specified it defaults to
+// the latest migration. This method handles context cancellation with graceful
+// stop on the migration goroutine.
+func Apply(
+	ctx context.Context,
+	migrator *migrate.Migrate,
+	direction Direction,
+	version *uint,
+) error {
 	done := make(chan struct{})
 	defer close(done)
+
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -300,65 +437,96 @@ func Apply(ctx context.Context, migrator *migrate.Migrate, direction Direction, 
 
 	var err error
 	switch direction {
+
 	case DirectionUp:
 		if version == nil {
 			err = migrator.Up()
 		} else {
 			err = migrator.Migrate(*version)
 		}
+
 	case DirectionDown:
 		if version == nil {
 			err = migrator.Steps(-1)
 		} else {
 			err = migrator.Migrate(*version)
 		}
+
 	default:
 		return fmt.Errorf("unsupported migration direction %q", direction)
+
 	}
+
 	if errors.Is(err, migrate.ErrNoChange) {
 		return nil
 	}
+
 	return err
 }
 
+// ValidateRequest validates the migration request by comparing the `status`
+// of the database (current version, dirty, available migrations, etc) against
+// the requested migration direction and version. It returns a descriptive
+// error if the request is invalid.
 func ValidateRequest(status Status, direction Direction, version *uint) error {
 	if status.Err != nil {
 		return status.Err
 	}
+
 	if status.Dirty {
-		return fmt.Errorf("%s schema is dirty at version %s", status.Target, status.CurrentVersionString())
+		return fmt.Errorf(
+			"%s schema is dirty at version %s",
+			status.Target, status.CurrentVersionString())
 	}
+
 	if version != nil && *version > status.AvailableVersion {
-		return fmt.Errorf("%s requested version %d exceeds highest available version %d", status.Target, *version, status.AvailableVersion)
+		return fmt.Errorf(
+			"%s requested version %d exceeds highest available version %d",
+			status.Target, *version, status.AvailableVersion)
 	}
+
 	if status.CurrentVersion == nil {
 		if direction == DirectionDown {
 			return fmt.Errorf("%s schema is not initialized", status.Target)
 		}
 		return nil
 	}
+
 	if version == nil {
 		if direction == DirectionUp && status.State == StateAhead {
-			return fmt.Errorf("%s current version %d is ahead of highest available version %d", status.Target, *status.CurrentVersion, status.AvailableVersion)
+			return fmt.Errorf(
+				"%s current version %d is ahead of highest available version %d",
+				status.Target, *status.CurrentVersion, status.AvailableVersion)
 		}
 		return nil
 	}
+
 	if direction == DirectionUp && *version < *status.CurrentVersion {
-		return fmt.Errorf("%s up target %d is below current version %d", status.Target, *version, *status.CurrentVersion)
+		return fmt.Errorf(
+			"%s up target %d is below current version %d",
+			status.Target, *version, *status.CurrentVersion)
 	}
+
 	if direction == DirectionDown && *version > *status.CurrentVersion {
-		return fmt.Errorf("%s down target %d is above current version %d", status.Target, *version, *status.CurrentVersion)
+		return fmt.Errorf(
+			"%s down target %d is above current version %d",
+			status.Target, *version, *status.CurrentVersion)
 	}
+
 	return nil
 }
 
 func IncompatibleError(status Status) error {
 	if status.Err != nil {
-		return fmt.Errorf("%s schema is unavailable: %w", status.Target, status.Err)
+		return fmt.Errorf(
+			"%s schema is unavailable: %w",
+			status.Target, status.Err)
 	}
+
 	if status.Compatible() {
 		return nil
 	}
+
 	return fmt.Errorf(
 		"%s schema is %s: current=%s expected=%d dirty=%t",
 		status.Target,

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,0 +1,379 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/mitchellh/go-homedir"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+)
+
+type Target string
+
+const (
+	TargetMainDatabase Target = "main-database"
+	TargetWorkflows    Target = "workflows"
+	TargetAppMetrics   Target = "app-metrics"
+	TargetAll          Target = "all"
+)
+
+var OrderedTargets = []Target{TargetMainDatabase, TargetWorkflows, TargetAppMetrics}
+
+func ParseTarget(value string, allowAll bool) (Target, error) {
+	target := Target(value)
+	for _, valid := range OrderedTargets {
+		if target == valid {
+			return target, nil
+		}
+	}
+	if allowAll && target == TargetAll {
+		return target, nil
+	}
+	return "", fmt.Errorf("unknown migration database %q", value)
+}
+
+type Direction string
+
+const (
+	DirectionUp   Direction = "up"
+	DirectionDown Direction = "down"
+)
+
+func ParseDirection(value string) (Direction, error) {
+	if value == "" {
+		return DirectionUp, nil
+	}
+	direction := Direction(value)
+	if direction != DirectionUp && direction != DirectionDown {
+		return "", fmt.Errorf("unknown migration direction %q; expected up or down", value)
+	}
+	return direction, nil
+}
+
+type State string
+
+const (
+	StateCurrent     State = "current"
+	StateBehind      State = "behind"
+	StateAhead       State = "ahead"
+	StateDirty       State = "dirty"
+	StateMissing     State = "missing"
+	StateUnavailable State = "unavailable"
+)
+
+type Status struct {
+	Target           Target
+	Provider         config.DatabaseProvider
+	CurrentVersion   *uint
+	AvailableVersion uint
+	Dirty            bool
+	State            State
+	Err              error
+}
+
+func (s Status) Compatible() bool {
+	return s.State == StateCurrent && s.Err == nil
+}
+
+func (s Status) CurrentVersionString() string {
+	if s.CurrentVersion == nil {
+		return "none"
+	}
+	return strconv.FormatUint(uint64(*s.CurrentVersion), 10)
+}
+
+func NewStatus(target Target, provider config.DatabaseProvider, current *uint, available uint, dirty bool) Status {
+	state := StateCurrent
+	switch {
+	case dirty:
+		state = StateDirty
+	case current == nil:
+		state = StateMissing
+	case *current < available:
+		state = StateBehind
+	case *current > available:
+		state = StateAhead
+	}
+	return Status{
+		Target:           target,
+		Provider:         provider,
+		CurrentVersion:   current,
+		AvailableVersion: available,
+		Dirty:            dirty,
+		State:            state,
+	}
+}
+
+func UnavailableStatus(target Target, provider config.DatabaseProvider, available uint, err error) Status {
+	return Status{
+		Target:           target,
+		Provider:         provider,
+		AvailableVersion: available,
+		State:            StateUnavailable,
+		Err:              err,
+	}
+}
+
+var migrationFilename = regexp.MustCompile(`^(\d+).+\.up\.sql$`)
+
+func LatestVersion(fsys fs.FS, directory string) (uint, error) {
+	entries, err := fs.ReadDir(fsys, directory)
+	if err != nil {
+		return 0, err
+	}
+	var latest uint64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		matches := migrationFilename.FindStringSubmatch(entry.Name())
+		if len(matches) != 2 {
+			continue
+		}
+		version, err := strconv.ParseUint(matches[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse migration version from %q: %w", entry.Name(), err)
+		}
+		if version > latest {
+			latest = version
+		}
+	}
+	if latest == 0 {
+		return 0, fmt.Errorf("no up migrations found in %q", directory)
+	}
+	return uint(latest), nil
+}
+
+func Inspect(ctx context.Context, target Target, cfg *config.Database, table string, available uint) Status {
+	if cfg == nil || cfg.InnerVal == nil {
+		return UnavailableStatus(target, "", available, errors.New("database configuration is required"))
+	}
+	if !validIdentifier(table) {
+		return UnavailableStatus(target, cfg.GetProvider(), available, fmt.Errorf("invalid migration table %q", table))
+	}
+
+	current, dirty, err := inspect(ctx, cfg, table)
+	if err != nil {
+		return UnavailableStatus(target, cfg.GetProvider(), available, err)
+	}
+	return NewStatus(target, cfg.GetProvider(), current, available, dirty)
+}
+
+var identifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func validIdentifier(value string) bool {
+	return identifier.MatchString(value)
+}
+
+func inspect(ctx context.Context, cfg *config.Database, table string) (*uint, bool, error) {
+	switch concrete := cfg.InnerVal.(type) {
+	case *config.DatabaseSqlite:
+		return inspectSQLite(ctx, concrete, table)
+	case *config.DatabasePostgres:
+		return inspectPostgres(ctx, concrete, table)
+	case *config.DatabaseClickhouse:
+		return inspectClickHouse(ctx, concrete, table)
+	default:
+		return nil, false, fmt.Errorf("unsupported database provider %q", cfg.GetProvider())
+	}
+}
+
+func inspectSQLite(ctx context.Context, cfg *config.DatabaseSqlite, table string) (*uint, bool, error) {
+	path, err := homedir.Expand(cfg.Path)
+	if err != nil {
+		return nil, false, fmt.Errorf("expand sqlite database path: %w", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("stat sqlite database: %w", err)
+	}
+
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro&_foreign_keys=on", path))
+	if err != nil {
+		return nil, false, fmt.Errorf("open sqlite database read-only: %w", err)
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, false, fmt.Errorf("ping sqlite database read-only: %w", err)
+	}
+
+	var exists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&exists); err != nil {
+		return nil, false, fmt.Errorf("inspect sqlite migration table: %w", err)
+	}
+	if exists == 0 {
+		return nil, false, nil
+	}
+	return readVersion(ctx, db, fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table))
+}
+
+func inspectPostgres(ctx context.Context, cfg *config.DatabasePostgres, table string) (*uint, bool, error) {
+	db, err := sql.Open("pgx", cfg.GetDsn())
+	if err != nil {
+		return nil, false, fmt.Errorf("open postgres database read-only inspection: %w", err)
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, false, fmt.Errorf("ping postgres database: %w", err)
+	}
+
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, table).Scan(&exists); err != nil {
+		return nil, false, fmt.Errorf("inspect postgres migration table: %w", err)
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	return readVersion(ctx, db, fmt.Sprintf(`SELECT version, dirty FROM "%s" LIMIT 1`, table))
+}
+
+func inspectClickHouse(ctx context.Context, cfg *config.DatabaseClickhouse, table string) (*uint, bool, error) {
+	opts, err := cfg.ToClickhouseOptions()
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve clickhouse configuration: %w", err)
+	}
+	db := sql.OpenDB(clickhouse.Connector(opts))
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, false, fmt.Errorf("ping clickhouse database: %w", err)
+	}
+
+	databaseName := opts.Auth.Database
+	var exists uint8
+	if err := db.QueryRowContext(ctx, `SELECT count() > 0 FROM system.tables WHERE database = ? AND name = ?`, databaseName, table).Scan(&exists); err != nil {
+		return nil, false, fmt.Errorf("inspect clickhouse migration table: %w", err)
+	}
+	if exists == 0 {
+		return nil, false, nil
+	}
+	var version uint
+	var dirty uint8
+	err = db.QueryRowContext(ctx, fmt.Sprintf("SELECT version, dirty FROM `%s` ORDER BY sequence DESC LIMIT 1", table)).Scan(&version, &dirty)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read clickhouse migration version: %w", err)
+	}
+	return &version, dirty == 1, nil
+}
+
+func readVersion(ctx context.Context, db *sql.DB, query string) (*uint, bool, error) {
+	var version uint
+	var dirty bool
+	err := db.QueryRowContext(ctx, query).Scan(&version, &dirty)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read migration version: %w", err)
+	}
+	return &version, dirty, nil
+}
+
+func Apply(ctx context.Context, migrator *migrate.Migrate, direction Direction, version *uint) error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			select {
+			case migrator.GracefulStop <- true:
+			case <-done:
+			}
+		case <-done:
+		}
+	}()
+
+	var err error
+	switch direction {
+	case DirectionUp:
+		if version == nil {
+			err = migrator.Up()
+		} else {
+			err = migrator.Migrate(*version)
+		}
+	case DirectionDown:
+		if version == nil {
+			err = migrator.Steps(-1)
+		} else {
+			err = migrator.Migrate(*version)
+		}
+	default:
+		return fmt.Errorf("unsupported migration direction %q", direction)
+	}
+	if errors.Is(err, migrate.ErrNoChange) {
+		return nil
+	}
+	return err
+}
+
+func ValidateRequest(status Status, direction Direction, version *uint) error {
+	if status.Err != nil {
+		return status.Err
+	}
+	if status.Dirty {
+		return fmt.Errorf("%s schema is dirty at version %s", status.Target, status.CurrentVersionString())
+	}
+	if version != nil && *version > status.AvailableVersion {
+		return fmt.Errorf("%s requested version %d exceeds highest available version %d", status.Target, *version, status.AvailableVersion)
+	}
+	if status.CurrentVersion == nil {
+		if direction == DirectionDown {
+			return fmt.Errorf("%s schema is not initialized", status.Target)
+		}
+		return nil
+	}
+	if version == nil {
+		if direction == DirectionUp && status.State == StateAhead {
+			return fmt.Errorf("%s current version %d is ahead of highest available version %d", status.Target, *status.CurrentVersion, status.AvailableVersion)
+		}
+		return nil
+	}
+	if direction == DirectionUp && *version < *status.CurrentVersion {
+		return fmt.Errorf("%s up target %d is below current version %d", status.Target, *version, *status.CurrentVersion)
+	}
+	if direction == DirectionDown && *version > *status.CurrentVersion {
+		return fmt.Errorf("%s down target %d is above current version %d", status.Target, *version, *status.CurrentVersion)
+	}
+	return nil
+}
+
+func IncompatibleError(status Status) error {
+	if status.Err != nil {
+		return fmt.Errorf("%s schema is unavailable: %w", status.Target, status.Err)
+	}
+	if status.Compatible() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s schema is %s: current=%s expected=%d dirty=%t",
+		status.Target,
+		status.State,
+		status.CurrentVersionString(),
+		status.AvailableVersion,
+		status.Dirty,
+	)
+}
+
+func FormatTargets() string {
+	values := make([]string, 0, len(OrderedTargets)+1)
+	for _, target := range OrderedTargets {
+		values = append(values, string(target))
+	}
+	values = append(values, string(TargetAll))
+	return strings.Join(values, ", ")
+}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -1,0 +1,89 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"testing/fstest"
+
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestVersion(t *testing.T) {
+	version, err := LatestVersion(fstest.MapFS{
+		"migrations/000001_init.up.sql":   {},
+		"migrations/000001_init.down.sql": {},
+		"migrations/000007_latest.up.sql": {},
+	}, "migrations")
+	require.NoError(t, err)
+	require.Equal(t, uint(7), version)
+}
+
+func TestInspectMissingSQLiteIsReadOnly(t *testing.T) {
+	path := t.TempDir() + "/missing.sqlite"
+	cfg := sqliteConfig(path)
+
+	status := Inspect(context.Background(), TargetMainDatabase, cfg, "schema_migrations", 4)
+
+	require.Equal(t, StateMissing, status.State)
+	require.Nil(t, status.CurrentVersion)
+	require.NoFileExists(t, path)
+}
+
+func TestInspectSQLiteStates(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   uint
+		dirty     bool
+		available uint
+		expected  State
+	}{
+		{name: "current", current: 4, available: 4, expected: StateCurrent},
+		{name: "behind", current: 3, available: 4, expected: StateBehind},
+		{name: "ahead", current: 5, available: 4, expected: StateAhead},
+		{name: "dirty", current: 4, dirty: true, available: 4, expected: StateDirty},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir() + "/status.sqlite"
+			db, err := sql.Open("sqlite3", path)
+			require.NoError(t, err)
+			_, err = db.Exec(`CREATE TABLE schema_migrations (version uint64, dirty bool)`)
+			require.NoError(t, err)
+			_, err = db.Exec(`INSERT INTO schema_migrations (version, dirty) VALUES (?, ?)`, tt.current, tt.dirty)
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			status := Inspect(context.Background(), TargetMainDatabase, sqliteConfig(path), "schema_migrations", tt.available)
+
+			require.NoError(t, status.Err)
+			require.Equal(t, tt.expected, status.State)
+			require.NotNil(t, status.CurrentVersion)
+			require.Equal(t, tt.current, *status.CurrentVersion)
+			require.Equal(t, tt.dirty, status.Dirty)
+		})
+	}
+}
+
+func TestValidateRequest(t *testing.T) {
+	current := uint(4)
+	status := NewStatus(TargetMainDatabase, config.DatabaseProviderSqlite, &current, 7, false)
+
+	tooLow := uint(3)
+	require.Error(t, ValidateRequest(status, DirectionUp, &tooLow))
+	tooHigh := uint(8)
+	require.Error(t, ValidateRequest(status, DirectionUp, &tooHigh))
+	validUp := uint(6)
+	require.NoError(t, ValidateRequest(status, DirectionUp, &validUp))
+	validDown := uint(2)
+	require.NoError(t, ValidateRequest(status, DirectionDown, &validDown))
+}
+
+func sqliteConfig(path string) *config.Database {
+	return &config.Database{InnerVal: &config.DatabaseSqlite{
+		Provider: config.DatabaseProviderSqlite,
+		Path:     path,
+	}}
+}

--- a/internal/schema/config/app_metrics.go
+++ b/internal/schema/config/app_metrics.go
@@ -16,10 +16,6 @@ const (
 
 // AppMetrics are the settings for application metrics storage and capture.
 type AppMetrics struct {
-	// AutoMigrate controls if the migration to build the indexes for app metrics happens automatically on startup.
-	// If this value is not specified in the config, it defaults to true.
-	AutoMigrate *bool `json:"autoMigrate,omitempty" yaml:"autoMigrate,omitempty"`
-
 	// Database is the database provider for app metrics. This can be the same database as the main database but would
 	// typically be a data warehouse in production.
 	Database *Database `json:"database" yaml:"database"`
@@ -78,14 +74,6 @@ func (d *AppMetrics) Validate(vc *common.ValidationContext) error {
 	}
 
 	return result.ErrorOrNil()
-}
-
-func (d *AppMetrics) GetAutoMigrate() bool {
-	if d == nil || d.AutoMigrate == nil {
-		return true
-	}
-
-	return *d.AutoMigrate
 }
 
 func (d *AppMetrics) GetResourceSnapshotInterval() time.Duration {

--- a/internal/schema/config/database.go
+++ b/internal/schema/config/database.go
@@ -18,7 +18,6 @@ const (
 // DatabaseImpl is the interface implemented by concrete database configurations.
 type DatabaseImpl interface {
 	GetProvider() DatabaseProvider
-	GetAutoMigrate() bool
 	GetAutoMigrationLockDuration() time.Duration
 	GetSoftDeleteRetention() *time.Duration
 	GetUri() string
@@ -38,13 +37,6 @@ func (d *Database) GetProvider() DatabaseProvider {
 		return ""
 	}
 	return d.InnerVal.GetProvider()
-}
-
-func (d *Database) GetAutoMigrate() bool {
-	if d == nil || d.InnerVal == nil {
-		return false
-	}
-	return d.InnerVal.GetAutoMigrate()
 }
 
 func (d *Database) GetAutoMigrationLockDuration() time.Duration {

--- a/internal/schema/config/database_clickhouse.go
+++ b/internal/schema/config/database_clickhouse.go
@@ -26,7 +26,6 @@ type DatabaseClickhouse struct {
 	User                      *StringValue     `json:"user,omitempty" yaml:"user,omitempty"`
 	Password                  *StringValue     `json:"password,omitempty" yaml:"password,omitempty"`
 	Protocol                  *string          `json:"protocol,omitempty" yaml:"protocol,omitempty"`
-	AutoMigrate               bool             `json:"autoMigrate,omitempty" yaml:"autoMigrate,omitempty"`
 	AutoMigrationLockDuration *HumanDuration   `json:"autoMigrationLockDuration,omitempty" yaml:"autoMigrationLockDuration,omitempty"`
 }
 
@@ -44,10 +43,6 @@ func (d *DatabaseClickhouse) GetProtocol() clickhouse.Protocol {
 		return clickhouse.Native
 	}
 	return clickhouse.HTTP
-}
-
-func (d *DatabaseClickhouse) GetAutoMigrate() bool {
-	return d.AutoMigrate
 }
 
 func (d *DatabaseClickhouse) GetAutoMigrationLockDuration() time.Duration {

--- a/internal/schema/config/database_postgres.go
+++ b/internal/schema/config/database_postgres.go
@@ -27,7 +27,6 @@ type DatabasePostgres struct {
 	MaxIdleConns              *IntegerValue     `json:"maxIdleConns,omitempty" yaml:"maxIdleConns,omitempty"`
 	ConnMaxLifetime           *HumanDuration    `json:"connMaxLifetime,omitempty" yaml:"connMaxLifetime,omitempty"`
 	ConnMaxIdleTime           *HumanDuration    `json:"connMaxIdleTime,omitempty" yaml:"connMaxIdleTime,omitempty"`
-	AutoMigrate               bool              `json:"autoMigrate,omitempty" yaml:"autoMigrate,omitempty"`
 	AutoMigrationLockDuration *HumanDuration    `json:"autoMigrationLockDuration,omitempty" yaml:"autoMigrationLockDuration,omitempty"`
 	SoftDeleteRetention       *HumanDuration    `json:"softDeleteRetention,omitempty" yaml:"softDeleteRetention,omitempty"`
 }
@@ -38,10 +37,6 @@ func (d *DatabasePostgres) GetProvider() DatabaseProvider {
 
 func (d *DatabasePostgres) GetDriver() string {
 	return "postgres"
-}
-
-func (d *DatabasePostgres) GetAutoMigrate() bool {
-	return d.AutoMigrate
 }
 
 func (d *DatabasePostgres) GetAutoMigrationLockDuration() time.Duration {

--- a/internal/schema/config/database_sqlite.go
+++ b/internal/schema/config/database_sqlite.go
@@ -11,7 +11,6 @@ import (
 type DatabaseSqlite struct {
 	Provider                  DatabaseProvider `json:"provider" yaml:"provider"`
 	Path                      string           `json:"path" yaml:"path"`
-	AutoMigrate               bool             `json:"autoMigrate,omitempty" yaml:"autoMigrate,omitempty"`
 	AutoMigrationLockDuration *HumanDuration   `json:"autoMigrationLockDuration,omitempty" yaml:"autoMigrationLockDuration,omitempty"`
 	SoftDeleteRetention       *HumanDuration   `json:"softDeleteRetention,omitempty" yaml:"softDeleteRetention,omitempty"`
 }
@@ -22,10 +21,6 @@ func (d *DatabaseSqlite) GetProvider() DatabaseProvider {
 
 func (d *DatabaseSqlite) GetDriver() string {
 	return "sqlite3"
-}
-
-func (d *DatabaseSqlite) GetAutoMigrate() bool {
-	return d.AutoMigrate
 }
 
 func (d *DatabaseSqlite) GetAutoMigrationLockDuration() time.Duration {

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -60,9 +60,6 @@
     },
     "Connectors": {
       "properties": {
-        "autoMigrate": {
-          "type": "boolean"
-        },
         "autoMigrationLockDuration": {
           "$ref": "../common/schema.json#/$defs/HumanDuration"
         },
@@ -160,9 +157,6 @@
         "path": {
           "type": "string"
         },
-        "autoMigrate": {
-          "type": "boolean"
-        },
         "autoMigrationLockDuration": {
           "$ref": "../common/schema.json#/$defs/HumanDuration"
         },
@@ -211,9 +205,6 @@
             }
           }
         },
-        "autoMigrate": {
-          "type": "boolean"
-        },
         "autoMigrationLockDuration": {
           "$ref": "../common/schema.json#/$defs/HumanDuration"
         },
@@ -260,9 +251,6 @@
             "http",
             "native"
           ]
-        },
-        "autoMigrate": {
-          "type": "boolean"
         },
         "autoMigrationLockDuration": {
           "$ref": "../common/schema.json#/$defs/HumanDuration"
@@ -375,9 +363,6 @@
     },
     "AppMetrics": {
       "properties": {
-        "autoMigrate": {
-          "type": "boolean"
-        },
         "database": {
           "$ref": "#/$defs/DatabaseOrWarehouse"
         },

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -128,6 +128,16 @@ func Test_SchemaAppMetricsShape(t *testing.T) {
 		},
 	}))
 
+	require.Error(t, schema.Validate(map[string]any{
+		"appMetrics": map[string]any{
+			"autoMigrate": true,
+			"database": map[string]any{
+				"provider": "sqlite",
+				"path":     "./tmp/app_metrics.db",
+			},
+		},
+	}))
+
 	require.NoError(t, schema.Validate(map[string]any{
 		"connections": map[string]any{
 			"setupTtl": "1s",
@@ -381,8 +391,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"provider": "sqlite", "path": "/data/db.sqlite"}}`,
 				},
 				{
-					Name:  "sqlite with auto_migrate",
-					Valid: true,
+					Name:  "sqlite rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"provider": "sqlite", "path": "/data/db.sqlite", "autoMigrate": true}}`,
 				},
 				{
@@ -401,8 +411,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"provider": "postgres", "host": "example", "port": 1234, "user": "bobdole", "password": "secret", "sslmode": "disable"}}`,
 				},
 				{
-					Name:  "postgres with auto_migrate",
-					Valid: true,
+					Name:  "postgres rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"provider": "postgres", "host": "localhost", "autoMigrate": true}}`,
 				},
 				{
@@ -454,8 +464,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"provider": "sqlite", "path": "/data/db.sqlite"}}`,
 				},
 				{
-					Name:  "sqlite with auto_migrate",
-					Valid: true,
+					Name:  "sqlite warehouse rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"provider": "sqlite", "path": "/data/db.sqlite", "autoMigrate": true}}`,
 				},
 				{
@@ -474,8 +484,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"provider": "postgres", "host": "example", "port": 1234, "user": "bobdole", "password": "secret", "sslmode": "disable"}}`,
 				},
 				{
-					Name:  "postgres with auto_migrate",
-					Valid: true,
+					Name:  "postgres warehouse rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"provider": "postgres", "host": "localhost", "autoMigrate": true}}`,
 				},
 				{
@@ -504,8 +514,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"provider": "clickhouse", "addressList": "host1,host2", "user": "bobdole", "password": "secret", "database": "authproxy"}}`,
 				},
 				{
-					Name:  "clickhouse with auto_migrate",
-					Valid: true,
+					Name:  "clickhouse rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"provider": "clickhouse", "address": "localhost", "autoMigrate": true}}`,
 				},
 				{
@@ -991,8 +1001,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"identifyingLabels": ["type", "region"]}}`,
 				},
 				{
-					Name:  "with auto_migrate",
-					Valid: true,
+					Name:  "rejects removed auto_migrate",
+					Valid: false,
 					Data:  `{"test": {"autoMigrate": true, "autoMigrationLockDuration": "30s"}}`,
 				},
 				{

--- a/internal/schema/config/test_data/invalid-bad-service-port.yaml
+++ b/internal/schema/config/test_data/invalid-bad-service-port.yaml
@@ -38,7 +38,6 @@ errorPages:
   internalError: https://example.com
 database:
   provider: sqlite
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   path: ./tmp/dev.db
 logging:
@@ -50,7 +49,6 @@ appMetrics:
     fullRequestRecording: always
   database:
     provider: sqlite
-    autoMigrate: true
     path: ./tmp/app_metrics.db
 redis:
   provider: redis
@@ -58,7 +56,6 @@ redis:
 oauth:
   roundTripTtl: 60m
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList:
     - type: google-drive

--- a/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
+++ b/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
@@ -1,5 +1,4 @@
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList:
     - name: asana

--- a/internal/schema/config/test_data/valid.yaml
+++ b/internal/schema/config/test_data/valid.yaml
@@ -39,7 +39,6 @@ errorPages:
   internalError: https://example.com
 database:
   provider: sqlite
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   path: ./tmp/dev.db
 logging:
@@ -51,7 +50,6 @@ appMetrics:
     fullRequestRecording: always
   database:
     provider: sqlite
-    autoMigrate: true
     path: ./tmp/app_metrics.db
 redis:
   provider: redis
@@ -59,7 +57,6 @@ redis:
 oauth:
   roundTripTtl: 60m
 connectors:
-  autoMigrate: true
   autoMigrationLockDuration: 30s
   loadFromList:
     - name: google-drive

--- a/internal/schema/resources/connectors/connectors.go
+++ b/internal/schema/resources/connectors/connectors.go
@@ -13,7 +13,6 @@ import (
 //
 // Note that the schema for this object is in the parent package.
 type Connectors struct {
-	AutoMigrate               *bool                 `json:"autoMigrate,omitempty" yaml:"autoMigrate,omitempty"`
 	AutoMigrationLockDuration *common.HumanDuration `json:"autoMigrationLockDuration,omitempty" yaml:"autoMigrationLockDuration,omitempty"`
 	LoadFromList              []Connector           `json:"loadFromList,omitempty" yaml:"loadFromList,omitempty"`
 }
@@ -22,13 +21,6 @@ func FromList(c []Connector) *Connectors {
 	return &Connectors{
 		LoadFromList: c,
 	}
-}
-
-func (c *Connectors) GetAutoMigrate() bool {
-	if c.AutoMigrate == nil {
-		return true
-	}
-	return *c.AutoMigrate
 }
 
 func (c *Connectors) GetAutoMigrationLockDurationOrDefault() time.Duration {

--- a/internal/service/admin_api/server.go
+++ b/internal/service/admin_api/server.go
@@ -287,8 +287,6 @@ func Serve(cfg config.C) {
 
 	defer dm.GetRedisClient().Close()
 
-	dm.AutoMigrateAll()
-
 	defer dm.ShutdownDatabase()
 	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -184,8 +184,6 @@ func Serve(cfg config.C) {
 	// Close redis connections when we exit
 	defer dm.GetRedisClient().Close()
 
-	dm.AutoMigrateAll()
-
 	defer dm.ShutdownDatabase()
 	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()

--- a/internal/service/dependency_manager.go
+++ b/internal/service/dependency_manager.go
@@ -8,15 +8,12 @@ import (
 	"math"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/hibiken/asynq"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rmorlok/authproxy/internal/apasynq"
-	"github.com/rmorlok/authproxy/internal/apauth/tasks"
-	authSync "github.com/rmorlok/authproxy/internal/apauth/tasks"
 	"github.com/rmorlok/authproxy/internal/aplog"
 	"github.com/rmorlok/authproxy/internal/app_metrics"
 	"github.com/rmorlok/authproxy/internal/apredis"
@@ -66,6 +63,7 @@ type DependencyManager struct {
 
 	rootLogger     *slog.Logger
 	rootLoggerOnce sync.Once
+	rootLoggerErr  error
 
 	// Rate-limit cache + refresher are owned by the dependency manager so
 	// the lifecycle is tied to the proxy process. The cache is populated
@@ -169,11 +167,23 @@ func (dm *DependencyManager) GetServiceId() string {
 }
 
 func (dm *DependencyManager) GetLogBuilder() aplog.Builder {
+	builder, err := dm.GetLogBuilderWithError()
+	if err != nil {
+		panic(err)
+	}
+	return builder
+}
+
+func (dm *DependencyManager) GetLogBuilderWithError() (aplog.Builder, error) {
 	if dm.logBuilder == nil {
-		dm.logBuilder = aplog.NewBuilder(dm.GetRootLogger())
+		logger, err := dm.GetRootLoggerWithError()
+		if err != nil {
+			return nil, err
+		}
+		dm.logBuilder = aplog.NewBuilder(logger)
 	}
 
-	return dm.logBuilder
+	return dm.logBuilder, nil
 }
 
 // GetRootLogger returns the application-wide root slog.Logger, wrapped with
@@ -187,74 +197,138 @@ func (dm *DependencyManager) GetLogBuilder() aplog.Builder {
 // bridge picks up the live LoggerProvider regardless of call order in the
 // service's Serve func.
 func (dm *DependencyManager) GetRootLogger() *slog.Logger {
+	logger, err := dm.GetRootLoggerWithError()
+	if err != nil {
+		panic(err)
+	}
+	return logger
+}
+
+func (dm *DependencyManager) GetRootLoggerWithError() (*slog.Logger, error) {
 	dm.rootLoggerOnce.Do(func() {
-		providers := dm.GetTelemetry()
+		providers, err := dm.GetTelemetryWithError()
+		if err != nil {
+			dm.rootLoggerErr = err
+			return
+		}
 		dm.rootLogger = aplog.WrapWithTelemetry(
 			dm.GetConfigRoot().GetRootLogger(),
 			providers,
 			dm.GetConfigRoot().Telemetry,
 		)
 	})
-	return dm.rootLogger
+	if dm.rootLoggerErr != nil {
+		return nil, dm.rootLoggerErr
+	}
+	return dm.rootLogger, nil
 }
 
 func (dm *DependencyManager) GetLogger() *slog.Logger {
+	logger, err := dm.GetLoggerWithError()
+	if err != nil {
+		panic(err)
+	}
+	return logger
+}
+
+func (dm *DependencyManager) GetLoggerWithError() (*slog.Logger, error) {
 	if dm.logger == nil {
-		b := dm.GetLogBuilder()
+		b, err := dm.GetLogBuilderWithError()
+		if err != nil {
+			return nil, err
+		}
 		b = b.WithService(dm.serviceId)
 		dm.logger = b.Build()
 	}
 
-	return dm.logger
+	return dm.logger, nil
 }
 
 func (dm *DependencyManager) GetRedisClient() apredis.Client {
+	client, err := dm.GetRedisClientWithError()
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func (dm *DependencyManager) GetRedisClientWithError() (apredis.Client, error) {
 	if dm.r == nil {
-		var err error
+		telemetry, err := dm.GetTelemetryWithError()
+		if err != nil {
+			return nil, err
+		}
 		dm.r, err = apredis.NewForRoot(
 			context.Background(),
 			dm.GetConfig().GetRoot(),
-			apredis.WithTelemetry(dm.GetTelemetry(), dm.GetConfigRoot().Telemetry),
+			apredis.WithTelemetry(telemetry, dm.GetConfigRoot().Telemetry),
 		)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
-	return dm.r
+	return dm.r, nil
 }
 
 func (dm *DependencyManager) GetDatabase() database.DB {
+	db, err := dm.GetDatabaseWithError()
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+func (dm *DependencyManager) GetDatabaseWithError() (database.DB, error) {
 	if dm.db == nil {
-		var err error
+		sqlDB, err := dm.GetSQLDBWithError()
+		if err != nil {
+			return nil, err
+		}
+		logger, err := dm.GetLoggerWithError()
+		if err != nil {
+			return nil, err
+		}
 		dm.db, err = database.NewService(
-			dm.GetSQLDB(),
+			sqlDB,
 			dm.GetConfigRoot().Database.InnerVal,
-			dm.GetLogger(),
+			logger,
 		)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
-	return dm.db
+	return dm.db, nil
 }
 
 func (dm *DependencyManager) GetSQLDB() *sql.DB {
+	db, err := dm.GetSQLDBWithError()
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+func (dm *DependencyManager) GetSQLDBWithError() (*sql.DB, error) {
 	if dm.sqlDB == nil {
 		db, err := dm.openConfiguredSQLDB()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		dm.sqlDB = db
 	}
-	return dm.sqlDB
+	return dm.sqlDB, nil
 }
 
 func (dm *DependencyManager) openConfiguredSQLDB() (*sql.DB, error) {
 	root := dm.GetConfigRoot()
 	if root == nil || root.Database == nil || root.Database.InnerVal == nil {
 		return nil, fmt.Errorf("database configuration is required")
+	}
+	telemetry, err := dm.GetTelemetryWithError()
+	if err != nil {
+		return nil, err
 	}
 
 	switch cfg := root.Database.InnerVal.(type) {
@@ -266,14 +340,14 @@ func (dm *DependencyManager) openConfiguredSQLDB() (*sql.DB, error) {
 			"sqlite3",
 			cfg.GetDsn(),
 			sqlh.DBSystemSQLite,
-			sqlh.WithTelemetry(dm.GetTelemetry(), root.Telemetry),
+			sqlh.WithTelemetry(telemetry, root.Telemetry),
 		)
 	case *sconfig.DatabasePostgres:
 		db, err := sqlh.OpenInstrumentedSQL(
 			"pgx",
 			cfg.GetDsn(),
 			sqlh.DBSystemPostgreSQL,
-			sqlh.WithTelemetry(dm.GetTelemetry(), root.Telemetry),
+			sqlh.WithTelemetry(telemetry, root.Telemetry),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open postgres database '%s': %w", cfg.GetDsn(), err)
@@ -363,40 +437,6 @@ func (dm *DependencyManager) ShutdownDatabase() {
 	dm.sqlDB = nil
 }
 
-// AutoMigrateDatabase will attempt to migrate the database if the root config has auto migrate enabled.
-func (dm *DependencyManager) AutoMigrateDatabase() {
-	if dm.GetConfigRoot().Database.GetAutoMigrate() {
-		lockDuration := dm.GetConfigRoot().Database.GetAutoMigrationLockDuration()
-		m := apredis.NewMutex(
-			dm.GetRedisClient(),
-			database.MigrateMutexKeyName,
-			apredis.MutexOptionLockFor(lockDuration),
-			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
-			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-			apredis.MutexOptionDetailedLockMetadata(),
-		)
-		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
-			if err := dm.GetDatabase().Migrate(ctx); err != nil {
-				return err
-			}
-
-			if err := workflows.Migrate(
-				ctx,
-				dm.GetConfigRoot(),
-				dm.GetLogBuilder().WithComponent("workflows").Build(),
-				workflows.WithPostgresMigrationDB(dm.GetSQLDB()),
-			); err != nil {
-				return fmt.Errorf("failed to migrate workflow database: %w", err)
-			}
-			return nil
-		})
-		if err != nil {
-			dm.GetLogger().Error("automatic database migration failed", "lock_key", database.MigrateMutexKeyName, "error", err)
-			panic(fmt.Errorf("failed to automatically migrate database: %w", err))
-		}
-	}
-}
-
 func (dm *DependencyManager) GetAppMetricsService() *app_metrics.StorageService {
 	ctx := context.Background()
 	var err error
@@ -476,31 +516,6 @@ func (dm *DependencyManager) GetHttpf() httpf.F {
 	}
 
 	return dm.httpf
-}
-
-func (dm *DependencyManager) AutoMigrateAppMetricsService() {
-	if dm.GetConfigRoot().AppMetrics.GetAutoMigrate() {
-		var dbConfig *sconfig.Database
-		if dm.GetConfigRoot().AppMetrics != nil {
-			dbConfig = dm.GetConfigRoot().AppMetrics.Database
-		}
-		lockDuration := dbConfig.GetAutoMigrationLockDuration()
-		m := apredis.NewMutex(
-			dm.GetRedisClient(),
-			app_metrics.MigrateMutexKeyName,
-			apredis.MutexOptionLockFor(lockDuration),
-			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
-			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-			apredis.MutexOptionDetailedLockMetadata(),
-		)
-		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
-			return dm.GetAppMetricsService().Migrate(ctx)
-		})
-		if err != nil {
-			dm.GetLogger().Error("automatic app metrics migration failed", "lock_key", app_metrics.MigrateMutexKeyName, "error", err)
-			panic(fmt.Errorf("failed to automatically migrate app metrics: %w", err))
-		}
-	}
 }
 
 func (dm *DependencyManager) GetEncryptService() encrypt.E {
@@ -589,6 +604,14 @@ func (dm *DependencyManager) ShutdownWorkflowRuntime() {
 // other dependencies on this manager. Use ShutdownTelemetry to flush and tear
 // down before exit.
 func (dm *DependencyManager) GetTelemetry() *aptelemetry.Providers {
+	telemetry, err := dm.GetTelemetryWithError()
+	if err != nil {
+		panic(err)
+	}
+	return telemetry
+}
+
+func (dm *DependencyManager) GetTelemetryWithError() (*aptelemetry.Providers, error) {
 	dm.telemetryOnce.Do(func() {
 		providers, err := aptelemetry.New(
 			context.Background(),
@@ -604,16 +627,29 @@ func (dm *DependencyManager) GetTelemetry() *aptelemetry.Providers {
 	})
 
 	if dm.telemetryErr != nil {
-		panic(fmt.Errorf("failed to initialise telemetry: %w", dm.telemetryErr))
+		return nil, fmt.Errorf("failed to initialise telemetry: %w", dm.telemetryErr)
 	}
 
-	return dm.telemetry
+	return dm.telemetry, nil
 }
 
 func (dm *DependencyManager) GetDataEncryptionKeyTelemetry() *encrypt.DataEncryptionKeyTelemetry {
+	telemetry, err := dm.GetDataEncryptionKeyTelemetryWithError()
+	if err != nil {
+		panic(err)
+	}
+	return telemetry
+}
+
+func (dm *DependencyManager) GetDataEncryptionKeyTelemetryWithError() (*encrypt.DataEncryptionKeyTelemetry, error) {
 	dm.dataEncryptionKeyTelemetryOnce.Do(func() {
+		providers, err := dm.GetTelemetryWithError()
+		if err != nil {
+			dm.dataEncryptionKeyTelemetryErr = err
+			return
+		}
 		tel, err := encrypt.NewDataEncryptionKeyTelemetry(
-			dm.GetTelemetry(),
+			providers,
 			dm.GetConfigRoot().Telemetry,
 		)
 		if err != nil {
@@ -624,10 +660,10 @@ func (dm *DependencyManager) GetDataEncryptionKeyTelemetry() *encrypt.DataEncryp
 	})
 
 	if dm.dataEncryptionKeyTelemetryErr != nil {
-		panic(fmt.Errorf("failed to initialise data encryption key telemetry: %w", dm.dataEncryptionKeyTelemetryErr))
+		return nil, fmt.Errorf("failed to initialise data encryption key telemetry: %w", dm.dataEncryptionKeyTelemetryErr)
 	}
 
-	return dm.dataEncryptionKeyTelemetry
+	return dm.dataEncryptionKeyTelemetry, nil
 }
 
 // ShutdownTelemetry flushes and tears down OTel providers if they were
@@ -690,113 +726,4 @@ func (dm *DependencyManager) StartRateLimitRefresher(ctx context.Context) (stop 
 		dm.rateLimitCache,
 		dm.GetLogBuilder().WithComponent("ratelimit-refresher").Build(),
 	)
-}
-
-// TODO: this automigrate should not be specific to the connectors config
-func (dm *DependencyManager) AutoMigrateCore() {
-	if dm.GetConfigRoot().Connectors.GetAutoMigrate() {
-		lockDuration := dm.GetConfigRoot().Connectors.GetAutoMigrationLockDurationOrDefault()
-		m := apredis.NewMutex(
-			dm.GetRedisClient(),
-			core.MigrateMutexKeyName,
-			apredis.MutexOptionLockFor(lockDuration),
-			apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
-			apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-			apredis.MutexOptionDetailedLockMetadata(),
-		)
-		err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
-			return dm.GetCoreService().Migrate(ctx)
-		})
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-// AutoMigratePredefinedActors synchronizes actors from ConfiguredActorsList configuration to the database.
-// This only runs for ConfiguredActorsList configuration (not ConfiguredActorsExternalSource which uses cron).
-// Uses a distributed Redis lock to ensure only one instance performs the migration.
-func (dm *DependencyManager) AutoMigratePredefinedActors() {
-	actors := dm.GetConfigRoot().SystemAuth.Actors
-	if actors == nil {
-		return
-	}
-
-	if _, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSource); ok {
-		// Don't actually run the sync here, just enqueue a task to run immediately.
-		task := authSync.NewSyncActorsExternalSourceTask()
-		_, err := dm.GetAsyncClient().Enqueue(task)
-		if err != nil {
-			panic(fmt.Errorf("failed to enqueue sync actors external source task: %w", err))
-		}
-
-		return
-	}
-
-	if _, ok := actors.InnerVal.(sconfig.ConfiguredActorsList); !ok {
-		// There aren't any other value types that we migrate
-		return
-	}
-
-	const lockDuration = 30 * time.Second
-	m := apredis.NewMutex(
-		dm.GetRedisClient(),
-		"actor_sync:migrate",
-		apredis.MutexOptionLockFor(lockDuration),
-		apredis.MutexOptionRetryFor(lockDuration+1*time.Second),
-		apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
-		apredis.MutexOptionDetailedLockMetadata(),
-	)
-	err := apredis.RunWithMutex(context.Background(), m, lockDuration, func(ctx context.Context) error {
-		svc := tasks.NewService(
-			dm.GetConfig(),
-			dm.GetDatabase(),
-			dm.GetRedisClient(),
-			dm.GetEncryptService(),
-			dm.GetLogger(),
-		)
-		return svc.SyncActorList(ctx)
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to sync actors from config list: %w", err))
-	}
-}
-
-// AutoMigrateGenerateDataEncryptionKeys ensures current DEKs exist before any
-// service constructs the runtime encryption cache.
-func (dm *DependencyManager) AutoMigrateGenerateDataEncryptionKeys() {
-	if err := encrypt.GenerateDataEncryptionKeysToDatabase(
-		context.Background(),
-		dm.GetConfig(),
-		dm.GetDatabase(),
-		dm.GetLogger(),
-		dm.GetRedisClient(),
-		encrypt.WithGenerateDataEncryptionKeysTelemetry(dm.GetDataEncryptionKeyTelemetry()),
-	); err != nil {
-		panic(fmt.Errorf("failed to generate data encryption keys: %w", err))
-	}
-}
-
-// AutoMigrateSyncKeysToDatabase syncs key wrapping state into the database.
-// Uses a Redis sentinel to avoid redundant runs across processes.
-func (dm *DependencyManager) AutoMigrateSyncKeysToDatabase() {
-	if err := encrypt.SyncKeysToDatabase(
-		context.Background(),
-		dm.GetConfig(),
-		dm.GetDatabase(),
-		dm.GetLogger(),
-		dm.GetRedisClient(),
-		encrypt.WithSyncKeysTelemetry(dm.GetDataEncryptionKeyTelemetry()),
-	); err != nil {
-		panic(fmt.Errorf("failed to sync keys to database: %w", err))
-	}
-}
-
-func (dm *DependencyManager) AutoMigrateAll() {
-	dm.AutoMigrateDatabase()
-	dm.AutoMigrateGenerateDataEncryptionKeys()
-	dm.AutoMigrateSyncKeysToDatabase()
-	dm.AutoMigrateAppMetricsService()
-	dm.AutoMigrateCore()
-	dm.AutoMigratePredefinedActors()
 }

--- a/internal/service/migrations.go
+++ b/internal/service/migrations.go
@@ -1,0 +1,364 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apauth/tasks"
+	"github.com/rmorlok/authproxy/internal/app_metrics"
+	"github.com/rmorlok/authproxy/internal/apredis"
+	"github.com/rmorlok/authproxy/internal/core"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/encrypt"
+	"github.com/rmorlok/authproxy/internal/migration"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/workflows"
+)
+
+func (dm *DependencyManager) MigrationStatuses(ctx context.Context, target migration.Target) []migration.Status {
+	if target == migration.TargetAll {
+		statuses := make([]migration.Status, 0, len(migration.OrderedTargets))
+		for _, currentTarget := range migration.OrderedTargets {
+			statuses = append(statuses, dm.migrationStatus(ctx, currentTarget))
+		}
+		return statuses
+	}
+	return []migration.Status{dm.migrationStatus(ctx, target)}
+}
+
+func (dm *DependencyManager) migrationStatus(ctx context.Context, target migration.Target) migration.Status {
+	root := dm.GetConfigRoot()
+	switch target {
+	case migration.TargetMainDatabase:
+		return database.MigrationStatus(ctx, root.Database)
+	case migration.TargetWorkflows:
+		return workflows.MigrationStatus(ctx, root)
+	case migration.TargetAppMetrics:
+		if root.AppMetrics == nil {
+			return migration.UnavailableStatus(target, "", 0, fmt.Errorf("app metrics configuration is required"))
+		}
+		return app_metrics.MigrationStatus(ctx, root.AppMetrics.Database)
+	default:
+		return migration.UnavailableStatus(target, "", 0, fmt.Errorf("unknown migration database %q", target))
+	}
+}
+
+func (dm *DependencyManager) VerifyMigrations(ctx context.Context) error {
+	var result error
+	for _, status := range dm.MigrationStatuses(ctx, migration.TargetAll) {
+		if err := migration.IncompatibleError(status); err != nil {
+			result = errors.Join(result, err)
+		}
+	}
+	if result != nil {
+		return fmt.Errorf("schema compatibility verification failed: %w", result)
+	}
+	return nil
+}
+
+func (dm *DependencyManager) MigrateSchemas(
+	ctx context.Context,
+	target migration.Target,
+	direction migration.Direction,
+	version *uint,
+) error {
+	if target == migration.TargetAll && version != nil {
+		return fmt.Errorf("a schema version cannot be used with all because each database has an independent version sequence")
+	}
+
+	if target != migration.TargetAll {
+		return dm.migrateTargetWithLock(ctx, target, direction, version)
+	}
+
+	if direction == migration.DirectionDown {
+		if err := dm.migrateTargetWithLock(ctx, migration.TargetAppMetrics, direction, nil); err != nil {
+			return err
+		}
+		return dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
+			if err := dm.migrateTarget(ctx, migration.TargetWorkflows, direction, nil); err != nil {
+				return err
+			}
+			return dm.migrateTarget(ctx, migration.TargetMainDatabase, direction, nil)
+		})
+	}
+
+	if err := dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
+		if err := dm.migrateTarget(ctx, migration.TargetMainDatabase, direction, nil); err != nil {
+			return err
+		}
+		return dm.migrateTarget(ctx, migration.TargetWorkflows, direction, nil)
+	}); err != nil {
+		return err
+	}
+	return dm.migrateTargetWithLock(ctx, migration.TargetAppMetrics, direction, nil)
+}
+
+func (dm *DependencyManager) migrateTargetWithLock(
+	ctx context.Context,
+	target migration.Target,
+	direction migration.Direction,
+	version *uint,
+) error {
+	switch target {
+	case migration.TargetMainDatabase, migration.TargetWorkflows:
+		return dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
+			return dm.migrateTarget(ctx, target, direction, version)
+		})
+	case migration.TargetAppMetrics:
+		root := dm.GetConfigRoot()
+		lockDuration := root.AppMetrics.Database.GetAutoMigrationLockDuration()
+		return dm.withMigrationLock(ctx, app_metrics.MigrateMutexKeyName, lockDuration, func(ctx context.Context) error {
+			return dm.migrateTarget(ctx, target, direction, version)
+		})
+	default:
+		return fmt.Errorf("unknown migration database %q", target)
+	}
+}
+
+func (dm *DependencyManager) withMainDatabaseMigrationLock(ctx context.Context, fn func(context.Context) error) error {
+	return dm.withMigrationLock(
+		ctx,
+		database.MigrateMutexKeyName,
+		dm.GetConfigRoot().Database.GetAutoMigrationLockDuration(),
+		fn,
+	)
+}
+
+func (dm *DependencyManager) withMigrationLock(
+	ctx context.Context,
+	key string,
+	duration time.Duration,
+	fn func(context.Context) error,
+) error {
+	redisClient, err := dm.GetRedisClientWithError()
+	if err != nil {
+		return fmt.Errorf("connect to redis for migration lock %q: %w", key, err)
+	}
+	mutex := apredis.NewMutex(
+		redisClient,
+		key,
+		apredis.MutexOptionLockFor(duration),
+		apredis.MutexOptionRetryFor(duration+time.Second),
+		apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
+		apredis.MutexOptionDetailedLockMetadata(),
+	)
+	if err := apredis.RunWithMutex(ctx, mutex, duration, fn); err != nil {
+		return fmt.Errorf("migration lock %q: %w", key, err)
+	}
+	return nil
+}
+
+func (dm *DependencyManager) migrateTarget(
+	ctx context.Context,
+	target migration.Target,
+	direction migration.Direction,
+	version *uint,
+) error {
+	status := dm.migrationStatus(ctx, target)
+	if err := migration.ValidateRequest(status, direction, version); err != nil {
+		return fmt.Errorf("validate %s migration: %w", target, err)
+	}
+
+	logBuilder, err := dm.GetLogBuilderWithError()
+	if err != nil {
+		return err
+	}
+	logger := logBuilder.WithComponent("migrations").Build()
+	started := time.Now()
+	requestedVersion := "latest"
+	if direction == migration.DirectionDown && version == nil {
+		requestedVersion = "previous"
+	} else if version != nil {
+		requestedVersion = fmt.Sprint(*version)
+	}
+	logger.Info(
+		"starting schema migration",
+		"target", target,
+		"provider", status.Provider,
+		"current_version", status.CurrentVersionString(),
+		"available_version", status.AvailableVersion,
+		"direction", direction,
+		"requested_version", requestedVersion,
+	)
+	err = nil
+	switch target {
+	case migration.TargetMainDatabase:
+		err = database.RunMigrations(ctx, dm.GetConfigRoot().Database, logger, direction, version)
+	case migration.TargetWorkflows:
+		err = workflows.RunMigrations(ctx, dm.GetConfigRoot(), logger, direction, version)
+	case migration.TargetAppMetrics:
+		err = app_metrics.RunMigrations(ctx, dm.GetConfigRoot().AppMetrics.Database, logger, direction, version)
+	default:
+		err = fmt.Errorf("unknown migration database %q", target)
+	}
+	if err != nil {
+		return fmt.Errorf("migrate %s: %w", target, err)
+	}
+	result := dm.migrationStatus(ctx, target)
+	if result.Err != nil {
+		return fmt.Errorf("inspect %s after migration: %w", target, result.Err)
+	}
+	if version != nil && (result.CurrentVersion == nil || *result.CurrentVersion != *version) {
+		return fmt.Errorf("%s migration finished at version %s instead of requested version %d", target, result.CurrentVersionString(), *version)
+	}
+	if direction == migration.DirectionUp && version == nil && !result.Compatible() {
+		return migration.IncompatibleError(result)
+	}
+	logger.Info(
+		"schema migration complete",
+		"target", target,
+		"current_version", result.CurrentVersionString(),
+		"available_version", result.AvailableVersion,
+		"duration", time.Since(started),
+	)
+	return nil
+}
+
+func (dm *DependencyManager) RunProductionMigration(
+	ctx context.Context,
+	target migration.Target,
+	direction migration.Direction,
+	version *uint,
+) error {
+	if err := dm.MigrateSchemas(ctx, target, direction, version); err != nil {
+		return err
+	}
+	if direction != migration.DirectionUp || (target != migration.TargetAll && target != migration.TargetMainDatabase) {
+		return nil
+	}
+	mainStatus := dm.migrationStatus(ctx, migration.TargetMainDatabase)
+	if !mainStatus.Compatible() {
+		return nil
+	}
+	return dm.BootstrapEncryption(ctx)
+}
+
+func (dm *DependencyManager) BootstrapEncryption(ctx context.Context) error {
+	db, err := dm.GetDatabaseWithError()
+	if err != nil {
+		return fmt.Errorf("open main database for encryption bootstrap: %w", err)
+	}
+	// The root namespace is runtime bootstrap data rather than schema or
+	// configured-resource reconciliation. A newly migrated database needs it
+	// before encryption keys can be associated with namespaces.
+	if err := db.EnsureNamespaceByPath(ctx, namespace.Root); err != nil {
+		return fmt.Errorf("ensure root namespace: %w", err)
+	}
+	redisClient, err := dm.GetRedisClientWithError()
+	if err != nil {
+		return fmt.Errorf("connect to redis for encryption bootstrap: %w", err)
+	}
+	logger, err := dm.GetLoggerWithError()
+	if err != nil {
+		return err
+	}
+	keyTelemetry, err := dm.GetDataEncryptionKeyTelemetryWithError()
+	if err != nil {
+		return err
+	}
+	if err := encrypt.GenerateDataEncryptionKeysToDatabase(
+		ctx,
+		dm.GetConfig(),
+		db,
+		logger,
+		redisClient,
+		encrypt.WithGenerateDataEncryptionKeysTelemetry(keyTelemetry),
+	); err != nil {
+		return fmt.Errorf("generate data encryption keys: %w", err)
+	}
+	if err := encrypt.SyncKeysToDatabase(
+		ctx,
+		dm.GetConfig(),
+		db,
+		logger,
+		redisClient,
+		encrypt.WithSyncKeysTelemetry(keyTelemetry),
+	); err != nil {
+		return fmt.Errorf("sync encryption keys: %w", err)
+	}
+	return nil
+}
+
+func (dm *DependencyManager) RunDevelopmentMigration(ctx context.Context) error {
+	if err := dm.RunProductionMigration(ctx, migration.TargetAll, migration.DirectionUp, nil); err != nil {
+		return err
+	}
+	if err := dm.ReconcileDevelopmentData(ctx); err != nil {
+		return err
+	}
+	return dm.VerifyMigrations(ctx)
+}
+
+func (dm *DependencyManager) ReconcileDevelopmentData(ctx context.Context) error {
+	if err := dm.reconcileConfiguredConnectors(ctx); err != nil {
+		return err
+	}
+	if err := dm.reconcileConfiguredActors(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (dm *DependencyManager) reconcileConfiguredConnectors(ctx context.Context) error {
+	lockDuration := dm.GetConfigRoot().Connectors.GetAutoMigrationLockDurationOrDefault()
+	return dm.withMigrationLock(ctx, core.MigrateMutexKeyName, lockDuration, func(ctx context.Context) error {
+		if err := dm.GetCoreService().Migrate(ctx); err != nil {
+			return fmt.Errorf("reconcile configured connectors: %w", err)
+		}
+		return nil
+	})
+}
+
+func (dm *DependencyManager) reconcileConfiguredActors(ctx context.Context) error {
+	actors := dm.GetConfigRoot().SystemAuth.Actors
+	if actors == nil {
+		return nil
+	}
+	if _, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSource); ok {
+		if _, err := dm.GetAsyncClient().Enqueue(tasks.NewSyncActorsExternalSourceTask()); err != nil {
+			return fmt.Errorf("enqueue configured actor synchronization: %w", err)
+		}
+		return nil
+	}
+	if _, ok := actors.InnerVal.(sconfig.ConfiguredActorsList); !ok {
+		return nil
+	}
+
+	const lockDuration = 30 * time.Second
+	return dm.withMigrationLock(ctx, "actor_sync:migrate", lockDuration, func(ctx context.Context) error {
+		db, err := dm.GetDatabaseWithError()
+		if err != nil {
+			return err
+		}
+		redisClient, err := dm.GetRedisClientWithError()
+		if err != nil {
+			return err
+		}
+		svc := tasks.NewService(dm.GetConfig(), db, redisClient, dm.GetEncryptService(), dm.GetLogger())
+		return svc.SyncActorList(ctx)
+	})
+}
+
+func (dm *DependencyManager) ShutdownMigrationResources() {
+	if dm.e != nil {
+		dm.e.Shutdown()
+	}
+	if dm.asynqClient != nil {
+		_ = dm.asynqClient.Close()
+		dm.asynqClient = nil
+	}
+	if dm.asynqInspector != nil {
+		_ = dm.asynqInspector.Close()
+		dm.asynqInspector = nil
+	}
+	dm.ShutdownWorkflowRuntime()
+	dm.ShutdownDatabase()
+	if dm.r != nil {
+		_ = dm.r.Close()
+		dm.r = nil
+	}
+	dm.ShutdownTelemetry()
+}

--- a/internal/service/migrations.go
+++ b/internal/service/migrations.go
@@ -18,7 +18,10 @@ import (
 	"github.com/rmorlok/authproxy/internal/workflows"
 )
 
-func (dm *DependencyManager) MigrationStatuses(ctx context.Context, target migration.Target) []migration.Status {
+func (dm *DependencyManager) MigrationStatuses(
+	ctx context.Context,
+	target migration.Target,
+) []migration.Status {
 	if target == migration.TargetAll {
 		statuses := make([]migration.Status, 0, len(migration.OrderedTargets))
 		for _, currentTarget := range migration.OrderedTargets {
@@ -26,23 +29,41 @@ func (dm *DependencyManager) MigrationStatuses(ctx context.Context, target migra
 		}
 		return statuses
 	}
+
 	return []migration.Status{dm.migrationStatus(ctx, target)}
 }
 
-func (dm *DependencyManager) migrationStatus(ctx context.Context, target migration.Target) migration.Status {
+func (dm *DependencyManager) migrationStatus(
+	ctx context.Context,
+	target migration.Target,
+) migration.Status {
 	root := dm.GetConfigRoot()
+
 	switch target {
 	case migration.TargetMainDatabase:
 		return database.MigrationStatus(ctx, root.Database)
+
 	case migration.TargetWorkflows:
 		return workflows.MigrationStatus(ctx, root)
+
 	case migration.TargetAppMetrics:
 		if root.AppMetrics == nil {
-			return migration.UnavailableStatus(target, "", 0, fmt.Errorf("app metrics configuration is required"))
+			return migration.UnavailableStatus(
+				target,
+				"", // provider
+				0,  // available
+				fmt.Errorf("app metrics configuration is required"),
+			)
 		}
 		return app_metrics.MigrationStatus(ctx, root.AppMetrics.Database)
+
 	default:
-		return migration.UnavailableStatus(target, "", 0, fmt.Errorf("unknown migration database %q", target))
+		return migration.UnavailableStatus(
+			target,
+			"", // provider
+			0,  // available
+			fmt.Errorf("unknown migration database %q", target),
+		)
 	}
 }
 
@@ -53,9 +74,11 @@ func (dm *DependencyManager) VerifyMigrations(ctx context.Context) error {
 			result = errors.Join(result, err)
 		}
 	}
+
 	if result != nil {
 		return fmt.Errorf("schema compatibility verification failed: %w", result)
 	}
+
 	return nil
 }
 
@@ -73,27 +96,76 @@ func (dm *DependencyManager) MigrateSchemas(
 		return dm.migrateTargetWithLock(ctx, target, direction, version)
 	}
 
+	//
+	// Migrate all targets in the correct order.
+	//
+
 	if direction == migration.DirectionDown {
-		if err := dm.migrateTargetWithLock(ctx, migration.TargetAppMetrics, direction, nil); err != nil {
+		// Reversed order from up direction
+
+		// metrics
+		if err := dm.migrateTargetWithLock(
+			ctx,
+			migration.TargetAppMetrics,
+			direction, // down
+			nil,       // version
+		); err != nil {
 			return err
 		}
+
 		return dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
-			if err := dm.migrateTarget(ctx, migration.TargetWorkflows, direction, nil); err != nil {
+			// workflows database (part of main database)
+			if err := dm.migrateTarget(
+				ctx,
+				migration.TargetWorkflows,
+				direction, // down
+				nil,       // version
+			); err != nil {
 				return err
 			}
-			return dm.migrateTarget(ctx, migration.TargetMainDatabase, direction, nil)
+
+			// main database
+			return dm.migrateTarget(
+				ctx,
+				migration.TargetMainDatabase,
+				direction, // down
+				nil,       // version
+			)
 		})
 	}
 
-	if err := dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
-		if err := dm.migrateTarget(ctx, migration.TargetMainDatabase, direction, nil); err != nil {
-			return err
-		}
-		return dm.migrateTarget(ctx, migration.TargetWorkflows, direction, nil)
-	}); err != nil {
+	if err := dm.withMainDatabaseMigrationLock(
+		ctx,
+		func(ctx context.Context) error {
+			// main database
+			if err := dm.migrateTarget(
+				ctx,
+				migration.TargetMainDatabase,
+				direction, // up
+				nil,       // version
+			); err != nil {
+				return err
+			}
+
+			// workflows database (part of main database)
+			return dm.migrateTarget(
+				ctx,
+				migration.TargetWorkflows,
+				direction, // up
+				nil,       // version
+			)
+		},
+	); err != nil {
 		return err
 	}
-	return dm.migrateTargetWithLock(ctx, migration.TargetAppMetrics, direction, nil)
+
+	// metrics database
+	return dm.migrateTargetWithLock(
+		ctx,
+		migration.TargetAppMetrics,
+		direction, // up
+		nil,       // version
+	)
 }
 
 func (dm *DependencyManager) migrateTargetWithLock(
@@ -107,18 +179,23 @@ func (dm *DependencyManager) migrateTargetWithLock(
 		return dm.withMainDatabaseMigrationLock(ctx, func(ctx context.Context) error {
 			return dm.migrateTarget(ctx, target, direction, version)
 		})
+
 	case migration.TargetAppMetrics:
 		root := dm.GetConfigRoot()
 		lockDuration := root.AppMetrics.Database.GetAutoMigrationLockDuration()
 		return dm.withMigrationLock(ctx, app_metrics.MigrateMutexKeyName, lockDuration, func(ctx context.Context) error {
 			return dm.migrateTarget(ctx, target, direction, version)
 		})
+
 	default:
 		return fmt.Errorf("unknown migration database %q", target)
 	}
 }
 
-func (dm *DependencyManager) withMainDatabaseMigrationLock(ctx context.Context, fn func(context.Context) error) error {
+func (dm *DependencyManager) withMainDatabaseMigrationLock(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
 	return dm.withMigrationLock(
 		ctx,
 		database.MigrateMutexKeyName,
@@ -145,9 +222,11 @@ func (dm *DependencyManager) withMigrationLock(
 		apredis.MutexOptionRetryExponentialBackoff(100*time.Millisecond, 5*time.Second),
 		apredis.MutexOptionDetailedLockMetadata(),
 	)
+
 	if err := apredis.RunWithMutex(ctx, mutex, duration, fn); err != nil {
 		return fmt.Errorf("migration lock %q: %w", key, err)
 	}
+
 	return nil
 }
 
@@ -166,14 +245,18 @@ func (dm *DependencyManager) migrateTarget(
 	if err != nil {
 		return err
 	}
+
 	logger := logBuilder.WithComponent("migrations").Build()
+
 	started := time.Now()
+
 	requestedVersion := "latest"
 	if direction == migration.DirectionDown && version == nil {
 		requestedVersion = "previous"
 	} else if version != nil {
 		requestedVersion = fmt.Sprint(*version)
 	}
+
 	logger.Info(
 		"starting schema migration",
 		"target", target,
@@ -183,6 +266,7 @@ func (dm *DependencyManager) migrateTarget(
 		"direction", direction,
 		"requested_version", requestedVersion,
 	)
+
 	err = nil
 	switch target {
 	case migration.TargetMainDatabase:
@@ -197,16 +281,22 @@ func (dm *DependencyManager) migrateTarget(
 	if err != nil {
 		return fmt.Errorf("migrate %s: %w", target, err)
 	}
+
 	result := dm.migrationStatus(ctx, target)
 	if result.Err != nil {
 		return fmt.Errorf("inspect %s after migration: %w", target, result.Err)
 	}
+
 	if version != nil && (result.CurrentVersion == nil || *result.CurrentVersion != *version) {
-		return fmt.Errorf("%s migration finished at version %s instead of requested version %d", target, result.CurrentVersionString(), *version)
+		return fmt.Errorf(
+			"%s migration finished at version %s instead of requested version %d",
+			target, result.CurrentVersionString(), *version)
 	}
+
 	if direction == migration.DirectionUp && version == nil && !result.Compatible() {
 		return migration.IncompatibleError(result)
 	}
+
 	logger.Info(
 		"schema migration complete",
 		"target", target,
@@ -214,6 +304,7 @@ func (dm *DependencyManager) migrateTarget(
 		"available_version", result.AvailableVersion,
 		"duration", time.Since(started),
 	)
+
 	return nil
 }
 

--- a/internal/service/public/server.go
+++ b/internal/service/public/server.go
@@ -279,8 +279,6 @@ func Serve(cfg config.C) {
 
 	defer dm.GetRedisClient().Close()
 
-	dm.AutoMigrateAll()
-
 	defer dm.ShutdownDatabase()
 	defer dm.ShutdownWorkflowRuntime()
 	defer dm.GetEncryptService().Shutdown()

--- a/internal/service/worker/server.go
+++ b/internal/service/worker/server.go
@@ -107,7 +107,6 @@ func Serve(cfg config.C) {
 		c.PureJSON(status, response)
 	})
 
-	dm.AutoMigrateAll()
 	defer dm.ShutdownDatabase()
 	defer dm.GetEncryptService().Shutdown()
 	defer dm.ShutdownWorkflowRuntime()

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"embed"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -24,9 +23,10 @@ import (
 	migratepostgres "github.com/golang-migrate/migrate/v4/database/postgres"
 	migratesqlite "github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/rmorlok/authproxy/internal/aptelemetry"
+	"github.com/rmorlok/authproxy/internal/migration"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
-	"github.com/rmorlok/authproxy/internal/util"
 )
 
 const (
@@ -134,7 +134,30 @@ func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
 	}
 }
 
+func MigrationStatus(ctx context.Context, root *sconfig.Root) migration.Status {
+	if root == nil || root.Database == nil {
+		return migration.UnavailableStatus(migration.TargetWorkflows, "", 0, fmt.Errorf("database configuration is required"))
+	}
+	provider := root.Database.GetProvider()
+	latest, err := migration.LatestVersion(migrationsFS, fmt.Sprintf("migrations/%s", provider))
+	if err != nil {
+		return migration.UnavailableStatus(migration.TargetWorkflows, provider, 0, err)
+	}
+	return migration.Inspect(ctx, migration.TargetWorkflows, root.Database, workflowMigrationsTable, latest)
+}
+
 func Migrate(ctx context.Context, root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) error {
+	return RunMigrations(ctx, root, logger, migration.DirectionUp, nil, opts...)
+}
+
+func RunMigrations(
+	ctx context.Context,
+	root *sconfig.Root,
+	logger *slog.Logger,
+	direction migration.Direction,
+	version *uint,
+	opts ...MigrateOption,
+) error {
 	if root == nil || root.Database == nil {
 		return fmt.Errorf("database configuration is required")
 	}
@@ -151,20 +174,25 @@ func Migrate(ctx context.Context, root *sconfig.Root, logger *slog.Logger, opts 
 			return fmt.Errorf("open workflow sqlite database: %w", err)
 		}
 		defer db.Close()
-		return migrateDB(ctx, db, "sqlite", "migrations/sqlite")
+		return migrateDB(ctx, db, "sqlite", "migrations/sqlite", direction, version)
 	case *sconfig.DatabasePostgres:
 		db := migrateOpts.postgresDB
 		if db == nil {
-			return fmt.Errorf("workflow postgres database handle is required")
+			var err error
+			db, err = sql.Open("pgx", cfg.GetDsn())
+			if err != nil {
+				return fmt.Errorf("open workflow postgres database: %w", err)
+			}
+			defer db.Close()
 		}
 
-		return migrateDB(ctx, db, "postgres", "migrations/postgres")
+		return migrateDB(ctx, db, "postgres", "migrations/postgres", direction, version)
 	default:
 		return fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
 	}
 }
 
-func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath string) error {
+func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath string, direction migration.Direction, version *uint) error {
 	var (
 		driver migratedatabase.Driver
 		err    error
@@ -194,7 +222,7 @@ func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath st
 	if err != nil {
 		return fmt.Errorf("creating workflow migration: %w", err)
 	}
-	if err := util.RunMigrationsUp(ctx, m); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+	if err := migration.Apply(ctx, m, direction, version); err != nil {
 		return fmt.Errorf("running workflow migrations: %w", err)
 	}
 

--- a/internal/workflows/runtime.go
+++ b/internal/workflows/runtime.go
@@ -46,9 +46,21 @@ type Runtime struct {
 }
 
 type Client interface {
-	CreateWorkflowInstance(ctx context.Context, options client.WorkflowInstanceOptions, workflow wflib.Workflow, args ...any) (*wflib.Instance, error)
-	GetWorkflowInstanceState(ctx context.Context, instance *wflib.Instance) (wfcore.WorkflowInstanceState, error)
-	GetWorkflowInstanceHistory(ctx context.Context, instance *wflib.Instance, lastSequenceID *int64) ([]*history.Event, error)
+	CreateWorkflowInstance(
+		ctx context.Context,
+		options client.WorkflowInstanceOptions,
+		workflow wflib.Workflow,
+		args ...any,
+	) (*wflib.Instance, error)
+	GetWorkflowInstanceState(
+		ctx context.Context,
+		instance *wflib.Instance,
+	) (wfcore.WorkflowInstanceState, error)
+	GetWorkflowInstanceHistory(
+		ctx context.Context,
+		instance *wflib.Instance,
+		lastSequenceID *int64,
+	) ([]*history.Event, error)
 }
 
 type RuntimeOption func(*runtimeOptions)
@@ -63,7 +75,12 @@ func WithPostgresDB(db *sql.DB) RuntimeOption {
 	}
 }
 
-func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *slog.Logger, opts ...RuntimeOption) (*Runtime, error) {
+func NewRuntime(
+	root *sconfig.Root,
+	telemetry *aptelemetry.Providers,
+	logger *slog.Logger,
+	opts ...RuntimeOption,
+) (*Runtime, error) {
 	if root == nil || root.Database == nil {
 		return nil, fmt.Errorf("database configuration is required")
 	}
@@ -76,6 +93,7 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 	backendOptions := []wfbackend.BackendOption{
 		wfbackend.WithLogger(logger),
 	}
+
 	if telemetry != nil && telemetry.TracerProvider != nil {
 		backendOptions = append(backendOptions, wfbackend.WithTracerProvider(telemetry.TracerProvider))
 	}
@@ -96,6 +114,7 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 			sqlite.WithApplyMigrations(false),
 			sqlite.WithBackendOptions(backendOptions...),
 		)
+
 	case *sconfig.DatabasePostgres:
 		db = runtimeOpts.postgresDB
 		if db == nil {
@@ -110,8 +129,10 @@ func NewRuntime(root *sconfig.Root, telemetry *aptelemetry.Providers, logger *sl
 			postgres.WithApplyMigrations(false),
 			postgres.WithBackendOptions(backendOptions...),
 		)
+
 	default:
 		return nil, fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
+
 	}
 
 	return &Runtime{
@@ -134,22 +155,40 @@ func WithPostgresMigrationDB(db *sql.DB) MigrateOption {
 	}
 }
 
-func MigrationStatus(ctx context.Context, root *sconfig.Root) migration.Status {
+// MigrationStatus returns the status of the workflow database migrations.
+func MigrationStatus(
+	ctx context.Context,
+	root *sconfig.Root,
+) migration.Status {
 	if root == nil || root.Database == nil {
-		return migration.UnavailableStatus(migration.TargetWorkflows, "", 0, fmt.Errorf("database configuration is required"))
+		return migration.UnavailableStatus(
+			migration.TargetWorkflows,
+			"", // provider
+			0,  // available
+			fmt.Errorf("database configuration is required"),
+		)
 	}
+
 	provider := root.Database.GetProvider()
-	latest, err := migration.LatestVersion(migrationsFS, fmt.Sprintf("migrations/%s", provider))
+	latest, err := migration.LatestVersion(
+		migrationsFS,
+		fmt.Sprintf("migrations/%s", provider),
+	)
+
 	if err != nil {
 		return migration.UnavailableStatus(migration.TargetWorkflows, provider, 0, err)
 	}
-	return migration.Inspect(ctx, migration.TargetWorkflows, root.Database, workflowMigrationsTable, latest)
+
+	return migration.Inspect(
+		ctx,
+		migration.TargetWorkflows,
+		root.Database,
+		workflowMigrationsTable,
+		latest,
+	)
 }
 
-func Migrate(ctx context.Context, root *sconfig.Root, logger *slog.Logger, opts ...MigrateOption) error {
-	return RunMigrations(ctx, root, logger, migration.DirectionUp, nil, opts...)
-}
-
+// RunMigrations runs the workflow database migrations.
 func RunMigrations(
 	ctx context.Context,
 	root *sconfig.Root,
@@ -168,6 +207,7 @@ func RunMigrations(
 	}
 
 	switch cfg := root.Database.InnerVal.(type) {
+
 	case *sconfig.DatabaseSqlite:
 		db, err := sql.Open("sqlite", fmt.Sprintf("file:%v?_txlock=immediate", cfg.Path))
 		if err != nil {
@@ -175,6 +215,7 @@ func RunMigrations(
 		}
 		defer db.Close()
 		return migrateDB(ctx, db, "sqlite", "migrations/sqlite", direction, version)
+
 	case *sconfig.DatabasePostgres:
 		db := migrateOpts.postgresDB
 		if db == nil {
@@ -187,27 +228,40 @@ func RunMigrations(
 		}
 
 		return migrateDB(ctx, db, "postgres", "migrations/postgres", direction, version)
+
 	default:
 		return fmt.Errorf("workflow database provider %q is not supported", root.Database.GetProvider())
 	}
 }
 
-func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath string, direction migration.Direction, version *uint) error {
+func migrateDB(
+	ctx context.Context,
+	db *sql.DB,
+	driverName string,
+	sourcePath string,
+	direction migration.Direction,
+	version *uint,
+) error {
 	var (
 		driver migratedatabase.Driver
 		err    error
 	)
+
 	switch driverName {
+
 	case "postgres":
 		driver, err = migratepostgres.WithInstance(db, &migratepostgres.Config{
 			MigrationsTable: workflowMigrationsTable,
 		})
+
 	case "sqlite":
 		driver, err = migratesqlite.WithInstance(db, &migratesqlite.Config{
 			MigrationsTable: workflowMigrationsTable,
 		})
+
 	default:
 		return fmt.Errorf("workflow migration driver %q is not supported", driverName)
+
 	}
 	if err != nil {
 		return fmt.Errorf("creating workflow migration instance: %w", err)
@@ -222,6 +276,7 @@ func migrateDB(ctx context.Context, db *sql.DB, driverName string, sourcePath st
 	if err != nil {
 		return fmt.Errorf("creating workflow migration: %w", err)
 	}
+
 	if err := migration.Apply(ctx, m, direction, version); err != nil {
 		return fmt.Errorf("running workflow migrations: %w", err)
 	}

--- a/internal/workflows/runtime_test.go
+++ b/internal/workflows/runtime_test.go
@@ -27,7 +27,13 @@ func TestMigrateSqliteAndRuntimePing(t *testing.T) {
 	}
 	logger := slog.New(slog.DiscardHandler)
 
-	require.NoError(t, Migrate(context.Background(), root, logger))
+	require.NoError(t, RunMigrations(
+		context.Background(),
+		root,
+		logger,
+		migration.DirectionUp,
+		nil,
+	))
 	status := MigrationStatus(context.Background(), root)
 	require.Equal(t, migration.StateCurrent, status.State)
 	require.Equal(t, uint(3), status.AvailableVersion)

--- a/internal/workflows/runtime_test.go
+++ b/internal/workflows/runtime_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/migration"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,10 @@ func TestMigrateSqliteAndRuntimePing(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 
 	require.NoError(t, Migrate(context.Background(), root, logger))
+	status := MigrationStatus(context.Background(), root)
+	require.Equal(t, migration.StateCurrent, status.State)
+	require.Equal(t, uint(3), status.AvailableVersion)
+	require.Equal(t, uint(3), *status.CurrentVersion)
 
 	db, err := sql.Open("sqlite", "file:"+dbPath)
 	require.NoError(t, err)
@@ -70,4 +76,22 @@ func TestNewRuntimePostgresBorrowedDBIsNotClosed(t *testing.T) {
 
 	require.NoError(t, runtime.Close())
 	require.NoError(t, db.Ping())
+}
+
+func TestMigrationStatusCurrentForConfiguredProvider(t *testing.T) {
+	cfg, _, rawDB := database.MustApplyBlankTestDbConfigRaw(t, nil)
+	root := cfg.GetRoot()
+	require.NoError(t, RunMigrations(
+		context.Background(),
+		root,
+		slog.New(slog.DiscardHandler),
+		migration.DirectionUp,
+		nil,
+		WithPostgresMigrationDB(rawDB),
+	))
+
+	status := MigrationStatus(context.Background(), root)
+	require.NoError(t, status.Err)
+	require.True(t, status.Compatible())
+	require.Equal(t, status.AvailableVersion, *status.CurrentVersion)
 }

--- a/loadtest/helm-values/admin-api.yaml
+++ b/loadtest/helm-values/admin-api.yaml
@@ -1,17 +1,11 @@
 replicaCount: 1
 
+migrationJob:
+  enabled: true
+
 services:
   adminApi:
     enabled: true
-
-database:
-  autoMigrate: true
-
-connectors:
-  autoMigrate: true
-
-appMetrics:
-  autoMigrate: true
 
 resources:
   requests:

--- a/loadtest/helm-values/common.yaml
+++ b/loadtest/helm-values/common.yaml
@@ -6,6 +6,9 @@ image:
 serviceAccount:
   create: true
 
+migrationJob:
+  enabled: false
+
 # `up` installs or reuses one cluster-level KEDA controller before these role
 # releases. Do not render a controller for each independently scaled release.
 keda:
@@ -35,7 +38,6 @@ database:
   database: authproxy
   user: authproxy
   sslmode: disable
-  autoMigrate: false
   existingSecret: authproxy-load-db
 
 redis:
@@ -69,12 +71,10 @@ blobStorage:
     emptyDir: true
 
 connectors:
-  autoMigrate: false
   loadFromList: []
 
 appMetrics:
   shareMainDatabase: false
-  autoMigrate: true
   existingSecret: authproxy-load-clickhouse
   database:
     provider: clickhouse

--- a/loadtest/scripts/background
+++ b/loadtest/scripts/background
@@ -51,7 +51,6 @@ tasks:
 
 database:
   provider: sqlite
-  autoMigrate: true
   path: $sqlite_path
 
 redis:
@@ -75,11 +74,9 @@ systemAuth:
     path: $REPO_ROOT/dev_config/keys/global_aes.key
 
 connectors:
-  autoMigrate: false
   loadFromList: []
 
 appMetrics:
-  autoMigrate: false
   database:
     provider: sqlite
     path: $sqlite_path

--- a/loadtest/scripts/seed
+++ b/loadtest/scripts/seed
@@ -30,7 +30,6 @@ tasks:
 
 database:
   provider: sqlite
-  autoMigrate: true
   path: $sqlite_path
 
 redis:
@@ -54,11 +53,9 @@ systemAuth:
     path: $REPO_ROOT/dev_config/keys/global_aes.key
 
 connectors:
-  autoMigrate: false
   loadFromList: []
 
 appMetrics:
-  autoMigrate: false
   database:
     provider: sqlite
     path: $sqlite_path

--- a/loadtest/scripts/up
+++ b/loadtest/scripts/up
@@ -127,6 +127,7 @@ install_release() {
   helm upgrade --install "$release" "$chart" \
     --namespace "$namespace" \
     --wait \
+    --wait-for-jobs \
     "--timeout=$helm_timeout" \
     -f "$common_values" \
     -f "$values_file" \


### PR DESCRIPTION
## Summary

- add explicit migrate and migrate status commands for main-database, workflows, app-metrics, and sequential fail-fast all plans, including up/down and exact-version semantics
- make serve perform read-only compatibility verification by default and centralize development-only migration/reconciliation behind --auto-migrate
- remove persisted autoMigrate configuration and retain renewable Redis locking across database providers
- add production bootstrap for the root namespace and encryption keys without connector or actor reconciliation
- add Helm and Kustomize migration Jobs, sequence the demo deployment before the AuthProxy rollout, and update local/deployment documentation

## Validation

- go test ./...
- AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test ./internal/database ./internal/workflows
- AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=postgres go test ./internal/app_metrics
- AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=clickhouse with the documented local ClickHouse credentials go test ./internal/app_metrics
- helm lint and Helm rendering, including the load-test release values
- kubectl kustomize for demo and dev overlays
- docker compose config --quiet
- workflow YAML parse validation
- yarn docs:build
- ./scripts/preflight.sh

Closes #817
Closes #818