### PR TITLE
Use v1alpha1 Actor resources in JWT claims

### DIFF
--- a/cmd/cli/config/resolver_test.go
+++ b/cmd/cli/config/resolver_test.go
@@ -150,6 +150,7 @@ func TestResolveBuilderWithGrafanaPreset(t *testing.T) {
 
 	claims := parseTestToken(t, ctx, token, []byte("test-secret"))
 	require.Equal(t, "grafana", claims.Subject)
+	require.Nil(t, claims.Actor, "CLI tokens resolve existing actors instead of embedding actor resources")
 	require.Equal(t, []string{string(config.ServiceIdApi)}, []string(claims.Audience))
 	require.True(t, apctx.GetClock(ctx).Now().Add(grafanaDefaultExpiresIn).Equal(claims.ExpiresAt.Time))
 	require.Contains(t, claims.Permissions, aschema.Permission{

--- a/docs/src/content/docs/development/cli.md
+++ b/docs/src/content/docs/development/cli.md
@@ -73,6 +73,12 @@ Every signed token has an **actor** (who is making the call) and a **service-id 
 - Service allowlist defaults to `all`. Override with `--apis admin-api,api` to scope a token down. Valid IDs: `admin-api`, `api`, `public`, `worker`.
 - `--admin` flips the token's permissions to match the `systemAuth.actors.permissions` block on the server (full access in the dev config).
 
+The CLI emits a subject-only token: the selected actor ID is placed in `sub`,
+and the server resolves the existing actor in the selected namespace. It does
+not embed or provision an actor resource. Applications that do embed actors
+must use the restricted `authproxy.net/v1alpha1` Actor claim described in
+[Authentication and Authorization](/security/authentication-and-authorization/#authentication-paths).
+
 ## Commands
 
 ### `ap list connectors` / `ap list connections`
@@ -131,7 +137,10 @@ ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs
 ap sign-jwt --actorId grafana --apis api,admin-api --grafana-preset logs --no-expiry
 ```
 
-Grafana presets use top-level JWT permissions. Those permissions only restrict the token; the backing actor still needs matching normal permissions.
+Grafana presets use top-level JWT permissions. Those permissions only restrict
+the token; the backing actor still needs matching normal permissions. The
+server rejects a token whose top-level permissions are broader than the
+backing actor's grants.
 
 Permission namespaces in a permissions file support the same actor templates as normal actor permissions: `{{externalId}}`, `{{labels.<label>}}`, and `{{annotations.<annotation>}}`. These render against the backing actor, and missing label or annotation values make the permission fail to match.
 

--- a/docs/src/content/docs/integration/host-application.md
+++ b/docs/src/content/docs/integration/host-application.md
@@ -10,7 +10,7 @@ minimum metadata needed to authorize and operate third-party connections.
 
 | Host entity | AuthProxy representation | Guidance |
 |---|---|---|
-| User or service principal | Actor `externalId` | Use an immutable primary key, not email or display name. |
+| User or service principal | Actor `spec.externalId` | Use an immutable primary key, not email or display name. |
 | Tenant or organization | Namespace | Derive a stable, namespace-safe segment and never rename it when the tenant's display name changes. |
 | Team | Optional child namespace | Create it only when it is an authorization boundary. Otherwise use a label. |
 | Integration installation | Connection | Store the immutable `cxn_...` ID in the host. Supply a human-readable name for display and exact-name discovery. |
@@ -75,6 +75,35 @@ AuthProxy supports two provisioning patterns:
 Provision-first is easier to audit. Just-in-time provisioning reduces sync work
 but makes the token issuer part of the actor-provisioning control plane.
 
+An embedded actor uses the same `authproxy.net/v1alpha1` resource shape as the
+Actor API, with a deliberately restricted field set:
+
+```yaml
+sub: usr_7
+namespace: root.tenants.tnt_42
+actor:
+  apiVersion: authproxy.net/v1alpha1
+  kind: Actor
+  metadata:
+    name: user-7
+    namespace: root.tenants.tnt_42
+    labels:
+      app.example.com/role: member
+  spec:
+    externalId: usr_7
+    permissions:
+      - namespace: root.tenants.tnt_42.**
+        resources: [connections]
+        verbs: [create, get, list, proxy]
+```
+
+The JWT `sub` must equal `actor.spec.externalId`, and the top-level
+`namespace` must equal `actor.metadata.namespace`. Do not include
+`metadata.id`, `metadata.generation`, lifecycle timestamps, `status`, or
+`spec.signingKey` in a JWT actor. Those fields are database identity,
+server-observed state, or secret configuration—not identity assertions. The
+legacy flat actor claim is not accepted.
+
 Do not copy an entire host user profile. AuthProxy generally needs the stable
 id, home namespace, permissions, and carefully selected labels or annotations.
 
@@ -105,9 +134,10 @@ separate operator identity. If connectors live in a shared parent namespace,
 grant their `list` and `get` permissions there while keeping connection
 permissions restricted to the tenant or user namespace.
 
-Request JWTs may narrow these permissions. AuthProxy intersects token
-restrictions with the actor's permissions, so a token can reduce authority but
-cannot elevate it.
+Request JWTs may narrow these permissions. AuthProxy verifies that every
+top-level token permission is a subset of the actor's base permissions and
+then intersects the two sets during authorization. A broader token is rejected
+instead of being silently trimmed.
 
 ## Track host installations
 

--- a/docs/src/content/docs/security/authentication-and-authorization.md
+++ b/docs/src/content/docs/security/authentication-and-authorization.md
@@ -16,7 +16,7 @@ recovery, or workforce/customer identity provider.
 
 ## Map Host Identities to Actors
 
-An actor represents a user or service principal. Its `externalId` should be a
+An actor represents a user or service principal. Its `spec.externalId` should be a
 stable, non-reassignable identifier from the host system. Avoid mutable values
 such as email addresses when a durable user id is available.
 
@@ -25,7 +25,7 @@ For example:
 ```text
 Host tenant:    org_123
 Host principal: usr_456
-AuthProxy actor externalId: usr_456
+AuthProxy actor spec.externalId: usr_456
 AuthProxy resource namespace: root.tenants.org_123
 ```
 
@@ -52,6 +52,31 @@ nonce can establish authentication only once. A subject-only token must resolve
 to an existing database actor. Integrations that include a full actor claim
 should treat the signed claim as an authoritative upsert from the host identity
 source.
+
+When present, the JWT actor is a restricted Actor resource:
+
+```yaml
+sub: usr_456
+namespace: root.tenants.org_123
+actor:
+  apiVersion: authproxy.net/v1alpha1
+  kind: Actor
+  metadata:
+    name: user-456
+    namespace: root.tenants.org_123
+  spec:
+    externalId: usr_456
+    permissions:
+      - namespace: root.tenants.org_123.**
+        resources: [connections]
+        verbs: [get, list, proxy]
+```
+
+`sub` must match `actor.spec.externalId`, and the top-level namespace must
+match `actor.metadata.namespace`. JWT actors cannot contain `metadata.id`,
+`metadata.generation`, `metadata.createdAt`, `metadata.updatedAt`, `status`, or
+`spec.signingKey`. AuthProxy also rejects unknown fields and the former flat
+actor claim shape.
 
 ## Browser Session Handoff
 
@@ -115,8 +140,9 @@ The dimensions are:
 Actor permissions are additive: any actor permission that matches can allow an
 operation. If a JWT also carries permissions, those permissions are
 restrictions. The action must be allowed by both the actor's stored permissions
-and the token's permission set. A caller cannot add a broad token permission to
-expand a narrow actor grant.
+and the token's permission set. Every token restriction must be contained by
+the actor's base permissions; AuthProxy rejects the JWT when its namespace,
+resource, verb, or resource-id scope is broader.
 
 Routes validate the namespace and, where relevant, the loaded resource id.
 List and aggregate routes constrain their database queries to effective

--- a/docs/src/content/docs/security/authentication-and-authorization.md
+++ b/docs/src/content/docs/security/authentication-and-authorization.md
@@ -75,8 +75,7 @@ actor:
 `sub` must match `actor.spec.externalId`, and the top-level namespace must
 match `actor.metadata.namespace`. JWT actors cannot contain `metadata.id`,
 `metadata.generation`, `metadata.createdAt`, `metadata.updatedAt`, `status`, or
-`spec.signingKey`. AuthProxy also rejects unknown fields and the former flat
-actor claim shape.
+`spec.signingKey`. AuthProxy also rejects unknown fields.
 
 ## Browser Session Handoff
 

--- a/internal/apauth/core/actor.go
+++ b/internal/apauth/core/actor.go
@@ -20,16 +20,13 @@ type IActorData interface {
 // Actor is the information that identifies who is making a request. This can be an actor in the calling
 // system, an admin from the calling system, a devops admin from the cli, etc.
 type Actor struct {
-	// This version of the actor is deserialized from the JWT directly. The JSON annotations apply to
-	// how the JWT is structured.
-
-	Id          apid.ID              `json:"-"` // This is the database ID of the actor. It cannot be set in the JWT directly.
-	Name        scommon.ResourceName `json:"name,omitempty"`
-	ExternalId  string               `json:"externalId"`
-	Namespace   string               `json:"namespace,omitempty"`
-	Labels      map[string]string    `json:"labels,omitempty"`
-	Annotations map[string]string    `json:"annotations,omitempty"`
-	Permissions []aschema.Permission `json:"permissions"`
+	Id          apid.ID
+	Name        scommon.ResourceName
+	ExternalId  string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Permissions []aschema.Permission
 }
 
 func (a *Actor) GetId() apid.ID {
@@ -57,7 +54,7 @@ func (a *Actor) GetNamespace() string {
 
 func (a *Actor) GetLabels() map[string]string { return a.Labels }
 
-// GetAnnotations returns actor annotations from database state or JWT claims.
+// GetAnnotations returns actor annotations from the source actor data.
 func (a *Actor) GetAnnotations() map[string]string { return a.Annotations }
 
 func isValidValueForNamespaceTemplating(val string) bool {

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -38,8 +38,8 @@ func ValidatePermissionRestrictions(
 						restrictionNamespace,
 						resource,
 						verb,
-						"",
-						true,
+						"",   // resourceId
+						true, // requireAllResourceIds
 					) {
 						return fmt.Errorf(
 							"request permission %d grants namespace %q, resource %q, and verb %q beyond the actor's permissions",

--- a/internal/apauth/core/permissions.go
+++ b/internal/apauth/core/permissions.go
@@ -1,12 +1,143 @@
 package core
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/rmorlok/authproxy/internal/aptmpl"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
+
+// ValidatePermissionRestrictions verifies that every action described by the
+// request-level restrictions is already granted by the actor's base
+// permissions. Runtime authorization still intersects the two sets; this
+// validation makes an accidentally or maliciously broader token fail instead
+// of silently trimming it.
+func ValidatePermissionRestrictions(
+	actor *Actor,
+	basePermissions []aschema.Permission,
+	restrictions []aschema.Permission,
+) error {
+	for restrictionIndex, restriction := range restrictions {
+		if err := restriction.Validate(); err != nil {
+			return fmt.Errorf("request permission %d is invalid: %w", restrictionIndex, err)
+		}
+
+		restrictionNamespace, ok := renderValidPermissionNamespace(actor, restriction.Namespace)
+		if !ok {
+			return fmt.Errorf("request permission %d has an invalid namespace matcher", restrictionIndex)
+		}
+
+		for _, resource := range restriction.Resources {
+			for _, verb := range restriction.Verbs {
+				if len(restriction.ResourceIds) == 0 {
+					if !basePermissionsCoverAction(
+						actor,
+						basePermissions,
+						restrictionNamespace,
+						resource,
+						verb,
+						"",
+						true,
+					) {
+						return fmt.Errorf(
+							"request permission %d grants namespace %q, resource %q, and verb %q beyond the actor's permissions",
+							restrictionIndex,
+							restrictionNamespace,
+							resource,
+							verb,
+						)
+					}
+					continue
+				}
+
+				// A resource-id-scoped permission also permits resource-level
+				// checks where no ID is available, matching authorization behavior.
+				if !basePermissionsCoverAction(
+					actor,
+					basePermissions,
+					restrictionNamespace,
+					resource,
+					verb,
+					"",
+					false,
+				) {
+					return fmt.Errorf(
+						"request permission %d grants namespace %q, resource %q, and verb %q beyond the actor's permissions",
+						restrictionIndex,
+						restrictionNamespace,
+						resource,
+						verb,
+					)
+				}
+
+				for _, resourceID := range restriction.ResourceIds {
+					if !basePermissionsCoverAction(
+						actor,
+						basePermissions,
+						restrictionNamespace,
+						resource,
+						verb,
+						resourceID,
+						false,
+					) {
+						return fmt.Errorf(
+							"request permission %d grants namespace %q, resource %q, verb %q, and resource ID %q beyond the actor's permissions",
+							restrictionIndex,
+							restrictionNamespace,
+							resource,
+							verb,
+							resourceID,
+						)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func basePermissionsCoverAction(
+	actor *Actor,
+	basePermissions []aschema.Permission,
+	restrictionNamespace, resource, verb, resourceID string,
+	requireAllResourceIDs bool,
+) bool {
+	for _, base := range basePermissions {
+		baseNamespace, ok := renderValidPermissionNamespace(actor, base.Namespace)
+		if !ok || !namespaceMatcherContains(baseNamespace, restrictionNamespace) {
+			continue
+		}
+		if !permissionValueContains(base.Resources, resource) || !permissionValueContains(base.Verbs, verb) {
+			continue
+		}
+		if requireAllResourceIDs {
+			if len(base.ResourceIds) == 0 {
+				return true
+			}
+			continue
+		}
+		if resourceID == "" || len(base.ResourceIds) == 0 || slices.Contains(base.ResourceIds, resourceID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func namespaceMatcherContains(container, contained string) bool {
+	constrained, ok := namespace.ConstrainMatcher(container, contained)
+	return ok && constrained == contained
+}
+
+func permissionValueContains(baseValues []string, restrictionValue string) bool {
+	if restrictionValue == aschema.PermissionWildcard {
+		return slices.Contains(baseValues, aschema.PermissionWildcard)
+	}
+	return slices.Contains(baseValues, aschema.PermissionWildcard) || slices.Contains(baseValues, restrictionValue)
+}
 
 // allowsForActor checks if this permission allows the specified action for the given actor.
 //

--- a/internal/apauth/core/permissions_test.go
+++ b/internal/apauth/core/permissions_test.go
@@ -586,6 +586,143 @@ func TestPermission_AllowsForActor(t *testing.T) {
 	}
 }
 
+func TestValidatePermissionRestrictions(t *testing.T) {
+	actor := &Actor{
+		ExternalId: "deploy-bot",
+		Labels:     map[string]string{"team": "platform"},
+	}
+	base := []aschema.Permission{
+		{
+			Namespace: "root.{{labels.team}}.**",
+			Resources: []string{"connections"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			Namespace:   "root.platform.secure",
+			Resources:   []string{"actors"},
+			ResourceIds: []string{"act_one", "act_two"},
+			Verbs:       []string{"get"},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		restrictions []aschema.Permission
+		wantError    bool
+	}{
+		{
+			name: "empty restrictions",
+		},
+		{
+			name: "narrower namespace and verb",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform.production.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"list"},
+			}},
+		},
+		{
+			name: "equivalent rendered namespace",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.{{labels.team}}.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			}},
+		},
+		{
+			name: "resource id subset split across base permissions",
+			restrictions: []aschema.Permission{{
+				Namespace:   "root.platform.secure",
+				Resources:   []string{"actors"},
+				ResourceIds: []string{"act_one", "act_two"},
+				Verbs:       []string{"get"},
+			}},
+		},
+		{
+			name: "broader namespace",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.**",
+				Resources: []string{"connections"},
+				Verbs:     []string{"list"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "new resource",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform",
+				Resources: []string{"connectors"},
+				Verbs:     []string{"get"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "wildcard resource",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform",
+				Resources: []string{"*"},
+				Verbs:     []string{"get"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "new verb",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform",
+				Resources: []string{"connections"},
+				Verbs:     []string{"delete"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "all resource ids from scoped base",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform.secure",
+				Resources: []string{"actors"},
+				Verbs:     []string{"get"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "new resource id",
+			restrictions: []aschema.Permission{{
+				Namespace:   "root.platform.secure",
+				Resources:   []string{"actors"},
+				ResourceIds: []string{"act_three"},
+				Verbs:       []string{"get"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "invalid restriction",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.platform",
+			}},
+			wantError: true,
+		},
+		{
+			name: "unrenderable namespace",
+			restrictions: []aschema.Permission{{
+				Namespace: "root.{{labels.missing}}",
+				Resources: []string{"connections"},
+				Verbs:     []string{"get"},
+			}},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePermissionRestrictions(actor, base, tt.restrictions)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPermissionsAllowForActor(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/apauth/jwt/actor_claim.go
+++ b/internal/apauth/jwt/actor_claim.go
@@ -1,0 +1,181 @@
+package jwt
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/util"
+)
+
+// ActorClaim is the restricted Actor resource representation accepted in a
+// JWT. It deliberately reuses the canonical Actor fields while applying a
+// tighter transport policy: database identity, lifecycle state, and signing
+// material are not valid JWT claims.
+type ActorClaim actorschema.Actor
+
+type actorClaimJSON ActorClaim
+
+// NewActorClaim creates the restricted resource view of runtime actor data.
+// Mutable maps and permission slices are cloned so later builder changes do
+// not mutate the caller's actor.
+func NewActorClaim(value core.IActorData) *ActorClaim {
+	if value == nil {
+		return nil
+	}
+
+	resource := actorschema.Actor{
+		TypeMeta: meta.NewTypeMeta(actorschema.ActorKind),
+		Metadata: meta.ObjectMeta{
+			Name:        value.GetName(),
+			Namespace:   value.GetNamespace(),
+			Labels:      cloneStringMap(value.GetLabels()),
+			Annotations: cloneStringMap(value.GetAnnotations()),
+		},
+		Spec: actorschema.ActorSpec{
+			ExternalId:  value.GetExternalId(),
+			Permissions: actorschema.ClonePermissions(value.GetPermissions()),
+		},
+	}
+
+	claim := ActorClaim(resource)
+	return &claim
+}
+
+// ToCoreActor converts the transport claim into the actor representation used
+// by authorization and persistence. JWT actor claims never carry a database
+// ID.
+func (a *ActorClaim) ToCoreActor() *core.Actor {
+	if a == nil {
+		return nil
+	}
+
+	return &core.Actor{
+		Id:          apid.Nil,
+		Name:        a.Metadata.Name,
+		ExternalId:  a.Spec.ExternalId,
+		Namespace:   a.Metadata.Namespace,
+		Labels:      cloneStringMap(a.Metadata.Labels),
+		Annotations: cloneStringMap(a.Metadata.Annotations),
+		Permissions: actorschema.ClonePermissions(a.Spec.Permissions),
+	}
+}
+
+func cloneStringMap(value map[string]string) map[string]string {
+	if value == nil {
+		return nil
+	}
+
+	result := make(map[string]string, len(value))
+	for key, item := range value {
+		result[key] = item
+	}
+	return result
+}
+
+// UnmarshalJSON accepts only the canonical Actor resource fields and rejects
+// forbidden fields even when their JSON values are null or zero. This also
+// intentionally rejects the pre-v1alpha1 flat actor claim.
+func (a *ActorClaim) UnmarshalJSON(data []byte) error {
+	if err := rejectForbiddenActorClaimFields(data); err != nil {
+		return err
+	}
+
+	var decoded actorClaimJSON
+	if err := util.DecodeJSONStrict(data, &decoded); err != nil {
+		return fmt.Errorf("decode JWT actor resource: %w", err)
+	}
+
+	*a = ActorClaim(decoded)
+	return nil
+}
+
+func rejectForbiddenActorClaimFields(data []byte) error {
+	var resource map[string]json.RawMessage
+	if err := json.Unmarshal(data, &resource); err != nil {
+		return fmt.Errorf("decode JWT actor resource: %w", err)
+	}
+
+	if _, present := resource["status"]; present {
+		return fmt.Errorf("actor status is forbidden in JWT claims")
+	}
+
+	if raw, present := resource["metadata"]; present {
+		var metadataFields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &metadataFields); err != nil {
+			return fmt.Errorf("decode JWT actor metadata: %w", err)
+		}
+		for _, field := range []string{"id", "generation", "createdAt", "updatedAt"} {
+			if _, present := metadataFields[field]; present {
+				return fmt.Errorf("actor metadata.%s is forbidden in JWT claims", field)
+			}
+		}
+	}
+
+	if raw, present := resource["spec"]; present {
+		var specFields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &specFields); err != nil {
+			return fmt.Errorf("decode JWT actor spec: %w", err)
+		}
+		if _, present := specFields["signingKey"]; present {
+			return fmt.Errorf("actor spec.signingKey is forbidden in JWT claims")
+		}
+	}
+
+	return nil
+}
+
+// Validate enforces the JWT-specific Actor resource contract.
+func (a *ActorClaim) Validate() error {
+	if a == nil {
+		return fmt.Errorf("actor is required")
+	}
+
+	vc := &common.ValidationContext{Path: "$.actor"}
+	var result *multierror.Error
+	if err := meta.ValidateResource(a.TypeMeta, a.Metadata, meta.ValidationOptions{
+		Mode:               meta.ValidationModeResponse,
+		Path:               vc,
+		ExpectedAPIVersion: meta.APIVersionV1Alpha1,
+		ExpectedKind:       actorschema.ActorKind,
+		RequireNamespace:   true,
+		NamespaceValidator: nschema.ValidatePath,
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if a.Metadata.ID != "" {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.id", "is forbidden in JWT claims"))
+	}
+	if a.Metadata.Generation != 0 {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.generation", "is forbidden in JWT claims"))
+	}
+	if a.Metadata.CreatedAt != nil {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.createdAt", "is forbidden in JWT claims"))
+	}
+	if a.Metadata.UpdatedAt != nil {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.updatedAt", "is forbidden in JWT claims"))
+	}
+	if a.Spec.ExternalId == "" {
+		result = multierror.Append(result, vc.NewErrorForField("spec.externalId", "is required"))
+	}
+	for i := range a.Spec.Permissions {
+		if err := a.Spec.Permissions[i].Validate(); err != nil {
+			result = multierror.Append(result, vc.PushField("spec").PushField("permissions").PushIndex(i).NewError(err.Error()))
+		}
+	}
+	if a.Spec.SigningKey != nil {
+		result = multierror.Append(result, vc.NewErrorForField("spec.signingKey", "is forbidden in JWT claims"))
+	}
+	if a.Status != nil {
+		result = multierror.Append(result, vc.NewErrorForField("status", "is forbidden in JWT claims"))
+	}
+
+	return result.ErrorOrNil()
+}

--- a/internal/apauth/jwt/actor_claim_test.go
+++ b/internal/apauth/jwt/actor_claim_test.go
@@ -1,0 +1,171 @@
+package jwt
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apauth/core"
+	"github.com/rmorlok/authproxy/internal/apid"
+	authschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewActorClaim(t *testing.T) {
+	id := apid.New(apid.PrefixActor)
+	labels := map[string]string{"team": "platform"}
+	permissions := []authschema.Permission{{
+		Namespace:   "root.platform.**",
+		Resources:   []string{"connections"},
+		ResourceIds: []string{"cxn_1"},
+		Verbs:       []string{"get"},
+	}}
+	value := &core.Actor{
+		Id:          id,
+		Name:        "deploy-bot",
+		ExternalId:  "deploy-bot@example.com",
+		Namespace:   "root.platform",
+		Labels:      labels,
+		Annotations: map[string]string{"owner": "auth"},
+		Permissions: permissions,
+	}
+
+	claim := NewActorClaim(value)
+	require.Equal(t, meta.APIVersionV1Alpha1, claim.APIVersion)
+	require.Equal(t, actorschema.ActorKind, claim.Kind)
+	require.Empty(t, claim.Metadata.ID)
+	require.Equal(t, value.Name, claim.Metadata.Name)
+	require.Equal(t, value.Namespace, claim.Metadata.Namespace)
+	require.Equal(t, value.ExternalId, claim.Spec.ExternalId)
+	require.Equal(t, value.Permissions, claim.Spec.Permissions)
+	require.Nil(t, claim.Spec.SigningKey)
+	require.Nil(t, claim.Status)
+
+	labels["team"] = "changed"
+	permissions[0].Resources[0] = "actors"
+	require.Equal(t, "platform", claim.Metadata.Labels["team"])
+	require.Equal(t, "connections", claim.Spec.Permissions[0].Resources[0])
+
+	runtimeActor := claim.ToCoreActor()
+	require.True(t, runtimeActor.Id.IsNil())
+	require.Equal(t, value.Name, runtimeActor.Name)
+	require.Equal(t, claim.Spec.ExternalId, runtimeActor.ExternalId)
+	require.Equal(t, claim.Metadata.Namespace, runtimeActor.Namespace)
+}
+
+func TestActorClaimJSON(t *testing.T) {
+	valid := `{
+		"apiVersion":"authproxy.net/v1alpha1",
+		"kind":"Actor",
+		"metadata":{
+			"name":"deploy-bot",
+			"namespace":"root.platform",
+			"labels":{"team":"platform"},
+			"annotations":{"owner":"auth"}
+		},
+		"spec":{
+			"externalId":"deploy-bot@example.com",
+			"permissions":[{
+				"namespace":"root.platform.**",
+				"resources":["connections"],
+				"verbs":["get"]
+			}]
+		}
+	}`
+
+	var claim ActorClaim
+	require.NoError(t, json.Unmarshal([]byte(valid), &claim))
+	require.NoError(t, claim.Validate())
+	require.Equal(t, "deploy-bot@example.com", claim.Spec.ExternalId)
+	require.Equal(t, "root.platform", claim.Metadata.Namespace)
+
+	roundTrip, err := json.Marshal(&claim)
+	require.NoError(t, err)
+	require.JSONEq(t, valid, string(roundTrip))
+}
+
+func TestActorClaimRejectsLegacyAndForbiddenJSON(t *testing.T) {
+	tests := map[string]string{
+		"legacy flat actor": `{
+			"externalId":"legacy",
+			"namespace":"root",
+			"permissions":[]
+		}`,
+		"metadata id": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"id":null,"namespace":"root"},
+			"spec":{"externalId":"actor"}
+		}`,
+		"metadata generation": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"generation":0,"namespace":"root"},
+			"spec":{"externalId":"actor"}
+		}`,
+		"metadata createdAt": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"createdAt":null,"namespace":"root"},
+			"spec":{"externalId":"actor"}
+		}`,
+		"metadata updatedAt": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"updatedAt":null,"namespace":"root"},
+			"spec":{"externalId":"actor"}
+		}`,
+		"signing key": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"namespace":"root"},
+			"spec":{"externalId":"actor","signingKey":null}
+		}`,
+		"status": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"namespace":"root"},
+			"spec":{"externalId":"actor"},
+			"status":null
+		}`,
+		"unknown metadata field": `{
+			"apiVersion":"authproxy.net/v1alpha1","kind":"Actor",
+			"metadata":{"namespace":"root","externalId":"actor"},
+			"spec":{"externalId":"actor"}
+		}`,
+	}
+
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			var claim ActorClaim
+			require.Error(t, json.Unmarshal([]byte(payload), &claim))
+		})
+	}
+}
+
+func TestActorClaimValidate(t *testing.T) {
+	valid := NewActorClaim(&core.Actor{ExternalId: "actor", Namespace: "root"})
+	require.NoError(t, valid.Validate())
+
+	now := time.Now()
+	tests := map[string]func(*ActorClaim){
+		"api version": func(claim *ActorClaim) { claim.APIVersion = "authproxy.net/v2" },
+		"kind":        func(claim *ActorClaim) { claim.Kind = "Connection" },
+		"namespace":   func(claim *ActorClaim) { claim.Metadata.Namespace = "outside" },
+		"id":          func(claim *ActorClaim) { claim.Metadata.ID = "act_123" },
+		"generation":  func(claim *ActorClaim) { claim.Metadata.Generation = 1 },
+		"created at":  func(claim *ActorClaim) { claim.Metadata.CreatedAt = &now },
+		"updated at":  func(claim *ActorClaim) { claim.Metadata.UpdatedAt = &now },
+		"external id": func(claim *ActorClaim) { claim.Spec.ExternalId = "" },
+		"permission": func(claim *ActorClaim) {
+			claim.Spec.Permissions = []authschema.Permission{{Namespace: "root"}}
+		},
+		"signing key": func(claim *ActorClaim) { claim.Spec.SigningKey = &keyschema.SigningKey{} },
+		"status":      func(claim *ActorClaim) { claim.Status = &actorschema.ActorStatus{} },
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			claim := *valid
+			mutate(&claim)
+			require.Error(t, claim.Validate())
+		})
+	}
+}

--- a/internal/apauth/jwt/auth_proxy_claims.go
+++ b/internal/apauth/jwt/auth_proxy_claims.go
@@ -22,20 +22,20 @@ type AuthProxyClaims struct {
 	jwt.RegisteredClaims
 
 	// Namespace is the namespace of the actor. This is used to identify valid signing keys for the request, as well
-	// where to lookup the actor in th database. THe value of subject must be unique within a given namespace. If
+	// as where to look up the actor in the database. The value of subject must be unique within a given namespace. If
 	// omitted, Namespace is assumed to be root. If Actor is provided, the value of namespace must be the same as
 	// the value of the actor's namespace.
 	Namespace string `json:"namespace,omitempty"`
 
-	// Actor is the entity taking the action. Specifying the full actor here (versus just the ID in the subject)
-	// implies that the actor should be upserted into the system as specified versus only working against a previous
-	// actor configured in the system. If Actor is specified, the value of ExternalId must be the same as sub in the
-	// base claims.
-	Actor *core.Actor `json:"actor,omitempty"`
+	// Actor is the entity taking the action, represented as a restricted
+	// authproxy.net/v1alpha1 Actor resource. Specifying it implies that the
+	// actor should be upserted into the system. Database identity, lifecycle
+	// status, timestamps, and signing material are forbidden in this claim.
+	Actor *ActorClaim `json:"actor,omitempty"`
 
-	// Permissions optionally restrict what this specific token can do. These
-	// permissions are intersected with the authenticated actor's permissions and
-	// cannot grant access the actor does not already have.
+	// Permissions optionally restrict what this specific token can do. Every
+	// permission must be contained by the authenticated actor's permissions, and
+	// the two sets are intersected during authorization.
 	Permissions []aschema.Permission `json:"permissions,omitempty"`
 
 	// SystemSigned indicates this token was signed by an AuthProxy service using the GlobalAESKey (HMAC).
@@ -80,17 +80,31 @@ func (tc *AuthProxyClaims) Validate(v *jwt.Validator) error {
 	}
 
 	if tc.Actor != nil {
-		if tc.Subject != tc.Actor.GetExternalId() {
-			result = multierror.Append(result, errors.New("token subject and actor id do not match"))
+		if err := tc.Actor.Validate(); err != nil {
+			result = multierror.Append(result, err)
 		}
 
-		if tc.GetNamespace() != tc.Actor.GetNamespace() {
-			result = multierror.Append(result, errors.New("token namespace and actor namespace do not match"))
+		if tc.Subject != tc.Actor.Spec.ExternalId {
+			result = multierror.Append(result, errors.New("token subject and actor spec.externalId do not match"))
+		}
+
+		if tc.GetNamespace() != tc.Actor.Metadata.Namespace {
+			result = multierror.Append(result, errors.New("token namespace and actor metadata.namespace do not match"))
 		}
 	}
 
 	for _, permission := range tc.Permissions {
 		if err := permission.Validate(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if tc.Actor != nil {
+		if err := core.ValidatePermissionRestrictions(
+			tc.Actor.ToCoreActor(),
+			tc.Actor.Spec.Permissions,
+			tc.Permissions,
+		); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/internal/apauth/jwt/auth_proxy_claims.go
+++ b/internal/apauth/jwt/auth_proxy_claims.go
@@ -16,15 +16,18 @@ import (
 
 var ErrInvalidClaims = errors.New("invalid jwt claims")
 
-// AuthProxyClaims is the struct that defines a JWT for the auth service. It contains information about the actor
-// (user or system taking the action) as well as standard JWT information.
+// AuthProxyClaims is the struct that defines a JWT for the auth service. It
+// contains information about the actor (user or system taking the action) as
+// well as standard JWT information.
 type AuthProxyClaims struct {
 	jwt.RegisteredClaims
 
-	// Namespace is the namespace of the actor. This is used to identify valid signing keys for the request, as well
-	// as where to look up the actor in the database. The value of subject must be unique within a given namespace. If
-	// omitted, Namespace is assumed to be root. If Actor is provided, the value of namespace must be the same as
-	// the value of the actor's namespace.
+	// Namespace is the namespace of the actor. This is used to identify valid
+	// signing keys for the request, as well as where to look up the actor in
+	// the database. The value of subject must be unique within a given
+	// namespace. If omitted, Namespace is assumed to be root. If Actor is
+	// provided, the value of namespace must be the same as the value of the
+	// actor's namespace.
 	Namespace string `json:"namespace,omitempty"`
 
 	// Actor is the entity taking the action, represented as a restricted
@@ -34,20 +37,24 @@ type AuthProxyClaims struct {
 	Actor *ActorClaim `json:"actor,omitempty"`
 
 	// Permissions optionally restrict what this specific token can do. Every
-	// permission must be contained by the authenticated actor's permissions, and
-	// the two sets are intersected during authorization.
+	// permission must be contained by the authenticated actor's permissions,
+	// and the two sets are intersected during authorization.
 	Permissions []aschema.Permission `json:"permissions,omitempty"`
 
-	// SystemSigned indicates this token was signed by an AuthProxy service using the GlobalAESKey (HMAC).
-	// This is used for internal auth transfer between services, OAuth redirects, etc.
+	// SystemSigned indicates this token was signed by an AuthProxy service using
+	// the GlobalAESKey (HMAC). This is used for internal auth transfer between
+	// services, OAuth redirects, etc.
 	SystemSigned bool `json:"systemSigned,omitempty"`
 
-	// ActorSigned indicates this token was signed by an actor using their own private key (asymmetric).
-	// This is used by the CLI and other external callers that have actor credentials.
+	// ActorSigned indicates this token was signed by an actor using their own
+	// private key (asymmetric). This is used by the CLI and other external
+	// callers that have actor credentials.
 	ActorSigned bool `json:"actorSigned,omitempty"`
 
-	// Nonce is a one-time-use value. Adding a nonce to the JWT make it a one-time-use for auth purposes. If you use
-	// a nonce, the JWT must also have an expiry so that tracking of the nonce values do not need to be kept forever.
+	// Nonce is a one-time-use value. Adding a nonce to the JWT makes it a
+	// one-time-use for auth purposes. If you use a nonce, the JWT must also
+	// have an expiry so that tracking of the nonce values do not need to be
+	// kept forever.
 	Nonce *apid.ID `json:"nonce,omitempty"`
 }
 

--- a/internal/apauth/jwt/auth_proxy_claims_test.go
+++ b/internal/apauth/jwt/auth_proxy_claims_test.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apauth/core"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJwtTokenClaims(t *testing.T) {
@@ -27,13 +29,14 @@ func TestJwtTokenClaims(t *testing.T) {
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject: "bobdole",
 			},
-			Actor: &core.Actor{
+			Actor: NewActorClaim(&core.Actor{
 				ExternalId: "bobdole",
-			},
+				Namespace:  "root",
+			}),
 		}
 
 		assert.NotNil(t, tc.Actor)
-		assert.Equal(t, "bobdole", tc.Actor.ExternalId)
+		assert.Equal(t, "bobdole", tc.Actor.Spec.ExternalId)
 	})
 	t.Run("IsExpired", func(t *testing.T) {
 		t.Run("nil", func(t *testing.T) {
@@ -75,4 +78,67 @@ func TestJwtTokenClaims(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidClaims)
 	})
+}
+
+func TestAuthProxyClaimsValidateActorContract(t *testing.T) {
+	basePermissions := []aschema.Permission{{
+		Namespace: "root.platform.**",
+		Resources: []string{"connections"},
+		Verbs:     []string{"get", "list"},
+	}}
+	valid := AuthProxyClaims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "deploy-bot"},
+		Namespace:        "root.platform",
+		Actor: NewActorClaim(&core.Actor{
+			ExternalId:  "deploy-bot",
+			Namespace:   "root.platform",
+			Permissions: basePermissions,
+		}),
+		Permissions: []aschema.Permission{{
+			Namespace: "root.platform.production",
+			Resources: []string{"connections"},
+			Verbs:     []string{"get"},
+		}},
+	}
+	require.NoError(t, valid.Validate(jwt.NewValidator()))
+
+	tests := map[string]struct {
+		mutate    func(*AuthProxyClaims)
+		errorText string
+	}{
+		"subject mismatch": {
+			mutate:    func(claims *AuthProxyClaims) { claims.Subject = "other" },
+			errorText: "subject and actor spec.externalId",
+		},
+		"namespace mismatch": {
+			mutate:    func(claims *AuthProxyClaims) { claims.Namespace = "root.other" },
+			errorText: "namespace and actor metadata.namespace",
+		},
+		"permission escalation": {
+			mutate: func(claims *AuthProxyClaims) {
+				claims.Permissions = []aschema.Permission{{
+					Namespace: "root.**",
+					Resources: []string{"actors"},
+					Verbs:     []string{"delete"},
+				}}
+			},
+			errorText: "beyond the actor's permissions",
+		},
+		"invalid actor resource": {
+			mutate:    func(claims *AuthProxyClaims) { claims.Actor.Kind = "Connection" },
+			errorText: "kind",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			claims := valid
+			actor := *valid.Actor
+			claims.Actor = &actor
+			tt.mutate(&claims)
+			err := claims.Validate(jwt.NewValidator())
+			require.ErrorIs(t, err, ErrInvalidClaims)
+			require.True(t, strings.Contains(err.Error(), tt.errorText), err.Error())
+		})
+	}
 }

--- a/internal/apauth/jwt/claims_builder.go
+++ b/internal/apauth/jwt/claims_builder.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -49,7 +50,7 @@ type claimsBuilder struct {
 	expiration   *time.Time
 	externalId   *string
 	namespace    *string
-	actor        *core.Actor
+	actor        *ActorClaim
 	permissions  []aschema.Permission
 	labels       map[string]string
 	annotations  map[string]string
@@ -118,7 +119,7 @@ func (b *claimsBuilder) WithNamespace(namespace string) ClaimsBuilder {
 }
 
 func (b *claimsBuilder) WithActor(actor core.IActorData) ClaimsBuilder {
-	b.actor = core.CreateActor(actor)
+	b.actor = NewActorClaim(actor)
 	return b
 }
 
@@ -161,12 +162,12 @@ func (b *claimsBuilder) WithNonce() ClaimsBuilder {
 
 func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) {
 	if b.actor != nil {
-		if b.actor.GetExternalId() != "" {
-			b.externalId = util.ToPtr(b.actor.GetExternalId())
+		if b.actor.Spec.ExternalId != "" {
+			b.externalId = util.ToPtr(b.actor.Spec.ExternalId)
 		}
 
-		if b.actor.GetNamespace() != "" {
-			b.namespace = util.ToPtr(b.actor.GetNamespace())
+		if b.actor.Metadata.Namespace != "" {
+			b.namespace = util.ToPtr(b.actor.Metadata.Namespace)
 		}
 
 		if b.namespace == nil {
@@ -174,36 +175,42 @@ func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) 
 		}
 
 		if b.namespace != nil {
-			b.actor.Namespace = *b.namespace
+			b.actor.Metadata.Namespace = *b.namespace
 		}
 
 		if b.externalId != nil {
-			b.actor.ExternalId = *b.externalId
+			b.actor.Spec.ExternalId = *b.externalId
 		}
 
 		if len(b.labels) > 0 {
-			if b.actor.Labels == nil {
-				b.actor.Labels = make(map[string]string)
+			if b.actor.Metadata.Labels == nil {
+				b.actor.Metadata.Labels = make(map[string]string)
 			}
 			for k, v := range b.labels {
-				b.actor.Labels[k] = v
+				b.actor.Metadata.Labels[k] = v
 			}
 		}
 
 		if len(b.annotations) > 0 {
-			if b.actor.Annotations == nil {
-				b.actor.Annotations = make(map[string]string)
+			if b.actor.Metadata.Annotations == nil {
+				b.actor.Metadata.Annotations = make(map[string]string)
 			}
 			for k, v := range b.annotations {
-				b.actor.Annotations[k] = v
+				b.actor.Metadata.Annotations[k] = v
 			}
 		}
 	}
 
 	if b.actor == nil && (len(b.labels) > 0 || len(b.annotations) > 0) {
-		b.actor = &core.Actor{
-			Labels:      b.labels,
-			Annotations: b.annotations,
+		b.actor = NewActorClaim(&core.Actor{
+			Labels:      cloneStringMap(b.labels),
+			Annotations: cloneStringMap(b.annotations),
+		})
+		if b.namespace != nil {
+			b.actor.Metadata.Namespace = *b.namespace
+		}
+		if b.externalId != nil {
+			b.actor.Spec.ExternalId = *b.externalId
 		}
 	}
 
@@ -249,6 +256,24 @@ func (b *claimsBuilder) BuildCtx(ctx context.Context) (*AuthProxyClaims, error) 
 		}
 
 		c.Nonce = b.nonce
+	}
+
+	for i := range c.Permissions {
+		if err := c.Permissions[i].Validate(); err != nil {
+			return nil, fmt.Errorf("invalid request permission %d: %w", i, err)
+		}
+	}
+	if c.Actor != nil {
+		if err := c.Actor.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid JWT actor resource: %w", err)
+		}
+		if err := core.ValidatePermissionRestrictions(
+			c.Actor.ToCoreActor(),
+			c.Actor.Spec.Permissions,
+			c.Permissions,
+		); err != nil {
+			return nil, fmt.Errorf("request permissions exceed actor permissions: %w", err)
+		}
 	}
 
 	return &c, nil

--- a/internal/apauth/jwt/claims_builder_test.go
+++ b/internal/apauth/jwt/claims_builder_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/rmorlok/authproxy/internal/apctx"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -78,8 +81,8 @@ func TestClaimsBuilder(t *testing.T) {
 		require.NotEmpty(t, claims.ID)
 		require.Equal(t, "me", claims.Issuer)
 		require.Equal(t, "public", claims.Audience[0])
-		require.Equal(t, "bob-dole", claims.Actor.ExternalId)
-		require.Equal(t, "root.child", claims.Actor.Namespace)
+		require.Equal(t, "bob-dole", claims.Actor.Spec.ExternalId)
+		require.Equal(t, "root.child", claims.Actor.Metadata.Namespace)
 		require.Equal(t, "bob-dole", claims.Subject)
 		require.Equal(t, "root.child", claims.Namespace)
 		require.Equal(t, apctx.GetClock(ctx).Now().Add(10*time.Minute), claims.ExpiresAt.Time)
@@ -111,11 +114,42 @@ func TestClaimsBuilder(t *testing.T) {
 		require.NotEmpty(t, claims.ID)
 		require.Equal(t, "me", claims.Issuer)
 		require.Equal(t, "public", claims.Audience[0])
-		require.Equal(t, "bob-dole", claims.Actor.ExternalId)
-		require.Equal(t, "root.child", claims.Actor.Namespace)
+		require.Equal(t, "bob-dole", claims.Actor.Spec.ExternalId)
+		require.Equal(t, "root.child", claims.Actor.Metadata.Namespace)
 		require.Equal(t, "bob-dole", claims.Subject)
 		require.Equal(t, "root.child", claims.Namespace)
 		require.Equal(t, apctx.GetClock(ctx).Now().Add(10*time.Minute), claims.ExpiresAt.Time)
+	})
+	t.Run("configured actor is restricted for JWT transport", func(t *testing.T) {
+		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
+		ctx := apctx.NewBuilderBackground().WithClock(clock.NewFakeClock(now)).Build()
+		source := &actorschema.Actor{
+			TypeMeta: meta.NewTypeMeta(actorschema.ActorKind),
+			Metadata: meta.ObjectMeta{
+				ID:         "act_database-id",
+				Name:       "deploy-bot",
+				Namespace:  "root.platform",
+				Generation: 7,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			},
+			Spec: actorschema.ActorSpec{
+				ExternalId: "deploy-bot",
+				SigningKey: &keyschema.SigningKey{},
+			},
+			Status: &actorschema.ActorStatus{SigningKeyConfigured: true},
+		}
+
+		claims, err := NewClaimsBuilder().WithActor(source).BuildCtx(ctx)
+		require.NoError(t, err)
+		require.NoError(t, claims.Actor.Validate())
+		require.Equal(t, source.Metadata.Name, claims.Actor.Metadata.Name)
+		require.Empty(t, claims.Actor.Metadata.ID)
+		require.Zero(t, claims.Actor.Metadata.Generation)
+		require.Nil(t, claims.Actor.Metadata.CreatedAt)
+		require.Nil(t, claims.Actor.Metadata.UpdatedAt)
+		require.Nil(t, claims.Actor.Spec.SigningKey)
+		require.Nil(t, claims.Actor.Status)
 	})
 	t.Run("valid with top-level permissions", func(t *testing.T) {
 		now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
@@ -141,6 +175,26 @@ func TestClaimsBuilder(t *testing.T) {
 		require.Nil(t, claims.Actor)
 		require.Equal(t, "bob-dole", claims.Subject)
 		require.Equal(t, "root.child", claims.Namespace)
+	})
+	t.Run("rejects top-level permission escalation for embedded actor", func(t *testing.T) {
+		_, err := NewClaimsBuilder().
+			WithActor(&core.Actor{
+				ExternalId: "bob-dole",
+				Namespace:  "root.child",
+				Permissions: []aschema.Permission{{
+					Namespace: "root.child",
+					Resources: []string{"connections"},
+					Verbs:     []string{"get"},
+				}},
+			}).
+			WithPermissions([]aschema.Permission{{
+				Namespace: "root.**",
+				Resources: []string{"actors"},
+				Verbs:     []string{"delete"},
+			}}).
+			Build()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "request permissions exceed actor permissions")
 	})
 	t.Run("nonce", func(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
@@ -186,8 +240,8 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NotEmpty(t, claims.ID)
 			require.Equal(t, "me", claims.Issuer)
 			require.Equal(t, "public", claims.Audience[0])
-			require.Equal(t, "bob-dole", claims.Actor.ExternalId)
-			require.Equal(t, "root.child", claims.Actor.Namespace)
+			require.Equal(t, "bob-dole", claims.Actor.Spec.ExternalId)
+			require.Equal(t, "root.child", claims.Actor.Metadata.Namespace)
 			require.Equal(t, "bob-dole", claims.Subject)
 			require.Equal(t, "root.child", claims.Namespace)
 			require.Equal(t, apctx.GetClock(ctx).Now().Add(10*time.Minute), claims.ExpiresAt.Time)
@@ -243,7 +297,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Labels)
 		})
 		t.Run("with map of labels", func(t *testing.T) {
 			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
@@ -261,7 +315,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Labels)
 		})
 		t.Run("merge labels with actor", func(t *testing.T) {
 			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
@@ -282,7 +336,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Labels)
 		})
 	})
 	t.Run("annotations", func(t *testing.T) {
@@ -303,7 +357,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Annotations)
 		})
 		t.Run("with map of annotations", func(t *testing.T) {
 			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
@@ -321,7 +375,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Annotations)
 		})
 		t.Run("merge annotations with actor", func(t *testing.T) {
 			now := time.Date(1955, time.November, 5, 6, 29, 0, 0, time.UTC)
@@ -342,7 +396,7 @@ func TestClaimsBuilder(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, claims.Actor)
-			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Annotations)
 		})
 	})
 }

--- a/internal/apauth/jwt/parser_builder.go
+++ b/internal/apauth/jwt/parser_builder.go
@@ -325,6 +325,14 @@ func (pb *parserBuilder) ParseCtx(ctx context.Context, token string) (*AuthProxy
 	if !ok {
 		return nil, errors.New("invalid token")
 	}
+	validator := jwt.NewValidator(
+		jwt.WithTimeFunc(func() time.Time {
+			return apctx.GetClock(ctx).Now()
+		}),
+	)
+	if err := claims.Validate(validator); err != nil {
+		return nil, fmt.Errorf("can't validate token claims: %w", err)
+	}
 
 	return claims, nil
 }

--- a/internal/apauth/jwt/parser_builder_test.go
+++ b/internal/apauth/jwt/parser_builder_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/rmorlok/authproxy/internal/apauth/core"
+	authschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,4 +64,118 @@ func TestJwtTokenParserBuilder(t *testing.T) {
 			require.True(t, ok)
 		})
 	})
+}
+
+func TestJwtTokenParserBuilderActorResource(t *testing.T) {
+	secret := []byte("a-long-enough-test-secret")
+	basePermissions := []authschema.Permission{{
+		Namespace: "root.platform.**",
+		Resources: []string{"connections"},
+		Verbs:     []string{"get", "list"},
+	}}
+	token, err := NewJwtTokenBuilder().
+		WithActor(&core.Actor{
+			Name:        "deploy-bot",
+			ExternalId:  "deploy-bot",
+			Namespace:   "root.platform",
+			Permissions: basePermissions,
+		}).
+		WithPermissions([]authschema.Permission{{
+			Namespace: "root.platform.production",
+			Resources: []string{"connections"},
+			Verbs:     []string{"get"},
+		}}).
+		WithSecretKey(secret).
+		Token()
+	require.NoError(t, err)
+
+	claims, err := NewJwtTokenParserBuilder().WithSharedKey(secret).Parse(token)
+	require.NoError(t, err)
+	require.NoError(t, claims.Validate(jwt.NewValidator()))
+	require.Equal(t, "authproxy.net/v1alpha1", string(claims.Actor.APIVersion))
+	require.Equal(t, "Actor", string(claims.Actor.Kind))
+	require.Equal(t, "deploy-bot", claims.Actor.Spec.ExternalId)
+	require.Equal(t, "root.platform", claims.Actor.Metadata.Namespace)
+	require.Empty(t, claims.Actor.Metadata.ID)
+	require.Nil(t, claims.Actor.Spec.SigningKey)
+	require.Nil(t, claims.Actor.Status)
+}
+
+func TestJwtTokenParserBuilderRejectsLegacyActor(t *testing.T) {
+	secret := []byte("a-long-enough-test-secret")
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":       "legacy",
+		"namespace": "root",
+		"actor": map[string]any{
+			"externalId":  "legacy",
+			"namespace":   "root",
+			"permissions": []any{},
+		},
+	})
+	signed, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	_, err = NewJwtTokenParserBuilder().WithSharedKey(secret).Parse(signed)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+}
+
+func TestJwtTokenParserBuilderRejectsActorClaimMismatches(t *testing.T) {
+	secret := []byte("a-long-enough-test-secret")
+	basePermissions := []authschema.Permission{{
+		Namespace: "root.platform.**",
+		Resources: []string{"connections"},
+		Verbs:     []string{"get"},
+	}}
+	newClaims := func() *AuthProxyClaims {
+		return &AuthProxyClaims{
+			RegisteredClaims: jwt.RegisteredClaims{Subject: "deploy-bot"},
+			Namespace:        "root.platform",
+			Actor: NewActorClaim(&core.Actor{
+				ExternalId:  "deploy-bot",
+				Namespace:   "root.platform",
+				Permissions: basePermissions,
+			}),
+		}
+	}
+
+	tests := map[string]struct {
+		mutate    func(*AuthProxyClaims)
+		errorText string
+	}{
+		"subject": {
+			mutate:    func(claims *AuthProxyClaims) { claims.Subject = "other" },
+			errorText: "subject and actor spec.externalId",
+		},
+		"namespace": {
+			mutate:    func(claims *AuthProxyClaims) { claims.Namespace = "root.other" },
+			errorText: "namespace and actor metadata.namespace",
+		},
+		"permissions": {
+			mutate: func(claims *AuthProxyClaims) {
+				claims.Permissions = []authschema.Permission{{
+					Namespace: "root.**",
+					Resources: []string{"actors"},
+					Verbs:     []string{"delete"},
+				}}
+			},
+			errorText: "beyond the actor's permissions",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			claims := newClaims()
+			tt.mutate(claims)
+			signed, err := NewJwtTokenBuilder().
+				WithClaims(claims).
+				WithSecretKey(secret).
+				Token()
+			require.NoError(t, err)
+
+			_, err = NewJwtTokenParserBuilder().WithSharedKey(secret).Parse(signed)
+			require.ErrorIs(t, err, ErrInvalidClaims)
+			require.Contains(t, err.Error(), tt.errorText)
+		})
+	}
 }

--- a/internal/apauth/jwt/schema-actor.json
+++ b/internal/apauth/jwt/schema-actor.json
@@ -1,38 +1,45 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/jwt/schema-actor.json",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/internal/apauth/jwt/schema-actor.json",
+  "title": "AuthProxy JWT Actor Claim",
+  "description": "The restricted authproxy.net/v1alpha1 Actor resource allowed in a JWT. Server identity, lifecycle state, and signing material are forbidden.",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
   "properties": {
-    "id": {
-      "type": "string",
-      "description": "Unique identifier for the actor. Required. This value should generally be the ID of the actor in the host system (e.g. user ID in a database)."
-    },
-    "admin": {
-      "type": "boolean",
-      "description": "Whether the actor is an admin. Optional. Defaults to false."
-    },
-    "super_admin": {
-      "type": "boolean",
-      "description": "Whether the actor is a super admin. Optional. Defaults to false."
-    },
-    "email": {
-      "type": "string",
-      "description": "The email address of the actor. Optional."
-    },
-    "permissions": {
-      "type": "array",
-      "description": "A list of permissions that the actor has. Required."
-    },
-    "labels": {
+    "apiVersion": { "const": "authproxy.net/v1alpha1" },
+    "kind": { "const": "Actor" },
+    "metadata": {
       "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Labels to carry on the actor."
+      "required": ["namespace"],
+      "properties": {
+        "name": { "type": "string" },
+        "namespace": { "type": "string" },
+        "labels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
     },
-    "annotations": {
+    "spec": {
       "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Annotations to carry on the actor."
+      "required": ["externalId"],
+      "properties": {
+        "externalId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "permissions": {
+          "type": "array",
+          "items": { "$ref": "../../schema/auth/schema.json#/$defs/Permission" }
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": false,
-  "type": "object"
+  "additionalProperties": false
 }

--- a/internal/apauth/jwt/schema.json
+++ b/internal/apauth/jwt/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/jwt/schema.json",
+  "$id": "https://raw.githubusercontent.com/rmorlok/authproxy/refs/heads/main/internal/apauth/jwt/schema.json",
   "title": "Auth Proxy JWT Payload Schema",
   "type": "object",
   "properties": {
@@ -10,7 +10,7 @@
     },
     "sub": {
       "type": "string",
-      "description": "Subject of the token. Required. This value is the id of the actor taking the action. If actor is specified in this JWT, this value must match the actor's id."
+      "description": "External ID of the actor taking the action. If actor is specified, this value must match actor.spec.externalId."
     },
     "aud": {
       "oneOf": [
@@ -38,10 +38,24 @@
       "type": "string",
       "description": "JWT ID. Optional. Not used by Auth Proxy."
     },
+    "namespace": {
+      "type": "string",
+      "description": "Namespace of the actor. Defaults to root. If actor is specified, this value must match actor.metadata.namespace."
+    },
     "actor": { "$ref": "schema-actor.json" },
     "permissions": {
       "type": "array",
-      "description": "Optional request-level permission restrictions. These are intersected with the authenticated actor's permissions and cannot grant additional access."
+      "items": { "$ref": "../../schema/auth/schema.json#/$defs/Permission" },
+      "description": "Optional request-level permission restrictions. Every action represented here must be a subset of the authenticated actor's base permissions."
+    },
+    "systemSigned": {
+      "type": "boolean"
+    },
+    "actorSigned": {
+      "type": "boolean"
+    },
+    "nonce": {
+      "type": "string"
     }
   },
   "additionalProperties": true

--- a/internal/apauth/jwt/test_data/example.json
+++ b/internal/apauth/jwt/test_data/example.json
@@ -33,7 +33,7 @@
   },
   "permissions": [
     {
-      "namespace": "root.prod.payments",
+      "namespace": "root.prod.**",
       "resources": ["connections"],
       "verbs": ["list"]
     }

--- a/internal/apauth/jwt/test_data/example.json
+++ b/internal/apauth/jwt/test_data/example.json
@@ -8,17 +8,32 @@
   "exp": 1735689600,
   "nbf": 1735603200,
   "iat": 1735603200,
-  "jti": "550e8400-e29b-41d4-a716-446655440000",
+  "jti": "jwt_550e8400-e29b-41d4-a716-446655440000",
+  "namespace": "root.prod",
   "actor": {
-    "id": "user/12345",
-    "permissions": [
-      "root.prod.actor-1234#/connections/_initiate",
-      "root.prod.**#/connections/_list"
-    ]
+    "apiVersion": "authproxy.net/v1alpha1",
+    "kind": "Actor",
+    "metadata": {
+      "name": "user-12345",
+      "namespace": "root.prod",
+      "labels": {
+        "team": "payments"
+      }
+    },
+    "spec": {
+      "externalId": "user/12345",
+      "permissions": [
+        {
+          "namespace": "root.prod.**",
+          "resources": ["connections"],
+          "verbs": ["get", "list"]
+        }
+      ]
+    }
   },
   "permissions": [
     {
-      "namespace": "root.prod.**",
+      "namespace": "root.prod.payments",
       "resources": ["connections"],
       "verbs": ["list"]
     }

--- a/internal/apauth/jwt/token_builder_test.go
+++ b/internal/apauth/jwt/token_builder_test.go
@@ -84,7 +84,7 @@ func TestJwtTokenBuilder(t *testing.T) {
 		claims, err := x.jwtBuilder.Build()
 		require.NoError(t, err)
 		require.NotNil(t, claims.Actor)
-		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Labels)
+		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Labels)
 	})
 	t.Run("annotations", func(t *testing.T) {
 		tb := NewJwtTokenBuilder().
@@ -97,6 +97,6 @@ func TestJwtTokenBuilder(t *testing.T) {
 		claims, err := x.jwtBuilder.Build()
 		require.NoError(t, err)
 		require.NotNil(t, claims.Actor)
-		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Annotations)
+		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, claims.Actor.Metadata.Annotations)
 	})
 }

--- a/internal/apauth/service/auth_methods.go
+++ b/internal/apauth/service/auth_methods.go
@@ -366,7 +366,7 @@ func (s *service) establishAuthFromRequest(ctx context.Context, requireSessionXs
 		} else {
 			// The actor was specified in the JWT. This means that we can upsert an actor, either creating it or making
 			// it consistent with the request's definition.
-			actor, err = s.db.UpsertActor(ctx, claims.Actor)
+			actor, err = s.db.UpsertActor(ctx, claims.Actor.ToCoreActor())
 			if err != nil {
 				return core.NewUnauthenticatedRequestAuth(), httperr.InternalServerErrorMsg("database error", httperr.WithInternalErrorf("failed to upsert actor: %w", err))
 			}
@@ -374,6 +374,14 @@ func (s *service) establishAuthFromRequest(ctx context.Context, requireSessionXs
 		}
 
 		if len(claims.Permissions) > 0 {
+			if err := core.ValidatePermissionRestrictions(
+				core.CreateActor(actor),
+				actor.GetPermissions(),
+				claims.Permissions,
+			); err != nil {
+				claimsErr := fmt.Errorf("%w: token permissions exceed actor permissions: %w", jwt2.ErrInvalidClaims, err)
+				return core.NewUnauthenticatedRequestAuth(), httperr.Unauthorized(httperr.WithPublicErr(claimsErr))
+			}
 			ra = core.NewAuthenticatedRequestAuthWithPermissions(actor, claims.Permissions)
 		} else {
 			ra = core.NewAuthenticatedRequestAuth(actor)

--- a/internal/apauth/service/auth_methods_test.go
+++ b/internal/apauth/service/auth_methods_test.go
@@ -53,6 +53,10 @@ func testConfiguredActor(
 	}
 }
 
+func jwtActor(value *core.Actor) *jwt2.ActorClaim {
+	return jwt2.NewActorClaim(value)
+}
+
 func TestAuth_Token(t *testing.T) {
 	t.Parallel()
 	cfg := config.FromRoot(&testConfigPublicPrivateKey)
@@ -63,7 +67,7 @@ func TestAuth_Token(t *testing.T) {
 
 	claims, err := j.Parse(testContext, res)
 	require.NoError(t, err)
-	require.NotNil(t, testClaims().Actor.Id, claims.Actor.Id)
+	require.Equal(t, testClaims().Actor, claims.Actor)
 }
 
 func TestAuth_RoundtripGlobaleAESKey(t *testing.T) {
@@ -82,10 +86,10 @@ func TestAuth_RoundtripGlobaleAESKey(t *testing.T) {
 			IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 		},
 
-		Actor: &core.Actor{
+		Actor: jwtActor(&core.Actor{
 			ExternalId: "id1",
 			Namespace:  "root",
-		},
+		}),
 	}
 
 	t.Run("via service methods", func(t *testing.T) {
@@ -93,7 +97,7 @@ func TestAuth_RoundtripGlobaleAESKey(t *testing.T) {
 		require.NoError(t, err)
 		rtClaims, err := j.Parse(testContext, tok)
 		require.NoError(t, err)
-		require.Equal(t, claims.Actor.Id, rtClaims.Actor.Id)
+		require.Equal(t, claims.Actor, rtClaims.Actor)
 
 		tokRunes := []rune(tok)
 		if len(tokRunes) >= 10 {
@@ -113,7 +117,7 @@ func TestAuth_RoundtripGlobaleAESKey(t *testing.T) {
 		require.NoError(t, err)
 		rtClaims, err := j.Parse(testContext, tok)
 		require.NoError(t, err)
-		require.Equal(t, claims.Actor.Id, rtClaims.Actor.Id)
+		require.Equal(t, claims.Actor, rtClaims.Actor)
 
 		tokRunes := []rune(tok)
 		if len(tokRunes) >= 10 {
@@ -141,17 +145,17 @@ func TestAuth_RoundtripPublicPrivate(t *testing.T) {
 			IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 		},
 
-		Actor: &core.Actor{
+		Actor: jwtActor(&core.Actor{
 			ExternalId: "id1",
 			Namespace:  "root",
-		},
+		}),
 	}
 
 	tok, err := j.Token(testContext, &claims)
 	require.NoError(t, err)
 	rtClaims, err := j.Parse(testContext, tok)
 	require.NoError(t, err)
-	require.Equal(t, claims.Actor.Id, rtClaims.Actor.Id)
+	require.Equal(t, claims.Actor, rtClaims.Actor)
 
 	tokRunes := []rune(tok)
 	if len(tokRunes) >= 10 {
@@ -191,10 +195,10 @@ func TestAuth_SecretKey(t *testing.T) {
 			IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 		},
 
-		Actor: &core.Actor{
+		Actor: jwtActor(&core.Actor{
 			ExternalId: "external-id7",
 			Namespace:  "root",
-		},
+		}),
 	}
 
 	tb, err := jwt2.NewJwtTokenBuilder().WithConfigKey(testContext, cfg.GetRoot().SystemAuth.JwtSigningKey)
@@ -205,7 +209,7 @@ func TestAuth_SecretKey(t *testing.T) {
 
 	rtClaims, err := authService.Parse(testContext, tok)
 	require.NoError(t, err)
-	require.Equal(t, claims.Actor.Id, rtClaims.Actor.Id)
+	require.Equal(t, claims.Actor, rtClaims.Actor)
 
 	tokRunes := []rune(tok)
 	if len(tokRunes) >= 10 {
@@ -228,7 +232,7 @@ func TestAuth_Parse(t *testing.T) {
 		claims, err := j.Parse(testContext, tok)
 		require.NoError(t, err)
 		require.False(t, claims.IsExpired(testContext))
-		require.Equal(t, testClaims().Actor.ExternalId, claims.Actor.ExternalId)
+		require.Equal(t, testClaims().Actor.Spec.ExternalId, claims.Actor.Spec.ExternalId)
 
 	})
 	t.Run("expired", func(t *testing.T) {
@@ -243,10 +247,10 @@ func TestAuth_Parse(t *testing.T) {
 				IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 			},
 
-			Actor: &core.Actor{
+			Actor: jwtActor(&core.Actor{
 				ExternalId: "id1",
 				Namespace:  "root",
-			},
+			}),
 		}
 
 		tok, err := j.Token(testContext, &org)
@@ -273,10 +277,10 @@ func TestAuth_Parse(t *testing.T) {
 				IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 			},
 
-			Actor: &core.Actor{
+			Actor: jwtActor(&core.Actor{
 				ExternalId: "id1",
 				Namespace:  "root",
-			},
+			}),
 		}
 
 		tok, err := j.Token(testContext, &org)
@@ -514,11 +518,11 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 				ra, err := raw.establishAuthFromRequest(testContext, true, req, w)
 				require.NoError(t, err)
 				require.True(t, ra.IsAuthenticated())
-				require.Equal(t, testClaims().Actor.ExternalId, ra.MustGetActor().ExternalId)
+				require.Equal(t, testClaims().Actor.Spec.ExternalId, ra.MustGetActor().ExternalId)
 
-				actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.ExternalId)
+				actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.Spec.ExternalId)
 				require.NoError(t, err)
-				require.Equal(t, testClaims().Actor.ExternalId, actor.ExternalId)
+				require.Equal(t, testClaims().Actor.Spec.ExternalId, actor.ExternalId)
 			})
 
 			t.Run("actor loaded from database", func(t *testing.T) {
@@ -528,7 +532,7 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 				dbActor := &database.Actor{
 					Id:         dbActorId,
 					Namespace:  "root",
-					ExternalId: testClaims().Actor.ExternalId,
+					ExternalId: testClaims().Actor.Spec.ExternalId,
 				}
 				require.NoError(t, db.CreateActor(testContext, dbActor))
 
@@ -544,7 +548,7 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 				ra, err := raw.establishAuthFromRequest(testContext, true, req, w)
 				require.NoError(t, err)
 				require.True(t, ra.IsAuthenticated())
-				require.Equal(t, testClaims().Actor.ExternalId, ra.MustGetActor().ExternalId)
+				require.Equal(t, testClaims().Actor.Spec.ExternalId, ra.MustGetActor().ExternalId)
 			})
 
 			t.Run("actor permissions updated in database", func(t *testing.T) {
@@ -590,11 +594,11 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 						NotBefore: &jwt.NumericDate{time.Date(2018, 5, 21, 6, 30, 22, 0, time.UTC)},
 						IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 					},
-					Actor: &core.Actor{
+					Actor: jwtActor(&core.Actor{
 						ExternalId:  externalId,
 						Namespace:   "root",
 						Permissions: newPerms,
-					},
+					}),
 				}
 
 				tok, err := a.Token(testContext, claims)
@@ -641,11 +645,11 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 						NotBefore: &jwt.NumericDate{time.Date(2018, 5, 21, 6, 30, 22, 0, time.UTC)},
 						IssuedAt:  &jwt.NumericDate{apctx.GetClock(testContext).Now()},
 					},
-					Actor: &core.Actor{
+					Actor: jwtActor(&core.Actor{
 						ExternalId:  externalId,
 						Namespace:   "root",
 						Annotations: map[string]string{"tenant": "acme"},
-					},
+					}),
 				}
 
 				tok, err := a.Token(testContext, claims)
@@ -684,7 +688,7 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 			_, err = raw.establishAuthFromRequest(futureCtx, true, req, w)
 			require.NotNil(t, err)
 
-			actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.ExternalId)
+			actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.Spec.ExternalId)
 			require.ErrorIs(t, err, database.ErrNotFound)
 			require.Nil(t, actor)
 		})
@@ -698,7 +702,7 @@ func TestAuth_establishAuthFromRequest(t *testing.T) {
 			_, err := raw.establishAuthFromRequest(testContext, true, req, w)
 			require.NotNil(t, err)
 
-			actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.ExternalId)
+			actor, err := db.GetActorByExternalId(testContext, "root", testClaims().Actor.Spec.ExternalId)
 			require.ErrorIs(t, err, database.ErrNotFound)
 			require.Nil(t, actor)
 		})
@@ -967,19 +971,14 @@ func TestAuth_TopLevelPermissionsRestrictRequest(t *testing.T) {
 			Resources: []string{"connections"},
 			Verbs:     []string{"list"},
 		},
-		{
-			Namespace: "root.**",
-			Resources: []string{"actors"},
-			Verbs:     []string{"list"},
-		},
 	}
 
 	claims := *testClaims()
-	claims.Actor = &core.Actor{
+	claims.Actor = jwtActor(&core.Actor{
 		ExternalId:  "grafana-token",
 		Namespace:   "root",
 		Permissions: actorPermissions,
-	}
+	})
 	claims.Subject = "grafana-token"
 	claims.Permissions = tokenPermissions
 
@@ -997,6 +996,58 @@ func TestAuth_TopLevelPermissionsRestrictRequest(t *testing.T) {
 	require.True(t, ra.Allows("root.prod", "connections", "list", ""))
 	require.False(t, ra.Allows("root.prod", "connections", "get", ""))
 	require.False(t, ra.Allows("root.prod", "actors", "list", ""))
+}
+
+func TestAuth_TopLevelPermissionsCannotEscalateDatabaseActor(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.FromRoot(&testConfigPublicPrivateKey)
+	cfg, db := database.MustApplyBlankTestDbConfig(t, cfg)
+	authService := NewService(
+		cfg,
+		cfg.MustGetService(sconfig.ServiceIdAdminApi).(sconfig.HttpService),
+		db,
+		nil,
+		nil,
+		test_utils.NewTestLogger(),
+	)
+	raw := authService.(*service)
+
+	externalID := "restricted-database-actor"
+	require.NoError(t, db.EnsureNamespaceByPath(testContext, "root.platform"))
+	require.NoError(t, db.CreateActor(testContext, &database.Actor{
+		Id:         apid.New(apid.PrefixActor),
+		ExternalId: externalID,
+		Namespace:  "root.platform",
+		Permissions: database.Permissions{{
+			Namespace: "root.platform.**",
+			Resources: []string{"connections"},
+			Verbs:     []string{"get"},
+		}},
+	}))
+
+	claims := &jwt2.AuthProxyClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:  externalID,
+			Audience: []string{string(sconfig.ServiceIdAdminApi)},
+		},
+		Namespace: "root.platform",
+		Permissions: []aschema.Permission{{
+			Namespace: "root.**",
+			Resources: []string{"actors"},
+			Verbs:     []string{"delete"},
+		}},
+	}
+	token, err := authService.Token(testContext, claims)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Add(JwtHeaderKey, fmt.Sprintf("Bearer %s", token))
+	ra, err := raw.establishAuthFromRequest(testContext, true, req, httptest.NewRecorder())
+	require.Error(t, err)
+	require.ErrorIs(t, err, jwt2.ErrInvalidClaims)
+	require.Contains(t, err.Error(), "token permissions exceed actor permissions")
+	require.False(t, ra.IsAuthenticated())
 }
 
 func TestAuth_Nonce(t *testing.T) {
@@ -1039,7 +1090,7 @@ func TestAuth_Nonce(t *testing.T) {
 		req := httptest.NewRequest("GET", "/?authToken="+tok, nil).WithContext(ctx)
 		ts.Gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, c.Actor.ExternalId, w.Body.String())
+		require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 	})
 
 	t.Run("expired", func(t *testing.T) {
@@ -1073,7 +1124,7 @@ func TestAuth_Nonce(t *testing.T) {
 		req := httptest.NewRequest("GET", "/?authToken="+tok, nil).WithContext(ctx)
 		ts.Gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, c.Actor.ExternalId, w.Body.String())
+		require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 
 		// Second request fail
 		w = httptest.NewRecorder()
@@ -1137,10 +1188,10 @@ func testClaims() *jwt2.AuthProxyClaims {
 		},
 
 		Namespace: "root",
-		Actor: &core.Actor{
+		Actor: jwtActor(&core.Actor{
 			ExternalId: "id1",
 			Namespace:  "root",
-		},
+		}),
 	}
 }
 

--- a/internal/apauth/service/gin_test.go
+++ b/internal/apauth/service/gin_test.go
@@ -34,10 +34,10 @@ func TestAuth_Gin(t *testing.T) {
 			},
 
 			Namespace: "root",
-			Actor: &core.Actor{
+			Actor: jwtActor(&core.Actor{
 				ExternalId: "id1",
 				Namespace:  "root",
-			},
+			}),
 		}
 	}
 
@@ -53,10 +53,10 @@ func TestAuth_Gin(t *testing.T) {
 				Subject:   "aid1",
 			},
 			Namespace: "root",
-			Actor: &core.Actor{
+			Actor: jwtActor(&core.Actor{
 				ExternalId: "aid1",
 				Namespace:  "root",
-			},
+			}),
 		}
 	}
 
@@ -100,7 +100,7 @@ func TestAuth_Gin(t *testing.T) {
 			SetJwtRequestHeader(req, tok)
 			ts.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
-			require.Equal(t, c.Actor.ExternalId, w.Body.String())
+			require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 		})
 
 		t.Run("valid with alt claims", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestAuth_Gin(t *testing.T) {
 			SetJwtRequestHeader(req, tok)
 			ts.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
-			require.Equal(t, c.Actor.ExternalId, w.Body.String())
+			require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 		})
 
 		t.Run("expired", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestAuth_Gin(t *testing.T) {
 			SetJwtRequestHeader(req, tok)
 			ts.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
-			require.Equal(t, c.Actor.ExternalId, w.Body.String())
+			require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 		})
 
 		t.Run("valid with alt claims", func(t *testing.T) {
@@ -197,7 +197,7 @@ func TestAuth_Gin(t *testing.T) {
 			SetJwtRequestHeader(req, tok)
 			ts.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
-			require.Equal(t, c.Actor.ExternalId, w.Body.String())
+			require.Equal(t, c.Actor.Spec.ExternalId, w.Body.String())
 		})
 
 		t.Run("valid without auth", func(t *testing.T) {

--- a/internal/apauth/service/test_auth.go
+++ b/internal/apauth/service/test_auth.go
@@ -133,7 +133,7 @@ func (atu *AuthTestUtil) claimsForActor(ctx context.Context, a core.Actor) *jwt2
 			ID:       idGen.NewString(apid.PrefixJwtId),
 		},
 		Namespace: a.Namespace,
-		Actor:     &a,
+		Actor:     jwt2.NewActorClaim(&a),
 	}
 
 	if claims.Subject == "" {


### PR DESCRIPTION
## Summary

- represent embedded JWT actors as restricted authproxy.net/v1alpha1 Actor resources while preserving subject-only tokens
- reject legacy flat actors plus database identity, lifecycle status, timestamps, signing material, unknown fields, subject/namespace mismatches, and permission escalation
- validate the contract in the shared parser and progressive claims builder, then convert to the runtime actor at the auth-service boundary
- update JWT schemas, fixtures, CLI expectations, and integration/security documentation

## Validation

- go test ./...
- go test -run ^$ ./... (integration_tests module)
- yarn docs:build
- ./scripts/preflight.sh

Closes #838