### PR TITLE
Fix actors table columns

### DIFF
--- a/ui/admin/src/pages/Actors.test.tsx
+++ b/ui/admin/src/pages/Actors.test.tsx
@@ -1,0 +1,20 @@
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('@mui/x-data-grid', () => ({
+    DataGrid: () => null,
+}));
+
+import {columns} from './Actors';
+
+describe('Actors table columns', () => {
+    it('shows current actor fields', () => {
+        expect(columns.map(({field}) => field)).toEqual([
+            'name',
+            'id',
+            'externalId',
+            'namespace',
+            'createdAt',
+            'updatedAt',
+        ]);
+    });
+});

--- a/ui/admin/src/pages/Actors.tsx
+++ b/ui/admin/src/pages/Actors.tsx
@@ -35,24 +35,10 @@ export const columns: GridColDef<Actor>[] = [
         sortable: true,
     },
     {
-        field: 'email',
-        headerName: 'Email',
-        flex: 0.3,
-        minWidth: 60,
-        sortable: true,
-    },
-    {
-        field: 'admin',
-        headerName: 'Admin',
+        field: 'namespace',
+        headerName: 'Namespace',
         flex: 0.5,
-        minWidth: 80,
-        sortable: true,
-    },
-    {
-        field: 'superAdmin',
-        headerName: 'Super Admin',
-        flex: 0.5,
-        minWidth: 80,
+        minWidth: 90,
         sortable: true,
     },
     {


### PR DESCRIPTION
## Summary
- remove the obsolete Email, Admin, and Super Admin actor columns
- add a sortable Namespace column
- add regression coverage for the actor table column set

## Testing
- yarn workspace @authproxy/admin test
- yarn workspace @authproxy/admin typecheck
- yarn workspace @authproxy/admin lint
- yarn workspace @authproxy/admin build
- ./scripts/preflight.sh

## Screenshot
The supplied screenshot shows the stale columns before this change. I could not capture the updated local page because the development auth flow redirects through a self-signed TLS endpoint that the screenshot browser rejects. The production build and exact column set are covered by the checks above.