### PR TITLE
Update demo OAuth provider UI

### DIFF
--- a/deploy/kustomize/authproxy-demo/base/go-oauth2-server.yaml
+++ b/deploy/kustomize/authproxy-demo/base/go-oauth2-server.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: go-oauth2-server
-          image: ghcr.io/rmorlok/go-oauth2-server@sha256:d1e5bdae007259b0c02255f26efce595f23eb2142e7da8caa3dac544dd445cb3
+          image: ghcr.io/rmorlok/go-oauth2-server@sha256:7b5e621fe57ed4b882a014b613b9d0c5dd58aefb52eab881556da40a61b4a5fa
           imagePullPolicy: IfNotPresent
           command:
             - go-oauth2-server


### PR DESCRIPTION
## Summary

- pin the hosted demo OAuth provider to the multi-architecture image built from go-oauth2-server merge commit 0715edb3
- bring the refreshed authorize/login UI into the demo environment

Upstream: https://github.com/rmorlok/go-oauth2-server/pull/67
Image build: https://github.com/rmorlok/go-oauth2-server/actions/runs/32802656776

## Testing

- ./scripts/preflight.sh
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/demo
- kubectl kustomize deploy/kustomize/authproxy-demo/overlays/dev