### PR TITLE
Support annotations on configured connectors

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -36,6 +36,8 @@ connectors:
       namespace: root.integrations
       labels:
         type: google-drive
+      annotations:
+        example.com/owner: integrations@example.com
       displayName: Google Drive
       logo:
         publicUrl: https://example.com/google-drive.svg
@@ -46,9 +48,10 @@ connectors:
 
 With the development-only `serve --auto-migrate` option, AuthProxy reconciles
 this entry to the live connector whose exact
-name is `google-drive` in `root.integrations`. Labels are ordinary selectable
-metadata and do not participate in identity. Multiple configured versions use
-the same name and namespace.
+name is `google-drive` in `root.integrations`. Labels are selectable metadata;
+annotations are non-selectable metadata for values such as ownership details,
+descriptions, and links. Neither participates in connector identity. Multiple
+configured versions use the same name and namespace.
 
 An entry with an explicit `id` may omit `name`; a newly created connector then
 defaults its name to the ID. To rename an existing configured connector, keep

--- a/internal/core/connector_builder.go
+++ b/internal/core/connector_builder.go
@@ -30,6 +30,7 @@ func (b *connectorBuilder) WithConfig(c *config.Connector) *connectorBuilder {
 			v.Id = c.Id
 			v.Namespace = c.GetNamespace()
 			v.Labels = c.Labels
+			v.Annotations = c.Annotations
 		},
 	}, b.versionSetters...)
 

--- a/internal/core/service_migration_test.go
+++ b/internal/core/service_migration_test.go
@@ -105,6 +105,36 @@ func TestMigration(t *testing.T) {
 		})
 
 		t.Run("names reconcile connector identity", func(t *testing.T) {
+			t.Run("annotation changes preserve the generated connector id", func(t *testing.T) {
+				cleanup := setup(t, []cschema.Connector{{
+					Name:        "configured",
+					Labels:      map[string]string{"type": "test"},
+					Annotations: map[string]string{"example.com/owner": "before@example.com"},
+					DisplayName: "Configured connector",
+				}})
+				defer cleanup()
+
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+				first := db.ListConnectorsBuilder().ForName("configured").FetchPage(context.Background())
+				require.NoError(t, first.Error)
+				require.Len(t, first.Results, 1)
+				generatedID := first.Results[0].Id
+				require.Equal(t, "before@example.com", first.Results[0].Annotations["example.com/owner"])
+
+				cfg.GetRoot().Connectors.LoadFromList[0].Annotations["example.com/owner"] = "after@example.com"
+				require.NoError(t, service.MigrateConnectors(context.Background()))
+
+				result := db.ListConnectorsBuilder().ForName("configured").FetchPage(context.Background())
+				require.NoError(t, result.Error)
+				require.Len(t, result.Results, 1)
+				require.Equal(t, generatedID, result.Results[0].Id)
+				require.Equal(t, "after@example.com", result.Results[0].Annotations["example.com/owner"])
+
+				versions := db.ListConnectorDefinitionVersionsBuilder().ForId(generatedID).FetchPage(context.Background())
+				require.NoError(t, versions.Error)
+				require.Len(t, versions.Results, 2)
+			})
+
 			t.Run("label changes preserve the generated connector id", func(t *testing.T) {
 				cleanup := setup(t, []cschema.Connector{{
 					Name:        "configured",

--- a/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
+++ b/internal/schema/config/test_data/valid-explicit-connector-versioning.yaml
@@ -4,6 +4,8 @@ connectors:
     - name: asana
       labels:
         type: asana
+      annotations:
+        example.com/owner: integrations@example.com
       id: D21753F8-2E91-43E7-ADEF-8ED80A6086AC
       version: 1
       displayName: Asana

--- a/internal/schema/resources/connectors/README.md
+++ b/internal/schema/resources/connectors/README.md
@@ -1,6 +1,6 @@
 # Connector Resource Schema
 
-This package defines connector resource configuration: auth methods, setup flow, probes, rate-limiting behavior, telemetry settings, labels, and connector metadata.
+This package defines connector resource configuration: auth methods, setup flow, probes, rate-limiting behavior, telemetry settings, labels, annotations, and connector metadata.
 
 Use this package for connector shapes that are shared between config, core logic, and future API DTOs. API-specific request/response wrappers belong in `internal/schema/api`.
 

--- a/internal/schema/resources/connectors/connector.go
+++ b/internal/schema/resources/connectors/connector.go
@@ -95,6 +95,9 @@ type Connector struct {
 	// Labels are the labels for the connector.
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
+	// Annotations are the annotations for the connector.
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+
 	// Telemetry carries per-connector overrides for OpenTelemetry behaviour
 	// on outbound calls routed through this connector. See ConnectorTelemetry.
 	Telemetry *ConnectorTelemetry `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
@@ -127,6 +130,13 @@ func (c *Connector) Clone() *Connector {
 		clone.Labels = make(map[string]string, len(c.Labels))
 		for k, v := range c.Labels {
 			clone.Labels[k] = v
+		}
+	}
+
+	if c.Annotations != nil {
+		clone.Annotations = make(map[string]string, len(c.Annotations))
+		for k, v := range c.Annotations {
+			clone.Annotations[k] = v
 		}
 	}
 

--- a/internal/schema/resources/connectors/connector_test.go
+++ b/internal/schema/resources/connectors/connector_test.go
@@ -30,6 +30,7 @@ func TestConnectorRoundtrip(t *testing.T) {
 				Id:          testID,
 				Name:        "test-connector",
 				Labels:      map[string]string{"type": "test-type"},
+				Annotations: map[string]string{"example.com/owner": "integration-team@example.com"},
 				Version:     1,
 				State:       "primary",
 				DisplayName: "Test Connector",
@@ -141,4 +142,13 @@ func TestConnectorHashIgnoresLogicalName(t *testing.T) {
 	before := connector.Hash()
 	connector.Name = "after"
 	require.Equal(t, before, connector.Hash())
+}
+
+func TestConnectorCloneCopiesAnnotations(t *testing.T) {
+	original := &Connector{Annotations: map[string]string{"example.com/owner": "before"}}
+	clone := original.Clone()
+
+	clone.Annotations["example.com/owner"] = "after"
+
+	require.Equal(t, "before", original.Annotations["example.com/owner"])
 }

--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -362,6 +362,12 @@
         "type": "string"
       }
     },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "version": {
       "type": "integer"
     },

--- a/internal/schema/resources/connectors/test_data/valid-api-key-header.yaml
+++ b/internal/schema/resources/connectors/test_data/valid-api-key-header.yaml
@@ -1,5 +1,7 @@
 labels:
   type: openweathermap
+annotations:
+  example.com/owner: integrations@example.com
 displayName: OpenWeatherMap
 logo:
   publicUrl: https://example.com/owm.png


### PR DESCRIPTION
## Summary
- accept annotations on connector entries loaded from YAML or JSON config
- reconcile configured annotations into logical connector metadata and deep-copy them with definitions
- document the field and cover schema, serialization, and migration behavior

## Testing
- go test ./internal/schema/resources/connectors ./internal/schema/config
- env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./internal/core -count=1
- yarn docs:build
- ./scripts/preflight.sh