### PR TITLE
Fix demo seed manifest validation

### DIFF
--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -134,8 +134,8 @@ jobs:
           grep -Fq "namespace: ${RELEASE_NS}" "${manifest}"
           grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-seed:${IMAGE_TAG}" "${manifest}"
           grep -Fq "value: http://${RELEASE_NAME}-authproxy:8082" "${manifest}"
-          grep -Fq "base_url: http://${RELEASE_NAME}-go-oauth2-server" "${manifest}"
-          grep -Fq "redirect_uri: https://marketplace.${DEMO_HOSTNAME}/oauth2/callback" "${manifest}"
+          grep -Fq "baseUrl: http://${RELEASE_NAME}-go-oauth2-server" "${manifest}"
+          grep -Fq "redirectUri: https://marketplace.${DEMO_HOSTNAME}/oauth2/callback" "${manifest}"
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
 


### PR DESCRIPTION
## Summary
- validate the rendered seed config using its actual camelCase fields
- allow the Seed Demo workflow to proceed to the Kubernetes Job

## Root cause
The rendered ConfigMap contains `baseUrl` and `redirectUri`, but the workflow asserted snake_case `base_url` and `redirect_uri`, so it exited before creating the seed Job.

## Validation
- `./scripts/preflight.sh`
- rendered the demo seed Kustomize overlay and verified the corrected fields
- [Seed Demo workflow from this branch passed end to end](https://github.com/rmorlok/authproxy/actions/runs/31904773930)

## Context
Discovered while resetting the demo environment after the migration changes. The original failed workflow stopped during render validation before changing demo data.