### PR TITLE
Use ephemeral system-signed smoke actors

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -171,12 +171,6 @@ jobs:
             fi
           done
 
-          smoke_user_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
-            -o jsonpath='{.data.demo-shell\.pub}')"
-          if [ -z "${smoke_user_public}" ]; then
-            echo "Configured demo-shell actor public key is empty" >&2
-            exit 1
-          fi
           stale_smoke_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
             -o jsonpath='{.data.smoke-user\.pub}')"
           if [ -n "${stale_smoke_public}" ]; then
@@ -184,13 +178,8 @@ jobs:
               --type json \
               --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
           fi
-          smoke_user_key="${RUNNER_TEMP}/smoke-user.pub"
-          printf '%s' "${smoke_user_public}" | base64 -d > "${smoke_user_key}"
-          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-smoke-actors" \
-            --from-file=smoke-user.pub="${smoke_user_key}" \
-            --dry-run=client -o yaml \
-            | kubectl apply -f -
-          secrets+=("${RELEASE_NAME}-smoke-actors")
+          kubectl -n "${RELEASE_NS}" delete secret "${RELEASE_NAME}-smoke-actors" \
+            --ignore-not-found
 
           kubectl -n "${RELEASE_NS}" get secret "${secrets[@]}" -o json \
             | jq 'del(
@@ -487,14 +476,14 @@ jobs:
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
 
-          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-demo-shell-key" \
-            -o jsonpath='{.data.private}' \
-            | base64 -d > "${workdir}/demo-shell.private"
-          chmod 600 "${workdir}/demo-shell.private"
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-encryption" \
+            -o jsonpath='{.data.global_aes\.key}' \
+            | base64 -d > "${workdir}/global_aes.key"
+          chmod 600 "${workdir}/global_aes.key"
 
           echo "Smoke-testing ${SMOKE_BASE_URL}"
           cd integration_tests
-          SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
+          SMOKE_GLOBAL_KEY="${workdir}/global_aes.key" \
             go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
 
       - name: Collect deploy diagnostics (on failure)

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -249,10 +249,8 @@ jobs:
               --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
           fi
 
-          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-smoke-actors" \
-            --from-file=smoke-user.pub="${workdir}/demo-shell.pub" \
-            --dry-run=client -o yaml \
-            | kubectl apply -f -
+          kubectl -n "${RELEASE_NS}" delete secret "${RELEASE_NAME}-smoke-actors" \
+            --ignore-not-found
 
       - name: Clear stale seed job
         env:
@@ -405,17 +403,17 @@ jobs:
           workdir="$(mktemp -d)"
           trap 'rm -rf "${workdir}"' EXIT
 
-          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-demo-shell-key" \
-            -o jsonpath='{.data.private}' \
-            | base64 -d > "${workdir}/demo-shell.private"
-          chmod 600 "${workdir}/demo-shell.private"
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-encryption" \
+            -o jsonpath='{.data.global_aes\.key}' \
+            | base64 -d > "${workdir}/global_aes.key"
+          chmod 600 "${workdir}/global_aes.key"
 
           log_path="${RUNNER_TEMP}/authproxy-smoke.log"
           echo "log_path=${log_path}" >> "$GITHUB_OUTPUT"
           {
             echo "Smoke-testing ${SMOKE_BASE_URL}"
             cd integration_tests
-            SMOKE_ADMIN_KEY="${workdir}/demo-shell.private" \
+            SMOKE_GLOBAL_KEY="${workdir}/global_aes.key" \
               go test -tags smoke ./smoke -run TestRemote -count=1 -v
           } 2>&1 | tee "${log_path}"
 

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-config.yaml
@@ -101,19 +101,4 @@ systemAuth:
             - "*"
           verbs:
             - "*"
-    root.smoke:
-      keysPath: /etc/authproxy/keys/actors/smoke
-      permissions:
-        - namespace: root.smoke
-          resources:
-            - connectors
-          verbs:
-            - list
-        - namespace: root.smoke.{{external_id}}
-          resources:
-            - connections
-          verbs:
-            - create
-            - get
-            - proxy
     syncCronSchedule: "* * * * *"

