### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/admin-ui-ci.yml
+++ b/.github/workflows/admin-ui-ci.yml
@@ -26,10 +26,10 @@ jobs:
         node-version: [20.x, 22.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: yarn.lock

--- a/.github/workflows/admin-ui-ci.yml
+++ b/.github/workflows/admin-ui-ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
           cache-dependency-path: yarn.lock
 
       - name: Enable corepack

--- a/.github/workflows/aws-integration.yml
+++ b/.github/workflows/aws-integration.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: integration_tests/go.mod
 
     - name: Start MinIO
       run: |

--- a/.github/workflows/aws-integration.yml
+++ b/.github/workflows/aws-integration.yml
@@ -47,10 +47,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,19 +29,19 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'deploy:demo'))
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/authproxy
           tags: |
@@ -61,7 +61,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -103,22 +103,22 @@ jobs:
         if: env.SHOULD_BUILD != 'true'
         run: echo "Skipping demo-only image build because this PR is not labeled deploy:demo."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: env.SHOULD_BUILD == 'true'
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up QEMU
         if: env.SHOULD_BUILD == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: env.SHOULD_BUILD == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: env.SHOULD_BUILD == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -127,7 +127,7 @@ jobs:
       - name: Extract metadata
         if: env.SHOULD_BUILD == 'true'
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image.name }}
           tags: |
@@ -140,7 +140,7 @@ jobs:
 
       - name: Build and push
         if: env.SHOULD_BUILD == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}

--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Volta
-        uses: volta-cli/action@v4
+        uses: volta-cli/action@v5
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -43,7 +43,7 @@ jobs:
         run: yarn blog:build
 
       - name: Upload static site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: authproxy-blog-${{ github.sha }}
           path: blog/dist
@@ -64,13 +64,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download static site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: authproxy-blog-${{ github.sha }}
           path: blog/dist
 
       - name: Assume the blog deployment role
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_BLOG_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -58,18 +58,18 @@ jobs:
       DEPLOY_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ env.DEPLOY_SHA }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 
@@ -132,7 +132,7 @@ jobs:
           done
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: integration_tests/go.mod
 
       - name: Set up Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: integration_tests/go.mod
 
       - name: Resolve environment names
         id: env

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -48,12 +48,12 @@ jobs:
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -176,7 +176,7 @@ jobs:
           done
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -408,7 +408,7 @@ jobs:
 
       - name: Post smoke failure comment
         if: failure() && steps.smoke.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SMOKE_LOG_PATH: ${{ steps.smoke.outputs.log_path }}
           DEV_URL: https://${{ steps.env.outputs.hostname }}/
@@ -469,7 +469,7 @@ jobs:
             }
 
       - name: Post dev environment comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DEV_URL: https://${{ steps.env.outputs.hostname }}/
           RELEASE_NS: ${{ steps.env.outputs.namespace }}
@@ -610,7 +610,7 @@ jobs:
           echo "Hostname:  https://${hostname}/"
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/gcp-integration.yml
+++ b/.github/workflows/gcp-integration.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: integration_tests/go.mod
 
     - name: Start MinIO
       run: |

--- a/.github/workflows/gcp-integration.yml
+++ b/.github/workflows/gcp-integration.yml
@@ -47,10 +47,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,12 +26,12 @@ jobs:
     environment: Github Pages Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Volta
-        uses: volta-cli/action@v4
+        uses: volta-cli/action@v5
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: terraform/provider/go.mod
 
     - name: Build
       run: go build -v ./...
@@ -175,7 +175,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: integration_tests/go.mod
 
     - name: Set up Node + Yarn
       uses: actions/setup-node@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,15 +22,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest
 
@@ -40,10 +40,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 
@@ -104,10 +104,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 
@@ -170,15 +170,15 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 
     - name: Set up Node + Yarn
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
 
@@ -189,7 +189,7 @@ jobs:
         yarn workspace @authproxy/marketplace build
 
     - name: Install Chrome for chromedp
-      uses: browser-actions/setup-chrome@v1
+      uses: browser-actions/setup-chrome@v2
       with:
         chrome-version: stable
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -181,6 +181,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         node-version: '20'
+        package-manager-cache: false
 
     - name: Install marketplace deps + build
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        version: v2.13.0
 
     - name: Check route JSON rendering guardrails
       run: go run ./tools/check-gin-json-rendering

