### PR TITLE
Isolate demo users and connections under root.demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -2,8 +2,8 @@
 name: Deploy Demo
 
 # Auto-deploys the hosted demo environment after Build Image publishes
-# main-branch images. Demo deploys are rendered with Kustomize; seeding is
-# intentionally handled by the manual Seed Demo workflow.
+# main-branch images. Demo deploys are rendered with Kustomize and the catalog
+# seed job runs after the application and TLS endpoints are ready.
 #
 # Trust + auth: this workflow assumes the `authproxy-eks-gh-actions`
 # IAM role via OIDC. The role's trust policy (from
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: gha-eks
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     env:
       RELEASE_NAME: demo
@@ -99,6 +99,7 @@ jobs:
             authproxy
             authproxy-demo-shell
             authproxy-demo-grafana
+            authproxy-demo-seed
           )
 
           echo "${{ secrets.GITHUB_TOKEN }}" \
@@ -150,6 +151,8 @@ jobs:
         run: |
           set -euo pipefail
           secrets_manifest="${RUNNER_TEMP}/demo-preserved-secrets.json"
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
 
           kubectl create namespace "${RELEASE_NS}" --dry-run=client -o yaml \
             | kubectl apply -f -
@@ -171,13 +174,24 @@ jobs:
             fi
           done
 
-          stale_smoke_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
-            -o jsonpath='{.data.smoke-user\.pub}')"
-          if [ -n "${stale_smoke_public}" ]; then
-            kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
-              --type json \
-              --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
-          fi
+          kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-demo-shell-key" \
+            -o jsonpath='{.data.demo-shell\.pub}' \
+            | base64 -d > "${workdir}/demo-shell.pub"
+          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-actors" \
+            --from-file=demo-admin.pub="${workdir}/demo-shell.pub" \
+            --from-file=grafana.pub="${workdir}/demo-shell.pub" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
+
+          for stale_actor in demo-shell demo-user fresh-user smoke-user; do
+            stale_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
+              -o "jsonpath={.data.${stale_actor}\\.pub}")"
+            if [ -n "${stale_public}" ]; then
+              kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+                --type json \
+                --patch="[{\"op\":\"remove\",\"path\":\"/data/${stale_actor}.pub\"}]"
+            fi
+          done
           kubectl -n "${RELEASE_NS}" delete secret "${RELEASE_NAME}-smoke-actors" \
             --ignore-not-found
 
@@ -434,6 +448,59 @@ jobs:
             kubectl -n "${RELEASE_NS}" get certificate,order,challenge || true
             exit 1
           done
+
+      - name: Render seed job
+        id: seed
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          manifest="${RUNNER_TEMP}/demo-seed.yaml"
+
+          perl -0pi -e 's#(name: ghcr\.io/rmorlok/authproxy-demo-seed\n\s+newTag: )main#${1}$ENV{IMAGE_TAG}#g' \
+            "${KUSTOMIZE_OVERLAY}/seed/kustomization.yaml"
+          kubectl kustomize "${KUSTOMIZE_OVERLAY}/seed" > "${manifest}"
+
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
+          grep -Fq "namespace: ${RELEASE_NS}" "${manifest}"
+          grep -Fq "image: ghcr.io/rmorlok/authproxy-demo-seed:${IMAGE_TAG}" "${manifest}"
+          grep -Fq "value: http://${RELEASE_NAME}-authproxy:8082" "${manifest}"
+          grep -Fq "namespace: root.demo" "${manifest}"
+
+      - name: Run seed job
+        run: |
+          set -euo pipefail
+          manifest="${{ steps.seed.outputs.manifest }}"
+
+          kubectl -n "${RELEASE_NS}" delete "job/${RELEASE_NAME}-seed" \
+            --ignore-not-found --wait=false
+
+          for _ in $(seq 1 24); do
+            if ! kubectl -n "${RELEASE_NS}" get "job/${RELEASE_NAME}-seed" >/dev/null 2>&1; then
+              break
+            fi
+            echo "Waiting for stale ${RELEASE_NAME}-seed Job to be deleted..."
+            sleep 5
+          done
+
+          if kubectl -n "${RELEASE_NS}" get "job/${RELEASE_NAME}-seed" >/dev/null 2>&1; then
+            echo "Timed out waiting for stale ${RELEASE_NAME}-seed Job to delete." >&2
+            exit 1
+          fi
+
+          kubectl -n "${RELEASE_NS}" apply -f "${manifest}"
+
+          if ! kubectl -n "${RELEASE_NS}" wait \
+            --for=condition=complete "job/${RELEASE_NAME}-seed" \
+            --timeout=10m; then
+            kubectl -n "${RELEASE_NS}" describe "job/${RELEASE_NAME}-seed" || true
+            kubectl -n "${RELEASE_NS}" logs "job/${RELEASE_NAME}-seed" \
+              --all-containers --tail=-1 || true
+            exit 1
+          fi
+
+          kubectl -n "${RELEASE_NS}" logs "job/${RELEASE_NAME}-seed" \
+            --all-containers --tail=-1
 
       - name: Smoke test telemetry links
         timeout-minutes: 2

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -230,24 +230,21 @@ jobs:
             echo "Reusing ${RELEASE_NAME}-demo-shell-key"
           fi
 
-          if ! kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" >/dev/null 2>&1; then
-            kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-actors" \
-              --from-file=demo-shell.pub="${workdir}/demo-shell.pub" \
-              --from-file=demo-admin.pub="${workdir}/demo-shell.pub" \
-              --from-file=demo-user.pub="${workdir}/demo-shell.pub" \
-              --from-file=fresh-user.pub="${workdir}/demo-shell.pub" \
-              --from-file=grafana.pub="${workdir}/demo-shell.pub"
-          else
-            echo "Reusing ${RELEASE_NAME}-actors"
-          fi
+          kubectl -n "${RELEASE_NS}" create secret generic "${RELEASE_NAME}-actors" \
+            --from-file=demo-admin.pub="${workdir}/demo-shell.pub" \
+            --from-file=grafana.pub="${workdir}/demo-shell.pub" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
 
-          stale_smoke_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
-            -o jsonpath='{.data.smoke-user\.pub}')"
-          if [ -n "${stale_smoke_public}" ]; then
-            kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
-              --type json \
-              --patch='[{"op":"remove","path":"/data/smoke-user.pub"}]'
-          fi
+          for stale_actor in demo-shell demo-user fresh-user smoke-user; do
+            stale_public="$(kubectl -n "${RELEASE_NS}" get secret "${RELEASE_NAME}-actors" \
+              -o "jsonpath={.data.${stale_actor}\\.pub}")"
+            if [ -n "${stale_public}" ]; then
+              kubectl -n "${RELEASE_NS}" patch secret "${RELEASE_NAME}-actors" \
+                --type json \
+                --patch="[{\"op\":\"remove\",\"path\":\"/data/${stale_actor}.pub\"}]"
+            fi
+          done
 
           kubectl -n "${RELEASE_NS}" delete secret "${RELEASE_NAME}-smoke-actors" \
             --ignore-not-found

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -1,9 +1,8 @@
 # schema: https://json.schemastore.org/github-workflow.json
 name: Seed Demo
 
