### PR TITLE
Upgrade EKS to Kubernetes 1.36

### DIFF
--- a/deploy/terraform/eks/README.md
+++ b/deploy/terraform/eks/README.md
@@ -5,7 +5,7 @@ Provisions the EKS cluster the deployment pipeline runs against.
 | Resource                | Notes                                                         |
 |-------------------------|---------------------------------------------------------------|
 | VPC                     | 3 AZs, public + private subnets, single NAT (~$32/mo)         |
-| EKS                     | 1.34, managed node group (t3.medium x 2, scale 1-4)           |
+| EKS                     | 1.36, managed node group (t3.medium x 2, scale 1-4)           |
 | Cluster addons          | coredns, kube-proxy, vpc-cni, ebs-csi-driver                  |
 | IAM OIDC provider       | Federates GH Actions from `rmorlok/authproxy`                 |
 | GH Actions role         | Tag pushes (`v*`, `chart-v*`) + dispatches with `gha-eks` env |

--- a/deploy/terraform/eks/variables.tf
+++ b/deploy/terraform/eks/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "kubernetes_version" {
   description = "EKS Kubernetes version."
   type        = string
-  default     = "1.34"
+  default     = "1.36"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
## Summary

- upgrade the EKS Terraform default from Kubernetes 1.34 to 1.36
- update the EKS package README to match
- roll the live cluster through the required 1.35 intermediate version, including managed nodes and add-ons

## Live rollout

- AWS 1.36 upgrade insights: all forward-compatibility checks passed
- control plane: ACTIVE on 1.36 / platform eks.10
- managed node group: ACTIVE on 1.36.2-20260818 with two Ready nodes
- add-ons: CoreDNS, kube-proxy, and VPC CNI ACTIVE
- final scoped Terraform plan: no changes
- demo recovery workflow passed after ephemeral database recreation: https://github.com/rmorlok/authproxy/actions/runs/32650734499
- demo, Marketplace, Admin, and Grafana health endpoints return HTTP 200

## Validation

- terraform validate
- terraform fmt -check -recursive deploy/terraform/eks
- yarn docs:build
- ./scripts/preflight.sh