### PR TITLE
Scope admin resource lists to the selected namespace

### DIFF
--- a/ui/admin/src/pages/Actors.test.tsx
+++ b/ui/admin/src/pages/Actors.test.tsx
@@ -1,12 +1,82 @@
-import {describe, expect, it, vi} from 'vitest';
+// @vitest-environment jsdom
+import * as React from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {act, cleanup, render, waitFor} from '@testing-library/react';
+import {configureStore} from '@reduxjs/toolkit';
+import {Provider} from 'react-redux';
+import {MemoryRouter} from 'react-router-dom';
+import {listActors} from '@authproxy/api';
 
 vi.mock('@mui/x-data-grid', () => ({
     DataGrid: () => null,
 }));
 
-import {columns} from './Actors';
+vi.mock('nuqs', () => ({
+    parseAsInteger: {withDefault: () => ({})},
+    parseAsString: {withDefault: () => ({})},
+    useQueryState: (key: string) => [key === 'page' ? 1 : key === 'pageSize' ? 20 : '', vi.fn()],
+}));
+
+vi.mock('@authproxy/api', () => ({
+    NAMESPACE_PATH_SEPARATOR: '.',
+    ROOT_NAMESPACE_PATH: 'root',
+    NamespaceState: {ACTIVE: 'active'},
+    listActors: vi.fn(),
+    namespaceAndChildren: (path: string) => `${path}.**`,
+    namespaces: {
+        getByPath: vi.fn(),
+        list: vi.fn(),
+    },
+}));
+
+import Actors, {columns} from './Actors';
+
+const initialNamespaceState = {
+    currentPath: 'root',
+    hasInitialized: true,
+    current: null,
+    status: 'succeeded',
+    error: null,
+    children: [],
+    childrenHasMore: false,
+    childrenStatus: 'succeeded',
+    childrenError: null,
+};
+
+function renderActors() {
+    const store = configureStore({
+        reducer: {
+            namespaces: (state = initialNamespaceState, action: {type: string; payload?: string}) =>
+                action.type === 'test/selectNamespace'
+                    ? {...state, currentPath: action.payload || 'root'}
+                    : state,
+        },
+    });
+
+    render(
+        <Provider store={store}>
+            <MemoryRouter>
+                <Actors />
+            </MemoryRouter>
+        </Provider>,
+    );
+
+    return store;
+}
 
 describe('Actors table columns', () => {
+    beforeEach(() => {
+        vi.mocked(listActors).mockResolvedValue({
+            status: 200,
+            data: {items: []},
+        } as any);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
     it('shows current actor fields', () => {
         expect(columns.map(({field}) => field)).toEqual([
             'name',
@@ -16,5 +86,23 @@ describe('Actors table columns', () => {
             'createdAt',
             'updatedAt',
         ]);
+    });
+
+    it('refetches actors for the selected namespace and its descendants', async () => {
+        const store = renderActors();
+
+        await waitFor(() => {
+            expect(listActors).toHaveBeenCalledWith(expect.objectContaining({namespace: 'root.**'}));
+        });
+
+        act(() => {
+            store.dispatch({type: 'test/selectNamespace', payload: 'root.platform'});
+        });
+
+        await waitFor(() => {
+            expect(listActors).toHaveBeenLastCalledWith(expect.objectContaining({
+                namespace: 'root.platform.**',
+            }));
+        });
     });
 });

--- a/ui/admin/src/pages/Actors.tsx
+++ b/ui/admin/src/pages/Actors.tsx
@@ -10,6 +10,8 @@ import {
 import dayjs from 'dayjs';
 import {useQueryState, parseAsInteger, parseAsString} from 'nuqs'
 import {useNavigate} from 'react-router-dom';
+import {useSelector} from 'react-redux';
+import {selectCurrentNamespaceMatcher} from '../store/namespacesSlice';
 import {toSnakeCase} from '../util';
 
 export const columns: GridColDef<Actor>[] = [
@@ -67,6 +69,7 @@ export const columns: GridColDef<Actor>[] = [
 
 export default function Actors() {
     const navigate = useNavigate();
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
     const defaultPageSize = 20;
 
     const [rows, setRows] = useState<Actor[]>([]);
@@ -134,6 +137,7 @@ export default function Actors() {
                 const prevResp = responsesCacheRef.current[responsesCacheRef.current.length - 1];
 
                 const params: ListActorsParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
+                    namespace: namespaceMatcher,
                     orderBy: sort || undefined,
                     limit: pageSize,
                 };
@@ -169,7 +173,7 @@ export default function Actors() {
         // Reset cursors/cache and immediately fetch first page to ensure initial load
         resetPagination();
         fetchPage(1);
-    }, [pageSize, sort]);
+    }, [namespaceMatcher, pageSize, sort]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/pages/Connections.tsx
+++ b/ui/admin/src/pages/Connections.tsx
@@ -15,14 +15,13 @@ import {
     ConnectionState,
     listConnections,
     ListConnectionsParams,
-    ListResponse,
-    namespaceAndChildren
+    ListResponse
 } from '@authproxy/api';
 import dayjs from 'dayjs';
 import { useNavigate } from 'react-router-dom';
 import {useQueryState, parseAsInteger, parseAsStringLiteral, parseAsString} from 'nuqs'
 import {useSelector} from "react-redux";
-import {selectCurrentNamespacePath} from "../store/namespacesSlice";
+import {selectCurrentNamespaceMatcher} from "../store/namespacesSlice";
 import {toSnakeCase} from '../util';
 
 function renderState(state: ConnectionState) {
@@ -146,7 +145,7 @@ export default function Connections() {
     ], []);
     const stateVals = useMemo(() => stateOptions.map(opt => opt.value), [stateOptions]);
     const navigate = useNavigate();
-    const ns = useSelector(selectCurrentNamespacePath);
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
 
     const [rows, setRows] = useState<Connection[]>([]);
     const [rowCount, setRowCount] = useState<number>(-1);
@@ -232,7 +231,7 @@ export default function Connections() {
 
                 const params: ListConnectionsParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
                     state: (stateFilter as ConnectionState) || undefined,
-                    namespace: namespaceAndChildren(ns),
+                    namespace: namespaceMatcher,
                     orderBy: sort || undefined,
                     limit: pageSize,
                 };
@@ -268,7 +267,7 @@ export default function Connections() {
         // Reset cursors/cache and immediately fetch first page to ensure initial load
         resetPagination();
         fetchPage(1);
-    }, [ns, pageSize, sort, stateFilter]);
+    }, [namespaceMatcher, pageSize, sort, stateFilter]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/pages/Connectors.tsx
+++ b/ui/admin/src/pages/Connectors.tsx
@@ -11,13 +11,13 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import {
-    listConnectors, ConnectorVersionState, Connector, ListResponse, ListConnectorsParams, namespaceAndChildren
+    listConnectors, ConnectorVersionState, Connector, ListResponse, ListConnectorsParams
 } from '@authproxy/api';
 import dayjs from 'dayjs';
 import {useQueryState, parseAsInteger, parseAsStringLiteral, parseAsString} from 'nuqs'
 import {useNavigate} from "react-router-dom";
 import {useSelector} from "react-redux";
-import {selectCurrentNamespacePath} from "../store/namespacesSlice";
+import {selectCurrentNamespaceMatcher} from "../store/namespacesSlice";
 import {toSnakeCase} from '../util';
 
 function renderState(state: ConnectorVersionState) {
@@ -135,7 +135,7 @@ export default function Connectors() {
     ], []);
     const navigate = useNavigate();
     const stateVals = useMemo(() => stateOptions.map(opt => opt.value), [stateOptions]);
-    const ns = useSelector(selectCurrentNamespacePath);
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
 
     const [rows, setRows] = useState<Connector[]>([]);
     const [rowCount, setRowCount] = useState<number>(-1);
@@ -221,7 +221,7 @@ export default function Connectors() {
 
                 const params: ListConnectorsParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
                     state: (stateFilter as ConnectorVersionState) || undefined,
-                    namespace: namespaceAndChildren(ns),
+                    namespace: namespaceMatcher,
                     orderBy: sort || undefined,
                     limit: pageSize,
                 };
@@ -257,7 +257,7 @@ export default function Connectors() {
         // Reset cursors/cache and immediately fetch first page to ensure initial load
         resetPagination();
         fetchPage(1);
-    }, [ns, pageSize, sort, stateFilter]);
+    }, [namespaceMatcher, pageSize, sort, stateFilter]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/pages/Keys.tsx
+++ b/ui/admin/src/pages/Keys.tsx
@@ -20,13 +20,13 @@ import TextField from '@mui/material/TextField';
 import AddIcon from '@mui/icons-material/Add';
 import {
     listKeys, KeyState, Key, ListResponse,
-    ListKeysParams, namespaceAndChildren, createKey, CreateKeyRequest
+    ListKeysParams, createKey, CreateKeyRequest
 } from '@authproxy/api';
 import dayjs from 'dayjs';
 import {useQueryState, parseAsInteger, parseAsStringLiteral, parseAsString} from 'nuqs'
 import {useNavigate} from "react-router-dom";
 import {useSelector} from "react-redux";
-import {selectCurrentNamespacePath} from "../store/namespacesSlice";
+import {selectCurrentNamespaceMatcher, selectCurrentNamespacePath} from "../store/namespacesSlice";
 import {toSnakeCase} from '../util';
 import KeyDataForm, {
     buildKeyDataPayload,
@@ -131,6 +131,7 @@ export default function Keys() {
     const navigate = useNavigate();
     const stateVals = useMemo(() => stateOptions.map(opt => opt.value), [stateOptions]);
     const ns = useSelector(selectCurrentNamespacePath);
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
 
     const [rows, setRows] = useState<Key[]>([]);
     const [rowCount, setRowCount] = useState<number>(-1);
@@ -213,7 +214,7 @@ export default function Keys() {
 
                 const params: ListKeysParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
                     state: (stateFilter as KeyState) || undefined,
-                    namespace: namespaceAndChildren(ns),
+                    namespace: namespaceMatcher,
                     orderBy: sort || undefined,
                     limit: pageSize,
                 };
@@ -247,7 +248,7 @@ export default function Keys() {
     useEffect(() => {
         resetPagination();
         fetchPage(1);
-    }, [ns, pageSize, sort, stateFilter]);
+    }, [namespaceMatcher, pageSize, sort, stateFilter]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/pages/RateLimits.tsx
+++ b/ui/admin/src/pages/RateLimits.tsx
@@ -21,7 +21,7 @@ import Alert from '@mui/material/Alert';
 import TextField from '@mui/material/TextField';
 import {
     listRateLimits, RateLimit, RateLimitMode, RateLimitDefinition,
-    ListResponse, ListRateLimitsParams, namespaceAndChildren,
+    ListResponse, ListRateLimitsParams,
     createRateLimit, updateRateLimit, CreateRateLimitRequest,
 } from '@authproxy/api';
 import RateLimitDefinitionEditor from '../components/RateLimitDefinitionEditor';
@@ -30,7 +30,7 @@ import dayjs from 'dayjs';
 import {useQueryState, parseAsInteger, parseAsStringLiteral, parseAsString} from 'nuqs'
 import {useNavigate} from "react-router-dom";
 import {useSelector} from "react-redux";
-import {selectCurrentNamespacePath} from "../store/namespacesSlice";
+import {selectCurrentNamespaceMatcher, selectCurrentNamespacePath} from "../store/namespacesSlice";
 import {toSnakeCase} from '../util';
 
 // Summarise the algorithm variant in one short string. Keeps the column
@@ -85,6 +85,7 @@ export default function RateLimits() {
     const navigate = useNavigate();
     const modeVals = useMemo(() => modeOptions.map(opt => opt.value), [modeOptions]);
     const ns = useSelector(selectCurrentNamespacePath);
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
 
     const [rows, setRows] = useState<RateLimit[]>([]);
     const [rowCount, setRowCount] = useState<number>(-1);
@@ -168,7 +169,7 @@ export default function RateLimits() {
                 const prevResp = responsesCacheRef.current[responsesCacheRef.current.length - 1];
 
                 const params: ListRateLimitsParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
-                    namespace: namespaceAndChildren(ns),
+                    namespace: namespaceMatcher,
                     orderBy: sort || undefined,
                     limit: pageSize,
                 };
@@ -210,7 +211,7 @@ export default function RateLimits() {
     useEffect(() => {
         resetPagination();
         fetchPage(1);
-    }, [ns, pageSize, sort, modeFilter]);
+    }, [namespaceMatcher, pageSize, sort, modeFilter]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/pages/Requests.tsx
+++ b/ui/admin/src/pages/Requests.tsx
@@ -23,7 +23,7 @@ import {HttpStatusChip, Duration, toSnakeCase} from '../util';
 import {useQueryState, parseAsInteger, parseAsStringLiteral, parseAsString} from 'nuqs'
 import RequestDetail from "../components/RequestDetail";
 import {useSelector} from "react-redux";
-import {selectCurrentNamespacePath} from "../store/namespacesSlice";
+import {selectCurrentNamespaceMatcher} from "../store/namespacesSlice";
 
 export const columns: (GridColDef<RequestEventRecord> & {hideInitial?: boolean})[] = [
     {
@@ -254,7 +254,7 @@ export default function Requests() {
         { label: 'Public', value: RequestType.PUBLIC },
     ], []);
     const stateVals = useMemo(() => stateOptions.map(opt => opt.value), [stateOptions]);
-    const ns = useSelector(selectCurrentNamespacePath);
+    const namespaceMatcher = useSelector(selectCurrentNamespaceMatcher);
 
     const [rows, setRows] = useState<RequestEventRecord[]>([]);
     const [rowCount, setRowCount] = useState<number>(-1);
@@ -342,7 +342,7 @@ export default function Requests() {
                 const prevResp = responsesCacheRef.current[responsesCacheRef.current.length - 1];
 
                 const params: ListRequestEventsParams = prevResp?.cursor ? {cursor: prevResp.cursor} : {
-                    namespace: ns + ".**",
+                    namespace: namespaceMatcher,
                     requestType: (typeFilter as RequestType) || undefined,
                     labelSelector: labelSelector || undefined,
                     orderBy: sort || undefined,
@@ -380,7 +380,7 @@ export default function Requests() {
         // Reset cursors/cache and immediately fetch first page to ensure initial load
         resetPagination();
         fetchPage(1);
-    }, [ns, pageSize, sort, typeFilter, labelSelector]);
+    }, [namespaceMatcher, pageSize, sort, typeFilter, labelSelector]);
 
     useEffect(() => {
         fetchPage(page);

--- a/ui/admin/src/store/namespacesSlice.test.ts
+++ b/ui/admin/src/store/namespacesSlice.test.ts
@@ -5,6 +5,7 @@ import namespaceReducer, {
     isValidNamespacePath,
     loadCurrentChildren,
     normalizeNamespacePath,
+    selectCurrentNamespaceMatcher,
     setCurrentNamespace,
 } from './namespacesSlice';
 
@@ -22,6 +23,7 @@ vi.mock('@authproxy/api', () => {
             DISCONNECTING: 'disconnecting',
             DISCONNECTED: 'disconnected',
         },
+        namespaceAndChildren: (path: string) => `${path}.**`,
         namespaces: apiNamespaces,
     };
 });
@@ -64,6 +66,16 @@ describe('namespacesSlice namespace path handling', () => {
         expect(normalizeNamespacePath('action.refresh')).toBe(ROOT_NAMESPACE_PATH);
         expect(normalizeNamespacePath('root..platform')).toBe(ROOT_NAMESPACE_PATH);
         expect(normalizeNamespacePath(null)).toBe(ROOT_NAMESPACE_PATH);
+    });
+
+    it('builds the resource-list matcher from the selected namespace', () => {
+        const store = createStore();
+
+        expect(selectCurrentNamespaceMatcher(store.getState() as any)).toBe('root.**');
+
+        store.dispatch(setCurrentNamespace('root.platform') as any);
+
+        expect(selectCurrentNamespaceMatcher(store.getState() as any)).toBe('root.platform.**');
     });
 
     it('loads root instead of a malformed namespace path', () => {

--- a/ui/admin/src/store/namespacesSlice.ts
+++ b/ui/admin/src/store/namespacesSlice.ts
@@ -2,6 +2,7 @@ import {createAsyncThunk, createSlice, PayloadAction} from '@reduxjs/toolkit';
 import type {RootState, AppThunk} from './store';
 import {
     namespaces, ListNamespaceParams, Namespace, NAMESPACE_PATH_SEPARATOR, ROOT_NAMESPACE_PATH, NamespaceState,
+    namespaceAndChildren,
 } from '@authproxy/api';
 
 interface NamespacesState {
@@ -170,6 +171,8 @@ export const namespacesSlice = createSlice({
 
 // Selectors
 export const selectCurrentNamespacePath = (state: RootState) => state.namespaces.currentPath;
+export const selectCurrentNamespaceMatcher = (state: RootState) =>
+    namespaceAndChildren(selectCurrentNamespacePath(state));
 export const selectCurrentNamespace = (state: RootState) => state.namespaces.current;
 export const selectCurrentNamespaceChildren = (state: RootState) => state.namespaces.children;
 export const selectCurrentNamespaceChildrenHasMore = (state: RootState) => state.namespaces.childrenHasMore;


### PR DESCRIPTION
## Summary
- filter the Actors list to the namespace selected in the admin header, including descendant namespaces
- centralize the selected namespace matcher used by Connectors, Connections, Requests, Actors, Keys, and Rate Limits
- refetch Actors when the selected namespace changes
- add regression coverage for matcher construction and Actors refetching

## Audit results
- Connectors, Connections, Requests, Keys, and Rate Limits were already namespace-scoped and now share the centralized selector
- Namespace detail uses childrenOf for its child list and exact ancestor paths for encryption-key selection, as intended
- Resource search and dashboard metrics already use the selected namespace and descendants
- Internal task and workflow monitoring APIs are global and do not expose namespace filters

## Testing
- yarn workspace @authproxy/admin test (96 tests)
- yarn workspace @authproxy/admin typecheck
- yarn workspace @authproxy/admin lint
- yarn workspace @authproxy/admin build
- ./scripts/preflight.sh

## Screenshots
Not applicable: this changes request scoping and refetch behavior without changing the rendered layout.