--- a/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/authproxy-secrets.yaml
@@ -28,9 +28,6 @@ spec:
               $patch: delete
             - name: actors-keys
               mountPath: /etc/authproxy/keys/actors/root
-            - name: smoke-actors-keys
-              mountPath: /etc/authproxy/keys/actors/smoke
-              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -41,9 +38,6 @@ spec:
         - name: actors-keys
           secret:
             secretName: demo-actors
-        - name: smoke-actors-keys
-          secret:
-            secretName: demo-smoke-actors
 ---
 apiVersion: batch/v1
 kind: Job
@@ -69,9 +63,6 @@ spec:
               $patch: delete
             - name: actors-keys
               mountPath: /etc/authproxy/keys/actors/root
-            - name: smoke-actors-keys
-              mountPath: /etc/authproxy/keys/actors/smoke
-              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -82,6 +73,3 @@ spec:
         - name: actors-keys
           secret:
             secretName: demo-actors
-        - name: smoke-actors-keys
-          secret:
-            secretName: demo-smoke-actors

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-config.yaml
@@ -49,19 +49,4 @@ systemAuth:
             - "*"
           verbs:
             - "*"
-    root.smoke:
-      keysPath: /etc/authproxy/keys/actors/smoke
-      permissions:
-        - namespace: root.smoke
-          resources:
-            - connectors
-          verbs:
-            - list
-        - namespace: root.smoke.{{external_id}}
-          resources:
-            - connections
-          verbs:
-            - create
-            - get
-            - proxy
     syncCronSchedule: "* * * * *"

--- a/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/authproxy-secrets.yaml
@@ -22,9 +22,6 @@ spec:
               $patch: delete
             - name: actors-keys
               mountPath: /etc/authproxy/keys/actors/root
-            - name: smoke-actors-keys
-              mountPath: /etc/authproxy/keys/actors/smoke
-              readOnly: true
       volumes:
         - name: jwt-keys
           secret:
@@ -35,6 +32,3 @@ spec:
         - name: actors-keys
           secret:
             secretName: dev-actors
-        - name: smoke-actors-keys
-          secret:
-            secretName: dev-smoke-actors

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rmorlok/authproxy/internal/apauth/core"
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
 	"github.com/rmorlok/authproxy/internal/apid"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
