### PR TITLE
deploy: add EBS CSI storage support

### DIFF
--- a/deploy/charts/bootstrap/Chart.yaml
+++ b/deploy/charts/bootstrap/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 name: authproxy-bootstrap
 description: |
   Cluster bootstrap layer for an AuthProxy EKS install: ingress-nginx,
-  cert-manager, external-dns, metrics-server, plus a Let's Encrypt
-  ClusterIssuer. Helm-of-helms — depends on each upstream chart.
+  cert-manager, external-dns, metrics-server, EBS storage, plus a Let's
+  Encrypt ClusterIssuer. Helm-of-helms — depends on each upstream chart.
 type: application
 
 # Chart version follows its own semver, decoupled from the upstreams
 # below. Bumped when bootstrap surface (values, ClusterIssuer config,
 # pinned versions) changes.
-version: 0.1.0
+version: 0.2.0
 
 # appVersion has no single meaning for a meta-chart; the upstream
 # chart versions in `dependencies` are what actually matters.
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 
 home: https://github.com/rmorlok/authproxy
 sources:
@@ -30,6 +30,7 @@ keywords:
   - cert-manager
   - external-dns
   - metrics-server
+  - ebs-csi
 
 annotations:
   category: Infrastructure

--- a/deploy/charts/bootstrap/README.md
+++ b/deploy/charts/bootstrap/README.md
@@ -9,11 +9,12 @@ in-cluster components every downstream workload depends on:
 | cert-manager    | Automatic TLS issuance (Let's Encrypt prod, HTTP-01 or DNS-01) |
 | external-dns    | Reconciles Ingress hosts → Route53 A records                |
 | metrics-server  | Resource metrics for HPA + `kubectl top`                    |
+| EBS StorageClass | Default encrypted `gp3` storage via the EBS CSI driver     |
 | ClusterIssuer   | Let's Encrypt prod issuer named `letsencrypt-prod`          |
 
 This is a **helm-of-helms** chart: each component above is an upstream
-chart pinned as a `dependencies` entry in `Chart.yaml`. The only
-template owned by this chart directly is `templates/cluster_issuer.yaml`.
+chart pinned as a `dependencies` entry in `Chart.yaml`. This chart directly
+owns the `ClusterIssuer` and EBS CSI `StorageClass` templates.
 
 ## Pre-requisites
 
@@ -106,6 +107,12 @@ kubectl get pods -n kube-system \
 ```
 
 All four `app.kubernetes.io/name` selectors should report Running pods.
+
+```bash
+kubectl get storageclass gp3
+```
+
+The class should use `ebs.csi.aws.com` and be marked as the default.
 
 ```bash
 kubectl get clusterissuer letsencrypt-prod -o wide

--- a/deploy/charts/bootstrap/ci/all-disabled-values.yaml
+++ b/deploy/charts/bootstrap/ci/all-disabled-values.yaml
@@ -1,6 +1,6 @@
 # chart-testing values for the helm-chart-ci workflow.
 #
-# Disables every subchart + the ClusterIssuer template so `ct install`
+# Disables every subchart plus the StorageClass and ClusterIssuer templates so `ct install`
 # can render and "install" the chart against a kind cluster without
 # needing real AWS resources (NLB, Route53, Let's Encrypt). The install
 # becomes an effectively-empty Helm release — what we're verifying is
@@ -20,6 +20,9 @@ external-dns:
   enabled: false
 
 metrics-server:
+  enabled: false
+
+storageClass:
   enabled: false
 
 clusterIssuer:

--- a/deploy/charts/bootstrap/templates/NOTES.txt
+++ b/deploy/charts/bootstrap/templates/NOTES.txt
@@ -3,6 +3,7 @@
   operator-facing checklist: confirm IRSA wiring, verify components are
   healthy, and run the throwaway echo smoke test.
 */ -}}
+{{- $storageClass := mergeOverwrite (dict "enabled" true "name" "gp3") (.Values.storageClass | default dict) -}}
 authproxy-bootstrap installed.
 
 Next steps
