### PR TITLE
Isolate demo smoke resources by namespace

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -177,9 +177,20 @@ jobs:
             echo "Configured demo-shell actor public key is empty" >&2
             exit 1
           fi
-          kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
-            --type merge \
-            --patch "{\"data\":{\"smoke-user.pub\":\"${smoke_user_public}\"}}"
+          stale_smoke_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
+            -o jsonpath='{.data.smoke-user\.pub}')"
+          if [ -n "${stale_smoke_public}" ]; then
+            kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+              --type json \
+              --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
+          fi
+          smoke_user_key="${RUNNER_TEMP}/smoke-user.pub"
+          printf '%s' "${smoke_user_public}" | base64 -d > "${smoke_user_key}"
+          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-smoke-actors" \
+            --from-file=smoke-user.pub="${smoke_user_key}" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
+          secrets+=("${RELEASE_NAME}-smoke-actors")
 
           kubectl -n "${RELEASE_NS}" get secret "${secrets[@]}" -o json \
             | jq 'del(

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -171,6 +171,16 @@ jobs:
             fi
           done
 
+          smoke_user_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
+            -o jsonpath='{.data.demo-shell\.pub}')"
+          if [ -z "${smoke_user_public}" ]; then
+            echo "Configured demo-shell actor public key is empty" >&2
+            exit 1
+          fi
+          kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+            --type merge \
+            --patch "{\"data\":{\"smoke-user.pub\":\"${smoke_user_public}\"}}"
+
           kubectl -n "${RELEASE_NS}" get secret "${secrets[@]}" -o json \
             | jq 'del(
                 .metadata.resourceVersion,

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -241,6 +241,11 @@ jobs:
             echo "Reusing ${RELEASE_NAME}-actors"
           fi
 
+          smoke_user_public="$(base64 < "${workdir}/demo-shell.pub" | tr -d '\n')"
+          kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+            --type merge \
+            --patch "{\"data\":{\"smoke-user.pub\":\"${smoke_user_public}\"}}"
+
       - name: Clear stale seed job
         env:
           RELEASE_NS: ${{ steps.env.outputs.namespace }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -241,10 +241,18 @@ jobs:
             echo "Reusing ${RELEASE_NAME}-actors"
           fi
 
-          smoke_user_public="$(base64 < "${workdir}/demo-shell.pub" | tr -d '\n')"
-          kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
-            --type merge \
-            --patch "{\"data\":{\"smoke-user.pub\":\"${smoke_user_public}\"}}"
+          stale_smoke_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
+            -o jsonpath='{.data.smoke-user\.pub}')"
+          if [ -n "${stale_smoke_public}" ]; then
+            kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+              --type json \
+              --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
+          fi
+
+          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-smoke-actors" \
+            --from-file=smoke-user.pub="${workdir}/demo-shell.pub" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
 
       - name: Clear stale seed job
         env:

--- a/deploy/charts/authproxy/templates/configmap.yaml
+++ b/deploy/charts/authproxy/templates/configmap.yaml
@@ -169,10 +169,11 @@ template syntax.
 {{-     $_ := set $sysAuth "globalAesKey" (dict "path" (printf "%s/%s" .Values.encryptionKeys.mountPath .Values.encryptionKeys.globalAesKeyFile)) -}}
 {{-   end -}}
 {{-   if .Values.actors.existingSecret -}}
-{{-     $actors := dict "keysPath" .Values.actors.mountPath -}}
+{{-     $actorSource := dict "keysPath" .Values.actors.mountPath -}}
 {{-     if .Values.actors.permissions -}}
-{{-       $_ := set $actors "permissions" .Values.actors.permissions -}}
+{{-       $_ := set $actorSource "permissions" .Values.actors.permissions -}}
 {{-     end -}}
+{{-     $actors := dict "root" $actorSource -}}
 {{-     $_ := set $sysAuth "actors" $actors -}}
 {{-   end -}}
 {{-   $_ := set $cfg "systemAuth" $sysAuth -}}

--- a/deploy/charts/authproxy/values.yaml
+++ b/deploy/charts/authproxy/values.yaml
@@ -305,7 +305,7 @@ actors:
   existingSecret: ""
   mountPath: /etc/authproxy/keys/actors
   # -- ACL permissions granted to every actor in the Secret. Mirrors
-  # AuthProxy's `systemAuth.actors.permissions` block.
+  # AuthProxy's `systemAuth.actors.root.permissions` block.
   permissions:
     - namespace: "root.**"
       resources: ["*"]

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -93,13 +93,27 @@ systemAuth:
   globalAesKey:
     path: /etc/authproxy/keys/encryption/global_aes.key
   actors:
-    keysPath: /etc/authproxy/keys/actors
-    namespaceByExternalId:
-      smoke-user: root.smoke
+    root:
+      keysPath: /etc/authproxy/keys/actors/root
+      permissions:
+        - namespace: root.**
+          resources:
+            - "*"
+          verbs:
+            - "*"
+    root.smoke:
+      keysPath: /etc/authproxy/keys/actors/smoke
+      permissions:
+        - namespace: root.smoke
+          resources:
+            - connectors
+          verbs:
+            - list
+        - namespace: root.smoke.{{external_id}}
+          resources:
+            - connections
+          verbs:
+            - create
+            - get
+            - proxy
     syncCronSchedule: "* * * * *"
-    permissions:
-      - namespace: root.**
-        resources:
-          - "*"
-        verbs:
-          - "*"

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -94,6 +94,9 @@ systemAuth:
     path: /etc/authproxy/keys/encryption/global_aes.key
   actors:
     keysPath: /etc/authproxy/keys/actors
+    namespaceByExternalId:
+      smoke-user: root.smoke
+    syncCronSchedule: "* * * * *"
     permissions:
       - namespace: root.**
         resources:

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
@@ -23,6 +23,14 @@ spec:
             - secretRef:
                 name: demo-minio-creds
                 optional: true
+          volumeMounts:
+            - mountPath: /etc/authproxy/keys/actors
+              $patch: delete
+            - name: actors-keys
+              mountPath: /etc/authproxy/keys/actors/root
+            - name: smoke-actors-keys
+              mountPath: /etc/authproxy/keys/actors/smoke
+              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -33,6 +41,9 @@ spec:
         - name: actors-keys
           secret:
             secretName: demo-actors
+        - name: smoke-actors-keys
+          secret:
+            secretName: demo-smoke-actors
 ---
 apiVersion: batch/v1
 kind: Job
@@ -53,6 +64,14 @@ spec:
             - secretRef:
                 name: demo-minio-creds
                 optional: true
+          volumeMounts:
+            - mountPath: /etc/authproxy/keys/actors
+              $patch: delete
+            - name: actors-keys
+              mountPath: /etc/authproxy/keys/actors/root
+            - name: smoke-actors-keys
+              mountPath: /etc/authproxy/keys/actors/smoke
+              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -63,3 +82,6 @@ spec:
         - name: actors-keys
           secret:
             secretName: demo-actors
+        - name: smoke-actors-keys
+          secret:
+            secretName: demo-smoke-actors

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -42,6 +42,9 @@ systemAuth:
     path: /etc/authproxy/keys/encryption/global_aes.key
   actors:
     keysPath: /etc/authproxy/keys/actors
+    namespaceByExternalId:
+      smoke-user: root.smoke
+    syncCronSchedule: "* * * * *"
     permissions:
       - namespace: root.**
         resources:

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -41,13 +41,27 @@ systemAuth:
   globalAesKey:
     path: /etc/authproxy/keys/encryption/global_aes.key
   actors:
-    keysPath: /etc/authproxy/keys/actors
-    namespaceByExternalId:
-      smoke-user: root.smoke
+    root:
+      keysPath: /etc/authproxy/keys/actors/root
+      permissions:
+        - namespace: root.**
+          resources:
+            - "*"
+          verbs:
+            - "*"
+    root.smoke:
+      keysPath: /etc/authproxy/keys/actors/smoke
+      permissions:
+        - namespace: root.smoke
+          resources:
+            - connectors
+          verbs:
+            - list
+        - namespace: root.smoke.{{external_id}}
+          resources:
+            - connections
+          verbs:
+            - create
+            - get
+            - proxy
     syncCronSchedule: "* * * * *"
-    permissions:
-      - namespace: root.**
-        resources:
-          - "*"
-        verbs:
-          - "*"

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
@@ -17,6 +17,14 @@ spec:
             - secretRef:
                 name: dev-minio-creds
                 optional: true
+          volumeMounts:
+            - mountPath: /etc/authproxy/keys/actors
+              $patch: delete
+            - name: actors-keys
+              mountPath: /etc/authproxy/keys/actors/root
+            - name: smoke-actors-keys
+              mountPath: /etc/authproxy/keys/actors/smoke
+              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -27,3 +35,6 @@ spec:
         - name: actors-keys
           secret:
             secretName: dev-actors
+        - name: smoke-actors-keys
+          secret:
+            secretName: dev-smoke-actors

--- a/dev_config/default.yaml
+++ b/dev_config/default.yaml
@@ -57,13 +57,14 @@ systemAuth:
     privateKey:
       path: ./dev_config/keys/system
   actors:
-    keysPath: ./dev_config/keys/admin
-    permissions:
-      - namespace: root.**
-        resources:
-          - "*"
-        verbs:
-          - "*"
+    root:
+      keysPath: ./dev_config/keys/admin
+      permissions:
+        - namespace: root.**
+          resources:
+            - "*"
+          verbs:
+            - "*"
   globalAesKey:
     path: ./dev_config/keys/global_aes.key
 

--- a/dev_config/docker.yaml
+++ b/dev_config/docker.yaml
@@ -46,13 +46,14 @@ systemAuth:
     privateKey:
       path: /app/dev_config/keys/system
   actors:
-    keysPath: /app/dev_config/keys/admin
-    permissions:
-      - namespace: root.**
-        resources:
-          - "*"
-        verbs:
-          - "*"
+    root:
+      keysPath: /app/dev_config/keys/admin
+      permissions:
+        - namespace: root.**
+          resources:
+            - "*"
+          verbs:
+            - "*"
   globalAesKey:
     path: /app/dev_config/keys/global_aes.key
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -63,21 +63,45 @@ that does not already specify `id`.
 ## Configured actor namespaces
 
 Configured actors live in `root` unless a namespace is specified. Inline actor
-entries accept `namespace` directly. For actors discovered from a public-key
-directory, map individual external IDs with `namespaceByExternalId`:
+entries accept `namespace` directly. For actors discovered from public-key
+directories, key each source by the namespace that owns its actors:
+
+```yaml
+systemAuth:
+  actors:
+    root:
+      keysPath: /etc/authproxy/keys/actors/root
+      permissions:
+        - namespace: root.**
+          resources: ["*"]
+          verbs: ["*"]
+    root.smoke:
+      keysPath: /etc/authproxy/keys/actors/smoke
+      permissions:
+        - namespace: root.smoke
+          resources: [connectors]
+          verbs: [list]
+        - namespace: root.smoke.{{external_id}}
+          resources: [connections]
+          verbs: [create, get, proxy]
+    syncCronSchedule: "* * * * *"
+```
+
+Every `.pub` file in a source directory creates an actor in that source's
+namespace. For example,
+`/etc/authproxy/keys/actors/smoke/smoke-user.pub` creates `smoke-user` in
+`root.smoke`. Permissions are source-specific, and permission namespaces can
+use actor templates such as `{{external_id}}`. Development migration creates
+each configured actor namespace and its missing parents before synchronization.
+
+The single-directory form remains available and creates all discovered actors
+in `root`:
 
 ```yaml
 systemAuth:
   actors:
     keysPath: /etc/authproxy/keys/actors
-    namespaceByExternalId:
-      smoke-user: root.smoke
 ```
-
-The key file for this example is
-`/etc/authproxy/keys/actors/smoke-user.pub`. Development migration creates the
-configured actor namespace and its missing parents before actor synchronization.
-Other keys in the directory continue to create actors in `root`.
 
 ## Kubernetes values
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -93,15 +93,8 @@ namespace. For example,
 `root.smoke`. Permissions are source-specific, and permission namespaces can
 use actor templates such as `{{external_id}}`. Development migration creates
 each configured actor namespace and its missing parents before synchronization.
-
-The single-directory form remains available and creates all discovered actors
-in `root`:
-
-```yaml
-systemAuth:
-  actors:
-    keysPath: /etc/authproxy/keys/actors
-```
+Directory sources must always be keyed by namespace; the former
+single-directory actor source shape is not supported.
 
 ## Kubernetes values
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -60,6 +60,25 @@ The former `connectors.identifyingLabels` setting has been removed. Delete it
 from existing configuration and add a stable `name` to every connector entry
 that does not already specify `id`.
 
+## Configured actor namespaces
+
+Configured actors live in `root` unless a namespace is specified. Inline actor
+entries accept `namespace` directly. For actors discovered from a public-key
+directory, map individual external IDs with `namespaceByExternalId`:
+
+```yaml
+systemAuth:
+  actors:
+    keysPath: /etc/authproxy/keys/actors
+    namespaceByExternalId:
+      smoke-user: root.smoke
+```
+
+The key file for this example is
+`/etc/authproxy/keys/actors/smoke-user.pub`. Development migration creates the
+configured actor namespace and its missing parents before actor synchronization.
+Other keys in the directory continue to create actors in `root`.
+
 ## Kubernetes values
 
 The Helm chart exposes typed values for common deployment settings and merges

--- a/integration_tests/config/integration.yaml
+++ b/integration_tests/config/integration.yaml
@@ -31,13 +31,14 @@ systemAuth:
     privateKey:
       path: ./dev_config/keys/system
   actors:
