### PR TITLE
Rename task navigation as internal

### DIFF
--- a/ui/admin/src/pages/Tasks.tsx
+++ b/ui/admin/src/pages/Tasks.tsx
@@ -75,7 +75,7 @@ export default function Tasks() {
     }, [autoRefresh, fetchQueues]);
 
     const handleQueueClick: GridEventListener<'rowClick'> = (params) => {
-        navigate(`/tasks/queues/${params.row.queue}`);
+        navigate(`/internal-tasks/queues/${params.row.queue}`);
     };
 
     const queueColumns: GridColDef<QueueInfo>[] = [

--- a/ui/admin/src/pages/WorkflowDetail.tsx
+++ b/ui/admin/src/pages/WorkflowDetail.tsx
@@ -135,7 +135,7 @@ export default function WorkflowDetail() {
         try {
             await removeWorkflowInstance(decodedInstanceId, decodedExecutionId);
             setConfirmRemoveOpen(false);
-            navigate('/workflows');
+            navigate('/internal-workflows');
         } catch {
             setActionError('Failed to remove workflow instance');
         } finally {

--- a/ui/admin/src/pages/Workflows.tsx
+++ b/ui/admin/src/pages/Workflows.tsx
@@ -135,7 +135,7 @@ export default function Workflows() {
     const handleWorkflowClick: GridEventListener<'rowClick'> = (params) => {
         const instance = params.row.instance;
         if (!instance) return;
-        navigate(`/workflows/${encodeURIComponent(instance.instanceId)}/${encodeURIComponent(instance.executionId)}`);
+        navigate(`/internal-workflows/${encodeURIComponent(instance.instanceId)}/${encodeURIComponent(instance.executionId)}`);
     };
 
     const columns: GridColDef<WorkflowInstanceRef>[] = [

--- a/ui/admin/src/routes.tsx
+++ b/ui/admin/src/routes.tsx
@@ -185,44 +185,44 @@ export const router = createBrowserRouter([
                 ],
             },
             {
-                path: 'tasks',
+                path: 'internal-tasks',
                 element: <TasksPage />,
                 handle: { title: 'Internal Tasks' }
             },
             {
-                path: 'tasks/queues/:queue',
+                path: 'internal-tasks/queues/:queue',
                 element: <TaskQueueDetailPage />,
                 handle: [
                     {
                         title: 'Internal Tasks',
-                        path: (_params: Params<string>) => `/tasks`,
+                        path: (_params: Params<string>) => `/internal-tasks`,
                     },
                     {
                         title: 'Queues',
-                        path: (_params: Params<string>) => `/tasks`,
+                        path: (_params: Params<string>) => `/internal-tasks`,
                     },
                     {
                         attr: 'queue',
-                        path: (params: Params<string>) => `/tasks/queues/${params.queue}`,
+                        path: (params: Params<string>) => `/internal-tasks/queues/${params.queue}`,
                     },
                 ],
             },
             {
-                path: 'workflows',
+                path: 'internal-workflows',
                 element: <WorkflowsPage />,
                 handle: { title: 'Internal Workflows' }
             },
             {
-                path: 'workflows/:instanceId/:executionId',
+                path: 'internal-workflows/:instanceId/:executionId',
                 element: <WorkflowDetailPage />,
                 handle: [
                     {
                         title: 'Internal Workflows',
-                        path: (_params: Params<string>) => `/workflows`,
+                        path: (_params: Params<string>) => `/internal-workflows`,
                     },
                     {
                         attr: 'instanceId',
-                        path: (params: Params<string>) => `/workflows/${params.instanceId}/${params.executionId}`,
+                        path: (params: Params<string>) => `/internal-workflows/${params.instanceId}/${params.executionId}`,
                     },
                 ],
             },

--- a/ui/admin/src/routes.tsx
+++ b/ui/admin/src/routes.tsx
@@ -187,14 +187,14 @@ export const router = createBrowserRouter([
             {
                 path: 'tasks',
                 element: <TasksPage />,
-                handle: { title: 'Tasks' }
+                handle: { title: 'Internal Tasks' }
             },
             {
                 path: 'tasks/queues/:queue',
                 element: <TaskQueueDetailPage />,
                 handle: [
                     {
-                        title: 'Tasks',
+                        title: 'Internal Tasks',
                         path: (_params: Params<string>) => `/tasks`,
                     },
                     {
@@ -210,14 +210,14 @@ export const router = createBrowserRouter([
             {
                 path: 'workflows',
                 element: <WorkflowsPage />,
-                handle: { title: 'Workflows' }
+                handle: { title: 'Internal Workflows' }
             },
             {
                 path: 'workflows/:instanceId/:executionId',
                 element: <WorkflowDetailPage />,
                 handle: [
                     {
-                        title: 'Workflows',
+                        title: 'Internal Workflows',
                         path: (_params: Params<string>) => `/workflows`,
                     },
                     {

--- a/ui/admin/src/search/CommandPalette.test.tsx
+++ b/ui/admin/src/search/CommandPalette.test.tsx
@@ -98,7 +98,7 @@ describe('CommandPalette', () => {
         ));
 
         await user.type(input, 'work');
-        expect(await screen.findByText('Workflows')).toBeTruthy();
+        expect(await screen.findByText('Internal Workflows')).toBeTruthy();
         await user.clear(input);
         await user.type(input, 'cxn_customer');
         await user.keyboard('{Enter}');
@@ -291,6 +291,6 @@ describe('CommandPalette', () => {
         expect(await screen.findByText(/Server search is unavailable/)).toBeTruthy();
         await user.clear(input);
         await user.type(input, 'work');
-        expect(await screen.findByText('Workflows')).toBeTruthy();
+        expect(await screen.findByText('Internal Workflows')).toBeTruthy();
     });
 });

--- a/ui/admin/src/search/navigation.test.ts
+++ b/ui/admin/src/search/navigation.test.ts
@@ -9,7 +9,12 @@ describe('Admin navigation catalog', () => {
     });
 
     it('finds commands by their local keywords', () => {
-        expect(matchingNavigationItems('jobs').map((item) => item.label)).toEqual(['Tasks']);
+        expect(matchingNavigationItems('jobs').map((item) => item.label)).toEqual(['Internal Tasks']);
         expect(matchingNavigationItems('integrations').map((item) => item.label)).toEqual(['Connectors']);
+    });
+
+    it('keeps internal tasks and workflows at the bottom of the main navigation', () => {
+        expect(adminNavigationItems.filter((item) => item.section === 'main').slice(-2).map((item) => item.label))
+            .toEqual(['Internal Tasks', 'Internal Workflows']);
     });
 });

--- a/ui/admin/src/search/navigation.test.ts
+++ b/ui/admin/src/search/navigation.test.ts
@@ -14,7 +14,12 @@ describe('Admin navigation catalog', () => {
     });
 
     it('keeps internal tasks and workflows at the bottom of the main navigation', () => {
-        expect(adminNavigationItems.filter((item) => item.section === 'main').slice(-2).map((item) => item.label))
-            .toEqual(['Internal Tasks', 'Internal Workflows']);
+        expect(adminNavigationItems.filter((item) => item.section === 'main').slice(-2).map((item) => [
+            item.label,
+            item.path,
+        ])).toEqual([
+            ['Internal Tasks', '/internal-tasks'],
+            ['Internal Workflows', '/internal-workflows'],
+        ]);
     });
 });

--- a/ui/admin/src/search/navigation.tsx
+++ b/ui/admin/src/search/navigation.tsx
@@ -31,8 +31,8 @@ export const adminNavigationItems: AdminNavigationItem[] = [
     {label: 'Keys', icon: KeyRoundedIcon, path: '/keys', keywords: ['encryption'], section: 'main'},
     {label: 'Rate Limits', icon: SpeedRoundedIcon, path: '/rate-limits', keywords: ['quota'], section: 'main'},
     {label: 'Actors', icon: PeopleRoundedIcon, path: '/actors', keywords: ['users'], section: 'main'},
-    {label: 'Internal Tasks', icon: AssignmentRoundedIcon, path: '/tasks', keywords: ['queues', 'jobs'], section: 'main'},
-    {label: 'Internal Workflows', icon: AccountTreeRoundedIcon, path: '/workflows', keywords: ['executions'], section: 'main'},
+    {label: 'Internal Tasks', icon: AssignmentRoundedIcon, path: '/internal-tasks', keywords: ['queues', 'jobs'], section: 'main'},
+    {label: 'Internal Workflows', icon: AccountTreeRoundedIcon, path: '/internal-workflows', keywords: ['executions'], section: 'main'},
     {
         label: 'Settings',
         icon: SettingsRoundedIcon,

--- a/ui/admin/src/search/navigation.tsx
+++ b/ui/admin/src/search/navigation.tsx
@@ -28,11 +28,11 @@ export const adminNavigationItems: AdminNavigationItem[] = [
     {label: 'Connectors', icon: PowerRoundedIcon, path: '/connectors', keywords: ['integrations'], section: 'main'},
     {label: 'Connections', icon: LinkRoundedIcon, path: '/connections', keywords: ['accounts'], section: 'main'},
     {label: 'Requests', icon: HttpRoundedIcon, path: '/requests', keywords: ['events', 'logs'], section: 'main'},
-    {label: 'Tasks', icon: AssignmentRoundedIcon, path: '/tasks', keywords: ['queues', 'jobs'], section: 'main'},
-    {label: 'Workflows', icon: AccountTreeRoundedIcon, path: '/workflows', keywords: ['executions'], section: 'main'},
     {label: 'Keys', icon: KeyRoundedIcon, path: '/keys', keywords: ['encryption'], section: 'main'},
     {label: 'Rate Limits', icon: SpeedRoundedIcon, path: '/rate-limits', keywords: ['quota'], section: 'main'},
     {label: 'Actors', icon: PeopleRoundedIcon, path: '/actors', keywords: ['users'], section: 'main'},
+    {label: 'Internal Tasks', icon: AssignmentRoundedIcon, path: '/tasks', keywords: ['queues', 'jobs'], section: 'main'},
+    {label: 'Internal Workflows', icon: AccountTreeRoundedIcon, path: '/workflows', keywords: ['executions'], section: 'main'},
     {
         label: 'Settings',
         icon: SettingsRoundedIcon,


### PR DESCRIPTION
## Summary

- rename the admin navigation entries to Internal Tasks and Internal Workflows
- move both entries to the bottom of the primary navigation list
- rename their list and detail routes to `/internal-tasks` and `/internal-workflows`
- align drill-down, return-navigation, and breadcrumb links with the renamed routes
- update command-palette expectations and cover the navigation ordering and paths

## Screenshots

Visual capture was unavailable: both connected browser surfaces redirected the healthy local dev server to an unreachable local browser endpoint. The production build and UI test suite pass.

## Testing

- `yarn workspace @authproxy/admin test`
- `yarn workspace @authproxy/admin typecheck`
- `yarn workspace @authproxy/admin lint`
- `yarn workspace @authproxy/admin build`
- `./scripts/preflight.sh`