### PR TITLE
Document permission resources and verbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ the hosted demos, and the shortest developer quick start. Put conceptual,
 integration, SDK, deployment, operations, security, reference, and detailed
 development material in the Starlight site under `docs/src/content/docs/`.
 
+`docs/src/content/docs/security/permission-resources-and-verbs.md` is the
+canonical list of permission resource types and verbs. Whenever a permission
+check is added, changed, or removed—including route `ForResource` /
+`ForVerb(s)` checks and direct checks such as secret replay—update that table in
+the same change.
+
 ## Workflow
 
 ### Preflight (required before commit)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
           items: [
             'security',
             'security/authentication-and-authorization',
+            'security/permission-resources-and-verbs',
             'security/encryption',
           ],
         },

--- a/docs/src/content/docs/security/authentication-and-authorization.md
+++ b/docs/src/content/docs/security/authentication-and-authorization.md
@@ -112,6 +112,9 @@ The dimensions are:
   with `*` as a wildcard; and
 - `resource_ids`: an optional restriction to named resources.
 
+See [Permission Resources and Verbs](/security/permission-resources-and-verbs/)
+for the complete matrix of exact resource and verb strings.
+
 Actor permissions are additive: any actor permission that matches can allow an
 operation. If a JWT also carries permissions, those permissions are
 restrictions. The action must be allowed by both the actor's stored permissions

--- a/docs/src/content/docs/security/permission-resources-and-verbs.md
+++ b/docs/src/content/docs/security/permission-resources-and-verbs.md
@@ -1,0 +1,55 @@
+---
+title: Permission Resources and Verbs
+description: Reference every resource type and verb available in AuthProxy permissions.
+---
+
+Use this reference when granting actor permissions or adding request-level JWT
+restrictions. Resource and verb strings are exact and case-sensitive. Although
+the permission schema accepts any non-empty string, only the combinations that
+AuthProxy checks have an effect.
+
+`*` is valid in either `resources` or `verbs` and matches every value in that
+dimension. Prefer the explicit values below for least-privilege grants.
+
+## Resource and Verb Matrix
+
+| Resource type | Available verbs | Controls |
+|---|---|---|
+| `actors` | `create`, `delete`, `get`, `list`, `update` | Actor records, permissions, labels, annotations, and signing keys |
+| `app-metrics` | `query`, `schema` | Aggregate application-metric queries and metric-schema discovery |
+| `connections` | `create`, `disconnect`, `force_state`, `get`, `list`, `proxy`, `update` | Connection setup, configuration, lifecycle, and authenticated proxy requests |
+| `connectors` | `archive`, `create`, `disconnect_all`, `force_state`, `get`, `list`, `list/versions`, `update` | Connector definitions, versions, metadata, and lifecycle operations |
+| `keys` | `create`, `delete`, `get`, `list`, `update` | Reusable signing and encryption-key resources |
+| `namespaces` | `create`, `get`, `list`, `update` | Namespace records, metadata, and namespace key assignments |
+| `rate_limits` | `create`, `delete`, `get`, `list`, `update` | Rate-limit rules, overrides, and related evaluation endpoints |
+| `request-events` | `get`, `list` | Individual and listed proxy request events |
+| `secrets` | `replay` | Unredacted replay of secret-tagged fields in an otherwise authorized API response |
+| `task_monitoring` | `get`, `list`, `manage` | Asynq queue, server, scheduler, and task inspection or mutation |
+| `workflow_monitoring` | `get`, `list`, `manage` | Workflow instance inspection, cancellation, and removal |
+
+## Specialized Verbs
+
+Most resources use the conventional `create`, `get`, `list`, `update`, and
+`delete` verbs. The specialized verbs mean:
+
+| Verb | Meaning |
+|---|---|
+| `archive` | Archive a connector. |
+| `disconnect` | Disconnect one connection. |
+| `disconnect_all` | Disconnect all connections for a connector. |
+| `force_state` | Force a connector or connection into a lifecycle state. |
+| `list/versions` | Read or list connector-version data. |
+| `manage` | Mutate task-queue or workflow-monitoring state. |
+| `proxy` | Send a request through a connection with its credentials injected. |
+| `query` | Run an aggregate application-metrics query. |
+| `replay` | Return original values for fields normally redacted as secrets. |
+| `schema` | Read the application-metrics schema. |
+
+The `secrets:replay` grant does not authorize a route by itself. It only
+disables response redaction after the caller passes that route's normal
+permission check, so grant it sparingly. The namespace dimension is not
+evaluated for `secrets:replay`, `task_monitoring`, or `workflow_monitoring`.
+
+See [Authentication and Authorization](/security/authentication-and-authorization/)
+for namespace matching, resource ID restrictions, actor permissions, and JWT
+permission intersection.


### PR DESCRIPTION
## Summary
- add a security reference page mapping every permission resource type to its available verbs
- document specialized permission verbs and the secrets replay caveat
- add the page to the Security sidebar and link it from the authorization guide
- require future permission changes to update the canonical table in AGENTS.md

## Validation
- yarn docs:build
- ./scripts/preflight.sh