-    keysPath: ./dev_config/keys/admin
-    permissions:
-      - namespace: root.**
-        resources:
-          - "*"
-        verbs:
-          - "*"
+    root:
+      keysPath: ./dev_config/keys/admin
+      permissions:
+        - namespace: root.**
+          resources:
+            - "*"
+          verbs:
+            - "*"
   globalAesKey:
     path: ./dev_config/keys/global_aes.key
 

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -159,17 +159,52 @@ func (h *RemoteAuthProxy) WaitForUserReady(t *testing.T, timeout time.Duration) 
 
 func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) schemaapi.ConnectorVersionJson {
 	t.Helper()
+	return h.CreateConnectorWithLabels(t, connector, map[string]string{"smoke": "true"})
+}
+
+func (h *RemoteAuthProxy) CreateConnectorWithLabels(t *testing.T, connector sconfig.Connector, labels map[string]string) schemaapi.ConnectorVersionJson {
+	t.Helper()
 
 	var created schemaapi.ConnectorVersionJson
 	h.doSigned(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodPost, h.AdminURL+"/api/v1/connectors", schemaapi.CreateConnectorRequestJson{
 		Namespace:  h.ConnectorNamespace,
 		Definition: connector,
-		Labels: map[string]string{
-			"smoke": "true",
-		},
+		Labels:     labels,
 	}, true, http.StatusCreated, &created)
 	require.Equal(t, h.ConnectorNamespace, created.Namespace)
 	return created
+}
+
+func (h *RemoteAuthProxy) ListConnectorsAsAdmin(t *testing.T, namespace, labelSelector string) []schemaapi.ConnectorJson {
+	t.Helper()
+
+	query := url.Values{"limit": []string{"100"}, "namespace": []string{namespace}}
+	if labelSelector != "" {
+		query.Set("labelSelector", labelSelector)
+	}
+	endpoint := h.AdminURL + "/api/v1/connectors?" + query.Encode()
+
+	var list schemaapi.ListConnectorsResponseJson
+	h.doSigned(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodGet, endpoint, nil, true, http.StatusOK, &list)
+	return list.Items
+}
+
+func (h *RemoteAuthProxy) GetConnectorVersionAsAdmin(t *testing.T, connectorID apid.ID, version uint64) schemaapi.ConnectorVersionJson {
+	t.Helper()
+
+	var connector schemaapi.ConnectorVersionJson
+	h.doSigned(
+		t,
+		h.AdminActorExternalID,
+		h.AdminActorNamespace,
+		http.MethodGet,
+		fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d", h.AdminURL, connectorID, version),
+		nil,
+		true,
+		http.StatusOK,
+		&connector,
+	)
+	return connector
 }
 
 func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []schemaapi.ConnectorJson {

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -29,8 +29,11 @@ type RemoteAuthProxyOptions struct {
 	ProviderURL string
 
 	AdminActorExternalID string
+	AdminActorNamespace  string
 	UserActorExternalID  string
-	Namespace            string
+	UserActorNamespace   string
+	ConnectorNamespace   string
+	ConnectionNamespace  string
 
 	AdminPrivateKey string
 }
@@ -41,8 +44,11 @@ type RemoteAuthProxy struct {
 	ProviderURL string
 
 	AdminActorExternalID string
+	AdminActorNamespace  string
 	UserActorExternalID  string
-	Namespace            string
+	UserActorNamespace   string
+	ConnectorNamespace   string
+	ConnectionNamespace  string
 
 	privateKey string
 	client     *http.Client
@@ -77,13 +83,25 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 	if adminActor == "" {
 		adminActor = "demo-shell"
 	}
+	adminActorNamespace := opts.AdminActorNamespace
+	if adminActorNamespace == "" {
+		adminActorNamespace = sconfig.RootNamespace
+	}
 	userActor := opts.UserActorExternalID
 	if userActor == "" {
 		userActor = "fresh-user"
 	}
-	namespace := opts.Namespace
-	if namespace == "" {
-		namespace = sconfig.RootNamespace
+	userActorNamespace := opts.UserActorNamespace
+	if userActorNamespace == "" {
+		userActorNamespace = sconfig.RootNamespace
+	}
+	connectorNamespace := opts.ConnectorNamespace
+	if connectorNamespace == "" {
+		connectorNamespace = sconfig.RootNamespace
+	}
+	connectionNamespace := opts.ConnectionNamespace
+	if connectionNamespace == "" {
+		connectionNamespace = userActorNamespace
 	}
 
 	return &RemoteAuthProxy{
@@ -91,36 +109,66 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 		PublicURL:            strings.TrimRight(publicURL, "/"),
 		ProviderURL:          strings.TrimRight(providerURL, "/"),
 		AdminActorExternalID: adminActor,
+		AdminActorNamespace:  adminActorNamespace,
 		UserActorExternalID:  userActor,
-		Namespace:            namespace,
+		UserActorNamespace:   userActorNamespace,
+		ConnectorNamespace:   connectorNamespace,
+		ConnectionNamespace:  connectionNamespace,
 		privateKey:           opts.AdminPrivateKey,
 		client:               &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
-func (h *RemoteAuthProxy) CreateActor(t *testing.T, externalID string, labels map[string]string) schemaapi.ActorJson {
+func (h *RemoteAuthProxy) EnsureNamespace(t *testing.T, namespace string) {
 	t.Helper()
 
+	endpoint := h.AdminURL + "/api/v1/namespaces/" + url.PathEscape(namespace)
+	resp := h.doSignedAllowing(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodGet, endpoint, nil, true, []int{http.StatusOK, http.StatusNotFound}, nil)
+	if resp.StatusCode == http.StatusOK {
+		return
+	}
+
+	h.doSignedAllowing(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodPost, h.AdminURL+"/api/v1/namespaces", schemaapi.CreateNamespaceRequestJson{
+		Path: namespace,
+	}, true, []int{http.StatusOK, http.StatusConflict}, nil)
+}
+
+func (h *RemoteAuthProxy) GetActorByExternalID(t *testing.T, namespace, externalID string) schemaapi.ActorJson {
+	t.Helper()
+
+	endpoint := h.AdminURL + "/api/v1/actors/external-id/" + url.PathEscape(externalID) + "?namespace=" + url.QueryEscape(namespace)
 	var actor schemaapi.ActorJson
-	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/actors", schemaapi.CreateActorRequestJson{
-		ExternalId: externalID,
-		Namespace:  h.Namespace,
-		Labels:     labels,
-	}, true, http.StatusCreated, &actor)
+	h.doSigned(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodGet, endpoint, nil, true, http.StatusOK, &actor)
 	return actor
+}
+
+func (h *RemoteAuthProxy) WaitForUserReady(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last remoteResponse
+	for time.Now().Before(deadline) {
+		last = h.doSignedAllowing(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, h.PublicURL+"/api/v1/connectors?limit=1", nil, true, []int{http.StatusOK, http.StatusUnauthorized}, nil)
+		if last.StatusCode == http.StatusOK {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	require.FailNowf(t, "smoke user did not become ready", "actor %q in namespace %q was not ready within %s; last response: %s", h.UserActorExternalID, h.UserActorNamespace, timeout, string(last.Body))
 }
 
 func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) schemaapi.ConnectorVersionJson {
 	t.Helper()
 
 	var created schemaapi.ConnectorVersionJson
-	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/connectors", schemaapi.CreateConnectorRequestJson{
-		Namespace:  h.Namespace,
+	h.doSigned(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodPost, h.AdminURL+"/api/v1/connectors", schemaapi.CreateConnectorRequestJson{
+		Namespace:  h.ConnectorNamespace,
 		Definition: connector,
 		Labels: map[string]string{
 			"smoke": "true",
 		},
 	}, true, http.StatusCreated, &created)
+	require.Equal(t, h.ConnectorNamespace, created.Namespace)
 	return created
 }
 
@@ -133,7 +181,7 @@ func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []s
 	}
 
 	var list schemaapi.ListConnectorsResponseJson
-	h.doSigned(t, h.UserActorExternalID, http.MethodGet, endpoint, nil, true, http.StatusOK, &list)
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, endpoint, nil, true, http.StatusOK, &list)
 	return list.Items
 }
 
@@ -152,6 +200,7 @@ func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID a
 	h.doSigned(
 		t,
 		h.AdminActorExternalID,
+		h.AdminActorNamespace,
 		http.MethodPut,
 		fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_forceState", h.AdminURL, connectorID, version),
 		schemaapi.ForceConnectorVersionStateRequestJson{State: state},
@@ -166,13 +215,14 @@ func (h *RemoteAuthProxy) InitiateOAuth2Connection(t *testing.T, connectorID api
 	t.Helper()
 
 	var redirect schemaapi.ConnectionSetupRedirect
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
 		ConnectorId:   connectorID,
-		IntoNamespace: h.Namespace,
+		IntoNamespace: h.ConnectionNamespace,
 		ReturnToUrl:   returnToURL,
 	}, true, http.StatusOK, &redirect)
 	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, redirect.Type)
 	require.NotEmpty(t, redirect.RedirectUrl)
+	require.Equal(t, h.ConnectionNamespace, h.GetConnection(t, redirect.Id.String()).Namespace)
 	return redirect.Id.String(), redirect.RedirectUrl
 }
 
@@ -180,13 +230,22 @@ func (h *RemoteAuthProxy) InitiateAPIKeyConnection(t *testing.T, connectorID api
 	t.Helper()
 
 	var form schemaapi.ConnectionSetupForm
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
 		ConnectorId:   connectorID,
-		IntoNamespace: h.Namespace,
+		IntoNamespace: h.ConnectionNamespace,
 	}, true, http.StatusOK, &form)
 	require.Equal(t, schemaapi.ConnectionSetupResponseTypeForm, form.Type)
 	require.NotEmpty(t, form.StepId)
+	require.Equal(t, h.ConnectionNamespace, h.GetConnection(t, form.Id.String()).Namespace)
 	return form.Id.String(), form.StepId
+}
+
+func (h *RemoteAuthProxy) GetConnection(t *testing.T, connectionID string) schemaapi.ConnectionJson {
+	t.Helper()
+
+	var connection schemaapi.ConnectionJson
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID, nil, true, http.StatusOK, &connection)
+	return connection
 }
 
 func (h *RemoteAuthProxy) SubmitAPIKeyCredentials(t *testing.T, connectionID, stepID, apiKey string) schemaapi.ConnectionSetupResponseType {
@@ -198,7 +257,7 @@ func (h *RemoteAuthProxy) SubmitAPIKeyCredentials(t *testing.T, connectionID, st
 	var generic struct {
 		Type schemaapi.ConnectionSetupResponseType `json:"type"`
 	}
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_submit", schemaapi.SubmitConnectionRequest{
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_submit", schemaapi.SubmitConnectionRequest{
 		StepId: stepID,
 		Data:   rawData,
 	}, true, http.StatusOK, &generic)
@@ -217,7 +276,7 @@ func (h *RemoteAuthProxy) WaitForSetupComplete(t *testing.T, connectionID string
 			Type  schemaapi.ConnectionSetupResponseType `json:"type"`
 			Error string                                `json:"error,omitempty"`
 		}
-		h.doSigned(t, h.UserActorExternalID, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID+"/_setupStep", nil, true, http.StatusOK, &generic)
+		h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID+"/_setupStep", nil, true, http.StatusOK, &generic)
 		lastType = generic.Type
 		lastError = generic.Error
 
@@ -236,7 +295,7 @@ func (h *RemoteAuthProxy) WaitForSetupComplete(t *testing.T, connectionID string
 func (h *RemoteAuthProxy) FollowOAuth2Redirect(t *testing.T, redirectURL string) string {
 	t.Helper()
 
-	resp := h.doSigned(t, h.UserActorExternalID, http.MethodGet, redirectURL, nil, false, http.StatusFound, nil)
+	resp := h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, redirectURL, nil, false, http.StatusFound, nil)
 	loc := resp.Header.Get("Location")
 	require.NotEmpty(t, loc, "OAuth2 redirect response should include Location")
 	return loc
@@ -245,7 +304,7 @@ func (h *RemoteAuthProxy) FollowOAuth2Redirect(t *testing.T, redirectURL string)
 func (h *RemoteAuthProxy) DeliverOAuth2Callback(t *testing.T, callbackURL string) string {
 	t.Helper()
 
-	resp := h.doSigned(t, h.UserActorExternalID, http.MethodGet, callbackURL, nil, false, http.StatusFound, nil)
+	resp := h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, callbackURL, nil, false, http.StatusFound, nil)
 	loc := resp.Header.Get("Location")
 	require.NotEmpty(t, loc, "OAuth2 callback response should include Location")
 	return loc
@@ -255,14 +314,19 @@ func (h *RemoteAuthProxy) DoProxyRequest(t *testing.T, connectionID, targetURL, 
 	t.Helper()
 
 	var proxyResp schemaapi.ProxyResponseJson
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_proxy", schemaapi.ProxyRequestJson{
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_proxy", schemaapi.ProxyRequestJson{
 		URL:    targetURL,
 		Method: method,
 	}, true, http.StatusOK, &proxyResp)
 	return proxyResp
 }
 
-func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, method, rawURL string, body any, followRedirects bool, wantStatus int, out any) remoteResponse {
+func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, actorNamespace, method, rawURL string, body any, followRedirects bool, wantStatus int, out any) remoteResponse {
+	t.Helper()
+	return h.doSignedAllowing(t, actorExternalID, actorNamespace, method, rawURL, body, followRedirects, []int{wantStatus}, out)
+}
+
+func (h *RemoteAuthProxy) doSignedAllowing(t *testing.T, actorExternalID, actorNamespace, method, rawURL string, body any, followRedirects bool, wantStatuses []int, out any) remoteResponse {
 	t.Helper()
 
 	var bodyReader io.Reader
@@ -279,7 +343,7 @@ func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, method, rawURL
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	signer, err := h.signer(actorExternalID)
+	signer, err := h.signer(actorExternalID, actorNamespace)
 	require.NoError(t, err, "build JWT signer for %s", actorExternalID)
 	signer.SignAuthHeader(req)
 
@@ -299,7 +363,7 @@ func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, method, rawURL
 
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "read response body")
-	require.Equalf(t, wantStatus, resp.StatusCode, "%s %s returned %d: %s", method, rawURL, resp.StatusCode, string(respBody))
+	require.Containsf(t, wantStatuses, resp.StatusCode, "%s %s returned %d: %s", method, rawURL, resp.StatusCode, string(respBody))
 
 	if out != nil {
 		require.NoError(t, json.Unmarshal(respBody, out), "decode response from %s %s: %s", method, rawURL, string(respBody))
@@ -312,10 +376,10 @@ func (h *RemoteAuthProxy) doSigned(t *testing.T, actorExternalID, method, rawURL
 	}
 }
 
