### PR TITLE
Fix idempotent demo namespace seeding

### DIFF
--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -3,7 +3,7 @@
 // post-upgrade hook from the authproxy-demo umbrella chart.
 //
 // Idempotency model: namespaces and actors are created when absent and
-// verified against the desired state when present. For each desired connector,
+// reconciled to the desired state when present. For each desired connector,
 // list by the stable demo seed label, create it when absent, or publish a new
 // version when the definition changes. Re-running the seed job is a no-op once
 // the state matches.
@@ -191,11 +191,14 @@ func upsertNamespace(c *resty.Client, baseUrl string, ns NamespaceSeed) (seedAct
 
 	switch getResp.StatusCode() {
 	case http.StatusOK:
-		if !stringMapsEqual(ns.Labels, existing.Labels) ||
-			!stringMapsEqual(ns.Annotations, existing.Annotations) {
-			return "", fmt.Errorf("namespace %q exists but does not match the configured labels and annotations", ns.Path)
+		if stringMapsEqual(ns.Labels, userLabels(existing.Labels)) &&
+			stringMapsEqual(ns.Annotations, existing.Annotations) {
+			return seedAlreadyPresent, nil
 		}
-		return seedAlreadyPresent, nil
+		if err := updateNamespace(c, baseUrl, ns); err != nil {
+			return "", err
+		}
+		return seedUpdated, nil
 	case http.StatusNotFound:
 		// fall through to create
 	default:
@@ -217,6 +220,32 @@ func upsertNamespace(c *resty.Client, baseUrl string, ns NamespaceSeed) (seedAct
 		return "", fmt.Errorf("POST namespace %q returned %d: %s", ns.Path, postResp.StatusCode(), postResp.String())
 	}
 	return seedCreated, nil
+}
+
+func updateNamespace(c *resty.Client, baseUrl string, ns NamespaceSeed) error {
+	labels := ns.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	annotations := ns.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	patchResp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(api.UpdateNamespaceRequestJson{
+			Labels:      labels,
+			Annotations: annotations,
+		}).
+		Patch(fmt.Sprintf("%s/api/v1/namespaces/%s", baseUrl, ns.Path))
+	if err != nil {
+		return fmt.Errorf("PATCH namespace %q: %w", ns.Path, err)
+	}
+	if patchResp.StatusCode() >= 400 {
+		return fmt.Errorf("PATCH namespace %q returned %d: %s", ns.Path, patchResp.StatusCode(), patchResp.String())
+	}
+	return nil
 }
 
 // upsertActor creates the actor if it doesn't already exist by external_id and
@@ -426,6 +455,18 @@ func stringMapsEqual(a, b map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func userLabels(labels map[string]string) map[string]string {
+	// AuthProxy materializes reserved identity and inherited labels in API
+	// responses. Seed configuration owns only labels that callers can set.
+	result := make(map[string]string)
+	for key, value := range labels {
+		if !strings.HasPrefix(key, "apxy/") {
+			result[key] = value
+		}
+	}
+	return result
 }
 
 func normalizeForJSON(v any) any {

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -66,15 +66,89 @@ func TestUpsertNamespaceCreatesMissingNamespace(t *testing.T) {
 	require.Equal(t, seedCreated, action)
 }
 
-func TestUpsertNamespaceVerifiesExistingNamespace(t *testing.T) {
+func TestUpsertNamespaceIgnoresSystemManagedLabels(t *testing.T) {
 	seed := NamespaceSeed{Path: "root.demo", Labels: map[string]string{"demo": "true"}}
 	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(t, w, api.NamespaceJson{Path: seed.Path, Labels: seed.Labels})
+		require.Equal(t, http.MethodGet, r.Method)
+		writeJSON(t, w, api.NamespaceJson{
+			Path: seed.Path,
+			Labels: map[string]string{
+				"demo":           "true",
+				"apxy/ns/-/id":   "root.demo",
+				"apxy/ns/-/name": "demo",
+				"apxy/ns/-/ns":   "root.demo",
+			},
+		})
 	}))
 
 	action, err := upsertNamespace(client, testBaseURL, seed)
 	require.NoError(t, err)
 	require.Equal(t, seedAlreadyPresent, action)
+}
+
+func TestUpsertNamespaceReconcilesUserMetadata(t *testing.T) {
+	seed := NamespaceSeed{
+		Path:        "root.demo",
+		Labels:      map[string]string{"demo": "true"},
+		Annotations: map[string]string{"description": "Demo resources"},
+	}
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/namespaces/root.demo":
+			writeJSON(t, w, api.NamespaceJson{
+				Path: seed.Path,
+				Labels: map[string]string{
+					"demo":         "false",
+					"apxy/ns/-/id": "root.demo",
+				},
+				Annotations: map[string]string{"description": "Stale description"},
+			})
+		case "PATCH /api/v1/namespaces/root.demo":
+			var req api.UpdateNamespaceRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, seed.Labels, req.Labels)
+			require.Equal(t, seed.Annotations, req.Annotations)
+			writeJSON(t, w, api.NamespaceJson{
+				Path:        seed.Path,
+				Labels:      seed.Labels,
+				Annotations: seed.Annotations,
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertNamespace(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedUpdated, action)
+}
+
+func TestUpsertNamespaceClearsUnconfiguredUserMetadata(t *testing.T) {
+	seed := NamespaceSeed{Path: "root.demo"}
+	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/namespaces/root.demo":
+			writeJSON(t, w, api.NamespaceJson{
+				Path:        seed.Path,
+				Labels:      map[string]string{"legacy": "true"},
+				Annotations: map[string]string{"legacy": "true"},
+			})
+		case "PATCH /api/v1/namespaces/root.demo":
+			var req api.UpdateNamespaceRequestJson
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.NotNil(t, req.Labels)
+			require.Empty(t, req.Labels)
+			require.NotNil(t, req.Annotations)
+			require.Empty(t, req.Annotations)
+			writeJSON(t, w, api.NamespaceJson{Path: seed.Path})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+
+	action, err := upsertNamespace(client, testBaseURL, seed)
+	require.NoError(t, err)
+	require.Equal(t, seedUpdated, action)
 }
 
 func TestUpsertActorCreatesThenAppliesPermissions(t *testing.T) {


### PR DESCRIPTION
## Summary

- ignore AuthProxy-managed `apxy/` labels when comparing an existing seeded namespace
- reconcile stale user labels and annotations through the namespace PATCH API
- cover system labels, metadata updates, and metadata clearing with regression tests

## Root cause

The first automatic seed run created `root.demo`. AuthProxy added implicit `apxy/` labels to that namespace, but subsequent seed runs compared the complete API label map with only the configured user labels. Every later deployment therefore retried a deterministic metadata mismatch until the Kubernetes job timed out.

## Verification

- `go test ./demos/seed/backend`
- `./scripts/preflight.sh`