### PR TITLE
Allow global JWT fallback for actors with signing keys

### DIFF
--- a/integration_tests/auth/jwt_signing_key_fallback_test.go
+++ b/integration_tests/auth/jwt_signing_key_fallback_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rmorlok/authproxy/integration_tests/helpers"
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/apauth/service"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJWTSigningKeyFallbackForActorWithKey(t *testing.T) {
+	const actorExternalID = "jwt-fallback-actor"
+
+	env := helpers.Setup(t, helpers.SetupOptions{
+		Service: helpers.ServiceTypeAdminAPI,
+		ConfigureRoot: func(root *sconfig.Root) {
+			root.SystemAuth.JwtSigningKey = publicPrivateKey(
+				"./test_data/system_keys/system.pub",
+				"./test_data/system_keys/system",
+			)
+			root.SystemAuth.Actors = &sconfig.ConfiguredActors{
+				InnerVal: sconfig.ConfiguredActorsList{
+					&sconfig.ConfiguredActor{
+						ExternalId: actorExternalID,
+						Key: publicPrivateKey(
+							"./test_data/admin_user_keys/bobdole.pub",
+							"",
+						),
+						Permissions: aschema.AllPermissions(),
+					},
+				},
+			}
+		},
+	})
+	defer env.Cleanup()
+
+	actor, err := env.Db.GetActorByExternalId(context.Background(), sconfig.RootNamespace, actorExternalID)
+	require.NoError(t, err)
+	require.True(t, actor.CanSelfSign(), "integration fixture must have an actor-specific verification key")
+
+	token, err := jwt.NewJwtTokenBuilder().
+		WithActorExternalId(actorExternalID).
+		WithPrivateKeyPath("./test_data/system_keys/system").
+		WithAudience(string(sconfig.ServiceIdAdminApi)).
+		TokenCtx(context.Background())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/actors/external-id/"+actorExternalID+"?namespace=root",
+		nil,
+	)
+	service.SetJwtRequestHeader(req, token)
+	recorder := httptest.NewRecorder()
+	env.ApiGin.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
+func publicPrivateKey(publicPath, privatePath string) *sconfig.Key {
+	key := &sconfig.KeyPublicPrivate{
+		PublicKey: &sconfig.KeyData{
+			InnerVal: &sconfig.KeyDataFile{Path: publicPath},
+		},
+	}
+	if privatePath != "" {
+		key.PrivateKey = &sconfig.KeyData{
+			InnerVal: &sconfig.KeyDataFile{Path: privatePath},
+		}
+	}
+
+	return &sconfig.Key{InnerVal: key}
+}

