### PR TITLE
Fix demo OAuth token exchange

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -564,7 +564,9 @@ jobs:
           echo "Smoke-testing ${SMOKE_BASE_URL}"
           cd integration_tests
           SMOKE_GLOBAL_KEY="${workdir}/global_aes.key" \
-            go test -tags smoke ./smoke -run TestRemoteOAuth2ProxySmoke -count=1 -v
+            go test -tags smoke ./smoke \
+              -run 'TestRemote(OAuth2Proxy|SeededOAuthConnector)Smoke' \
+              -count=1 -v
 
       - name: Collect deploy diagnostics (on failure)
         if: failure()

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -74,12 +74,14 @@ type OAuth2TestProviderSeed struct {
 	APIKeyResourcePolicies []APIKeyResourcePolicy     `yaml:"apiKeyResourcePolicies,omitempty"`
 }
 
+// The provider control-plane API uses snake_case JSON. The seed file remains
+// camelCase YAML to match the rest of the demo configuration surface.
 type OAuth2TestProviderClient struct {
 	Key                     string `json:"key" yaml:"key"`
 	Secret                  string `json:"secret,omitempty" yaml:"secret,omitempty"`
-	RedirectURI             string `json:"redirectUri,omitempty" yaml:"redirectUri,omitempty"`
-	TokenEndpointAuthMethod string `json:"tokenEndpointAuthMethod,omitempty" yaml:"tokenEndpointAuthMethod,omitempty"`
-	RequirePKCE             bool   `json:"requirePkce,omitempty" yaml:"requirePkce,omitempty"`
+	RedirectURI             string `json:"redirect_uri,omitempty" yaml:"redirectUri,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" yaml:"tokenEndpointAuthMethod,omitempty"`
+	RequirePKCE             bool   `json:"require_pkce,omitempty" yaml:"requirePkce,omitempty"`
 	Scope                   string `json:"scope,omitempty" yaml:"scope,omitempty"`
 }
 
@@ -88,20 +90,20 @@ type OAuth2TestProviderUser struct {
 	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
 	Role        string `json:"role,omitempty" yaml:"role,omitempty"`
 	Email       string `json:"email,omitempty" yaml:"email,omitempty"`
-	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	DisplayName string `json:"display_name,omitempty" yaml:"displayName,omitempty"`
 	Sub         string `json:"sub,omitempty" yaml:"sub,omitempty"`
 }
 
 type OAuth2ResourcePolicy struct {
 	Path          string `json:"path" yaml:"path"`
-	RequiredScope string `json:"requiredScope" yaml:"requiredScope"`
+	RequiredScope string `json:"required_scope" yaml:"requiredScope"`
 }
 
 type APIKeyResourcePolicy struct {
 	Path       string `json:"path" yaml:"path"`
 	Key        string `json:"key" yaml:"key"`
 	Placement  string `json:"placement,omitempty" yaml:"placement,omitempty"`
-	HeaderName string `json:"headerName,omitempty" yaml:"headerName,omitempty"`
+	HeaderName string `json:"header_name,omitempty" yaml:"headerName,omitempty"`
 	Prefix     string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 }
 

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -340,27 +341,56 @@ func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
 		seen[r.Method+" "+r.URL.Path]++
 		switch r.Method + " " + r.URL.Path {
 		case "POST /test/clients":
-			var req OAuth2TestProviderClient
+			var req struct {
+				Key                     string `json:"key"`
+				Secret                  string `json:"secret"`
+				RedirectURI             string `json:"redirect_uri"`
+				TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+				RequirePKCE             bool   `json:"require_pkce"`
+				Scope                   string `json:"scope"`
+			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "demo-oauth-simple", req.Key)
+			require.Equal(t, "secret", req.Secret)
 			require.Equal(t, "https://marketplace.example.test/oauth2/callback", req.RedirectURI)
+			require.Equal(t, "client_secret_post", req.TokenEndpointAuthMethod)
+			require.True(t, req.RequirePKCE)
+			require.Equal(t, "read", req.Scope)
 			w.WriteHeader(http.StatusCreated)
 		case "POST /test/users":
-			var req OAuth2TestProviderUser
+			var req struct {
+				Username    string `json:"username"`
+				Password    string `json:"password"`
+				DisplayName string `json:"display_name"`
+			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "demo-oauth-user@example.test", req.Username)
+			require.Equal(t, "demo-password", req.Password)
+			require.Equal(t, "Demo OAuth User", req.DisplayName)
 			w.WriteHeader(http.StatusCreated)
 		case "POST /test/resource-policy":
-			var req OAuth2ResourcePolicy
+			var req struct {
+				Path          string `json:"path"`
+				RequiredScope string `json:"required_scope"`
+			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "/test/resource/demo-resources", req.Path)
+			require.Equal(t, "read", req.RequiredScope)
 			w.WriteHeader(http.StatusNoContent)
 		case "POST /test/api-key-resource-policy":
-			var req APIKeyResourcePolicy
+			var req struct {
+				Path       string `json:"path"`
+				Key        string `json:"key"`
+				Placement  string `json:"placement"`
+				HeaderName string `json:"header_name"`
+				Prefix     string `json:"prefix"`
+			}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "/test/api-key-resource/demo-api-key", req.Path)
 			require.Equal(t, "demo-api-key", req.Key)