--- a/.github/workflows/grafana-datasource-ci.yml
+++ b/.github/workflows/grafana-datasource-ci.yml
@@ -22,15 +22,15 @@ jobs:
         working-directory: plugins/grafana/authproxy-datasource
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version-file: plugins/grafana/authproxy-datasource/go.mod
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 
@@ -185,12 +185,12 @@ jobs:
     needs: lint
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 
@@ -221,7 +221,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changed.outputs.found == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build local AuthProxy image (amd64-only)
         if: steps.changed.outputs.found == 'true'
@@ -229,7 +229,7 @@ jobs:
         # the code on this branch, not whatever happens to be tagged `:main`
         # in GHCR. amd64-only keeps the build under ~5 min; the runner is
         # always amd64 anyway.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -241,7 +241,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.changed.outputs.found == 'true'
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.14.0
         with:
           version: v0.24.0
           node_image: kindest/node:v1.30.4

--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -27,10 +27,10 @@ jobs:
         node-version: [20.x, 22.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: yarn.lock

--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
           cache-dependency-path: yarn.lock
 
       - name: Enable corepack

--- a/.github/workflows/marketplace-ui-ci.yml
+++ b/.github/workflows/marketplace-ui-ci.yml
@@ -26,10 +26,10 @@ jobs:
         node-version: [20.x, 22.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: yarn.lock

--- a/.github/workflows/marketplace-ui-ci.yml
+++ b/.github/workflows/marketplace-ui-ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
           cache-dependency-path: yarn.lock
 
       - name: Enable corepack

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -35,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Need full history so we can resolve the latest vX.Y.Z app tag.
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -51,7 +51,7 @@ jobs:
       REGISTRY: ghcr.io
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
           echo "Found ${ref}"
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -22,14 +22,14 @@ jobs:
   swagger:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         # Use a token with write access for pushing commits
         token: ${{ secrets.GITHUB_TOKEN }}
         ref: ${{ github.head_ref || github.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 

--- a/.github/workflows/teardown-dev.yml
+++ b/.github/workflows/teardown-dev.yml
@@ -56,7 +56,7 @@ jobs:
           echo "Namespace: ${namespace}"
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/vault-integration.yml
+++ b/.github/workflows/vault-integration.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: integration_tests/go.mod
 
     - name: Start MinIO
       run: |

--- a/.github/workflows/vault-integration.yml
+++ b/.github/workflows/vault-integration.yml
@@ -49,10 +49,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
 

--- a/.github/workflows/verify-eks-oidc.yml
+++ b/.github/workflows/verify-eks-oidc.yml
@@ -42,10 +42,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Assume GH Actions role via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,15 @@
+version: "2"
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - depguard
-
-linters-settings:
-  depguard:
-    rules:
-      pkg-errors:
-        deny:
-          - pkg: "github.com/pkg/errors"
-            desc: "Use fmt.Errorf(\"...: %w\", err) or standard errors package instead"
+  settings:
+    depguard:
+      rules:
+        pkg-errors:
+          deny:
+            - pkg: "github.com/pkg/errors"
+              desc: "Use fmt.Errorf(\"...: %w\", err) or standard errors package instead"
+  exclusions:
+    generated: lax


### PR DESCRIPTION
## Summary
- update JavaScript actions that still declare Node 20 or earlier runtimes to their first Node 24-compatible major releases across 19 workflows
- preserve the existing Yarn setup order by disabling setup-node's new automatic package-manager cache in Corepack-based jobs
- migrate the depguard-only golangci-lint configuration to v2 and pin v2.13.0, as required by the Node 24 lint action
- select the nested modules' declared Go toolchains explicitly for setup-go v6 while keeping root lint/tests on Go 1.24
- keep the explicit Node 20 application compatibility test matrix unchanged

## Validation
- parsed every workflow and the lint configuration as YAML
- golangci-lint v2.13.0 config verify
- golangci-lint v2.13.0 run (0 issues)
- git diff --check
- ./scripts/preflight.sh