-# Manually reseeds the persistent demo environment. This is intentionally
-# decoupled from Deploy Demo so demo data can be refreshed on demand
-# without rolling the application.
+# Manually reruns the same seed process used by Deploy Demo, so demo data can
+# also be verified or refreshed on demand without rolling the application.
 on:
   workflow_dispatch:
     inputs:

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -35,11 +35,10 @@ import (
 
 // SeedConfig is the YAML shape the binary consumes.
 type SeedConfig struct {
-	Namespaces                []NamespaceSeed         `yaml:"namespaces"`
-	Actors                    []ActorSeed             `yaml:"actors"`
-	OAuth2TestProvider        *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
-	Connectors                []ConnectorSeed         `yaml:"connectors"`
-	LegacyConnectorNamespaces []string                `yaml:"legacyConnectorNamespaces"`
+	Namespaces         []NamespaceSeed         `yaml:"namespaces"`
+	Actors             []ActorSeed             `yaml:"actors"`
+	OAuth2TestProvider *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
+	Connectors         []ConnectorSeed         `yaml:"connectors"`
 }
 
 type NamespaceSeed struct {
@@ -464,44 +463,6 @@ func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*
 	return &list.Items[0], nil
 }
 
-func archiveLegacySeededConnectors(c *resty.Client, baseUrl string, seed ConnectorSeed, legacyNamespaces []string) (int, error) {
-	archived := 0
-	for _, legacyNamespace := range legacyNamespaces {
-		if legacyNamespace == connectorNamespace(seed) {
-			continue
-		}
-
-		legacySeed := seed
-		legacySeed.Namespace = legacyNamespace
-		legacy, err := listSeededConnector(c, baseUrl, legacySeed)
-		if err != nil {
-			return archived, err
-		}
-		if legacy == nil || legacy.State == api.ConnectorVersionStateArchived {
-			continue
-		}
-
-		resp, err := c.R().
-			SetHeader("Content-Type", "application/json").
-			SetBody(map[string]any{}).
-			Post(fmt.Sprintf("%s/api/v1/connectors/%s/_archive", baseUrl, legacy.Id))
-		if err != nil {
-			return archived, fmt.Errorf("POST archive legacy connector seed %q in %q: %w", seed.Key, legacyNamespace, err)
-		}
-		if resp.StatusCode() >= 400 {
-			return archived, fmt.Errorf(
-				"POST archive legacy connector seed %q in %q returned %d: %s",
-				seed.Key,
-				legacyNamespace,
-				resp.StatusCode(),
-				resp.String(),
-			)
-		}
-		archived++
-	}
-	return archived, nil
-}
-
 func getConnectorVersion(c *resty.Client, baseUrl string, connector api.ConnectorJson) (*api.ConnectorVersionJson, error) {
 	var version api.ConnectorVersionJson
 	resp, err := c.R().
@@ -712,17 +673,8 @@ func run(logger *slog.Logger) error {
 	for _, connector := range cfg.Connectors {
 		deadline := time.Now().Add(seedRetryTimeout)
 		var action connectorAction
-		var legacyArchived int
 		for attempt := 1; ; attempt++ {
 			action, err = upsertConnector(client, s.adminApiUrl, connector)
-			if err == nil {
-				legacyArchived, err = archiveLegacySeededConnectors(
-					client,
-					s.adminApiUrl,
-					connector,
-					cfg.LegacyConnectorNamespaces,
-				)
-			}
 			if err == nil {
 				break
 			}
@@ -745,9 +697,6 @@ func run(logger *slog.Logger) error {
 			logger.Info("connector updated", "key", connector.Key, "namespace", connectorNamespace(connector))
 		case connectorAlreadyPresent:
 			logger.Info("connector already present", "key", connector.Key, "namespace", connectorNamespace(connector))
-		}
-		if legacyArchived > 0 {
-			logger.Info("legacy connector archived", "key", connector.Key, "count", legacyArchived)
 		}
 	}
 	return nil

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -2,14 +2,14 @@
 // against a running AuthProxy admin API. Run as a Helm post-install /
 // post-upgrade hook from the authproxy-demo umbrella chart.
 //
-// Idempotency model: for each desired actor, first GET it by
-// external_id; if AuthProxy returns 404, POST it. For each desired
-// connector, list by the stable demo seed label, create it when absent,
-// or publish a new version when the definition changes. Re-running the
-// seed job is a no-op once the state matches.
+// Idempotency model: namespaces and actors are created when absent and
+// verified against the desired state when present. For each desired connector,
+// list by the stable demo seed label, create it when absent, or publish a new
+// version when the definition changes. Re-running the seed job is a no-op once
+// the state matches.
 //
-// Auth: signs requests as the demo-shell admin actor using the same
-// keypair the demo-shell itself uses. AuthProxy already trusts that
+// Auth: signs requests as the demo-admin actor using the same keypair the
+// demo-shell uses for that actor. AuthProxy already trusts that
 // actor to create/list other actors via the admin-api access scope.
 package main
 
@@ -28,22 +28,32 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // SeedConfig is the YAML shape the binary consumes.
 type SeedConfig struct {
-	Actors             []ActorSeed             `yaml:"actors"`
-	OAuth2TestProvider *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
-	Connectors         []ConnectorSeed         `yaml:"connectors"`
+	Namespaces                []NamespaceSeed         `yaml:"namespaces"`
+	Actors                    []ActorSeed             `yaml:"actors"`
+	OAuth2TestProvider        *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
+	Connectors                []ConnectorSeed         `yaml:"connectors"`
+	LegacyConnectorNamespaces []string                `yaml:"legacyConnectorNamespaces"`
+}
+
+type NamespaceSeed struct {
+	Path        string            `yaml:"path"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 type ActorSeed struct {
-	ExternalId  string            `yaml:"externalId"`
-	Namespace   string            `yaml:"namespace,omitempty"`
-	Labels      map[string]string `yaml:"labels,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty"`
+	ExternalId  string               `yaml:"externalId"`
+	Namespace   string               `yaml:"namespace,omitempty"`
+	Permissions []aschema.Permission `yaml:"permissions"`
+	Labels      map[string]string    `yaml:"labels,omitempty"`
+	Annotations map[string]string    `yaml:"annotations,omitempty"`
 }
 
 type ConnectorSeed struct {
@@ -115,6 +125,7 @@ type seedAction string
 const (
 	seedCreated        seedAction = "created"
 	seedAlreadyPresent seedAction = "already-present"
+	seedUpdated        seedAction = "updated"
 )
 
 func mustGetenv(key string) string {
@@ -169,27 +180,79 @@ func newSignedClient(s settings) (*resty.Client, error) {
 	return c, nil
 }
 
-// upsertActor creates the actor if it doesn't already exist by
-// external_id. Returns true when a create was performed, false on
-// no-op.
-func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, err error) {
+func upsertNamespace(c *resty.Client, baseUrl string, ns NamespaceSeed) (seedAction, error) {
+	var existing api.NamespaceJson
+	getResp, err := c.R().
+		SetHeader("Accept", "application/json").
+		SetResult(&existing).
+		Get(fmt.Sprintf("%s/api/v1/namespaces/%s", baseUrl, ns.Path))
+	if err != nil {
+		return "", fmt.Errorf("GET namespace %q: %w", ns.Path, err)
+	}
+
+	switch getResp.StatusCode() {
+	case http.StatusOK:
+		if !stringMapsEqual(ns.Labels, existing.Labels) ||
+			!stringMapsEqual(ns.Annotations, existing.Annotations) {
+			return "", fmt.Errorf("namespace %q exists but does not match the configured labels and annotations", ns.Path)
+		}
+		return seedAlreadyPresent, nil
+	case http.StatusNotFound:
+		// fall through to create
+	default:
+		return "", fmt.Errorf("GET namespace %q returned %d: %s", ns.Path, getResp.StatusCode(), getResp.String())
+	}
+
+	postResp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(api.CreateNamespaceRequestJson{
+			Path:        ns.Path,
+			Labels:      ns.Labels,
+			Annotations: ns.Annotations,
+		}).
+		Post(fmt.Sprintf("%s/api/v1/namespaces", baseUrl))
+	if err != nil {
+		return "", fmt.Errorf("POST namespace %q: %w", ns.Path, err)
+	}
+	if postResp.StatusCode() >= 400 {
+		return "", fmt.Errorf("POST namespace %q returned %d: %s", ns.Path, postResp.StatusCode(), postResp.String())
+	}
+	return seedCreated, nil
+}
+
+// upsertActor creates the actor if it doesn't already exist by external_id and
+// reconciles its mutable state when necessary.
+func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (seedAction, error) {
 	// GET by external_id (with optional namespace).
-	getReq := c.R().SetHeader("Accept", "application/json")
+	var existing api.ActorJson
+	getReq := c.R().SetHeader("Accept", "application/json").SetResult(&existing)
 	if a.Namespace != "" {
 		getReq.SetQueryParam("namespace", a.Namespace)
 	}
 	getResp, err := getReq.Get(fmt.Sprintf("%s/api/v1/actors/external-id/%s", baseUrl, a.ExternalId))
 	if err != nil {
-		return false, fmt.Errorf("GET actor %q: %w", a.ExternalId, err)
+		return "", fmt.Errorf("GET actor %q: %w", a.ExternalId, err)
 	}
 
 	switch getResp.StatusCode() {
 	case http.StatusOK:
-		return false, nil
+		if existing.Namespace != a.Namespace ||
+			existing.ExternalId != a.ExternalId {
+			return "", fmt.Errorf("actor %q exists in namespace %q but does not match the configured state", a.ExternalId, a.Namespace)
+		}
+		if !reflect.DeepEqual(existing.Permissions, a.Permissions) ||
+			!stringMapsEqual(existing.Labels, a.Labels) ||
+			!stringMapsEqual(existing.Annotations, a.Annotations) {
+			if err := updateActor(c, baseUrl, a); err != nil {
+				return "", err
+			}
+			return seedUpdated, nil
+		}
+		return seedAlreadyPresent, nil
 	case http.StatusNotFound:
 		// fall through to create
 	default:
-		return false, fmt.Errorf("GET actor %q returned %d: %s", a.ExternalId, getResp.StatusCode(), getResp.String())
+		return "", fmt.Errorf("GET actor %q returned %d: %s", a.ExternalId, getResp.StatusCode(), getResp.String())
 	}
 
 	body := api.CreateActorRequestJson{
@@ -203,12 +266,35 @@ func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, er
 		SetBody(body).
 		Post(fmt.Sprintf("%s/api/v1/actors", baseUrl))
 	if err != nil {
-		return false, fmt.Errorf("POST actor %q: %w", a.ExternalId, err)
+		return "", fmt.Errorf("POST actor %q: %w", a.ExternalId, err)
 	}
 	if postResp.StatusCode() >= 400 {
-		return false, fmt.Errorf("POST actor %q returned %d: %s", a.ExternalId, postResp.StatusCode(), postResp.String())
+		return "", fmt.Errorf("POST actor %q returned %d: %s", a.ExternalId, postResp.StatusCode(), postResp.String())
 	}
-	return true, nil
+
+	if err := updateActor(c, baseUrl, a); err != nil {
+		return "", err
+	}
+	return seedCreated, nil
+}
+
+func updateActor(c *resty.Client, baseUrl string, a ActorSeed) error {
+	patchResp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetQueryParam("namespace", a.Namespace).
+		SetBody(api.UpdateActorRequestJson{
+			Permissions: a.Permissions,
+			Labels:      a.Labels,
+			Annotations: a.Annotations,
+		}).
+		Patch(fmt.Sprintf("%s/api/v1/actors/external-id/%s", baseUrl, a.ExternalId))
+	if err != nil {
+		return fmt.Errorf("PATCH actor %q permissions: %w", a.ExternalId, err)
+	}
+	if patchResp.StatusCode() >= 400 {
+		return fmt.Errorf("PATCH actor %q permissions returned %d: %s", a.ExternalId, patchResp.StatusCode(), patchResp.String())
+	}
+	return nil
 }
 
 func seedOAuth2TestProvider(c *resty.Client, seed OAuth2TestProviderSeed) error {
@@ -378,6 +464,44 @@ func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*
 	return &list.Items[0], nil
 }
 
+func archiveLegacySeededConnectors(c *resty.Client, baseUrl string, seed ConnectorSeed, legacyNamespaces []string) (int, error) {
+	archived := 0
+	for _, legacyNamespace := range legacyNamespaces {
+		if legacyNamespace == connectorNamespace(seed) {
+			continue
+		}
+
+		legacySeed := seed
+		legacySeed.Namespace = legacyNamespace
+		legacy, err := listSeededConnector(c, baseUrl, legacySeed)
+		if err != nil {
+			return archived, err
+		}
+		if legacy == nil || legacy.State == api.ConnectorVersionStateArchived {
+			continue
+		}
+
+		resp, err := c.R().
+			SetHeader("Content-Type", "application/json").
+			SetBody(map[string]any{}).
+			Post(fmt.Sprintf("%s/api/v1/connectors/%s/_archive", baseUrl, legacy.Id))
+		if err != nil {
+			return archived, fmt.Errorf("POST archive legacy connector seed %q in %q: %w", seed.Key, legacyNamespace, err)
+		}
+		if resp.StatusCode() >= 400 {
+			return archived, fmt.Errorf(
+				"POST archive legacy connector seed %q in %q returned %d: %s",
+				seed.Key,
+				legacyNamespace,
+				resp.StatusCode(),
+				resp.String(),
+			)
+		}
+		archived++
+	}
+	return archived, nil
+}
+
 func getConnectorVersion(c *resty.Client, baseUrl string, connector api.ConnectorJson) (*api.ConnectorVersionJson, error) {
 	var version api.ConnectorVersionJson
 	resp, err := c.R().
@@ -513,11 +637,28 @@ func run(logger *slog.Logger) error {
 	}
 	providerClient := resty.New().SetTimeout(30 * time.Second)
 
+	for _, ns := range cfg.Namespaces {
+		deadline := time.Now().Add(seedRetryTimeout)
+		var action seedAction
+		for attempt := 1; ; attempt++ {
+			action, err = upsertNamespace(client, s.adminApiUrl, ns)
+			if err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("upsert namespace %q after %s: %w", ns.Path, seedRetryTimeout, err)
+			}
+			logger.Warn("namespace seed attempt failed; retrying", "path", ns.Path, "attempt", attempt, "err", err)
+			time.Sleep(seedRetryInterval)
+		}
+		logger.Info("namespace seed complete", "path", ns.Path, "action", action)
+	}
+
 	for _, a := range cfg.Actors {
 		deadline := time.Now().Add(seedRetryTimeout)
-		var created bool
+		var action seedAction
 		for attempt := 1; ; attempt++ {
-			created, err = upsertActor(client, s.adminApiUrl, a)
+			action, err = upsertActor(client, s.adminApiUrl, a)
 			if err == nil {
 				break
 			}
@@ -532,9 +673,12 @@ func run(logger *slog.Logger) error {
 			)
 			time.Sleep(seedRetryInterval)
 		}
-		if created {
+		switch action {
+		case seedCreated:
 			logger.Info("actor created", "external_id", a.ExternalId, "namespace", a.Namespace)
-		} else {
+		case seedUpdated:
+			logger.Info("actor updated", "external_id", a.ExternalId, "namespace", a.Namespace)
+		case seedAlreadyPresent:
 			logger.Info("actor already present", "external_id", a.ExternalId, "namespace", a.Namespace)
 		}
 	}
@@ -568,8 +712,17 @@ func run(logger *slog.Logger) error {
 	for _, connector := range cfg.Connectors {
 		deadline := time.Now().Add(seedRetryTimeout)
 		var action connectorAction
+		var legacyArchived int
 		for attempt := 1; ; attempt++ {
 			action, err = upsertConnector(client, s.adminApiUrl, connector)
+			if err == nil {
+				legacyArchived, err = archiveLegacySeededConnectors(
+					client,
+					s.adminApiUrl,
+					connector,
+					cfg.LegacyConnectorNamespaces,
+				)
+			}
 			if err == nil {
 				break
 			}
@@ -592,6 +745,9 @@ func run(logger *slog.Logger) error {
 			logger.Info("connector updated", "key", connector.Key, "namespace", connectorNamespace(connector))
 		case connectorAlreadyPresent:
 			logger.Info("connector already present", "key", connector.Key, "namespace", connectorNamespace(connector))
+		}
+		if legacyArchived > 0 {
+			logger.Info("legacy connector archived", "key", connector.Key, "count", legacyArchived)
 		}
 	}
 	return nil

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -12,13 +14,146 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 var testConnectorID = apid.MustParse("cxr_testgmail0000001")
 
 const testBaseURL = "http://seed.test"
+
+func demoUserSeed() ActorSeed {
+	return ActorSeed{
+		ExternalId: "demo-user",
+		Namespace:  "root.demo",
+		Permissions: []aschema.Permission{
+			{
+				Namespace: "root.demo",
+				Resources: []string{"connectors"},
+				Verbs:     []string{"list"},
+			},
+			{
+				Namespace: "root.demo.{{external_id}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"create", "list", "get", "update", "disconnect"},
+			},
+		},
+		Labels: map[string]string{"demo": "true", "role": "user"},
+	}
+}
+
+func TestUpsertNamespaceCreatesMissingNamespace(t *testing.T) {
+	seed := NamespaceSeed{Path: "root.demo", Labels: map[string]string{"demo": "true"}}
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/namespaces/root.demo":
+			w.WriteHeader(http.StatusNotFound)
+		case "POST /api/v1/namespaces":
+			var req api.CreateNamespaceRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, seed.Path, req.Path)
+			require.Equal(t, seed.Labels, req.Labels)
+			writeJSON(t, w, api.NamespaceJson{Path: seed.Path, Labels: seed.Labels})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertNamespace(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedCreated, action)
+}
+
+func TestUpsertNamespaceVerifiesExistingNamespace(t *testing.T) {
+	seed := NamespaceSeed{Path: "root.demo", Labels: map[string]string{"demo": "true"}}
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, api.NamespaceJson{Path: seed.Path, Labels: seed.Labels})
+	}))
+
+	action, err := upsertNamespace(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedAlreadyPresent, action)
+}
+
+func TestUpsertActorCreatesThenAppliesPermissions(t *testing.T) {
+	seed := demoUserSeed()
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/actors/external-id/demo-user":
+			require.Equal(t, seed.Namespace, r.URL.Query().Get("namespace"))
+			w.WriteHeader(http.StatusNotFound)
+		case "POST /api/v1/actors":
+			var req api.CreateActorRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, seed.ExternalId, req.ExternalId)
+			require.Equal(t, seed.Namespace, req.Namespace)
+			writeJSON(t, w, api.ActorJson{ExternalId: seed.ExternalId, Namespace: seed.Namespace})
+		case "PATCH /api/v1/actors/external-id/demo-user":
+			require.Equal(t, seed.Namespace, r.URL.Query().Get("namespace"))
+			var req api.UpdateActorRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, seed.Permissions, req.Permissions)
+			require.Equal(t, seed.Labels, req.Labels)
+			writeJSON(t, w, api.ActorJson{
+				ExternalId:  seed.ExternalId,
+				Namespace:   seed.Namespace,
+				Permissions: seed.Permissions,
+				Labels:      seed.Labels,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertActor(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedCreated, action)
+}
+
+func TestUpsertActorVerifiesExistingActorWithoutChangingIt(t *testing.T) {
+	seed := demoUserSeed()
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		writeJSON(t, w, api.ActorJson{
+			ExternalId:  seed.ExternalId,
+			Namespace:   seed.Namespace,
+			Permissions: seed.Permissions,
+			Labels:      seed.Labels,
+		})
+	}))
+
+	action, err := upsertActor(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedAlreadyPresent, action)
+}
+
+func TestUpsertActorReconcilesDrift(t *testing.T) {
+	seed := demoUserSeed()
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(t, w, api.ActorJson{
+				ExternalId:  seed.ExternalId,
+				Namespace:   seed.Namespace,
+				Permissions: aschema.AllPermissions(),
+				Labels:      seed.Labels,
+			})
+		case http.MethodPatch:
+			var req api.UpdateActorRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, seed.Permissions, req.Permissions)
+			writeJSON(t, w, api.ActorJson{})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertActor(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedUpdated, action)
+}
 
 func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
 	seed := ConnectorSeed{
@@ -123,6 +258,52 @@ func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, connectorUpdated, action)
 	require.True(t, forcedPrimary)
+}
+
+func TestArchiveLegacySeededConnectorsArchivesActiveSeed(t *testing.T) {
+	seed := ConnectorSeed{
+		Key:       "demo-noauth",
+		Namespace: "root.demo",
+	}
+	archived := false
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/connectors":
+			require.Equal(t, "root", r.URL.Query().Get("namespace"))
+			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("labelSelector"))
+			writeJSON(t, w, api.ListConnectorsResponseJson{Items: []api.ConnectorJson{{
+				Id:        testConnectorID,
+				Namespace: "root",
+				State:     api.ConnectorVersionStatePrimary,
+			}}})
+		case "POST /api/v1/connectors/cxr_testgmail0000001/_archive":
+			archived = true
+			writeJSON(t, w, map[string]any{"connectorId": testConnectorID})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	count, err := archiveLegacySeededConnectors(client, testBaseURL, seed, []string{"root", "root.demo"})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.True(t, archived)
+}
+
+func TestArchiveLegacySeededConnectorsSkipsArchivedSeed(t *testing.T) {
+	seed := ConnectorSeed{Key: "demo-noauth", Namespace: "root.demo"}
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		writeJSON(t, w, api.ListConnectorsResponseJson{Items: []api.ConnectorJson{{
+			Id:        testConnectorID,
+			Namespace: "root",
+			State:     api.ConnectorVersionStateArchived,
+		}}})
+	}))
+
+	count, err := archiveLegacySeededConnectors(client, testBaseURL, seed, []string{"root"})
+	require.NoError(t, err)
+	require.Zero(t, count)
 }
 
 func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
@@ -303,6 +484,48 @@ connectors:
 	require.NotNil(t, cfg.OAuth2TestProvider)
 	require.Len(t, cfg.OAuth2TestProvider.APIKeyResourcePolicies, 1)
 	require.Len(t, cfg.Connectors, 1)
+	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
+}
+
+func TestDeploymentSeedConfigsUseIsolatedDemoResources(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "..", "deploy", "kustomize", "authproxy-demo", "overlays", "demo", "seed", "seed-config.yaml"),
+		filepath.Join("..", "..", "..", "deploy", "kustomize", "authproxy-demo", "overlays", "dev", "seed", "seed-config.yaml"),
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(filepath.Dir(filepath.Dir(path))), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			var configMap struct {
+				Data map[string]string `yaml:"data"`
+			}
+			require.NoError(t, yaml.Unmarshal(data, &configMap))
+
+			var cfg SeedConfig
+			require.NoError(t, util.DecodeYAMLStrict([]byte(configMap.Data["seed.yaml"]), &cfg))
+			require.Equal(t, []NamespaceSeed{{Path: "root.demo", Labels: map[string]string{"demo": "true"}}}, cfg.Namespaces)
+			require.Equal(t, []string{"root"}, cfg.LegacyConnectorNamespaces)
+			require.Len(t, cfg.Actors, 1)
+			require.Equal(t, demoUserSeed(), cfg.Actors[0])
+			require.Len(t, cfg.Connectors, 5)
+			for _, connector := range cfg.Connectors {
+				require.Equal(t, "root.demo", connectorNamespace(connector))
+			}
+		})
+	}
+}
+
+func TestComposeSeedConfigUsesIsolatedDemoResources(t *testing.T) {
+	path := filepath.Join("..", "..", "shell", "compose", "seed.yaml")
+	cfg, err := loadConfig(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Namespaces, 1)
+	require.Equal(t, "root.demo", cfg.Namespaces[0].Path)
+	require.Equal(t, []ActorSeed{demoUserSeed()}, cfg.Actors)
+	require.Len(t, cfg.Connectors, 1)
+	require.Equal(t, "root.demo", connectorNamespace(cfg.Connectors[0]))
 	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
 }
 

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -260,52 +260,6 @@ func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
 	require.True(t, forcedPrimary)
 }
 
-func TestArchiveLegacySeededConnectorsArchivesActiveSeed(t *testing.T) {
-	seed := ConnectorSeed{
-		Key:       "demo-noauth",
-		Namespace: "root.demo",
-	}
-	archived := false
-	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method + " " + r.URL.Path {
-		case "GET /api/v1/connectors":
-			require.Equal(t, "root", r.URL.Query().Get("namespace"))
-			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("labelSelector"))
-			writeJSON(t, w, api.ListConnectorsResponseJson{Items: []api.ConnectorJson{{
-				Id:        testConnectorID,
-				Namespace: "root",
-				State:     api.ConnectorVersionStatePrimary,
-			}}})
-		case "POST /api/v1/connectors/cxr_testgmail0000001/_archive":
-			archived = true
-			writeJSON(t, w, map[string]any{"connectorId": testConnectorID})
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
-		}
-	}))
-
-	count, err := archiveLegacySeededConnectors(client, testBaseURL, seed, []string{"root", "root.demo"})
-	require.NoError(t, err)
-	require.Equal(t, 1, count)
-	require.True(t, archived)
-}
-
-func TestArchiveLegacySeededConnectorsSkipsArchivedSeed(t *testing.T) {
-	seed := ConnectorSeed{Key: "demo-noauth", Namespace: "root.demo"}
-	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		writeJSON(t, w, api.ListConnectorsResponseJson{Items: []api.ConnectorJson{{
-			Id:        testConnectorID,
-			Namespace: "root",
-			State:     api.ConnectorVersionStateArchived,
-		}}})
-	}))
-
-	count, err := archiveLegacySeededConnectors(client, testBaseURL, seed, []string{"root"})
-	require.NoError(t, err)
-	require.Zero(t, count)
-}
-
 func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
 	seen := map[string]int{}
 	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -506,7 +460,6 @@ func TestDeploymentSeedConfigsUseIsolatedDemoResources(t *testing.T) {
 			var cfg SeedConfig
 			require.NoError(t, util.DecodeYAMLStrict([]byte(configMap.Data["seed.yaml"]), &cfg))
 			require.Equal(t, []NamespaceSeed{{Path: "root.demo", Labels: map[string]string{"demo": "true"}}}, cfg.Namespaces)
-			require.Equal(t, []string{"root"}, cfg.LegacyConnectorNamespaces)
 			require.Len(t, cfg.Actors, 1)
 			require.Equal(t, demoUserSeed(), cfg.Actors[0])
 			require.Len(t, cfg.Connectors, 5)

--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -24,16 +24,24 @@ before redirecting them into the appropriate AuthProxy UI.
                             └──────────────────────────────────────────────────┘
 ```
 
-The backend holds the demo actor private key for pre-provisioned identities and
-the host JWT private key for just-in-time provisioning. Selecting **Fresh user**
-creates a random `fresh-user-<uuid>` external ID, includes the complete actor in
-the JWT, and lets AuthProxy create that actor during session initiation.
+The backend holds the demo administrator's private key and the system JWT
+private key. The pre-provisioned `demo-admin` continues to self-sign. The
+API-provisioned `demo-user` receives a subject-only system-key-signed token, so
+its stored actor permissions remain authoritative. Selecting **Fresh user**
+creates a random `fresh-user-<uuid>` external ID and includes the complete,
+least-privilege actor in a system-key-signed JWT so AuthProxy can create it
+during session initiation.
+
+Demo Marketplace actors live in `root.demo`. They can list the demo connectors
+there and manage connections only in `root.demo.<external_id>`, isolating each
+user's connections from every other demo user.
 
 ## Running locally
 
 Pre-requisites:
 - AuthProxy server running locally (`go run ./cmd/server serve --config=./dev_config/default.yaml all`)
-- A configured admin actor in your AuthProxy config that the demo shell can use as its signing identity
+- A configured `demo-admin` actor in your AuthProxy config that the demo shell can use as its signing identity
+- A `root.demo` namespace, seeded demo connectors, and an API-created `demo-user` actor (the hosted deployment's seed job provisions these)
 - Node + Yarn pinned via Volta (see root `package.json`)
 
 ### 1. Generate the demo admin keypair (one-time, local)
@@ -49,7 +57,7 @@ Add the public key as an admin actor in `dev_config/default.yaml`:
 ```yaml
 systemAuth:
   actors:
-    - externalId: demo-shell
+    - externalId: demo-admin
       key:
         publicKey:
           path: ./demos/shell/dev_keys/demo-shell.pub
@@ -72,7 +80,7 @@ yarn workspace @authproxy/demo-shell dev
 ### 3. Start the demo-shell backend
 
 ```bash
-ADMIN_USERNAME=demo-shell \
+ADMIN_USERNAME=demo-admin \
 ADMIN_PRIVATE_KEY_PATH=./demos/shell/dev_keys/demo-shell \
 AUTHPROXY_JWT_PRIVATE_KEY_PATH=./dev_config/keys/system \
 AUTHPROXY_ADMIN_UI_URL=http://localhost:5174 \
@@ -99,8 +107,8 @@ views and the demo OAuth provider.
 
 ## Local smoke via docker-compose
 
-Self-contained recipe that pulls `authproxy` + `authproxy-demo-shell`
-from GHCR — no local Go / Node toolchain required.
+Lightweight recipe that pulls `authproxy` + `authproxy-demo-shell` from GHCR —
+no local Go / Node toolchain required.
 
 ```bash
 cd demos/shell/compose
@@ -113,11 +121,13 @@ The recipe wires:
 - `authproxy:main` (postgres + redis + AuthProxy) on ports 8080/8081/8082
 - `authproxy-demo-shell:main` on port 8888, mounting the generated
   private key + pointing at the host-mapped AuthProxy URLs
+- `authproxy-demo-seed:main` as a one-shot job that creates `root.demo`,
+  `demo-user`, and a local no-auth demo connector
 
 `./keys/demo-shell.pub` is bind-mounted into AuthProxy's actors directory
 so `dev_config/docker.yaml`'s `keys_path` picks it up and registers
-`demo-shell` as an admin actor. The smoke recipe lives entirely under
-`demos/shell/compose/` — pin to a non-`:main` image via
+`demo-admin` as an admin actor. The recipe lives entirely under
+`demos/shell/compose/` — pin all three application images to a non-`:main` tag via
 `IMAGE_TAG=pr-NNN docker compose up` when testing branches.
 
 ## Configuration reference

--- a/demos/shell/README.md
+++ b/demos/shell/README.md
@@ -25,7 +25,7 @@ before redirecting them into the appropriate AuthProxy UI.
 ```
 
 The backend holds the demo administrator's private key and the system JWT
-private key. The pre-provisioned `demo-admin` continues to self-sign. The
+private key. The pre-provisioned `demo-admin` self-signs. The
 API-provisioned `demo-user` receives a subject-only system-key-signed token, so
 its stored actor permissions remain authoritative. Selecting **Fresh user**
 creates a random `fresh-user-<uuid>` external ID and includes the complete,

--- a/demos/shell/backend/main.go
+++ b/demos/shell/backend/main.go
@@ -36,6 +36,8 @@ import (
 
 const freshUserSelection = "fresh-user"
 
+const demoNamespace = "root.demo"
+
 // demoActorSelections enumerates the identities the shell UI can request.
 // fresh-user is a selector rather than a literal actor external ID; each
 // request for it is resolved to a new external ID before the JWT is signed.
@@ -155,11 +157,10 @@ func loadTelemetryLinks() []telemetryLink {
 	return links
 }
 
-// signTokenFor mints a JWT for a well-known actor that already exists in
-// AuthProxy and has the demo shell's public key configured.
-func signTokenFor(s settings, actorExternalID string) (string, error) {
+// signAdminToken mints a self-signed JWT for the pre-provisioned demo admin.
+func signAdminToken(s settings) (string, error) {
 	b := jwt.NewJwtTokenBuilder().
-		WithActorExternalId(actorExternalID).
+		WithActorExternalId(s.adminUsername).
 		WithActorSigned().
 		WithServiceIds(config.AllServiceIds()).
 		WithNonce().
@@ -169,6 +170,38 @@ func signTokenFor(s settings, actorExternalID string) (string, error) {
 	return b.Token()
 }
 
+// demoMarketplacePermissions is the minimum access needed by the Marketplace.
+// The connection namespace is rendered from the authenticated actor so demo
+// users cannot list or operate on another user's connections.
+func demoMarketplacePermissions() []aschema.Permission {
+	return []aschema.Permission{
+		{
+			Namespace: demoNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: demoNamespace + ".{{external_id}}",
+			Resources: []string{"connections"},
+			Verbs:     []string{"create", "list", "get", "update", "disconnect"},
+		},
+	}
+}
+
+// signTokenForDemoUser mints a subject-only JWT for the API-provisioned demo
+// user. The actor's namespace and permissions remain authoritative in the
+// database; the system JWT key only vouches for the subject.
+func signTokenForDemoUser(s settings) (string, error) {
+	return jwt.NewJwtTokenBuilder().
+		WithActorExternalId("demo-user").
+		WithNamespace(demoNamespace).
+		WithServiceIds(config.AllServiceIds()).
+		WithNonce().
+		WithExpiresIn(s.tokenTtl).
+		WithPrivateKeyPath(s.jwtPrivateKeyPath).
+		Token()
+}
+
 // signTokenForFreshUser includes the complete actor claim so AuthProxy creates
 // the never-before-seen actor during authentication. Just-in-time actor claims
 // are signed with the host JWT key rather than an existing actor's key.
@@ -176,18 +209,12 @@ func signTokenForFreshUser(s settings, actorExternalID string) (string, error) {
 	return jwt.NewJwtTokenBuilder().
 		WithActor(&core.Actor{
 			ExternalId: actorExternalID,
-			Namespace:  config.RootNamespace,
+			Namespace:  demoNamespace,
 			Labels: map[string]string{
 				"demo": "true",
 				"role": "user",
 			},
-			Permissions: []aschema.Permission{
-				{
-					Namespace: "root.**",
-					Resources: []string{"*"},
-					Verbs:     []string{"*"},
-				},
-			},
+			Permissions: demoMarketplacePermissions(),
 		}).
 		WithServiceIds(config.AllServiceIds()).
 		WithNonce().
@@ -231,10 +258,13 @@ func ssoHandler(s settings, logger *slog.Logger) http.HandlerFunc {
 		actor := actorExternalID(actorSelection)
 		var token string
 		var err error
-		if actorSelection == freshUserSelection {
+		switch actorSelection {
+		case freshUserSelection:
 			token, err = signTokenForFreshUser(s, actor)
-		} else {
-			token, err = signTokenFor(s, actor)
+		case "demo-user":
+			token, err = signTokenForDemoUser(s)
+		case "demo-admin":
+			token, err = signAdminToken(s)
 		}
 		if err != nil {
 			logger.Error("failed to sign token", "err", err, "actor", actor)

--- a/demos/shell/backend/main_test.go
+++ b/demos/shell/backend/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	authjwt "github.com/rmorlok/authproxy/internal/apauth/jwt"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,28 +34,83 @@ func TestActorExternalID(t *testing.T) {
 	})
 }
 
-func TestSignTokenForFreshUserIncludesActorForJustInTimeProvisioning(t *testing.T) {
-	externalID := actorExternalID(freshUserSelection)
+func testKeyPaths() (privateKeyPath, publicKeyPath string) {
 	keyDir := filepath.Join("..", "..", "..", "test_data", "admin_user_keys")
+	return filepath.Join(keyDir, "bobdole"), filepath.Join(keyDir, "bobdole.pub")
+}
+
+func parseTestToken(t *testing.T, token string) *authjwt.AuthProxyClaims {
+	t.Helper()
+	_, publicKeyPath := testKeyPaths()
+	claims, err := authjwt.NewJwtTokenParserBuilder().
+		WithPublicKeyPath(publicKeyPath).
+		Parse(token)
+	require.NoError(t, err)
+	return claims
+}
+
+func TestSignAdminTokenUsesSelfSigningIdentity(t *testing.T) {
+	privateKeyPath, _ := testKeyPaths()
+	token, err := signAdminToken(settings{
+		adminUsername:       "demo-admin",
+		adminPrivateKeyPath: privateKeyPath,
+		tokenTtl:            time.Minute,
+	})
+	require.NoError(t, err)
+
+	claims := parseTestToken(t, token)
+	require.Equal(t, "demo-admin", claims.Subject)
+	require.Equal(t, "root", claims.GetNamespace())
+	require.True(t, claims.ActorSigned)
+	require.Nil(t, claims.Actor)
+	require.Empty(t, claims.Permissions)
+}
+
+func TestSignTokenForDemoUserUsesSubjectOnlySystemKeyJWT(t *testing.T) {
+	privateKeyPath, _ := testKeyPaths()
+	token, err := signTokenForDemoUser(settings{
+		jwtPrivateKeyPath: privateKeyPath,
+		tokenTtl:          time.Minute,
+	})
+	require.NoError(t, err)
+
+	claims := parseTestToken(t, token)
+	require.Equal(t, "demo-user", claims.Subject)
+	require.Equal(t, demoNamespace, claims.GetNamespace())
+	require.False(t, claims.ActorSigned)
+	require.False(t, claims.SystemSigned)
+	require.Nil(t, claims.Actor)
+	require.Empty(t, claims.Permissions)
+}
+
+func TestSignTokenForFreshUserIncludesLeastPrivilegeActor(t *testing.T) {
+	externalID := actorExternalID(freshUserSelection)
+	privateKeyPath, _ := testKeyPaths()
 	token, err := signTokenForFreshUser(settings{
-		jwtPrivateKeyPath: filepath.Join(keyDir, "bobdole"),
+		jwtPrivateKeyPath: privateKeyPath,
 		tokenTtl:          time.Minute,
 	}, externalID)
 	require.NoError(t, err)
 
-	claims, err := authjwt.NewJwtTokenParserBuilder().
-		WithPublicKeyPath(filepath.Join(keyDir, "bobdole.pub")).
-		Parse(token)
-	require.NoError(t, err)
+	claims := parseTestToken(t, token)
 	require.Equal(t, externalID, claims.Subject)
 	require.False(t, claims.ActorSigned)
 	require.NotNil(t, claims.Actor)
 	require.Equal(t, externalID, claims.Actor.ExternalId)
-	require.Equal(t, "root", claims.Actor.Namespace)
+	require.Equal(t, demoNamespace, claims.Actor.Namespace)
 	require.Equal(t, map[string]string{"demo": "true", "role": "user"}, claims.Actor.Labels)
-	require.Len(t, claims.Actor.Permissions, 1)
-	require.Equal(t, []string{"*"}, claims.Actor.Permissions[0].Resources)
-	require.Equal(t, []string{"*"}, claims.Actor.Permissions[0].Verbs)
+	require.Equal(t, []aschema.Permission{
+		{
+			Namespace: demoNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list"},
+		},
+		{
+			Namespace: demoNamespace + ".{{external_id}}",
+			Resources: []string{"connections"},
+			Verbs:     []string{"create", "list", "get", "update", "disconnect"},
+		},
+	}, claims.Actor.Permissions)
 }
 
 func TestLoadTelemetryLinksFromGrafanaBaseURL(t *testing.T) {

--- a/demos/shell/compose/docker-compose.yaml
+++ b/demos/shell/compose/docker-compose.yaml
@@ -39,8 +39,8 @@ services:
     volumes:
       # Mount the demo-shell's public key into AuthProxy's actors
       # directory so dev_config/docker.yaml's `keys_path: ...keys/admin`
-      # picks it up and registers `demo-shell` as an admin actor.
-      - ./keys/demo-shell.pub:/app/dev_config/keys/admin/demo-shell.pub:ro
+      # picks it up and registers `demo-admin` as an admin actor.
+      - ./keys/demo-shell.pub:/app/dev_config/keys/admin/demo-admin.pub:ro
       # Use the same local-only keypair as the host JWT key so the shell can
       # provision a new actor for each Fresh user launch.
       - ./keys/demo-shell:/app/dev_config/keys/system:ro
@@ -55,7 +55,7 @@ services:
     ports:
       - "8888:8888"
     environment:
-      ADMIN_USERNAME: demo-shell
+      ADMIN_USERNAME: demo-admin
       ADMIN_PRIVATE_KEY_PATH: /keys/demo-shell
       AUTHPROXY_JWT_PRIVATE_KEY_PATH: /keys/demo-shell
       # URLs the BROWSER reaches — must be host-mapped, not container DNS.
@@ -64,5 +64,19 @@ services:
       AUTHPROXY_ADMIN_UI_URL: http://localhost:8082
     volumes:
       - ./keys/demo-shell:/keys/demo-shell:ro
+    depends_on:
+      authproxy: { condition: service_started }
+
+  demo-seed:
+    image: ghcr.io/rmorlok/authproxy-demo-seed:${IMAGE_TAG:-main}
+    pull_policy: always
+    environment:
+      ADMIN_API_URL: http://authproxy:8082
+      ADMIN_USERNAME: demo-admin
+      ADMIN_PRIVATE_KEY_PATH: /keys/demo-shell
+      SEED_CONFIG_PATH: /seed/seed.yaml
+    volumes:
+      - ./keys/demo-shell:/keys/demo-shell:ro
+      - ./seed.yaml:/seed/seed.yaml:ro
     depends_on:
       authproxy: { condition: service_started }

--- a/demos/shell/compose/seed.yaml
+++ b/demos/shell/compose/seed.yaml
@@ -1,0 +1,41 @@
+namespaces:
+  - path: root.demo
+    labels:
+      demo: "true"
+actors:
+  - externalId: demo-user
+    namespace: root.demo
+    permissions:
+      - namespace: root.demo
+        resources:
+          - connectors
+        verbs:
+          - list
+      - namespace: root.demo.{{external_id}}
+        resources:
+          - connections
+        verbs:
+          - create
+          - list
+          - get
+          - update
+          - disconnect
+    labels:
+      demo: "true"
+      role: user
+connectors:
+  - key: demo-compose-noauth
+    namespace: root.demo
+    definition:
+      displayName: Demo Compose NoAuth
+      description: A local no-auth connector for exercising the demo Marketplace.
+      highlight: Connect without third-party credentials.
+      labels:
+        demo: "true"
+        type: demo-compose-noauth
+      auth:
+        type: no-auth
+    labels:
+      auth_method: no_auth
+      demo: "true"
+      showcase: local-compose

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -22,8 +22,8 @@ kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev
 ```
 
 `Deploy Demo` renders `overlays/demo`, rewrites the checked-out overlay with
-the selected image tag and configured hostname, and applies the resulting
-manifest with `kubectl apply`. The demo overlay includes Grafana at
+the selected image tag and configured hostname, applies the resulting
+manifest with `kubectl apply`, and then runs the seed job. The demo overlay includes Grafana at
 `https://<hostname>/grafana` with the bundled AuthProxy datasource plugin,
 Prometheus, Tempo, and Loki datasources, and sample app metrics dashboard
 provisioned from Kustomize ConfigMaps. Prometheus, Tempo, Loki, and the OTel
@@ -61,8 +61,8 @@ Set the `DEMO_GRAFANA_ADMIN_USER` repo variable and
 password is unset, the first deploy generates a random password and stores it
 in the cluster Secret.
 
-Seeding is intentionally not part of the Kustomize deployment apply. Run the
-`Seed Demo` GitHub Actions workflow to reseed the persistent demo environment
-on demand; it renders `overlays/demo/seed` and applies the resulting Job.
-Dev seeding will be run by the per-branch deploy workflow after the environment
-is applied.
+Both demo and dev deployment workflows run their seed job after the environment
+is ready. The job idempotently provisions `root.demo`, verifies or creates the
+least-privilege `demo-user`, publishes demo connectors in `root.demo`, and
+archives legacy seeded connectors from `root`. The `Seed Demo` GitHub Actions
+workflow remains available to rerun the same job on demand.

--- a/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
+++ b/deploy/kustomize/authproxy-demo/base/demo-shell.yaml
@@ -28,7 +28,7 @@ spec:
             - name: PORT
               value: "8888"
             - name: ADMIN_USERNAME
-              value: demo-shell
+              value: demo-admin
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
             - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH

--- a/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/demo-shell-env.yaml
@@ -11,7 +11,7 @@ spec:
             - name: PORT
               value: "8888"
             - name: ADMIN_USERNAME
-              value: demo-shell
+              value: demo-admin
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
             - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
@@ -29,8 +29,6 @@ data:
         labels:
           demo: "true"
           role: user
-    legacyConnectorNamespaces:
-      - root
     oauth2TestProvider:
       apiKeyResourcePolicies:
         - key: demo-api-key

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
@@ -4,27 +4,33 @@ metadata:
   name: seed-config
 data:
   seed.yaml: |
+    namespaces:
+      - path: root.demo
+        labels:
+          demo: "true"
     actors:
-      - externalId: demo-admin
-        namespace: root
-        labels:
-          demo: "true"
-          role: admin
       - externalId: demo-user
-        namespace: root
+        namespace: root.demo
+        permissions:
+          - namespace: root.demo
+            resources:
+              - connectors
+            verbs:
+              - list
+          - namespace: root.demo.{{external_id}}
+            resources:
+              - connections
+            verbs:
+              - create
+              - list
+              - get
+              - update
+              - disconnect
         labels:
           demo: "true"
           role: user
-      - externalId: fresh-user
-        namespace: root
-        labels:
-          demo: "true"
-          role: user
-      - externalId: grafana
-        namespace: root
-        labels:
-          demo: "true"
-          role: datasource
+    legacyConnectorNamespaces:
+      - root
     oauth2TestProvider:
       apiKeyResourcePolicies:
         - key: demo-api-key
@@ -78,7 +84,7 @@ data:
           auth_method: no_auth
           demo: "true"
           showcase: catalog
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             placement:
@@ -109,7 +115,7 @@ data:
           auth_method: api-key
           demo: "true"
           showcase: api-key
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -142,7 +148,7 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: simple-oauth
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -202,7 +208,7 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: preconnect
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -273,4 +279,4 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: postconnect-configure
-        namespace: root
+        namespace: root.demo

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-job.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-job.yaml
@@ -23,7 +23,7 @@ spec:
             - name: ADMIN_API_URL
               value: "http://demo-authproxy:8082"
             - name: ADMIN_USERNAME
-              value: "demo-shell"
+              value: "demo-admin"
             - name: ADMIN_PRIVATE_KEY_PATH
               value: "/etc/authproxy/demo-shell/private"
             - name: SEED_CONFIG_PATH

--- a/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/demo-shell-env.yaml
@@ -11,7 +11,7 @@ spec:
             - name: PORT
               value: "8888"
             - name: ADMIN_USERNAME
-              value: demo-shell
+              value: demo-admin
             - name: ADMIN_PRIVATE_KEY_PATH
               value: /etc/authproxy/demo-shell/private
             - name: AUTHPROXY_JWT_PRIVATE_KEY_PATH

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -29,8 +29,6 @@ data:
         labels:
           demo: "true"
           role: user
-    legacyConnectorNamespaces:
-      - root
     oauth2TestProvider:
       apiKeyResourcePolicies:
         - key: demo-api-key

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -4,27 +4,33 @@ metadata:
   name: seed-config
 data:
   seed.yaml: |
+    namespaces:
+      - path: root.demo
+        labels:
+          demo: "true"
     actors:
-      - externalId: demo-admin
-        namespace: root
-        labels:
-          demo: "true"
-          role: admin
       - externalId: demo-user
-        namespace: root
+        namespace: root.demo
+        permissions:
+          - namespace: root.demo
+            resources:
+              - connectors
+            verbs:
+              - list
+          - namespace: root.demo.{{external_id}}
+            resources:
+              - connections
+            verbs:
+              - create
+              - list
+              - get
+              - update
+              - disconnect
         labels:
           demo: "true"
           role: user
-      - externalId: fresh-user
-        namespace: root
-        labels:
-          demo: "true"
-          role: user
-      - externalId: grafana
-        namespace: root
-        labels:
-          demo: "true"
-          role: datasource
+    legacyConnectorNamespaces:
+      - root
     oauth2TestProvider:
       apiKeyResourcePolicies:
         - key: demo-api-key
@@ -78,7 +84,7 @@ data:
           auth_method: no_auth
           demo: "true"
           showcase: catalog
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             placement:
@@ -109,7 +115,7 @@ data:
           auth_method: api-key
           demo: "true"
           showcase: api-key
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -142,7 +148,7 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: simple-oauth
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -202,7 +208,7 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: preconnect
-        namespace: root
+        namespace: root.demo
       - definition:
           auth:
             authorization:
@@ -273,4 +279,4 @@ data:
           auth_method: oauth2
           demo: "true"
           showcase: postconnect-configure
-        namespace: root
+        namespace: root.demo

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-job.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-job.yaml
@@ -23,7 +23,7 @@ spec:
             - name: ADMIN_API_URL
               value: "http://dev-authproxy:8082"
             - name: ADMIN_USERNAME
-              value: "demo-shell"
+              value: "demo-admin"
             - name: ADMIN_PRIVATE_KEY_PATH
               value: "/etc/authproxy/demo-shell/private"
             - name: SEED_CONFIG_PATH

--- a/docs/src/content/docs/getting-started/demo.md
+++ b/docs/src/content/docs/getting-started/demo.md
@@ -37,11 +37,15 @@ sequenceDiagram
     AP-->>UI: Session cookie and UI configuration
 ```
 
-`demo-admin` and `demo-user` demonstrate pre-provisioned host identities. Every
-**Fresh user** launch generates a new `fresh-user-<uuid>` external ID and
-provisions that actor during the JWT handoff, so it starts without connections.
-Connection data for the pre-provisioned identities is shared and changes as
-visitors use the demo.
+`demo-admin` is a pre-provisioned, self-signing administrator. `demo-user` is
+provisioned through the API, while its subject-only JWT is signed by the host's
+system JWT key. Every **Fresh user** launch generates a new
+`fresh-user-<uuid>` external ID and provisions that actor from a full actor
+claim signed by the same host key.
+
+Marketplace actors and connectors live in `root.demo`. Each user's connections
+live in `root.demo.<external_id>`, so fresh users start empty and no demo user
+can see or operate on another user's connections.
 
 See [host application integration](/integration/host-application/) for the
 production version of this handoff.

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -60,6 +60,12 @@ Content-Type: application/json
 }
 ```
 
+`intoNamespace` is optional. AuthProxy first tries the connector's namespace.
+If the actor cannot create connections there but has `connections:create` in
+exactly one permitted child namespace, AuthProxy uses that unambiguous child.
+It never infers from wildcard permissions or from multiple candidate
+namespaces; pass `intoNamespace` explicitly in those cases.
+
 Rename through the immutable ID. The response keeps the same `id` and returns
 the new `name`:
 

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -31,6 +31,7 @@ var (
 )
 
 const smokeConnectorNamespace = "root.smoke"
+const demoConnectorNamespace = "root.demo"
 
 func newSmokeActorExternalID(t *testing.T, prefix string) string {
 	t.Helper()
@@ -50,7 +51,7 @@ func smokeAdminPermissions(adminExternalID, userExternalID, connectionNamespace 
 			Verbs:       []string{"get", "delete"},
 		},
 		{
-			Namespace: config.RootNamespace,
+			Namespace: demoConnectorNamespace,
 			Resources: []string{"connectors"},
 			Verbs:     []string{"list", "list/versions"},
 		},
@@ -144,8 +145,8 @@ func cloneSeededConnectorsIntoSmokeNamespace(
 ) string {
 	t.Helper()
 
-	sources := rig.ListConnectorsAsAdmin(t, config.RootNamespace, "demo=true")
-	require.NotEmpty(t, sources, "the demo seed job did not create any root connectors")
+	sources := rig.ListConnectorsAsAdmin(t, demoConnectorNamespace, "demo=true")
+	require.NotEmpty(t, sources, "the demo seed job did not create any root.demo connectors")
 	suffix := time.Now().UnixNano()
 	runID := fmt.Sprintf("%d", suffix)
 	const runLabel = "smoke.authproxy.net/run-id"

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -52,6 +52,18 @@ func (s *service) InitiateConnection(
 	targetNamespace := c.GetNamespace()
 	if req.HasIntoNamespace() {
 		targetNamespace = req.IntoNamespace
+	} else if val.ValidateNamespaceResourceId(targetNamespace, c.GetId().String()) != nil {
+		// Existing clients omit intoNamespace. When their permissions grant
+		// connection creation in one exact child namespace, use that unambiguous
+		// destination rather than forcing every client to duplicate tenancy
+		// routing logic.
+		if inferred, ok := inferConnectionNamespace(
+			c.GetNamespace(),
+			apauth.ActorFromContext(ctx).GetNamespace(),
+			val.GetEffectiveNamespaceMatchers(nil),
+		); ok {
+			targetNamespace = inferred
+		}
 	}
 
 	if err := namespace.ValidatePath(targetNamespace); err != nil {
@@ -115,4 +127,19 @@ func (s *service) InitiateConnection(
 	}
 
 	return connection.advanceToStep(ctx, first, flow, req.ReturnToUrl)
+}
+
+func inferConnectionNamespace(connectorNamespace, actorNamespace string, allowedNamespaces []string) (string, bool) {
+	if len(allowedNamespaces) != 1 {
+		return "", false
+	}
+
+	candidate := allowedNamespaces[0]
+	if namespace.ValidatePath(candidate) != nil ||
+		!namespace.IsSameOrChild(connectorNamespace, candidate) ||
+		!namespace.IsSameOrChild(actorNamespace, candidate) {
+		return "", false
+	}
+
+	return candidate, true
 }

--- a/internal/core/service_connection_initiate.go
+++ b/internal/core/service_connection_initiate.go
@@ -53,10 +53,14 @@ func (s *service) InitiateConnection(
 	if req.HasIntoNamespace() {
 		targetNamespace = req.IntoNamespace
 	} else if val.ValidateNamespaceResourceId(targetNamespace, c.GetId().String()) != nil {
-		// Existing clients omit intoNamespace. When their permissions grant
-		// connection creation in one exact child namespace, use that unambiguous
-		// destination rather than forcing every client to duplicate tenancy
-		// routing logic.
+		// If the `intoNamespace` option is not specified, attempt to infer where
+		// the connection should be placed based on the actor's permissions.
+		// Try to colocate the connection with the connector first (use the
+		// connector's namespace). If that is not possible, see if the actor has
+		// a single namespace they are authorized to create connections in that
+		// is a child of the connector's namespace. If so, use that. If permissions
+		// would be ambiguous, reject and force the client to specify. This covers
+		// the common case where actors can only connect into their own namespace.
 		if inferred, ok := inferConnectionNamespace(
 			c.GetNamespace(),
 			apauth.ActorFromContext(ctx).GetNamespace(),
@@ -129,6 +133,11 @@ func (s *service) InitiateConnection(
 	return connection.advanceToStep(ctx, first, flow, req.ReturnToUrl)
 }
 
+// inferConnectionNamespace returns an inferred connection namespace only when
+// the actor has one exact, unambiguous namespace in which they can create the
+// connection and that namespace is a child of both the connector and actor
+// namespaces. Ambiguous, wildcard, unrelated, and invalid namespaces cannot be
+// inferred, requiring the client to specify intoNamespace explicitly.
 func inferConnectionNamespace(connectorNamespace, actorNamespace string, allowedNamespaces []string) (string, bool) {
 	if len(allowedNamespaces) != 1 {
 		return "", false

--- a/internal/core/service_connection_initiate_test.go
+++ b/internal/core/service_connection_initiate_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInferConnectionNamespace(t *testing.T) {
+	tests := []struct {
+		name               string
+		connectorNamespace string
+		actorNamespace     string
+		allowedNamespaces  []string
+		wantNamespace      string
+		wantInferred       bool
+	}{
+		{
+			name:               "uses one exact child namespace",
+			connectorNamespace: "root.demo",
+			actorNamespace:     "root.demo",
+			allowedNamespaces:  []string{"root.demo.demo-user"},
+			wantNamespace:      "root.demo.demo-user",
+			wantInferred:       true,
+		},
+		{
+			name:               "rejects namespace matcher",
+			connectorNamespace: "root.demo",
+			actorNamespace:     "root.demo",
+			allowedNamespaces:  []string{"root.demo.**"},
+		},
+		{
+			name:               "rejects ambiguous namespaces",
+			connectorNamespace: "root.demo",
+			actorNamespace:     "root.demo",
+			allowedNamespaces:  []string{"root.demo.alice", "root.demo.bob"},
+		},
+		{
+			name:               "rejects namespace outside connector",
+			connectorNamespace: "root.demo",
+			actorNamespace:     "root",
+			allowedNamespaces:  []string{"root.other.alice"},
+		},
+		{
+			name:               "rejects namespace outside actor",
+			connectorNamespace: "root",
+			actorNamespace:     "root.demo",
+			allowedNamespaces:  []string{"root.other.alice"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNamespace, gotInferred := inferConnectionNamespace(
+				tt.connectorNamespace,
+				tt.actorNamespace,
+				tt.allowedNamespaces,
+			)
+			require.Equal(t, tt.wantNamespace, gotNamespace)
+			require.Equal(t, tt.wantInferred, gotInferred)
+		})
+	}
+}

--- a/internal/core/workflow_disconnect_connection_test.go
+++ b/internal/core/workflow_disconnect_connection_test.go
@@ -228,14 +228,17 @@ func TestDisconnectConnectionWorkflowV1ForcesOnTimeout(t *testing.T) {
 	connectionId := apid.New(apid.PrefixConnection)
 	workflowTester := tester.NewWorkflowTester[any](disconnectConnectionWorkflowV1)
 
-	revokeActivity := func(ctx context.Context, _ apid.ID) error {
-		<-ctx.Done()
-		return ctx.Err()
+	revokeActivity := func(context.Context, apid.ID) error {
+		return nil
 	}
 	forceActivity := func(context.Context, apid.ID) error {
 		return nil
 	}
 
+	// OnActivityByName uses revokeActivity to determine the activity signature;
+	// the mock behavior comes from Run and Return. Keep the mock active well
+	// beyond the workflow timeout so the timer wins deterministically instead of
+	// racing an immediate mocked cancellation.
 	workflowTester.
 		OnActivityByName(
 			ActivityNameDisconnectConnectionRevokeCredentialsV1,
@@ -243,8 +246,11 @@ func TestDisconnectConnectionWorkflowV1ForcesOnTimeout(t *testing.T) {
 			testifymock.Anything,
 			connectionId,
 		).
+		Run(func(testifymock.Arguments) {
+			time.Sleep(250 * time.Millisecond)
+		}).
 		Return(context.Canceled).
-		Maybe()
+		Once()
 	workflowTester.
 		OnActivityByName(
 			ActivityNameDisconnectConnectionForceV1,
@@ -257,7 +263,7 @@ func TestDisconnectConnectionWorkflowV1ForcesOnTimeout(t *testing.T) {
 
 	workflowTester.Execute(context.Background(), disconnectConnectionWorkflowInputV1{
 		ConnectionID: connectionId,
-		Timeout:      time.Millisecond,
+		Timeout:      25 * time.Millisecond,
 	})
 
 	require.True(t, workflowTester.WorkflowFinished())

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -48,6 +48,9 @@ func TestConnections(t *testing.T) {
 	connectorVersion := uint64(1)
 	oauthConnectorId := apid.MustParse("cxr_test0000000000002")
 	oauthConnectorVersion := uint64(1)
+	demoConnectorId := apid.MustParse("cxr_test0000000000003")
+	demoConnectorVersion := uint64(1)
+	demoConnectorNamespace := "root.demo"
 
 	setup := func(t *testing.T, cfg config.C) (*TestSetup, func()) {
 		cfg = config.FromRoot(&sconfig.Root{
@@ -67,6 +70,13 @@ func TestConnections(t *testing.T) {
 						Auth: &sconfig.Auth{InnerVal: &sconfig.AuthOAuth2{
 							Type: sconfig.AuthTypeOAuth2,
 						}},
+					},
+					{
+						Id:          demoConnectorId,
+						Version:     demoConnectorVersion,
+						Namespace:   &demoConnectorNamespace,
+						Labels:      map[string]string{"type": "demo-connector"},
+						DisplayName: "Demo Connector",
 					},
 				},
 			},
@@ -554,6 +564,34 @@ func TestConnections(t *testing.T) {
 
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+
+		t.Run("infers an exact permitted child namespace when omitted", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			connectionNamespace := "root.demo.some-actor"
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connections/_initiate",
+				util.JsonToReader(map[string]interface{}{
+					"connectorId": demoConnectorId.String(),
+					"returnToUrl": "https://example.com/callback",
+				}),
+				demoConnectorNamespace,
+				"some-actor",
+				aschema.PermissionsSingle(connectionNamespace, "connections", "create"),
+			)
+			require.NoError(t, err)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp struct {
+				Id apid.ID `json:"id"`
+			}
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			created, err := tu.Db.GetConnection(context.Background(), resp.Id)
+			require.NoError(t, err)
+			require.Equal(t, connectionNamespace, created.Namespace)
 		})
 	})
 


### PR DESCRIPTION
## Summary

- keep demo-admin as a synced, self-signing actor while signing demo-user and fresh-user JWTs with the configured system JWT key
- provision root.demo and the least-privilege demo-user through the deployment seed API; dynamically provision fresh users from full actor claims
- publish demo connectors in root.demo and isolate every Marketplace user connection under root.demo.<external_id>
- automatically run the seed job during demo deploys and remove stale public-key actors
- infer one exact permitted child connection namespace when clients omit intoNamespace, preserving the current Marketplace request shape
- update smoke cloning, local compose seeding, and documentation

## Migration and gaps

Connector namespaces are immutable. The seed job therefore creates new root.demo connector records and archives the legacy seeded root connectors. Existing historical records remain in root as archived resources.

The system JWT key is used without the internal systemSigned claim. That claim selects GlobalAES/HMAC and is reserved for AuthProxy internal token transfer; external demo JWTs use the configured asymmetric system JWT signing key.

## Validation

- ./scripts/preflight.sh
- AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core ./internal/routes
- go test ./demos/shell/backend ./demos/seed/backend
- go test -tags smoke ./smoke -run ^$ (integration_tests module)
- yarn docs:build
- kubectl kustomize for demo, demo/seed, dev, and dev/seed overlays
- docker compose config --quiet for demos/shell/compose