-			require.Equal(t, "bearer", req.Placement)
+			require.Equal(t, "header", req.Placement)
+			require.Equal(t, "X-Demo-Key", req.HeaderName)
+			require.Equal(t, "Token ", req.Prefix)
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
@@ -374,20 +404,24 @@ func TestSeedOAuth2TestProviderSeedsClientsUsersAndPolicies(t *testing.T) {
 			Secret:                  "secret",
 			RedirectURI:             "https://marketplace.example.test/oauth2/callback",
 			TokenEndpointAuthMethod: "client_secret_post",
+			RequirePKCE:             true,
 			Scope:                   "read",
 		}},
 		Users: []OAuth2TestProviderUser{{
-			Username: "demo-oauth-user@example.test",
-			Password: "demo-password",
+			Username:    "demo-oauth-user@example.test",
+			Password:    "demo-password",
+			DisplayName: "Demo OAuth User",
 		}},
 		ResourcePolicies: []OAuth2ResourcePolicy{{
 			Path:          "/test/resource/demo-resources",
 			RequiredScope: "read",
 		}},
 		APIKeyResourcePolicies: []APIKeyResourcePolicy{{
-			Path:      "/test/api-key-resource/demo-api-key",
-			Key:       "demo-api-key",
-			Placement: "bearer",
+			Path:       "/test/api-key-resource/demo-api-key",
+			Key:        "demo-api-key",
+			Placement:  "header",
+			HeaderName: "X-Demo-Key",
+			Prefix:     "Token ",
 		}},
 	})
 	require.NoError(t, err)
@@ -533,14 +567,33 @@ func TestDeploymentSeedConfigsUseIsolatedDemoResources(t *testing.T) {
 
 			var cfg SeedConfig
 			require.NoError(t, util.DecodeYAMLStrict([]byte(configMap.Data["seed.yaml"]), &cfg))
+			require.NotNil(t, cfg.OAuth2TestProvider)
 			require.Equal(t, []NamespaceSeed{{Path: "root.demo", Labels: map[string]string{"demo": "true"}}}, cfg.Namespaces)
 			require.Len(t, cfg.Actors, 1)
 			require.Equal(t, demoUserSeed(), cfg.Actors[0])
 			require.Len(t, cfg.Connectors, 5)
+
+			providerClients := make(map[string]OAuth2TestProviderClient, len(cfg.OAuth2TestProvider.Clients))
+			for _, client := range cfg.OAuth2TestProvider.Clients {
+				providerClients[client.Key] = client
+			}
+			oauthConnectorCount := 0
 			for _, connector := range cfg.Connectors {
 				require.Equal(t, "root.demo", connectorNamespace(connector))
 				require.NoError(t, connector.Definition.Validate(&common.ValidationContext{}))
+
+				oauthAuth, ok := connector.Definition.Auth.Inner().(*config.AuthOAuth2)
+				if !ok {
+					continue
+				}
+				oauthConnectorCount++
+				clientID, err := oauthAuth.ClientId.GetValue(context.Background())
+				require.NoError(t, err)
+				providerClient, ok := providerClients[clientID]
+				require.Truef(t, ok, "OAuth connector %q references unseeded provider client %q", connector.Key, clientID)
+				require.Equal(t, string(oauthAuth.GetTokenEndpointAuthMethodOrDefault()), providerClient.TokenEndpointAuthMethod)
 			}
+			require.Equal(t, 3, oauthConnectorCount)
 		})
 	}
 }

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
@@ -36,17 +36,19 @@ data:
           placement: bearer
       baseUrl: http://demo-go-oauth2-server
       clients:
