### PR TITLE
Preserve scoped JWT permissions in browser sessions

### DIFF
--- a/integration_tests/session/scoped_permissions_test.go
+++ b/integration_tests/session/scoped_permissions_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	"github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopedPermissionsPersistInBrowserSession(t *testing.T) {
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service:         helpers.ServiceTypeAPI,
+		StartHTTPServer: true,
+		IncludePublic:   true,
+	})
+	defer env.Cleanup()
+
+	ctx := context.Background()
+	actorPermissions := aschema.AllPermissions()
+	tokenPermissions := aschema.PermissionsSingle("root.**", "connectors", "list")
+
+	t.Run("new session retains jwt restrictions", func(t *testing.T) {
+		client := newBrowserClient(t)
+		token, err := env.PublicAuthUtil.GenerateScopedBearerToken(
+			ctx,
+			fmt.Sprintf("new-scoped-session-%d", time.Now().UnixNano()),
+			config.RootNamespace,
+			actorPermissions,
+			tokenPermissions,
+		)
+		require.NoError(t, err)
+
+		initiateSession(t, client, env.PublicURL, token)
+		requireStatus(t, client, env.PublicURL+"/api/v1/connectors?limit=1", http.StatusOK)
+		requireStatus(t, client, env.PublicURL+"/api/v1/connections?limit=1", http.StatusForbidden)
+	})
+
+	t.Run("scoped jwt narrows existing same actor session", func(t *testing.T) {
+		client := newBrowserClient(t)
+		externalID := fmt.Sprintf("existing-scoped-session-%d", time.Now().UnixNano())
+
+		unscopedToken, err := env.PublicAuthUtil.GenerateScopedBearerToken(
+			ctx,
+			externalID,
+			config.RootNamespace,
+			actorPermissions,
+			nil,
+		)
+		require.NoError(t, err)
+		initiateSession(t, client, env.PublicURL, unscopedToken)
+		requireStatus(t, client, env.PublicURL+"/api/v1/connections?limit=1", http.StatusOK)
+
+		scopedToken, err := env.PublicAuthUtil.GenerateScopedBearerToken(
+			ctx,
+			externalID,
+			config.RootNamespace,
+			actorPermissions,
+			tokenPermissions,
+		)
+		require.NoError(t, err)
+		initiateSession(t, client, env.PublicURL, scopedToken)
+
+		requireStatus(t, client, env.PublicURL+"/api/v1/connectors?limit=1", http.StatusOK)
+		requireStatus(t, client, env.PublicURL+"/api/v1/connections?limit=1", http.StatusForbidden)
+	})
+}
+
+func newBrowserClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	return &http.Client{Jar: jar}
+}
+
+func initiateSession(t *testing.T, client *http.Client, publicURL, token string) {
+	t.Helper()
+
+	body, err := json.Marshal(schemaapi.SessionInitiateParams{
+		ReturnToUrl: publicURL + "/connectors",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		publicURL+"/api/v1/session/_initiate",
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	respBody, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.NoError(t, resp.Body.Close())
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "session response: %s", respBody)
+
+	parsedPublicURL, err := url.Parse(publicURL)
+	require.NoError(t, err)
+	hasSessionCookie := false
+	for _, cookie := range client.Jar.Cookies(parsedPublicURL) {
+		if cookie.Name == "SESSION-ID" {
+			hasSessionCookie = true
+			break
+		}
+	}
+	require.True(t, hasSessionCookie, "session initiation should set a SESSION-ID cookie")
+}
+
+func requireStatus(t *testing.T, client *http.Client, endpoint string, expected int) {
+	t.Helper()
+
+	resp, err := client.Get(endpoint)
+	require.NoError(t, err)
+	respBody, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.NoError(t, resp.Body.Close())
+	require.Equalf(t, expected, resp.StatusCode, "response body: %s", respBody)
+}

--- a/internal/apauth/service/auth_test.go
+++ b/internal/apauth/service/auth_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/test_utils"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -910,6 +911,13 @@ func TestAuth(t *testing.T) {
 
 					gctx.PureJSON(http.StatusOK, gin.H{"ok": true})
 				}).