@@ -35,7 +36,8 @@ type RemoteAuthProxyOptions struct {
 	ConnectorNamespace   string
 	ConnectionNamespace  string
 
-	AdminPrivateKey string
+	GlobalKey            string
+	UserActorPermissions []aschema.Permission
 }
 
 type RemoteAuthProxy struct {
@@ -50,8 +52,9 @@ type RemoteAuthProxy struct {
 	ConnectorNamespace   string
 	ConnectionNamespace  string
 
-	privateKey string
-	client     *http.Client
+	globalKey            string
+	userActorPermissions []aschema.Permission
+	client               *http.Client
 }
 
 type remoteResponse struct {
@@ -64,7 +67,11 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 	t.Helper()
 
 	require.NotEmpty(t, opts.BaseURL, "base URL is required")
-	require.NotEmpty(t, opts.AdminPrivateKey, "admin private key is required")
+	require.NotEmpty(t, opts.GlobalKey, "global key is required")
+	require.NotEmpty(t, opts.UserActorPermissions, "user actor permissions are required")
+	for i, permission := range opts.UserActorPermissions {
+		require.NoErrorf(t, permission.Validate(), "user actor permission %d is invalid", i)
+	}
 
 	adminURL := opts.AdminURL
 	if adminURL == "" {
@@ -114,7 +121,8 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 		UserActorNamespace:   userActorNamespace,
 		ConnectorNamespace:   connectorNamespace,
 		ConnectionNamespace:  connectionNamespace,
-		privateKey:           opts.AdminPrivateKey,
+		globalKey:            opts.GlobalKey,
+		userActorPermissions: opts.UserActorPermissions,
 		client:               &http.Client{Timeout: 30 * time.Second},
 	}
 }
@@ -142,19 +150,17 @@ func (h *RemoteAuthProxy) GetActorByExternalID(t *testing.T, namespace, external
 	return actor
 }
 
-func (h *RemoteAuthProxy) WaitForUserReady(t *testing.T, timeout time.Duration) {
+func (h *RemoteAuthProxy) ProvisionUserFromJWT(t *testing.T) {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
-	var last remoteResponse
-	for time.Now().Before(deadline) {
-		last = h.doSignedAllowing(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, h.PublicURL+"/api/v1/connectors?limit=1", nil, true, []int{http.StatusOK, http.StatusUnauthorized}, nil)
-		if last.StatusCode == http.StatusOK {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	require.FailNowf(t, "smoke user did not become ready", "actor %q in namespace %q was not ready within %s; last response: %s", h.UserActorExternalID, h.UserActorNamespace, timeout, string(last.Body))
+	h.doSigned(t, h.UserActorExternalID, h.UserActorNamespace, http.MethodGet, h.PublicURL+"/api/v1/connectors?limit=1", nil, true, http.StatusOK, nil)
+}
+
+func (h *RemoteAuthProxy) DeleteActorByExternalIDAsAdmin(t *testing.T, namespace, externalID string) {
+	t.Helper()
+
+	endpoint := h.AdminURL + "/api/v1/actors/external-id/" + url.PathEscape(externalID) + "?namespace=" + url.QueryEscape(namespace)
+	h.doSigned(t, h.AdminActorExternalID, h.AdminActorNamespace, http.MethodDelete, endpoint, nil, true, http.StatusNoContent, nil)
 }
 
 func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) schemaapi.ConnectorVersionJson {
@@ -413,17 +419,29 @@ func (h *RemoteAuthProxy) doSignedAllowing(t *testing.T, actorExternalID, actorN
 
 func (h *RemoteAuthProxy) signer(actorExternalID, actorNamespace string) (jwt.Signer, error) {
 	builder := jwt.NewJwtTokenBuilder().
-		WithActorExternalId(actorExternalID).
-		WithNamespace(actorNamespace).
-		WithActorSigned().
+		WithSystemSigned().
 		WithServiceIds(sconfig.AllServiceIds()).
-		WithPermissions(aschema.AllPermissions()).
 		WithExpiresIn(15 * time.Minute)
 
-	if looksLikePath(h.privateKey) {
-		builder = builder.WithPrivateKeyPath(h.privateKey)
+	if actorExternalID == h.UserActorExternalID && actorNamespace == h.UserActorNamespace {
+		builder = builder.
+			WithActor(&core.Actor{
+				ExternalId:  actorExternalID,
+				Namespace:   actorNamespace,
+				Permissions: h.userActorPermissions,
+			}).
+			WithPermissions(h.userActorPermissions)
 	} else {
-		builder = builder.WithPrivateKeyString(h.privateKey)
+		builder = builder.
+			WithActorExternalId(actorExternalID).
+			WithNamespace(actorNamespace).
+			WithPermissions(aschema.AllPermissions())
+	}
+
+	if looksLikePath(h.globalKey) {
+		builder = builder.WithSecretKeyPath(h.globalKey)
+	} else {
+		builder = builder.WithSecretKeyString(h.globalKey)
 	}
 
 	return builder.Signer()

--- a/integration_tests/helpers/remote_authproxy_test.go
+++ b/integration_tests/helpers/remote_authproxy_test.go
@@ -1,0 +1,86 @@
+package helpers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureRemoteAuthProxyClaims(
+	t *testing.T,
+	rig *RemoteAuthProxy,
+	sharedKey string,
+	actorExternalID string,
+	actorNamespace string,
+) *jwt.AuthProxyClaims {
+	t.Helper()
+
+	var claims *jwt.AuthProxyClaims
+	var parseErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		claims, parseErr = jwt.NewJwtTokenParserBuilder().
+			WithSharedKeyString(sharedKey).
+			Parse(token)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	rig.doSigned(t, actorExternalID, actorNamespace, http.MethodGet, server.URL, nil, true, http.StatusNoContent, nil)
+	require.NoError(t, parseErr)
+	require.NotNil(t, claims)
+	return claims
+}
+
+func TestRemoteAuthProxySignsWithGlobalKeyAndProvisionsUser(t *testing.T) {
+	const globalKey = "test-global-key-material"
+	keyPath := filepath.Join(t.TempDir(), "global_aes.key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(globalKey), 0o600))
+
+	permissions := []aschema.Permission{
+		{
+			Namespace: "root.smoke",
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: "root.smoke.smoke-user-20260821T010203Z-a1b2c3d4",
+			Resources: []string{"connections"},
+			Verbs:     []string{"create", "get", "proxy"},
+		},
+	}
+	rig := NewRemoteAuthProxy(t, RemoteAuthProxyOptions{
+		BaseURL:              "https://demo.authproxy.net",
+		GlobalKey:            keyPath,
+		UserActorExternalID:  "smoke-user-20260821T010203Z-a1b2c3d4",
+		UserActorNamespace:   "root.smoke",
+		UserActorPermissions: permissions,
+		ConnectorNamespace:   "root.smoke",
+		ConnectionNamespace:  "root.smoke.smoke-user-20260821T010203Z-a1b2c3d4",
+	})
+
+	userClaims := captureRemoteAuthProxyClaims(t, rig, globalKey, rig.UserActorExternalID, rig.UserActorNamespace)
+	assert.True(t, userClaims.SystemSigned)
+	assert.False(t, userClaims.ActorSigned)
+	assert.Equal(t, rig.UserActorExternalID, userClaims.Subject)
+	assert.Equal(t, rig.UserActorNamespace, userClaims.Namespace)
+	require.NotNil(t, userClaims.Actor)
+	assert.Equal(t, rig.UserActorExternalID, userClaims.Actor.ExternalId)
+	assert.Equal(t, rig.UserActorNamespace, userClaims.Actor.Namespace)
+	assert.Equal(t, permissions, userClaims.Actor.Permissions)
+	assert.Equal(t, permissions, userClaims.Permissions)
+
+	adminClaims := captureRemoteAuthProxyClaims(t, rig, globalKey, rig.AdminActorExternalID, rig.AdminActorNamespace)
+	assert.True(t, adminClaims.SystemSigned)
+	assert.False(t, adminClaims.ActorSigned)
+	assert.Nil(t, adminClaims.Actor)
+	assert.Equal(t, aschema.AllPermissions(), adminClaims.Permissions)
+}

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -3,6 +3,8 @@
 package smoke
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"net/http"
@@ -16,6 +18,7 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
@@ -23,35 +26,63 @@ import (
 )
 
 var (
-	smokeBaseURL  = flag.String("base-url", os.Getenv("SMOKE_BASE_URL"), "base AuthProxy demo URL, e.g. https://demo.authproxy.net")
-	smokeAdminKey = flag.String("admin-key", os.Getenv("SMOKE_ADMIN_KEY"), "admin actor private key PEM, or a path to it")
+	smokeBaseURL   = flag.String("base-url", os.Getenv("SMOKE_BASE_URL"), "base AuthProxy demo URL, e.g. https://demo.authproxy.net")
+	smokeGlobalKey = flag.String("global-key", os.Getenv("SMOKE_GLOBAL_KEY"), "AuthProxy global key, or a path to it")
 )
 
-const (
-	smokeConnectorNamespace  = "root.smoke"
-	smokeUserExternalID      = "smoke-user"
-	smokeConnectionNamespace = "root.smoke.smoke-user"
-)
+const smokeConnectorNamespace = "root.smoke"
+
+func newSmokeUserExternalID(t *testing.T) string {
+	t.Helper()
+
+	var entropy [4]byte
+	_, err := rand.Read(entropy[:])
+	require.NoError(t, err)
+	return fmt.Sprintf("smoke-user-%s-%s", time.Now().UTC().Format("20060102T150405Z"), hex.EncodeToString(entropy[:]))
+}
+
+func smokeUserPermissions(connectionNamespace string) []aschema.Permission {
+	return []aschema.Permission{
+		{
+			Namespace: smokeConnectorNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: connectionNamespace,
+			Resources: []string{"connections"},
+			Verbs:     []string{"create", "get", "proxy"},
+		},
+	}
+}
 
 func newRemoteSmokeRig(t *testing.T) *helpers.RemoteAuthProxy {
 	t.Helper()
 
+	userExternalID := newSmokeUserExternalID(t)
+	connectionNamespace := smokeConnectorNamespace + "." + userExternalID
+	permissions := smokeUserPermissions(connectionNamespace)
 	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
-		BaseURL:             *smokeBaseURL,
-		AdminPrivateKey:     *smokeAdminKey,
-		AdminActorNamespace: config.RootNamespace,
-		UserActorExternalID: smokeUserExternalID,
-		UserActorNamespace:  smokeConnectorNamespace,
-		ConnectorNamespace:  smokeConnectorNamespace,
-		ConnectionNamespace: smokeConnectionNamespace,
+		BaseURL:              *smokeBaseURL,
+		GlobalKey:            *smokeGlobalKey,
+		AdminActorNamespace:  config.RootNamespace,
+		UserActorExternalID:  userExternalID,
+		UserActorNamespace:   smokeConnectorNamespace,
+		UserActorPermissions: permissions,
+		ConnectorNamespace:   smokeConnectorNamespace,
+		ConnectionNamespace:  connectionNamespace,
 	})
 	rig.EnsureNamespace(t, smokeConnectorNamespace)
-	rig.EnsureNamespace(t, smokeConnectionNamespace)
-	rig.WaitForUserReady(t, 3*time.Minute)
+	rig.EnsureNamespace(t, connectionNamespace)
+	rig.ProvisionUserFromJWT(t)
 
-	actor := rig.GetActorByExternalID(t, smokeConnectorNamespace, smokeUserExternalID)
+	actor := rig.GetActorByExternalID(t, smokeConnectorNamespace, userExternalID)
 	require.Equal(t, smokeConnectorNamespace, actor.Namespace)
-	require.Equal(t, smokeUserExternalID, actor.ExternalId)
+	require.Equal(t, userExternalID, actor.ExternalId)
+	require.Equal(t, permissions, actor.Permissions)
+	t.Cleanup(func() {
+		rig.DeleteActorByExternalIDAsAdmin(t, smokeConnectorNamespace, userExternalID)
+	})
 	return rig
 }
 
@@ -107,8 +138,8 @@ func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 	if *smokeBaseURL == "" {
 		t.Skip("set SMOKE_BASE_URL or pass -base-url")
 	}
-	if *smokeAdminKey == "" {
-		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
+	if *smokeGlobalKey == "" {
+		t.Skip("set SMOKE_GLOBAL_KEY or pass -global-key")
 	}
 
 	rig := newRemoteSmokeRig(t)
@@ -200,8 +231,8 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 	if *smokeBaseURL == "" {
 		t.Skip("set SMOKE_BASE_URL or pass -base-url")
 	}
-	if *smokeAdminKey == "" {
-		t.Skip("set SMOKE_ADMIN_KEY or pass -admin-key")
+	if *smokeGlobalKey == "" {
+		t.Skip("set SMOKE_GLOBAL_KEY or pass -global-key")
 	}
 
 	rig := newRemoteSmokeRig(t)


### PR DESCRIPTION
## Summary

- sign remote smoke-test requests with the deployment global key
- provision a unique root.smoke actor from JWT claims for each top-level smoke test
- grant only connector-list and per-run connection permissions, then delete the actor during cleanup
- remove the obsolete root.smoke key-sync configuration, secret mounts, and workflow-managed smoke actor secret

## Gaps addressed

The demo and dev deployments previously exposed only actor public-key material to AuthProxy and supplied the demo-shell private key to smoke tests. They also continuously synced one static smoke-user. This change makes the global key available to the smoke-test job, removes the stale static actor source and Kubernetes secret wiring, and removes the legacy smoke actor secret during rollout.

## Validation

- ./scripts/preflight.sh
- cd integration_tests && go test ./helpers
- cd integration_tests && go test -tags smoke ./smoke -run ^$
- rendered demo and dev Kustomize overlays and verified no smoke actor key source or secret mount remains