-        - key: demo-oauth-simple
+        # Versioned IDs replace clients previously seeded with the wrong JSON
+        # field names; the provider's test API intentionally rejects updates.
+        - key: demo-oauth-simple-v2
           redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-simple-secret
           tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-tenant
+        - key: demo-oauth-tenant-v2
           redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-tenant-secret
           tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-configure
+        - key: demo-oauth-configure-v2
           redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-configure-secret
@@ -118,8 +120,9 @@ data:
           auth:
             authorization:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
-            clientId: demo-oauth-simple
+            clientId: demo-oauth-simple-v2
             clientSecret: demo-oauth-simple-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Read basic profile information from the demo provider.
@@ -153,8 +156,9 @@ data:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
               queryOverrides:
                 tenant: "{{cfg.tenant}}"
-            clientId: demo-oauth-tenant
+            clientId: demo-oauth-tenant-v2
             clientSecret: demo-oauth-tenant-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Read access after the selected tenant has authorized the app.
@@ -211,8 +215,9 @@ data:
           auth:
             authorization:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
-            clientId: demo-oauth-configure
+            clientId: demo-oauth-configure-v2
             clientSecret: demo-oauth-configure-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Complete the OAuth flow against the demo provider.

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -36,17 +36,19 @@ data:
           placement: bearer
       baseUrl: http://dev-go-oauth2-server
       clients:
-        - key: demo-oauth-simple
+        # Versioned IDs replace clients previously seeded with the wrong JSON
+        # field names; the provider's test API intentionally rejects updates.
+        - key: demo-oauth-simple-v2
           redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-simple-secret
           tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-tenant
+        - key: demo-oauth-tenant-v2
           redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-tenant-secret
           tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-configure
+        - key: demo-oauth-configure-v2
           redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
           scope: read profile resources
           secret: demo-oauth-configure-secret
@@ -118,8 +120,9 @@ data:
           auth:
             authorization:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
-            clientId: demo-oauth-simple
+            clientId: demo-oauth-simple-v2
             clientSecret: demo-oauth-simple-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Read basic profile information from the demo provider.
@@ -153,8 +156,9 @@ data:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
               queryOverrides:
                 tenant: "{{cfg.tenant}}"
-            clientId: demo-oauth-tenant
+            clientId: demo-oauth-tenant-v2
             clientSecret: demo-oauth-tenant-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Read access after the selected tenant has authorized the app.
@@ -211,8 +215,9 @@ data:
           auth:
             authorization:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
-            clientId: demo-oauth-configure
+            clientId: demo-oauth-configure-v2
             clientSecret: demo-oauth-configure-secret