--- a/internal/apauth/jwt/parser_builder.go
+++ b/internal/apauth/jwt/parser_builder.go
@@ -293,7 +293,7 @@ func (pb *parserBuilder) getVerifyingKeyData(ctx context.Context, unverified *Au
 func (pb *parserBuilder) ParseCtx(ctx context.Context, token string) (*AuthProxyClaims, error) {
 	if pb.secretKeyPath == nil && pb.secretKeyData == nil &&
 		pb.publicKeyData == nil && pb.publicKeyPath == nil &&
-		pb.keySelector == nil {
+		pb.keySelector == nil && pb.key == nil {
 		return nil, errors.New("key material must be specified in some form")
 	}
 

--- a/internal/apauth/service/auth_methods.go
+++ b/internal/apauth/service/auth_methods.go
@@ -22,11 +22,12 @@ import (
 
 // keyForToken loads an appropriate key to sign or verify a given token. This accounts for the
 // fact that admin users will verify with different keys to sign/verify tokens.
-// For admin users, the key is retrieved from the database where it is stored encrypted.
-func (s *service) keyForToken(ctx context.Context, claims *jwt2.AuthProxyClaims) (*config.Key, error) {
+// For admin users, the key is retrieved from the database where it is stored encrypted. The
+// boolean return value indicates whether the returned key is actor-specific.
+func (s *service) keyForToken(ctx context.Context, claims *jwt2.AuthProxyClaims) (*config.Key, bool, error) {
 	// If no database is configured, fall back to JWT signing key
 	if s.db == nil {
-		return s.config.GetRoot().SystemAuth.JwtSigningKey, nil
+		return s.config.GetRoot().SystemAuth.JwtSigningKey, false, nil
 	}
 
 	// Check actor cache first, then fall back to database
@@ -38,44 +39,45 @@ func (s *service) keyForToken(ctx context.Context, claims *jwt2.AuthProxyClaims)
 		if err != nil {
 			if errors.Is(err, database.ErrNotFound) {
 				// Actor does not exist. Fall back to JWT signing key
-				return s.config.GetRoot().SystemAuth.JwtSigningKey, nil
+				return s.config.GetRoot().SystemAuth.JwtSigningKey, false, nil
 			}
-			return nil, fmt.Errorf("failed to get actor: %w", err)
+			return nil, false, fmt.Errorf("failed to get actor: %w", err)
 		}
 		cache.Put(actor)
 	}
 
 	if actor.EncryptedKey == nil {
 		// Actor is not configured with self-signing key
-		return s.config.GetRoot().SystemAuth.JwtSigningKey, nil
+		return s.config.GetRoot().SystemAuth.JwtSigningKey, false, nil
 	}
 
 	// Decrypt the key JSON
 	decrypted, err := s.encrypt.DecryptString(ctx, *actor.EncryptedKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt actor key: %w", err)
+		return nil, true, fmt.Errorf("failed to decrypt actor key: %w", err)
 	}
 
 	// Unmarshal to *config.Key
 	var key config.Key
 	if err := json.Unmarshal([]byte(decrypted), &key); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal actor key: %w", err)
+		return nil, true, fmt.Errorf("failed to unmarshal actor key: %w", err)
 	}
 
-	return &key, nil
+	return &key, true, nil
 }
 
 // keyForActorSignedToken returns the key for verifying an actor-signed token.
 // For actors with their own key, returns the actor's key.
-// Falls back to GlobalAESKey if no key is found.
-func (s *service) keyForActorSignedToken(ctx context.Context, claims *jwt2.AuthProxyClaims) (*config.Key, error) {
+// Falls back to GlobalAESKey if no key is found. The boolean return value indicates whether the
+// returned key is actor-specific.
+func (s *service) keyForActorSignedToken(ctx context.Context, claims *jwt2.AuthProxyClaims) (*config.Key, bool, error) {
 	// If no database or encrypt service, fall back to GlobalAESKey
 	if s.db == nil || s.encrypt == nil {
 		return &config.Key{
 			InnerVal: &config.KeyShared{
 				SharedKey: s.config.GetRoot().SystemAuth.GlobalAESKey,
 			},
-		}, nil
+		}, false, nil
 	}
 
 	// Check actor cache first, then fall back to database
@@ -91,9 +93,9 @@ func (s *service) keyForActorSignedToken(ctx context.Context, claims *jwt2.AuthP
 					InnerVal: &config.KeyShared{
 						SharedKey: s.config.GetRoot().SystemAuth.GlobalAESKey,
 					},
-				}, nil
+				}, false, nil
 			}
-			return nil, fmt.Errorf("failed to get actor: %w", err)
+			return nil, false, fmt.Errorf("failed to get actor: %w", err)
 		}
 		cache.Put(actor)
 	}
@@ -104,22 +106,22 @@ func (s *service) keyForActorSignedToken(ctx context.Context, claims *jwt2.AuthP
 			InnerVal: &config.KeyShared{
 				SharedKey: s.config.GetRoot().SystemAuth.GlobalAESKey,
 			},
-		}, nil
+		}, false, nil
 	}
 
 	// Decrypt the key JSON
 	decrypted, err := s.encrypt.DecryptString(ctx, *actor.EncryptedKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt actor key: %w", err)
+		return nil, true, fmt.Errorf("failed to decrypt actor key: %w", err)
 	}
 
 	// Unmarshal to *config.Key
 	var key config.Key
 	if err := json.Unmarshal([]byte(decrypted), &key); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal actor key: %w", err)
+		return nil, true, fmt.Errorf("failed to unmarshal actor key: %w", err)
 	}
 
-	return &key, nil
+	return &key, true, nil
 }
 
 // Token mints a signed JWT with the specified claims. The token will be self-signed using the GlobalAESKey. The
