### PR TITLE
Persist hosted demo backing services

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -165,6 +165,16 @@ jobs:
           grep -q "secretName: demo-jwt" "${demo_manifest}"
           grep -q "name: demo-authproxy-migrate" "${demo_manifest}"
           grep -q "suspend: true" "${demo_manifest}"
+          test "$(grep -c '^kind: PersistentVolumeClaim$' "${demo_manifest}")" -eq 3
+          test "$(grep -c '^  storageClassName: gp3$' "${demo_manifest}")" -eq 3
+          test "$(grep -c '^    type: Recreate$' "${demo_manifest}")" -eq 3
+          for claim in demo-postgresql-data demo-redis-data demo-minio-data; do
+            grep -q "name: ${claim}" "${demo_manifest}"
+            grep -q "claimName: ${claim}" "${demo_manifest}"
+          done
+          grep -q "mountPath: /bitnami/postgresql" "${demo_manifest}"
+          grep -q "mountPath: /bitnami/redis/data" "${demo_manifest}"
+          grep -q "mountPath: /bitnami/minio/data" "${demo_manifest}"
 
           grep -q "name: dev-authproxy" "${dev_manifest}"
           grep -q "provider: miniredis" "${dev_manifest}"

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -8,7 +8,8 @@ The base contains the shared AuthProxy, demo-shell, and go-oauth2-server
 workloads. Overlays choose backing services and public hostnames:
 
 - `overlays/demo` targets `demo.authproxy.net` and includes Postgres, Redis,
-  and MinIO backing workloads.
+  and MinIO backing workloads. Each stateful backing workload uses an encrypted
+  `gp3` persistent volume so data survives pod rescheduling and node replacement.
 - `overlays/dev` targets an example per-branch namespace and keeps the slim
   dev profile: SQLite, embedded miniredis, and filesystem blob storage. Its
   disposable pod-local database uses `serve --auto-migrate`; it removes the

--- a/deploy/kustomize/authproxy-demo/overlays/demo/minio.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/minio.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: object-storage
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: minio
@@ -34,6 +36,13 @@ spec:
                   key: root-password
             - name: MINIO_DEFAULT_BUCKETS
               value: authproxy-request-logs
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/minio/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
 ---
 apiVersion: v1
 kind: Service
@@ -51,3 +60,15 @@ spec:
     - name: api
       port: 9000
       targetPort: api
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kustomize/authproxy-demo/overlays/demo/postgres.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/postgres.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: database
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: postgresql
@@ -34,6 +36,13 @@ spec:
                 secretKeyRef:
                   name: demo-db
                   key: AUTHPROXY_DB_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgresql-data
 ---
 apiVersion: v1
 kind: Service
@@ -51,3 +60,15 @@ spec:
     - name: postgresql
       port: 5432
       targetPort: postgresql
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kustomize/authproxy-demo/overlays/demo/redis.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/redis.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: redis
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: redis
@@ -32,6 +34,13 @@ spec:
                 secretKeyRef:
                   name: demo-redis-creds
                   key: AUTHPROXY_REDIS_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/redis/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: redis-data
 ---
 apiVersion: v1
 kind: Service
@@ -49,3 +58,15 @@ spec:
     - name: redis
       port: 6379
       targetPort: redis
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Summary

- add encrypted `gp3` PVCs for the hosted demo PostgreSQL, Redis, and MinIO workloads
- mount each claim at the Bitnami data directory and use `Recreate` rollout strategy for the RWO volumes
- add Kustomize render assertions that require all three claims, mounts, and strategies

## Incident and recovery

On 2026-09-01 an EKS node became unavailable. The demo PostgreSQL pod rescheduled onto another node, but the deployment had no persistent volume, so PostgreSQL initialized an empty database. AuthProxy then crash-looped on its schema compatibility check, leaving the Marketplace and Admin services without ready endpoints and returning HTTP 503.

I restored availability by rerunning the deployed migration job and the `Seed Demo` workflow. Both public endpoints returned HTTP 200 afterward. The historical ephemeral database contents were already lost when the node failed.

## Rollout note

The first deployment of this change creates new empty claims and restarts the three backing workloads. The normal Deploy Demo sequence waits for PostgreSQL, runs migrations, starts AuthProxy, and reseeds the catalog, but the live cutover should be treated as a short maintenance window because the currently reseeded ephemeral data will be replaced once.

## Verification

- `./scripts/preflight.sh`
- exact Helm Chart CI Kustomize render assertions
- live Kubernetes server-side dry run of the Deploy Demo prerequisite selector
- confirmed the live `gp3` StorageClass uses EBS CSI with `encrypted: true`
- recovered Marketplace and Admin endpoints both return HTTP 200