### PR TITLE
Add v1alpha1 resource schema foundation

### DIFF
--- a/internal/core/iface/proxy.go
+++ b/internal/core/iface/proxy.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	"github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"gopkg.in/h2non/gentleman.v2"
 )
 
@@ -74,7 +74,7 @@ func (r *ProxyRequest) Validate() error {
 	}
 
 	if r.Labels != nil {
-		if err := database.ValidateUserLabels(r.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(r.Labels); err != nil {
 			errors = append(errors, "invalid labels: "+err.Error())
 		}
 	}

--- a/internal/core/workflow_migrate_connection_version_hooks.go
+++ b/internal/core/workflow_migrate_connection_version_hooks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
 // applyMigrationHookForVersion applies the javascript upgrade/downgrade hook,
@@ -100,16 +101,16 @@ func applyMigrationHookPatch(
 
 	// Update the user labels
 	for key, value := range patch.Labels.Set {
-		if err := database.ValidateUserLabelKey(key); err != nil {
+		if err := smeta.ValidateUserLabelKey(key); err != nil {
 			return err
 		}
-		if err := database.ValidateLabelValue(value); err != nil {
+		if err := smeta.ValidateLabelValue(value); err != nil {
 			return err
 		}
 		candidate.UserLabels[key] = value
 	}
 	for _, key := range patch.Labels.Unset {
-		if err := database.ValidateUserLabelKey(key); err != nil {
+		if err := smeta.ValidateUserLabelKey(key); err != nil {
 			return err
 		}
 		delete(candidate.UserLabels, key)
@@ -117,13 +118,13 @@ func applyMigrationHookPatch(
 
 	// Update the annotations
 	for key, value := range patch.Annotations.Set {
-		if err := database.ValidateAnnotationKey(key); err != nil {
+		if err := smeta.ValidateAnnotationKey(key); err != nil {
 			return err
 		}
 		candidate.Annotations[key] = value
 	}
 	for _, key := range patch.Annotations.Unset {
-		if err := database.ValidateAnnotationKey(key); err != nil {
+		if err := smeta.ValidateAnnotationKey(key); err != nil {
 			return err
 		}
 		delete(candidate.Annotations, key)

--- a/internal/database/actor.go
+++ b/internal/database/actor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -889,7 +890,7 @@ func (s *service) PutActorLabels(ctx context.Context, id apid.ID, labels map[str
 		return s.GetActor(ctx, id)
 	}
 
-	if err := ValidateUserLabels(labels); err != nil {
+	if err := smeta.ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -937,7 +938,7 @@ func (s *service) UpdateActorAnnotations(ctx context.Context, id apid.ID, annota
 	}
 
 	if annotations != nil {
-		if err := ValidateAnnotations(annotations); err != nil {
+		if err := smeta.ValidateAnnotations(annotations); err != nil {
 			return nil, fmt.Errorf("invalid annotations: %w", err)
 		}
 	}
@@ -989,7 +990,7 @@ func (s *service) PutActorAnnotations(ctx context.Context, id apid.ID, annotatio
 		return s.GetActor(ctx, id)
 	}
 
-	if err := ValidateAnnotations(annotations); err != nil {
+	if err := smeta.ValidateAnnotations(annotations); err != nil {
 		return nil, fmt.Errorf("invalid annotations: %w", err)
 	}
 
@@ -1087,7 +1088,7 @@ func (s *service) DeleteActorLabels(ctx context.Context, id apid.ID, keys []stri
 		return s.GetActor(ctx, id)
 	}
 
-	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+	if err := smeta.ValidateUserLabelDeletionKeys(keys); err != nil {
 		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 

--- a/internal/database/annotations.go
+++ b/internal/database/annotations.go
@@ -14,11 +14,6 @@ import (
 	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
-const (
-	// AnnotationsTotalMaxSize is the maximum total size of all annotations (keys + values) in bytes.
-	AnnotationsTotalMaxSize = smeta.AnnotationsTotalMaxSize
-)
-
 // Annotations is a map of key-value pairs similar to Kubernetes annotations.
 // Keys follow the same format as label keys ([prefix/]name).
 // Values have no format restriction — any string is allowed.
@@ -63,31 +58,13 @@ func (a *Annotations) Scan(value interface{}) error {
 	}
 }
 
-// ValidateAnnotationKey validates a single annotation key.
-// Annotation keys follow the same format as label keys.
-func ValidateAnnotationKey(key string) error {
-	return smeta.ValidateAnnotationKey(key)
-}
-
-// ValidateAnnotationValue validates a single annotation value.
-// Annotation values have no format restriction — any string is allowed.
-// Individual value size is not restricted; only the total annotations size is checked.
-func ValidateAnnotationValue(value string) error {
-	return smeta.ValidateAnnotationValue(value)
-}
-
-// ValidateAnnotations validates all annotations in a map.
-func ValidateAnnotations(annotations map[string]string) error {
-	return smeta.ValidateAnnotations(annotations)
-}
-
 // Validate validates all annotations.
 func (a Annotations) Validate() error {
 	if a == nil {
 		return nil
 	}
 
-	return ValidateAnnotations(a)
+	return smeta.ValidateAnnotations(a)
 }
 
 // Get returns the value for an annotation key, and whether the key exists.

--- a/internal/database/annotations.go
+++ b/internal/database/annotations.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
 const (
 	// AnnotationsTotalMaxSize is the maximum total size of all annotations (keys + values) in bytes.
-	AnnotationsTotalMaxSize = 256 * 1024 // 256KB
+	AnnotationsTotalMaxSize = smeta.AnnotationsTotalMaxSize
 )
 
 // Annotations is a map of key-value pairs similar to Kubernetes annotations.
@@ -66,32 +66,19 @@ func (a *Annotations) Scan(value interface{}) error {
 // ValidateAnnotationKey validates a single annotation key.
 // Annotation keys follow the same format as label keys.
 func ValidateAnnotationKey(key string) error {
-	return ValidateLabelKey(key)
+	return smeta.ValidateAnnotationKey(key)
 }
 
 // ValidateAnnotationValue validates a single annotation value.
 // Annotation values have no format restriction — any string is allowed.
 // Individual value size is not restricted; only the total annotations size is checked.
-func ValidateAnnotationValue(_ string) error {
-	return nil
+func ValidateAnnotationValue(value string) error {
+	return smeta.ValidateAnnotationValue(value)
 }
 
 // ValidateAnnotations validates all annotations in a map.
 func ValidateAnnotations(annotations map[string]string) error {
-	var result *multierror.Error
-	totalSize := 0
-	for key, value := range annotations {
-		if err := ValidateAnnotationKey(key); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid annotation key %q: %w", key, err))
-		}
-		totalSize += len(key) + len(value)
-	}
-
-	if totalSize > AnnotationsTotalMaxSize {
-		result = multierror.Append(result, fmt.Errorf("total annotations size %d exceeds maximum of %d bytes", totalSize, AnnotationsTotalMaxSize))
-	}
-
-	return result.ErrorOrNil()
+	return smeta.ValidateAnnotations(annotations)
 }
 
 // Validate validates all annotations.

--- a/internal/database/annotations_test.go
+++ b/internal/database/annotations_test.go
@@ -1,99 +1,12 @@
 package database
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestAnnotations(t *testing.T) {
-	t.Run("ValidateAnnotationKey", func(t *testing.T) {
-		t.Run("valid keys", func(t *testing.T) {
-			validKeys := []string{
-				"a",
-				"key",
-				"my-key",
-				"my_key",
-				"my.key",
-				"example.com/my-key",
-				"app.kubernetes.io/name",
-			}
-
-			for _, key := range validKeys {
-				t.Run(key, func(t *testing.T) {
-					err := ValidateAnnotationKey(key)
-					require.NoError(t, err, "key %q should be valid", key)
-				})
-			}
-		})
-
-		t.Run("invalid keys", func(t *testing.T) {
-			invalidKeys := []struct {
-				key    string
-				reason string
-			}{
-				{"", "empty key"},
-				{"-key", "starts with hyphen"},
-				{"my key", "contains space"},
-				{"/name", "empty prefix"},
-				{strings.Repeat("a", 64), "name too long"},
-			}
-
-			for _, tc := range invalidKeys {
-				t.Run(tc.reason, func(t *testing.T) {
-					err := ValidateAnnotationKey(tc.key)
-					require.Error(t, err, "key %q should be invalid: %s", tc.key, tc.reason)
-				})
-			}
-		})
-	})
-
-	t.Run("ValidateAnnotationValue", func(t *testing.T) {
-		// Annotation values have no format restriction
-		t.Run("any string is valid", func(t *testing.T) {
-			validValues := []string{
-				"",
-				"simple",
-				"has spaces",
-				"has-special@chars#!",
-				strings.Repeat("a", 1000), // long values are fine
-				"multi\nline\nvalue",
-			}
-			for _, v := range validValues {
-				require.NoError(t, ValidateAnnotationValue(v))
-			}
-		})
-	})
-
-	t.Run("ValidateAnnotations", func(t *testing.T) {
-		t.Run("valid annotations", func(t *testing.T) {
-			annotations := Annotations{
-				"app":                "my application description",
-				"example.com/note":   "this can be any string value with spaces & symbols!",
-				"example.com/config": `{"key": "value"}`,
-				"example.com/empty":  "",
-			}
-			require.NoError(t, ValidateAnnotations(annotations))
-		})
-
-		t.Run("invalid key", func(t *testing.T) {
-			annotations := Annotations{
-				"-bad-key": "value",
-			}
-			require.Error(t, ValidateAnnotations(annotations))
-		})
-
-		t.Run("total size exceeds limit", func(t *testing.T) {
-			annotations := Annotations{
-				"key": strings.Repeat("x", AnnotationsTotalMaxSize),
-			}
-			err := ValidateAnnotations(annotations)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "exceeds maximum")
-		})
-	})
-
 	t.Run("Annotations.Validate", func(t *testing.T) {
 		t.Run("valid annotations", func(t *testing.T) {
 			annotations := Annotations{

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encfield"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -599,10 +600,10 @@ func (u ConnectionVersionMigrationUpdate) validate() error {
 	if u.ConnectorVersion == 0 {
 		result = multierror.Append(result, errors.New("connector version is required"))
 	}
-	if err := ValidateUserLabels(u.UserLabels); err != nil {
+	if err := smeta.ValidateUserLabels(u.UserLabels); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid migration labels: %w", err))
 	}
-	if err := ValidateAnnotations(u.Annotations); err != nil {
+	if err := smeta.ValidateAnnotations(u.Annotations); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid migration annotations: %w", err))
 	}
 	if u.HealthState != nil && !IsValidConnectionHealthState(*u.HealthState) {
@@ -1007,7 +1008,7 @@ func (s *service) UpdateConnectionLabels(ctx context.Context, id apid.ID, labels
 	}
 
 	if labels != nil {
-		if err := ValidateUserLabels(labels); err != nil {
+		if err := smeta.ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -1060,7 +1061,7 @@ func (s *service) PutConnectionLabels(ctx context.Context, id apid.ID, labels ma
 		return s.GetConnection(ctx, id)
 	}
 
-	if err := ValidateUserLabels(labels); err != nil {
+	if err := smeta.ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -1108,7 +1109,7 @@ func (s *service) UpdateConnectionAnnotations(ctx context.Context, id apid.ID, a
 	}
 
 	if annotations != nil {
-		if err := ValidateAnnotations(annotations); err != nil {
+		if err := smeta.ValidateAnnotations(annotations); err != nil {
 			return nil, fmt.Errorf("invalid annotations: %w", err)
 		}
 	}
@@ -1159,7 +1160,7 @@ func (s *service) PutConnectionAnnotations(ctx context.Context, id apid.ID, anno
 		return s.GetConnection(ctx, id)
 	}
 
-	if err := ValidateAnnotations(annotations); err != nil {
+	if err := smeta.ValidateAnnotations(annotations); err != nil {
 		return nil, fmt.Errorf("invalid annotations: %w", err)
 	}
 
@@ -1256,7 +1257,7 @@ func (s *service) DeleteConnectionLabels(ctx context.Context, id apid.ID, keys [
 		return s.GetConnection(ctx, id)
 	}
 
-	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+	if err := smeta.ValidateUserLabelDeletionKeys(keys); err != nil {
 		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 

--- a/internal/database/key.go
+++ b/internal/database/key.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/encfield"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -430,7 +431,7 @@ func (s *service) UpdateKeyLabels(ctx context.Context, id apid.ID, labels map[st
 	}
 
 	if labels != nil {
-		if err := ValidateUserLabels(labels); err != nil {
+		if err := smeta.ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -481,7 +482,7 @@ func (s *service) PutKeyLabels(ctx context.Context, id apid.ID, labels map[strin
 		return s.GetKey(ctx, id)
 	}
 
-	if err := ValidateUserLabels(labels); err != nil {
+	if err := smeta.ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -530,7 +531,7 @@ func (s *service) DeleteKeyLabels(ctx context.Context, id apid.ID, keys []string
 		return s.GetKey(ctx, id)
 	}
 
-	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+	if err := smeta.ValidateUserLabelDeletionKeys(keys); err != nil {
 		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
@@ -576,7 +577,7 @@ func (s *service) UpdateKeyAnnotations(ctx context.Context, id apid.ID, annotati
 	}
 
 	if annotations != nil {
-		if err := ValidateAnnotations(annotations); err != nil {
+		if err := smeta.ValidateAnnotations(annotations); err != nil {
 			return nil, fmt.Errorf("invalid annotations: %w", err)
 		}
 	}
@@ -626,7 +627,7 @@ func (s *service) PutKeyAnnotations(ctx context.Context, id apid.ID, annotations
 		return s.GetKey(ctx, id)
 	}
 
-	if err := ValidateAnnotations(annotations); err != nil {
+	if err := smeta.ValidateAnnotations(annotations); err != nil {
 		return nil, fmt.Errorf("invalid annotations: %w", err)
 	}
 

--- a/internal/database/label_selector.go
+++ b/internal/database/label_selector.go
@@ -7,6 +7,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
 type LabelOperator string
@@ -50,10 +51,10 @@ func ParseLabelSelector(selector string) (LabelSelector, error) {
 			opParts := strings.SplitN(part, "!=", 2)
 			key := strings.TrimSpace(opParts[0])
 			val := strings.TrimSpace(opParts[1])
-			if err := ValidateLabelKey(key); err != nil {
+			if err := smeta.ValidateLabelKey(key); err != nil {
 				return nil, fmt.Errorf("invalid label key in selector %q: %w", part, err)
 			}
-			if err := validateValueForKey(key, val); err != nil {
+			if err := smeta.ValidateLabelValueForKey(key, val); err != nil {
 				return nil, fmt.Errorf("invalid label value in selector %q: %w", part, err)
 			}
 			requirements = append(requirements, LabelRequirement{
@@ -65,10 +66,10 @@ func ParseLabelSelector(selector string) (LabelSelector, error) {
 			opParts := strings.SplitN(part, "==", 2)
 			key := strings.TrimSpace(opParts[0])
 			val := strings.TrimSpace(opParts[1])
-			if err := ValidateLabelKey(key); err != nil {
+			if err := smeta.ValidateLabelKey(key); err != nil {
 				return nil, fmt.Errorf("invalid label key in selector %q: %w", part, err)
 			}
-			if err := validateValueForKey(key, val); err != nil {
+			if err := smeta.ValidateLabelValueForKey(key, val); err != nil {
 				return nil, fmt.Errorf("invalid label value in selector %q: %w", part, err)
 			}
 			requirements = append(requirements, LabelRequirement{
@@ -80,10 +81,10 @@ func ParseLabelSelector(selector string) (LabelSelector, error) {
 			opParts := strings.SplitN(part, "=", 2)
 			key := strings.TrimSpace(opParts[0])
 			val := strings.TrimSpace(opParts[1])
-			if err := ValidateLabelKey(key); err != nil {
+			if err := smeta.ValidateLabelKey(key); err != nil {
 				return nil, fmt.Errorf("invalid label key in selector %q: %w", part, err)
 			}
-			if err := validateValueForKey(key, val); err != nil {
+			if err := smeta.ValidateLabelValueForKey(key, val); err != nil {
 				return nil, fmt.Errorf("invalid label value in selector %q: %w", part, err)
 			}
 			requirements = append(requirements, LabelRequirement{
@@ -93,7 +94,7 @@ func ParseLabelSelector(selector string) (LabelSelector, error) {
 			})
 		} else if strings.HasPrefix(part, "!") {
 			key := strings.TrimSpace(part[1:])
-			if err := ValidateLabelKey(key); err != nil {
+			if err := smeta.ValidateLabelKey(key); err != nil {
 				return nil, fmt.Errorf("invalid label key in selector %q: %w", part, err)
 			}
 			requirements = append(requirements, LabelRequirement{
@@ -102,7 +103,7 @@ func ParseLabelSelector(selector string) (LabelSelector, error) {
 			})
 		} else {
 			key := strings.TrimSpace(part)
-			if err := ValidateLabelKey(key); err != nil {
+			if err := smeta.ValidateLabelKey(key); err != nil {
 				return nil, fmt.Errorf("invalid label key in selector %q: %w", part, err)
 			}
 			requirements = append(requirements, LabelRequirement{

--- a/internal/database/labels.go
+++ b/internal/database/labels.go
@@ -19,34 +19,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
-// Kubernetes-style label restrictions
-const (
-	// LabelKeyNameMaxLength is the maximum length for the name portion of a label key
-	LabelKeyNameMaxLength = smeta.LabelKeyNameMaxLength
-
-	// LabelKeyPrefixMaxLength is the maximum length for the optional prefix portion of a label key
-	LabelKeyPrefixMaxLength = smeta.LabelKeyPrefixMaxLength
-
-	// LabelValueMaxLength is the maximum length for a label value
-	LabelValueMaxLength = smeta.LabelValueMaxLength
-
-	// ApxyLabelValueMaxLength is the maximum length for a label value stored
-	// under an apxy/-prefixed key. System-managed labels such as
-	// apxy/<rt>/-/ns can hold a namespace path that may exceed the standard
-	// LabelValueMaxLength. User-supplied values are still capped at
-	// LabelValueMaxLength via ValidateLabelValue.
-	ApxyLabelValueMaxLength = smeta.SystemLabelValueMaxLength
-
-	// ApxyReservedPrefix is the reserved label-key prefix for system-managed
-	// labels (implicit identifier labels and parent carry-forward labels).
-	// User-supplied label keys may not begin with this prefix.
-	ApxyReservedPrefix = smeta.SystemLabelPrefix
-
-	// ApxyImplicitSegment is the segment used inside apxy/ keys to mark an
-	// implicit identifier label, e.g. apxy/<rt>/-/id.
-	ApxyImplicitSegment = smeta.SystemLabelSentinel
-)
-
 // Labels is a map of key-value pairs following Kubernetes label restrictions.
 // Keys follow the format [prefix/]name where:
 // - prefix (optional): valid DNS subdomain, max 253 characters
@@ -92,89 +64,14 @@ func (l *Labels) Scan(value interface{}) error {
 	}
 }
 
-// ValidateLabelKey validates a single label key.
-//
-// Two grammars are accepted:
-//
-//  1. Standard Kubernetes-style key: [prefix/]name
-//     - prefix (optional): valid DNS subdomain, max 253 characters
-//     - name (required): 1-63 characters, must start/end with alphanumeric,
-//     may contain '-', '_', '.'
-//
-//  2. Reserved apxy/ multi-segment key: apxy/<seg>(/<seg>)*/<name>
-//     - each <seg> is a DNS-label-like token or the literal "-" sentinel
-//     - <name> follows the standard name rule above
-//     - total prefix portion (everything before the final '/') still capped
-//     at LabelKeyPrefixMaxLength characters
-//
-// This function accepts apxy/ keys; user-input call sites should use
-// ValidateUserLabelKey to additionally reject the reserved namespace.
-func ValidateLabelKey(key string) error {
-	return smeta.ValidateLabelKey(key)
-}
-
-// ValidateUserLabelKey validates a label key supplied directly by an end user.
-// In addition to the rules of ValidateLabelKey, it rejects any key in the
-// reserved apxy/ namespace — those keys are managed by the system and may not
-// be set, modified, or deleted through user-input endpoints.
-func ValidateUserLabelKey(key string) error {
-	return smeta.ValidateUserLabelKey(key)
-}
-
-// ValidateLabelValue validates a single label value according to Kubernetes restrictions.
-// - 0-63 characters (can be empty)
-// - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
-func ValidateLabelValue(value string) error {
-	return smeta.ValidateLabelValue(value)
-}
-
-// ValidateApxyLabelValue validates a label value stored under an apxy/-prefixed
-// key. It allows up to ApxyLabelValueMaxLength characters so namespace paths
-// (e.g. root.foo.bar.baz...) can fit, including the leading underscores and
-// trailing hyphens accepted in namespace path segments.
-func ValidateApxyLabelValue(value string) error {
-	return smeta.ValidateSystemLabelValue(value)
-}
-
-// ValidateLabels validates all labels in a map. apxy/-prefixed keys are
-// accepted (use ValidateUserLabels at user-input boundaries instead) and
-// values stored under apxy/ keys are validated against the longer
-// ApxyLabelValueMaxLength cap.
-func ValidateLabels(labels map[string]string) error {
-	return smeta.ValidateLabels(labels)
-}
-
-// validateValueForKey retains the database selector helper while delegating
-// the actual metadata grammar to the resource schema package.
-func validateValueForKey(key, value string) error {
-	if strings.HasPrefix(key, ApxyReservedPrefix) {
-		return smeta.ValidateSystemLabelValue(value)
-	}
-	return smeta.ValidateLabelValue(value)
-}
-
-// ValidateUserLabels validates a labels map supplied by a user. It applies
-// the same key/value rules as ValidateLabels but rejects any key in the
-// reserved apxy/ namespace.
-func ValidateUserLabels(labels map[string]string) error {
-	return smeta.ValidateUserLabels(labels)
-}
-
-// ValidateUserLabelDeletionKeys validates a list of keys passed to a
-// user-facing label-deletion endpoint. Keys must be well-formed and must not
-// reference the reserved apxy/ namespace.
-func ValidateUserLabelDeletionKeys(keys []string) error {
-	return smeta.ValidateUserLabelDeletionKeys(keys)
-}
-
 // Validate validates all labels (system mode — apxy/ keys allowed, with the
-// longer ApxyLabelValueMaxLength value cap for those keys).
+// longer SystemLabelValueMaxLength value cap for those keys).
 func (l Labels) Validate() error {
 	if l == nil {
 		return nil
 	}
 
-	return ValidateLabels(map[string]string(l))
+	return smeta.ValidateLabels(map[string]string(l))
 }
 
 // Get returns the value for a label key, and whether the key exists.
@@ -409,9 +306,9 @@ func BuildImplicitResourceLabelsForToken(rt, id string, name scommon.ResourceNam
 		name = scommon.ResourceName(id)
 	}
 	return Labels{
-		fmt.Sprintf("%s%s/%s/id", ApxyReservedPrefix, rt, ApxyImplicitSegment):   id,
-		fmt.Sprintf("%s%s/%s/name", ApxyReservedPrefix, rt, ApxyImplicitSegment): string(name),
-		fmt.Sprintf("%s%s/%s/ns", ApxyReservedPrefix, rt, ApxyImplicitSegment):   namespacePath,
+		fmt.Sprintf("%s%s/%s/id", smeta.SystemLabelPrefix, rt, smeta.SystemLabelSentinel):   id,
+		fmt.Sprintf("%s%s/%s/name", smeta.SystemLabelPrefix, rt, smeta.SystemLabelSentinel): string(name),
+		fmt.Sprintf("%s%s/%s/ns", smeta.SystemLabelPrefix, rt, smeta.SystemLabelSentinel):   namespacePath,
 	}
 }
 
@@ -535,7 +432,7 @@ func (s *service) updateResourceNameAndSelfLabels(
 // Either map may be nil if its half is empty.
 func SplitUserAndApxyLabels(labels Labels) (user, apxy Labels) {
 	for k, v := range labels {
-		if strings.HasPrefix(k, ApxyReservedPrefix) {
+		if strings.HasPrefix(k, smeta.SystemLabelPrefix) {
 			if apxy == nil {
 				apxy = make(Labels)
 			}
@@ -646,11 +543,11 @@ func BuildCarriedLabels(parentRt string, parentLabels Labels) Labels {
 	}
 	out := make(Labels, len(parentLabels))
 	for k, v := range parentLabels {
-		if strings.HasPrefix(k, ApxyReservedPrefix) {
+		if strings.HasPrefix(k, smeta.SystemLabelPrefix) {
 			out[k] = v
 			continue
 		}
-		out[fmt.Sprintf("%s%s/%s", ApxyReservedPrefix, parentRt, k)] = v
+		out[fmt.Sprintf("%s%s/%s", smeta.SystemLabelPrefix, parentRt, k)] = v
 	}
 	return out
 }

--- a/internal/database/labels.go
+++ b/internal/database/labels.go
@@ -7,76 +7,44 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
 // Kubernetes-style label restrictions
 const (
 	// LabelKeyNameMaxLength is the maximum length for the name portion of a label key
-	LabelKeyNameMaxLength = 63
+	LabelKeyNameMaxLength = smeta.LabelKeyNameMaxLength
 
 	// LabelKeyPrefixMaxLength is the maximum length for the optional prefix portion of a label key
-	LabelKeyPrefixMaxLength = 253
+	LabelKeyPrefixMaxLength = smeta.LabelKeyPrefixMaxLength
 
 	// LabelValueMaxLength is the maximum length for a label value
-	LabelValueMaxLength = 63
+	LabelValueMaxLength = smeta.LabelValueMaxLength
 
 	// ApxyLabelValueMaxLength is the maximum length for a label value stored
 	// under an apxy/-prefixed key. System-managed labels such as
 	// apxy/<rt>/-/ns can hold a namespace path that may exceed the standard
 	// LabelValueMaxLength. User-supplied values are still capped at
 	// LabelValueMaxLength via ValidateLabelValue.
-	ApxyLabelValueMaxLength = 253
+	ApxyLabelValueMaxLength = smeta.SystemLabelValueMaxLength
 
 	// ApxyReservedPrefix is the reserved label-key prefix for system-managed
 	// labels (implicit identifier labels and parent carry-forward labels).
 	// User-supplied label keys may not begin with this prefix.
-	ApxyReservedPrefix = "apxy/"
+	ApxyReservedPrefix = smeta.SystemLabelPrefix
 
 	// ApxyImplicitSegment is the segment used inside apxy/ keys to mark an
 	// implicit identifier label, e.g. apxy/<rt>/-/id.
-	ApxyImplicitSegment = "-"
-)
-
-var (
-	// labelKeyNameRegex validates the name portion of a label key:
-	// - 1-63 characters
-	// - must start and end with alphanumeric
-	// - may contain alphanumeric, '-', '_', '.'
-	labelKeyNameRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$`)
-
-	// labelKeyPrefixRegex validates the prefix portion of a label key (DNS subdomain):
-	// - max 253 characters
-	// - one or more DNS labels separated by '.'
-	// - each label: starts/ends with alphanumeric, may contain alphanumeric and '-'
-	labelKeyPrefixRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
-
-	// labelValueRegex validates a label value:
-	// - 0-63 characters (can be empty)
-	// - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
-	labelValueRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?)?$|^[a-zA-Z0-9]?$`)
-
-	// apxyPathSegmentRegex validates a single segment inside an apxy/ path.
-	// A segment is either a DNS-label-like token (alphanumeric start/end, may
-	// contain '-' in the middle) or the literal "-" sentinel used to mark
-	// implicit identifier labels (e.g. apxy/cxr/-/id).
-	apxyPathSegmentRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|-)$`)
-
-	// apxyLabelValueRegex accepts the trusted system-value character set and
-	// allows leading/trailing underscores or hyphens used by the established
-	// namespace-segment grammar. User label values retain the stricter
-	// Kubernetes-style boundary rules.
-	apxyLabelValueRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,253}$`)
+	ApxyImplicitSegment = smeta.SystemLabelSentinel
 )
 
 // Labels is a map of key-value pairs following Kubernetes label restrictions.
@@ -142,92 +110,7 @@ func (l *Labels) Scan(value interface{}) error {
 // This function accepts apxy/ keys; user-input call sites should use
 // ValidateUserLabelKey to additionally reject the reserved namespace.
 func ValidateLabelKey(key string) error {
-	if key == "" {
-		return errors.New("label key cannot be empty")
-	}
-
-	if strings.HasPrefix(key, ApxyReservedPrefix) {
-		return validateApxyLabelKey(key)
-	}
-
-	var prefix, name string
-	if idx := strings.LastIndex(key, "/"); idx != -1 {
-		prefix = key[:idx]
-		name = key[idx+1:]
-
-		// If there's a slash, the prefix must not be empty
-		if prefix == "" {
-			return errors.New("label key prefix cannot be empty when slash is present")
-		}
-	} else {
-		name = key
-	}
-
-	// Validate prefix if present
-	if prefix != "" {
-		if len(prefix) > LabelKeyPrefixMaxLength {
-			return fmt.Errorf("label key prefix exceeds maximum length of %d characters", LabelKeyPrefixMaxLength)
-		}
-		if !labelKeyPrefixRegex.MatchString(prefix) {
-			return fmt.Errorf("label key prefix %q is not a valid DNS subdomain", prefix)
-		}
-	}
-
-	// Validate name
-	if name == "" {
-		return errors.New("label key name cannot be empty")
-	}
-	if len(name) > LabelKeyNameMaxLength {
-		return fmt.Errorf("label key name exceeds maximum length of %d characters", LabelKeyNameMaxLength)
-	}
-	if !labelKeyNameRegex.MatchString(name) {
-		return fmt.Errorf("label key name %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", name)
-	}
-
-	return nil
-}
-
-// validateApxyLabelKey validates a key already known to start with apxy/.
-// The grammar is apxy/<seg>(/<seg>)*/<name>.
-func validateApxyLabelKey(key string) error {
-	idx := strings.LastIndex(key, "/")
-	// idx must exist because the key starts with "apxy/"; the final '/'
-	// separates the (possibly multi-segment) prefix from the name.
-	prefix := key[:idx]
-	name := key[idx+1:]
-
-	if len(prefix) > LabelKeyPrefixMaxLength {
-		return fmt.Errorf("label key prefix exceeds maximum length of %d characters", LabelKeyPrefixMaxLength)
-	}
-
-	// Trim the leading "apxy" segment (we know it's there) and require at
-	// least one further segment before the name — apxy/<rt>/...
-	innerPath := strings.TrimPrefix(prefix, "apxy")
-	if innerPath == "" {
-		return errors.New("apxy/ label key requires at least one segment after apxy/")
-	}
-	// innerPath now starts with '/'.
-	innerSegments := strings.Split(innerPath[1:], "/")
-	for _, seg := range innerSegments {
-		if seg == "" {
-			return errors.New("apxy/ label key has empty path segment")
-		}
-		if !apxyPathSegmentRegex.MatchString(seg) {
-			return fmt.Errorf("apxy/ label key segment %q must be a DNS label or the '-' sentinel", seg)
-		}
-	}
-
-	if name == "" {
-		return errors.New("label key name cannot be empty")
-	}
-	if len(name) > LabelKeyNameMaxLength {
-		return fmt.Errorf("label key name exceeds maximum length of %d characters", LabelKeyNameMaxLength)
-	}
-	if !labelKeyNameRegex.MatchString(name) {
-		return fmt.Errorf("label key name %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", name)
-	}
-
-	return nil
+	return smeta.ValidateLabelKey(key)
 }
 
 // ValidateUserLabelKey validates a label key supplied directly by an end user.
@@ -235,25 +118,14 @@ func validateApxyLabelKey(key string) error {
 // reserved apxy/ namespace — those keys are managed by the system and may not
 // be set, modified, or deleted through user-input endpoints.
 func ValidateUserLabelKey(key string) error {
-	if strings.HasPrefix(key, ApxyReservedPrefix) {
-		return fmt.Errorf("label key %q is in the reserved %q namespace and cannot be set by users", key, ApxyReservedPrefix)
-	}
-	return ValidateLabelKey(key)
+	return smeta.ValidateUserLabelKey(key)
 }
 
 // ValidateLabelValue validates a single label value according to Kubernetes restrictions.
 // - 0-63 characters (can be empty)
 // - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
 func ValidateLabelValue(value string) error {
-	if len(value) > LabelValueMaxLength {
-		return fmt.Errorf("label value exceeds maximum length of %d characters", LabelValueMaxLength)
-	}
-
-	if value != "" && !labelValueRegex.MatchString(value) {
-		return fmt.Errorf("label value %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", value)
-	}
-
-	return nil
+	return smeta.ValidateLabelValue(value)
 }
 
 // ValidateApxyLabelValue validates a label value stored under an apxy/-prefixed
@@ -261,15 +133,7 @@ func ValidateLabelValue(value string) error {
 // (e.g. root.foo.bar.baz...) can fit, including the leading underscores and
 // trailing hyphens accepted in namespace path segments.
 func ValidateApxyLabelValue(value string) error {
-	if len(value) > ApxyLabelValueMaxLength {
-		return fmt.Errorf("apxy label value exceeds maximum length of %d characters", ApxyLabelValueMaxLength)
-	}
-
-	if value != "" && !apxyLabelValueRegex.MatchString(value) {
-		return fmt.Errorf("apxy label value %q may contain only alphanumeric characters, '-', '_', or '.'", value)
-	}
-
-	return nil
+	return smeta.ValidateSystemLabelValue(value)
 }
 
 // ValidateLabels validates all labels in a map. apxy/-prefixed keys are
@@ -277,56 +141,30 @@ func ValidateApxyLabelValue(value string) error {
 // values stored under apxy/ keys are validated against the longer
 // ApxyLabelValueMaxLength cap.
 func ValidateLabels(labels map[string]string) error {
-	var result *multierror.Error
-	for key, value := range labels {
-		if err := ValidateLabelKey(key); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
-		}
-		if err := validateValueForKey(key, value); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, err))
-		}
-	}
-
-	return result.ErrorOrNil()
+	return smeta.ValidateLabels(labels)
 }
 
-// validateValueForKey selects the appropriate value validator based on
-// whether the key is in the apxy/ namespace.
+// validateValueForKey retains the database selector helper while delegating
+// the actual metadata grammar to the resource schema package.
 func validateValueForKey(key, value string) error {
 	if strings.HasPrefix(key, ApxyReservedPrefix) {
-		return ValidateApxyLabelValue(value)
+		return smeta.ValidateSystemLabelValue(value)
 	}
-	return ValidateLabelValue(value)
+	return smeta.ValidateLabelValue(value)
 }
 
 // ValidateUserLabels validates a labels map supplied by a user. It applies
 // the same key/value rules as ValidateLabels but rejects any key in the
 // reserved apxy/ namespace.
 func ValidateUserLabels(labels map[string]string) error {
-	var result *multierror.Error
-	for key, value := range labels {
-		if err := ValidateUserLabelKey(key); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
-		}
-		if err := ValidateLabelValue(value); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, err))
-		}
-	}
-
-	return result.ErrorOrNil()
+	return smeta.ValidateUserLabels(labels)
 }
 
 // ValidateUserLabelDeletionKeys validates a list of keys passed to a
 // user-facing label-deletion endpoint. Keys must be well-formed and must not
 // reference the reserved apxy/ namespace.
 func ValidateUserLabelDeletionKeys(keys []string) error {
-	var result *multierror.Error
-	for _, k := range keys {
-		if err := ValidateUserLabelKey(k); err != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", k, err))
-		}
-	}
-	return result.ErrorOrNil()
+	return smeta.ValidateUserLabelDeletionKeys(keys)
 }
 
 // Validate validates all labels (system mode — apxy/ keys allowed, with the

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -9,248 +8,7 @@ import (
 )
 
 func TestLabels(t *testing.T) {
-	t.Run("ValidateLabelKey", func(t *testing.T) {
-		t.Run("valid keys", func(t *testing.T) {
-			validKeys := []string{
-				"a",
-				"A",
-				"0",
-				"key",
-				"Key",
-				"KEY",
-				"my-key",
-				"my_key",
-				"my.key",
-				"my-key.name",
-				"a1",
-				"1a",
-				"a-1",
-				"a_1",
-				"a.1",
-				"app.kubernetes.io",
-				"example.com/my-key",
-				"app.kubernetes.io/name",
-				"my-company.com/component",
-				"a" + strings.Repeat("b", 61) + "c", // exactly 63 chars
-			}
-
-			for _, key := range validKeys {
-				t.Run(key, func(t *testing.T) {
-					err := ValidateLabelKey(key)
-					require.NoError(t, err, "key %q should be valid", key)
-				})
-			}
-		})
-
-		t.Run("invalid keys", func(t *testing.T) {
-			invalidKeys := []struct {
-				key    string
-				reason string
-			}{
-				{"", "empty key"},
-				{"-key", "starts with hyphen"},
-				{"key-", "ends with hyphen"},
-				{"_key", "starts with underscore"},
-				{"key_", "ends with underscore"},
-				{".key", "starts with dot"},
-				{"key.", "ends with dot"},
-				{"my key", "contains space"},
-				{"my@key", "contains invalid character"},
-				{"my#key", "contains invalid character"},
-				{"/name", "empty prefix"},
-				{"example.com/", "empty name after prefix"},
-				{strings.Repeat("a", 64), "name too long (64 chars)"},
-				{strings.Repeat("a", 254) + "/name", "prefix too long"},
-				{"invalid..prefix/name", "double dot in prefix"},
-				{"-invalid.prefix/name", "prefix starts with hyphen"},
-			}
-
-			for _, tc := range invalidKeys {
-				t.Run(tc.reason, func(t *testing.T) {
-					err := ValidateLabelKey(tc.key)
-					require.Error(t, err, "key %q should be invalid: %s", tc.key, tc.reason)
-				})
-			}
-		})
-
-		t.Run("apxy/ multi-segment keys", func(t *testing.T) {
-			t.Run("valid", func(t *testing.T) {
-				validKeys := []string{
-					"apxy/cxr/-/id",
-					"apxy/cxr/-/ns",
-					"apxy/cxn/-/id",
-					"apxy/ns/-/id",
-					"apxy/cxr/type",
-					"apxy/cxr/my-key",
-					"apxy/cxr/my.key",
-					"apxy/cxr/my_key",
-					"apxy/ns/dog",
-					"apxy/cxr/cxn/userkey",
-				}
-				for _, key := range validKeys {
-					t.Run(key, func(t *testing.T) {
-						require.NoError(t, ValidateLabelKey(key), "key %q should be valid", key)
-					})
-				}
-			})
-
-			t.Run("invalid", func(t *testing.T) {
-				invalidKeys := []struct {
-					key    string
-					reason string
-				}{
-					{"apxy/", "no segments after apxy/"},
-					{"apxy//id", "empty intermediate segment"},
-					{"apxy/cxr//id", "empty intermediate segment in middle"},
-					{"apxy/cxr/", "empty name"},
-					{"apxy/cxr/-/", "empty name after sentinel"},
-					{"apxy/cx@r/id", "invalid character in segment"},
-					{"apxy/cxr/-/-bad", "name starts with hyphen"},
-				}
-				for _, tc := range invalidKeys {
-					t.Run(tc.reason, func(t *testing.T) {
-						err := ValidateLabelKey(tc.key)
-						require.Error(t, err, "key %q should be invalid: %s", tc.key, tc.reason)
-					})
-				}
-			})
-		})
-	})
-
-	t.Run("ValidateUserLabelKey", func(t *testing.T) {
-		t.Run("rejects apxy/ prefix", func(t *testing.T) {
-			err := ValidateUserLabelKey("apxy/cxr/type")
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "reserved")
-		})
-
-		t.Run("accepts non-apxy keys", func(t *testing.T) {
-			require.NoError(t, ValidateUserLabelKey("my-key"))
-			require.NoError(t, ValidateUserLabelKey("example.com/key"))
-		})
-
-		t.Run("still rejects invalid keys", func(t *testing.T) {
-			require.Error(t, ValidateUserLabelKey("-bad"))
-			require.Error(t, ValidateUserLabelKey(""))
-		})
-	})
-
-	t.Run("ValidateUserLabels", func(t *testing.T) {
-		t.Run("rejects map containing apxy/ key", func(t *testing.T) {
-			err := ValidateUserLabels(map[string]string{
-				"good":         "ok",
-				"apxy/cxr/bad": "nope",
-			})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "reserved")
-		})
-
-		t.Run("accepts pure user labels", func(t *testing.T) {
-			require.NoError(t, ValidateUserLabels(map[string]string{
-				"team": "platform",
-				"env":  "prod",
-			}))
-		})
-	})
-
-	t.Run("ValidateUserLabelDeletionKeys", func(t *testing.T) {
-		t.Run("rejects apxy/ keys", func(t *testing.T) {
-			err := ValidateUserLabelDeletionKeys([]string{"team", "apxy/cxr/type"})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "reserved")
-		})
-
-		t.Run("accepts user keys", func(t *testing.T) {
-			require.NoError(t, ValidateUserLabelDeletionKeys([]string{"team", "env"}))
-		})
-	})
-
-	t.Run("ValidateLabelValue", func(t *testing.T) {
-		t.Run("valid values", func(t *testing.T) {
-			validValues := []string{
-				"", // empty is valid
-				"a",
-				"A",
-				"0",
-				"value",
-				"Value",
-				"VALUE",
-				"my-value",
-				"my_value",
-				"my.value",
-				"v1.2.3",
-				"a1",
-				"1a",
-				"a" + strings.Repeat("b", 61) + "c", // exactly 63 chars
-			}
-
-			for _, value := range validValues {
-				t.Run("value_"+value, func(t *testing.T) {
-					err := ValidateLabelValue(value)
-					require.NoError(t, err, "value %q should be valid", value)
-				})
-			}
-		})
-
-		t.Run("invalid values", func(t *testing.T) {
-			invalidValues := []struct {
-				value  string
-				reason string
-			}{
-				{"-value", "starts with hyphen"},
-				{"value-", "ends with hyphen"},
-				{"_value", "starts with underscore"},
-				{"value_", "ends with underscore"},
-				{".value", "starts with dot"},
-				{"value.", "ends with dot"},
-				{"my value", "contains space"},
-				{"my@value", "contains invalid character"},
-				{strings.Repeat("a", 64), "value too long (64 chars)"},
-			}
-
-			for _, tc := range invalidValues {
-				t.Run(tc.reason, func(t *testing.T) {
-					err := ValidateLabelValue(tc.value)
-					require.Error(t, err, "value %q should be invalid: %s", tc.value, tc.reason)
-				})
-			}
-		})
-	})
-
-	t.Run("ValidateLabels", func(t *testing.T) {
-		t.Run("valid labels", func(t *testing.T) {
-			labels := Labels{
-				"app":                      "myapp",
-				"version":                  "v1.2.3",
-				"app.kubernetes.io/name":   "myapp",
-				"example.com/my-component": "frontend",
-				"empty-value":              "",
-			}
-			require.NoError(t, ValidateLabels(labels))
-		})
-		t.Run("invalid value", func(t *testing.T) {
-			labels := Labels{
-				"app":                      "**bad**",
-				"version":                  "v1.2.3",
-				"app.kubernetes.io/name":   "myapp",
-				"example.com/my-component": "frontend",
-				"empty-value":              "",
-			}
-			require.Error(t, ValidateLabels(labels))
-		})
-		t.Run("invalid key", func(t *testing.T) {
-			labels := Labels{
-				"-bad":                     "myapp",
-				"version":                  "v1.2.3",
-				"app.kubernetes.io/name":   "myapp",
-				"example.com/my-component": "frontend",
-				"empty-value":              "",
-			}
-			require.Error(t, ValidateLabels(labels))
-		})
-	})
-
-	t.Run("Labels.Validate", func(t *testing.T) {
+	t.Run("Validate", func(t *testing.T) {
 		t.Run("valid labels", func(t *testing.T) {
 			labels := Labels{
 				"app":                      "myapp",
@@ -272,32 +30,12 @@ func TestLabels(t *testing.T) {
 			require.NoError(t, labels.Validate())
 		})
 
-		t.Run("invalid key", func(t *testing.T) {
-			labels := Labels{
-				"valid-key":   "value",
-				"invalid key": "value",
-			}
-			err := labels.Validate()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "invalid key")
-		})
-
-		t.Run("invalid value", func(t *testing.T) {
-			labels := Labels{
-				"valid-key": "invalid value",
-			}
-			err := labels.Validate()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "invalid label value")
-		})
-
-		t.Run("multiple errors", func(t *testing.T) {
+		t.Run("delegates validation", func(t *testing.T) {
 			labels := Labels{
 				"invalid key": "invalid value",
 			}
 			err := labels.Validate()
 			require.Error(t, err)
-			// Should have errors for both key and value
 			require.Contains(t, err.Error(), "invalid label key")
 			require.Contains(t, err.Error(), "invalid label value")
 		})
@@ -606,43 +344,6 @@ func TestMergeUpsertLabels(t *testing.T) {
 	t.Run("returns nil when both inputs are empty", func(t *testing.T) {
 		require.Nil(t, MergeUpsertLabels(nil, nil))
 		require.Nil(t, MergeUpsertLabels(Labels{}, Labels{}))
-	})
-}
-
-func TestApxyLabelValueValidation(t *testing.T) {
-	// A namespace path that exceeds the standard 63-char user-value cap.
-	longPath := "root." + strings.Repeat("a", 60) + ".more"
-	require.Greater(t, len(longPath), LabelValueMaxLength)
-
-	t.Run("user-mode rejects long values", func(t *testing.T) {
-		require.Error(t, ValidateLabelValue(longPath))
-	})
-
-	t.Run("apxy mode accepts long namespace path", func(t *testing.T) {
-		require.NoError(t, ValidateApxyLabelValue(longPath))
-	})
-
-	t.Run("apxy mode accepts namespace name boundaries", func(t *testing.T) {
-		require.NoError(t, ValidateApxyLabelValue("_billing-"))
-		require.Error(t, ValidateLabelValue("_billing-"))
-	})
-
-	t.Run("apxy mode rejects values exceeding apxy cap", func(t *testing.T) {
-		// 254 chars: starts/ends alphanumeric so the regex is the only constraint.
-		tooLong := "a" + strings.Repeat("b", 252) + "c"
-		require.Equal(t, ApxyLabelValueMaxLength+1, len(tooLong))
-		require.Error(t, ValidateApxyLabelValue(tooLong))
-	})
-
-	t.Run("ValidateLabels uses apxy cap for apxy keys only", func(t *testing.T) {
-		// Long value under an apxy/ key is valid.
-		require.NoError(t, ValidateLabels(map[string]string{
-			"apxy/cxn/-/ns": longPath,
-		}))
-		// Same long value under a user key is rejected.
-		require.Error(t, ValidateLabels(map[string]string{
-			"team": longPath,
-		}))
 	})
 }
 

--- a/internal/database/namespace.go
+++ b/internal/database/namespace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/httperr"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -773,7 +774,7 @@ func (s *service) UpdateNamespaceLabels(ctx context.Context, path string, labels
 	}
 
 	if labels != nil {
-		if err := ValidateUserLabels(labels); err != nil {
+		if err := smeta.ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -815,7 +816,7 @@ func (s *service) PutNamespaceLabels(ctx context.Context, path string, labels ma
 		return s.GetNamespace(ctx, path)
 	}
 
-	if err := ValidateUserLabels(labels); err != nil {
+	if err := smeta.ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -856,7 +857,7 @@ func (s *service) DeleteNamespaceLabels(ctx context.Context, path string, keys [
 		return s.GetNamespace(ctx, path)
 	}
 
-	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+	if err := smeta.ValidateUserLabelDeletionKeys(keys); err != nil {
 		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
@@ -893,7 +894,7 @@ func (s *service) UpdateNamespaceAnnotations(ctx context.Context, path string, a
 	}
 
 	if annotations != nil {
-		if err := ValidateAnnotations(annotations); err != nil {
+		if err := smeta.ValidateAnnotations(annotations); err != nil {
 			return nil, fmt.Errorf("invalid annotations: %w", err)
 		}
 	}
@@ -934,7 +935,7 @@ func (s *service) PutNamespaceAnnotations(ctx context.Context, path string, anno
 		return s.GetNamespace(ctx, path)
 	}
 
-	if err := ValidateAnnotations(annotations); err != nil {
+	if err := smeta.ValidateAnnotations(annotations); err != nil {
 		return nil, fmt.Errorf("invalid annotations: %w", err)
 	}
 

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -312,7 +313,7 @@ func (n *Notification) Validate() error {
 	if err := namespace.ValidatePath(n.Namespace); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid notification namespace: %w", err))
 	}
-	if err := ValidateLabels(n.Labels); err != nil {
+	if err := smeta.ValidateLabels(n.Labels); err != nil {
 		result = multierror.Append(result, fmt.Errorf("invalid notification labels: %w", err))
 	}
 	if n.Title == "" {

--- a/internal/database/rate_limit.go
+++ b/internal/database/rate_limit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	"github.com/rmorlok/authproxy/internal/apid"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -300,7 +301,7 @@ func (s *service) UpdateRateLimitLabels(ctx context.Context, id apid.ID, labels 
 	}
 
 	if labels != nil {
-		if err := ValidateUserLabels(labels); err != nil {
+		if err := smeta.ValidateUserLabels(labels); err != nil {
 			return nil, fmt.Errorf("invalid labels: %w", err)
 		}
 	}
@@ -347,7 +348,7 @@ func (s *service) PutRateLimitLabels(ctx context.Context, id apid.ID, labels map
 		return s.GetRateLimit(ctx, id)
 	}
 
-	if err := ValidateUserLabels(labels); err != nil {
+	if err := smeta.ValidateUserLabels(labels); err != nil {
 		return nil, fmt.Errorf("invalid labels: %w", err)
 	}
 
@@ -393,7 +394,7 @@ func (s *service) DeleteRateLimitLabels(ctx context.Context, id apid.ID, keys []
 		return s.GetRateLimit(ctx, id)
 	}
 
-	if err := ValidateUserLabelDeletionKeys(keys); err != nil {
+	if err := smeta.ValidateUserLabelDeletionKeys(keys); err != nil {
 		return nil, fmt.Errorf("invalid label keys: %w", err)
 	}
 
@@ -436,7 +437,7 @@ func (s *service) UpdateRateLimitAnnotations(ctx context.Context, id apid.ID, an
 	}
 
 	if annotations != nil {
-		if err := ValidateAnnotations(annotations); err != nil {
+		if err := smeta.ValidateAnnotations(annotations); err != nil {
 			return nil, fmt.Errorf("invalid annotations: %w", err)
 		}
 	}
@@ -483,7 +484,7 @@ func (s *service) PutRateLimitAnnotations(ctx context.Context, id apid.ID, annot
 		return s.GetRateLimit(ctx, id)
 	}
 
-	if err := ValidateAnnotations(annotations); err != nil {
+	if err := smeta.ValidateAnnotations(annotations); err != nil {
 		return nil, fmt.Errorf("invalid annotations: %w", err)
 	}
 

--- a/internal/database/resource_search_test.go
+++ b/internal/database/resource_search_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/apid"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -226,9 +227,9 @@ func TestSearchResourcesSeedCoversNamespaceKeyAndRateLimit(t *testing.T) {
 	}
 }
 
-func TestParseLabelSelectorAllowsLongApxyValues(t *testing.T) {
+func TestParseLabelSelectorAllowsLongSystemValues(t *testing.T) {
 	value := "root." + strings.Repeat("segment.", 12) + "tail"
-	require.Greater(t, len(value), LabelValueMaxLength)
+	require.Greater(t, len(value), smeta.LabelValueMaxLength)
 
 	tests := []struct {
 		operator string

--- a/internal/httpf/factory.go
+++ b/internal/httpf/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"gopkg.in/h2non/gentleman.v2"
 	"gopkg.in/h2non/gentleman.v2/plugins/transport"
 )
@@ -143,10 +144,10 @@ func (f *clientFactory) ForActor(actor Actor) F {
 	actorContribution := make(map[string]string)
 	actToken := database.ApidPrefixToLabelToken(apid.PrefixActor)
 	for k, v := range actor.GetLabels() {
-		if strings.HasPrefix(k, database.ApxyReservedPrefix) {
+		if strings.HasPrefix(k, smeta.SystemLabelPrefix) {
 			continue
 		}
-		actorContribution[fmt.Sprintf("%s%s/%s", database.ApxyReservedPrefix, actToken, k)] = v
+		actorContribution[fmt.Sprintf("%s%s/%s", smeta.SystemLabelPrefix, actToken, k)] = v
 	}
 	for k, v := range database.BuildImplicitResourceLabels(actor.GetId(), actor.GetName(), actor.GetNamespace()) {
 		actorContribution[k] = v
@@ -194,7 +195,7 @@ func (f *clientFactory) ForLabels(labels map[string]string) F {
 	// ProxyRequest.Validate already rejects apxy/ keys; this is
 	// defense-in-depth against internal callers that might bypass it.
 	for k, v := range labels {
-		if strings.HasPrefix(k, database.ApxyReservedPrefix) {
+		if strings.HasPrefix(k, smeta.SystemLabelPrefix) {
 			continue
 		}
 		ri.Labels[k] = v

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -17,6 +17,7 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
@@ -597,8 +598,8 @@ func slugForNamespace(value string) string {
 
 func slugForLabelValue(value string) string {
 	slug := slugForID(value)
-	if len(slug) > database.LabelValueMaxLength {
-		return slug[:database.LabelValueMaxLength]
+	if len(slug) > smeta.LabelValueMaxLength {
+		return slug[:smeta.LabelValueMaxLength]
 	}
 	return slug
 }

--- a/internal/routes/actors.go
+++ b/internal/routes/actors.go
@@ -19,6 +19,7 @@ import (
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -469,7 +470,7 @@ func (r *ActorsRoutes) create(gctx *gin.Context) {
 
 	// Validate labels if provided
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid labels: %s", err.Error()), httperr.WithInternalErr(err)))
 			val.MarkErrorReturn()
 			return
@@ -592,7 +593,7 @@ func (r *ActorsRoutes) update(gctx *gin.Context) {
 
 	// Validate labels if provided
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid labels: %s", err.Error()), httperr.WithInternalErr(err)))
 			val.MarkErrorReturn()
 			return
@@ -721,7 +722,7 @@ func (r *ActorsRoutes) updateByExternalId(gctx *gin.Context) {
 
 	// Validate labels if provided
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, r.logger, httperr.BadRequest(fmt.Sprintf("invalid labels: %s", err.Error()), httperr.WithInternalErr(err)))
 			val.MarkErrorReturn()
 			return

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -22,6 +22,7 @@ import (
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 
@@ -1110,7 +1111,7 @@ func (r *ConnectionsRoutes) update(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -23,6 +23,7 @@ import (
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/tasks"
 	"github.com/rmorlok/authproxy/internal/util"
@@ -539,7 +540,7 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 		return
 	}
 
-	if err := database.ValidateUserLabels(req.Labels); err != nil {
+	if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 		val.MarkErrorReturn()
 		return
@@ -617,7 +618,7 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(*req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return
@@ -802,7 +803,7 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 	var labels map[string]string
 	if req.Labels != nil {
 		labels = *req.Labels
-		if err := database.ValidateUserLabels(labels); err != nil {
+		if err := smeta.ValidateUserLabels(labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return
@@ -888,7 +889,7 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(*req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return

--- a/internal/routes/key_value/labels.go
+++ b/internal/routes/key_value/labels.go
@@ -12,8 +12,8 @@
 package key_value
 
 import (
-	"github.com/rmorlok/authproxy/internal/database"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
 // Resource is the minimal contract a fetched resource must satisfy so the
@@ -52,8 +52,8 @@ var Label = Kind{
 	PathSegment:   "labels",
 	ParamName:     "label",
 	Singular:      "label",
-	ValidateKey:   database.ValidateUserLabelKey,
-	ValidateValue: database.ValidateLabelValue,
+	ValidateKey:   smeta.ValidateUserLabelKey,
+	ValidateValue: smeta.ValidateLabelValue,
 	Get:           func(r Resource) map[string]string { return r.GetLabels() },
 }
 
@@ -62,8 +62,8 @@ var Annotation = Kind{
 	PathSegment:   "annotations",
 	ParamName:     "annotation",
 	Singular:      "annotation",
-	ValidateKey:   database.ValidateAnnotationKey,
-	ValidateValue: database.ValidateAnnotationValue,
+	ValidateKey:   smeta.ValidateAnnotationKey,
+	ValidateValue: smeta.ValidateAnnotationValue,
 	Get:           func(r Resource) map[string]string { return r.GetAnnotations() },
 }
 

--- a/internal/routes/keys.go
+++ b/internal/routes/keys.go
@@ -20,6 +20,7 @@ import (
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -192,7 +193,7 @@ func (r *KeysRoutes) create(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return
@@ -398,7 +399,7 @@ func (r *KeysRoutes) update(gctx *gin.Context) {
 
 	// Validate labels if provided
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(*req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return

--- a/internal/routes/namespaces.go
+++ b/internal/routes/namespaces.go
@@ -18,6 +18,7 @@ import (
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
@@ -148,7 +149,7 @@ func (r *NamespacesRoutes) create(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return
@@ -355,7 +356,7 @@ func (r *NamespacesRoutes) update(gctx *gin.Context) {
 
 	// Validate labels if provided
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return

--- a/internal/routes/rate_limits.go
+++ b/internal/routes/rate_limits.go
@@ -19,6 +19,7 @@ import (
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
+	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
@@ -215,7 +216,7 @@ func (r *RateLimitsRoutes) create(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return
@@ -381,7 +382,7 @@ func (r *RateLimitsRoutes) update(gctx *gin.Context) {
 	}
 
 	if req.Labels != nil {
-		if err := database.ValidateUserLabels(*req.Labels); err != nil {
+		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
 			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
 			val.MarkErrorReturn()
 			return

--- a/internal/schema/api/v1alpha1/README.md
+++ b/internal/schema/api/v1alpha1/README.md
@@ -1,0 +1,8 @@
+# API v1alpha1 Transport Schema
+
+This package owns API-version-specific list and action transport composition.
+Managed resource objects, metadata, references, and conditions remain under
+`internal/schema/resources`; pagination and imperative action envelopes do not.
+
+Resource packages must not import this package. Route and API schema packages
+compose resource-owned item/spec/status types with `ResourceList` and `Action`.

--- a/internal/schema/api/v1alpha1/schema.go
+++ b/internal/schema/api/v1alpha1/schema.go
@@ -1,0 +1,8 @@
+package v1alpha1
+
+import "github.com/rmorlok/authproxy/internal/schema/resources/meta"
+
+const (
+	SchemaID   = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/v1alpha1/schema.json"
+	APIVersion = meta.APIVersionV1Alpha1
+)

--- a/internal/schema/api/v1alpha1/schema.json
+++ b/internal/schema/api/v1alpha1/schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/api/v1alpha1/schema.json",
+  "$defs": {
+    "ListMeta": {
+      "type": "object",
+      "properties": {
+        "resourceVersion": { "type": "string" },
+        "continue": { "type": "string" },
+        "remainingItemCount": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "ResourceList": {
+      "allOf": [
+        { "$ref": "../../resources/meta/schema.json#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "items"],
+          "properties": {
+            "kind": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*List$" },
+            "metadata": { "$ref": "#/$defs/ListMeta" },
+            "items": { "type": "array", "items": { "type": "object" } }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "ActionMeta": {
+      "type": "object",
+      "required": ["target"],
+      "properties": {
+        "target": { "$ref": "../../resources/meta/schema.json#/$defs/ObjectReference" }
+      },
+      "additionalProperties": false
+    },
+    "Action": {
+      "allOf": [
+        { "$ref": "../../resources/meta/schema.json#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "spec"],
+          "properties": {
+            "metadata": { "$ref": "#/$defs/ActionMeta" },
+            "spec": {},
+            "status": {}
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/internal/schema/api/v1alpha1/schema.json
+++ b/internal/schema/api/v1alpha1/schema.json
@@ -4,23 +4,46 @@
   "$defs": {
     "ListMeta": {
       "type": "object",
+      "description": "Pagination details returned with a list of resources.",
       "properties": {
-        "resourceVersion": { "type": "string" },
-        "continue": { "type": "string" },
-        "remainingItemCount": { "type": "integer", "minimum": 0 }
+        "resourceVersion": {
+          "type": "string",
+          "description": "Opaque version identifying the resource-list snapshot."
+        },
+        "continue": {
+          "type": "string",
+          "description": "Opaque token used to request the next page."
+        },
+        "remainingItemCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of resources remaining after the current page."
+        }
       },
       "additionalProperties": false
     },
     "ResourceList": {
+      "description": "A paginated API response containing resources of one kind.",
       "allOf": [
         { "$ref": "../../resources/meta/schema.json#/$defs/TypeMeta" },
         {
           "type": "object",
           "required": ["metadata", "items"],
           "properties": {
-            "kind": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*List$" },
-            "metadata": { "$ref": "#/$defs/ListMeta" },
-            "items": { "type": "array", "items": { "type": "object" } }
+            "kind": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Za-z0-9]*List$",
+              "description": "Resource kind followed by List, such as ConnectionList."
+            },
+            "metadata": {
+              "$ref": "#/$defs/ListMeta",
+              "description": "Pagination details for this list."
+            },
+            "items": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "Resources returned in the current page."
+            }
           }
         }
       ],
@@ -28,22 +51,34 @@
     },
     "ActionMeta": {
       "type": "object",
+      "description": "Identifies the resource on which an action operates.",
       "required": ["target"],
       "properties": {
-        "target": { "$ref": "../../resources/meta/schema.json#/$defs/ObjectReference" }
+        "target": {
+          "$ref": "../../resources/meta/schema.json#/$defs/ObjectReference",
+          "description": "Reference to the resource on which the action operates."
+        }
       },
       "additionalProperties": false
     },
     "Action": {
+      "description": "A request to perform an operation on a resource, optionally including its result.",
       "allOf": [
         { "$ref": "../../resources/meta/schema.json#/$defs/TypeMeta" },
         {
           "type": "object",
           "required": ["metadata", "spec"],
           "properties": {
-            "metadata": { "$ref": "#/$defs/ActionMeta" },
-            "spec": {},
-            "status": {}
+            "metadata": {
+              "$ref": "#/$defs/ActionMeta",
+              "description": "Identifies the resource targeted by the action."
+            },
+            "spec": {
+              "description": "Input parameters for the action."
+            },
+            "status": {
+              "description": "Result of the action when returned by the server."
+            }
           }
         }
       ],

--- a/internal/schema/api/v1alpha1/schema_test.go
+++ b/internal/schema/api/v1alpha1/schema_test.go
@@ -1,0 +1,73 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func addSchema(t *testing.T, compiler *jsonschemav5.Compiler, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var header struct {
+		ID string `json:"$id"`
+	}
+	require.NoError(t, json.Unmarshal(data, &header))
+	require.NoError(t, compiler.AddResource(header.ID, bytes.NewReader(data)))
+	return header.ID
+}
+
+func compileDefinition(t *testing.T, definition string) *jsonschemav5.Schema {
+	t.Helper()
+	compiler := jsonschemav5.NewCompiler()
+	addSchema(t, compiler, "../../common/schema.json")
+	addSchema(t, compiler, "../../resources/meta/schema.json")
+	id := addSchema(t, compiler, "schema.json")
+	require.Equal(t, SchemaID, id)
+	schema, err := compiler.Compile(id + "#/$defs/" + definition)
+	require.NoError(t, err)
+	return schema
+}
+
+func validateJSON(t *testing.T, schema *jsonschemav5.Schema, value string) error {
+	t.Helper()
+	var decoded any
+	require.NoError(t, json.Unmarshal([]byte(value), &decoded))
+	return schema.Validate(decoded)
+}
+
+func TestSchemaDefinitions(t *testing.T) {
+	listSchema := compileDefinition(t, "ResourceList")
+	require.NoError(t, validateJSON(t, listSchema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"WidgetList",
+      "metadata":{"continue":"next","remainingItemCount":2},
+      "items":[]
+    }`))
+	require.Error(t, validateJSON(t, listSchema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Widget",
+      "metadata":{},
+      "items":[]
+    }`))
+
+	actionSchema := compileDefinition(t, "Action")
+	require.NoError(t, validateJSON(t, actionSchema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"ConnectionDisconnect",
+      "metadata":{"target":{"apiVersion":"authproxy.net/v1alpha1","kind":"Connection","id":"cxn_123"}},
+      "spec":{"timeoutSeconds":30}
+    }`))
+	require.Error(t, validateJSON(t, actionSchema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"ConnectionDisconnect",
+      "metadata":{},
+      "spec":{},
+      "unexpected":true
+    }`))
+}

--- a/internal/schema/api/v1alpha1/schema_test.go
+++ b/internal/schema/api/v1alpha1/schema_test.go
@@ -69,5 +69,21 @@ func TestSchemaDefinitions(t *testing.T) {
       "metadata":{},
       "spec":{},
       "unexpected":true
-    }`))
+	}`))
+}
+
+func TestSchemaDefinitionsHaveDescriptions(t *testing.T) {
+	data, err := os.ReadFile("schema.json")
+	require.NoError(t, err)
+
+	var schema struct {
+		Definitions map[string]struct {
+			Description string `json:"description"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal(data, &schema))
+
+	for _, definition := range []string{"ListMeta", "ResourceList", "ActionMeta", "Action"} {
+		require.NotEmpty(t, schema.Definitions[definition].Description, "%s should have a description", definition)
+	}
 }

--- a/internal/schema/api/v1alpha1/transport.go
+++ b/internal/schema/api/v1alpha1/transport.go
@@ -1,0 +1,100 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+)
+
+// ListMeta contains pagination and snapshot information for a resource list.
+// Continue is an opaque token supplied to the next request.
+type ListMeta struct {
+	ResourceVersion    string `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	Continue           string `json:"continue,omitempty" yaml:"continue,omitempty"`
+	RemainingItemCount *int64 `json:"remainingItemCount,omitempty" yaml:"remainingItemCount,omitempty"`
+}
+
+// ResourceList is the common Kubernetes-style list transport. Item packages
+// own T; the API package owns this envelope and pagination metadata.
+type ResourceList[T any] struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      ListMeta `json:"metadata" yaml:"metadata"`
+	Items         []T      `json:"items" yaml:"items"`
+}
+
+// ActionMeta identifies the resource targeted by an imperative action.
+type ActionMeta struct {
+	Target meta.ObjectReference `json:"target" yaml:"target"`
+}
+
+// Action is a typed, non-durable imperative transport. Status is absent on a
+// request and may be populated by synchronous or asynchronous results.
+type Action[TSpec any, TStatus any] struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      ActionMeta `json:"metadata" yaml:"metadata"`
+	Spec          TSpec      `json:"spec" yaml:"spec"`
+	Status        *TStatus   `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+func ListKind(itemKind meta.Kind) meta.Kind {
+	if strings.HasSuffix(string(itemKind), "List") {
+		return itemKind
+	}
+	return meta.Kind(string(itemKind) + "List")
+}
+
+func NewResourceList[T any](itemKind meta.Kind, items []T, listMeta ListMeta) ResourceList[T] {
+	if items == nil {
+		items = make([]T, 0)
+	}
+	return ResourceList[T]{
+		TypeMeta: meta.NewTypeMeta(ListKind(itemKind)),
+		Metadata: listMeta,
+		Items:    items,
+	}
+}
+
+func NewActionRequest[TSpec any](kind meta.Kind, target meta.ObjectReference, spec TSpec) Action[TSpec, struct{}] {
+	return Action[TSpec, struct{}]{
+		TypeMeta: meta.NewTypeMeta(kind),
+		Metadata: ActionMeta{Target: target},
+		Spec:     spec,
+	}
+}
+
+func NewActionResponse[TSpec any, TStatus any](kind meta.Kind, target meta.ObjectReference, spec TSpec, status TStatus) Action[TSpec, TStatus] {
+	return Action[TSpec, TStatus]{
+		TypeMeta: meta.NewTypeMeta(kind),
+		Metadata: ActionMeta{Target: target},
+		Spec:     spec,
+		Status:   &status,
+	}
+}
+
+func ValidateResourceListType(typeMeta meta.TypeMeta, itemKind meta.Kind) error {
+	expectedKind := ListKind(itemKind)
+	if err := meta.ValidateTypeMeta(typeMeta, APIVersion, expectedKind, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateListMeta(value ListMeta) error {
+	if value.RemainingItemCount != nil && *value.RemainingItemCount < 0 {
+		return (&common.ValidationContext{Path: "$.metadata"}).NewErrorForField("remainingItemCount", "must not be negative")
+	}
+	return nil
+}
+
+func ValidateActionType(typeMeta meta.TypeMeta, expectedKind meta.Kind) error {
+	if strings.HasSuffix(string(expectedKind), "List") {
+		return fmt.Errorf("action kind %q must not be a list kind", expectedKind)
+	}
+	return meta.ValidateTypeMeta(typeMeta, APIVersion, expectedKind, nil)
+}
+
+func ValidateActionMeta(value ActionMeta) error {
+	return meta.ValidateObjectReference(value.Target, &common.ValidationContext{Path: "$.metadata.target"})
+}

--- a/internal/schema/api/v1alpha1/transport.go
+++ b/internal/schema/api/v1alpha1/transport.go
@@ -1,9 +1,9 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
@@ -38,6 +38,7 @@ type Action[TSpec any, TStatus any] struct {
 	Status        *TStatus   `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
+// ListKind returns the list kind corresponding to itemKind.
 func ListKind(itemKind meta.Kind) meta.Kind {
 	if strings.HasSuffix(string(itemKind), "List") {
 		return itemKind
@@ -45,6 +46,7 @@ func ListKind(itemKind meta.Kind) meta.Kind {
 	return meta.Kind(string(itemKind) + "List")
 }
 
+// NewResourceList creates a list response and normalizes nil items to an empty array.
 func NewResourceList[T any](itemKind meta.Kind, items []T, listMeta ListMeta) ResourceList[T] {
 	if items == nil {
 		items = make([]T, 0)
@@ -56,6 +58,7 @@ func NewResourceList[T any](itemKind meta.Kind, items []T, listMeta ListMeta) Re
 	}
 }
 
+// NewActionRequest creates an action request without response status.
 func NewActionRequest[TSpec any](kind meta.Kind, target meta.ObjectReference, spec TSpec) Action[TSpec, struct{}] {
 	return Action[TSpec, struct{}]{
 		TypeMeta: meta.NewTypeMeta(kind),
@@ -64,6 +67,7 @@ func NewActionRequest[TSpec any](kind meta.Kind, target meta.ObjectReference, sp
 	}
 }
 
+// NewActionResponse creates an action response containing its status.
 func NewActionResponse[TSpec any, TStatus any](kind meta.Kind, target meta.ObjectReference, spec TSpec, status TStatus) Action[TSpec, TStatus] {
 	return Action[TSpec, TStatus]{
 		TypeMeta: meta.NewTypeMeta(kind),
@@ -73,28 +77,52 @@ func NewActionResponse[TSpec any, TStatus any](kind meta.Kind, target meta.Objec
 	}
 }
 
-func ValidateResourceListType(typeMeta meta.TypeMeta, itemKind meta.Kind) error {
+// Validate verifies the list envelope for resources of itemKind.
+func (r *ResourceList[T]) Validate(itemKind meta.Kind) error {
+	vc := &common.ValidationContext{Path: "$"}
+	var result *multierror.Error
 	expectedKind := ListKind(itemKind)
-	if err := meta.ValidateTypeMeta(typeMeta, APIVersion, expectedKind, nil); err != nil {
-		return err
+	if err := meta.ValidateTypeMeta(r.TypeMeta, APIVersion, expectedKind, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := r.Metadata.Validate(vc.PushField("metadata")); err != nil {
+		result = multierror.Append(result, err)
+	}
+	return result.ErrorOrNil()
+}
+
+// Validate verifies list pagination metadata.
+func (m *ListMeta) Validate(vc *common.ValidationContext) error {
+	if vc == nil {
+		vc = &common.ValidationContext{Path: "$.metadata"}
+	}
+	if m.RemainingItemCount != nil && *m.RemainingItemCount < 0 {
+		return vc.NewErrorForField("remainingItemCount", "must not be negative")
 	}
 	return nil
 }
 
-func ValidateListMeta(value ListMeta) error {
-	if value.RemainingItemCount != nil && *value.RemainingItemCount < 0 {
-		return (&common.ValidationContext{Path: "$.metadata"}).NewErrorForField("remainingItemCount", "must not be negative")
-	}
-	return nil
-}
-
-func ValidateActionType(typeMeta meta.TypeMeta, expectedKind meta.Kind) error {
+// Validate verifies the action envelope for expectedKind.
+func (a *Action[TSpec, TStatus]) Validate(expectedKind meta.Kind) error {
+	vc := &common.ValidationContext{Path: "$"}
 	if strings.HasSuffix(string(expectedKind), "List") {
-		return fmt.Errorf("action kind %q must not be a list kind", expectedKind)
+		return vc.NewErrorfForField("kind", "action kind %q must not be a list kind", expectedKind)
 	}
-	return meta.ValidateTypeMeta(typeMeta, APIVersion, expectedKind, nil)
+
+	var result *multierror.Error
+	if err := meta.ValidateTypeMeta(a.TypeMeta, APIVersion, expectedKind, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := a.Metadata.Validate(vc.PushField("metadata")); err != nil {
+		result = multierror.Append(result, err)
+	}
+	return result.ErrorOrNil()
 }
 
-func ValidateActionMeta(value ActionMeta) error {
-	return meta.ValidateObjectReference(value.Target, &common.ValidationContext{Path: "$.metadata.target"})
+// Validate verifies action target metadata.
+func (m *ActionMeta) Validate(vc *common.ValidationContext) error {
+	if vc == nil {
+		vc = &common.ValidationContext{Path: "$.metadata"}
+	}
+	return meta.ValidateObjectReference(m.Target, vc.PushField("target"))
 }

--- a/internal/schema/api/v1alpha1/transport_test.go
+++ b/internal/schema/api/v1alpha1/transport_test.go
@@ -1,0 +1,92 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type testItem struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      meta.ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec          struct {
+		Enabled bool `json:"enabled" yaml:"enabled"`
+	} `json:"spec" yaml:"spec"`
+}
+
+func TestResourceListConstructorAndSerialization(t *testing.T) {
+	remaining := int64(4)
+	list := NewResourceList[testItem]("Widget", nil, ListMeta{
+		Continue:           "next-page",
+		RemainingItemCount: &remaining,
+	})
+	require.Equal(t, meta.APIVersionV1Alpha1, list.APIVersion)
+	require.Equal(t, meta.Kind("WidgetList"), list.Kind)
+	require.NotNil(t, list.Items)
+
+	data, err := json.Marshal(list)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"WidgetList",
+      "metadata":{"continue":"next-page","remainingItemCount":4},
+      "items":[]
+    }`, string(data))
+
+	yamlData, err := yaml.Marshal(list)
+	require.NoError(t, err)
+	require.Contains(t, string(yamlData), "apiVersion: authproxy.net/v1alpha1\nkind: WidgetList\nmetadata:")
+	require.Contains(t, string(yamlData), "items: []")
+	require.NoError(t, ValidateResourceListType(list.TypeMeta, "Widget"))
+}
+
+func TestActionConstructorsPutTargetInMetadata(t *testing.T) {
+	target := meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       "Connection",
+		ID:         "cxn_123",
+	}
+	type disconnectSpec struct {
+		TimeoutSeconds int `json:"timeoutSeconds" yaml:"timeoutSeconds"`
+	}
+	type disconnectStatus struct {
+		TaskID string `json:"taskId" yaml:"taskId"`
+	}
+
+	request := NewActionRequest("ConnectionDisconnect", target, disconnectSpec{TimeoutSeconds: 30})
+	require.Nil(t, request.Status)
+	requestJSON, err := json.Marshal(request)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"ConnectionDisconnect",
+      "metadata":{"target":{"apiVersion":"authproxy.net/v1alpha1","kind":"Connection","id":"cxn_123"}},
+      "spec":{"timeoutSeconds":30}
+    }`, string(requestJSON))
+
+	response := NewActionResponse("ConnectionDisconnect", target, disconnectSpec{TimeoutSeconds: 30}, disconnectStatus{TaskID: "task-1"})
+	require.Equal(t, "task-1", response.Status.TaskID)
+	require.NoError(t, ValidateActionType(response.TypeMeta, "ConnectionDisconnect"))
+}
+
+func TestListAndActionTypeValidationIsFieldAddressable(t *testing.T) {
+	err := ValidateResourceListType(meta.TypeMeta{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       "GadgetList",
+	}, "Widget")
+	require.ErrorContains(t, err, `$.kind: must be "WidgetList"`)
+
+	err = ValidateActionType(meta.NewTypeMeta("WidgetList"), "WidgetList")
+	require.ErrorContains(t, err, "must not be a list kind")
+
+	negative := int64(-1)
+	require.ErrorContains(t, ValidateListMeta(ListMeta{RemainingItemCount: &negative}), "$.metadata.remainingItemCount")
+	require.NoError(t, ValidateActionMeta(ActionMeta{Target: meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       "Widget",
+		Name:       "example",
+	}}))
+}

--- a/internal/schema/api/v1alpha1/transport_test.go
+++ b/internal/schema/api/v1alpha1/transport_test.go
@@ -40,7 +40,7 @@ func TestResourceListConstructorAndSerialization(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(yamlData), "apiVersion: authproxy.net/v1alpha1\nkind: WidgetList\nmetadata:")
 	require.Contains(t, string(yamlData), "items: []")
-	require.NoError(t, ValidateResourceListType(list.TypeMeta, "Widget"))
+	require.NoError(t, list.Validate("Widget"))
 }
 
 func TestActionConstructorsPutTargetInMetadata(t *testing.T) {
@@ -69,24 +69,32 @@ func TestActionConstructorsPutTargetInMetadata(t *testing.T) {
 
 	response := NewActionResponse("ConnectionDisconnect", target, disconnectSpec{TimeoutSeconds: 30}, disconnectStatus{TaskID: "task-1"})
 	require.Equal(t, "task-1", response.Status.TaskID)
-	require.NoError(t, ValidateActionType(response.TypeMeta, "ConnectionDisconnect"))
+	require.NoError(t, response.Validate("ConnectionDisconnect"))
 }
 
-func TestListAndActionTypeValidationIsFieldAddressable(t *testing.T) {
-	err := ValidateResourceListType(meta.TypeMeta{
+func TestListAndActionValidationIsFieldAddressable(t *testing.T) {
+	list := ResourceList[testItem]{TypeMeta: meta.TypeMeta{
 		APIVersion: meta.APIVersionV1Alpha1,
 		Kind:       "GadgetList",
-	}, "Widget")
+	}}
+	err := list.Validate("Widget")
 	require.ErrorContains(t, err, `$.kind: must be "WidgetList"`)
 
-	err = ValidateActionType(meta.NewTypeMeta("WidgetList"), "WidgetList")
+	action := Action[struct{}, struct{}]{TypeMeta: meta.NewTypeMeta("WidgetList")}
+	err = action.Validate("WidgetList")
 	require.ErrorContains(t, err, "must not be a list kind")
 
 	negative := int64(-1)
-	require.ErrorContains(t, ValidateListMeta(ListMeta{RemainingItemCount: &negative}), "$.metadata.remainingItemCount")
-	require.NoError(t, ValidateActionMeta(ActionMeta{Target: meta.ObjectReference{
+	list = NewResourceList[testItem]("Widget", nil, ListMeta{RemainingItemCount: &negative})
+	require.ErrorContains(t, list.Validate("Widget"), "$.metadata.remainingItemCount")
+
+	request := NewActionRequest("WidgetAction", meta.ObjectReference{
 		APIVersion: meta.APIVersionV1Alpha1,
 		Kind:       "Widget",
 		Name:       "example",
-	}}))
+	}, struct{}{})
+	require.NoError(t, request.Validate("WidgetAction"))
+
+	request.Metadata.Target.Name = ""
+	require.ErrorContains(t, request.Validate("WidgetAction"), "$.metadata.target: must contain id or name")
 }

--- a/internal/schema/manifest/README.md
+++ b/internal/schema/manifest/README.md
@@ -1,0 +1,11 @@
+# Manifest Scheme
+
+This package owns strict JSON/YAML decoding and GVK dispatch for AuthProxy
+manifests. Callers register resource, list, projection, or action contract
+types; the scheme reads `apiVersion` and `kind`, selects a fresh typed value,
+then rejects unknown fields while decoding it.
+
+Multi-document support is intentionally YAML-only. A JSON list is itself a
+registered `<Kind>List` object rather than an untyped array of manifests. This
+package owns decoding infrastructure, not a serialized contract, so it has no
+independent JSON Schema.

--- a/internal/schema/manifest/scheme.go
+++ b/internal/schema/manifest/scheme.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"reflect"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
@@ -48,12 +47,23 @@ func (s *Scheme) Register(gvk GVK, factory Factory) error {
 	if s == nil {
 		return fmt.Errorf("manifest scheme is nil")
 	}
-	if err := meta.ValidateTypeMeta(meta.TypeMeta{APIVersion: gvk.APIVersion, Kind: gvk.Kind}, "", "", nil); err != nil {
+
+	if err := meta.ValidateTypeMeta(
+		meta.TypeMeta{
+			APIVersion: gvk.APIVersion,
+			Kind:       gvk.Kind,
+		},
+		"",  // expectedVersion
+		"",  // expectedKind
+		nil, // path
+	); err != nil {
 		return fmt.Errorf("invalid registration %s: %w", gvk, err)
 	}
+
 	if factory == nil {
 		return fmt.Errorf("register %s: factory is required", gvk)
 	}
+
 	sample := factory()
 	if err := validateFactoryResult(sample); err != nil {
 		return fmt.Errorf("register %s: %w", gvk, err)
@@ -61,11 +71,13 @@ func (s *Scheme) Register(gvk GVK, factory Factory) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	if _, exists := s.factories[gvk]; exists {
 		return fmt.Errorf("register %s: already registered", gvk)
 	}
 	s.factories[gvk] = factory
 	s.versions[gvk.APIVersion] = struct{}{}
+
 	return nil
 }
 
@@ -160,7 +172,7 @@ func (s *Scheme) DecodeYAMLDocuments(data []byte) ([]any, error) {
 			return nil, fmt.Errorf("decode YAML document %d: %w", document, err)
 		}
 
-		if yamlDocumentEmpty(&node) {
+		if util.YamlDocumentEmpty(&node) {
 			continue
 		}
 
@@ -264,27 +276,24 @@ func (s *Scheme) resolve(value meta.TypeMeta) (Factory, error) {
 	if s == nil {
 		return nil, fmt.Errorf("manifest scheme is nil")
 	}
+
 	gvk := GVK{APIVersion: value.APIVersion, Kind: value.Kind}
+
 	s.mu.RLock()
 	factory, exists := s.factories[gvk]
 	_, versionExists := s.versions[value.APIVersion]
 	s.mu.RUnlock()
+
 	if exists {
 		return factory, nil
 	}
+
 	vc := &common.ValidationContext{Path: "$"}
 	if !versionExists {
 		return nil, vc.NewErrorfForField("apiVersion", "unsupported value %q", value.APIVersion)
 	}
-	return nil, vc.NewErrorfForField("kind", "unsupported value %q for apiVersion %q", value.Kind, value.APIVersion)
-}
 
-func yamlDocumentEmpty(node *yaml.Node) bool {
-	if node == nil || len(node.Content) == 0 {
-		return true
-	}
-	value := node.Content[0]
-	return value.Kind == yaml.ScalarNode && value.Tag == "!!null" && strings.TrimSpace(value.Value) == ""
+	return nil, vc.NewErrorfForField("kind", "unsupported value %q for apiVersion %q", value.Kind, value.APIVersion)
 }
 
 func validateFactoryResult(value any) error {

--- a/internal/schema/manifest/scheme.go
+++ b/internal/schema/manifest/scheme.go
@@ -16,7 +16,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// GVK is the lookup key for a registered manifest type.
+// GVK (Group-Version-Kind) identifies a manifest contract by its API version
+// and kind. APIVersion contains both the API group and version, for example
+// authproxy.net/v1alpha1.
 type GVK struct {
 	APIVersion meta.APIVersion
 	Kind       meta.Kind

--- a/internal/schema/manifest/scheme.go
+++ b/internal/schema/manifest/scheme.go
@@ -1,0 +1,258 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/util"
+	"gopkg.in/yaml.v3"
+)
+
+// GVK is the lookup key for a registered manifest type.
+type GVK struct {
+	APIVersion meta.APIVersion
+	Kind       meta.Kind
+}
+
+func (g GVK) String() string { return fmt.Sprintf("%s, Kind=%s", g.APIVersion, g.Kind) }
+
+// Factory creates a fresh pointer to a registered manifest contract.
+type Factory func() any
+
+// Scheme dispatches strict JSON and YAML manifests by apiVersion and kind.
+// It is safe for concurrent registration and decoding.
+type Scheme struct {
+	mu        sync.RWMutex
+	factories map[GVK]Factory
+	versions  map[meta.APIVersion]struct{}
+}
+
+func NewScheme() *Scheme {
+	return &Scheme{
+		factories: make(map[GVK]Factory),
+		versions:  make(map[meta.APIVersion]struct{}),
+	}
+}
+
+func (s *Scheme) Register(gvk GVK, factory Factory) error {
+	if s == nil {
+		return fmt.Errorf("manifest scheme is nil")
+	}
+	if err := meta.ValidateTypeMeta(meta.TypeMeta{APIVersion: gvk.APIVersion, Kind: gvk.Kind}, "", "", nil); err != nil {
+		return fmt.Errorf("invalid registration %s: %w", gvk, err)
+	}
+	if factory == nil {
+		return fmt.Errorf("register %s: factory is required", gvk)
+	}
+	sample := factory()
+	if err := validateFactoryResult(sample); err != nil {
+		return fmt.Errorf("register %s: %w", gvk, err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.factories[gvk]; exists {
+		return fmt.Errorf("register %s: already registered", gvk)
+	}
+	s.factories[gvk] = factory
+	s.versions[gvk.APIVersion] = struct{}{}
+	return nil
+}
+
+func RegisterType[T any](scheme *Scheme, gvk GVK) error {
+	return scheme.Register(gvk, func() any { return new(T) })
+}
+
+func MustRegisterType[T any](scheme *Scheme, gvk GVK) {
+	if err := RegisterType[T](scheme, gvk); err != nil {
+		panic(err)
+	}
+}
+
+func (s *Scheme) RegisteredGVKs() []GVK {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	result := make([]GVK, 0, len(s.factories))
+	for gvk := range s.factories {
+		result = append(result, gvk)
+	}
+	s.mu.RUnlock()
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].APIVersion != result[j].APIVersion {
+			return result[i].APIVersion < result[j].APIVersion
+		}
+		return result[i].Kind < result[j].Kind
+	})
+	return result
+}
+
+func (s *Scheme) DecodeJSON(data []byte) (any, error) {
+	typeMeta, err := decodeJSONTypeMeta(data)
+	if err != nil {
+		return nil, err
+	}
+	factory, err := s.resolve(typeMeta)
+	if err != nil {
+		return nil, err
+	}
+	result := factory()
+	if err := validateFactoryResult(result); err != nil {
+		return nil, fmt.Errorf("decode %s: registered factory %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
+	}
+	if err := util.DecodeJSONStrict(data, result); err != nil {
+		return nil, fmt.Errorf("decode %s JSON: %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
+	}
+	return result, nil
+}
+
+// DecodeYAML decodes exactly one non-empty YAML document.
+func (s *Scheme) DecodeYAML(data []byte) (any, error) {
+	results, err := s.DecodeYAMLDocuments(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("decode YAML: expected one document, got none")
+	}
+	if len(results) != 1 {
+		return nil, fmt.Errorf("decode YAML: expected one document, got %d", len(results))
+	}
+	return results[0], nil
+}
+
+// DecodeYAMLDocuments decodes a YAML stream, skips empty documents, and
+// dispatches every remaining document independently by GVK.
+func (s *Scheme) DecodeYAMLDocuments(data []byte) ([]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var results []any
+	for document := 1; ; document++ {
+		var node yaml.Node
+		if err := decoder.Decode(&node); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode YAML document %d: %w", document, err)
+		}
+		if yamlDocumentEmpty(&node) {
+			continue
+		}
+		payload, err := yaml.Marshal(&node)
+		if err != nil {
+			return nil, fmt.Errorf("encode YAML document %d: %w", document, err)
+		}
+		result, err := s.decodeYAMLDocument(payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode YAML document %d: %w", document, err)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func (s *Scheme) decodeYAMLDocument(data []byte) (any, error) {
+	var typeMeta meta.TypeMeta
+	if err := yaml.Unmarshal(data, &typeMeta); err != nil {
+		return nil, fmt.Errorf("decode type metadata: %w", err)
+	}
+	if err := validatePresentTypeMeta(typeMeta); err != nil {
+		return nil, err
+	}
+	factory, err := s.resolve(typeMeta)
+	if err != nil {
+		return nil, err
+	}
+	result := factory()
+	if err := validateFactoryResult(result); err != nil {
+		return nil, fmt.Errorf("decode %s: registered factory %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
+	}
+	if err := util.DecodeYAMLStrict(data, result); err != nil {
+		return nil, fmt.Errorf("decode %s YAML: %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
+	}
+	return result, nil
+}
+
+func decodeJSONTypeMeta(data []byte) (meta.TypeMeta, error) {
+	var raw map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&raw); err != nil {
+		return meta.TypeMeta{}, fmt.Errorf("decode type metadata: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return meta.TypeMeta{}, fmt.Errorf("decode type metadata: unexpected additional JSON value")
+		}
+		return meta.TypeMeta{}, fmt.Errorf("decode type metadata: %w", err)
+	}
+
+	var result meta.TypeMeta
+	if value, exists := raw["apiVersion"]; exists {
+		if err := json.Unmarshal(value, &result.APIVersion); err != nil {
+			return meta.TypeMeta{}, (&common.ValidationContext{Path: "$"}).NewErrorfForField("apiVersion", "must be a string: %v", err)
+		}
+	}
+	if value, exists := raw["kind"]; exists {
+		if err := json.Unmarshal(value, &result.Kind); err != nil {
+			return meta.TypeMeta{}, (&common.ValidationContext{Path: "$"}).NewErrorfForField("kind", "must be a string: %v", err)
+		}
+	}
+	if err := validatePresentTypeMeta(result); err != nil {
+		return meta.TypeMeta{}, err
+	}
+	return result, nil
+}
+
+func validatePresentTypeMeta(value meta.TypeMeta) error {
+	return meta.ValidateTypeMeta(value, "", "", &common.ValidationContext{Path: "$"})
+}
+
+func (s *Scheme) resolve(value meta.TypeMeta) (Factory, error) {
+	if s == nil {
+		return nil, fmt.Errorf("manifest scheme is nil")
+	}
+	gvk := GVK{APIVersion: value.APIVersion, Kind: value.Kind}
+	s.mu.RLock()
+	factory, exists := s.factories[gvk]
+	_, versionExists := s.versions[value.APIVersion]
+	s.mu.RUnlock()
+	if exists {
+		return factory, nil
+	}
+	vc := &common.ValidationContext{Path: "$"}
+	if !versionExists {
+		return nil, vc.NewErrorfForField("apiVersion", "unsupported value %q", value.APIVersion)
+	}
+	return nil, vc.NewErrorfForField("kind", "unsupported value %q for apiVersion %q", value.Kind, value.APIVersion)
+}
+
+func yamlDocumentEmpty(node *yaml.Node) bool {
+	if node == nil || len(node.Content) == 0 {
+		return true
+	}
+	value := node.Content[0]
+	return value.Kind == yaml.ScalarNode && value.Tag == "!!null" && strings.TrimSpace(value.Value) == ""
+}
+
+func validateFactoryResult(value any) error {
+	if value == nil {
+		return fmt.Errorf("returned nil")
+	}
+	valueType := reflect.TypeOf(value)
+	if valueType.Kind() != reflect.Pointer {
+		return fmt.Errorf("must return a pointer, got %s", valueType)
+	}
+	if reflect.ValueOf(value).IsNil() {
+		return fmt.Errorf("returned a nil %s", valueType)
+	}
+	return nil
+}

--- a/internal/schema/manifest/scheme.go
+++ b/internal/schema/manifest/scheme.go
@@ -83,18 +83,23 @@ func (s *Scheme) RegisteredGVKs() []GVK {
 	if s == nil {
 		return nil
 	}
+
 	s.mu.RLock()
+
 	result := make([]GVK, 0, len(s.factories))
 	for gvk := range s.factories {
 		result = append(result, gvk)
 	}
+
 	s.mu.RUnlock()
+
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].APIVersion != result[j].APIVersion {
 			return result[i].APIVersion < result[j].APIVersion
 		}
 		return result[i].Kind < result[j].Kind
 	})
+
 	return result
 }
 
@@ -103,17 +108,21 @@ func (s *Scheme) DecodeJSON(data []byte) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	factory, err := s.resolve(typeMeta)
 	if err != nil {
 		return nil, err
 	}
+
 	result := factory()
 	if err := validateFactoryResult(result); err != nil {
 		return nil, fmt.Errorf("decode %s: registered factory %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
 	}
+
 	if err := util.DecodeJSONStrict(data, result); err != nil {
 		return nil, fmt.Errorf("decode %s JSON: %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
 	}
+
 	return result, nil
 }
 
@@ -123,12 +132,15 @@ func (s *Scheme) DecodeYAML(data []byte) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if len(results) == 0 {
 		return nil, fmt.Errorf("decode YAML: expected one document, got none")
 	}
+
 	if len(results) != 1 {
 		return nil, fmt.Errorf("decode YAML: expected one document, got %d", len(results))
 	}
+
 	return results[0], nil
 }
 
@@ -136,59 +148,81 @@ func (s *Scheme) DecodeYAML(data []byte) (any, error) {
 // dispatches every remaining document independently by GVK.
 func (s *Scheme) DecodeYAMLDocuments(data []byte) ([]any, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
+
 	var results []any
 	for document := 1; ; document++ {
 		var node yaml.Node
+
 		if err := decoder.Decode(&node); err != nil {
 			if err == io.EOF {
 				break
 			}
 			return nil, fmt.Errorf("decode YAML document %d: %w", document, err)
 		}
+
 		if yamlDocumentEmpty(&node) {
 			continue
 		}
+
 		payload, err := yaml.Marshal(&node)
 		if err != nil {
 			return nil, fmt.Errorf("encode YAML document %d: %w", document, err)
 		}
+
 		result, err := s.decodeYAMLDocument(payload)
 		if err != nil {
 			return nil, fmt.Errorf("decode YAML document %d: %w", document, err)
 		}
+
 		results = append(results, result)
 	}
+
 	return results, nil
 }
 
 func (s *Scheme) decodeYAMLDocument(data []byte) (any, error) {
 	var typeMeta meta.TypeMeta
+
+	// Get the type metadata (kind, api version) from the YAML document so we
+	// use that metadata to load the appropriate factory to load the rest of
+	// the data.
 	if err := yaml.Unmarshal(data, &typeMeta); err != nil {
 		return nil, fmt.Errorf("decode type metadata: %w", err)
 	}
+
 	if err := validatePresentTypeMeta(typeMeta); err != nil {
 		return nil, err
 	}
+
 	factory, err := s.resolve(typeMeta)
 	if err != nil {
 		return nil, err
 	}
+
 	result := factory()
 	if err := validateFactoryResult(result); err != nil {
 		return nil, fmt.Errorf("decode %s: registered factory %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
 	}
+
 	if err := util.DecodeYAMLStrict(data, result); err != nil {
 		return nil, fmt.Errorf("decode %s YAML: %w", GVK{typeMeta.APIVersion, typeMeta.Kind}, err)
 	}
+
 	return result, nil
 }
 
+// decodeJSONTypeMeta decodes the type metadata (API version and kind) from
+// JSON so that information can be used to look up the appropriate struct in
+// the registered factories for decoding.
 func decodeJSONTypeMeta(data []byte) (meta.TypeMeta, error) {
 	var raw map[string]json.RawMessage
+
 	decoder := json.NewDecoder(bytes.NewReader(data))
+
 	if err := decoder.Decode(&raw); err != nil {
 		return meta.TypeMeta{}, fmt.Errorf("decode type metadata: %w", err)
 	}
+
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		if err == nil {
@@ -203,19 +237,27 @@ func decodeJSONTypeMeta(data []byte) (meta.TypeMeta, error) {
 			return meta.TypeMeta{}, (&common.ValidationContext{Path: "$"}).NewErrorfForField("apiVersion", "must be a string: %v", err)
 		}
 	}
+
 	if value, exists := raw["kind"]; exists {
 		if err := json.Unmarshal(value, &result.Kind); err != nil {
 			return meta.TypeMeta{}, (&common.ValidationContext{Path: "$"}).NewErrorfForField("kind", "must be a string: %v", err)
 		}
 	}
+
 	if err := validatePresentTypeMeta(result); err != nil {
 		return meta.TypeMeta{}, err
 	}
+
 	return result, nil
 }
 
 func validatePresentTypeMeta(value meta.TypeMeta) error {
-	return meta.ValidateTypeMeta(value, "", "", &common.ValidationContext{Path: "$"})
+	return meta.ValidateTypeMeta(
+		value,
+		"", // expectedVersion
+		"", // expectedKind
+		&common.ValidationContext{Path: "$"},
+	)
 }
 
 func (s *Scheme) resolve(value meta.TypeMeta) (Factory, error) {

--- a/internal/schema/manifest/scheme_test.go
+++ b/internal/schema/manifest/scheme_test.go
@@ -1,0 +1,143 @@
+package manifest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+)
+
+type widget struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      meta.ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec          widgetSpec      `json:"spec" yaml:"spec"`
+}
+
+type widgetSpec struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+}
+
+var widgetGVK = GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "Widget"}
+
+func newWidgetScheme(t *testing.T) *Scheme {
+	t.Helper()
+	scheme := NewScheme()
+	require.NoError(t, RegisterType[widget](scheme, widgetGVK))
+	return scheme
+}
+
+func TestDecodeJSONStrictDispatch(t *testing.T) {
+	scheme := newWidgetScheme(t)
+	decoded, err := scheme.DecodeJSON([]byte(`{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Widget",
+      "metadata":{"name":"example"},
+      "spec":{"enabled":true}
+    }`))
+	require.NoError(t, err)
+	resource, ok := decoded.(*widget)
+	require.True(t, ok)
+	require.Equal(t, meta.Kind("Widget"), resource.Kind)
+	require.Equal(t, common.ResourceName("example"), resource.Metadata.Name)
+	require.True(t, resource.Spec.Enabled)
+
+	_, err = scheme.DecodeJSON([]byte(`{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Widget",
+      "metadata":{"name":"example"},
+      "spec":{"enabled":true,"unknown":1}
+    }`))
+	require.ErrorContains(t, err, "unknown field")
+
+	_, err = scheme.DecodeJSON([]byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Widget","metadata":{},"spec":{}} {}`))
+	require.ErrorContains(t, err, "unexpected additional JSON value")
+}
+
+func TestUnknownAndMismatchedGVKsAreFieldAddressable(t *testing.T) {
+	scheme := newWidgetScheme(t)
+	tests := []struct {
+		name string
+		data string
+		path string
+	}{
+		{"missing version", `{"kind":"Widget"}`, "$.apiVersion"},
+		{"missing kind", `{"apiVersion":"authproxy.net/v1alpha1"}`, "$.kind"},
+		{"unknown version", `{"apiVersion":"authproxy.net/v1alpha2","kind":"Widget"}`, "$.apiVersion"},
+		{"unknown kind", `{"apiVersion":"authproxy.net/v1alpha1","kind":"Gadget"}`, "$.kind"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := scheme.DecodeJSON([]byte(test.data))
+			require.Error(t, err)
+			var fieldError *common.ValidationError
+			require.True(t, errors.As(err, &fieldError), "expected field-addressable error, got %T: %v", err, err)
+			require.Equal(t, test.path, fieldError.Path)
+		})
+	}
+
+	_, err := scheme.DecodeYAML([]byte("apiVersion: authproxy.net/v1alpha1\nkind: Gadget\n"))
+	require.Error(t, err)
+	var fieldError *common.ValidationError
+	require.True(t, errors.As(err, &fieldError))
+	require.Equal(t, "$.kind", fieldError.Path)
+}
+
+func TestDecodeYAMLAndMultiDocumentStream(t *testing.T) {
+	scheme := newWidgetScheme(t)
+	stream := []byte(`
+apiVersion: authproxy.net/v1alpha1
+kind: Widget
+metadata:
+  name: first
+spec:
+  enabled: true
+---
+---
+apiVersion: authproxy.net/v1alpha1
+kind: Widget
+metadata:
+  name: second
+spec:
+  enabled: false
+`)
+	resources, err := scheme.DecodeYAMLDocuments(stream)
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	require.Equal(t, common.ResourceName("first"), resources[0].(*widget).Metadata.Name)
+	require.Equal(t, common.ResourceName("second"), resources[1].(*widget).Metadata.Name)
+
+	_, err = scheme.DecodeYAML(stream)
+	require.ErrorContains(t, err, "expected one document, got 2")
+
+	decoded, err := scheme.DecodeYAML([]byte(`
+apiVersion: authproxy.net/v1alpha1
+kind: Widget
+metadata:
+  name: one
+spec:
+  enabled: true
+`))
+	require.NoError(t, err)
+	require.Equal(t, common.ResourceName("one"), decoded.(*widget).Metadata.Name)
+
+	_, err = scheme.DecodeYAML([]byte(`
+apiVersion: authproxy.net/v1alpha1
+kind: Widget
+metadata: {}
+spec:
+  enabled: true
+  unknown: value
+`))
+	require.ErrorContains(t, err, "field unknown not found")
+}
+
+func TestSchemeRegistration(t *testing.T) {
+	scheme := newWidgetScheme(t)
+	require.Equal(t, []GVK{widgetGVK}, scheme.RegisteredGVKs())
+	require.ErrorContains(t, RegisterType[widget](scheme, widgetGVK), "already registered")
+	require.ErrorContains(t, scheme.Register(GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "Value"}, func() any { return widget{} }), "must return a pointer")
+	require.ErrorContains(t, scheme.Register(GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "NilValue"}, func() any { return (*widget)(nil) }), "returned a nil")
+	require.ErrorContains(t, scheme.Register(GVK{APIVersion: "not-a-version", Kind: "Value"}, func() any { return &widget{} }), "apiVersion")
+}

--- a/internal/schema/resources/meta/README.md
+++ b/internal/schema/resources/meta/README.md
@@ -1,0 +1,19 @@
+# Resource Metadata Schema
+
+This package owns the schema-version, kind, identity, labels, annotations,
+references, and conditions shared by AuthProxy resource contracts. It also
+provides lifecycle-aware metadata validation/defaulting, merge-patch helpers,
+and canonical spec hashing.
+
+Resource packages embed these definitions and add only their own kind, spec,
+status, and business-neutral resource validation. API list and action
+transports belong in `internal/schema/api/v1alpha1`; GVK decoding belongs in
+`internal/schema/manifest`. This package must not import either API package.
+
+Database rows remain persistence models. Conversion code may use this package,
+but public resource structs should not become database models.
+
+The JSON Schema exposes an open `Resource` base for composition. A concrete
+resource schema adds its kind/spec/status definitions with `allOf`, then sets
+`unevaluatedProperties: false`; this reuses TypeMeta without repeating fields
+or allowing unknown properties at the concrete boundary.

--- a/internal/schema/resources/meta/canonical.go
+++ b/internal/schema/resources/meta/canonical.go
@@ -20,21 +20,26 @@ func CanonicalSpecJSON(spec any) ([]byte, error) {
 
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
+
 	var normalized any
 	if err := decoder.Decode(&normalized); err != nil {
 		return nil, fmt.Errorf("decode marshaled spec: %w", err)
 	}
+
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		if err == nil {
 			return nil, fmt.Errorf("decode marshaled spec: unexpected additional JSON value")
 		}
+
 		return nil, fmt.Errorf("decode marshaled spec: %w", err)
 	}
+
 	canonical, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, fmt.Errorf("marshal canonical spec: %w", err)
 	}
+
 	return canonical, nil
 }
 
@@ -46,6 +51,7 @@ func SemanticSpecHash(spec any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	digest := sha256.Sum256(canonical)
 	return hex.EncodeToString(digest[:]), nil
 }

--- a/internal/schema/resources/meta/canonical.go
+++ b/internal/schema/resources/meta/canonical.go
@@ -1,0 +1,51 @@
+package meta
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// CanonicalSpecJSON serializes a spec into deterministic JSON. It normalizes
+// nested maps and json.RawMessage values by decoding once with UseNumber and
+// re-encoding with sorted object keys.
+func CanonicalSpecJSON(spec any) ([]byte, error) {
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshal spec: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var normalized any
+	if err := decoder.Decode(&normalized); err != nil {
+		return nil, fmt.Errorf("decode marshaled spec: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("decode marshaled spec: unexpected additional JSON value")
+		}
+		return nil, fmt.Errorf("decode marshaled spec: %w", err)
+	}
+	canonical, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("marshal canonical spec: %w", err)
+	}
+	return canonical, nil
+}
+
+// SemanticSpecHash returns the lowercase SHA-256 hex digest of canonical spec
+// JSON. Metadata and status affect the result only if a caller incorrectly
+// includes them in the value passed as spec.
+func SemanticSpecHash(spec any) (string, error) {
+	canonical, err := CanonicalSpecJSON(spec)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(canonical)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/schema/resources/meta/constructors.go
+++ b/internal/schema/resources/meta/constructors.go
@@ -1,0 +1,42 @@
+package meta
+
+import "time"
+
+func NewObjectReference(typeMeta TypeMeta, metadata ObjectMeta) ObjectReference {
+	return ObjectReference{
+		APIVersion: typeMeta.APIVersion,
+		Kind:       typeMeta.Kind,
+		ID:         metadata.ID,
+		Name:       metadata.Name,
+		Namespace:  metadata.Namespace,
+		Generation: metadata.Generation,
+	}
+}
+
+func NewCondition(conditionType string, status ConditionStatus, observedGeneration uint64, reason, message string, transitionTime time.Time) Condition {
+	return Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: transitionTime.UTC(),
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// UpsertCondition replaces a condition with the same type or appends it. A
+// status that did not transition retains its previous transition timestamp.
+func UpsertCondition(conditions []Condition, next Condition) []Condition {
+	result := append([]Condition(nil), conditions...)
+	for i := range result {
+		if result[i].Type != next.Type {
+			continue
+		}
+		if result[i].Status == next.Status {
+			next.LastTransitionTime = result[i].LastTransitionTime
+		}
+		result[i] = next
+		return result
+	}
+	return append(result, next)
+}

--- a/internal/schema/resources/meta/constructors.go
+++ b/internal/schema/resources/meta/constructors.go
@@ -2,7 +2,10 @@ package meta
 
 import "time"
 
-func NewObjectReference(typeMeta TypeMeta, metadata ObjectMeta) ObjectReference {
+func NewObjectReference(
+	typeMeta TypeMeta,
+	metadata ObjectMeta,
+) ObjectReference {
 	return ObjectReference{
 		APIVersion: typeMeta.APIVersion,
 		Kind:       typeMeta.Kind,
@@ -13,7 +16,13 @@ func NewObjectReference(typeMeta TypeMeta, metadata ObjectMeta) ObjectReference 
 	}
 }
 
-func NewCondition(conditionType string, status ConditionStatus, observedGeneration uint64, reason, message string, transitionTime time.Time) Condition {
+func NewCondition(
+	conditionType string,
+	status ConditionStatus,
+	observedGeneration uint64,
+	reason, message string,
+	transitionTime time.Time,
+) Condition {
 	return Condition{
 		Type:               conditionType,
 		Status:             status,
@@ -32,11 +41,14 @@ func UpsertCondition(conditions []Condition, next Condition) []Condition {
 		if result[i].Type != next.Type {
 			continue
 		}
+
 		if result[i].Status == next.Status {
 			next.LastTransitionTime = result[i].LastTransitionTime
 		}
+
 		result[i] = next
 		return result
 	}
+
 	return append(result, next)
 }

--- a/internal/schema/resources/meta/labels.go
+++ b/internal/schema/resources/meta/labels.go
@@ -4,18 +4,20 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // Kubernetes-style label restrictions
 const (
-	// LabelKeyNameMaxLength is the maximum length for the name portion of a label key
+	// LabelKeyNameMaxLength is the maximum length for the name portion of a
+	// label key
 	LabelKeyNameMaxLength = 63
 
-	// LabelKeyPrefixMaxLength is the maximum length for the optional prefix portion of a label key
+	// LabelKeyPrefixMaxLength is the maximum length for the optional prefix
+	// portion of a label key
 	LabelKeyPrefixMaxLength = 253
 
 	// LabelValueMaxLength is the maximum length for a label value
@@ -28,7 +30,8 @@ const (
 	// LabelValueMaxLength via ValidateLabelValue.
 	SystemLabelValueMaxLength = 253
 
-	// AnnotationsTotalMaxSize is the maximum total size of all annotations (keys + values) in bytes.
+	// AnnotationsTotalMaxSize is the maximum total size of all annotations
+	// (keys + values) in bytes.
 	AnnotationsTotalMaxSize = 256 * 1024
 
 	// SystemLabelPrefix is the reserved label-key prefix for system-managed
@@ -146,7 +149,9 @@ func ValidateUserLabelKey(key string) error {
 	return ValidateLabelKey(key)
 }
 
-// ValidateLabelValue validates a single label value according to Kubernetes restrictions.
+// ValidateLabelValue validates a single label value according to Kubernetes
+// restrictions.
+//
 // - 0-63 characters (can be empty)
 // - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
 func ValidateLabelValue(value string) error {
@@ -159,10 +164,10 @@ func ValidateLabelValue(value string) error {
 	return nil
 }
 
-// ValidateSystemLabelValue validates a label value stored under an apxy/-prefixed
-// key. It allows up to SystemLabelValueMaxLength characters so namespace paths
-// (e.g. root.foo.bar.baz...) can fit, including the leading underscores and
-// trailing hyphens accepted in namespace path segments.
+// ValidateSystemLabelValue validates a label value stored under an apxy/-
+// prefixed key. It allows up to SystemLabelValueMaxLength characters so
+// namespace paths (e.g. root.foo.bar.baz...) can fit, including the leading
+// underscores and trailing hyphens accepted in namespace path segments.
 func ValidateSystemLabelValue(value string) error {
 	if len(value) > SystemLabelValueMaxLength {
 		return fmt.Errorf("system label value exceeds maximum length of %d characters", SystemLabelValueMaxLength)
@@ -173,7 +178,8 @@ func ValidateSystemLabelValue(value string) error {
 	return nil
 }
 
-// ValidateLabelValueForKey validates a label value using the user or system limit implied by its key.
+// ValidateLabelValueForKey validates a label value using the user or system
+// limit implied by its key.
 func ValidateLabelValueForKey(key, value string) error {
 	if strings.HasPrefix(key, SystemLabelPrefix) {
 		return ValidateSystemLabelValue(value)
@@ -187,7 +193,7 @@ func ValidateLabelValueForKey(key, value string) error {
 // SystemLabelValueMaxLength cap.
 func ValidateLabels(labels map[string]string) error {
 	var result *multierror.Error
-	for _, key := range sortedMapKeys(labels) {
+	for _, key := range util.SortedStringMapKeys(labels) {
 		value := labels[key]
 		if err := ValidateLabelKey(key); err != nil {
 			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
@@ -204,7 +210,7 @@ func ValidateLabels(labels map[string]string) error {
 // reserved apxy/ namespace.
 func ValidateUserLabels(labels map[string]string) error {
 	var result *multierror.Error
-	for _, key := range sortedMapKeys(labels) {
+	for _, key := range util.SortedStringMapKeys(labels) {
 		value := labels[key]
 		if err := ValidateUserLabelKey(key); err != nil {
 			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
@@ -235,14 +241,15 @@ func ValidateAnnotationKey(key string) error { return ValidateLabelKey(key) }
 
 // ValidateAnnotationValue validates a single annotation value.
 // Annotation values have no format restriction — any string is allowed.
-// Individual value size is not restricted; only the total annotations size is checked.
+// Individual value size is not restricted; only the total annotations size is
+// checked.
 func ValidateAnnotationValue(_ string) error { return nil }
 
 // ValidateAnnotations validates all annotations in a map.
 func ValidateAnnotations(annotations map[string]string) error {
 	var result *multierror.Error
 	totalSize := 0
-	for _, key := range sortedMapKeys(annotations) {
+	for _, key := range util.SortedStringMapKeys(annotations) {
 		value := annotations[key]
 		if err := ValidateAnnotationKey(key); err != nil {
 			result = multierror.Append(result, fmt.Errorf("invalid annotation key %q: %w", key, err))
@@ -253,13 +260,4 @@ func ValidateAnnotations(annotations map[string]string) error {
 		result = multierror.Append(result, fmt.Errorf("total annotations size %d exceeds maximum of %d bytes", totalSize, AnnotationsTotalMaxSize))
 	}
 	return result.ErrorOrNil()
-}
-
-func sortedMapKeys(values map[string]string) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/internal/schema/resources/meta/labels.go
+++ b/internal/schema/resources/meta/labels.go
@@ -1,0 +1,196 @@
+package meta
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	LabelKeyNameMaxLength     = 63
+	LabelKeyPrefixMaxLength   = 253
+	LabelValueMaxLength       = 63
+	SystemLabelValueMaxLength = 253
+	AnnotationsTotalMaxSize   = 256 * 1024
+
+	SystemLabelPrefix   = "apxy/"
+	SystemLabelSentinel = "-"
+)
+
+var (
+	labelKeyNamePattern      = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$`)
+	labelKeyPrefixPattern    = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+	labelValuePattern        = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?)?$|^[a-zA-Z0-9]?$`)
+	systemPathSegmentPattern = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|-)$`)
+	systemLabelValuePattern  = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,253}$`)
+)
+
+func ValidateLabelKey(key string) error {
+	if key == "" {
+		return errors.New("label key cannot be empty")
+	}
+	if strings.HasPrefix(key, SystemLabelPrefix) {
+		return validateSystemLabelKey(key)
+	}
+
+	prefix, name, err := splitQualifiedKey(key)
+	if err != nil {
+		return err
+	}
+	if prefix != "" {
+		if len(prefix) > LabelKeyPrefixMaxLength {
+			return fmt.Errorf("label key prefix exceeds maximum length of %d characters", LabelKeyPrefixMaxLength)
+		}
+		if !labelKeyPrefixPattern.MatchString(prefix) {
+			return fmt.Errorf("label key prefix %q is not a valid DNS subdomain", prefix)
+		}
+	}
+	return validateLabelKeyName(name)
+}
+
+func splitQualifiedKey(key string) (string, string, error) {
+	if idx := strings.LastIndex(key, "/"); idx >= 0 {
+		if idx == 0 {
+			return "", "", errors.New("label key prefix cannot be empty when slash is present")
+		}
+		return key[:idx], key[idx+1:], nil
+	}
+	return "", key, nil
+}
+
+func validateLabelKeyName(name string) error {
+	if name == "" {
+		return errors.New("label key name cannot be empty")
+	}
+	if len(name) > LabelKeyNameMaxLength {
+		return fmt.Errorf("label key name exceeds maximum length of %d characters", LabelKeyNameMaxLength)
+	}
+	if !labelKeyNamePattern.MatchString(name) {
+		return fmt.Errorf("label key name %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", name)
+	}
+	return nil
+}
+
+func validateSystemLabelKey(key string) error {
+	prefix, name, err := splitQualifiedKey(key)
+	if err != nil {
+		return err
+	}
+	if len(prefix) > LabelKeyPrefixMaxLength {
+		return fmt.Errorf("label key prefix exceeds maximum length of %d characters", LabelKeyPrefixMaxLength)
+	}
+	innerPath := strings.TrimPrefix(prefix, strings.TrimSuffix(SystemLabelPrefix, "/"))
+	if innerPath == "" {
+		return fmt.Errorf("%s label key requires at least one segment after %s", SystemLabelPrefix, SystemLabelPrefix)
+	}
+	for _, segment := range strings.Split(strings.TrimPrefix(innerPath, "/"), "/") {
+		if segment == "" {
+			return fmt.Errorf("%s label key has empty path segment", SystemLabelPrefix)
+		}
+		if !systemPathSegmentPattern.MatchString(segment) {
+			return fmt.Errorf("%s label key segment %q must be a DNS label or the %q sentinel", SystemLabelPrefix, segment, SystemLabelSentinel)
+		}
+	}
+	return validateLabelKeyName(name)
+}
+
+func ValidateUserLabelKey(key string) error {
+	if strings.HasPrefix(key, SystemLabelPrefix) {
+		return fmt.Errorf("label key %q is in the reserved %q namespace and cannot be set by users", key, SystemLabelPrefix)
+	}
+	return ValidateLabelKey(key)
+}
+
+func ValidateLabelValue(value string) error {
+	if len(value) > LabelValueMaxLength {
+		return fmt.Errorf("label value exceeds maximum length of %d characters", LabelValueMaxLength)
+	}
+	if value != "" && !labelValuePattern.MatchString(value) {
+		return fmt.Errorf("label value %q must start and end with alphanumeric and contain only alphanumeric, '-', '_', or '.'", value)
+	}
+	return nil
+}
+
+func ValidateSystemLabelValue(value string) error {
+	if len(value) > SystemLabelValueMaxLength {
+		return fmt.Errorf("system label value exceeds maximum length of %d characters", SystemLabelValueMaxLength)
+	}
+	if value != "" && !systemLabelValuePattern.MatchString(value) {
+		return fmt.Errorf("system label value %q may contain only alphanumeric characters, '-', '_', or '.'", value)
+	}
+	return nil
+}
+
+func ValidateLabels(labels map[string]string) error {
+	var result *multierror.Error
+	for _, key := range sortedMapKeys(labels) {
+		value := labels[key]
+		if err := ValidateLabelKey(key); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
+		}
+		valueErr := ValidateLabelValue(value)
+		if strings.HasPrefix(key, SystemLabelPrefix) {
+			valueErr = ValidateSystemLabelValue(value)
+		}
+		if valueErr != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, valueErr))
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateUserLabels(labels map[string]string) error {
+	var result *multierror.Error
+	for _, key := range sortedMapKeys(labels) {
+		value := labels[key]
+		if err := ValidateUserLabelKey(key); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
+		}
+		if err := ValidateLabelValue(value); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, err))
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateUserLabelDeletionKeys(keys []string) error {
+	var result *multierror.Error
+	for _, key := range keys {
+		if err := ValidateUserLabelKey(key); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateAnnotationKey(key string) error { return ValidateLabelKey(key) }
+func ValidateAnnotationValue(_ string) error { return nil }
+
+func ValidateAnnotations(annotations map[string]string) error {
+	var result *multierror.Error
+	totalSize := 0
+	for _, key := range sortedMapKeys(annotations) {
+		value := annotations[key]
+		if err := ValidateAnnotationKey(key); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid annotation key %q: %w", key, err))
+		}
+		totalSize += len(key) + len(value)
+	}
+	if totalSize > AnnotationsTotalMaxSize {
+		result = multierror.Append(result, fmt.Errorf("total annotations size %d exceeds maximum of %d bytes", totalSize, AnnotationsTotalMaxSize))
+	}
+	return result.ErrorOrNil()
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/schema/resources/meta/labels.go
+++ b/internal/schema/resources/meta/labels.go
@@ -10,14 +10,34 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// Kubernetes-style label restrictions
 const (
-	LabelKeyNameMaxLength     = 63
-	LabelKeyPrefixMaxLength   = 253
-	LabelValueMaxLength       = 63
-	SystemLabelValueMaxLength = 253
-	AnnotationsTotalMaxSize   = 256 * 1024
+	// LabelKeyNameMaxLength is the maximum length for the name portion of a label key
+	LabelKeyNameMaxLength = 63
 
-	SystemLabelPrefix   = "apxy/"
+	// LabelKeyPrefixMaxLength is the maximum length for the optional prefix portion of a label key
+	LabelKeyPrefixMaxLength = 253
+
+	// LabelValueMaxLength is the maximum length for a label value
+	LabelValueMaxLength = 63
+
+	// SystemLabelValueMaxLength is the maximum length for a label value stored
+	// under an apxy/-prefixed key. System-managed labels such as
+	// apxy/<rt>/-/ns can hold a namespace path that may exceed the standard
+	// LabelValueMaxLength. User-supplied values are still capped at
+	// LabelValueMaxLength via ValidateLabelValue.
+	SystemLabelValueMaxLength = 253
+
+	// AnnotationsTotalMaxSize is the maximum total size of all annotations (keys + values) in bytes.
+	AnnotationsTotalMaxSize = 256 * 1024
+
+	// SystemLabelPrefix is the reserved label-key prefix for system-managed
+	// labels (implicit identifier labels and parent carry-forward labels).
+	// User-supplied label keys may not begin with this prefix.
+	SystemLabelPrefix = "apxy/"
+
+	// SystemLabelSentinel is the segment used inside apxy/ keys to mark an
+	// implicit identifier label, e.g. apxy/<rt>/-/id.
 	SystemLabelSentinel = "-"
 )
 
@@ -29,6 +49,23 @@ var (
 	systemLabelValuePattern  = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,253}$`)
 )
 
+// ValidateLabelKey validates a single label key.
+//
+// Two grammars are accepted:
+//
+//  1. Standard Kubernetes-style key: [prefix/]name
+//     - prefix (optional): valid DNS subdomain, max 253 characters
+//     - name (required): 1-63 characters, must start/end with alphanumeric,
+//     may contain '-', '_', '.'
+//
+//  2. Reserved apxy/ multi-segment key: apxy/<seg>(/<seg>)*/<name>
+//     - each <seg> is a DNS-label-like token or the literal "-" sentinel
+//     - <name> follows the standard name rule above
+//     - total prefix portion (everything before the final '/') still capped
+//     at LabelKeyPrefixMaxLength characters
+//
+// This function accepts apxy/ keys; user-input call sites should use
+// ValidateUserLabelKey to additionally reject the reserved namespace.
 func ValidateLabelKey(key string) error {
 	if key == "" {
 		return errors.New("label key cannot be empty")
@@ -98,6 +135,10 @@ func validateSystemLabelKey(key string) error {
 	return validateLabelKeyName(name)
 }
 
+// ValidateUserLabelKey validates a label key supplied directly by an end user.
+// In addition to the rules of ValidateLabelKey, it rejects any key in the
+// reserved apxy/ namespace — those keys are managed by the system and may not
+// be set, modified, or deleted through user-input endpoints.
 func ValidateUserLabelKey(key string) error {
 	if strings.HasPrefix(key, SystemLabelPrefix) {
 		return fmt.Errorf("label key %q is in the reserved %q namespace and cannot be set by users", key, SystemLabelPrefix)
@@ -105,6 +146,9 @@ func ValidateUserLabelKey(key string) error {
 	return ValidateLabelKey(key)
 }
 
+// ValidateLabelValue validates a single label value according to Kubernetes restrictions.
+// - 0-63 characters (can be empty)
+// - if non-empty: must start and end with alphanumeric, may contain alphanumeric, '-', '_', '.'
 func ValidateLabelValue(value string) error {
 	if len(value) > LabelValueMaxLength {
 		return fmt.Errorf("label value exceeds maximum length of %d characters", LabelValueMaxLength)
@@ -115,6 +159,10 @@ func ValidateLabelValue(value string) error {
 	return nil
 }
 
+// ValidateSystemLabelValue validates a label value stored under an apxy/-prefixed
+// key. It allows up to SystemLabelValueMaxLength characters so namespace paths
+// (e.g. root.foo.bar.baz...) can fit, including the leading underscores and
+// trailing hyphens accepted in namespace path segments.
 func ValidateSystemLabelValue(value string) error {
 	if len(value) > SystemLabelValueMaxLength {
 		return fmt.Errorf("system label value exceeds maximum length of %d characters", SystemLabelValueMaxLength)
@@ -125,6 +173,18 @@ func ValidateSystemLabelValue(value string) error {
 	return nil
 }
 
+// ValidateLabelValueForKey validates a label value using the user or system limit implied by its key.
+func ValidateLabelValueForKey(key, value string) error {
+	if strings.HasPrefix(key, SystemLabelPrefix) {
+		return ValidateSystemLabelValue(value)
+	}
+	return ValidateLabelValue(value)
+}
+
+// ValidateLabels validates all labels in a map. apxy/-prefixed keys are
+// accepted (use ValidateUserLabels at user-input boundaries instead) and
+// values stored under apxy/ keys are validated against the longer
+// SystemLabelValueMaxLength cap.
 func ValidateLabels(labels map[string]string) error {
 	var result *multierror.Error
 	for _, key := range sortedMapKeys(labels) {
@@ -132,17 +192,16 @@ func ValidateLabels(labels map[string]string) error {
 		if err := ValidateLabelKey(key); err != nil {
 			result = multierror.Append(result, fmt.Errorf("invalid label key %q: %w", key, err))
 		}
-		valueErr := ValidateLabelValue(value)
-		if strings.HasPrefix(key, SystemLabelPrefix) {
-			valueErr = ValidateSystemLabelValue(value)
-		}
-		if valueErr != nil {
-			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, valueErr))
+		if err := ValidateLabelValueForKey(key, value); err != nil {
+			result = multierror.Append(result, fmt.Errorf("invalid label value for key %q: %w", key, err))
 		}
 	}
 	return result.ErrorOrNil()
 }
 
+// ValidateUserLabels validates a labels map supplied by a user. It applies
+// the same key/value rules as ValidateLabels but rejects any key in the
+// reserved apxy/ namespace.
 func ValidateUserLabels(labels map[string]string) error {
 	var result *multierror.Error
 	for _, key := range sortedMapKeys(labels) {
@@ -157,6 +216,9 @@ func ValidateUserLabels(labels map[string]string) error {
 	return result.ErrorOrNil()
 }
 
+// ValidateUserLabelDeletionKeys validates a list of keys passed to a
+// user-facing label-deletion endpoint. Keys must be well-formed and must not
+// reference the reserved apxy/ namespace.
 func ValidateUserLabelDeletionKeys(keys []string) error {
 	var result *multierror.Error
 	for _, key := range keys {
@@ -167,9 +229,16 @@ func ValidateUserLabelDeletionKeys(keys []string) error {
 	return result.ErrorOrNil()
 }
 
+// ValidateAnnotationKey validates a single annotation key.
+// Annotation keys follow the same format as label keys.
 func ValidateAnnotationKey(key string) error { return ValidateLabelKey(key) }
+
+// ValidateAnnotationValue validates a single annotation value.
+// Annotation values have no format restriction — any string is allowed.
+// Individual value size is not restricted; only the total annotations size is checked.
 func ValidateAnnotationValue(_ string) error { return nil }
 
+// ValidateAnnotations validates all annotations in a map.
 func ValidateAnnotations(annotations map[string]string) error {
 	var result *multierror.Error
 	totalSize := 0

--- a/internal/schema/resources/meta/labels_test.go
+++ b/internal/schema/resources/meta/labels_test.go
@@ -1,0 +1,189 @@
+package meta
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelValidation(t *testing.T) {
+	t.Run("label keys", func(t *testing.T) {
+		validKeys := []string{
+			"a",
+			"A",
+			"0",
+			"my-key",
+			"my_key",
+			"my.key",
+			"app.kubernetes.io/name",
+			"a" + strings.Repeat("b", 61) + "c",
+			"apxy/cxr/-/id",
+			"apxy/cxn/-/ns",
+			"apxy/cxr/cxn/userkey",
+		}
+		for _, key := range validKeys {
+			t.Run("valid "+key, func(t *testing.T) {
+				require.NoError(t, ValidateLabelKey(key))
+			})
+		}
+
+		invalidKeys := []string{
+			"",
+			"-key",
+			"key-",
+			"_key",
+			"key_",
+			".key",
+			"key.",
+			"my key",
+			"my@key",
+			"/name",
+			"example.com/",
+			strings.Repeat("a", 64),
+			strings.Repeat("a", 254) + "/name",
+			"invalid..prefix/name",
+			"-invalid.prefix/name",
+			"apxy/",
+			"apxy//id",
+			"apxy/cxr//id",
+			"apxy/cxr/-/",
+			"apxy/cx@r/id",
+			"apxy/cxr/-/-bad",
+		}
+		for _, key := range invalidKeys {
+			t.Run("invalid "+key, func(t *testing.T) {
+				require.Error(t, ValidateLabelKey(key))
+			})
+		}
+	})
+
+	t.Run("user label keys", func(t *testing.T) {
+		require.NoError(t, ValidateUserLabelKey("my-key"))
+		require.NoError(t, ValidateUserLabelKey("example.com/key"))
+		require.Error(t, ValidateUserLabelKey("-bad"))
+		require.Error(t, ValidateUserLabelKey(""))
+
+		err := ValidateUserLabelKey("apxy/cxr/type")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reserved")
+	})
+
+	t.Run("user label maps", func(t *testing.T) {
+		require.NoError(t, ValidateUserLabels(map[string]string{
+			"team": "platform",
+			"env":  "prod",
+		}))
+
+		err := ValidateUserLabels(map[string]string{
+			"good":         "ok",
+			"apxy/cxr/bad": "nope",
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reserved")
+
+		require.NoError(t, ValidateUserLabelDeletionKeys([]string{"team", "env"}))
+		err = ValidateUserLabelDeletionKeys([]string{"team", "apxy/cxr/type"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reserved")
+	})
+
+	t.Run("label values", func(t *testing.T) {
+		validValues := []string{
+			"",
+			"a",
+			"A",
+			"0",
+			"my-value",
+			"my_value",
+			"v1.2.3",
+			"a" + strings.Repeat("b", 61) + "c",
+		}
+		for _, value := range validValues {
+			require.NoError(t, ValidateLabelValue(value), "value %q should be valid", value)
+		}
+
+		invalidValues := []string{
+			"-value",
+			"value-",
+			"_value",
+			"value_",
+			".value",
+			"value.",
+			"my value",
+			"my@value",
+			strings.Repeat("a", 64),
+		}
+		for _, value := range invalidValues {
+			require.Error(t, ValidateLabelValue(value), "value %q should be invalid", value)
+		}
+	})
+
+	t.Run("system label values", func(t *testing.T) {
+		longPath := "root." + strings.Repeat("a", 60) + ".more"
+		require.Greater(t, len(longPath), LabelValueMaxLength)
+		require.Error(t, ValidateLabelValue(longPath))
+		require.NoError(t, ValidateSystemLabelValue(longPath))
+		require.NoError(t, ValidateSystemLabelValue("_billing-"))
+		require.Error(t, ValidateLabelValue("_billing-"))
+
+		tooLong := "a" + strings.Repeat("b", 252) + "c"
+		require.Equal(t, SystemLabelValueMaxLength+1, len(tooLong))
+		require.Error(t, ValidateSystemLabelValue(tooLong))
+
+		require.NoError(t, ValidateLabelValueForKey("apxy/cxn/-/ns", longPath))
+		require.Error(t, ValidateLabelValueForKey("team", longPath))
+	})
+
+	t.Run("label maps", func(t *testing.T) {
+		require.NoError(t, ValidateLabels(map[string]string{
+			"app":                    "myapp",
+			"app.kubernetes.io/name": "myapp",
+			"empty-value":            "",
+		}))
+		require.Error(t, ValidateLabels(map[string]string{"app": "**bad**"}))
+		require.Error(t, ValidateLabels(map[string]string{"-bad": "myapp"}))
+
+		longPath := "root." + strings.Repeat("a", 60) + ".more"
+		require.NoError(t, ValidateLabels(map[string]string{"apxy/cxn/-/ns": longPath}))
+		require.Error(t, ValidateLabels(map[string]string{"team": longPath}))
+	})
+}
+
+func TestAnnotationValidation(t *testing.T) {
+	t.Run("annotation keys", func(t *testing.T) {
+		for _, key := range []string{"a", "my-key", "my_key", "my.key", "example.com/my-key"} {
+			require.NoError(t, ValidateAnnotationKey(key))
+		}
+		for _, key := range []string{"", "-key", "my key", "/name", strings.Repeat("a", 64)} {
+			require.Error(t, ValidateAnnotationKey(key))
+		}
+	})
+
+	t.Run("annotation values", func(t *testing.T) {
+		for _, value := range []string{
+			"",
+			"simple",
+			"has spaces",
+			"has-special@chars#!",
+			strings.Repeat("a", 1000),
+			"multi\nline\nvalue",
+		} {
+			require.NoError(t, ValidateAnnotationValue(value))
+		}
+	})
+
+	t.Run("annotation maps", func(t *testing.T) {
+		require.NoError(t, ValidateAnnotations(map[string]string{
+			"app":                "my application description",
+			"example.com/config": `{"key": "value"}`,
+		}))
+		require.Error(t, ValidateAnnotations(map[string]string{"-bad-key": "value"}))
+
+		err := ValidateAnnotations(map[string]string{
+			"key": strings.Repeat("x", AnnotationsTotalMaxSize),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "exceeds maximum")
+	})
+}

--- a/internal/schema/resources/meta/meta_test.go
+++ b/internal/schema/resources/meta/meta_test.go
@@ -1,0 +1,272 @@
+package meta
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestTypeMetaSerializationIsTopLevelWhenEmbedded(t *testing.T) {
+	type resource struct {
+		TypeMeta `json:",inline" yaml:",inline"`
+		Metadata ObjectMeta     `json:"metadata" yaml:"metadata"`
+		Spec     map[string]any `json:"spec" yaml:"spec"`
+	}
+	value := resource{
+		TypeMeta: NewTypeMeta("Widget"),
+		Metadata: ObjectMeta{Name: "example"},
+		Spec:     map[string]any{"enabled": true},
+	}
+
+	jsonBytes, err := json.Marshal(value)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"apiVersion":"authproxy.net/v1alpha1","kind":"Widget","metadata":{"name":"example"},"spec":{"enabled":true}}`, string(jsonBytes))
+
+	yamlBytes, err := yaml.Marshal(value)
+	require.NoError(t, err)
+	require.Contains(t, string(yamlBytes), "apiVersion: authproxy.net/v1alpha1\nkind: Widget\nmetadata:")
+}
+
+func TestAPIVersionParsing(t *testing.T) {
+	parsed, err := ParseAPIVersion("authproxy.net/v1alpha1")
+	require.NoError(t, err)
+	require.Equal(t, APIGroup, parsed.Group())
+	require.Equal(t, APIVersionName, parsed.Version())
+
+	for _, invalid := range []string{"", "v1alpha1", "authproxy.net/alpha1", "AuthProxy.net/v1", "authproxy..net/v1"} {
+		t.Run(invalid, func(t *testing.T) {
+			_, err := ParseAPIVersion(invalid)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidationContexts(t *testing.T) {
+	now := time.Date(2026, 8, 28, 14, 30, 0, 0, time.FixedZone("offset", -5*60*60))
+	typeMeta := NewTypeMeta("Widget")
+
+	t.Run("create rejects server-owned identity", func(t *testing.T) {
+		err := ValidateResource(typeMeta, ObjectMeta{
+			ID:         "wid_123",
+			Name:       "example",
+			Namespace:  "root",
+			Generation: 1,
+			CreatedAt:  &now,
+		}, ValidationOptions{
+			Mode:               ValidationModeCreate,
+			ExpectedAPIVersion: APIVersionV1Alpha1,
+			ExpectedKind:       "Widget",
+			RequireName:        true,
+			RequireNamespace:   true,
+		})
+		require.ErrorContains(t, err, "$.metadata.id: is server-owned on create")
+		require.ErrorContains(t, err, "$.metadata.generation: is server-owned on create")
+		require.ErrorContains(t, err, "$.metadata.createdAt: is server-owned")
+	})
+
+	t.Run("update accepts immutable identity for comparison but rejects timestamps", func(t *testing.T) {
+		err := ValidateObjectMeta(ObjectMeta{
+			ID:         "wid_123",
+			Name:       "example",
+			Namespace:  "root",
+			Generation: 2,
+			UpdatedAt:  &now,
+		}, ValidationOptions{Mode: ValidationModeUpdate})
+		require.ErrorContains(t, err, "$.metadata.updatedAt: is server-owned")
+		require.NotContains(t, err.Error(), "generation")
+	})
+
+	t.Run("config permits explicit identity and generation", func(t *testing.T) {
+		err := ValidateObjectMeta(ObjectMeta{
+			ID:         "wid_123",
+			Name:       "example",
+			Namespace:  "root",
+			Generation: 2,
+			Labels:     map[string]string{"environment": "demo"},
+		}, ValidationOptions{Mode: ValidationModeConfig})
+		require.NoError(t, err)
+	})
+
+	t.Run("persistence permits system metadata", func(t *testing.T) {
+		err := ValidateObjectMeta(ObjectMeta{
+			ID:         "wid_123",
+			Name:       "example",
+			Namespace:  "root",
+			Generation: 2,
+			Labels:     map[string]string{"apxy/wid/-/ns": "root.child"},
+			CreatedAt:  &now,
+			UpdatedAt:  &now,
+		}, ValidationOptions{Mode: ValidationModePersistence, RequireID: true})
+		require.NoError(t, err)
+	})
+
+	t.Run("response enforces resource-selected requirements", func(t *testing.T) {
+		err := ValidateObjectMeta(ObjectMeta{Name: "example"}, ValidationOptions{
+			Mode:             ValidationModeResponse,
+			RequireID:        true,
+			RequireName:      true,
+			RequireNamespace: true,
+		})
+		require.ErrorContains(t, err, "$.metadata.id: is required")
+		require.ErrorContains(t, err, "$.metadata.namespace: is required")
+	})
+}
+
+func TestTypeMetaAndImmutableValidationUseFieldPaths(t *testing.T) {
+	err := ValidateTypeMeta(
+		TypeMeta{APIVersion: "authproxy.net/v1alpha2", Kind: "Gadget"},
+		APIVersionV1Alpha1,
+		"Widget",
+		&common.ValidationContext{Path: "$"},
+	)
+	require.ErrorContains(t, err, `$.apiVersion: must be "authproxy.net/v1alpha1"`)
+	require.ErrorContains(t, err, `$.kind: must be "Widget"`)
+
+	created := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	later := created.Add(time.Minute)
+	err = ValidateMetadataUpdate(
+		ObjectMeta{ID: "wid_1", Name: "old", Namespace: "root", Generation: 1, CreatedAt: &created},
+		ObjectMeta{ID: "wid_2", Name: "new", Namespace: "root.child", Generation: 2, CreatedAt: &later},
+		UpdateOptions{ImmutableName: true, ImmutableNamespace: true},
+		nil,
+	)
+	for _, path := range []string{"$.metadata.id", "$.metadata.name", "$.metadata.namespace", "$.metadata.generation", "$.metadata.createdAt"} {
+		require.ErrorContains(t, err, path)
+	}
+}
+
+func TestStatusReferenceAndConditionValidation(t *testing.T) {
+	status := struct {
+		State string
+	}{State: "ready"}
+	require.ErrorContains(t, ValidateStatus(status, ValidationModeCreate, nil), "$.status: is server-owned")
+	require.ErrorContains(t, ValidateStatus(status, ValidationModeUpdate, nil), "$.status: is server-owned")
+	require.ErrorContains(t, ValidateStatus(status, ValidationModeConfig, nil), "$.status: is server-owned")
+	require.NoError(t, ValidateStatus(status, ValidationModePersistence, nil))
+	require.NoError(t, ValidateStatus(status, ValidationModeResponse, nil))
+	require.NoError(t, ValidateStatus(nil, ValidationModeCreate, nil))
+
+	reference := ObjectReference{APIVersion: APIVersionV1Alpha1, Kind: "Connector", ID: "cxr_123"}
+	require.NoError(t, ValidateObjectReference(reference, &common.ValidationContext{Path: "$.metadata.target"}))
+	reference.ID = ""
+	require.ErrorContains(t, ValidateObjectReference(reference, &common.ValidationContext{Path: "$.metadata.target"}), "$.metadata.target: must contain id or name")
+
+	condition := NewCondition("Ready", ConditionTrue, 1, "Configured", "ready", time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC))
+	require.NoError(t, ValidateCondition(condition, &common.ValidationContext{Path: "$.status.conditions[0]"}))
+	condition.Status = "yes"
+	require.ErrorContains(t, ValidateCondition(condition, nil), "$.status")
+}
+
+func TestObjectMetaDefaultingNormalizationAndPatchSemantics(t *testing.T) {
+	local := time.Date(2026, 8, 28, 9, 0, 0, 0, time.FixedZone("offset", 2*60*60))
+	defaults := ObjectMeta{
+		ID:          "wid_1",
+		Name:        "default-name",
+		Namespace:   "root",
+		Generation:  1,
+		Labels:      map[string]string{"default": "true"},
+		Annotations: map[string]string{"note": "default"},
+		CreatedAt:   &local,
+		UpdatedAt:   &local,
+	}
+
+	value, err := ApplyObjectMetaDefaults(ObjectMeta{
+		Name:        "explicit-name",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}, defaults, ValidationModePersistence, nil)
+	require.NoError(t, err)
+	require.Equal(t, "wid_1", value.ID)
+	require.Equal(t, common.ResourceName("explicit-name"), value.Name)
+	require.Empty(t, value.Labels)
+	require.NotNil(t, value.Labels)
+	require.Empty(t, value.Annotations)
+	require.NotNil(t, value.Annotations)
+	require.Equal(t, time.UTC, value.CreatedAt.Location())
+
+	_, err = ApplyObjectMetaDefaults(ObjectMeta{}, ObjectMeta{ID: "wid_1"}, ValidationModeCreate, nil)
+	require.ErrorContains(t, err, "$.metadata.id")
+
+	original := ObjectMeta{
+		Name:        "before",
+		Labels:      map[string]string{"keep": "me"},
+		Annotations: map[string]string{"keep": "me"},
+	}
+	unchanged := ApplyObjectMetaPatch(original, ObjectMetaPatch{})
+	require.Equal(t, original, unchanged)
+	unchanged.Labels["mutated"] = "copy"
+	require.NotContains(t, original.Labels, "mutated")
+
+	emptyLabels := map[string]string{}
+	replaced := ApplyObjectMetaPatch(original, ObjectMetaPatch{Labels: &emptyLabels})
+	require.Empty(t, replaced.Labels)
+	require.NotNil(t, replaced.Labels)
+	require.Equal(t, original.Annotations, replaced.Annotations)
+
+	var omittedPatch ObjectMetaPatch
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &omittedPatch))
+	require.Nil(t, omittedPatch.Labels)
+	var clearPatch ObjectMetaPatch
+	require.NoError(t, json.Unmarshal([]byte(`{"labels":{},"annotations":{}}`), &clearPatch))
+	require.NotNil(t, clearPatch.Labels)
+	require.Empty(t, *clearPatch.Labels)
+	require.NotNil(t, clearPatch.Annotations)
+	require.Empty(t, *clearPatch.Annotations)
+}
+
+func TestCanonicalSpecJSONAndSemanticHash(t *testing.T) {
+	left := map[string]any{
+		"nested": json.RawMessage(`{ "z": 2, "a": 1 }`),
+		"name":   "example",
+	}
+	right := map[string]any{
+		"name":   "example",
+		"nested": map[string]any{"a": json.Number("1"), "z": json.Number("2")},
+	}
+
+	leftJSON, err := CanonicalSpecJSON(left)
+	require.NoError(t, err)
+	rightJSON, err := CanonicalSpecJSON(right)
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"example","nested":{"a":1,"z":2}}`, string(leftJSON))
+	require.Equal(t, leftJSON, rightJSON)
+
+	leftHash, err := SemanticSpecHash(left)
+	require.NoError(t, err)
+	rightHash, err := SemanticSpecHash(right)
+	require.NoError(t, err)
+	require.Equal(t, leftHash, rightHash)
+	require.Len(t, leftHash, 64)
+
+	differentHash, err := SemanticSpecHash(map[string]any{"name": "different"})
+	require.NoError(t, err)
+	require.NotEqual(t, leftHash, differentHash)
+}
+
+func TestReferenceAndConditionConstructors(t *testing.T) {
+	reference := NewObjectReference(NewTypeMeta("Connector"), ObjectMeta{
+		ID: "cxr_123", Name: "greenhouse", Namespace: "root", Generation: 3,
+	})
+	require.Equal(t, ObjectReference{
+		APIVersion: APIVersionV1Alpha1,
+		Kind:       "Connector",
+		ID:         "cxr_123",
+		Name:       "greenhouse",
+		Namespace:  "root",
+		Generation: 3,
+	}, reference)
+
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.FixedZone("offset", 60*60))
+	condition := NewCondition("Ready", ConditionTrue, 3, "Configured", "ready", now)
+	require.Equal(t, time.UTC, condition.LastTransitionTime.Location())
+
+	later := now.Add(time.Hour)
+	updated := UpsertCondition([]Condition{condition}, NewCondition("Ready", ConditionTrue, 4, "StillConfigured", "still ready", later))
+	require.Len(t, updated, 1)
+	require.Equal(t, condition.LastTransitionTime, updated[0].LastTransitionTime)
+	require.Equal(t, uint64(4), updated[0].ObservedGeneration)
+}

--- a/internal/schema/resources/meta/normalize.go
+++ b/internal/schema/resources/meta/normalize.go
@@ -1,0 +1,132 @@
+package meta
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// NormalizeObjectMeta returns a deep copy with timestamps normalized to UTC.
+// It deliberately does not trim or case-fold names, namespaces, labels, or
+// annotations because those values are case-sensitive resource data.
+func NormalizeObjectMeta(value ObjectMeta) ObjectMeta {
+	value.Labels = cloneStringMap(value.Labels)
+	value.Annotations = cloneStringMap(value.Annotations)
+	value.CreatedAt = utcTimePointer(value.CreatedAt)
+	value.UpdatedAt = utcTimePointer(value.UpdatedAt)
+	return value
+}
+
+// ApplyObjectMetaDefaults fills only zero or nil fields. Explicit empty maps
+// are preserved, so callers can distinguish "not supplied" from "supplied but
+// empty" before or after defaulting.
+func ApplyObjectMetaDefaults(value, defaults ObjectMeta, mode ValidationMode, path *common.ValidationContext) (ObjectMeta, error) {
+	if err := mode.Validate(); err != nil {
+		return ObjectMeta{}, validationPath(path).NewError(err.Error())
+	}
+	if err := validateDefaultsForMode(defaults, mode, path); err != nil {
+		return ObjectMeta{}, err
+	}
+
+	value = NormalizeObjectMeta(value)
+	defaults = NormalizeObjectMeta(defaults)
+	if value.ID == "" {
+		value.ID = defaults.ID
+	}
+	if value.Name == "" {
+		value.Name = defaults.Name
+	}
+	if value.Namespace == "" {
+		value.Namespace = defaults.Namespace
+	}
+	if value.Generation == 0 {
+		value.Generation = defaults.Generation
+	}
+	if value.Labels == nil {
+		value.Labels = defaults.Labels
+	}
+	if value.Annotations == nil {
+		value.Annotations = defaults.Annotations
+	}
+	if value.CreatedAt == nil {
+		value.CreatedAt = defaults.CreatedAt
+	}
+	if value.UpdatedAt == nil {
+		value.UpdatedAt = defaults.UpdatedAt
+	}
+	return value, nil
+}
+
+func validateDefaultsForMode(defaults ObjectMeta, mode ValidationMode, path *common.ValidationContext) error {
+	vc := validationPath(path).PushField("metadata")
+	if mode == ValidationModeCreate {
+		if defaults.ID != "" {
+			return vc.NewErrorForField("id", "cannot be defaulted in create context")
+		}
+		if defaults.Generation != 0 {
+			return vc.NewErrorForField("generation", "cannot be defaulted in create context")
+		}
+	}
+	if mode == ValidationModeCreate || mode == ValidationModeUpdate || mode == ValidationModeConfig {
+		if defaults.CreatedAt != nil {
+			return vc.NewErrorForField("createdAt", fmt.Sprintf("cannot be defaulted in %s context", mode))
+		}
+		if defaults.UpdatedAt != nil {
+			return vc.NewErrorForField("updatedAt", fmt.Sprintf("cannot be defaulted in %s context", mode))
+		}
+	}
+	return nil
+}
+
+// ApplyObjectMetaPatch applies every non-nil patch field to a deep copy of the
+// original metadata. Call ValidateMetadataUpdate and the applicable lifecycle
+// validation after applying it so attempts to modify immutable or server-owned
+// fields fail instead of being silently discarded.
+func ApplyObjectMetaPatch(original ObjectMeta, patch ObjectMetaPatch) ObjectMeta {
+	result := NormalizeObjectMeta(original)
+	if patch.ID != nil {
+		result.ID = *patch.ID
+	}
+	if patch.Name != nil {
+		result.Name = *patch.Name
+	}
+	if patch.Namespace != nil {
+		result.Namespace = *patch.Namespace
+	}
+	if patch.Generation != nil {
+		result.Generation = *patch.Generation
+	}
+	if patch.Labels != nil {
+		result.Labels = cloneStringMap(*patch.Labels)
+	}
+	if patch.Annotations != nil {
+		result.Annotations = cloneStringMap(*patch.Annotations)
+	}
+	if patch.CreatedAt != nil {
+		result.CreatedAt = utcTimePointer(patch.CreatedAt)
+	}
+	if patch.UpdatedAt != nil {
+		result.UpdatedAt = utcTimePointer(patch.UpdatedAt)
+	}
+	return result
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}
+
+func utcTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
+}

--- a/internal/schema/resources/meta/normalize.go
+++ b/internal/schema/resources/meta/normalize.go
@@ -2,35 +2,43 @@ package meta
 
 import (
 	"fmt"
-	"time"
+	"maps"
 
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // NormalizeObjectMeta returns a deep copy with timestamps normalized to UTC.
 // It deliberately does not trim or case-fold names, namespaces, labels, or
 // annotations because those values are case-sensitive resource data.
 func NormalizeObjectMeta(value ObjectMeta) ObjectMeta {
-	value.Labels = cloneStringMap(value.Labels)
-	value.Annotations = cloneStringMap(value.Annotations)
-	value.CreatedAt = utcTimePointer(value.CreatedAt)
-	value.UpdatedAt = utcTimePointer(value.UpdatedAt)
+	value.Labels = maps.Clone(value.Labels)
+	value.Annotations = maps.Clone(value.Annotations)
+	value.CreatedAt = util.UtcTimePointer(value.CreatedAt)
+	value.UpdatedAt = util.UtcTimePointer(value.UpdatedAt)
 	return value
 }
 
 // ApplyObjectMetaDefaults fills only zero or nil fields. Explicit empty maps
 // are preserved, so callers can distinguish "not supplied" from "supplied but
 // empty" before or after defaulting.
-func ApplyObjectMetaDefaults(value, defaults ObjectMeta, mode ValidationMode, path *common.ValidationContext) (ObjectMeta, error) {
+func ApplyObjectMetaDefaults(
+	value, defaults ObjectMeta,
+	mode ValidationMode,
+	path *common.ValidationContext,
+) (ObjectMeta, error) {
 	if err := mode.Validate(); err != nil {
 		return ObjectMeta{}, validationPath(path).NewError(err.Error())
 	}
+
 	if err := validateDefaultsForMode(defaults, mode, path); err != nil {
 		return ObjectMeta{}, err
 	}
 
 	value = NormalizeObjectMeta(value)
 	defaults = NormalizeObjectMeta(defaults)
+
+	// Apply defaults for values that aren't populated
 	if value.ID == "" {
 		value.ID = defaults.ID
 	}
@@ -55,27 +63,39 @@ func ApplyObjectMetaDefaults(value, defaults ObjectMeta, mode ValidationMode, pa
 	if value.UpdatedAt == nil {
 		value.UpdatedAt = defaults.UpdatedAt
 	}
+
 	return value, nil
 }
 
-func validateDefaultsForMode(defaults ObjectMeta, mode ValidationMode, path *common.ValidationContext) error {
+func validateDefaultsForMode(
+	defaults ObjectMeta,
+	mode ValidationMode,
+	path *common.ValidationContext,
+) error {
 	vc := validationPath(path).PushField("metadata")
+
 	if mode == ValidationModeCreate {
 		if defaults.ID != "" {
 			return vc.NewErrorForField("id", "cannot be defaulted in create context")
 		}
+
 		if defaults.Generation != 0 {
 			return vc.NewErrorForField("generation", "cannot be defaulted in create context")
 		}
 	}
-	if mode == ValidationModeCreate || mode == ValidationModeUpdate || mode == ValidationModeConfig {
+
+	if mode == ValidationModeCreate ||
+		mode == ValidationModeUpdate ||
+		mode == ValidationModeConfig {
 		if defaults.CreatedAt != nil {
 			return vc.NewErrorForField("createdAt", fmt.Sprintf("cannot be defaulted in %s context", mode))
 		}
+
 		if defaults.UpdatedAt != nil {
 			return vc.NewErrorForField("updatedAt", fmt.Sprintf("cannot be defaulted in %s context", mode))
 		}
 	}
+
 	return nil
 }
 
@@ -83,8 +103,12 @@ func validateDefaultsForMode(defaults ObjectMeta, mode ValidationMode, path *com
 // original metadata. Call ValidateMetadataUpdate and the applicable lifecycle
 // validation after applying it so attempts to modify immutable or server-owned
 // fields fail instead of being silently discarded.
-func ApplyObjectMetaPatch(original ObjectMeta, patch ObjectMetaPatch) ObjectMeta {
+func ApplyObjectMetaPatch(
+	original ObjectMeta,
+	patch ObjectMetaPatch,
+) ObjectMeta {
 	result := NormalizeObjectMeta(original)
+
 	if patch.ID != nil {
 		result.ID = *patch.ID
 	}
@@ -98,35 +122,17 @@ func ApplyObjectMetaPatch(original ObjectMeta, patch ObjectMetaPatch) ObjectMeta
 		result.Generation = *patch.Generation
 	}
 	if patch.Labels != nil {
-		result.Labels = cloneStringMap(*patch.Labels)
+		result.Labels = maps.Clone(*patch.Labels)
 	}
 	if patch.Annotations != nil {
-		result.Annotations = cloneStringMap(*patch.Annotations)
+		result.Annotations = maps.Clone(*patch.Annotations)
 	}
 	if patch.CreatedAt != nil {
-		result.CreatedAt = utcTimePointer(patch.CreatedAt)
+		result.CreatedAt = util.UtcTimePointer(patch.CreatedAt)
 	}
 	if patch.UpdatedAt != nil {
-		result.UpdatedAt = utcTimePointer(patch.UpdatedAt)
+		result.UpdatedAt = util.UtcTimePointer(patch.UpdatedAt)
 	}
-	return result
-}
 
-func cloneStringMap(values map[string]string) map[string]string {
-	if values == nil {
-		return nil
-	}
-	result := make(map[string]string, len(values))
-	for key, value := range values {
-		result[key] = value
-	}
 	return result
-}
-
-func utcTimePointer(value *time.Time) *time.Time {
-	if value == nil {
-		return nil
-	}
-	normalized := value.UTC()
-	return &normalized
 }

--- a/internal/schema/resources/meta/schema.go
+++ b/internal/schema/resources/meta/schema.go
@@ -1,0 +1,3 @@
+package meta
+
+const SchemaID = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/resources/meta/schema.json"

--- a/internal/schema/resources/meta/schema.json
+++ b/internal/schema/resources/meta/schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/resources/meta/schema.json",
+  "$defs": {
+    "APIVersion": {
+      "type": "string",
+      "const": "authproxy.net/v1alpha1"
+    },
+    "Kind": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Za-z0-9]*$"
+    },
+    "TypeMeta": {
+      "type": "object",
+      "required": ["apiVersion", "kind"],
+      "properties": {
+        "apiVersion": { "$ref": "#/$defs/APIVersion" },
+        "kind": { "$ref": "#/$defs/Kind" }
+      }
+    },
+    "Resource": {
+      "description": "Open base envelope for composition by a concrete resource schema. The concrete schema must close unevaluated properties.",
+      "allOf": [
+        { "$ref": "#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "spec"],
+          "properties": {
+            "metadata": { "$ref": "#/$defs/ObjectMeta" },
+            "spec": { "type": "object" },
+            "status": { "type": "object" }
+          }
+        }
+      ]
+    },
+    "LabelKey": {
+      "type": "string",
+      "anyOf": [
+        {
+          "pattern": "^(([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?/)?[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$"
+        },
+        {
+          "pattern": "^apxy/([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?|-)(/([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?|-))*/[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$"
+        }
+      ]
+    },
+    "Labels": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/LabelKey" },
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 253,
+        "pattern": "^[A-Za-z0-9._-]*$"
+      }
+    },
+    "Annotations": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/LabelKey" },
+      "additionalProperties": { "type": "string" }
+    },
+    "ObjectMeta": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "../../common/schema.json#/$defs/ResourceName" },
+        "namespace": { "type": "string", "minLength": 1 },
+        "generation": { "type": "integer", "minimum": 1 },
+        "labels": { "$ref": "#/$defs/Labels" },
+        "annotations": { "$ref": "#/$defs/Annotations" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "ObjectMetaPatch": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "$ref": "../../common/schema.json#/$defs/ResourceName" },
+        "namespace": { "type": "string", "minLength": 1 },
+        "generation": { "type": "integer", "minimum": 1 },
+        "labels": { "$ref": "#/$defs/Labels" },
+        "annotations": { "$ref": "#/$defs/Annotations" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "ObjectReference": {
+      "allOf": [
+        { "$ref": "#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "name": { "$ref": "../../common/schema.json#/$defs/ResourceName" },
+            "namespace": { "type": "string", "minLength": 1 },
+            "generation": { "type": "integer", "minimum": 1 }
+          },
+          "anyOf": [
+            { "required": ["id"] },
+            { "required": ["name"] }
+          ]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Condition": {
+      "type": "object",
+      "required": ["type", "status", "lastTransitionTime"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["True", "False", "Unknown"] },
+        "observedGeneration": { "type": "integer", "minimum": 1 },
+        "lastTransitionTime": { "type": "string", "format": "date-time" },
+        "reason": { "type": "string" },
+        "message": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/internal/schema/resources/meta/schema_test.go
+++ b/internal/schema/resources/meta/schema_test.go
@@ -1,0 +1,105 @@
+package meta
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func addSchema(t *testing.T, compiler *jsonschemav5.Compiler, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var header struct {
+		ID string `json:"$id"`
+	}
+	require.NoError(t, json.Unmarshal(data, &header))
+	require.NoError(t, compiler.AddResource(header.ID, bytes.NewReader(data)))
+	return header.ID
+}
+
+func compileDefinition(t *testing.T, definition string) *jsonschemav5.Schema {
+	t.Helper()
+	compiler := jsonschemav5.NewCompiler()
+	addSchema(t, compiler, "../../common/schema.json")
+	id := addSchema(t, compiler, "schema.json")
+	require.Equal(t, SchemaID, id)
+	schema, err := compiler.Compile(id + "#/$defs/" + definition)
+	require.NoError(t, err)
+	return schema
+}
+
+func validateJSON(t *testing.T, schema *jsonschemav5.Schema, value string) error {
+	t.Helper()
+	var decoded any
+	require.NoError(t, json.Unmarshal([]byte(value), &decoded))
+	return schema.Validate(decoded)
+}
+
+func TestSchemaDefinitions(t *testing.T) {
+	tests := []struct {
+		definition string
+		valid      string
+		invalid    string
+	}{
+		{"TypeMeta", `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector"}`, `{"apiVersion":"authproxy.net/v1alpha2","kind":"connector"}`},
+		{"ObjectMeta", `{"id":"cxr_123","name":"greenhouse","namespace":"root","generation":3,"labels":{"environment":"demo"}}`, `{"name":"-bad","unknown":true}`},
+		{"ObjectMetaPatch", `{"labels":{},"annotations":{}}`, `{"generation":0}`},
+		{"ObjectReference", `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","id":"cxr_123","generation":3}`, `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector"}`},
+		{"Condition", `{"type":"Ready","status":"True","observedGeneration":3,"lastTransitionTime":"2026-08-28T10:00:00Z"}`, `{"type":"Ready","status":"yes","lastTransitionTime":"not-a-time"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.definition, func(t *testing.T) {
+			schema := compileDefinition(t, test.definition)
+			require.NoError(t, validateJSON(t, schema, test.valid))
+			require.Error(t, validateJSON(t, schema, test.invalid))
+		})
+	}
+}
+
+func TestResourceSchemaComposesWithoutRepeatingTypeMeta(t *testing.T) {
+	compiler := jsonschemav5.NewCompiler()
+	addSchema(t, compiler, "../../common/schema.json")
+	addSchema(t, compiler, "schema.json")
+	const concreteID = "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/schema/resources/meta/test-widget.json"
+	require.NoError(t, compiler.AddResource(concreteID, strings.NewReader(`{
+      "$schema":"https://json-schema.org/draft/2020-12/schema",
+      "$id":"`+concreteID+`",
+      "allOf":[
+        {"$ref":"./schema.json#/$defs/Resource"},
+        {
+          "type":"object",
+          "properties":{
+            "kind":{"const":"Widget"},
+            "spec":{
+              "type":"object",
+              "required":["enabled"],
+              "properties":{"enabled":{"type":"boolean"}},
+              "additionalProperties":false
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties":false
+    }`)))
+	schema, err := compiler.Compile(concreteID)
+	require.NoError(t, err)
+	require.NoError(t, validateJSON(t, schema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Widget",
+      "metadata":{"name":"example"},
+      "spec":{"enabled":true}
+    }`))
+	require.Error(t, validateJSON(t, schema, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Widget",
+      "metadata":{"name":"example"},
+      "spec":{"enabled":true},
+      "unknown":true
+    }`))
+}

--- a/internal/schema/resources/meta/types.go
+++ b/internal/schema/resources/meta/types.go
@@ -1,0 +1,74 @@
+package meta
+
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// TypeMeta identifies the schema used to decode a resource or transport
+// object. Embed it in a resource with yaml:",inline" so apiVersion and kind
+// remain top-level fields in both JSON and YAML.
+type TypeMeta struct {
+	APIVersion APIVersion `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind       `json:"kind" yaml:"kind"`
+}
+
+// ObjectMeta contains identity and common lifecycle metadata shared by
+// AuthProxy resources. Resource packages decide which fields are applicable
+// and required for each operation.
+type ObjectMeta struct {
+	ID          string              `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        common.ResourceName `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace   string              `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Generation  uint64              `json:"generation,omitempty" yaml:"generation,omitempty"`
+	Labels      map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   *time.Time          `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt   *time.Time          `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+}
+
+// ObjectMetaPatch represents a metadata merge patch. A nil field leaves the
+// current value unchanged. A non-nil pointer to an empty labels or annotations
+// map clears that map.
+type ObjectMetaPatch struct {
+	ID          *string              `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        *common.ResourceName `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace   *string              `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Generation  *uint64              `json:"generation,omitempty" yaml:"generation,omitempty"`
+	Labels      *map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations *map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CreatedAt   *time.Time           `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt   *time.Time           `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+}
+
+// ObjectReference contains stable identity without copying another resource's
+// spec or status. ID, name, namespace, and generation are populated only when
+// they apply to the referenced kind.
+type ObjectReference struct {
+	APIVersion APIVersion          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                `json:"kind" yaml:"kind"`
+	ID         string              `json:"id,omitempty" yaml:"id,omitempty"`
+	Name       common.ResourceName `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace  string              `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Generation uint64              `json:"generation,omitempty" yaml:"generation,omitempty"`
+}
+
+// ConditionStatus is the tri-state status of a resource condition.
+type ConditionStatus string
+
+const (
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
+)
+
+// Condition describes one server-observed aspect of resource state.
+type Condition struct {
+	Type               string          `json:"type" yaml:"type"`
+	Status             ConditionStatus `json:"status" yaml:"status"`
+	ObservedGeneration uint64          `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	LastTransitionTime time.Time       `json:"lastTransitionTime" yaml:"lastTransitionTime"`
+	Reason             string          `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Message            string          `json:"message,omitempty" yaml:"message,omitempty"`
+}

--- a/internal/schema/resources/meta/validation.go
+++ b/internal/schema/resources/meta/validation.go
@@ -1,0 +1,247 @@
+package meta
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+)
+
+// ValidationMode identifies the source or lifecycle operation whose metadata
+// policy is being applied.
+type ValidationMode string
+
+const (
+	ValidationModeCreate      ValidationMode = "create"
+	ValidationModeUpdate      ValidationMode = "update"
+	ValidationModeConfig      ValidationMode = "config"
+	ValidationModePersistence ValidationMode = "persistence"
+	ValidationModeResponse    ValidationMode = "response"
+)
+
+func (m ValidationMode) Validate() error {
+	switch m {
+	case ValidationModeCreate, ValidationModeUpdate, ValidationModeConfig, ValidationModePersistence, ValidationModeResponse:
+		return nil
+	default:
+		return fmt.Errorf("unknown metadata validation mode %q", m)
+	}
+}
+
+// ValidationOptions supplies resource-specific requirements while retaining a
+// single shared implementation for lifecycle and metadata rules.
+type ValidationOptions struct {
+	Mode               ValidationMode
+	Path               *common.ValidationContext
+	ExpectedAPIVersion APIVersion
+	ExpectedKind       Kind
+	RequireID          bool
+	RequireName        bool
+	RequireNamespace   bool
+	IDValidator        func(string) error
+}
+
+// UpdateOptions selects the resource-specific metadata fields that are
+// immutable in addition to ID, generation, and createdAt.
+type UpdateOptions struct {
+	ImmutableName      bool
+	ImmutableNamespace bool
+}
+
+func validationPath(path *common.ValidationContext) *common.ValidationContext {
+	if path == nil {
+		return &common.ValidationContext{Path: "$"}
+	}
+	return path
+}
+
+func ValidateTypeMeta(value TypeMeta, expectedVersion APIVersion, expectedKind Kind, path *common.ValidationContext) error {
+	vc := validationPath(path)
+	var result *multierror.Error
+	if value.APIVersion == "" {
+		result = multierror.Append(result, vc.NewErrorForField("apiVersion", "is required"))
+	} else if err := value.APIVersion.Validate(); err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("apiVersion", "%v", err))
+	} else if expectedVersion != "" && value.APIVersion != expectedVersion {
+		result = multierror.Append(result, vc.NewErrorfForField("apiVersion", "must be %q, got %q", expectedVersion, value.APIVersion))
+	}
+	if value.Kind == "" {
+		result = multierror.Append(result, vc.NewErrorForField("kind", "is required"))
+	} else if err := value.Kind.Validate(); err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("kind", "%v", err))
+	} else if expectedKind != "" && value.Kind != expectedKind {
+		result = multierror.Append(result, vc.NewErrorfForField("kind", "must be %q, got %q", expectedKind, value.Kind))
+	}
+	return result.ErrorOrNil()
+}
+
+// ValidateStatus enforces the shared rule that status is server-owned on API
+// and configuration writes. Resource packages remain responsible for the
+// contents of their status types.
+func ValidateStatus(value any, mode ValidationMode, path *common.ValidationContext) error {
+	if err := mode.Validate(); err != nil {
+		return validationPath(path).NewError(err.Error())
+	}
+	if mode == ValidationModePersistence || mode == ValidationModeResponse || isZeroValue(value) {
+		return nil
+	}
+	return validationPath(path).NewErrorForField("status", "is server-owned")
+}
+
+func isZeroValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	return reflect.ValueOf(value).IsZero()
+}
+
+func ValidateObjectReference(value ObjectReference, path *common.ValidationContext) error {
+	vc := validationPath(path)
+	var result *multierror.Error
+	if err := ValidateTypeMeta(TypeMeta{APIVersion: value.APIVersion, Kind: value.Kind}, "", "", vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if value.ID == "" && value.Name == "" {
+		result = multierror.Append(result, vc.NewError("must contain id or name"))
+	}
+	if value.Name != "" {
+		if err := value.Name.Validate(); err != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("name", "%v", err))
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateCondition(value Condition, path *common.ValidationContext) error {
+	vc := validationPath(path)
+	var result *multierror.Error
+	if value.Type == "" {
+		result = multierror.Append(result, vc.NewErrorForField("type", "is required"))
+	}
+	switch value.Status {
+	case ConditionTrue, ConditionFalse, ConditionUnknown:
+	default:
+		result = multierror.Append(result, vc.NewErrorfForField("status", "must be one of %q, %q, or %q", ConditionTrue, ConditionFalse, ConditionUnknown))
+	}
+	if value.LastTransitionTime.IsZero() {
+		result = multierror.Append(result, vc.NewErrorForField("lastTransitionTime", "is required"))
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
+	vc := validationPath(options.Path).PushField("metadata")
+	var result *multierror.Error
+	if err := options.Mode.Validate(); err != nil {
+		result = multierror.Append(result, validationPath(options.Path).NewError(err.Error()))
+	}
+
+	if options.RequireID && value.ID == "" {
+		result = multierror.Append(result, vc.NewErrorForField("id", "is required"))
+	}
+	if value.ID != "" && options.IDValidator != nil {
+		if err := options.IDValidator(value.ID); err != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("id", "%v", err))
+		}
+	}
+	if options.RequireName && value.Name == "" {
+		result = multierror.Append(result, vc.NewErrorForField("name", "is required"))
+	} else if value.Name != "" {
+		if err := value.Name.Validate(); err != nil {
+			result = multierror.Append(result, vc.NewErrorfForField("name", "%v", err))
+		}
+	}
+	if options.RequireNamespace && value.Namespace == "" {
+		result = multierror.Append(result, vc.NewErrorForField("namespace", "is required"))
+	}
+
+	switch options.Mode {
+	case ValidationModeCreate:
+		if value.ID != "" {
+			result = multierror.Append(result, vc.NewErrorForField("id", "is server-owned on create"))
+		}
+		if value.Generation != 0 {
+			result = multierror.Append(result, vc.NewErrorForField("generation", "is server-owned on create"))
+		}
+		result = appendTimestampWriteErrors(result, vc, value)
+	case ValidationModeUpdate:
+		result = appendTimestampWriteErrors(result, vc, value)
+	case ValidationModeConfig:
+		result = appendTimestampWriteErrors(result, vc, value)
+	}
+
+	labelValidator := ValidateUserLabels
+	if options.Mode == ValidationModePersistence || options.Mode == ValidationModeResponse {
+		labelValidator = ValidateLabels
+	}
+	if err := labelValidator(value.Labels); err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("labels", "%v", err))
+	}
+	if err := ValidateAnnotations(value.Annotations); err != nil {
+		result = multierror.Append(result, vc.NewErrorfForField("annotations", "%v", err))
+	}
+	return result.ErrorOrNil()
+}
+
+func appendTimestampWriteErrors(result *multierror.Error, vc *common.ValidationContext, value ObjectMeta) *multierror.Error {
+	if value.CreatedAt != nil {
+		result = multierror.Append(result, vc.NewErrorForField("createdAt", "is server-owned"))
+	}
+	if value.UpdatedAt != nil {
+		result = multierror.Append(result, vc.NewErrorForField("updatedAt", "is server-owned"))
+	}
+	return result
+}
+
+func ValidateResource(value TypeMeta, metadata ObjectMeta, options ValidationOptions) error {
+	var result *multierror.Error
+	if err := ValidateTypeMeta(value, options.ExpectedAPIVersion, options.ExpectedKind, options.Path); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := ValidateObjectMeta(metadata, options); err != nil {
+		result = multierror.Append(result, err)
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateMetadataUpdate(before, after ObjectMeta, options UpdateOptions, path *common.ValidationContext) error {
+	vc := validationPath(path).PushField("metadata")
+	var result *multierror.Error
+	if before.ID != after.ID {
+		result = multierror.Append(result, vc.NewErrorForField("id", "is immutable"))
+	}
+	if before.Generation != after.Generation {
+		result = multierror.Append(result, vc.NewErrorForField("generation", "is immutable"))
+	}
+	if !equalTimePointers(before.CreatedAt, after.CreatedAt) {
+		result = multierror.Append(result, vc.NewErrorForField("createdAt", "is immutable"))
+	}
+	if options.ImmutableName && before.Name != after.Name {
+		result = multierror.Append(result, vc.NewErrorForField("name", "is immutable"))
+	}
+	if options.ImmutableNamespace && before.Namespace != after.Namespace {
+		result = multierror.Append(result, vc.NewErrorForField("namespace", "is immutable"))
+	}
+	return result.ErrorOrNil()
+}
+
+func ValidateTypeMetaUpdate(before, after TypeMeta, path *common.ValidationContext) error {
+	vc := validationPath(path)
+	var result *multierror.Error
+	if before.APIVersion != after.APIVersion {
+		result = multierror.Append(result, vc.NewErrorForField("apiVersion", "is immutable"))
+	}
+	if before.Kind != after.Kind {
+		result = multierror.Append(result, vc.NewErrorForField("kind", "is immutable"))
+	}
+	return result.ErrorOrNil()
+}
+
+func equalTimePointers(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}

--- a/internal/schema/resources/meta/validation.go
+++ b/internal/schema/resources/meta/validation.go
@@ -2,11 +2,10 @@ package meta
 
 import (
 	"fmt"
-	"reflect"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 // ValidationMode identifies the source or lifecycle operation whose metadata
@@ -50,16 +49,31 @@ type UpdateOptions struct {
 	ImmutableNamespace bool
 }
 
-func validationPath(path *common.ValidationContext) *common.ValidationContext {
+// validationPath returns a validation context for the given path. It defaults
+// to the root path if no path is provided.
+func validationPath(
+	path *common.ValidationContext,
+) *common.ValidationContext {
 	if path == nil {
 		return &common.ValidationContext{Path: "$"}
 	}
+
 	return path
 }
 
-func ValidateTypeMeta(value TypeMeta, expectedVersion APIVersion, expectedKind Kind, path *common.ValidationContext) error {
+// ValidateTypeMeta validates that TypeMeta has the expected APIVersion and
+// Kind. It optionally validates those values are specific values.
+func ValidateTypeMeta(
+	value TypeMeta,
+	expectedVersion APIVersion, // optional if specific version is expected
+	expectedKind Kind, // optional if specific kind is expected
+	path *common.ValidationContext,
+) error {
 	vc := validationPath(path)
 	var result *multierror.Error
+
+	// APIVersion must be present, valid format, and match expectations if
+	// expectations are specified.
 	if value.APIVersion == "" {
 		result = multierror.Append(result, vc.NewErrorForField("apiVersion", "is required"))
 	} else if err := value.APIVersion.Validate(); err != nil {
@@ -67,6 +81,9 @@ func ValidateTypeMeta(value TypeMeta, expectedVersion APIVersion, expectedKind K
 	} else if expectedVersion != "" && value.APIVersion != expectedVersion {
 		result = multierror.Append(result, vc.NewErrorfForField("apiVersion", "must be %q, got %q", expectedVersion, value.APIVersion))
 	}
+
+	// Kind must be present, valid format and match expectations if expectations
+	// are specified.
 	if value.Kind == "" {
 		result = multierror.Append(result, vc.NewErrorForField("kind", "is required"))
 	} else if err := value.Kind.Validate(); err != nil {
@@ -74,66 +91,89 @@ func ValidateTypeMeta(value TypeMeta, expectedVersion APIVersion, expectedKind K
 	} else if expectedKind != "" && value.Kind != expectedKind {
 		result = multierror.Append(result, vc.NewErrorfForField("kind", "must be %q, got %q", expectedKind, value.Kind))
 	}
+
 	return result.ErrorOrNil()
 }
 
 // ValidateStatus enforces the shared rule that status is server-owned on API
 // and configuration writes. Resource packages remain responsible for the
 // contents of their status types.
-func ValidateStatus(value any, mode ValidationMode, path *common.ValidationContext) error {
+func ValidateStatus(
+	value any,
+	mode ValidationMode,
+	path *common.ValidationContext,
+) error {
 	if err := mode.Validate(); err != nil {
 		return validationPath(path).NewError(err.Error())
 	}
-	if mode == ValidationModePersistence || mode == ValidationModeResponse || isZeroValue(value) {
+
+	if mode == ValidationModePersistence ||
+		mode == ValidationModeResponse ||
+		util.IsZeroValue(value) {
 		return nil
 	}
-	return validationPath(path).NewErrorForField("status", "is server-owned")
+
+	return validationPath(path).
+		NewErrorForField("status", "is server-owned")
 }
 
-func isZeroValue(value any) bool {
-	if value == nil {
-		return true
-	}
-	return reflect.ValueOf(value).IsZero()
-}
-
-func ValidateObjectReference(value ObjectReference, path *common.ValidationContext) error {
+func ValidateObjectReference(
+	value ObjectReference,
+	path *common.ValidationContext,
+) error {
 	vc := validationPath(path)
 	var result *multierror.Error
-	if err := ValidateTypeMeta(TypeMeta{APIVersion: value.APIVersion, Kind: value.Kind}, "", "", vc); err != nil {
+
+	if err := ValidateTypeMeta(
+		TypeMeta{
+			APIVersion: value.APIVersion,
+			Kind:       value.Kind,
+		},
+		"", // expectedVersion
+		"", // expectedKind
+		vc,
+	); err != nil {
 		result = multierror.Append(result, err)
 	}
+
 	if value.ID == "" && value.Name == "" {
 		result = multierror.Append(result, vc.NewError("must contain id or name"))
 	}
+
 	if value.Name != "" {
 		if err := value.Name.Validate(); err != nil {
 			result = multierror.Append(result, vc.NewErrorfForField("name", "%v", err))
 		}
 	}
+
 	return result.ErrorOrNil()
 }
 
 func ValidateCondition(value Condition, path *common.ValidationContext) error {
 	vc := validationPath(path)
 	var result *multierror.Error
+
 	if value.Type == "" {
 		result = multierror.Append(result, vc.NewErrorForField("type", "is required"))
 	}
+
 	switch value.Status {
 	case ConditionTrue, ConditionFalse, ConditionUnknown:
 	default:
 		result = multierror.Append(result, vc.NewErrorfForField("status", "must be one of %q, %q, or %q", ConditionTrue, ConditionFalse, ConditionUnknown))
 	}
+
 	if value.LastTransitionTime.IsZero() {
 		result = multierror.Append(result, vc.NewErrorForField("lastTransitionTime", "is required"))
 	}
+
 	return result.ErrorOrNil()
 }
 
 func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
 	vc := validationPath(options.Path).PushField("metadata")
 	var result *multierror.Error
+
 	if err := options.Mode.Validate(); err != nil {
 		result = multierror.Append(result, validationPath(options.Path).NewError(err.Error()))
 	}
@@ -141,11 +181,13 @@ func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
 	if options.RequireID && value.ID == "" {
 		result = multierror.Append(result, vc.NewErrorForField("id", "is required"))
 	}
+
 	if value.ID != "" && options.IDValidator != nil {
 		if err := options.IDValidator(value.ID); err != nil {
 			result = multierror.Append(result, vc.NewErrorfForField("id", "%v", err))
 		}
 	}
+
 	if options.RequireName && value.Name == "" {
 		result = multierror.Append(result, vc.NewErrorForField("name", "is required"))
 	} else if value.Name != "" {
@@ -153,6 +195,7 @@ func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
 			result = multierror.Append(result, vc.NewErrorfForField("name", "%v", err))
 		}
 	}
+
 	if options.RequireNamespace && value.Namespace == "" {
 		result = multierror.Append(result, vc.NewErrorForField("namespace", "is required"))
 	}
@@ -176,58 +219,88 @@ func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
 	if options.Mode == ValidationModePersistence || options.Mode == ValidationModeResponse {
 		labelValidator = ValidateLabels
 	}
+
 	if err := labelValidator(value.Labels); err != nil {
 		result = multierror.Append(result, vc.NewErrorfForField("labels", "%v", err))
 	}
+
 	if err := ValidateAnnotations(value.Annotations); err != nil {
 		result = multierror.Append(result, vc.NewErrorfForField("annotations", "%v", err))
 	}
+
 	return result.ErrorOrNil()
 }
 
-func appendTimestampWriteErrors(result *multierror.Error, vc *common.ValidationContext, value ObjectMeta) *multierror.Error {
+func appendTimestampWriteErrors(
+	result *multierror.Error,
+	vc *common.ValidationContext,
+	value ObjectMeta,
+) *multierror.Error {
 	if value.CreatedAt != nil {
 		result = multierror.Append(result, vc.NewErrorForField("createdAt", "is server-owned"))
 	}
+
 	if value.UpdatedAt != nil {
 		result = multierror.Append(result, vc.NewErrorForField("updatedAt", "is server-owned"))
 	}
+
 	return result
 }
 
-func ValidateResource(value TypeMeta, metadata ObjectMeta, options ValidationOptions) error {
+func ValidateResource(
+	value TypeMeta,
+	metadata ObjectMeta,
+	options ValidationOptions,
+) error {
 	var result *multierror.Error
-	if err := ValidateTypeMeta(value, options.ExpectedAPIVersion, options.ExpectedKind, options.Path); err != nil {
+
+	if err := ValidateTypeMeta(
+		value,
+		options.ExpectedAPIVersion,
+		options.ExpectedKind,
+		options.Path,
+	); err != nil {
 		result = multierror.Append(result, err)
 	}
+
 	if err := ValidateObjectMeta(metadata, options); err != nil {
 		result = multierror.Append(result, err)
 	}
+
 	return result.ErrorOrNil()
 }
 
 func ValidateMetadataUpdate(before, after ObjectMeta, options UpdateOptions, path *common.ValidationContext) error {
 	vc := validationPath(path).PushField("metadata")
 	var result *multierror.Error
+
 	if before.ID != after.ID {
 		result = multierror.Append(result, vc.NewErrorForField("id", "is immutable"))
 	}
+
 	if before.Generation != after.Generation {
 		result = multierror.Append(result, vc.NewErrorForField("generation", "is immutable"))
 	}
-	if !equalTimePointers(before.CreatedAt, after.CreatedAt) {
+
+	if !util.EqualTimePointers(before.CreatedAt, after.CreatedAt) {
 		result = multierror.Append(result, vc.NewErrorForField("createdAt", "is immutable"))
 	}
+
 	if options.ImmutableName && before.Name != after.Name {
 		result = multierror.Append(result, vc.NewErrorForField("name", "is immutable"))
 	}
+
 	if options.ImmutableNamespace && before.Namespace != after.Namespace {
 		result = multierror.Append(result, vc.NewErrorForField("namespace", "is immutable"))
 	}
+
 	return result.ErrorOrNil()
 }
 
-func ValidateTypeMetaUpdate(before, after TypeMeta, path *common.ValidationContext) error {
+func ValidateTypeMetaUpdate(
+	before, after TypeMeta,
+	path *common.ValidationContext,
+) error {
 	vc := validationPath(path)
 	var result *multierror.Error
 	if before.APIVersion != after.APIVersion {
@@ -237,11 +310,4 @@ func ValidateTypeMetaUpdate(before, after TypeMeta, path *common.ValidationConte
 		result = multierror.Append(result, vc.NewErrorForField("kind", "is immutable"))
 	}
 	return result.ErrorOrNil()
-}
-
-func equalTimePointers(left, right *time.Time) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return left.Equal(*right)
 }

--- a/internal/schema/resources/meta/version.go
+++ b/internal/schema/resources/meta/version.go
@@ -1,0 +1,66 @@
+package meta
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	APIGroup                      = "authproxy.net"
+	APIVersionName                = "v1alpha1"
+	APIVersionV1Alpha1 APIVersion = APIGroup + "/" + APIVersionName
+)
+
+var (
+	apiGroupPattern = regexp.MustCompile(`^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?\.)*[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+	versionPattern  = regexp.MustCompile(`^v[0-9]+(?:(?:alpha|beta)[0-9]+)?$`)
+	kindPattern     = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*$`)
+)
+
+// APIVersion identifies a group and schema version independently of the HTTP
+// route version.
+type APIVersion string
+
+// ParseAPIVersion validates Kubernetes-style group/version syntax. Whether a
+// syntactically valid version is registered is the manifest scheme's concern.
+func ParseAPIVersion(value string) (APIVersion, error) {
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 || len(parts[0]) > 253 || !apiGroupPattern.MatchString(parts[0]) || !versionPattern.MatchString(parts[1]) {
+		return "", fmt.Errorf("must use group/version syntax, for example %q", APIVersionV1Alpha1)
+	}
+	return APIVersion(value), nil
+}
+
+func (v APIVersion) Validate() error {
+	_, err := ParseAPIVersion(string(v))
+	return err
+}
+
+func (v APIVersion) Group() string {
+	if parsed, err := ParseAPIVersion(string(v)); err == nil {
+		return strings.SplitN(string(parsed), "/", 2)[0]
+	}
+	return ""
+}
+
+func (v APIVersion) Version() string {
+	if parsed, err := ParseAPIVersion(string(v)); err == nil {
+		return strings.SplitN(string(parsed), "/", 2)[1]
+	}
+	return ""
+}
+
+// Kind is a singular PascalCase resource, list, projection, or action kind.
+type Kind string
+
+func (k Kind) Validate() error {
+	if !kindPattern.MatchString(string(k)) {
+		return fmt.Errorf("must be a non-empty PascalCase kind")
+	}
+	return nil
+}
+
+func NewTypeMeta(kind Kind) TypeMeta {
+	return TypeMeta{APIVersion: APIVersionV1Alpha1, Kind: kind}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -11,7 +11,7 @@ import (
 	jsonschemav5 "github.com/santhosh-tekuri/jsonschema/v5"
 )
 
-//go:embed **/schema*.json resources/*/schema*.json
+//go:embed **/schema*.json api/*/schema*.json resources/*/schema*.json
 var schemaFs embed.FS
 
 type schemaIdStruct struct {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	apiV1Alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	"github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/stretchr/testify/require"
@@ -15,10 +17,12 @@ import (
 
 var allSchemaIDs = []string{
 	api.SchemaIdAPI,
+	apiV1Alpha1.SchemaID,
 	auth.SchemaIdAuth,
 	common.SchemaIdCommon,
 	config.SchemaIdConfig,
 	connectors.SchemaIdConnectors,
+	meta.SchemaID,
 	namespace.SchemaId,
 	rate_limit.SchemaIdRateLimit,
 }

--- a/internal/util/map.go
+++ b/internal/util/map.go
@@ -1,5 +1,7 @@
 package util
 
+import "sort"
+
 // Map applies a function to each element of the input slice and returns a new slice with the results
 func Map[T any, U any](input []T, transform func(T) U) []U {
 	// Create a new slice with the same length as input to hold the results
@@ -34,4 +36,15 @@ func FlatMap[T, V any](input []T, transform func(T) []V) []V {
 		result = append(result, transform(item)...)
 	}
 	return result
+}
+
+// SortedStringMapKeys returns a sorted slice of keys from a string map.
+func SortedStringMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/util/map_test.go
+++ b/internal/util/map_test.go
@@ -31,3 +31,10 @@ func TestFlatMap(t *testing.T) {
 	assert.Equal(t, []int{}, FlatMap([][]int{}, func(i []int) []int { return i }))
 	assert.Equal(t, []int{}, FlatMap(nil, func(i []int) []int { return i }))
 }
+
+func TestSortedStringMapKeys(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"a", "b", "c"}, SortedStringMapKeys(map[string]string{"a": "1", "b": "2", "c": "3"}))
+	assert.Equal(t, []string{}, SortedStringMapKeys(map[string]string{}))
+	assert.Equal(t, []string{}, SortedStringMapKeys[map[string]string](nil))
+}

--- a/internal/util/time_ptr.go
+++ b/internal/util/time_ptr.go
@@ -1,0 +1,13 @@
+package util
+
+import "time"
+
+// EqualTimePointers returns true if the two time pointers are equal. Both
+// values being nil is considered equal.
+func EqualTimePointers(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.Equal(*right)
+}

--- a/internal/util/time_ptr.go
+++ b/internal/util/time_ptr.go
@@ -11,3 +11,14 @@ func EqualTimePointers(left, right *time.Time) bool {
 
 	return left.Equal(*right)
 }
+
+// UtcTimePointer converts the passed time to UTC if present passing nil
+// through.
+func UtcTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	normalized := value.UTC()
+	return &normalized
+}

--- a/internal/util/time_ptr_test.go
+++ b/internal/util/time_ptr_test.go
@@ -22,3 +22,17 @@ func TestEqualTimePointers(t *testing.T) {
 		ToPtr(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC))),
 	)
 }
+
+func TestUtcTimePointer(t *testing.T) {
+	assert.Nil(t, UtcTimePointer(nil))
+	assert.Equal(
+		t,
+		time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+		*UtcTimePointer(ToPtr(time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC))),
+	)
+	assert.Equal(
+		t,
+		time.Date(2023, time.January, 1, 1, 0, 0, 0, time.UTC),
+		*UtcTimePointer(ToPtr(time.Date(2023, time.January, 1, 2, 0, 0, 0, time.FixedZone("foo", int(time.Hour/time.Second))))),
+	)
+}

--- a/internal/util/time_ptr_test.go
+++ b/internal/util/time_ptr_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualTimePointers(t *testing.T) {
+	time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	assert.True(t, EqualTimePointers(nil, nil))
+	assert.True(t, EqualTimePointers(&time.Time{}, &time.Time{}))
+	assert.False(t, EqualTimePointers(&time.Time{}, nil))
+	assert.False(t, EqualTimePointers(nil, &time.Time{}))
+	assert.True(t, EqualTimePointers(
+		ToPtr(time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)),
+		ToPtr(time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC))),
+	)
+	assert.False(t, EqualTimePointers(
+		ToPtr(time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)),
+		ToPtr(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC))),
+	)
+}

--- a/internal/util/yaml.go
+++ b/internal/util/yaml.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,4 +21,14 @@ func YamlBytesToJSON(yamlData []byte) ([]byte, error) {
 	}
 
 	return j, nil
+}
+
+// YamlDocumentEmpty reports whether the specified YAML document has no content.
+func YamlDocumentEmpty(node *yaml.Node) bool {
+	if node == nil || len(node.Content) == 0 {
+		return true
+	}
+
+	value := node.Content[0]
+	return value.Kind == yaml.ScalarNode && value.Tag == "!!null" && strings.TrimSpace(value.Value) == ""
 }

--- a/internal/util/yaml_test.go
+++ b/internal/util/yaml_test.go
@@ -38,3 +38,104 @@ func TestYamlBytesToJSON(t *testing.T) {
 
 	require.Equal(t, *testData, resultData)
 }
+
+func TestYamlDocumentEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		node  *yaml.Node
+		empty bool
+	}{
+		{
+			name:  "nil node",
+			empty: true,
+		},
+		{
+			name:  "document without content",
+			node:  &yaml.Node{Kind: yaml.DocumentNode},
+			empty: true,
+		},
+		{
+			name: "implicit null scalar",
+			node: &yaml.Node{
+				Kind: yaml.DocumentNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!null", Value: " \n"},
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "explicit null scalar",
+			node: &yaml.Node{
+				Kind: yaml.DocumentNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"},
+				},
+			},
+			empty: false,
+		},
+		{
+			name: "empty string scalar",
+			node: &yaml.Node{
+				Kind: yaml.DocumentNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: ""},
+				},
+			},
+			empty: false,
+		},
+		{
+			name: "mapping node",
+			node: &yaml.Node{
+				Kind: yaml.DocumentNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.MappingNode, Tag: "!!map"},
+				},
+			},
+			empty: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.empty, YamlDocumentEmpty(test.node))
+		})
+	}
+}
+
+func TestYamlDocumentEmptyWithDecodedYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		data  string
+		empty bool
+	}{
+		{name: "empty input", data: "", empty: true},
+		{name: "whitespace", data: "  \n", empty: true},
+		{name: "comment only", data: "# comment\n", empty: true},
+		{name: "empty document marker", data: "---\n", empty: true},
+		{name: "explicit null", data: "null\n", empty: false},
+		{name: "null shorthand", data: "~\n", empty: false},
+		{name: "quoted empty string", data: `""`, empty: false},
+		{name: "empty mapping", data: "{}\n", empty: false},
+		{name: "empty sequence", data: "[]\n", empty: false},
+		{name: "scalar", data: "value\n", empty: false},
+		{name: "mapping", data: "key: value\n", empty: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var node yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(test.data), &node))
+			require.Equal(t, test.empty, YamlDocumentEmpty(&node))
+		})
+	}
+}

--- a/internal/util/zero.go
+++ b/internal/util/zero.go
@@ -1,0 +1,13 @@
+package util
+
+import "reflect"
+
+// IsZeroValue returns true if the given value is a zero value. This
+// includes nil values and values that are zeroed out.
+func IsZeroValue(value any) bool {
+	if value == nil {
+		return true
+	}
+
+	return reflect.ValueOf(value).IsZero()
+}

--- a/internal/util/zero_test.go
+++ b/internal/util/zero_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZeroValue(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  any
+		isZero bool
+	}{
+		{
+			name:   "nil value",
+			value:  nil,
+			isZero: true,
+		},
+		{
+			name:   "empty string",
+			value:  "",
+			isZero: true,
+		},
+		{
+			name:   "false",
+			value:  false,
+			isZero: true,
+		},
+		{
+			name:   "zero",
+			value:  int64(0),
+			isZero: true,
+		},
+		{
+			name:   "empty struct",
+			value:  struct{}{},
+			isZero: true,
+		},
+		{
+			name:   "ptr value",
+			value:  ToPtr("foo"),
+			isZero: false,
+		},
+		{
+			name:   "populated string",
+			value:  "foo",
+			isZero: false,
+		},
+		{
+			name:   "true",
+			value:  true,
+			isZero: false,
+		},
+		{
+			name:   "integer",
+			value:  int64(1),
+			isZero: false,
+		},
+		{
+			name:   "populated struct",
+			value:  struct{ foo string }{"foo"},
+			isZero: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.isZero, IsZeroValue(tc.value))
+		})
+	}
+}


### PR DESCRIPTION
Closes #831

Design dependency: #850

## Summary

- add the shared `resources/meta` contracts for `authproxy.net/v1alpha1` TypeMeta, ObjectMeta, ObjectReference, conditions, labels, and annotations
- add lifecycle-aware create/update/config/persistence/response validation, server-owned and immutable checks, metadata defaulting/normalization and patch helpers, and deterministic canonical spec hashing
- add reusable JSON Schema composition through the open Resource base and concrete `unevaluatedProperties` closure
- add `api/v1alpha1` typed resource-list and action transports with list/action constructors and validation
- add strict JSON/YAML manifest GVK dispatch, including multi-document YAML streams and field-addressable unsupported version/kind errors
- make existing database label/annotation validators delegate to the shared metadata package so there is one validation implementation during migration

## Verification

- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test ./...`
- `./scripts/preflight.sh`