### PR TITLE
Fix demo fresh user identities

### DIFF
--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -24,9 +24,10 @@ before redirecting them into the appropriate AuthProxy UI.
                             └──────────────────────────────────────────────────┘
 ```
 
-The backend holds **one** admin private key. AuthProxy's auth model
-trusts an admin-signed JWT to represent any actor `externalId` — so
-one key is enough to "be" any of the three demo identities.
+The backend holds the demo actor private key for pre-provisioned identities and
+the host JWT private key for just-in-time provisioning. Selecting **Fresh user**
+creates a random `fresh-user-<uuid>` external ID, includes the complete actor in
+the JWT, and lets AuthProxy create that actor during session initiation.
 
 ## Running locally
 
@@ -73,6 +74,7 @@ yarn workspace @authproxy/demo-shell dev
 ```bash
 ADMIN_USERNAME=demo-shell \
 ADMIN_PRIVATE_KEY_PATH=./demos/shell/dev_keys/demo-shell \
+AUTHPROXY_JWT_PRIVATE_KEY_PATH=./dev_config/keys/system \
 AUTHPROXY_ADMIN_UI_URL=http://localhost:5174 \
 AUTHPROXY_MARKETPLACE_URL=http://localhost:5173 \
 AUTHPROXY_AUTH_URL=http://localhost:8080 \
@@ -91,8 +93,9 @@ the embedded build at the same root.
 Open <http://localhost:8888>. Choose **Admin UI** → submit → you're redirected
 to the AuthProxy admin UI as `demo-admin` with a fresh session. Choose
 **Integration Marketplace**, then **Fresh user** → submit → an empty
-Marketplace opens with no connections. When configured, the shell also links
-directly to Grafana's telemetry views and the demo OAuth provider.
+Marketplace opens with no connections under a newly generated actor external
+ID. When configured, the shell also links directly to Grafana's telemetry
+views and the demo OAuth provider.
 
 ## Local smoke via docker-compose
 
@@ -125,6 +128,7 @@ The backend reads the following env vars:
 |---------------------------|----------|-----------------------------------------------------------------------------|
 | `ADMIN_USERNAME`          | ✅        | externalId of the admin actor whose key is mounted at `ADMIN_PRIVATE_KEY_PATH` |
 | `ADMIN_PRIVATE_KEY_PATH`  | ✅        | File path; PEM RSA or EC                                                    |
+| `AUTHPROXY_JWT_PRIVATE_KEY_PATH` | ✅ | Host JWT private key used to provision each randomly generated fresh actor |
 | `AUTHPROXY_ADMIN_UI_URL`  | ✅        | Base URL of the admin SPA                                                   |
 | `AUTHPROXY_MARKETPLACE_URL` | ✅      | Base URL of the marketplace SPA                                             |
 | `AUTHPROXY_AUTH_URL`      | ⛔        | Optional today; kept for future routes that call back into AuthProxy        |
@@ -143,14 +147,13 @@ provider card. In Vite dev mode, `/config.json` and `/sso` are proxied to the
 backend; override `AUTHPROXY_DEMO_SHELL_BACKEND_URL` if the backend is not on
 `http://localhost:8888`.
 
-## Why one signing key, not three
+## Why two signing paths
 
-It's tempting to give the demo shell one keypair per demo identity. The
-existing AuthProxy auth model already covers the multi-identity case via
-admin-actor vouching: an admin's JWT can represent any actor `externalId`
-and AuthProxy will trust the user assignment. That's the same
-pattern `cmd/cli/sign-marketplace-login-url` uses, so the demo shell
-mirrors it.
+The pre-provisioned identities use actor-signed JWTs and the shared demo actor
+key. A random fresh actor cannot have a public key provisioned ahead of time,
+so that path uses the host JWT key and includes a complete actor claim. This is
+the just-in-time provisioning pattern described in the host application
+integration guide.
 
 ## Why this lives in `demos/`, not `cmd/` or `internal/`
 

--- a/demos/shell/backend/main.go
+++ b/demos/shell/backend/main.go
@@ -2,16 +2,15 @@
 // demo environment.
 //
 // AuthProxy is normally embedded in a host application that handles user
