### PR TITLE
Fix demo telemetry link test expectations

### DIFF
--- a/demos/shell/backend/main_test.go
+++ b/demos/shell/backend/main_test.go
@@ -19,12 +19,12 @@ func TestLoadTelemetryLinksFromGrafanaBaseURL(t *testing.T) {
 	require.Equal(t, []telemetryLink{
 		{
 			Label:       "Grafana",
-			Description: "Open the demo observability workspace.",
+			Description: "Open the demo observability workspace and navigate Grafana as you wish.",
 			URL:         "https://demo.example.test/grafana",
 		},
 		{
 			Label:       "App metrics",
-			Description: "View request, resource, connection, and rate-limit telemetry.",
+			Description: "View request, resource, connection, and rate-limit telemetry. Go to the dashboard for the AuthProxy Grafana data source plugin.",
 			URL:         "https://demo.example.test/grafana/d/authproxy-app-metrics-demo/authproxy-app-metrics?orgId=1&from=now-1h&to=now",
 		},
 		{
@@ -45,7 +45,7 @@ func TestLoadTelemetryLinksAllowsExplicitURLsWithoutGrafanaBaseURL(t *testing.T)
 	require.Equal(t, []telemetryLink{
 		{
 			Label:       "App metrics",
-			Description: "View request, resource, connection, and rate-limit telemetry.",
+			Description: "View request, resource, connection, and rate-limit telemetry. Go to the dashboard for the AuthProxy Grafana data source plugin.",
 			URL:         "https://grafana.example.test/d/app",
 		},
 		{


### PR DESCRIPTION
## Summary
- update demo-shell telemetry link expectations to match the copy merged in #824
- retain the independent config-handler round-trip fixture unchanged

## Root cause
PR #824 changed the Grafana and app-metrics descriptions in `loadTelemetryLinks`, but the exact-value assertions in `main_test.go` still expected the previous descriptions. That caused every Go test matrix variant on master to fail in `demos/shell/backend`.

## Validation
- `go test ./demos/shell/backend`
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite AUTH_PROXY_APP_METRICS_TEST_DATABASE_PROVIDER=sqlite go test ./...`
- `yarn workspace @authproxy/demo-shell typecheck`
- `yarn workspace @authproxy/demo-shell build`
- `./scripts/preflight.sh`