-func (h *RemoteAuthProxy) signer(actorExternalID string) (jwt.Signer, error) {
+func (h *RemoteAuthProxy) signer(actorExternalID, actorNamespace string) (jwt.Signer, error) {
 	builder := jwt.NewJwtTokenBuilder().
 		WithActorExternalId(actorExternalID).
-		WithNamespace(h.Namespace).
+		WithNamespace(actorNamespace).
 		WithActorSigned().
 		WithServiceIds(sconfig.AllServiceIds()).
 		WithPermissions(aschema.AllPermissions()).

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -356,12 +356,9 @@ func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL s
 // JSON tags must stay in sync with the production struct; if they drift,
 // the production decode will fail with errStateTampered.
 type OAuth2StateForTest struct {
-	Id                  apid.ID `json:"id"`
-	ActorNamespace      string  `json:"actorNamespace,omitempty"`
-	ConnectionNamespace string  `json:"connectionNamespace,omitempty"`
-	// Namespace exercises the legacy state shape accepted during rolling
-	// upgrades. New state records use ActorNamespace and ConnectionNamespace.
-	Namespace              string                `json:"namespace,omitempty"`
+	Id                     apid.ID               `json:"id"`
+	ActorNamespace         string                `json:"actorNamespace,omitempty"`
+	ConnectionNamespace    string                `json:"connectionNamespace,omitempty"`
 	ActorId                apid.ID               `json:"actorId"`
 	ConnectorId            apid.ID               `json:"connectorId"`
 	ConnectorVersion       uint64                `json:"connectorVersion"`

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -356,8 +356,12 @@ func (env *IntegrationTestEnv) DeliverOAuth2Callback(t *testing.T, callbackURL s
 // JSON tags must stay in sync with the production struct; if they drift,
 // the production decode will fail with errStateTampered.
 type OAuth2StateForTest struct {
-	Id                     apid.ID               `json:"id"`
-	Namespace              string                `json:"namespace"`
+	Id                  apid.ID `json:"id"`
+	ActorNamespace      string  `json:"actorNamespace,omitempty"`
+	ConnectionNamespace string  `json:"connectionNamespace,omitempty"`
+	// Namespace exercises the legacy state shape accepted during rolling
+	// upgrades. New state records use ActorNamespace and ConnectionNamespace.
+	Namespace              string                `json:"namespace,omitempty"`
 	ActorId                apid.ID               `json:"actorId"`
 	ConnectorId            apid.ID               `json:"connectorId"`
 	ConnectorVersion       uint64                `json:"connectorVersion"`

--- a/integration_tests/oauth2/callback_cross_namespace_test.go
+++ b/integration_tests/oauth2/callback_cross_namespace_test.go
@@ -93,7 +93,8 @@ func TestCallbackRejection_CrossNamespace(t *testing.T) {
 	require.NotEmpty(t, providerUser.ID)
 
 	// 1. Attacker initiates as alice in tenant-a. State stored with
-	//    Namespace=tenant-a, ActorId=<alice's tenant-a actor>.
+	//    ActorNamespace=tenant-a, ConnectionNamespace=tenant-a, and
+	//    ActorId=<alice's tenant-a actor>.
 	returnTo := "https://example.com/return"
 	connID, redirectURL := env.InitiateOAuth2Connection(t, connectorID, returnTo, helpers.WithActor(sharedExternalID, tenantA))
 	parsed, err := url.Parse(redirectURL)

--- a/integration_tests/oauth2/callback_cross_namespace_test.md
+++ b/integration_tests/oauth2/callback_cross_namespace_test.md
@@ -33,12 +33,12 @@ What can go wrong, ordered by validation:
    Two AuthProxy instances share Redis and happen to allocate the
    same actor id in different namespaces, or a state envelope is
    constructed via a process that picks an actor id colliding with
-   the caller. The actor-id check passes, but `s.Namespace !=
+   the caller. The actor-id check passes, but `s.ActorNamespace !=
    actor.GetNamespace()` fires `namespace_mismatch_actor`. This is a
    guard against the actor-id-uniqueness assumption breaking.
 
 3. **State pointing at a connection in the wrong tenant (case 7).**
-   A state envelope claims namespace X (matching the caller's), but
+   A state envelope claims actor namespace X (matching the caller's), but
    `state.ConnectionId` points at a connection that lives in
    namespace Y. The actor-id and actor-namespace checks both pass,
    but the connection-namespace check fires
@@ -48,13 +48,13 @@ What can go wrong, ordered by validation:
 
 ## Validation order in production
 
-`internal/auth_methods/oauth2/state.go:191–242` runs these checks in
+`getOAuth2State` in `internal/auth_methods/oauth2/state.go` runs these checks in
 sequence, returning on the first failure:
 
 1. `s.ActorId != actor.GetId()` → `actor_mismatch`
-2. `s.Namespace != actor.GetNamespace()` → `namespace_mismatch_actor`
+2. `s.ActorNamespace != actor.GetNamespace()` → `namespace_mismatch_actor`
 3. Load connection from DB
-4. `s.Namespace != connection.GetNamespace()` → `namespace_mismatch_connection`
+4. `s.ConnectionNamespace != connection.GetNamespace()` → `namespace_mismatch_connection`
 
 The earliest-failing check is the one that fires. Test 1 below
 exercises check 1 in a multi-tenant context; tests 2 and 3 exercise
@@ -84,7 +84,7 @@ attacker-sends-link-to-victim delivery vector.
 | Step | Action |
 | ---- | ------ |
 | Setup | Create namespaces `root.tenant-a-<suffix>`, `root.tenant-b-<suffix>`. |
-| Attacker | Alice (externalId = `user-123-<suffix>`) initiates in tenant-a. State has `Namespace=tenant-a`, `ActorId=act_alice`. |
+| Attacker | Alice (externalId = `user-123-<suffix>`) initiates in tenant-a. State has `ActorNamespace=tenant-a`, `ConnectionNamespace=tenant-a`, `ActorId=act_alice`. |
 | Provider | `/test/authorize` issues a code under alice's stateId. |
 | Victim | Bob (externalId = `user-123-<suffix>`, same as alice) bootstraps via `/connectors?authToken=<bob>` in tenant-b. Browser holds `SESSION-ID` cookie scoped to bob. |
 | Forge | Browser navigates to the cross-tenant callback URL. |
@@ -108,9 +108,9 @@ assumption breaks.
 | Setup | Create namespace `root.tenant-a-<suffix>`. |
 | Real initiate | Alice initiates in tenant-a so a real connection row exists. |
 | Lookup | Read alice's actor id via `env.Db.GetActorByExternalId(ctx, tenant-a, alice)`. |
-| Inject | `env.WriteOAuth2StateForTest` at a fresh `forgedStateID` with `ActorId=alice.Id`, `ConnectionId=conn.Id`, but `Namespace="root.tenant-b-<suffix>"` (lie). |
+| Inject | `env.WriteOAuth2StateForTest` at a fresh `forgedStateID` with `ActorId=alice.Id`, `ConnectionId=conn.Id`, valid `ConnectionNamespace=tenant-a`, but `ActorNamespace="root.tenant-b-<suffix>"` (lie). |
 | Deliver | `env.DeliverOAuth2Callback(callback, helpers.WithActor(alice, tenant-a))`. |
-| Reject | `s.ActorId == caller.Id` ✓, `s.Namespace ("tenant-b") != caller.Namespace ("tenant-a")` → `namespace_mismatch_actor`. |
+| Reject | `s.ActorId == caller.Id` ✓, `s.ActorNamespace ("tenant-b") != caller.Namespace ("tenant-a")` → `namespace_mismatch_actor`. |
 
 **Why direct HTTP:** the scenario hinges on programmatic state
 injection — there is no realistic browser-driven path to land a
@@ -129,9 +129,9 @@ different tenant.
 | Setup | Create namespaces `root.tenant-a-<suffix>`, `root.tenant-b-<suffix>`. |
 | Bob's connection | Bob initiates in tenant-b so a real connection row exists in tenant-b. |
 | Materialize alice | Alice initiates a throwaway connection in tenant-a so her actor row exists; we discard the connection id. |
-| Inject | Synthetic state: `Namespace=tenant-a`, `ActorId=alice.Id`, `ConnectionId=bob.Conn.Id` (in tenant-b). |
+| Inject | Synthetic state: `ActorNamespace=tenant-a`, `ConnectionNamespace=tenant-a`, `ActorId=alice.Id`, `ConnectionId=bob.Conn.Id` (in tenant-b). |
 | Deliver | `env.DeliverOAuth2Callback(callback, helpers.WithActor(alice, tenant-a))`. |
-| Reject | `s.ActorId == caller.Id` ✓, `s.Namespace == caller.Namespace` ✓, connection lookup returns bob's connection in tenant-b, `s.Namespace ("tenant-a") != connection.Namespace ("tenant-b")` → `namespace_mismatch_connection`. |
+| Reject | `s.ActorId == caller.Id` ✓, `s.ActorNamespace == caller.Namespace` ✓, connection lookup returns bob's connection in tenant-b, `s.ConnectionNamespace ("tenant-a") != connection.Namespace ("tenant-b")` → `namespace_mismatch_connection`. |
 
 **Why bob's connection isn't modified:** the rejection happens
 before any token exchange, so neither alice nor bob accumulates a
@@ -165,7 +165,7 @@ sequenceDiagram
     participant P as OAuth provider
 
     T->>API: POST /api/v1/connections/_initiate (signed alice@tenant-a, IntoNamespace=tenant-a)
-    API->>R: write encrypted state<br/>(ActorId=act_alice, Namespace=tenant-a)
+    API->>R: write encrypted state<br/>(ActorId=act_alice, ActorNamespace=tenant-a,<br/>ConnectionNamespace=tenant-a)
     API->>DB: insert connection in tenant-a
 
     T->>P: POST /test/authorize (decision=approve)

--- a/integration_tests/oauth2/callback_namespace_mismatch_test.go
+++ b/integration_tests/oauth2/callback_namespace_mismatch_test.go
@@ -19,11 +19,11 @@ import (
 
 // TestCallbackRejection_NamespaceMismatchActor exercises the
 // `namespace_mismatch_actor` defense-in-depth check at
-// internal/auth_methods/oauth2/state.go:203-213. The check fires when the
+// internal/auth_methods/oauth2/state.go. The check fires when the
 // caller's actor id matches the state's actor id but the namespaces differ
 // — a configuration that the natural _initiate flow can't produce because
 // actor ids are allocated per (namespace, externalId). The only realistic
-// way to land in this state is via a corrupted state envelope (e.g., a
+// way to land in this state is via a forged state envelope (e.g., a
 // secondary AuthProxy instance writing into the same Redis with a colliding
 // actor id), so the test injects a synthetic state envelope directly.
 //
@@ -85,18 +85,19 @@ func TestCallbackRejection_NamespaceMismatchActor(t *testing.T) {
 	// state id so the assertion targets exactly the synthetic value.
 	forgedStateID := apid.New(apid.PrefixOauth2State)
 	env.WriteOAuth2StateForTest(t, helpers.OAuth2StateForTest{
-		Id:               forgedStateID,
-		Namespace:        lyingNamespace,
-		ActorId:          alice.Id,
-		ConnectorId:      conn.ConnectorId,
-		ConnectorVersion: conn.ConnectorVersion,
-		ConnectionId:     conn.Id,
-		ReturnToUrl:      "https://example.com/return",
-		ExpiresAt:        time.Now().Add(5 * time.Minute),
+		Id:                  forgedStateID,
+		ActorNamespace:      lyingNamespace,
+		ConnectionNamespace: conn.Namespace,
+		ActorId:             alice.Id,
+		ConnectorId:         conn.ConnectorId,
+		ConnectorVersion:    conn.ConnectorVersion,
+		ConnectionId:        conn.Id,
+		ReturnToUrl:         "https://example.com/return",
+		ExpiresAt:           time.Now().Add(5 * time.Minute),
 	}, 5*time.Minute)
 
 	// Deliver the callback as alice in tenant-a. The actor-id check passes
-	// (alice signed her own JWT), but s.Namespace ("tenant-b") doesn't
+	// (alice signed her own JWT), but s.ActorNamespace ("tenant-b") doesn't
 	// match the caller's namespace ("tenant-a") — fires
 	// `namespace_mismatch_actor` before the connection lookup runs.
 	loc := env.DeliverOAuth2Callback(t,
@@ -127,11 +128,11 @@ func TestCallbackRejection_NamespaceMismatchActor(t *testing.T) {
 
 // TestCallbackRejection_NamespaceMismatchConnection exercises the
 // `namespace_mismatch_connection` defense-in-depth check at
-// internal/auth_methods/oauth2/state.go:232-242. The check fires when
-// state.Namespace and the *connection's* namespace disagree — even
-// after the caller-vs-state namespace check passes. A natural _initiate
-// always produces matching namespaces, so this also requires synthetic
-// state injection.
+// internal/auth_methods/oauth2/state.go. The check fires when
+// state.ConnectionNamespace and the *connection's* namespace disagree —
+// even after the caller-vs-state actor namespace check passes. A natural
+// _initiate always captures both actual namespaces, so this also requires
+// synthetic state injection.
 //
 // Scenario: bob owns a connection in tenant-b. An attacker forges a state
 // envelope that points the connectionId at bob's connection but claims
@@ -193,20 +194,21 @@ func TestCallbackRejection_NamespaceMismatchConnection(t *testing.T) {
 	alice, err := env.Db.GetActorByExternalId(ctx, tenantA, aliceExternalID)
 	require.NoError(t, err)
 
-	// Synthetic state: ActorId+Namespace agree with alice's caller
+	// Synthetic state: ActorId+ActorNamespace agree with alice's caller
 	// identity, but ConnectionId points at bob's connection in tenant-b.
-	// The first two checks pass; the third (state.Namespace vs
+	// The first two checks pass; the third (state.ConnectionNamespace vs
 	// connection.Namespace) rejects.
 	forgedStateID := apid.New(apid.PrefixOauth2State)
 	env.WriteOAuth2StateForTest(t, helpers.OAuth2StateForTest{
-		Id:               forgedStateID,
-		Namespace:        tenantA,
-		ActorId:          alice.Id,
-		ConnectorId:      bobConn.ConnectorId,
-		ConnectorVersion: bobConn.ConnectorVersion,
-		ConnectionId:     bobConn.Id,
-		ReturnToUrl:      "https://example.com/return",
-		ExpiresAt:        time.Now().Add(5 * time.Minute),
+		Id:                  forgedStateID,
+		ActorNamespace:      tenantA,
+		ConnectionNamespace: tenantA,
+		ActorId:             alice.Id,
+		ConnectorId:         bobConn.ConnectorId,
+		ConnectorVersion:    bobConn.ConnectorVersion,
+		ConnectionId:        bobConn.Id,
+		ReturnToUrl:         "https://example.com/return",
+		ExpiresAt:           time.Now().Add(5 * time.Minute),
 	}, 5*time.Minute)
 
 	loc := env.DeliverOAuth2Callback(t,

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,6 +26,34 @@ var (
 	smokeAdminKey = flag.String("admin-key", os.Getenv("SMOKE_ADMIN_KEY"), "admin actor private key PEM, or a path to it")
 )
 
+const (
+	smokeConnectorNamespace  = "root.smoke"
+	smokeUserExternalID      = "smoke-user"
+	smokeConnectionNamespace = "root.smoke.smoke-user"
+)
+
+func newRemoteSmokeRig(t *testing.T) *helpers.RemoteAuthProxy {
+	t.Helper()
+
+	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
+		BaseURL:             *smokeBaseURL,
+		AdminPrivateKey:     *smokeAdminKey,
+		AdminActorNamespace: config.RootNamespace,
+		UserActorExternalID: smokeUserExternalID,
+		UserActorNamespace:  smokeConnectorNamespace,
+		ConnectorNamespace:  smokeConnectorNamespace,
+		ConnectionNamespace: smokeConnectionNamespace,
+	})
+	rig.EnsureNamespace(t, smokeConnectorNamespace)
+	rig.EnsureNamespace(t, smokeConnectionNamespace)
+	rig.WaitForUserReady(t, 3*time.Minute)
+
+	actor := rig.GetActorByExternalID(t, smokeConnectorNamespace, smokeUserExternalID)
+	require.Equal(t, smokeConnectorNamespace, actor.Namespace)
+	require.Equal(t, smokeUserExternalID, actor.ExternalId)
+	return rig
+}
+
 func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 	if *smokeBaseURL == "" {
 		t.Skip("set SMOKE_BASE_URL or pass -base-url")
@@ -33,10 +62,7 @@ func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
 	}
 
-	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
-		BaseURL:         *smokeBaseURL,
-		AdminPrivateKey: *smokeAdminKey,
-	})
+	rig := newRemoteSmokeRig(t)
 	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
 
 	startedAt := time.Now().Add(-1 * time.Second)
@@ -129,10 +155,7 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
 	}
 
-	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
-		BaseURL:         *smokeBaseURL,
-		AdminPrivateKey: *smokeAdminKey,
-	})
+	rig := newRemoteSmokeRig(t)
 	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
 
 	t.Run("catalog contains expected seeded connectors", func(t *testing.T) {

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,54 @@ func newRemoteSmokeRig(t *testing.T) *helpers.RemoteAuthProxy {
 	require.Equal(t, smokeConnectorNamespace, actor.Namespace)
 	require.Equal(t, smokeUserExternalID, actor.ExternalId)
 	return rig
+}
+
+func cloneSeededConnectorsIntoSmokeNamespace(
+	t *testing.T,
+	rig *helpers.RemoteAuthProxy,
+	provider *helpers.OAuth2TestProvider,
+	oauthClientID string,
+	oauthClientSecret string,
+) string {
+	t.Helper()
+
+	sources := rig.ListConnectorsAsAdmin(t, config.RootNamespace, "demo=true")
+	require.NotEmpty(t, sources, "the demo seed job did not create any root connectors")
+	suffix := time.Now().UnixNano()
+	runID := fmt.Sprintf("%d", suffix)
+	const runLabel = "smoke.authproxy.net/run-id"
+	for i, source := range sources {
+		detailed := rig.GetConnectorVersionAsAdmin(t, source.Id, source.Version)
+		definition := detailed.Definition
+		definition.Id = apid.New(apid.PrefixConnectorVersion)
+		definition.Version = 1
+		definition.Name = common.ResourceName(fmt.Sprintf("%s-smoke-%d-%d", source.Name, suffix, i))
+		namespace := smokeConnectorNamespace
+		definition.Namespace = &namespace
+		if source.Labels["demo.authproxy.net/seed-key"] == "demo-oauth-simple" {
+			replacement := helpers.NewOAuth2Connector(definition.Id, string(definition.Name), provider, helpers.OAuth2ConnectorOptions{
+				ClientID:     oauthClientID,
+				ClientSecret: oauthClientSecret,
+				Scopes:       []string{"read", "profile"},
+			})
+			definition.Auth = replacement.Auth
+		}
+
+		labels := make(map[string]string, len(source.Labels)+1)
+		for key, value := range source.Labels {
+			if !strings.HasPrefix(key, "apxy/") {
+				labels[key] = value
+			}
+		}
+		labels["smoke"] = "true"
+		labels[runLabel] = runID
+		created := rig.CreateConnectorWithLabels(t, definition, labels)
+		rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStatePrimary))
+		t.Cleanup(func() {
+			rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStateArchived))
+		})
+	}
+	return runLabel + "=" + runID
 }
 
 func TestRemoteOAuth2ProxySmoke(t *testing.T) {
@@ -157,16 +206,28 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 
 	rig := newRemoteSmokeRig(t)
 	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	oauthClientID := "seeded-smoke-client-" + suffix
+	oauthClientSecret := "seeded-smoke-secret-" + suffix
+	client := provider.CreateClient(helpers.CreateClientRequest{
+		Key:                     oauthClientID,
+		Secret:                  oauthClientSecret,
+		RedirectURI:             rig.PublicURL + "/oauth2/callback",
+		TokenEndpointAuthMethod: helpers.TokenEndpointAuthPost,
+		Scope:                   "read profile resources",
+	})
+	require.Equal(t, oauthClientID, client.Key)
+
+	runSelector := cloneSeededConnectorsIntoSmokeNamespace(t, rig, provider, oauthClientID, oauthClientSecret)
+	items := rig.ListConnectors(t, runSelector)
+	bySeedKey := map[string]api.ConnectorJson{}
+	for _, item := range items {
+		if key := item.Labels["demo.authproxy.net/seed-key"]; key != "" {
+			bySeedKey[key] = item
+		}
+	}
 
 	t.Run("catalog contains expected seeded connectors", func(t *testing.T) {
-		items := rig.ListConnectors(t, "demo=true")
-		bySeedKey := map[string]api.ConnectorJson{}
-		for _, item := range items {
-			if key := item.Labels["demo.authproxy.net/seed-key"]; key != "" {
-				bySeedKey[key] = item
-			}
-		}
-
 		expected := map[string]string{
 			"demo-readme-noauth":   "Demo README Resource",
 			"demo-api-key-bearer":  "Demo API Key: Bearer Token",
@@ -184,17 +245,18 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 
 	t.Run("seeded basic OAuth connector completes and proxies", func(t *testing.T) {
 		startedAt := time.Now().Add(-1 * time.Second)
-		connector := rig.FindConnectorBySeedKey(t, "demo-oauth-simple")
+		connector, ok := bySeedKey["demo-oauth-simple"]
+		require.True(t, ok, "isolated seeded OAuth connector was not created")
 		connectionID, redirectURL := rig.InitiateOAuth2Connection(t, connector.Id, rig.PublicURL+"/connections")
 
 		authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
 		authorizeParams := parseQuery(t, authorizeURL)
-		require.Equal(t, "demo-oauth-simple", authorizeParams.Get("client_id"))
+		require.Equal(t, oauthClientID, authorizeParams.Get("client_id"))
 		require.Equal(t, rig.PublicURL+"/oauth2/callback", authorizeParams.Get("redirect_uri"))
 		require.NotEmpty(t, authorizeParams.Get("state"))
 
 		callback := provider.Authorize(helpers.AuthorizeRequest{
-			ClientID:    "demo-oauth-simple",
+			ClientID:    oauthClientID,
 			Username:    "demo-oauth-user@example.test",
 			RedirectURI: authorizeParams.Get("redirect_uri"),
 			Scope:       authorizeParams.Get("scope"),
@@ -206,20 +268,22 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 		finalLocation := rig.DeliverOAuth2Callback(t, callback.RedirectURL)
 		assert.Truef(t, strings.HasPrefix(finalLocation, rig.PublicURL+"/connections"),
 			"expected callback to land on marketplace connections page, got %q", finalLocation)
+		rig.WaitForSetupComplete(t, connectionID, 30*time.Second)
 
 		proxyResp := rig.DoProxyRequest(t, connectionID, provider.ResourceURL("/echo"), http.MethodGet)
 		require.Equal(t, http.StatusOK, proxyResp.StatusCode)
 
 		tokenReqs := provider.Requests(helpers.RequestsFilter{
 			Endpoint: helpers.EndpointToken,
-			ClientID: "demo-oauth-simple",
+			ClientID: oauthClientID,
 			Since:    startedAt,
 		})
 		require.NotEmpty(t, tokenReqs, "provider should record seeded OAuth token exchange")
 	})
 
 	t.Run("seeded API key connector completes and proxies", func(t *testing.T) {
-		connector := rig.FindConnectorBySeedKey(t, "demo-api-key-bearer")
+		connector, ok := bySeedKey["demo-api-key-bearer"]
+		require.True(t, ok, "isolated seeded API-key connector was not created")
 		connectionID, stepID := rig.InitiateAPIKeyConnection(t, connector.Id)
 		respType := rig.SubmitAPIKeyCredentials(t, connectionID, stepID, "demo-api-key")
 		switch respType {

--- a/internal/apauth/tasks/service.go
+++ b/internal/apauth/tasks/service.go
@@ -37,8 +37,8 @@ type Service interface {
 	// This is typically called at startup when ConfiguredActorsList is configured.
 	SyncActorList(ctx context.Context) error
 
-	// SyncConfiguredActorsExternalSource synchronizes actors from single or
-	// namespaced external-source configuration to the database. This is
+	// SyncConfiguredActorsExternalSource synchronizes actors from namespaced
+	// external-source configuration to the database. This is
 	// typically called periodically via cron.
 	SyncConfiguredActorsExternalSource(ctx context.Context) error
 }

--- a/internal/apauth/tasks/service.go
+++ b/internal/apauth/tasks/service.go
@@ -37,8 +37,9 @@ type Service interface {
 	// This is typically called at startup when ConfiguredActorsList is configured.
 	SyncActorList(ctx context.Context) error
 
-	// SyncConfiguredActorsExternalSource synchronizes actors from ConfiguredActorsExternalSource configuration to the database.
-	// This is typically called periodically via cron when ConfiguredActorsExternalSource is configured.
+	// SyncConfiguredActorsExternalSource synchronizes actors from single or
+	// namespaced external-source configuration to the database. This is
+	// typically called periodically via cron.
 	SyncConfiguredActorsExternalSource(ctx context.Context) error
 }
 

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -29,7 +29,7 @@ func (s *service) SyncActorList(ctx context.Context) error {
 	return s.syncConfiguredActors(ctx, actors.All(), LabelValueConfigList)
 }
 
-// SyncConfiguredActorsExternalSource synchronizes actors from ConfiguredActorsExternalSource configuration to the database.
+// SyncConfiguredActorsExternalSource synchronizes actors from external source configuration to the database.
 // This function uses a distributed lock to prevent concurrent syncs across multiple workers.
 func (s *service) SyncConfiguredActorsExternalSource(ctx context.Context) error {
 	actors := s.cfg.GetRoot().SystemAuth.Actors
@@ -38,8 +38,10 @@ func (s *service) SyncConfiguredActorsExternalSource(ctx context.Context) error 
 		return nil
 	}
 
-	// Check if this is a ConfiguredActorsExternalSource
-	if _, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSource); !ok {
+	// Check if this is a single or namespaced external source configuration.
+	switch actors.InnerVal.(type) {
+	case *sconfig.ConfiguredActorsExternalSource, *sconfig.ConfiguredActorsExternalSources:
+	default:
 		s.logger.Debug("actors is not an external source type, skipping external source sync")
 		return nil
 	}

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -38,10 +38,8 @@ func (s *service) SyncConfiguredActorsExternalSource(ctx context.Context) error 
 		return nil
 	}
 
-	// Check if this is a single or namespaced external source configuration.
-	switch actors.InnerVal.(type) {
-	case *sconfig.ConfiguredActorsExternalSource, *sconfig.ConfiguredActorsExternalSources:
-	default:
+	// Check if this is a namespaced external source configuration.
+	if _, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSources); !ok {
 		s.logger.Debug("actors is not an external source type, skipping external source sync")
 		return nil
 	}

--- a/internal/apauth/tasks/sync_actors.go
+++ b/internal/apauth/tasks/sync_actors.go
@@ -72,13 +72,20 @@ func (s *service) SyncConfiguredActorsExternalSource(ctx context.Context) error 
 
 // syncConfiguredActors performs the actual sync of configured actors to the database.
 func (s *service) syncConfiguredActors(ctx context.Context, actors []*sconfig.ConfiguredActor, sourceLabel string) error {
-	// Build a set of expected external IDs
-	expectedExternalIds := make(map[string]bool)
+	type actorIdentity struct {
+		namespace  string
+		externalId string
+	}
+
+	// Actor external IDs are unique only within a namespace. Track both so
+	// moving a configured actor removes the stale copy from its old namespace.
+	expectedActors := make(map[actorIdentity]struct{}, len(actors))
 
 	// Upsert each configured actor
 	for _, actor := range actors {
 		externalId := actor.ExternalId
-		expectedExternalIds[externalId] = true
+		namespace := actor.GetNamespace()
+		expectedActors[actorIdentity{namespace: namespace, externalId: externalId}] = struct{}{}
 
 		// Serialize and encrypt the key
 		var encryptedKey *encfield.EncryptedField
@@ -105,7 +112,7 @@ func (s *service) syncConfiguredActors(ctx context.Context, actors []*sconfig.Co
 
 		// Create actor data with labels and encrypted key
 		actorData := &configuredActorData{
-			namespace:    "root",
+			namespace:    namespace,
 			externalId:   externalId,
 			labels:       labels,
 			permissions:  actor.Permissions,
@@ -127,7 +134,9 @@ func (s *service) syncConfiguredActors(ctx context.Context, actors []*sconfig.Co
 		Enumerate(ctx, func(result pagination.PageResult[*database.Actor]) (keepGoing pagination.KeepGoing, err error) {
 			for _, dbActor := range result.Results {
 				// Only delete actors with matching source label that aren't in current config
-				if dbActor.Labels[LabelConfiguredActorSyncSource] == sourceLabel && !expectedExternalIds[dbActor.ExternalId] {
+				identity := actorIdentity{namespace: dbActor.Namespace, externalId: dbActor.ExternalId}
+				_, expected := expectedActors[identity]
+				if dbActor.Labels[LabelConfiguredActorSyncSource] == sourceLabel && !expected {
 					s.logger.Info("deleting stale configured actor", "external_id", dbActor.ExternalId)
 					if err := s.db.DeleteActor(ctx, dbActor.Id); err != nil {
 						return pagination.Stop, fmt.Errorf("failed to delete stale actor %s: %w", dbActor.ExternalId, err)

--- a/internal/apauth/tasks/sync_actors_test.go
+++ b/internal/apauth/tasks/sync_actors_test.go
@@ -87,6 +87,60 @@ func TestSyncActorsList(t *testing.T) {
 		require.NotNil(t, bob.EncryptedKey)
 	})
 
+	t.Run("syncs actor into configured namespace", func(t *testing.T) {
+		actors := &sconfig.ConfiguredActors{
+			InnerVal: sconfig.ConfiguredActorsList{
+				{
+					ExternalId: "smoke-user",
+					Namespace:  "root.smoke",
+					Key: &sconfig.Key{
+						InnerVal: &sconfig.KeyShared{
+							SharedKey: &sconfig.KeyData{
+								InnerVal: &sconfig.KeyDataBase64Val{Base64: "dGVzdA=="},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		cfg := setup(t, actors)
+		require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.smoke"))
+		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
+
+		require.NoError(t, svc.SyncActorList(ctx))
+		_, err := db.GetActorByExternalId(ctx, "root.smoke", "smoke-user")
+		require.NoError(t, err)
+		_, err = db.GetActorByExternalId(ctx, "root", "smoke-user")
+		require.ErrorIs(t, err, database.ErrNotFound)
+	})
+
+	t.Run("removes stale actor after namespace changes", func(t *testing.T) {
+		key := &sconfig.Key{InnerVal: &sconfig.KeyShared{SharedKey: &sconfig.KeyData{InnerVal: &sconfig.KeyDataBase64Val{Base64: "dGVzdA=="}}}}
+		actors := &sconfig.ConfiguredActors{
+			InnerVal: sconfig.ConfiguredActorsList{{ExternalId: "smoke-user", Key: key}},
+		}
+
+		cfg := setup(t, actors)
+		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
+		require.NoError(t, svc.SyncActorList(ctx))
+
+		require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.smoke"))
+		cfg.GetRoot().SystemAuth.Actors = &sconfig.ConfiguredActors{
+			InnerVal: sconfig.ConfiguredActorsList{{
+				ExternalId: "smoke-user",
+				Namespace:  "root.smoke",
+				Key:        key,
+			}},
+		}
+		require.NoError(t, svc.SyncActorList(ctx))
+
+		_, err := db.GetActorByExternalId(ctx, "root", "smoke-user")
+		require.ErrorIs(t, err, database.ErrNotFound)
+		_, err = db.GetActorByExternalId(ctx, "root.smoke", "smoke-user")
+		require.NoError(t, err)
+	})
+
 	t.Run("deletes stale actors", func(t *testing.T) {
 		actors := &sconfig.ConfiguredActors{
 			InnerVal: sconfig.ConfiguredActorsList{
@@ -211,6 +265,9 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 		actors := &sconfig.ConfiguredActors{
 			InnerVal: &sconfig.ConfiguredActorsExternalSource{
 				KeysPath: tu.TestDataPath("admin_user_keys"),
+				NamespaceByExternalId: map[string]string{
+					"bobdole": "root.smoke",
+				},
 				Permissions: []aschema.Permission{
 					{Namespace: "root", Resources: []string{"connections"}, Verbs: []string{"list", "get"}},
 				},
@@ -218,13 +275,14 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 		}
 
 		cfg := setup(t, actors)
+		require.NoError(t, db.EnsureNamespaceByPath(ctx, "root.smoke"))
 		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
 
 		err := svc.SyncConfiguredActorsExternalSource(ctx)
 		require.NoError(t, err)
 
 		// Verify bobdole was created (one of the .pub files in test data)
-		bobdole, err := db.GetActorByExternalId(ctx, "root", "bobdole")
+		bobdole, err := db.GetActorByExternalId(ctx, "root.smoke", "bobdole")
 		require.NoError(t, err)
 		require.NotNil(t, bobdole.EncryptedKey)
 		require.Equal(t, LabelValuePublicKeyDir, bobdole.Labels[LabelConfiguredActorSyncSource])

--- a/internal/apauth/tasks/sync_actors_test.go
+++ b/internal/apauth/tasks/sync_actors_test.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -262,14 +264,20 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 	}
 
 	t.Run("syncs actors from external source", func(t *testing.T) {
+		smokeKeysPath := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(smokeKeysPath, "smoke-user.pub"), []byte("test-public-key"), 0o600))
 		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-				NamespaceByExternalId: map[string]string{
-					"bobdole": "root.smoke",
-				},
-				Permissions: []aschema.Permission{
-					{Namespace: "root", Resources: []string{"connections"}, Verbs: []string{"list", "get"}},
+			InnerVal: &sconfig.ConfiguredActorsExternalSources{
+				Sources: map[string]*sconfig.ConfiguredActorsExternalSource{
+					"root": {
+						KeysPath: tu.TestDataPath("admin_user_keys"),
+					},
+					"root.smoke": {
+						KeysPath: smokeKeysPath,
+						Permissions: []aschema.Permission{
+							{Namespace: "root.smoke.{{external_id}}", Resources: []string{"connections"}, Verbs: []string{"create"}},
+						},
+					},
 				},
 			},
 		}
@@ -281,17 +289,19 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 		err := svc.SyncConfiguredActorsExternalSource(ctx)
 		require.NoError(t, err)
 
-		// Verify bobdole was created (one of the .pub files in test data)
-		bobdole, err := db.GetActorByExternalId(ctx, "root.smoke", "bobdole")
+		// Verify a root actor was created from the root source.
+		bobdole, err := db.GetActorByExternalId(ctx, "root", "bobdole")
 		require.NoError(t, err)
 		require.NotNil(t, bobdole.EncryptedKey)
 		require.Equal(t, LabelValuePublicKeyDir, bobdole.Labels[LabelConfiguredActorSyncSource])
 
-		// Verify billclinton was created
-		billclinton, err := db.GetActorByExternalId(ctx, "root", "billclinton")
+		// Verify the smoke actor was created in its source's namespace with the
+		// source-specific, templated permissions.
+		smokeUser, err := db.GetActorByExternalId(ctx, "root.smoke", "smoke-user")
 		require.NoError(t, err)
-		require.NotNil(t, billclinton.EncryptedKey)
-		require.Equal(t, LabelValuePublicKeyDir, billclinton.Labels[LabelConfiguredActorSyncSource])
+		require.NotNil(t, smokeUser.EncryptedKey)
+		require.Equal(t, LabelValuePublicKeyDir, smokeUser.Labels[LabelConfiguredActorSyncSource])
+		require.Equal(t, "root.smoke.{{external_id}}", smokeUser.Permissions[0].Namespace)
 	})
 
 	t.Run("deletes stale actors from external source", func(t *testing.T) {

--- a/internal/apauth/tasks/sync_actors_test.go
+++ b/internal/apauth/tasks/sync_actors_test.go
@@ -20,6 +20,16 @@ import (
 	clock "k8s.io/utils/clock/testing"
 )
 
+func externalActorsInRoot(keysPath string) *sconfig.ConfiguredActors {
+	return &sconfig.ConfiguredActors{
+		InnerVal: &sconfig.ConfiguredActorsExternalSources{
+			Sources: map[string]*sconfig.ConfiguredActorsExternalSource{
+				sconfig.RootNamespace: {KeysPath: keysPath},
+			},
+		},
+	}
+}
+
 func TestSyncActorsList(t *testing.T) {
 	var db database.DB
 	var redis apredis.Client
@@ -220,11 +230,7 @@ func TestSyncActorsList(t *testing.T) {
 	})
 
 	t.Run("skips sync for non-list actors", func(t *testing.T) {
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: "/tmp/keys",
-			},
-		}
+		actors := externalActorsInRoot("/tmp/keys")
 
 		cfg := setup(t, actors)
 		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
@@ -306,11 +312,7 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 
 	t.Run("deletes stale actors from external source", func(t *testing.T) {
 		// First sync with external source to create actors
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-			},
-		}
+		actors := externalActorsInRoot(tu.TestDataPath("admin_user_keys"))
 
 		cfg := setup(t, actors)
 		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
@@ -347,11 +349,7 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 	})
 
 	t.Run("does not delete actors from different sync source", func(t *testing.T) {
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-			},
-		}
+		actors := externalActorsInRoot(tu.TestDataPath("admin_user_keys"))
 
 		cfg := setup(t, actors)
 		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
@@ -376,11 +374,7 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 	})
 
 	t.Run("encrypted key can be decrypted", func(t *testing.T) {
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-			},
-		}
+		actors := externalActorsInRoot(tu.TestDataPath("admin_user_keys"))
 
 		cfg := setup(t, actors)
 		svc := NewService(cfg, db, redis, enc, cfg.GetRootLogger())
@@ -444,11 +438,7 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 	})
 
 	t.Run("skips sync when lock already held", func(t *testing.T) {
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-			},
-		}
+		actors := externalActorsInRoot(tu.TestDataPath("admin_user_keys"))
 
 		cfg := setup(t, actors)
 
@@ -473,11 +463,7 @@ func TestSyncConfiguredActorsExternalSource(t *testing.T) {
 	})
 
 	t.Run("works without redis", func(t *testing.T) {
-		actors := &sconfig.ConfiguredActors{
-			InnerVal: &sconfig.ConfiguredActorsExternalSource{
-				KeysPath: tu.TestDataPath("admin_user_keys"),
-			},
-		}
+		actors := externalActorsInRoot(tu.TestDataPath("admin_user_keys"))
 
 		cfg := setup(t, actors)
 

--- a/internal/apauth/tasks/tasks.go
+++ b/internal/apauth/tasks/tasks.go
@@ -56,19 +56,14 @@ func (th *taskHandler) GetCronTasks() []*asynq.PeriodicTaskConfig {
 		return nil
 	}
 
-	var cronspec string
-	switch sources := actors.InnerVal.(type) {
-	case *sconfig.ConfiguredActorsExternalSource:
-		cronspec = sources.GetSyncCronScheduleOrDefault()
-	case *sconfig.ConfiguredActorsExternalSources:
-		cronspec = sources.GetSyncCronScheduleOrDefault()
-	default:
+	sources, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSources)
+	if !ok {
 		return nil
 	}
 
 	return []*asynq.PeriodicTaskConfig{
 		{
-			Cronspec: cronspec,
+			Cronspec: sources.GetSyncCronScheduleOrDefault(),
 			Task:     NewSyncActorsExternalSourceTask(),
 		},
 		{

--- a/internal/apauth/tasks/tasks.go
+++ b/internal/apauth/tasks/tasks.go
@@ -49,22 +49,26 @@ func (th *taskHandler) RegisterTasks(mux *asynq.ServeMux) {
 }
 
 // GetCronTasks returns the cron task configurations for actor sync.
-// Only returns tasks if ConfiguredActorsExternalSource is configured.
+// Only returns tasks if an external actor source is configured.
 func (th *taskHandler) GetCronTasks() []*asynq.PeriodicTaskConfig {
 	actors := th.cfg.GetRoot().SystemAuth.Actors
 	if actors == nil {
 		return nil
 	}
 
-	// Only create cron task for external source configuration
-	caes, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSource)
-	if !ok {
+	var cronspec string
+	switch sources := actors.InnerVal.(type) {
+	case *sconfig.ConfiguredActorsExternalSource:
+		cronspec = sources.GetSyncCronScheduleOrDefault()
+	case *sconfig.ConfiguredActorsExternalSources:
+		cronspec = sources.GetSyncCronScheduleOrDefault()
+	default:
 		return nil
 	}
 
 	return []*asynq.PeriodicTaskConfig{
 		{
-			Cronspec: caes.GetSyncCronScheduleOrDefault(),
+			Cronspec: cronspec,
 			Task:     NewSyncActorsExternalSourceTask(),
 		},
 		{

--- a/internal/auth_methods/oauth2/callback_rejection.go
+++ b/internal/auth_methods/oauth2/callback_rejection.go
@@ -36,7 +36,7 @@ const (
 	// cannot trust a state we cannot fully validate.
 	rejectionStateLoadError rejectionCategory = "state_load_error"
 	// rejectionStateInvalid — the decrypted state was missing required
-	// fields per state.IsValid (empty namespace, zero ids, etc.).
+	// fields per state.IsValid (empty actor/connection namespace, zero ids, etc.).
 	rejectionStateInvalid rejectionCategory = "state_invalid"
 	// rejectionExpiredState — the state's ExpiresAt is in the past.
 	rejectionExpiredState rejectionCategory = "expired_state"
@@ -45,12 +45,13 @@ const (
 	// complete someone else's flow.
 	rejectionActorMismatch rejectionCategory = "actor_mismatch"
 	// rejectionNamespaceMismatchActor — the inbound actor's namespace does
-	// not match the state's namespace. Cross-tenant probe via a stolen or
-	// guessed state id.
+	// not match the actor namespace recorded on the state. Cross-tenant probe
+	// via a stolen or guessed state id.
 	rejectionNamespaceMismatchActor rejectionCategory = "namespace_mismatch_actor"
 	// rejectionNamespaceMismatchConnection — the connection referenced by
-	// the state lives in a different namespace than the state itself.
-	// State was crafted against another tenant's connection id.
+	// the state lives in a different namespace than the connection namespace
+	// recorded on the state. State was crafted against another tenant's
+	// connection id.
 	rejectionNamespaceMismatchConnection rejectionCategory = "namespace_mismatch_connection"
 	// rejectionConnectionNotFound — the connection id on the state has no
 	// matching record. Usually a deleted connection or a fabricated id.

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -22,12 +22,9 @@ import (
 )
 
 type state struct {
-	Id                  apid.ID `json:"id"`
-	ActorNamespace      string  `json:"actorNamespace,omitempty"`
-	ConnectionNamespace string  `json:"connectionNamespace,omitempty"`
-	// LegacyNamespace keeps OAuth flows created before actor and connection
-	// namespaces were stored independently valid across a rolling deployment.
-	LegacyNamespace        string    `json:"namespace,omitempty"`
+	Id                     apid.ID   `json:"id"`
+	ActorNamespace         string    `json:"actorNamespace,omitempty"`
+	ConnectionNamespace    string    `json:"connectionNamespace,omitempty"`
 	ActorId                apid.ID   `json:"actorId"`
 	ConnectorId            apid.ID   `json:"connectorId"`
 	ConnectorVersion       uint64    `json:"connectorVersion"`
@@ -50,21 +47,7 @@ type state struct {
 }
 
 func (s *state) IsValid() bool {
-	return s.GetActorNamespace() != "" && s.GetConnectionNamespace() != "" && s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
-}
-
-func (s *state) GetActorNamespace() string {
-	if s.ActorNamespace != "" {
-		return s.ActorNamespace
-	}
-	return s.LegacyNamespace
-}
-
-func (s *state) GetConnectionNamespace() string {
-	if s.ConnectionNamespace != "" {
-		return s.ConnectionNamespace
-	}
-	return s.LegacyNamespace
+	return s.ActorNamespace != "" && s.ConnectionNamespace != "" && s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
 }
 
 // writeStateToRedis encrypts the state with the global key (AES-GCM AEAD)
@@ -211,7 +194,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetActorNamespace(),
+			Namespace:    s.ActorNamespace,
 			Err:          err,
 		})
 		return nil, err
@@ -223,7 +206,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetActorNamespace(),
+			Namespace:    s.ActorNamespace,
 			Err:          err,
 		})
 		return nil, err
@@ -235,19 +218,19 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetActorNamespace(),
+			Namespace:    s.ActorNamespace,
 			Err:          err,
 		})
 		return nil, err
 	}
 
-	if s.GetActorNamespace() != actor.GetNamespace() {
-		err := fmt.Errorf("actor namespace %q does not match state actor namespace %q", actor.GetNamespace(), s.GetActorNamespace())
+	if s.ActorNamespace != actor.GetNamespace() {
+		err := fmt.Errorf("actor namespace %q does not match state actor namespace %q", actor.GetNamespace(), s.ActorNamespace)
 		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchActor, rejectionAttrs{
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetActorNamespace(),
+			Namespace:    s.ActorNamespace,
 			Err:          err,
 		})
 		return nil, err
@@ -261,7 +244,7 @@ func getOAuth2State(
 				StateId:      stateId,
 				ActorId:      actor.GetId(),
 				ConnectionId: s.ConnectionId,
-				Namespace:    s.GetConnectionNamespace(),
+				Namespace:    s.ConnectionNamespace,
 				Err:          notFoundErr,
 			})
 			return nil, notFoundErr
@@ -270,13 +253,13 @@ func getOAuth2State(
 		return nil, fmt.Errorf("failed to get connection %s for state %s: %w", s.ConnectionId.String(), stateId.String(), err)
 	}
 
-	if s.GetConnectionNamespace() != connection.GetNamespace() {
-		err := fmt.Errorf("connection namespace %q does not match state connection namespace %q", connection.GetNamespace(), s.GetConnectionNamespace())
+	if s.ConnectionNamespace != connection.GetNamespace() {
+		err := fmt.Errorf("connection namespace %q does not match state connection namespace %q", connection.GetNamespace(), s.ConnectionNamespace)
 		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchConnection, rejectionAttrs{
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetConnectionNamespace(),
+			Namespace:    s.ConnectionNamespace,
 			Err:          err,
 		})
 		return nil, err
@@ -290,7 +273,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.GetConnectionNamespace(),
+			Namespace:    s.ConnectionNamespace,
 			Err:          err,
 		})
 		return nil, err

--- a/internal/auth_methods/oauth2/state.go
+++ b/internal/auth_methods/oauth2/state.go
@@ -22,8 +22,12 @@ import (
 )
 
 type state struct {
-	Id                     apid.ID   `json:"id"`
-	Namespace              string    `json:"namespace"`
+	Id                  apid.ID `json:"id"`
+	ActorNamespace      string  `json:"actorNamespace,omitempty"`
+	ConnectionNamespace string  `json:"connectionNamespace,omitempty"`
+	// LegacyNamespace keeps OAuth flows created before actor and connection
+	// namespaces were stored independently valid across a rolling deployment.
+	LegacyNamespace        string    `json:"namespace,omitempty"`
 	ActorId                apid.ID   `json:"actorId"`
 	ConnectorId            apid.ID   `json:"connectorId"`
 	ConnectorVersion       uint64    `json:"connectorVersion"`
@@ -46,7 +50,21 @@ type state struct {
 }
 
 func (s *state) IsValid() bool {
-	return s.Namespace != "" && s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
+	return s.GetActorNamespace() != "" && s.GetConnectionNamespace() != "" && s.ActorId != apid.Nil && s.ConnectorId != apid.Nil && s.ConnectionId != apid.Nil && !s.ExpiresAt.IsZero()
+}
+
+func (s *state) GetActorNamespace() string {
+	if s.ActorNamespace != "" {
+		return s.ActorNamespace
+	}
+	return s.LegacyNamespace
+}
+
+func (s *state) GetConnectionNamespace() string {
+	if s.ConnectionNamespace != "" {
+		return s.ConnectionNamespace
+	}
+	return s.LegacyNamespace
 }
 
 // writeStateToRedis encrypts the state with the global key (AES-GCM AEAD)
@@ -116,14 +134,15 @@ func getStateRedisKey(u apid.ID) string {
 func (o *oAuth2Connection) saveStateToRedis(ctx context.Context, actor IActorData, stateId apid.ID, returnToUrl string) error {
 	ttl := o.cfg.GetRoot().Oauth.GetRoundTripTtlOrDefault()
 	s := &state{
-		Id:               stateId,
-		Namespace:        actor.GetNamespace(),
-		ActorId:          actor.GetId(),
-		ConnectorId:      o.connection.GetConnector().GetId(),
-		ConnectorVersion: o.connection.GetConnector().GetVersion(),
-		ConnectionId:     o.connection.GetId(),
-		ExpiresAt:        time.Now().Add(ttl),
-		ReturnToUrl:      returnToUrl,
+		Id:                  stateId,
+		ActorNamespace:      actor.GetNamespace(),
+		ConnectionNamespace: o.connection.GetNamespace(),
+		ActorId:             actor.GetId(),
+		ConnectorId:         o.connection.GetConnector().GetId(),
+		ConnectorVersion:    o.connection.GetConnector().GetVersion(),
+		ConnectionId:        o.connection.GetId(),
+		ExpiresAt:           time.Now().Add(ttl),
+		ReturnToUrl:         returnToUrl,
 	}
 
 	if o.auth != nil && o.auth.Authorization.PKCE != nil {
@@ -192,7 +211,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetActorNamespace(),
 			Err:          err,
 		})
 		return nil, err
@@ -204,7 +223,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetActorNamespace(),
 			Err:          err,
 		})
 		return nil, err
@@ -216,19 +235,19 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetActorNamespace(),
 			Err:          err,
 		})
 		return nil, err
 	}
 
-	if s.Namespace != actor.GetNamespace() {
-		err := fmt.Errorf("actor namespace %q does not match state namespace %q", actor.GetNamespace(), s.Namespace)
+	if s.GetActorNamespace() != actor.GetNamespace() {
+		err := fmt.Errorf("actor namespace %q does not match state actor namespace %q", actor.GetNamespace(), s.GetActorNamespace())
 		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchActor, rejectionAttrs{
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetActorNamespace(),
 			Err:          err,
 		})
 		return nil, err
@@ -242,7 +261,7 @@ func getOAuth2State(
 				StateId:      stateId,
 				ActorId:      actor.GetId(),
 				ConnectionId: s.ConnectionId,
-				Namespace:    s.Namespace,
+				Namespace:    s.GetConnectionNamespace(),
 				Err:          notFoundErr,
 			})
 			return nil, notFoundErr
@@ -251,13 +270,13 @@ func getOAuth2State(
 		return nil, fmt.Errorf("failed to get connection %s for state %s: %w", s.ConnectionId.String(), stateId.String(), err)
 	}
 
-	if s.Namespace != connection.GetNamespace() {
-		err := fmt.Errorf("connection namespace %q does not match state namespace %q", connection.GetNamespace(), s.Namespace)
+	if s.GetConnectionNamespace() != connection.GetNamespace() {
+		err := fmt.Errorf("connection namespace %q does not match state connection namespace %q", connection.GetNamespace(), s.GetConnectionNamespace())
 		emitCallbackRejection(ctx, logger, rejectionNamespaceMismatchConnection, rejectionAttrs{
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetConnectionNamespace(),
 			Err:          err,
 		})
 		return nil, err
@@ -271,7 +290,7 @@ func getOAuth2State(
 			StateId:      stateId,
 			ActorId:      actor.GetId(),
 			ConnectionId: s.ConnectionId,
-			Namespace:    s.Namespace,
+			Namespace:    s.GetConnectionNamespace(),
 			Err:          err,
 		})
 		return nil, err

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -93,17 +94,10 @@ func TestState_RoundTripPreservesNamespaces(t *testing.T) {
 
 	loaded, err := readStateFromRedis(ctx, r, e, original.Id)
 	require.NoError(t, err)
-	assert.Equal(t, original.ActorNamespace, loaded.GetActorNamespace())
-	assert.Equal(t, original.ConnectionNamespace, loaded.GetConnectionNamespace())
+	assert.Equal(t, original.ActorNamespace, loaded.ActorNamespace)
+	assert.Equal(t, original.ConnectionNamespace, loaded.ConnectionNamespace)
 	assert.Equal(t, original.ActorId, loaded.ActorId)
 	assert.Equal(t, original.ConnectionId, loaded.ConnectionId)
-}
-
-func TestState_LegacyNamespaceAppliesToActorAndConnection(t *testing.T) {
-	s := &state{LegacyNamespace: "root.tenant-a"}
-
-	assert.Equal(t, "root.tenant-a", s.GetActorNamespace())
-	assert.Equal(t, "root.tenant-a", s.GetConnectionNamespace())
 }
 
 func TestSaveStateCapturesDistinctActorAndConnectionNamespaces(t *testing.T) {
@@ -134,8 +128,8 @@ func TestSaveStateCapturesDistinctActorAndConnectionNamespaces(t *testing.T) {
 	require.NoError(t, o.saveStateToRedis(ctx, actor, stateId, "https://example.com/return"))
 	loaded, err := readStateFromRedis(ctx, r, e, stateId)
 	require.NoError(t, err)
-	assert.Equal(t, "root.smoke", loaded.GetActorNamespace())
-	assert.Equal(t, "root.smoke.smoke-user", loaded.GetConnectionNamespace())
+	assert.Equal(t, "root.smoke", loaded.ActorNamespace)
+	assert.Equal(t, "root.smoke.smoke-user", loaded.ConnectionNamespace)
 }
 
 func TestState_RedisValueIsCiphertext(t *testing.T) {
@@ -220,8 +214,8 @@ func TestState_IsValidRequiresActorAndConnectionNamespaces(t *testing.T) {
 	require.False(t, withoutConnectionNamespace.IsValid(), "empty connection namespace must invalidate the state")
 
 	legacy := base
-	legacy.LegacyNamespace = "root.tenant-a"
-	require.True(t, legacy.IsValid(), "legacy namespace must remain valid for in-flight states")
+	require.NoError(t, json.Unmarshal([]byte(`{"namespace":"root.tenant-a"}`), &legacy))
+	require.False(t, legacy.IsValid(), "legacy namespace-only state must be invalid")
 }
 
 func TestGetOAuth2State_RejectsEmptyNamespaceInState(t *testing.T) {

--- a/internal/auth_methods/oauth2/state_test.go
+++ b/internal/auth_methods/oauth2/state_test.go
@@ -51,6 +51,17 @@ func (c *stateTestCore) GetConnection(_ context.Context, _ apid.ID) (coreIface.C
 	return c.conn, nil
 }
 
+type stateTestConnection struct {
+	coreIface.Connection
+	id        apid.ID
+	namespace string
+	connector coreIface.Connector
+}
+
+func (c *stateTestConnection) GetId() apid.ID                    { return c.id }
+func (c *stateTestConnection) GetNamespace() string              { return c.namespace }
+func (c *stateTestConnection) GetConnector() coreIface.Connector { return c.connector }
+
 func newStateTestEncrypt(t *testing.T) encrypt.E {
 	t.Helper()
 	cfg := config.FromRoot(&sconfig.Root{
@@ -63,27 +74,68 @@ func newStateTestEncrypt(t *testing.T) encrypt.E {
 	return e
 }
 
-func TestState_RoundTripPreservesNamespace(t *testing.T) {
+func TestState_RoundTripPreservesNamespaces(t *testing.T) {
 	ctx := context.Background()
 	_, r := apredis.MustApplyTestConfig(nil)
 	e := encrypt.NewFakeEncryptService(false)
 
 	original := &state{
-		Id:           apid.New(apid.PrefixOauth2State),
-		Namespace:    "root.tenant-a",
-		ActorId:      apid.New(apid.PrefixActor),
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
-		ReturnToUrl:  "https://example.com/return",
+		Id:                  apid.New(apid.PrefixOauth2State),
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             apid.New(apid.PrefixActor),
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
+		ReturnToUrl:         "https://example.com/return",
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, original, time.Minute))
 
 	loaded, err := readStateFromRedis(ctx, r, e, original.Id)
 	require.NoError(t, err)
-	assert.Equal(t, original.Namespace, loaded.Namespace)
+	assert.Equal(t, original.ActorNamespace, loaded.GetActorNamespace())
+	assert.Equal(t, original.ConnectionNamespace, loaded.GetConnectionNamespace())
 	assert.Equal(t, original.ActorId, loaded.ActorId)
 	assert.Equal(t, original.ConnectionId, loaded.ConnectionId)
+}
+
+func TestState_LegacyNamespaceAppliesToActorAndConnection(t *testing.T) {
+	s := &state{LegacyNamespace: "root.tenant-a"}
+
+	assert.Equal(t, "root.tenant-a", s.GetActorNamespace())
+	assert.Equal(t, "root.tenant-a", s.GetConnectionNamespace())
+}
+
+func TestSaveStateCapturesDistinctActorAndConnectionNamespaces(t *testing.T) {
+	ctx := context.Background()
+	_, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	connector := &mockCore.Connector{
+		Id:      apid.New(apid.PrefixConnectorVersion),
+		Version: 1,
+	}
+	connection := &stateTestConnection{
+		id:        apid.New(apid.PrefixConnection),
+		namespace: "root.smoke.smoke-user",
+		connector: connector,
+	}
+	o := &oAuth2Connection{
+		cfg:        config.FromRoot(&sconfig.Root{}),
+		r:          r,
+		encrypt:    e,
+		connection: connection,
+	}
+	actor := stateTestActor{
+		id:        apid.New(apid.PrefixActor),
+		namespace: "root.smoke",
+	}
+	stateId := apid.New(apid.PrefixOauth2State)
+
+	require.NoError(t, o.saveStateToRedis(ctx, actor, stateId, "https://example.com/return"))
+	loaded, err := readStateFromRedis(ctx, r, e, stateId)
+	require.NoError(t, err)
+	assert.Equal(t, "root.smoke", loaded.GetActorNamespace())
+	assert.Equal(t, "root.smoke.smoke-user", loaded.GetConnectionNamespace())
 }
 
 func TestState_RedisValueIsCiphertext(t *testing.T) {
@@ -92,19 +144,21 @@ func TestState_RedisValueIsCiphertext(t *testing.T) {
 	e := newStateTestEncrypt(t)
 
 	s := &state{
-		Id:           apid.New(apid.PrefixOauth2State),
-		Namespace:    "root.tenant-a",
-		ActorId:      apid.New(apid.PrefixActor),
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  apid.New(apid.PrefixOauth2State),
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             apid.New(apid.PrefixActor),
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
 	raw, err := r.Get(ctx, getStateRedisKey(s.Id)).Result()
 	require.NoError(t, err)
 	// Sanity: the raw blob must NOT contain the namespace string in plaintext.
-	assert.NotContains(t, raw, s.Namespace, "namespace must not appear in cleartext in redis")
+	assert.NotContains(t, raw, s.ActorNamespace, "actor namespace must not appear in cleartext in redis")
+	assert.NotContains(t, raw, s.ConnectionNamespace, "connection namespace must not appear in cleartext in redis")
 	assert.NotContains(t, raw, s.ActorId.String(), "actor id must not appear in cleartext in redis")
 }
 
@@ -114,12 +168,13 @@ func TestState_TamperedCiphertextFailsToDecrypt(t *testing.T) {
 	e := newStateTestEncrypt(t)
 
 	s := &state{
-		Id:           apid.New(apid.PrefixOauth2State),
-		Namespace:    "root.tenant-a",
-		ActorId:      apid.New(apid.PrefixActor),
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  apid.New(apid.PrefixOauth2State),
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             apid.New(apid.PrefixActor),
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
@@ -143,7 +198,7 @@ func TestState_TamperedCiphertextFailsToDecrypt(t *testing.T) {
 	assert.Contains(t, err.Error(), "decrypt")
 }
 
-func TestState_IsValidRequiresNamespace(t *testing.T) {
+func TestState_IsValidRequiresActorAndConnectionNamespaces(t *testing.T) {
 	base := state{
 		ActorId:      apid.New(apid.PrefixActor),
 		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
@@ -151,12 +206,22 @@ func TestState_IsValidRequiresNamespace(t *testing.T) {
 		ExpiresAt:    time.Now().Add(time.Minute),
 	}
 
-	withNs := base
-	withNs.Namespace = "root.tenant-a"
-	require.True(t, withNs.IsValid(), "state with all fields populated must be valid")
+	withNamespaces := base
+	withNamespaces.ActorNamespace = "root.tenant-a"
+	withNamespaces.ConnectionNamespace = "root.tenant-a.user-a"
+	require.True(t, withNamespaces.IsValid(), "state with all fields populated must be valid")
 
-	withoutNs := base
-	require.False(t, withoutNs.IsValid(), "empty namespace must invalidate the state")
+	withoutActorNamespace := withNamespaces
+	withoutActorNamespace.ActorNamespace = ""
+	require.False(t, withoutActorNamespace.IsValid(), "empty actor namespace must invalidate the state")
+
+	withoutConnectionNamespace := withNamespaces
+	withoutConnectionNamespace.ConnectionNamespace = ""
+	require.False(t, withoutConnectionNamespace.IsValid(), "empty connection namespace must invalidate the state")
+
+	legacy := base
+	legacy.LegacyNamespace = "root.tenant-a"
+	require.True(t, legacy.IsValid(), "legacy namespace must remain valid for in-flight states")
 }
 
 func TestGetOAuth2State_RejectsEmptyNamespaceInState(t *testing.T) {
@@ -171,7 +236,6 @@ func TestGetOAuth2State_RejectsEmptyNamespaceInState(t *testing.T) {
 	// when the inbound actor's namespace happens to be empty too.
 	s := &state{
 		Id:           stateId,
-		Namespace:    "",
 		ActorId:      actorId,
 		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
 		ConnectionId: apid.New(apid.PrefixConnection),
@@ -196,19 +260,20 @@ func TestGetOAuth2State_RejectsNamespaceMismatchOnActor(t *testing.T) {
 	stateId := apid.New(apid.PrefixOauth2State)
 	actorId := apid.New(apid.PrefixActor)
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      actorId,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             actorId,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
 	// The state was created against tenant-a but the inbound actor claims tenant-b.
 	// Even with a matching actor id, the namespace check must reject.
 	actor := stateTestActor{id: actorId, namespace: "root.tenant-b"}
-	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-a.user-a"}}
 
 	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
 	require.Error(t, err)
@@ -224,12 +289,13 @@ func TestGetOAuth2State_RejectsNamespaceMismatchOnConnection(t *testing.T) {
 	stateId := apid.New(apid.PrefixOauth2State)
 	actorId := apid.New(apid.PrefixActor)
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      actorId,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             actorId,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
@@ -237,11 +303,54 @@ func TestGetOAuth2State_RejectsNamespaceMismatchOnConnection(t *testing.T) {
 	// namespace — likely because the state was crafted against another tenant's
 	// connection id. Reject before we reach the auth-method dispatch.
 	actor := stateTestActor{id: actorId, namespace: "root.tenant-a"}
-	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b.user-a"}}
 
 	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection namespace")
+}
+
+func TestGetOAuth2State_AcceptsDistinctActorAndConnectionNamespaces(t *testing.T) {
+	ctx := context.Background()
+	cfg, r := apredis.MustApplyTestConfig(nil)
+	e := encrypt.NewFakeEncryptService(false)
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+
+	stateId := apid.New(apid.PrefixOauth2State)
+	actorId := apid.New(apid.PrefixActor)
+	connectorId := apid.New(apid.PrefixConnectorVersion)
+	connectionId := apid.New(apid.PrefixConnection)
+	s := &state{
+		Id:                  stateId,
+		ActorNamespace:      "root.smoke",
+		ConnectionNamespace: "root.smoke.smoke-user",
+		ActorId:             actorId,
+		ConnectorId:         connectorId,
+		ConnectionId:        connectionId,
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
+	}
+	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
+
+	connector := &mockCore.Connector{
+		Id: connectorId,
+		Definition: &sconfig.Connector{
+			Id: connectorId,
+			Auth: &sconfig.Auth{InnerVal: &sconfig.AuthOAuth2{
+				Type: sconfig.AuthTypeOAuth2,
+			}},
+		},
+	}
+	connection := &stateTestConnection{
+		id:        connectionId,
+		namespace: "root.smoke.smoke-user",
+		connector: connector,
+	}
+	actor := stateTestActor{id: actorId, namespace: "root.smoke"}
+	core := &stateTestCore{conn: connection}
+
+	o2, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
+	require.NoError(t, err)
+	assert.NotNil(t, o2)
 }
 
 // testWriter routes slog output through t.Log so it shows up under -v.
@@ -281,12 +390,13 @@ func TestGetOAuth2State_EmitsRejectionEvent_TamperedState(t *testing.T) {
 	stateId := apid.New(apid.PrefixOauth2State)
 	actor := stateTestActor{id: apid.New(apid.PrefixActor), namespace: "root.tenant-a"}
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      actor.id,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             actor.id,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
@@ -318,18 +428,19 @@ func TestGetOAuth2State_EmitsRejectionEvent_ActorMismatch(t *testing.T) {
 	stateId := apid.New(apid.PrefixOauth2State)
 	stateActorId := apid.New(apid.PrefixActor)
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      stateActorId,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             stateActorId,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
 	// Inbound actor differs from the actor recorded on the state.
 	actor := stateTestActor{id: apid.New(apid.PrefixActor), namespace: "root.tenant-a"}
-	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-a"}}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-a.user-a"}}
 
 	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
 	require.Error(t, err)
@@ -349,17 +460,18 @@ func TestGetOAuth2State_EmitsRejectionEvent_NamespaceMismatchActor(t *testing.T)
 	stateId := apid.New(apid.PrefixOauth2State)
 	actorId := apid.New(apid.PrefixActor)
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      actorId,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             actorId,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
 	actor := stateTestActor{id: actorId, namespace: "root.tenant-b"}
-	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-a.user-a"}}
 
 	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
 	require.Error(t, err)
@@ -379,17 +491,18 @@ func TestGetOAuth2State_EmitsRejectionEvent_NamespaceMismatchConnection(t *testi
 	stateId := apid.New(apid.PrefixOauth2State)
 	actorId := apid.New(apid.PrefixActor)
 	s := &state{
-		Id:           stateId,
-		Namespace:    "root.tenant-a",
-		ActorId:      actorId,
-		ConnectorId:  apid.New(apid.PrefixConnectorVersion),
-		ConnectionId: apid.New(apid.PrefixConnection),
-		ExpiresAt:    time.Now().Add(time.Minute).UTC(),
+		Id:                  stateId,
+		ActorNamespace:      "root.tenant-a",
+		ConnectionNamespace: "root.tenant-a.user-a",
+		ActorId:             actorId,
+		ConnectorId:         apid.New(apid.PrefixConnectorVersion),
+		ConnectionId:        apid.New(apid.PrefixConnection),
+		ExpiresAt:           time.Now().Add(time.Minute).UTC(),
 	}
 	require.NoError(t, writeStateToRedis(ctx, r, e, s, time.Minute))
 
 	actor := stateTestActor{id: actorId, namespace: "root.tenant-a"}
-	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b"}}
+	core := &stateTestCore{conn: &mockCore.Connection{Namespace: "root.tenant-b.user-a"}}
 
 	_, err := getOAuth2State(ctx, cfg, nil, r, core, nil, e, logger, actor, stateId)
 	require.Error(t, err)

--- a/internal/auth_methods/oauth2/token_exchange_failure.go
+++ b/internal/auth_methods/oauth2/token_exchange_failure.go
@@ -181,7 +181,7 @@ func (o *oAuth2Connection) tokenExchangeAttrsFromConn(err error) tokenExchangeAt
 	if o.state != nil {
 		attrs.StateId = o.state.Id
 		attrs.ActorId = o.state.ActorId
-		attrs.Namespace = o.state.GetConnectionNamespace()
+		attrs.Namespace = o.state.ConnectionNamespace
 	}
 	return attrs
 }

--- a/internal/auth_methods/oauth2/token_exchange_failure.go
+++ b/internal/auth_methods/oauth2/token_exchange_failure.go
@@ -181,7 +181,7 @@ func (o *oAuth2Connection) tokenExchangeAttrsFromConn(err error) tokenExchangeAt
 	if o.state != nil {
 		attrs.StateId = o.state.Id
 		attrs.ActorId = o.state.ActorId
-		attrs.Namespace = o.state.Namespace
+		attrs.Namespace = o.state.GetConnectionNamespace()
 	}
 	return attrs
 }

--- a/internal/core/service_connection_create.go
+++ b/internal/core/service_connection_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	apauth "github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/aplog"
@@ -28,7 +29,12 @@ func (s *service) CreateConnection(
 	)
 
 	if !ns.IsSameOrChild(c.GetNamespace(), namespace) {
-		return nil, httperr.BadRequestErr(errors.New("connections must be created in the same or child namespace of the connector"))
+		return nil, httperr.BadRequest("connections must be created in the same or child namespace of the connector")
+	}
+
+	actor := apauth.ActorFromContext(ctx)
+	if !ns.IsSameOrChild(actor.GetNamespace(), namespace) {
+		return nil, httperr.Forbidden("connection namespace must be child of creating actor")
 	}
 
 	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnection)

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	apauth "github.com/rmorlok/authproxy/internal/apauth/core"
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
@@ -20,7 +21,10 @@ import (
 
 // InitiateConnection starts the process of initiating the connection. This method provides auth validation as part of
 // the logic.
-func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConnectionRequest) (iface.ConnectionSetupResponse, error) {
+func (s *service) InitiateConnection(
+	ctx context.Context,
+	req iface.InitiateConnectionRequest,
+) (iface.ConnectionSetupResponse, error) {
 	val := auth.MustGetValidatorFromContext(ctx)
 	if err := req.Validate(); err != nil {
 		val.MarkErrorReturn()
@@ -60,8 +64,13 @@ func (s *service) InitiateConnection(ctx context.Context, req iface.InitiateConn
 		return nil, httperr.BadRequestf("target namespace '%s' is not a child of the connector's namespace '%s'", targetNamespace, c.GetNamespace())
 	}
 
-	// Primary validation for the request -- make sure the user can initiate connections in the target namespace with
-	// the specified connector id.
+	actor := apauth.ActorFromContext(ctx)
+	if !namespace.IsSameOrChild(actor.GetNamespace(), targetNamespace) {
+		return nil, httperr.Forbidden("connection namespace must be child of creating actor")
+	}
+
+	// Primary validation for the request -- make sure the user can initiate
+	// connections in the target namespace with the specified connector id.
 	if err := val.ValidateNamespaceResourceId(targetNamespace, c.GetId().String()); err != nil {
 		val.MarkErrorReturn()
 		return nil, httperr.Forbidden(err.Error(), httperr.WithInternalErr(err))

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -53,6 +53,9 @@ func (s *service) MigrateNamespaces(ctx context.Context) error {
 	for _, configConnector := range cfgRoot.Connectors.GetConnectors() {
 		namespaces = append(namespaces, configConnector.GetNamespace())
 	}
+	for _, configuredActor := range cfgRoot.SystemAuth.Actors.All() {
+		namespaces = append(namespaces, configuredActor.GetNamespace())
+	}
 
 	prefixOrderedList := namespace.SplitPathsToPrefixes(namespaces)
 

--- a/internal/core/service_migration_test.go
+++ b/internal/core/service_migration_test.go
@@ -1866,4 +1866,29 @@ func TestMigration(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("namespaces", func(t *testing.T) {
+		t.Run("includes configured actor namespaces", func(t *testing.T) {
+			cleanup := setup(t, []cschema.Connector{})
+			defer cleanup()
+
+			cfg.GetRoot().SystemAuth.Actors = &cfgschema.ConfiguredActors{
+				InnerVal: cfgschema.ConfiguredActorsList{{
+					ExternalId: "smoke-user",
+					Namespace:  "root.smoke",
+					Key: &cfgschema.Key{
+						InnerVal: &cfgschema.KeyShared{
+							SharedKey: &cfgschema.KeyData{
+								InnerVal: &cfgschema.KeyDataBase64Val{Base64: "dGVzdA=="},
+							},
+						},
+					},
+				}},
+			}
+
+			require.NoError(t, service.Migrate(context.Background()))
+			_, err := db.GetNamespace(context.Background(), "root.smoke")
+			require.NoError(t, err)
+		})
+	})
 }

--- a/internal/schema/config/configured_actor.go
+++ b/internal/schema/config/configured_actor.go
@@ -6,7 +6,15 @@ import (
 
 type ConfiguredActor struct {
 	ExternalId  string               `json:"externalId" yaml:"externalId"`
+	Namespace   string               `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Key         *Key                 `json:"key" yaml:"key"`
 	Permissions []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+func (a *ConfiguredActor) GetNamespace() string {
+	if a == nil || a.Namespace == "" {
+		return RootNamespace
+	}
+	return a.Namespace
 }

--- a/internal/schema/config/configured_actors.go
+++ b/internal/schema/config/configured_actors.go
@@ -55,25 +55,11 @@ func (ca *ConfiguredActors) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// If it's not a string, it should be an object
-	var valueMap map[string]interface{}
-	if err := json.Unmarshal(data, &valueMap); err != nil {
-		return fmt.Errorf("failed to unmarshal string value: %v", err)
-	}
-
-	var t ConfiguredActorsType
-
-	if _, ok := valueMap["keysPath"]; ok {
-		t = &ConfiguredActorsExternalSource{}
-	} else {
-		t = &ConfiguredActorsExternalSources{}
-	}
-
-	if err := util.DecodeJSONStrict(data, t); err != nil {
+	var sources ConfiguredActorsExternalSources
+	if err := util.DecodeJSONStrict(data, &sources); err != nil {
 		return err
 	}
-
-	ca.InnerVal = t
+	ca.InnerVal = &sources
 
 	return nil
 }
@@ -101,22 +87,11 @@ func (ca *ConfiguredActors) UnmarshalYAML(value *yaml.Node) error {
 		return fmt.Errorf("actors expected a sequence node or mapping node, got %s", KindToString(value.Kind))
 	}
 
-	var t ConfiguredActorsType
-	for i := 0; i < len(value.Content); i += 2 {
-		if value.Content[i].Value == "keysPath" {
-			t = &ConfiguredActorsExternalSource{}
-			break
-		}
-	}
-	if t == nil {
-		t = &ConfiguredActorsExternalSources{}
-	}
-
-	if err := util.DecodeYAMLNodeStrict(value, t); err != nil {
+	var sources ConfiguredActorsExternalSources
+	if err := util.DecodeYAMLNodeStrict(value, &sources); err != nil {
 		return err
 	}
-
-	ca.InnerVal = t
+	ca.InnerVal = &sources
 	return nil
 }
 

--- a/internal/schema/config/configured_actors.go
+++ b/internal/schema/config/configured_actors.go
@@ -66,7 +66,7 @@ func (ca *ConfiguredActors) UnmarshalJSON(data []byte) error {
 	if _, ok := valueMap["keysPath"]; ok {
 		t = &ConfiguredActorsExternalSource{}
 	} else {
-		return fmt.Errorf("invalid structure for actors; must be list or have keysPath")
+		t = &ConfiguredActorsExternalSources{}
 	}
 
 	if err := util.DecodeJSONStrict(data, t); err != nil {
@@ -101,12 +101,22 @@ func (ca *ConfiguredActors) UnmarshalYAML(value *yaml.Node) error {
 		return fmt.Errorf("actors expected a sequence node or mapping node, got %s", KindToString(value.Kind))
 	}
 
-	var actorsExternalSource ConfiguredActorsExternalSource
-	if err := util.DecodeYAMLNodeStrict(value, &actorsExternalSource); err != nil {
+	var t ConfiguredActorsType
+	for i := 0; i < len(value.Content); i += 2 {
+		if value.Content[i].Value == "keysPath" {
+			t = &ConfiguredActorsExternalSource{}
+			break
+		}
+	}
+	if t == nil {
+		t = &ConfiguredActorsExternalSources{}
+	}
+
+	if err := util.DecodeYAMLNodeStrict(value, t); err != nil {
 		return err
 	}
 
-	ca.InnerVal = &actorsExternalSource
+	ca.InnerVal = t
 	return nil
 }
 

--- a/internal/schema/config/configured_actors_external_source.go
+++ b/internal/schema/config/configured_actors_external_source.go
@@ -10,13 +10,8 @@ import (
 )
 
 type ConfiguredActorsExternalSource struct {
-	KeysPath         string               `json:"keysPath" yaml:"keysPath"`
-	Permissions      []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
-	SyncCronSchedule string               `json:"syncCronSchedule,omitempty" yaml:"syncCronSchedule,omitempty"`
-}
-
-func (s *ConfiguredActorsExternalSource) All() []*ConfiguredActor {
-	return s.AllInNamespace(RootNamespace)
+	KeysPath    string               `json:"keysPath" yaml:"keysPath"`
+	Permissions []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 }
 
 func (s *ConfiguredActorsExternalSource) AllInNamespace(namespace string) []*ConfiguredActor {
@@ -54,29 +49,3 @@ func (s *ConfiguredActorsExternalSource) AllInNamespace(namespace string) []*Con
 
 	return actors
 }
-
-func (s *ConfiguredActorsExternalSource) GetByExternalId(externalId string) (*ConfiguredActor, bool) {
-	for _, actor := range s.All() {
-		if actor.ExternalId == externalId {
-			return actor, true
-		}
-	}
-
-	return nil, false
-}
-
-func (s *ConfiguredActorsExternalSource) GetBySubject(subject string) (*ConfiguredActor, bool) {
-	// Subject is the same as ExternalId (no admin/ prefix handling)
-	return s.GetByExternalId(subject)
-}
-
-// GetSyncCronScheduleOrDefault returns the cron schedule for actors sync,
-// or a default of every 5 minutes if not configured.
-func (s *ConfiguredActorsExternalSource) GetSyncCronScheduleOrDefault() string {
-	if s == nil || s.SyncCronSchedule == "" {
-		return "*/5 * * * *" // Every 5 minutes
-	}
-	return s.SyncCronSchedule
-}
-
-var _ ConfiguredActorsType = (*ConfiguredActorsExternalSource)(nil)

--- a/internal/schema/config/configured_actors_external_source.go
+++ b/internal/schema/config/configured_actors_external_source.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ConfiguredActorsExternalSource struct {
-	KeysPath         string               `json:"keysPath" yaml:"keysPath"`
-	Permissions      []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
-	SyncCronSchedule string               `json:"syncCronSchedule,omitempty" yaml:"syncCronSchedule,omitempty"`
+	KeysPath              string               `json:"keysPath" yaml:"keysPath"`
+	Permissions           []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	NamespaceByExternalId map[string]string    `json:"namespaceByExternalId,omitempty" yaml:"namespaceByExternalId,omitempty"`
+	SyncCronSchedule      string               `json:"syncCronSchedule,omitempty" yaml:"syncCronSchedule,omitempty"`
 }
 
 func (s *ConfiguredActorsExternalSource) All() []*ConfiguredActor {
@@ -31,8 +32,10 @@ func (s *ConfiguredActorsExternalSource) All() []*ConfiguredActor {
 		// Check if the file has the desired extension
 		if strings.HasSuffix(entry.Name(), ".pub") {
 			externalId := strings.TrimSuffix(entry.Name(), ".pub")
+			namespace := s.NamespaceByExternalId[externalId]
 			actors = append(actors, &ConfiguredActor{
 				ExternalId: externalId,
+				Namespace:  namespace,
 				Key: &Key{
 					InnerVal: &KeyPublicPrivate{
 						PublicKey: &KeyData{

--- a/internal/schema/config/configured_actors_external_source.go
+++ b/internal/schema/config/configured_actors_external_source.go
@@ -10,13 +10,16 @@ import (
 )
 
 type ConfiguredActorsExternalSource struct {
-	KeysPath              string               `json:"keysPath" yaml:"keysPath"`
-	Permissions           []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
-	NamespaceByExternalId map[string]string    `json:"namespaceByExternalId,omitempty" yaml:"namespaceByExternalId,omitempty"`
-	SyncCronSchedule      string               `json:"syncCronSchedule,omitempty" yaml:"syncCronSchedule,omitempty"`
+	KeysPath         string               `json:"keysPath" yaml:"keysPath"`
+	Permissions      []aschema.Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	SyncCronSchedule string               `json:"syncCronSchedule,omitempty" yaml:"syncCronSchedule,omitempty"`
 }
 
 func (s *ConfiguredActorsExternalSource) All() []*ConfiguredActor {
+	return s.AllInNamespace(RootNamespace)
+}
+
+func (s *ConfiguredActorsExternalSource) AllInNamespace(namespace string) []*ConfiguredActor {
 	entries, err := os.ReadDir(s.KeysPath)
 	if err != nil {
 		panic(err)
@@ -32,7 +35,6 @@ func (s *ConfiguredActorsExternalSource) All() []*ConfiguredActor {
 		// Check if the file has the desired extension
 		if strings.HasSuffix(entry.Name(), ".pub") {
 			externalId := strings.TrimSuffix(entry.Name(), ".pub")
-			namespace := s.NamespaceByExternalId[externalId]
 			actors = append(actors, &ConfiguredActor{
 				ExternalId: externalId,
 				Namespace:  namespace,

--- a/internal/schema/config/configured_actors_external_sources.go
+++ b/internal/schema/config/configured_actors_external_sources.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"gopkg.in/yaml.v3"
+)
+
+const configuredActorsSyncCronScheduleKey = "syncCronSchedule"
+
+// ConfiguredActorsExternalSources groups public-key directories by the
+// namespace that owns the actors loaded from each directory.
+type ConfiguredActorsExternalSources struct {
+	Sources          map[string]*ConfiguredActorsExternalSource
+	SyncCronSchedule string
+}
+
+func (s *ConfiguredActorsExternalSources) All() []*ConfiguredActor {
+	if s == nil {
+		return nil
+	}
+
+	namespaces := make([]string, 0, len(s.Sources))
+	for namespace := range s.Sources {
+		namespaces = append(namespaces, namespace)
+	}
+	slices.Sort(namespaces)
+
+	var actors []*ConfiguredActor
+	for _, namespace := range namespaces {
+		actors = append(actors, s.Sources[namespace].AllInNamespace(namespace)...)
+	}
+	return actors
+}
+
+func (s *ConfiguredActorsExternalSources) GetByExternalId(externalId string) (*ConfiguredActor, bool) {
+	for _, actor := range s.All() {
+		if actor.ExternalId == externalId {
+			return actor, true
+		}
+	}
+	return nil, false
+}
+
+func (s *ConfiguredActorsExternalSources) GetBySubject(subject string) (*ConfiguredActor, bool) {
+	return s.GetByExternalId(subject)
+}
+
+func (s *ConfiguredActorsExternalSources) GetSyncCronScheduleOrDefault() string {
+	if s == nil || s.SyncCronSchedule == "" {
+		return "*/5 * * * *"
+	}
+	return s.SyncCronSchedule
+}
+
+func (s *ConfiguredActorsExternalSources) MarshalJSON() ([]byte, error) {
+	values := make(map[string]any, len(s.Sources)+1)
+	for namespace, source := range s.Sources {
+		values[namespace] = source
+	}
+	if s.SyncCronSchedule != "" {
+		values[configuredActorsSyncCronScheduleKey] = s.SyncCronSchedule
+	}
+	return json.Marshal(values)
+}
+
+func (s *ConfiguredActorsExternalSources) UnmarshalJSON(data []byte) error {
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+
+	s.Sources = make(map[string]*ConfiguredActorsExternalSource, len(values))
+	for namespace, raw := range values {
+		if namespace == configuredActorsSyncCronScheduleKey {
+			if err := json.Unmarshal(raw, &s.SyncCronSchedule); err != nil {
+				return fmt.Errorf("invalid %s: %w", configuredActorsSyncCronScheduleKey, err)
+			}
+			continue
+		}
+		if err := ValidateNamespacePath(namespace); err != nil {
+			return fmt.Errorf("invalid actor source namespace %q: %w", namespace, err)
+		}
+		var source ConfiguredActorsExternalSource
+		if err := util.DecodeJSONStrict(raw, &source); err != nil {
+			return fmt.Errorf("invalid actor source %q: %w", namespace, err)
+		}
+		s.Sources[namespace] = &source
+	}
+	if len(s.Sources) == 0 {
+		return fmt.Errorf("at least one namespaced actor source is required")
+	}
+	return nil
+}
+
+func (s *ConfiguredActorsExternalSources) MarshalYAML() (any, error) {
+	values := make(map[string]any, len(s.Sources)+1)
+	for namespace, source := range s.Sources {
+		values[namespace] = source
+	}
+	if s.SyncCronSchedule != "" {
+		values[configuredActorsSyncCronScheduleKey] = s.SyncCronSchedule
+	}
+	return values, nil
+}
+
+func (s *ConfiguredActorsExternalSources) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("namespaced actor sources expected a mapping node, got %s", KindToString(value.Kind))
+	}
+
+	s.Sources = make(map[string]*ConfiguredActorsExternalSource, len(value.Content)/2)
+	for i := 0; i < len(value.Content); i += 2 {
+		namespace := value.Content[i].Value
+		sourceNode := value.Content[i+1]
+		if namespace == configuredActorsSyncCronScheduleKey {
+			if err := sourceNode.Decode(&s.SyncCronSchedule); err != nil {
+				return fmt.Errorf("invalid %s: %w", configuredActorsSyncCronScheduleKey, err)
+			}
+			continue
+		}
+		if err := ValidateNamespacePath(namespace); err != nil {
+			return fmt.Errorf("invalid actor source namespace %q: %w", namespace, err)
+		}
+		var source ConfiguredActorsExternalSource
+		if err := util.DecodeYAMLNodeStrict(sourceNode, &source); err != nil {
+			return fmt.Errorf("invalid actor source %q: %w", namespace, err)
+		}
+		s.Sources[namespace] = &source
+	}
+	if len(s.Sources) == 0 {
+		return fmt.Errorf("at least one namespaced actor source is required")
+	}
+	return nil
+}
+
+var _ ConfiguredActorsType = (*ConfiguredActorsExternalSources)(nil)

--- a/internal/schema/config/configured_actors_external_sources_test.go
+++ b/internal/schema/config/configured_actors_external_sources_test.go
@@ -36,6 +36,12 @@ func TestConfiguredActorsExternalSources(t *testing.T) {
 		require.ErrorContains(t, err, "invalid actor source namespace")
 	})
 
+	t.Run("rejects legacy single source", func(t *testing.T) {
+		var actors ConfiguredActors
+		err := json.Unmarshal([]byte(`{"keysPath": "/keys/root"}`), &actors)
+		require.ErrorContains(t, err, "invalid actor source namespace")
+	})
+
 	t.Run("loads every source into its namespace", func(t *testing.T) {
 		rootKeys := t.TempDir()
 		smokeKeys := t.TempDir()

--- a/internal/schema/config/configured_actors_external_sources_test.go
+++ b/internal/schema/config/configured_actors_external_sources_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfiguredActorsExternalSources(t *testing.T) {
+	t.Run("decodes namespaced sources from JSON", func(t *testing.T) {
+		var actors ConfiguredActors
+		err := json.Unmarshal([]byte(`{
+  "root": {"keysPath": "/keys/root"},
+  "root.smoke": {
+    "keysPath": "/keys/smoke",
+    "permissions": [{"namespace": "root.smoke.{{external_id}}", "resources": ["connections"], "verbs": ["create"]}]
+  },
+  "syncCronSchedule": "* * * * *"
+}`), &actors)
+		require.NoError(t, err)
+
+		sources, ok := actors.InnerVal.(*ConfiguredActorsExternalSources)
+		require.True(t, ok)
+		require.Equal(t, "* * * * *", sources.SyncCronSchedule)
+		require.Equal(t, "/keys/root", sources.Sources["root"].KeysPath)
+		require.Equal(t, "root.smoke.{{external_id}}", sources.Sources["root.smoke"].Permissions[0].Namespace)
+	})
+
+	t.Run("rejects invalid source namespace", func(t *testing.T) {
+		var actors ConfiguredActors
+		err := json.Unmarshal([]byte(`{"smoke": {"keysPath": "/keys/smoke"}}`), &actors)
+		require.ErrorContains(t, err, "invalid actor source namespace")
+	})
+
+	t.Run("loads every source into its namespace", func(t *testing.T) {
+		rootKeys := t.TempDir()
+		smokeKeys := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(rootKeys, "admin.pub"), []byte("root-key"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(smokeKeys, "smoke-user.pub"), []byte("smoke-key"), 0o600))
+
+		sources := &ConfiguredActorsExternalSources{
+			Sources: map[string]*ConfiguredActorsExternalSource{
+				"root": {KeysPath: rootKeys},
+				"root.smoke": {
+					KeysPath: smokeKeys,
+					Permissions: []aschema.Permission{{
+						Namespace: "root.smoke.{{external_id}}",
+						Resources: []string{"connections"},
+						Verbs:     []string{"create"},
+					}},
+				},
+			},
+		}
+
+		loaded := sources.All()
+		require.Len(t, loaded, 2)
+		require.Equal(t, "admin", loaded[0].ExternalId)
+		require.Equal(t, "root", loaded[0].Namespace)
+		require.Equal(t, "smoke-user", loaded[1].ExternalId)
+		require.Equal(t, "root.smoke", loaded[1].Namespace)
+		require.Equal(t, "root.smoke.{{external_id}}", loaded[1].Permissions[0].Namespace)
+	})
+}

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -1093,6 +1093,9 @@
         "externalId": {
           "type": "string"
         },
+        "namespace": {
+          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
+        },
         "key": {
           "$ref": "../resources/key/schema.json#/$defs/Key"
         },
@@ -1132,6 +1135,12 @@
               "type": "array",
               "items": {
                 "$ref": "../auth/schema.json#/$defs/Permission"
+              }
+            },
+            "namespaceByExternalId": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
               }
             },
             "syncCronSchedule": {

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -1126,33 +1126,69 @@
           }
         },
         {
+          "$ref": "#/$defs/ConfiguredActorsExternalSource"
+        },
+        {
           "type": "object",
           "properties": {
-            "keysPath": {
-              "type": "string"
-            },
-            "permissions": {
-              "type": "array",
-              "items": {
-                "$ref": "../auth/schema.json#/$defs/Permission"
-              }
-            },
-            "namespaceByExternalId": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
-              }
-            },
             "syncCronSchedule": {
               "type": "string"
             }
           },
-          "required": [
-            "keysPath"
-          ],
-          "additionalProperties": false
+          "patternProperties": {
+            "^root(?:\\.[a-zA-Z0-9_]+[a-zA-Z0-9_\\-]*)*$": {
+              "$ref": "#/$defs/ConfiguredActorsNamespacedExternalSource"
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1,
+          "not": {
+            "required": [
+              "syncCronSchedule"
+            ],
+            "maxProperties": 1
+          }
         }
       ]
+    },
+    "ConfiguredActorsExternalSource": {
+      "type": "object",
+      "properties": {
+        "keysPath": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "../auth/schema.json#/$defs/Permission"
+          }
+        },
+        "syncCronSchedule": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "keysPath"
+      ],
+      "additionalProperties": false
+    },
+    "ConfiguredActorsNamespacedExternalSource": {
+      "type": "object",
+      "properties": {
+        "keysPath": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "../auth/schema.json#/$defs/Permission"
+          }
+        }
+      },
+      "required": [
+        "keysPath"
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/internal/schema/config/schema.json
+++ b/internal/schema/config/schema.json
@@ -1126,9 +1126,6 @@
           }
         },
         {
-          "$ref": "#/$defs/ConfiguredActorsExternalSource"
-        },
-        {
           "type": "object",
           "properties": {
             "syncCronSchedule": {
@@ -1137,7 +1134,7 @@
           },
           "patternProperties": {
             "^root(?:\\.[a-zA-Z0-9_]+[a-zA-Z0-9_\\-]*)*$": {
-              "$ref": "#/$defs/ConfiguredActorsNamespacedExternalSource"
+              "$ref": "#/$defs/ConfiguredActorsExternalSource"
             }
           },
           "additionalProperties": false,
@@ -1152,27 +1149,6 @@
       ]
     },
     "ConfiguredActorsExternalSource": {
-      "type": "object",
-      "properties": {
-        "keysPath": {
-          "type": "string"
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "$ref": "../auth/schema.json#/$defs/Permission"
-          }
-        },
-        "syncCronSchedule": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "keysPath"
-      ],
-      "additionalProperties": false
-    },
-    "ConfiguredActorsNamespacedExternalSource": {
       "type": "object",
       "properties": {
         "keysPath": {

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -814,14 +814,24 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"keysPath": "/keys/actors", "permissions": [{"namespace": "root.**", "resources": ["*"], "verbs": ["*"]}]}}`,
 				},
 				{
-					Name:  "external source with actor namespaces",
+					Name:  "namespaced external sources",
 					Valid: true,
-					Data:  `{"test": {"keysPath": "/keys/actors", "namespaceByExternalId": {"smoke-user": "root.smoke"}}}`,
+					Data:  `{"test": {"root": {"keysPath": "/keys/actors/root"}, "root.smoke": {"keysPath": "/keys/actors/smoke", "permissions": [{"namespace": "root.smoke.{{external_id}}", "resources": ["connections"], "verbs": ["create"]}]}, "syncCronSchedule": "*/5 * * * *"}}`,
 				},
 				{
-					Name:  "external source with invalid actor namespace",
+					Name:  "namespaced external source with invalid namespace",
 					Valid: false,
-					Data:  `{"test": {"keysPath": "/keys/actors", "namespaceByExternalId": {"smoke-user": "smoke"}}}`,
+					Data:  `{"test": {"smoke": {"keysPath": "/keys/actors/smoke"}}}`,
+				},
+				{
+					Name:  "namespaced external source missing keys path",
+					Valid: false,
+					Data:  `{"test": {"root.smoke": {"permissions": [{"namespace": "root.smoke", "resources": ["connectors"], "verbs": ["list"]}]}}}`,
+				},
+				{
+					Name:  "namespaced external source requires a source",
+					Valid: false,
+					Data:  `{"test": {"syncCronSchedule": "*/5 * * * *"}}`,
 				},
 				{
 					Name:  "external source with sync cron",

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -804,13 +804,13 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": [{"externalId": "actor-1", "key": {"sharedKey": {"value": "secret"}}}]}`,
 				},
 				{
-					Name:  "external source",
-					Valid: true,
+					Name:  "legacy external source",
+					Valid: false,
 					Data:  `{"test": {"keysPath": "/keys/actors"}}`,
 				},
 				{
-					Name:  "external source with permissions",
-					Valid: true,
+					Name:  "legacy external source with permissions",
+					Valid: false,
 					Data:  `{"test": {"keysPath": "/keys/actors", "permissions": [{"namespace": "root.**", "resources": ["*"], "verbs": ["*"]}]}}`,
 				},
 				{
@@ -834,8 +834,8 @@ func TestSchemaDefinitions(t *testing.T) {
 					Data:  `{"test": {"syncCronSchedule": "*/5 * * * *"}}`,
 				},
 				{
-					Name:  "external source with sync cron",
-					Valid: true,
+					Name:  "legacy external source with sync cron",
+					Valid: false,
 					Data:  `{"test": {"keysPath": "/keys/actors", "syncCronSchedule": "*/5 * * * *"}}`,
 				},
 				{
@@ -985,7 +985,7 @@ func TestSchemaDefinitions(t *testing.T) {
 				{
 					Name:  "actors as external source",
 					Valid: true,
-					Data:  `{"test": {"actors": {"keysPath": "/keys/actors"}}}`,
+					Data:  `{"test": {"actors": {"root": {"keysPath": "/keys/actors"}}}}`,
 				},
 				{
 					Name:  "actors as inline list",

--- a/internal/schema/config/schema_test.go
+++ b/internal/schema/config/schema_test.go
@@ -758,7 +758,7 @@ func TestSchemaDefinitions(t *testing.T) {
 				{
 					Name:  "with permissions",
 					Valid: true,
-					Data:  `{"test": {"externalId": "actor-1", "key": {"sharedKey": {"value": "secret"}}, "permissions": [{"namespace": "root", "resources": ["*"], "verbs": ["*"]}]}}`,
+					Data:  `{"test": {"externalId": "actor-1", "namespace": "root.operators", "key": {"sharedKey": {"value": "secret"}}, "permissions": [{"namespace": "root", "resources": ["*"], "verbs": ["*"]}]}}`,
 				},
 				{
 					Name:  "with labels",
@@ -774,6 +774,11 @@ func TestSchemaDefinitions(t *testing.T) {
 					Name:  "missing key",
 					Valid: false,
 					Data:  `{"test": {"externalId": "actor-1"}}`,
+				},
+				{
+					Name:  "invalid namespace",
+					Valid: false,
+					Data:  `{"test": {"externalId": "actor-1", "namespace": "other", "key": {"sharedKey": {"value": "secret"}}}}`,
 				},
 			},
 		},
@@ -807,6 +812,16 @@ func TestSchemaDefinitions(t *testing.T) {
 					Name:  "external source with permissions",
 					Valid: true,
 					Data:  `{"test": {"keysPath": "/keys/actors", "permissions": [{"namespace": "root.**", "resources": ["*"], "verbs": ["*"]}]}}`,
+				},
+				{
+					Name:  "external source with actor namespaces",
+					Valid: true,
+					Data:  `{"test": {"keysPath": "/keys/actors", "namespaceByExternalId": {"smoke-user": "root.smoke"}}}`,
+				},
+				{
+					Name:  "external source with invalid actor namespace",
+					Valid: false,
+					Data:  `{"test": {"keysPath": "/keys/actors", "namespaceByExternalId": {"smoke-user": "smoke"}}}`,
 				},
 				{
 					Name:  "external source with sync cron",

--- a/internal/schema/config/system_auth_test.go
+++ b/internal/schema/config/system_auth_test.go
@@ -11,7 +11,7 @@ func TestSystemAuth(t *testing.T) {
 	assert := require.New(t)
 
 	t.Run("yaml parse", func(t *testing.T) {
-		t.Run("actors path", func(t *testing.T) {
+		t.Run("namespaced actor path", func(t *testing.T) {
 			data := `
   cookieDomain: localhost:8080
   jwtSigningKey:
@@ -20,7 +20,8 @@ func TestSystemAuth(t *testing.T) {
     privateKey:
       path: ./dev_config/keys/system
   actors:
-    keysPath: ./dev_config/keys/actors
+    root:
+      keysPath: ./dev_config/keys/actors
 `
 			expected := SystemAuth{
 				JwtSigningKey: &Key{
@@ -38,8 +39,10 @@ func TestSystemAuth(t *testing.T) {
 					},
 				},
 				Actors: &ConfiguredActors{
-					InnerVal: &ConfiguredActorsExternalSource{
-						KeysPath: "./dev_config/keys/actors",
+					InnerVal: &ConfiguredActorsExternalSources{
+						Sources: map[string]*ConfiguredActorsExternalSource{
+							"root": {KeysPath: "./dev_config/keys/actors"},
+						},
 					},
 				},
 			}
@@ -48,6 +51,15 @@ func TestSystemAuth(t *testing.T) {
 			err := yaml.Unmarshal([]byte(data), &sa)
 			assert.NoError(err)
 			assert.Equal(expected, sa)
+		})
+		t.Run("rejects legacy actor path", func(t *testing.T) {
+			data := `
+actors:
+  keysPath: ./dev_config/keys/actors
+`
+			var sa SystemAuth
+			err := yaml.Unmarshal([]byte(data), &sa)
+			assert.ErrorContains(err, "invalid actor source namespace")
 		})
 		t.Run("namespaced actor paths", func(t *testing.T) {
 			data := `

--- a/internal/schema/config/system_auth_test.go
+++ b/internal/schema/config/system_auth_test.go
@@ -21,6 +21,8 @@ func TestSystemAuth(t *testing.T) {
       path: ./dev_config/keys/system
   actors:
     keysPath: ./dev_config/keys/actors
+    namespaceByExternalId:
+      smoke-user: root.smoke
 `
 			expected := SystemAuth{
 				JwtSigningKey: &Key{
@@ -40,6 +42,9 @@ func TestSystemAuth(t *testing.T) {
 				Actors: &ConfiguredActors{
 					InnerVal: &ConfiguredActorsExternalSource{
 						KeysPath: "./dev_config/keys/actors",
+						NamespaceByExternalId: map[string]string{
+							"smoke-user": "root.smoke",
+						},
 					},
 				},
 			}
@@ -59,6 +64,7 @@ jwtSigningKey:
     path: ./dev_config/keys/system
 actors:
   - externalId: bobdole
+    namespace: root.admins
     key:
       publicKey:
         path: ./dev_config/keys/actors/bobdole.pub
@@ -82,6 +88,7 @@ actors:
 					InnerVal: ConfiguredActorsList{
 						&ConfiguredActor{
 							ExternalId: "bobdole",
+							Namespace:  "root.admins",
 							Key: &Key{
 								InnerVal: &KeyPublicPrivate{
 									PublicKey: &KeyData{

--- a/internal/schema/config/system_auth_test.go
+++ b/internal/schema/config/system_auth_test.go
@@ -21,8 +21,6 @@ func TestSystemAuth(t *testing.T) {
       path: ./dev_config/keys/system
   actors:
     keysPath: ./dev_config/keys/actors
-    namespaceByExternalId:
-      smoke-user: root.smoke
 `
 			expected := SystemAuth{
 				JwtSigningKey: &Key{
@@ -42,9 +40,6 @@ func TestSystemAuth(t *testing.T) {
 				Actors: &ConfiguredActors{
 					InnerVal: &ConfiguredActorsExternalSource{
 						KeysPath: "./dev_config/keys/actors",
-						NamespaceByExternalId: map[string]string{
-							"smoke-user": "root.smoke",
-						},
 					},
 				},
 			}
@@ -53,6 +48,36 @@ func TestSystemAuth(t *testing.T) {
 			err := yaml.Unmarshal([]byte(data), &sa)
 			assert.NoError(err)
 			assert.Equal(expected, sa)
+		})
+		t.Run("namespaced actor paths", func(t *testing.T) {
+			data := `
+cookieDomain: localhost:8080
+jwtSigningKey:
+  publicKey:
+    path: ./dev_config/keys/system.pub
+  privateKey:
+    path: ./dev_config/keys/system
+actors:
+  root:
+    keysPath: ./dev_config/keys/actors/root
+  root.smoke:
+    keysPath: ./dev_config/keys/actors/smoke
+    permissions:
+      - namespace: root.smoke.{{external_id}}
+        resources: [connections]
+        verbs: [create]
+  syncCronSchedule: "* * * * *"
+`
+			var sa SystemAuth
+			err := yaml.Unmarshal([]byte(data), &sa)
+			assert.NoError(err)
+
+			sources, ok := sa.Actors.InnerVal.(*ConfiguredActorsExternalSources)
+			assert.True(ok)
+			assert.Equal("* * * * *", sources.SyncCronSchedule)
+			assert.Equal("./dev_config/keys/actors/root", sources.Sources["root"].KeysPath)
+			assert.Equal("./dev_config/keys/actors/smoke", sources.Sources["root.smoke"].KeysPath)
+			assert.Equal("root.smoke.{{external_id}}", sources.Sources["root.smoke"].Permissions[0].Namespace)
 		})
 		t.Run("actors list", func(t *testing.T) {
 			data := `

--- a/internal/schema/config/test_data/invalid-bad-service-port.yaml
+++ b/internal/schema/config/test_data/invalid-bad-service-port.yaml
@@ -31,7 +31,8 @@ systemAuth:
     privateKey:
       path: ./dev_config/keys/system
   actors:
-    keysPath: ./dev_config/keys/admin
+    root:
+      keysPath: ./dev_config/keys/admin
   globalAesKey:
     envVarBase64: GLOBAL_AES_KEY
 errorPages:

--- a/internal/schema/config/test_data/valid.yaml
+++ b/internal/schema/config/test_data/valid.yaml
@@ -32,7 +32,8 @@ systemAuth:
     privateKey:
       path: ./dev_config/keys/system
   actors:
-    keysPath: ./dev_config/keys/admin
+    root:
+      keysPath: ./dev_config/keys/admin
   globalAesKey:
     envVarBase64: GLOBAL_AES_KEY
 errorPages:

--- a/internal/service/migrations.go
+++ b/internal/service/migrations.go
@@ -408,7 +408,8 @@ func (dm *DependencyManager) reconcileConfiguredActors(ctx context.Context) erro
 	if actors == nil {
 		return nil
 	}
-	if _, ok := actors.InnerVal.(*sconfig.ConfiguredActorsExternalSource); ok {
+	switch actors.InnerVal.(type) {
+	case *sconfig.ConfiguredActorsExternalSource, *sconfig.ConfiguredActorsExternalSources:
 		if _, err := dm.GetAsyncClient().Enqueue(tasks.NewSyncActorsExternalSourceTask()); err != nil {
 			return fmt.Errorf("enqueue configured actor synchronization: %w", err)
 		}

--- a/internal/service/migrations.go
+++ b/internal/service/migrations.go
@@ -409,7 +409,7 @@ func (dm *DependencyManager) reconcileConfiguredActors(ctx context.Context) erro
 		return nil
 	}
 	switch actors.InnerVal.(type) {
-	case *sconfig.ConfiguredActorsExternalSource, *sconfig.ConfiguredActorsExternalSources:
+	case *sconfig.ConfiguredActorsExternalSources:
 		if _, err := dm.GetAsyncClient().Enqueue(tasks.NewSyncActorsExternalSourceTask()); err != nil {
 			return fmt.Errorf("enqueue configured actor synchronization: %w", err)
 		}


### PR DESCRIPTION
## Summary

- configure external actors as independent namespace-scoped sync sources
- place smoke-user in root.smoke with only the permissions needed to list root.smoke connectors and create/get/proxy root.smoke.smoke-user connections
- create every smoke connector in root.smoke and every smoke connection in root.smoke.smoke-user
- keep root and smoke actor keys in separate Kubernetes Secrets and mounts
- exercise dynamic and seeded OAuth/API-key flows with isolated per-run connector definitions

## Gaps found and addressed

1. The remote smoke helper used one namespace for admin actors, user actors, connectors, and connections. Those concerns are now modeled independently and asserted through the live API.
2. External actor synchronization supported one key directory and one permission set, effectively coupling all configured actors to root. The configuration now requires namespace-keyed sources, each with its own keysPath and permissions. The legacy single-source shape is intentionally rejected, and repository configs plus Helm output have been migrated.
3. Development namespace migration did not create namespaces required by the configured actor sources. It now creates each source namespace and its parents before synchronization.
4. The demo deployments mounted all actor keys together. Root and root.smoke now use separate Secrets and mounts; workflows remove any stale smoke-user key from the root Secret.
5. OAuth state assumed the actor and connection shared a namespace. State now carries actorNamespace and connectionNamespace separately and still decodes legacy namespace state during rolling deployments.
6. Seeded smoke tests depended on root connector visibility. The admin now copies seeded definitions into uniquely labelled, per-run root.smoke connectors, so smoke-user remains restricted to root.smoke and archived copies cannot collide with later runs.
7. The OAuth integration helper mirrored the legacy state JSON shape and discarded the new namespace fields during PKCE state mutation. It now preserves both fields while retaining the legacy field for rolling-upgrade rejection tests.

## Verification

- go test ./internal/schema/config ./internal/config ./internal/apauth/tasks ./internal/core ./internal/service/...
- go test ./internal/auth_methods/oauth2
- go test -tags smoke ./smoke -run ^$ (from integration_tests)
- full live TestRemote suite against the PR environment: dynamic OAuth, seeded catalog, seeded OAuth, and seeded API key all passed
- helm lint and helm template for the AuthProxy chart
- kubectl kustomize for the dev and demo overlays
- workflow and overlay YAML parse checks
- yarn docs:build
- ./scripts/preflight.sh
- all GitHub checks green, including the integration suite, Helm install, and Deploy Dev smoke test
