### PR TITLE
Rename integration test actor options

### DIFF
--- a/integration_tests/helpers/setup_api_key.go
+++ b/integration_tests/helpers/setup_api_key.go
@@ -107,12 +107,12 @@ func NewApiKeyConnector(connectorID apid.ID, displayName string, opts ApiKeyConn
 // step), not a redirect. Returns the new connection id and the form payload.
 // Signed by default as actor "test-actor" in the root namespace; pass
 // WithActor(...) to mirror a specific tenant.
-func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorID apid.ID, opts ...OAuth2Option) (connectionID string, form *coreIface.ConnectionSetupForm) {
+func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorID apid.ID, opts ...ActorOption) (connectionID string, form *coreIface.ConnectionSetupForm) {
 	t.Helper()
 	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
 		"InitiateApiKeyConnection requires either in-process gin or a running HTTP server")
 
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 
 	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
 		ConnectorId:   connectorID,
@@ -139,9 +139,9 @@ func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorI
 // SubmitApiKeyCredentials POSTs to /api/v1/connections/{id}/_submit with the
 // supplied step id and field data. Returns the response body so callers can
 // inspect what shape came back (form / verifying / complete).
-func (env *IntegrationTestEnv) SubmitApiKeyCredentials(t *testing.T, connectionID, stepID string, data map[string]any, opts ...OAuth2Option) *httptest.ResponseRecorder {
+func (env *IntegrationTestEnv) SubmitApiKeyCredentials(t *testing.T, connectionID, stepID string, data map[string]any, opts ...ActorOption) *httptest.ResponseRecorder {
 	t.Helper()
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 
 	rawData, err := json.Marshal(data)
 	require.NoError(t, err)
@@ -158,9 +158,9 @@ func (env *IntegrationTestEnv) SubmitApiKeyCredentials(t *testing.T, connectionI
 // ReauthConnection POSTs to /api/v1/connections/{id}/_reauth and returns the
 // raw response. For api-key connectors the response is a form (credentials
 // step) the user fills in to rotate the key.
-func (env *IntegrationTestEnv) ReauthConnection(t *testing.T, connectionID string, opts ...OAuth2Option) *httptest.ResponseRecorder {
+func (env *IntegrationTestEnv) ReauthConnection(t *testing.T, connectionID string, opts ...ActorOption) *httptest.ResponseRecorder {
 	t.Helper()
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 
 	// Body is optional for api-key; sending an empty struct exercises the
 	// JSON unmarshal path on the route.
@@ -212,7 +212,7 @@ func (env *IntegrationTestEnv) DecryptApiKeyCredential(t *testing.T, connectionI
 // doSignedRequest signs an admin-namespace request as the configured actor
 // and dispatches it through either the in-process gin engine or the real
 // HTTP server, returning a recorder uniformly.
-func (env *IntegrationTestEnv) doSignedRequest(t *testing.T, method, path string, body io.Reader, cfg oauth2Options) *httptest.ResponseRecorder {
+func (env *IntegrationTestEnv) doSignedRequest(t *testing.T, method, path string, body io.Reader, cfg actorOptions) *httptest.ResponseRecorder {
 	t.Helper()
 
 	req, err := env.ApiAuthUtil.NewSignedRequestForActorExternalId(

--- a/integration_tests/helpers/setup_no_auth.go
+++ b/integration_tests/helpers/setup_no_auth.go
@@ -15,13 +15,13 @@ import (
 func (env *IntegrationTestEnv) InitiateNoAuthConnection(
 	t *testing.T,
 	connectorID apid.ID,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) string {
 	t.Helper()
 	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
 		"InitiateNoAuthConnection requires either in-process gin or a running HTTP server")
 
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
 		ConnectorId:   connectorID,
 		IntoNamespace: cfg.actorNamespace,

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -22,22 +22,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// OAuth2Option configures an OAuth2 helper invocation. The same option type
-// is shared across the OAuth2 helpers (InitiateOAuth2Connection,
-// DeliverOAuth2Callback, …) so callers learn one pattern. Each helper applies
-// the fields that are meaningful to it and ignores the rest.
-type OAuth2Option func(*oauth2Options)
+// ActorOption configures the actor used by an integration-test helper. The
+// same option type is shared by helpers for every authentication method, so
+// callers can use one pattern to select an actor and namespace.
+type ActorOption func(*actorOptions)
 
-// oauth2Options is the resolved configuration produced by applying the
-// caller-supplied OAuth2Option values on top of the defaults each helper
+// actorOptions is the resolved configuration produced by applying the
+// caller-supplied ActorOption values on top of the defaults each helper
 // installs (default actor "test-actor" in the root namespace).
-type oauth2Options struct {
+type actorOptions struct {
 	actorExternalID string
 	actorNamespace  string
 }
 
-func (env *IntegrationTestEnv) resolveOAuth2Options(opts []OAuth2Option) oauth2Options {
-	cfg := oauth2Options{
+func (env *IntegrationTestEnv) resolveActorOptions(opts []ActorOption) actorOptions {
+	cfg := actorOptions{
 		actorExternalID: "test-actor",
 		actorNamespace:  sconfig.RootNamespace,
 	}
@@ -47,14 +46,14 @@ func (env *IntegrationTestEnv) resolveOAuth2Options(opts []OAuth2Option) oauth2O
 	return cfg
 }
 
-// WithActor signs the OAuth2 helper request as the named actor in the given
-// namespace. Mirrors the JWT a real browser session for that actor would
-// carry. Defaults are actor "test-actor" in sconfig.RootNamespace.
+// WithActor signs a helper request as the named actor in the given namespace.
+// It mirrors the JWT a real browser session for that actor would carry.
+// Defaults are actor "test-actor" in sconfig.RootNamespace.
 //
 // Caller is responsible for ensuring a non-root namespace already exists
 // (see env.Core.CreateNamespace) before signing into it.
-func WithActor(externalID, namespace string) OAuth2Option {
-	return func(c *oauth2Options) {
+func WithActor(externalID, namespace string) ActorOption {
+	return func(c *actorOptions) {
 		c.actorExternalID = externalID
 		c.actorNamespace = namespace
 	}
@@ -197,12 +196,12 @@ func (env *IntegrationTestEnv) ForgeOAuth2CallbackURL(state, code string) string
 //
 // Caller is responsible for ensuring the actor's namespace exists (via
 // env.Core.CreateNamespace or its ancestors) when it is not the root namespace.
-func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToUrl string, opts ...OAuth2Option) (connectionID, redirectURL string) {
+func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToUrl string, opts ...ActorOption) (connectionID, redirectURL string) {
 	t.Helper()
 	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
 		"InitiateOAuth2Connection requires either in-process gin or a running HTTP server")
 
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 
 	// Land the connection in the actor's namespace by default. Without
 	// IntoNamespace, the API places the connection in the connector's
@@ -258,7 +257,7 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 // existing connection and returns the proxy redirect URL. The supplied
 // return-to URL is carried through the OAuth callback after successful token
 // exchange.
-func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID, returnToUrl string, opts ...OAuth2Option) string {
+func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID, returnToUrl string, opts ...ActorOption) string {
 	t.Helper()
 
 	body, err := jsonMarshal(struct {
@@ -273,7 +272,7 @@ func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID
 		http.MethodPost,
 		"/api/v1/connections/"+connectionID+"/_reauth",
 		body,
-		env.resolveOAuth2Options(opts),
+		env.resolveActorOptions(opts),
 	)
 	require.Equalf(t, http.StatusOK, w.Code, "reauth failed: %s", w.Body.String())
 
@@ -320,11 +319,11 @@ func (env *IntegrationTestEnv) FollowOAuth2Redirect(t *testing.T, redirectURL st
 // the test's returnToUrl on success, or error_pages.internal_error on
 // rejection. By default the request is signed as actor "test-actor" in the root
 // namespace; pass WithActor(...) to mirror a specific tenant's browser session.
-func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL string, opts ...OAuth2Option) string {
+func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL string, opts ...ActorOption) string {
 	t.Helper()
 	require.NotNil(t, env.PublicGin, "DeliverOAuth2Callback requires SetupOptions.IncludePublic=true")
 
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 
 	parsed, err := url.Parse(callbackURL)
 	require.NoError(t, err)

--- a/integration_tests/helpers/version_migration.go
+++ b/integration_tests/helpers/version_migration.go
@@ -27,7 +27,7 @@ func (env *IntegrationTestEnv) CreateConnector(
 	definition sconfig.Connector,
 	labels map[string]string,
 	annotations map[string]string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
@@ -39,7 +39,7 @@ func (env *IntegrationTestEnv) CreateConnector(
 	})
 	require.NoError(t, err)
 
-	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connectors", body, env.resolveOAuth2Options(opts))
+	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connectors", body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusCreated, w.Code, "create connector failed: %s", w.Body.String())
 
 	var out schemaapi.ConnectorVersionJson
@@ -55,7 +55,7 @@ func (env *IntegrationTestEnv) CreateDraftConnectorVersion(
 	definition sconfig.Connector,
 	labels map[string]string,
 	annotations map[string]string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
@@ -71,7 +71,7 @@ func (env *IntegrationTestEnv) CreateDraftConnectorVersion(
 	require.NoError(t, err)
 
 	path := fmt.Sprintf("/api/v1/connectors/%s/versions", connectorID)
-	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveOAuth2Options(opts))
+	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusCreated, w.Code, "create connector version failed: %s", w.Body.String())
 
 	var out schemaapi.ConnectorVersionJson
@@ -86,7 +86,7 @@ func (env *IntegrationTestEnv) ForceConnectorVersionState(
 	connectorID apid.ID,
 	version uint64,
 	state schemaapi.ConnectorVersionState,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
@@ -94,7 +94,7 @@ func (env *IntegrationTestEnv) ForceConnectorVersionState(
 	require.NoError(t, err)
 
 	path := fmt.Sprintf("/api/v1/connectors/%s/versions/%d/_forceState", connectorID, version)
-	w := env.doSignedRequest(t, http.MethodPut, path, body, env.resolveOAuth2Options(opts))
+	w := env.doSignedRequest(t, http.MethodPut, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusOK, w.Code, "force connector version state failed: %s", w.Body.String())
 
 	var out schemaapi.ConnectorVersionJson
@@ -111,7 +111,7 @@ func (env *IntegrationTestEnv) PublishConnectorVersion(
 	definition sconfig.Connector,
 	labels map[string]string,
 	annotations map[string]string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
@@ -126,7 +126,7 @@ func (env *IntegrationTestEnv) MigrateConnectionVersion(
 	connectionID string,
 	targetVersion uint64,
 	timeoutSeconds int64,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.MigrateConnectionVersionResponseJson {
 	t.Helper()
 
@@ -138,7 +138,7 @@ func (env *IntegrationTestEnv) MigrateConnectionVersion(
 	require.NoError(t, err)
 
 	path := "/api/v1/connections/" + connectionID + "/_migrateVersion"
-	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveOAuth2Options(opts))
+	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusOK, w.Code, "migrate connection version failed: %s", w.Body.String())
 
 	var out schemaapi.MigrateConnectionVersionResponseJson
@@ -157,7 +157,7 @@ func (env *IntegrationTestEnv) MigrateConnectionVersionAndWait(
 	connectionID string,
 	targetVersion uint64,
 	timeout time.Duration,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.MigrateConnectionVersionResponseJson {
 	t.Helper()
 
@@ -177,7 +177,7 @@ func (env *IntegrationTestEnv) SubmitSetupForm(
 	connectionID string,
 	stepID string,
 	data map[string]any,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
@@ -189,7 +189,7 @@ func (env *IntegrationTestEnv) SubmitSetupForm(
 	})
 	require.NoError(t, err)
 
-	return env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/"+connectionID+"/_submit", body, env.resolveOAuth2Options(opts))
+	return env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/"+connectionID+"/_submit", body, env.resolveActorOptions(opts))
 }
 
 // DecryptConnectionConfiguration reads and decrypts a connection's current
@@ -219,7 +219,7 @@ func (env *IntegrationTestEnv) ListNotifications(
 	t *testing.T,
 	state schemaapi.NotificationState,
 	includeViewed bool,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) []schemaapi.NotificationJson {
 	t.Helper()
 
@@ -235,7 +235,7 @@ func (env *IntegrationTestEnv) ListNotifications(
 		path += "?" + encoded
 	}
 
-	w := env.doSignedRequest(t, http.MethodGet, path, nil, env.resolveOAuth2Options(opts))
+	w := env.doSignedRequest(t, http.MethodGet, path, nil, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusOK, w.Code, "list notifications failed: %s", w.Body.String())
 
 	var out schemaapi.ListNotificationsResponseJson
@@ -250,7 +250,7 @@ func (env *IntegrationTestEnv) ListConnectionNotifications(
 	connectionID string,
 	state schemaapi.NotificationState,
 	includeViewed bool,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) []schemaapi.NotificationJson {
 	t.Helper()
 
@@ -274,7 +274,7 @@ func (env *IntegrationTestEnv) RequireSingleActiveConnectionNotification(
 	t *testing.T,
 	connectionID string,
 	keySuffix string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.NotificationJson {
 	t.Helper()
 
@@ -290,7 +290,7 @@ func (env *IntegrationTestEnv) RequireSingleActiveConnectionNotification(
 func (env *IntegrationTestEnv) RequireNoActiveConnectionNotifications(
 	t *testing.T,
 	connectionID string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) {
 	t.Helper()
 	require.Empty(t, env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateActive, false, opts...))
@@ -302,7 +302,7 @@ func (env *IntegrationTestEnv) RequireResolvedConnectionNotification(
 	t *testing.T,
 	connectionID string,
 	keySuffix string,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.NotificationJson {
 	t.Helper()
 

--- a/integration_tests/helpers/workflow.go
+++ b/integration_tests/helpers/workflow.go
@@ -66,11 +66,11 @@ func RequireWorkflowTaskCompleted(
 	env *IntegrationTestEnv,
 	taskID string,
 	timeout time.Duration,
-	opts ...OAuth2Option,
+	opts ...ActorOption,
 ) schemaapi.TaskInfoJson {
 	t.Helper()
 
-	cfg := env.resolveOAuth2Options(opts)
+	cfg := env.resolveActorOptions(opts)
 	var lastStatus int
 	var lastBody string
 	var lastState schemaapi.TaskState
@@ -138,6 +138,6 @@ func RequireWorkflowTaskCompleted(
 }
 
 // RootActor returns helper options for the default integration-test actor.
-func RootActor() OAuth2Option {
+func RootActor() ActorOption {
 	return WithActor("test-actor", sconfig.RootNamespace)
 }

--- a/integration_tests/oauth2/multiple_connections_test.go
+++ b/integration_tests/oauth2/multiple_connections_test.go
@@ -141,7 +141,7 @@ func completeAuthFlowAsActor(t *testing.T, r *proxyRefreshRig, actorExternalID, 
 	)
 }
 
-func completeAuthFlowWithRedirect(t *testing.T, r *proxyRefreshRig, connID, redirectURL, providerUserID string, callbackOpts ...helpers.OAuth2Option) string {
+func completeAuthFlowWithRedirect(t *testing.T, r *proxyRefreshRig, connID, redirectURL, providerUserID string, callbackOpts ...helpers.ActorOption) string {
 	t.Helper()
 
 	parsed, err := url.Parse(redirectURL)


### PR DESCRIPTION
## Summary
- rename the shared integration-test actor option from OAuth2Option to ActorOption
- update OAuth2, API-key, no-auth, workflow, and migration helpers to use the actor-specific name
- clarify that WithActor applies to helpers across authentication methods

Closes #744

## Testing
- go test -tags=integration ./oauth2 -run '^$' -count=1
- ./scripts/preflight.sh

The affected end-to-end OAuth2 tests require the local OAuth2 test-provider container; they could not run because port 8086 was unavailable.