@@ -19,12 +20,18 @@ Next steps
 
      kubectl get pods -n kube-system -l 'app.kubernetes.io/name in (ingress-nginx,cert-manager,external-dns,metrics-server)'
 
-3. Confirm the ClusterIssuer reached Ready (cert-manager has to register
+{{ if $storageClass.enabled }}
+3. Confirm the default EBS CSI storage class exists:
+
+     kubectl get storageclass {{ $storageClass.name }}
+
+{{ end }}
+{{ if $storageClass.enabled }}4{{ else }}3{{ end }}. Confirm the ClusterIssuer reached Ready (cert-manager has to register
    with Let's Encrypt — takes ~10-30s):
 
      kubectl get clusterissuer {{ .Values.clusterIssuer.name }} -o wide
 
-4. Smoke test — apply examples/hello-echo.yaml from this chart's source
+{{ if $storageClass.enabled }}5{{ else }}4{{ end }}. Smoke test — apply examples/hello-echo.yaml from this chart's source
    tree, then watch DNS + TLS land:
 
      kubectl apply -f deploy/charts/bootstrap/examples/hello-echo.yaml

--- a/deploy/charts/bootstrap/templates/storage_class.yaml
+++ b/deploy/charts/bootstrap/templates/storage_class.yaml
@@ -1,0 +1,29 @@
+{{- $storageClass := mergeOverwrite (dict
+  "enabled" true
+  "name" "gp3"
+  "default" true
+  "type" "gp3"
+  "encrypted" true
+  "fsType" "ext4"
+  "reclaimPolicy" "Delete"
+  "volumeBindingMode" "WaitForFirstConsumer"
+  "allowVolumeExpansion" true
+) (.Values.storageClass | default dict) -}}
+{{- if $storageClass.enabled -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $storageClass.name | quote }}
+  {{- if $storageClass.default }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
+provisioner: ebs.csi.aws.com
+parameters:
+  type: {{ $storageClass.type | quote }}
+  encrypted: {{ $storageClass.encrypted | quote }}
+  csi.storage.k8s.io/fstype: {{ $storageClass.fsType | quote }}
+reclaimPolicy: {{ $storageClass.reclaimPolicy }}
+allowVolumeExpansion: {{ $storageClass.allowVolumeExpansion }}
+volumeBindingMode: {{ $storageClass.volumeBindingMode }}
+{{- end }}

--- a/deploy/charts/bootstrap/values.schema.json
+++ b/deploy/charts/bootstrap/values.schema.json
@@ -13,6 +13,21 @@
         "domain":       { "type": "string" }
       }
     },
+    "storageClass": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":              { "type": "boolean" },
+        "name":                 { "type": "string", "minLength": 1 },
+        "default":              { "type": "boolean" },
+        "type":                 { "type": "string", "enum": ["gp2", "gp3", "io1", "io2", "sc1", "st1"] },
+        "encrypted":            { "type": "boolean" },
+        "fsType":               { "type": "string", "enum": ["ext2", "ext3", "ext4", "xfs"] },
+        "reclaimPolicy":        { "type": "string", "enum": ["Delete", "Retain"] },
+        "volumeBindingMode":    { "type": "string", "enum": ["Immediate", "WaitForFirstConsumer"] },
+        "allowVolumeExpansion": { "type": "boolean" }
+      }
+    },
     "clusterIssuer": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/charts/bootstrap/values.yaml
+++ b/deploy/charts/bootstrap/values.yaml
@@ -6,6 +6,7 @@
 #   cert-manager        — passthrough values forwarded to the upstream chart
 #   external-dns        — passthrough values forwarded to the upstream chart
 #   metrics-server      — passthrough values forwarded to the upstream chart
+#   storageClass        — default encrypted EBS CSI StorageClass
 #   clusterIssuer       — Let's Encrypt prod ClusterIssuer config (this chart's own template)
 
 global:
@@ -117,6 +118,20 @@ metrics-server:
   enabled: true
   args:
     - --kubelet-preferred-address-types=InternalIP