+            tokenEndpointAuthMethod: client_secret_post
             scopes:
               - id: read
                 reason: Complete the OAuth flow against the demo provider.

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -82,6 +82,11 @@ func smokeAdminPermissions(adminExternalID, userExternalID, connectionNamespace 
 func smokeUserPermissions(connectionNamespace string) []aschema.Permission {
 	return []aschema.Permission{
 		{
+			Namespace: demoConnectorNamespace,
+			Resources: []string{"connectors"},
+			Verbs:     []string{"list"},
+		},
+		{
 			Namespace: smokeConnectorNamespace,
 			Resources: []string{"connectors"},
 			Verbs:     []string{"list"},
@@ -275,6 +280,53 @@ func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 	}
 	require.Truef(t, strings.HasPrefix(strings.ToLower(authHeader), "bearer "),
 		"proxied resource call should use bearer auth, got %q", authHeader)
+}
+
+func TestRemoteSeededOAuthConnectorSmoke(t *testing.T) {
+	if *smokeBaseURL == "" {
+		t.Skip("set SMOKE_BASE_URL or pass -base-url")
+	}
+	if *smokeGlobalKey == "" {
+		t.Skip("set SMOKE_GLOBAL_KEY or pass -global-key")
+	}
+
+	rig := newRemoteSmokeRig(t)
+	provider := helpers.NewOAuth2TestProviderAt(t, rig.ProviderURL)
+	connector := rig.FindConnectorBySeedKey(t, "demo-oauth-simple")
+
+	startedAt := time.Now().Add(-1 * time.Second)
+	connectionID, redirectURL := rig.InitiateOAuth2Connection(t, connector.Id, rig.PublicURL+"/connections")
+	authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
+	authorizeParams := parseQuery(t, authorizeURL)
+	clientID := authorizeParams.Get("client_id")
+	require.NotEmpty(t, clientID)
+	require.Equal(t, rig.PublicURL+"/oauth2/callback", authorizeParams.Get("redirect_uri"))
+	require.NotEmpty(t, authorizeParams.Get("state"))
+
+	callback := provider.Authorize(helpers.AuthorizeRequest{
+		ClientID:    clientID,
+		Username:    "demo-oauth-user@example.test",
+		RedirectURI: authorizeParams.Get("redirect_uri"),
+		Scope:       authorizeParams.Get("scope"),
+		State:       authorizeParams.Get("state"),
+		Decision:    helpers.AuthorizeApprove,
+	})
+	require.NotEmpty(t, callback.RedirectURL)
+
+	finalLocation := rig.DeliverOAuth2Callback(t, callback.RedirectURL)
+	assert.Truef(t, strings.HasPrefix(finalLocation, rig.PublicURL+"/connections"),
+		"expected callback to land on marketplace connections page, got %q", finalLocation)
+	rig.WaitForSetupComplete(t, connectionID, 30*time.Second)
+
+	proxyResp := rig.DoProxyRequest(t, connectionID, provider.ResourceURL("/echo"), http.MethodGet)
+	require.Equal(t, http.StatusOK, proxyResp.StatusCode)
+
+	tokenReqs := provider.Requests(helpers.RequestsFilter{
+		Endpoint: helpers.EndpointToken,
+		ClientID: clientID,
+		Since:    startedAt,
+	})
+	require.NotEmpty(t, tokenReqs, "provider should record the seeded client token exchange")
 }
 
 func TestRemoteSeededConnectorsSmoke(t *testing.T) {

--- a/tools/check-contract-casing/main.go
+++ b/tools/check-contract-casing/main.go
@@ -23,6 +23,20 @@ import (
 
 var lowerCamelCase = regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)
 
+// These tags belong to an external provider API rather than AuthProxy's wire
+// contract. Keep the exception exact so other seed-service fields remain
+// covered by the lowerCamelCase guard.
+var externalJSONTags = map[string]map[string]struct{}{
+	"demos/seed/backend/main.go": {
+		"display_name":               {},
+		"header_name":                {},
+		"redirect_uri":               {},
+		"require_pkce":               {},
+		"required_scope":             {},
+		"token_endpoint_auth_method": {},
+	},
+}
+
 var goContractDirs = []string{
 	"cmd/cli", "cmd/loadtest", "demos/seed/backend", "demos/shell/backend",
 	"internal/apauth", "internal/app_metrics", "internal/apredis", "internal/config",
@@ -86,7 +100,8 @@ func checkGoTags() []string {
 				tag := reflect.StructTag(tagText)
 				for _, kind := range []string{"json", "yaml", "form"} {
 					name := strings.Split(tag.Get(kind), ",")[0]
-					if name != "" && name != "-" && name != "$id" && !lowerCamelCase.MatchString(name) {
+					if name != "" && name != "-" && name != "$id" && !lowerCamelCase.MatchString(name) &&
+						!(kind == "json" && isExternalJSONTag(path, name)) {
 						violations = append(violations, fmt.Sprintf("%s: %s tag %q must be lowerCamelCase", path, kind, name))
 					}
 				}
@@ -96,6 +111,15 @@ func checkGoTags() []string {
 		})
 	}
 	return violations
+}
+
+func isExternalJSONTag(path, name string) bool {
+	allowed, ok := externalJSONTags[filepath.ToSlash(path)]
+	if !ok {
+		return false
+	}
+	_, ok = allowed[name]
+	return ok
 }
 
 func checkSchemas() []string {


### PR DESCRIPTION
## Root cause

The demo seed service serialized provider control-plane requests with camelCase JSON field names. The go-oauth2-server test API expects snake_case, so it ignored tokenEndpointAuthMethod and registered each demo client with its client_secret_basic default. AuthProxy then attempted client_secret_post during authorization-code exchange, which the provider rejected with 401. The same mismatch also dropped redirect URI, PKCE, display-name, and resource-policy fields.

This predates the provider image pin update.

## Fix

- encode the external provider control-plane JSON with its snake_case contract while preserving the existing camelCase seed YAML
- explicitly align connector and provider token-endpoint auth methods
- use v2 provider client IDs so the live seed can replace malformed records that the provider API does not update
- validate connector-to-provider client mappings in the deployment seed configs
- add a deployment smoke test that completes OAuth with the actual seeded connector instead of only a newly registered smoke client

## Testing

- go test ./demos/seed/backend -count=1
- go test -tags smoke ./smoke -run ^$ -count=1 (from integration_tests)
- rendered demo, dev, and both seed Kustomize overlays
- ./scripts/preflight.sh