+				WithRequiredAuthRoute(http.MethodGet, "/session-permissions", func(gctx *gin.Context, _ A) {
+					ra := GetAuthFromGinContext(gctx)
+					gctx.PureJSON(http.StatusOK, gin.H{
+						"allowsList":   ra.Allows("root", "connections", "list", ""),
+						"allowsCreate": ra.Allows("root", "connections", "create", ""),
+					})
+				}).
 				WithGetPingRequiredAuthRoute("/ping-get").
 				WithPostPingRequiredAuthRoute("/ping-post").
 				Build()
@@ -995,6 +1003,77 @@ func TestAuth(t *testing.T) {
 			resp, statusCode, debugHeader = ts.POST(ctx, "/ping-post", gin.H{})
 			require.Equal(t, http.StatusForbidden, statusCode, debugHeader) // Requires xsrf
 			require.Equal(t, 1, ts.GetPingCount())
+		})
+
+		t.Run("preserves scoped jwt permissions", func(t *testing.T) {
+			ts := setup(t)
+			actorPermissions := []aschema.Permission{{
+				Namespace: "root.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"list", "create"},
+			}}
+			tokenPermissions := aschema.PermissionsSingle("root.**", "connections", "list")
+			s := jwt.NewJwtTokenBuilder().
+				WithActor(&core.Actor{
+					ExternalId:  "scoped-session-user",
+					Namespace:   "root",
+					Permissions: actorPermissions,
+				}).
+				WithPermissions(tokenPermissions).
+				WithServiceId(ts.Service).
+				MustWithConfigKey(ctx, ts.MustGetValidSigningTokenForUser()).
+				MustSignerCtx(ctx)
+
+			_, statusCode, debugHeader := ts.GET(ctx, s.SignUrlQuery("/initiate-session"))
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+
+			resp, statusCode, debugHeader := ts.GET(ctx, "/session-permissions")
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, gin.H{
+				"allowsList":   true,
+				"allowsCreate": false,
+			}, resp)
+		})
+
+		t.Run("scoped jwt refreshes existing same actor session", func(t *testing.T) {
+			ts := setup(t)
+			actor := &core.Actor{
+				ExternalId: "rescope-session-user",
+				Namespace:  "root",
+				Permissions: []aschema.Permission{{
+					Namespace: "root.**",
+					Resources: []string{"connections"},
+					Verbs:     []string{"list", "create"},
+				}},
+			}
+
+			unscoped := jwt.NewJwtTokenBuilder().
+				WithActor(actor).
+				WithServiceId(ts.Service).
+				MustWithConfigKey(ctx, ts.MustGetValidSigningTokenForUser()).
+				MustSignerCtx(ctx)
+			_, statusCode, debugHeader := ts.GET(ctx, unscoped.SignUrlQuery("/initiate-session"))
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+
+			resp, statusCode, debugHeader := ts.GET(ctx, "/session-permissions")
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, true, resp["allowsCreate"])
+
+			scoped := jwt.NewJwtTokenBuilder().
+				WithActor(actor).
+				WithPermissions(aschema.PermissionsSingle("root.**", "connections", "list")).
+				WithServiceId(ts.Service).
+				MustWithConfigKey(ctx, ts.MustGetValidSigningTokenForUser()).
+				MustSignerCtx(ctx)
+			_, statusCode, debugHeader = ts.GET(ctx, scoped.SignUrlQuery("/initiate-session"))
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+
+			resp, statusCode, debugHeader = ts.GET(ctx, "/session-permissions")
+			require.Equal(t, http.StatusOK, statusCode, debugHeader)
+			require.Equal(t, gin.H{
+				"allowsList":   true,
+				"allowsCreate": false,
+			}, resp)
 		})
 	})
 	t.Run("session initiate via post", func(t *testing.T) {

--- a/internal/apauth/service/session.go
+++ b/internal/apauth/service/session.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	"github.com/rmorlok/authproxy/internal/httperr"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 )
 
@@ -31,10 +32,11 @@ type Encrypt interface {
 
 // session is the object stored in redis to track the session
 type session struct {
-	Id              apid.ID   `json:"id"`
-	ActorId         apid.ID   `json:"actorId"`
-	ValidXsrfValues []string  `json:"-"` // Serialized separately in a different key
-	ExpiresAt       time.Time `json:"expiresAt"`
+	Id                     apid.ID              `json:"id"`
+	ActorId                apid.ID              `json:"actorId"`
+	PermissionRestrictions []aschema.Permission `json:"permissionRestrictions,omitempty"`
+	ValidXsrfValues        []string             `json:"-"` // Serialized separately in a different key
+	ExpiresAt              time.Time            `json:"expiresAt"`
 }
 
 func (s *session) MarshalBinary() ([]byte, error) {
@@ -226,7 +228,11 @@ func (s *service) establishAuthFromSession(
 		return core.NewUnauthenticatedRequestAuth(), fmt.Errorf("failed to extend session: %w", err)
 	}
 
-	return core.NewAuthenticatedRequestAuthWithSession(actor, &sess.Id), nil
+	return core.NewAuthenticatedRequestAuthWithSessionAndPermissions(
+		actor,
+		&sess.Id,
+		sess.PermissionRestrictions,
+	), nil
 }
 
 // EstablishSession is used to start a new session explicitly from a service that is using auth. Generally this
@@ -275,6 +281,12 @@ func (s *service) EstablishSession(ctx context.Context, w http.ResponseWriter, r
 			ExpiresAt: apctx.GetClock(ctx).Now().Add(sessionService.SessionTimeout()),
 		}
 	}
+
+	// A browser session must retain any request-level restrictions from the JWT
+	// that established or refreshed it. The actor is still loaded from the
+	// database on each session-authenticated request, so these restrictions are
+	// always intersected with the actor's current permissions.
+	sess.PermissionRestrictions = append([]aschema.Permission(nil), ra.GetPermissions()...)
 
 	err = s.extendSession(ctx, sess, w)
 	if err != nil {

--- a/internal/apauth/service/test_auth.go
+++ b/internal/apauth/service/test_auth.go
@@ -175,6 +175,28 @@ func (atu *AuthTestUtil) GenerateBearerToken(ctx context.Context, externalId, na
 	return atu.s.Token(ctx, claims)
 }
 
+// GenerateScopedBearerToken creates a token whose actor permissions and
+// request-level permission restrictions can be controlled independently.
+func (atu *AuthTestUtil) GenerateScopedBearerToken(
+	ctx context.Context,
+	externalId string,
+	namespace string,
+	actorPermissions []aschema.Permission,
+	tokenPermissions []aschema.Permission,
+) (string, error) {
+	claims := atu.claimsForActor(ctx, core.Actor{
+		ExternalId:  externalId,
+		Namespace:   namespace,
+		Permissions: actorPermissions,
+	})
+	if claims == nil {
+		return "", errors.New("failed to create claims for actor")
+	}
+
+	claims.Permissions = tokenPermissions
+	return atu.s.Token(ctx, claims)
+}
+
 func (atu *AuthTestUtil) SignRequestQueryAs(ctx context.Context, req *http.Request, a core.Actor) (*http.Request, error) {
 	claims := atu.claimsForActor(ctx, a)
 	claims.Nonce = util.ToPtr(apid.New(apid.PrefixNonce))

--- a/internal/routes/session.go
+++ b/internal/routes/session.go
@@ -89,8 +89,9 @@ func (r *SessionRoutes) initiate(gctx *gin.Context) {
 
 	logger.Debug("request was authenticated")
 
-	if !ra.IsSession() {
-		logger.Debug("existing request was not in a session, creating one")
+	hasJwt := gctx.GetHeader(auth.JwtHeaderKey) != "" || gctx.Query(auth.JwtQueryParam) != ""
+	if !ra.IsSession() || hasJwt {
+		logger.Debug("creating or refreshing session from jwt", "existingSession", ra.IsSession())
 		err := r.authService.EstablishGinSession(gctx, ra)
 		if err != nil {
 			apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErrorf("failed to establish gin session: %w", err)))


### PR DESCRIPTION
## Summary

- persist top-level JWT permission restrictions in Redis-backed browser sessions
- restore those restrictions for cookie-authenticated requests
- refresh an existing same-actor session when `/session/_initiate` receives a new JWT
- add unit and Docker-backed integration coverage for new and existing sessions

## Testing

- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/apauth/service ./internal/routes -count=1`
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_PORT=5433 go test -tags integration -v ./session -run TestScopedPermissionsPersistInBrowserSession -count=1`
- `./scripts/preflight.sh`