### PR TITLE
Fix demo OAuth resource options

### DIFF
--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -465,6 +465,7 @@ func TestDeploymentSeedConfigsUseIsolatedDemoResources(t *testing.T) {
 			require.Len(t, cfg.Connectors, 5)
 			for _, connector := range cfg.Connectors {
 				require.Equal(t, "root.demo", connectorNamespace(connector))
+				require.NoError(t, connector.Definition.Validate(&common.ValidationContext{}))
 			}
 		})
 	}

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
@@ -262,7 +262,7 @@ data:
                           credentials.
                         title: Demo resource
                         type: string
-                        x-data-source: demo_resources
+                        x-data-source: demoResources
                     required:
                       - resource_id
                     type: object

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -262,7 +262,7 @@ data:
                           credentials.
                         title: Demo resource
                         type: string
-                        x-data-source: demo_resources
+                        x-data-source: demoResources
                     required:
                       - resource_id
                     type: object

--- a/internal/schema/resources/connectors/setup_flow.go
+++ b/internal/schema/resources/connectors/setup_flow.go
@@ -463,6 +463,8 @@ func (s *SetupFlowStep) validate(vc *common.ValidationContext, seenIds map[strin
 			result = multierror.Append(result, vc.NewErrorfForField("json_schema", "json_schema is required for form steps"))
 		} else if !json.Valid(s.JsonSchema) {
 			result = multierror.Append(result, vc.NewErrorfForField("json_schema", "json_schema is not valid JSON"))
+		} else if err := s.validateDataSourceReferences(vc.PushField("json_schema")); err != nil {
+			result = multierror.Append(result, err)
 		}
 		if !s.UiSchema.IsEmpty() && !json.Valid(s.UiSchema) {
 			result = multierror.Append(result, vc.NewErrorfForField("ui_schema", "ui_schema is not valid JSON"))
@@ -492,6 +494,48 @@ func (s *SetupFlowStep) validate(vc *common.ValidationContext, seenIds map[strin
 			if err := s.Redirect.Validate(vc.PushField("redirect")); err != nil {
 				result = multierror.Append(result, err)
 			}
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+// validateDataSourceReferences ensures fields backed by dynamic options name a
+// data source defined on the same step. The Marketplace only resolves
+// x-data-source annotations on top-level properties, so validate the same
+// surface here and reject connector definitions that would render an empty
+// input instead of a select control.
+func (s *SetupFlowStep) validateDataSourceReferences(vc *common.ValidationContext) error {
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(s.JsonSchema, &schema); err != nil {
+		return nil
+	}
+
+	var properties map[string]json.RawMessage
+	if err := json.Unmarshal(schema["properties"], &properties); err != nil {
+		return nil
+	}
+
+	result := &multierror.Error{}
+	for propertyName, rawProperty := range properties {
+		var property map[string]json.RawMessage
+		if err := json.Unmarshal(rawProperty, &property); err != nil {
+			continue
+		}
+
+		rawSourceID, ok := property["x-data-source"]
+		if !ok {
+			continue
+		}
+
+		propertyVc := vc.PushField("properties").PushField(propertyName)
+		var sourceID string
+		if err := json.Unmarshal(rawSourceID, &sourceID); err != nil || sourceID == "" {
+			result = multierror.Append(result, propertyVc.NewErrorfForField("x-data-source", "x-data-source must be a non-empty string"))
+			continue
+		}
+		if _, ok := s.DataSources[sourceID]; !ok {
+			result = multierror.Append(result, propertyVc.NewErrorfForField("x-data-source", "x-data-source %q is not defined in data_sources", sourceID))
 		}
 	}
 

--- a/internal/schema/resources/connectors/setup_flow_test.go
+++ b/internal/schema/resources/connectors/setup_flow_test.go
@@ -295,6 +295,44 @@ func TestSetupFlowValidation(t *testing.T) {
 		assert.NoError(t, sf.Validate(vc))
 	})
 
+	t.Run("data source reference must match a defined source", func(t *testing.T) {
+		sf := &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "step1",
+						JsonSchema: common.RawJSON(`{"type":"object","properties":{"item_id":{"type":"string","x-data-source":"missing_items"}}}`),
+						DataSources: map[string]DataSourceDef{
+							"items": {
+								ProxyRequest: &DataSourceProxyRequest{Method: "GET", Url: "https://api.example.com"},
+								Transform:    "data",
+							},
+						},
+					},
+				},
+			},
+		}
+		err := sf.Validate(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `x-data-source "missing_items" is not defined in data_sources`)
+	})
+
+	t.Run("data source reference must be a non-empty string", func(t *testing.T) {
+		sf := &SetupFlow{
+			Configure: &SetupFlowPhase{
+				Steps: []SetupFlowStep{
+					{
+						Id:         "step1",
+						JsonSchema: common.RawJSON(`{"type":"object","properties":{"item_id":{"type":"string","x-data-source":true}}}`),
+					},
+				},
+			},
+		}
+		err := sf.Validate(vc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "x-data-source must be a non-empty string")
+	})
+
 	t.Run("data source missing proxy_request", func(t *testing.T) {
 		sf := &SetupFlow{
 			Configure: &SetupFlowPhase{

--- a/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-setup-flow.yaml
+++ b/internal/schema/resources/connectors/test_data/valid-oauth-connector-with-setup-flow.yaml
@@ -51,6 +51,7 @@ setupFlow:
             workspace_id:
               type: string
               title: Workspace
+              x-data-source: workspaces
         uiSchema:
           type: VerticalLayout
           elements:


### PR DESCRIPTION
## Summary

- align the Demo OAuth resource field with its demoResources data-source ID in both demo deployment overlays
- reject connector definitions whose x-data-source annotation does not match a source defined on the setup step
- validate all deployment seed connector definitions in the seed test suite

## Root cause

The data source was renamed to camelCase during contract-casing cleanup, but its reference lives inside an opaque JSON Schema and remained demo_resources. The Marketplace requested that nonexistent source ID, so the setup form never received options.

## Validation

- go test ./internal/schema/... ./demos/seed/backend
- ./scripts/preflight.sh

## Screenshots

Not required: this changes demo seed configuration and connector validation; it does not modify ui/admin or ui/marketplace source files.