@@ -154,6 +156,7 @@ func (s *service) Token(ctx context.Context, claims *jwt2.AuthProxyClaims) (stri
 
 // Parse token string and verify.
 func (s *service) Parse(ctx context.Context, tokenString string) (*jwt2.AuthProxyClaims, error) {
+	actorKeySelected := false
 	claims, err := jwt2.NewJwtTokenParserBuilder().
 		WithKeySelector(func(ctx context.Context, unverified *jwt2.AuthProxyClaims) (kd config.KeyDataType, isShared bool, err error) {
 			if unverified.SystemSigned {
@@ -165,7 +168,8 @@ func (s *service) Parse(ctx context.Context, tokenString string) (*jwt2.AuthProx
 			if unverified.ActorSigned {
 				// Actor-signed tokens are minted externally (e.g. CLI) using
 				// the actor's private key. Look up the actor's public key to verify.
-				key, err := s.keyForActorSignedToken(ctx, unverified)
+				key, isActorKey, err := s.keyForActorSignedToken(ctx, unverified)
+				actorKeySelected = isActorKey
 				if err != nil {
 					return nil, false, fmt.Errorf("failed to get key: %w", err)
 				}
@@ -179,7 +183,8 @@ func (s *service) Parse(ctx context.Context, tokenString string) (*jwt2.AuthProx
 			}
 
 			// For non-self-signed tokens, use keyForToken
-			key, err := s.keyForToken(ctx, unverified)
+			key, isActorKey, err := s.keyForToken(ctx, unverified)
+			actorKeySelected = isActorKey
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to get key: %w", err)
 			}
@@ -195,6 +200,18 @@ func (s *service) Parse(ctx context.Context, tokenString string) (*jwt2.AuthProx
 			return nil, false, errors.New("invalid key type")
 		}).
 		ParseCtx(ctx, tokenString)
+	if err != nil && actorKeySelected {
+		// An actor-specific key takes precedence, but host applications may also sign tokens for
+		// that actor with the global JWT signing key. Retry only when actor-key selection was the
+		// failing path; system-signed tokens and actors without keys retain their existing behavior.
+		fallbackClaims, fallbackErr := jwt2.NewJwtTokenParserBuilder().
+			WithConfigKey(ctx, s.config.GetRoot().SystemAuth.JwtSigningKey).
+			ParseCtx(ctx, tokenString)
+		if fallbackErr == nil {
+			claims = fallbackClaims
+			err = nil
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("can't parse token: %w", err)
 	}

--- a/internal/apauth/service/auth_methods_test.go
+++ b/internal/apauth/service/auth_methods_test.go
@@ -426,6 +426,31 @@ func TestAuth_Parse(t *testing.T) {
 			require.Equal(t, "bobdole", claims.Subject)
 		})
 
+		for _, tt := range []struct {
+			name        string
+			actorSigned bool
+		}{
+			{name: "actor-signed claim", actorSigned: true},
+			{name: "legacy token without signing claim"},
+		} {
+			t.Run("JWT signing key fallback/"+tt.name, func(t *testing.T) {
+				builder := jwt2.NewJwtTokenBuilder().
+					WithActorExternalId("bobdole").
+					WithPrivateKeyPath(pathToTestData("system_keys/other-system")).
+					WithAudience(string(sconfig.ServiceIdAdminApi))
+				if tt.actorSigned {
+					builder = builder.WithActorSigned()
+				}
+
+				token, err := builder.TokenCtx(testContext)
+				require.NoError(t, err)
+
+				claims, err := actorSrv.Parse(testContext, token)
+				require.NoError(t, err)
+				require.Equal(t, "bobdole", claims.Subject)
+			})
+		}
+
 		t.Run("system-signed for actor with asymmetric key", func(t *testing.T) {
 			// This covers the scenario where a service mints a system-signed token
 			// (using GlobalAESKey) for an actor that also has an asymmetric key stored


### PR DESCRIPTION
## Summary

- keep actor-specific JWT verification as the first attempt
- retry with `systemAuth.jwtSigningKey` only when an actor-specific key was selected and did not validate
- preserve the existing `GlobalAESKey` path for `systemSigned` tokens
- support the fallback for both `actorSigned` and legacy unmarked JWTs
- add unit coverage and a Docker-backed Admin API integration test with a real persisted actor key

## Testing

- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...`
- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres POSTGRES_TEST_HOST=localhost POSTGRES_TEST_PORT=5433 POSTGRES_TEST_USER=postgres POSTGRES_TEST_PASSWORD=postgres POSTGRES_TEST_DATABASE=postgres POSTGRES_TEST_OPTIONS=sslmode=disable go test -tags integration -v ./auth -run TestJWTSigningKeyFallbackForActorWithKey -count=1`
- `./scripts/preflight.sh`

## Follow-up

JOSE `kid`-based key lookup optimization is tracked separately in #883.