-// authentication; the host signs a JWT vouching for the authenticated user
-// using an admin signing key registered with AuthProxy, then redirects the
-// user to the appropriate AuthProxy UI (marketplace or admin) with the JWT
-// as a query parameter. AuthProxy validates the signature against the
-// admin's stored public key and establishes a session.
+// authentication; the host signs a JWT vouching for the authenticated user,
+// then redirects the user to the appropriate AuthProxy UI (marketplace or
+// admin) with the JWT as a query parameter. AuthProxy validates the signature
+// and establishes a session.
 //
 // The demo shell short-circuits the "actual auth" step: it guides a visitor
 // to a demo surface and, when that surface needs an AuthProxy session, signs
-// a JWT for the selected well-known demo actor. **Not** something you'd ship
-// to customers — lives only in the demo environment.
+// a JWT for the selected demo identity. **Not** something you'd ship to
+// customers — lives only in the demo environment.
 package main
 
 import (
@@ -27,18 +26,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rmorlok/authproxy/demos/shell/backend/embed"
+	"github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
-// demoActors enumerates the three identities the shell can sign JWTs for.
-// The same three are expected to exist as ConfiguredActors on the AuthProxy
-// side (the umbrella chart's seed job pre-creates them — see #A11).
-var demoActors = map[string]struct{}{
-	"demo-admin": {},
-	"demo-user":  {},
-	"fresh-user": {},
+const freshUserSelection = "fresh-user"
+
+// demoActorSelections enumerates the identities the shell UI can request.
+// fresh-user is a selector rather than a literal actor external ID; each
+// request for it is resolved to a new external ID before the JWT is signed.
+var demoActorSelections = map[string]struct{}{
+	"demo-admin":       {},
+	"demo-user":        {},
+	freshUserSelection: {},
 }
 
 // demoDestinations maps the UI's `destination` form field to the env var
@@ -61,6 +65,7 @@ type settings struct {
 	authUrl             string
 	destinationUrls     map[string]string
 	devFrontendUrl      string
+	jwtPrivateKeyPath   string
 	oauthProviderURL    string
 	telemetryLinks      []telemetryLink
 	tokenTtl            time.Duration
@@ -90,6 +95,7 @@ func loadSettings() settings {
 		addr:                ":" + port,
 		adminPrivateKeyPath: mustGetenv("ADMIN_PRIVATE_KEY_PATH"),
 		adminUsername:       mustGetenv("ADMIN_USERNAME"),
+		jwtPrivateKeyPath:   mustGetenv("AUTHPROXY_JWT_PRIVATE_KEY_PATH"),
 		// AUTHPROXY_AUTH_URL isn't strictly required for the redirect itself
 		// (the destination URLs are what we redirect to) but it's kept here
 		// in case future routes need to call back into AuthProxy directly.
@@ -149,13 +155,11 @@ func loadTelemetryLinks() []telemetryLink {
 	return links
 }
 
-// signTokenFor mints a JWT signed by the admin keypair, claiming the
-// picked actor's external_id. AuthProxy validates the signature against
-// the admin's stored public key and — because the admin has trust to
-// vouch for arbitrary actors — establishes a session for that actor.
-func signTokenFor(s settings, actorExternalId string) (string, error) {
+// signTokenFor mints a JWT for a well-known actor that already exists in
+// AuthProxy and has the demo shell's public key configured.
+func signTokenFor(s settings, actorExternalID string) (string, error) {
 	b := jwt.NewJwtTokenBuilder().
-		WithActorExternalId(actorExternalId).
+		WithActorExternalId(actorExternalID).
 		WithActorSigned().
 		WithServiceIds(config.AllServiceIds()).
 		WithNonce().
@@ -163,6 +167,41 @@ func signTokenFor(s settings, actorExternalId string) (string, error) {
 		WithPrivateKeyPath(s.adminPrivateKeyPath)
 
 	return b.Token()
+}
+
+// signTokenForFreshUser includes the complete actor claim so AuthProxy creates
+// the never-before-seen actor during authentication. Just-in-time actor claims
+// are signed with the host JWT key rather than an existing actor's key.
+func signTokenForFreshUser(s settings, actorExternalID string) (string, error) {
+	return jwt.NewJwtTokenBuilder().
+		WithActor(&core.Actor{
+			ExternalId: actorExternalID,
+			Namespace:  config.RootNamespace,
+			Labels: map[string]string{
+				"demo": "true",
+				"role": "user",
+			},
+			Permissions: []aschema.Permission{
+				{
+					Namespace: "root.**",
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
+			},
+		}).
+		WithServiceIds(config.AllServiceIds()).
+		WithNonce().
+		WithExpiresIn(s.tokenTtl).
+		WithPrivateKeyPath(s.jwtPrivateKeyPath).
+		Token()
+}
+
+func actorExternalID(selection string) string {
+	if selection == freshUserSelection {
+		return freshUserSelection + "-" + uuid.NewString()
+	}
+
+	return selection
 }
 
 func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
@@ -176,10 +215,10 @@ func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
 			return
 		}
 
-		actor := strings.TrimSpace(r.FormValue("actor"))
+		actorSelection := strings.TrimSpace(r.FormValue("actor"))
 		destination := strings.TrimSpace(r.FormValue("destination"))
 
-		if _, ok := demoActors[actor]; !ok {
+		if _, ok := demoActorSelections[actorSelection]; !ok {
 			http.Error(w, "unknown actor", http.StatusBadRequest)
 			return
 		}
@@ -189,7 +228,14 @@ func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
 			return
 		}
 
-		token, err := signTokenFor(s, actor)
+		actor := actorExternalID(actorSelection)
+		var token string
+		var err error
+		if actorSelection == freshUserSelection {
+			token, err = signTokenForFreshUser(s, actor)
+		} else {
+			token, err = signTokenFor(s, actor)
+		}
 		if err != nil {
 			logger.Error("failed to sign token", "err", err, "actor", actor)
 			http.Error(w, "internal error", http.StatusInternalServerError)

--- a/demos/shell/backend/main_test.go
+++ b/demos/shell/backend/main_test.go
@@ -4,10 +4,58 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	authjwt "github.com/rmorlok/authproxy/internal/apauth/jwt"
 	"github.com/stretchr/testify/require"
 )
+
+func TestActorExternalID(t *testing.T) {
+	t.Run("keeps well-known actor external IDs stable", func(t *testing.T) {
+		require.Equal(t, "demo-admin", actorExternalID("demo-admin"))
+		require.Equal(t, "demo-user", actorExternalID("demo-user"))
+	})
+
+	t.Run("generates a new external ID for every fresh user", func(t *testing.T) {
+		first := actorExternalID(freshUserSelection)
+		second := actorExternalID(freshUserSelection)
+
+		require.NotEqual(t, first, second)
+		for _, externalID := range []string{first, second} {
+			suffix, found := strings.CutPrefix(externalID, freshUserSelection+"-")
+			require.True(t, found)
+			require.NoError(t, uuid.Validate(suffix))
+		}
+	})
+}
+
+func TestSignTokenForFreshUserIncludesActorForJustInTimeProvisioning(t *testing.T) {
+	externalID := actorExternalID(freshUserSelection)
+	keyDir := filepath.Join("..", "..", "..", "test_data", "admin_user_keys")
+	token, err := signTokenForFreshUser(settings{
+		jwtPrivateKeyPath: filepath.Join(keyDir, "bobdole"),
+		tokenTtl:          time.Minute,
+	}, externalID)
+	require.NoError(t, err)
+
+	claims, err := authjwt.NewJwtTokenParserBuilder().
+		WithPublicKeyPath(filepath.Join(keyDir, "bobdole.pub")).
+		Parse(token)
+	require.NoError(t, err)
+	require.Equal(t, externalID, claims.Subject)
+	require.False(t, claims.ActorSigned)
+	require.NotNil(t, claims.Actor)
+	require.Equal(t, externalID, claims.Actor.ExternalId)
+	require.Equal(t, "root", claims.Actor.Namespace)
+	require.Equal(t, map[string]string{"demo": "true", "role": "user"}, claims.Actor.Labels)
+	require.Len(t, claims.Actor.Permissions, 1)
+	require.Equal(t, []string{"*"}, claims.Actor.Permissions[0].Resources)
+	require.Equal(t, []string{"*"}, claims.Actor.Permissions[0].Verbs)
+}
 
 func TestLoadTelemetryLinksFromGrafanaBaseURL(t *testing.T) {
 	t.Setenv("AUTHPROXY_GRAFANA_URL", "https://demo.example.test/grafana/")

--- a/demos/shell/compose/docker-compose.yaml
+++ b/demos/shell/compose/docker-compose.yaml
@@ -41,6 +41,10 @@ services:
       # directory so dev_config/docker.yaml's `keys_path: ...keys/admin`
       # picks it up and registers `demo-shell` as an admin actor.
       - ./keys/demo-shell.pub:/app/dev_config/keys/admin/demo-shell.pub:ro
+      # Use the same local-only keypair as the host JWT key so the shell can
+      # provision a new actor for each Fresh user launch.
+      - ./keys/demo-shell:/app/dev_config/keys/system:ro
+      - ./keys/demo-shell.pub:/app/dev_config/keys/system.pub:ro
     depends_on:
       postgres: { condition: service_healthy }
       redis:    { condition: service_healthy }
@@ -53,6 +57,7 @@ services:
     environment:
       ADMIN_USERNAME: demo-shell
       ADMIN_PRIVATE_KEY_PATH: /keys/demo-shell
+      AUTHPROXY_JWT_PRIVATE_KEY_PATH: /keys/demo-shell
       # URLs the BROWSER reaches — must be host-mapped, not container DNS.
       AUTHPROXY_AUTH_URL: http://localhost:8080
       AUTHPROXY_MARKETPLACE_URL: http://localhost:8080

--- a/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
+++ b/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
@@ -31,6 +31,8 @@ spec:
               value: demo-shell
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH
+              value: /etc/authproxy/jwt/system
             - name: AUTHPROXY_AUTH_URL
               value: https://marketplace.demo.authproxy.net
             - name: AUTHPROXY_MARKETPLACE_URL
@@ -49,6 +51,9 @@ spec:
             - name: admin-key
               mountPath: /etc/authproxy/demo-shell
               readOnly: true
+            - name: jwt-key
+              mountPath: /etc/authproxy/jwt
+              readOnly: true
       volumes:
         - name: admin-key
           secret:
@@ -56,6 +61,12 @@ spec:
             items:
               - key: private
                 path: private
+        - name: jwt-key
+          secret:
+            secretName: authproxy-jwt-placeholder
+            items:
+              - key: system
+                path: system
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
@@ -14,6 +14,8 @@ spec:
               value: demo-shell
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH
+              value: /etc/authproxy/jwt/system
             - name: AUTHPROXY_AUTH_URL
               value: https://marketplace.demo.authproxy.net
             - name: AUTHPROXY_MARKETPLACE_URL
@@ -29,3 +31,9 @@ spec:
             items:
               - key: private
                 path: private
+        - name: jwt-key
+          secret:
+            secretName: demo-jwt
+            items:
+              - key: system
+                path: system

--- a/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
@@ -14,6 +14,8 @@ spec:
               value: demo-shell
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
+            - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH
+              value: /etc/authproxy/jwt/system
             - name: AUTHPROXY_AUTH_URL
               value: https://marketplace.branch.dev.authproxy.net
             - name: AUTHPROXY_MARKETPLACE_URL
@@ -29,3 +31,9 @@ spec:
             items:
               - key: private
                 path: private
+        - name: jwt-key
+          secret:
+            secretName: dev-jwt
+            items:
+              - key: system
+                path: system

--- a/docs/src/content/docs/getting-started/demo.md
+++ b/docs/src/content/docs/getting-started/demo.md
@@ -37,9 +37,11 @@ sequenceDiagram
     AP-->>UI: Session cookie and UI configuration
 ```
 
-`demo-admin`, `demo-user`, and `fresh-user` demonstrate distinct host
-identities. Connection data is shared and changes as visitors use the demo, so
-do not rely on any identity having a permanently empty or populated account.
+`demo-admin` and `demo-user` demonstrate pre-provisioned host identities. Every
+**Fresh user** launch generates a new `fresh-user-<uuid>` external ID and
+provisions that actor during the JWT handoff, so it starts without connections.
+Connection data for the pre-provisioned identities is shared and changes as
+visitors use the demo.
 
 See [host application integration](/integration/host-application/) for the
 production version of this handoff.


### PR DESCRIPTION
## Summary
- generate a unique fresh-user UUID external ID for every demo Marketplace launch
- provision each fresh actor just in time with the existing demo labels and permissions
- mount the host JWT signing key in demo, dev, and local Compose configurations and update the docs

## Testing
- go test ./demos/shell/backend
- yarn workspace @authproxy/demo-shell typecheck
- yarn docs:build
- docker compose config --quiet
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
- ./scripts/preflight.sh