### PR TITLE
Use ephemeral least-privilege smoke admins

### DIFF
--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -36,8 +36,9 @@ type RemoteAuthProxyOptions struct {
 	ConnectorNamespace   string
 	ConnectionNamespace  string
 
-	GlobalKey            string
-	UserActorPermissions []aschema.Permission
+	GlobalKey             string
+	AdminActorPermissions []aschema.Permission
+	UserActorPermissions  []aschema.Permission
 }
 
 type RemoteAuthProxy struct {
@@ -52,9 +53,10 @@ type RemoteAuthProxy struct {
 	ConnectorNamespace   string
 	ConnectionNamespace  string
 
-	globalKey            string
-	userActorPermissions []aschema.Permission
-	client               *http.Client
+	globalKey             string
+	adminActorPermissions []aschema.Permission
+	userActorPermissions  []aschema.Permission
+	client                *http.Client
 }
 
 type remoteResponse struct {
@@ -68,6 +70,10 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 
 	require.NotEmpty(t, opts.BaseURL, "base URL is required")
 	require.NotEmpty(t, opts.GlobalKey, "global key is required")
+	require.NotEmpty(t, opts.AdminActorPermissions, "admin actor permissions are required")
+	for i, permission := range opts.AdminActorPermissions {
+		require.NoErrorf(t, permission.Validate(), "admin actor permission %d is invalid", i)
+	}
 	require.NotEmpty(t, opts.UserActorPermissions, "user actor permissions are required")
 	for i, permission := range opts.UserActorPermissions {
 		require.NoErrorf(t, permission.Validate(), "user actor permission %d is invalid", i)
@@ -112,18 +118,19 @@ func NewRemoteAuthProxy(t *testing.T, opts RemoteAuthProxyOptions) *RemoteAuthPr
 	}
 
 	return &RemoteAuthProxy{
-		AdminURL:             strings.TrimRight(adminURL, "/"),
-		PublicURL:            strings.TrimRight(publicURL, "/"),
-		ProviderURL:          strings.TrimRight(providerURL, "/"),
-		AdminActorExternalID: adminActor,
-		AdminActorNamespace:  adminActorNamespace,
-		UserActorExternalID:  userActor,
-		UserActorNamespace:   userActorNamespace,
-		ConnectorNamespace:   connectorNamespace,
-		ConnectionNamespace:  connectionNamespace,
-		globalKey:            opts.GlobalKey,
-		userActorPermissions: opts.UserActorPermissions,
-		client:               &http.Client{Timeout: 30 * time.Second},
+		AdminURL:              strings.TrimRight(adminURL, "/"),
+		PublicURL:             strings.TrimRight(publicURL, "/"),
+		ProviderURL:           strings.TrimRight(providerURL, "/"),
+		AdminActorExternalID:  adminActor,
+		AdminActorNamespace:   adminActorNamespace,
+		UserActorExternalID:   userActor,
+		UserActorNamespace:    userActorNamespace,
+		ConnectorNamespace:    connectorNamespace,
+		ConnectionNamespace:   connectionNamespace,
+		globalKey:             opts.GlobalKey,
+		adminActorPermissions: opts.AdminActorPermissions,
+		userActorPermissions:  opts.UserActorPermissions,
+		client:                &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -423,20 +430,22 @@ func (h *RemoteAuthProxy) signer(actorExternalID, actorNamespace string) (jwt.Si
 		WithServiceIds(sconfig.AllServiceIds()).
 		WithExpiresIn(15 * time.Minute)
 
-	if actorExternalID == h.UserActorExternalID && actorNamespace == h.UserActorNamespace {
-		builder = builder.
-			WithActor(&core.Actor{
-				ExternalId:  actorExternalID,
-				Namespace:   actorNamespace,
-				Permissions: h.userActorPermissions,
-			}).
-			WithPermissions(h.userActorPermissions)
-	} else {
-		builder = builder.
-			WithActorExternalId(actorExternalID).
-			WithNamespace(actorNamespace).
-			WithPermissions(aschema.AllPermissions())
+	var permissions []aschema.Permission
+	switch {
+	case actorExternalID == h.AdminActorExternalID && actorNamespace == h.AdminActorNamespace:
+		permissions = h.adminActorPermissions
+	case actorExternalID == h.UserActorExternalID && actorNamespace == h.UserActorNamespace:
+		permissions = h.userActorPermissions
+	default:
+		return nil, fmt.Errorf("no permissions configured for actor %q in namespace %q", actorExternalID, actorNamespace)
 	}
+	builder = builder.
+		WithActor(&core.Actor{
+			ExternalId:  actorExternalID,
+			Namespace:   actorNamespace,
+			Permissions: permissions,
+		}).
+		WithPermissions(permissions)
 
 	if looksLikePath(h.globalKey) {
 		builder = builder.WithSecretKeyPath(h.globalKey)

--- a/integration_tests/helpers/remote_authproxy_test.go
+++ b/integration_tests/helpers/remote_authproxy_test.go
@@ -40,12 +40,29 @@ func captureRemoteAuthProxyClaims(
 	return claims
 }
 
-func TestRemoteAuthProxySignsWithGlobalKeyAndProvisionsUser(t *testing.T) {
+func TestRemoteAuthProxySignsWithGlobalKeyAndProvisionsActors(t *testing.T) {
 	const globalKey = "test-global-key-material"
 	keyPath := filepath.Join(t.TempDir(), "global_aes.key")
 	require.NoError(t, os.WriteFile(keyPath, []byte(globalKey), 0o600))
 
-	permissions := []aschema.Permission{
+	adminPermissions := []aschema.Permission{
+		{
+			Namespace: "root.smoke",
+			Resources: []string{"namespaces"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			Namespace: "root.smoke.smoke-user-20260821T010203Z-a1b2c3d4",
+			Resources: []string{"namespaces"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			Namespace: "root.smoke",
+			Resources: []string{"connectors"},
+			Verbs:     []string{"create", "force_state"},
+		},
+	}
+	userPermissions := []aschema.Permission{
 		{
 			Namespace: "root.smoke",
 			Resources: []string{"connectors"},
@@ -58,13 +75,16 @@ func TestRemoteAuthProxySignsWithGlobalKeyAndProvisionsUser(t *testing.T) {
 		},
 	}
 	rig := NewRemoteAuthProxy(t, RemoteAuthProxyOptions{
-		BaseURL:              "https://demo.authproxy.net",
-		GlobalKey:            keyPath,
-		UserActorExternalID:  "smoke-user-20260821T010203Z-a1b2c3d4",
-		UserActorNamespace:   "root.smoke",
-		UserActorPermissions: permissions,
-		ConnectorNamespace:   "root.smoke",
-		ConnectionNamespace:  "root.smoke.smoke-user-20260821T010203Z-a1b2c3d4",
+		BaseURL:               "https://demo.authproxy.net",
+		GlobalKey:             keyPath,
+		AdminActorExternalID:  "smoke-admin-20260821T010203Z-a1b2c3d4",
+		AdminActorNamespace:   "root",
+		AdminActorPermissions: adminPermissions,
+		UserActorExternalID:   "smoke-user-20260821T010203Z-a1b2c3d4",
+		UserActorNamespace:    "root.smoke",
+		UserActorPermissions:  userPermissions,
+		ConnectorNamespace:    "root.smoke",
+		ConnectionNamespace:   "root.smoke.smoke-user-20260821T010203Z-a1b2c3d4",
 	})
 
 	userClaims := captureRemoteAuthProxyClaims(t, rig, globalKey, rig.UserActorExternalID, rig.UserActorNamespace)
@@ -75,12 +95,20 @@ func TestRemoteAuthProxySignsWithGlobalKeyAndProvisionsUser(t *testing.T) {
 	require.NotNil(t, userClaims.Actor)
 	assert.Equal(t, rig.UserActorExternalID, userClaims.Actor.ExternalId)
 	assert.Equal(t, rig.UserActorNamespace, userClaims.Actor.Namespace)
-	assert.Equal(t, permissions, userClaims.Actor.Permissions)
-	assert.Equal(t, permissions, userClaims.Permissions)
+	assert.Equal(t, userPermissions, userClaims.Actor.Permissions)
+	assert.Equal(t, userPermissions, userClaims.Permissions)
 
 	adminClaims := captureRemoteAuthProxyClaims(t, rig, globalKey, rig.AdminActorExternalID, rig.AdminActorNamespace)
 	assert.True(t, adminClaims.SystemSigned)
 	assert.False(t, adminClaims.ActorSigned)
-	assert.Nil(t, adminClaims.Actor)
-	assert.Equal(t, aschema.AllPermissions(), adminClaims.Permissions)
+	assert.Equal(t, rig.AdminActorExternalID, adminClaims.Subject)
+	assert.Equal(t, rig.AdminActorNamespace, adminClaims.Namespace)
+	require.NotNil(t, adminClaims.Actor)
+	assert.Equal(t, rig.AdminActorExternalID, adminClaims.Actor.ExternalId)
+	assert.Equal(t, rig.AdminActorNamespace, adminClaims.Actor.Namespace)
+	assert.Equal(t, adminPermissions, adminClaims.Actor.Permissions)
+	assert.Equal(t, adminPermissions, adminClaims.Permissions)
+
+	_, err := rig.signer("unconfigured-actor", "root")
+	require.EqualError(t, err, `no permissions configured for actor "unconfigured-actor" in namespace "root"`)
 }

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -32,13 +32,50 @@ var (
 
 const smokeConnectorNamespace = "root.smoke"
 
-func newSmokeUserExternalID(t *testing.T) string {
+func newSmokeActorExternalID(t *testing.T, prefix string) string {
 	t.Helper()
 
 	var entropy [4]byte
 	_, err := rand.Read(entropy[:])
 	require.NoError(t, err)
-	return fmt.Sprintf("smoke-user-%s-%s", time.Now().UTC().Format("20060102T150405Z"), hex.EncodeToString(entropy[:]))
+	return fmt.Sprintf("%s-%s-%s", prefix, time.Now().UTC().Format("20060102T150405Z"), hex.EncodeToString(entropy[:]))
+}
+
+func smokeAdminPermissions(adminExternalID, userExternalID, connectionNamespace string) []aschema.Permission {
+	return []aschema.Permission{
+		{
+			Namespace:   config.RootNamespace,
+			Resources:   []string{"actors"},
+			ResourceIds: []string{adminExternalID},
+			Verbs:       []string{"get", "delete"},
+		},
+		{
+			Namespace: config.RootNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list", "list/versions"},
+		},
+		{
+			Namespace: smokeConnectorNamespace,
+			Resources: []string{"namespaces"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			Namespace: connectionNamespace,
+			Resources: []string{"namespaces"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			Namespace:   smokeConnectorNamespace,
+			Resources:   []string{"actors"},
+			ResourceIds: []string{userExternalID},
+			Verbs:       []string{"get", "delete"},
+		},
+		{
+			Namespace: smokeConnectorNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"create", "force_state"},
+		},
+	}
 }
 
 func smokeUserPermissions(connectionNamespace string) []aschema.Permission {
@@ -59,27 +96,39 @@ func smokeUserPermissions(connectionNamespace string) []aschema.Permission {
 func newRemoteSmokeRig(t *testing.T) *helpers.RemoteAuthProxy {
 	t.Helper()
 
-	userExternalID := newSmokeUserExternalID(t)
+	adminExternalID := newSmokeActorExternalID(t, "smoke-admin")
+	userExternalID := newSmokeActorExternalID(t, "smoke-user")
 	connectionNamespace := smokeConnectorNamespace + "." + userExternalID
-	permissions := smokeUserPermissions(connectionNamespace)
+	adminPermissions := smokeAdminPermissions(adminExternalID, userExternalID, connectionNamespace)
+	userPermissions := smokeUserPermissions(connectionNamespace)
 	rig := helpers.NewRemoteAuthProxy(t, helpers.RemoteAuthProxyOptions{
-		BaseURL:              *smokeBaseURL,
-		GlobalKey:            *smokeGlobalKey,
-		AdminActorNamespace:  config.RootNamespace,
-		UserActorExternalID:  userExternalID,
-		UserActorNamespace:   smokeConnectorNamespace,
-		UserActorPermissions: permissions,
-		ConnectorNamespace:   smokeConnectorNamespace,
-		ConnectionNamespace:  connectionNamespace,
+		BaseURL:               *smokeBaseURL,
+		GlobalKey:             *smokeGlobalKey,
+		AdminActorExternalID:  adminExternalID,
+		AdminActorNamespace:   config.RootNamespace,
+		AdminActorPermissions: adminPermissions,
+		UserActorExternalID:   userExternalID,
+		UserActorNamespace:    smokeConnectorNamespace,
+		UserActorPermissions:  userPermissions,
+		ConnectorNamespace:    smokeConnectorNamespace,
+		ConnectionNamespace:   connectionNamespace,
 	})
 	rig.EnsureNamespace(t, smokeConnectorNamespace)
+	adminActor := rig.GetActorByExternalID(t, config.RootNamespace, adminExternalID)
+	require.Equal(t, config.RootNamespace, adminActor.Namespace)
+	require.Equal(t, adminExternalID, adminActor.ExternalId)
+	require.Equal(t, adminPermissions, adminActor.Permissions)
+	t.Cleanup(func() {
+		rig.DeleteActorByExternalIDAsAdmin(t, config.RootNamespace, adminExternalID)
+	})
+
 	rig.EnsureNamespace(t, connectionNamespace)
 	rig.ProvisionUserFromJWT(t)
 
 	actor := rig.GetActorByExternalID(t, smokeConnectorNamespace, userExternalID)
 	require.Equal(t, smokeConnectorNamespace, actor.Namespace)
 	require.Equal(t, userExternalID, actor.ExternalId)
-	require.Equal(t, permissions, actor.Permissions)
+	require.Equal(t, userPermissions, actor.Permissions)
 	t.Cleanup(func() {
 		rig.DeleteActorByExternalIDAsAdmin(t, smokeConnectorNamespace, userExternalID)
 	})


### PR DESCRIPTION
## Summary

- create a unique smoke-admin actor for each top-level smoke test
- include the full smoke-admin actor and its permissions in every global-key-signed JWT
- restrict the admin to the exact smoke namespaces, actor IDs, connector resources, and verbs the suite uses
- delete the ephemeral smoke-admin after test cleanup
- reject signing requests for actors that were not explicitly configured

The smoke-admin remains in `root` so it can bootstrap `root.smoke` when that namespace does not yet exist. Its root access is limited to its own actor and read-only discovery of seeded demo connectors.

## Testing

- `go test ./helpers` (from `integration_tests`)
- `go test -tags smoke ./smoke` (from `integration_tests`; live tests skip without demo credentials)
- `./scripts/preflight.sh`