### PR TITLE
Prioritize AMD64 demo image builds

### DIFF
--- a/.github/workflows/build-authproxy-multiarch.yml
+++ b/.github/workflows/build-authproxy-multiarch.yml
@@ -1,0 +1,94 @@
+# schema: https://json.schemastore.org/github-workflow.json
+name: Build AuthProxy Multi-Architecture
+
+# Main builds start only after the deployment-gating amd64 images have been
+# published by Build Image. Release tags run directly so their semver and
+# latest tags are generated from the tag ref. This workflow never gates the
+# hosted demo deployment.
+
+on:
+  workflow_run:
+    workflows: ["Build Image"]
+    branches: [main]
+    types: [completed]
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-authproxy-multiarch-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+  # Only the newest main image is useful. Tags and explicit manual builds are
+  # release operations and remain non-cancellable.
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
+
+env:
+  REGISTRY: ghcr.io
+  DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+  BUILD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  build-authproxy-multiarch:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'pull_request')
+    name: build-and-push (authproxy amd64+arm64, Dockerfile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BUILD_SHA }}
+
+      - name: Resolve image tag
+        id: ref
+        run: |
+          set -euo pipefail
+          echo "sha_tag=sha-$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          # workflow_run normally exposes the default branch's current SHA,
+          # which can move past the commit that produced the fast images.
+          # Read labels from the explicitly checked-out triggering commit.
+          context: ${{ github.event_name == 'workflow_run' && 'git' || 'workflow' }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/authproxy
+          tags: |
+            type=ref,event=branch,enable=${{ github.event_name != 'workflow_run' }}
+            type=raw,value=main,enable=${{ github.event_name == 'workflow_run' }}
+            type=raw,value=${{ steps.ref.outputs.sha_tag }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=authproxy
+          cache-to: type=gha,scope=authproxy,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,6 +1,10 @@
 # schema: https://json.schemastore.org/github-workflow.json
 name: Build Image
 
+# Publishes the amd64 images consumed by the hosted demo and PR environments.
+# The slower multi-architecture AuthProxy image is published by the follow-up
+# Build AuthProxy Multi-Architecture workflow after this workflow succeeds.
+
 on:
   push:
     branches: [main]
@@ -16,25 +20,27 @@ permissions:
 
 concurrency:
   group: build-image-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Main and PR builds are deployment inputs, so only the newest commit is
+  # useful. Release-tag builds remain non-cancellable.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
 
 env:
   REGISTRY: ghcr.io
   DOCKER_METADATA_SHORT_SHA_LENGTH: 8
 
 jobs:
-  build-authproxy:
-    name: build-and-push (authproxy, Dockerfile)
+  build-authproxy-amd64:
+    name: build-and-push (authproxy amd64, Dockerfile)
+    # Release tags are published directly by the multi-architecture workflow;
+    # avoid racing an amd64-only tag against its manifest list.
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -65,17 +71,16 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          # arm64 builds run under QEMU emulation on GH-hosted amd64 runners,
-          # which is ~5x slower than native — fine for the merge/tag path
-          # where we ship the multi-arch manifest. PRs build amd64 only.
-          platforms: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: linux/amd64
           # Unlabeled PRs get a simple Dockerfile verification build. The
           # pr-<number> tag is only pushed when the PR opts into demo deploys.
           push: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'deploy:demo')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Consume the full-build cache, but do not export a replacement here.
+          # Cache export previously added several minutes to the path that gates
+          # demo deployment; the follow-up multi-architecture build refreshes it.
           cache-from: type=gha,scope=authproxy
-          cache-to: type=gha,scope=authproxy,mode=max
 
   build-demo-images:
     name: build-and-push (${{ matrix.image.name }}, ${{ matrix.image.dockerfile }})
@@ -107,10 +112,6 @@ jobs:
         if: env.SHOULD_BUILD == 'true'
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: Set up QEMU
-        if: env.SHOULD_BUILD == 'true'
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: env.SHOULD_BUILD == 'true'
@@ -144,10 +145,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
-          # Demo-only images are skipped on ordinary PRs. When a PR opts
-          # into demo deploys, build the branch Dockerfile and publish the
-          # pr-<number> tag that Deploy Dev consumes.
-          platforms: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          # Hosted demo and PR environments use amd64 nodes, so demo-only
+          # images do not pay the QEMU cost of an unused arm64 variant.
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- make AuthProxy, demo shell, demo seed, and demo Grafana publish AMD64 deployment images through the existing `Build Image` workflow
- remove QEMU from the deployment-gating workflow and omit the slow AuthProxy cache export from its fast path
- publish the core AMD64+ARM64 manifest in a separate follow-up workflow after the fast main build succeeds
- keep release tags multi-architecture without racing them against the AMD64-only core job
- cancel stale main/PR fast builds while leaving release builds non-cancellable

`Deploy Demo` and `Deploy Dev` continue to wait for `Build Image`, so they can start once the required AMD64 images are available. The core multi-architecture workflow runs independently and does not gate deployment.

## Verification
- `./scripts/preflight.sh`
- `actionlint v1.7.12`
- YAML parse validation for the changed workflows
- workflow topology assertions confirming ARM64/QEMU work exists only in the follow-up core workflow