### PR TITLE
Fix manual demo deploy image wait

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -48,7 +48,10 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: gha-eks
-    timeout-minutes: 35
+    # Manual deploys without an explicit tag may start while Build Image is
+    # still publishing the current commit. Leave enough time for that wait
+    # plus the normal rollout and smoke tests.
+    timeout-minutes: 65
 
     env:
       RELEASE_NAME: demo
@@ -104,7 +107,17 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | docker login "${REGISTRY}" -u "${{ github.actor }}" --password-stdin >/dev/null
 
-          deadline=$((SECONDS + 5 * 60))
+          verify_timeout_minutes=5
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+            && [ -z "${{ inputs.image_tag }}" ]; then
+            # A manual deploy of the current commit can race its Build Image
+            # run. The automatic workflow_run path and explicit rollback tags
+            # should already be published, so they retain the short timeout.
+            verify_timeout_minutes=30
+          fi
+
+          echo "Waiting up to ${verify_timeout_minutes} minutes for ${tag} in GHCR."
+          deadline=$((SECONDS + verify_timeout_minutes * 60))
           while true; do
             missing=()
             for image in "${images[@]}"; do


### PR DESCRIPTION
## Summary
- allow a manually dispatched demo deploy with no explicit image tag to wait up to 30 minutes for the current commit images
- retain the 5-minute verification window for automatic post-build deploys and explicit rollback tags
- expand the overall job timeout so a delayed manual deploy still has time to roll out and run smoke tests

## Root cause
The failed manual deploy started while Build Image was still running for `66d7f678`. The sidecar images appeared first, but the primary `authproxy` image was published about 17 minutes after deploy start, beyond the fixed 5-minute verification window. The automatic post-build deploy for the same SHA succeeded once all images were available.

## Verification
- `./scripts/preflight.sh`
- workflow YAML parse
- automatic Deploy Demo run 32540243892 succeeded, including migration, rollout, telemetry, and live-service smoke tests