+
+# --- EBS CSI StorageClass (this chart's own template) -----------------------
+storageClass:
+  # -- Create an EBS CSI StorageClass for persistent workload storage.
+  enabled: true
+  name: gp3
+  # -- Mark this class as the cluster default for PVCs that omit storageClassName.
+  default: true
+  type: gp3
+  encrypted: true
+  fsType: ext4
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true
 
 # --- ClusterIssuer (this chart's own template) ------------------------------
 clusterIssuer:

--- a/deploy/terraform/eks/irsa_ebs_csi.tf
+++ b/deploy/terraform/eks/irsa_ebs_csi.tf
@@ -1,0 +1,65 @@
+# IRSA role and EKS-managed add-on for the Amazon EBS CSI driver.
+#
+# The controller uses the fixed kube-system/ebs-csi-controller-sa ServiceAccount
+# created by the managed add-on. AmazonEBSCSIDriverPolicyV2 limits destructive
+# EBS operations to CSI-tagged volumes and snapshots.
+
+data "aws_partition" "current" {}
+
+data "aws_eks_addon_version" "ebs_csi" {
+  addon_name         = "aws-ebs-csi-driver"
+  kubernetes_version = module.eks.cluster_version
+  most_recent        = true
+}
+
+locals {
+  ebs_csi_namespace            = "kube-system"
+  ebs_csi_service_account_name = "ebs-csi-controller-sa"
+}
+
+data "aws_iam_policy_document" "ebs_csi_trust" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:sub"
+      values   = ["system:serviceaccount:${local.ebs_csi_namespace}:${local.ebs_csi_service_account_name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi" {
+  name               = "${var.cluster_name}-ebs-csi"
+  description        = "IRSA role assumed by the Amazon EBS CSI controller in ${var.cluster_name}"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_trust.json
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.ebs_csi.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEBSCSIDriverPolicyV2"
+}
+
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name             = module.eks.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = data.aws_eks_addon_version.ebs_csi.version
+  service_account_role_arn = aws_iam_role.ebs_csi.arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [aws_iam_role_policy_attachment.ebs_csi]
+}

--- a/deploy/terraform/eks/outputs.tf
+++ b/deploy/terraform/eks/outputs.tf
@@ -62,3 +62,8 @@ output "oidc_provider_arn" {
   description = "ARN of the cluster's OIDC provider. Future IRSA roles bind their trust policy to this."
   value       = module.eks.oidc_provider_arn
 }
+
+output "ebs_csi_role_arn" {
+  description = "ARN of the IRSA role used by the Amazon EBS CSI controller."
+  value       = aws_iam_role.ebs_csi.arn
+}


### PR DESCRIPTION
## Summary

- install the AWS-managed EBS CSI add-on with a dedicated IRSA role and AmazonEBSCSIDriverPolicyV2
- add an encrypted, expandable gp3 StorageClass to the bootstrap chart and make it the default
- preserve upgrades from bootstrap chart 0.1.0 when operators use --reuse-values
- expose the CSI role ARN as a Terraform output

## Kubernetes version and drift

Latest main declares Kubernetes 1.36, matching the live EKS control plane and node group. The full Terraform plan contains no Kubernetes version change and no CSI change after the live rollout.

The remaining unrelated plan changes are the existing node-group scaling drift, GitHub OIDC thumbprint refresh, and kube-proxy patch update; this PR does not apply them.

## Live verification

- EKS add-on aws-ebs-csi-driver v1.64.0-eksbuild.1 is ACTIVE with no health issues
- controller deployment is 2/2 ready and node DaemonSet is 2/2 ready
- a temporary 1 GiB gp3 PVC provisioned, attached, mounted, and passed a write/read check
- the temporary pod, PVC, PV, and EBS volume were deleted afterward
- existing gp3 StorageClass was assigned to the authproxy-bootstrap Helm release; server-side upgrade dry-run succeeds

## Checks

- terraform fmt -check -diff
- terraform validate -no-color
- full Terraform plan reviewed
- helm lint deploy/charts/bootstrap
- Helm template checks for default and all-disabled values
- server-side Helm upgrade dry-run with --reuse-values
- yarn docs:build
- ./scripts/preflight.sh