### PR TITLE
Migrate connector API to v1alpha1 resources

### DIFF
--- a/cmd/cli/list_connectors.go
+++ b/cmd/cli/list_connectors.go
@@ -7,14 +7,15 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/rmorlok/authproxy/cmd/cli/config"
 	"github.com/rmorlok/authproxy/internal/httperr"
-	routes2 "github.com/rmorlok/authproxy/internal/routes"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/spf13/cobra"
 )
 
 func cmdListConnectors() *cobra.Command {
 	var (
 		resolver *config.Resolver
-		out      Output[routes2.ConnectorJson]
+		out      Output[cschema.Connector]
 
 		name  string
 		state string
@@ -44,7 +45,7 @@ func cmdListConnectors() *cobra.Command {
 
 			client := resty.New()
 
-			var response routes2.ListConnectorsResponseJson
+			var response schemaapi.ListConnectorsResponseJson
 			var apiErr httperr.ErrorResponse
 			var resp *resty.Response
 
@@ -67,7 +68,7 @@ func cmdListConnectors() *cobra.Command {
 
 			for response.Metadata.Continue != "" && !out.ShouldStop() {
 				cursor := response.Metadata.Continue
-				response = routes2.ListConnectorsResponseJson{}
+				response = schemaapi.ListConnectorsResponseJson{}
 				req = signer.SignRestyRequest(client.R()).
 					SetResult(&response).
 					SetError(&apiErr)
@@ -86,7 +87,7 @@ func cmdListConnectors() *cobra.Command {
 	}
 
 	resolver = config.WithConfigParams(cmd)
-	out = OutputMultiple[routes2.ConnectorJson](cmd)
+	out = OutputMultiple[cschema.Connector](cmd)
 
 	cmd.Flags().StringVar(&name, "name", "", "Only show connectors with this exact name")
 	cmd.Flags().StringVar(&state, "state", "", "Only show connectors in the specified state")

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -316,8 +317,24 @@ func connectorLabels(seed ConnectorSeed) map[string]string {
 	return labels
 }
 
-func connectorDefinitionsEqual(want config.ConnectorDefinition, got api.ConnectorVersionJson) bool {
-	return reflect.DeepEqual(normalizeForJSON(want), normalizeForJSON(got.Definition))
+func connectorDefinitionsEqual(want config.ConnectorDefinition, got cschema.Connector) bool {
+	return reflect.DeepEqual(normalizeForJSON(want), normalizeForJSON(got.Spec.Definition))
+}
+
+func connectorResourceForSeed(seed ConnectorSeed) cschema.Connector {
+	resource := cschema.NewConnector()
+	resource.Metadata.Namespace = connectorNamespace(seed)
+	resource.Metadata.Labels = connectorLabels(seed)
+	resource.Metadata.Annotations = seed.Annotations
+	resource.Spec.Definition = seed.Definition
+	return *resource
+}
+
+func connectorObservedState(connector cschema.Connector) cschema.ConnectorReleaseState {
+	if connector.Status == nil {
+		return ""
+	}
+	return connector.Status.Release.State
 }
 
 func stringMapsEqual(a, b map[string]string) bool {
@@ -346,7 +363,7 @@ func normalizeForJSON(v any) any {
 	return out
 }
 
-func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*api.ConnectorJson, error) {
+func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*cschema.Connector, error) {
 	var list api.ListConnectorsResponseJson
 	resp, err := c.R().
 		SetHeader("Accept", "application/json").
@@ -367,29 +384,24 @@ func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*
 	return &list.Items[0], nil
 }
 
-func getConnectorVersion(c *resty.Client, baseUrl string, connector api.ConnectorJson) (*api.ConnectorVersionJson, error) {
-	var version api.ConnectorVersionJson
+func getConnectorVersion(c *resty.Client, baseUrl string, connector cschema.Connector) (*cschema.Connector, error) {
+	var version cschema.Connector
 	resp, err := c.R().
 		SetHeader("Accept", "application/json").
 		SetResult(&version).
-		Get(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d", baseUrl, connector.Id, connector.Version))
+		Get(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d", baseUrl, connector.GetId(), connector.Metadata.Generation))
 	if err != nil {
-		return nil, fmt.Errorf("GET connector version %s:%d: %w", connector.Id, connector.Version, err)
+		return nil, fmt.Errorf("GET connector version %s:%d: %w", connector.GetId(), connector.Metadata.Generation, err)
 	}
 	if resp.StatusCode() >= 400 {
-		return nil, fmt.Errorf("GET connector version %s:%d returned %d: %s", connector.Id, connector.Version, resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("GET connector version %s:%d returned %d: %s", connector.GetId(), connector.Metadata.Generation, resp.StatusCode(), resp.String())
 	}
 	return &version, nil
 }
 
-func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*api.ConnectorVersionJson, error) {
-	body := api.CreateConnectorRequestJson{
-		Namespace:   connectorNamespace(seed),
-		Definition:  seed.Definition,
-		Labels:      connectorLabels(seed),
-		Annotations: seed.Annotations,
-	}
-	var created api.ConnectorVersionJson
+func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*cschema.Connector, error) {
+	body := connectorResourceForSeed(seed)
+	var created cschema.Connector
 	resp, err := c.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(body).
@@ -404,19 +416,15 @@ func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*api.
 	return &created, nil
 }
 
-func createConnectorDraft(c *resty.Client, baseUrl string, connector api.ConnectorJson, seed ConnectorSeed) (*api.ConnectorVersionJson, error) {
-	labels := connectorLabels(seed)
-	body := api.CreateConnectorVersionRequestJson{
-		Definition:  &seed.Definition,
-		Labels:      &labels,
-		Annotations: &seed.Annotations,
-	}
-	var created api.ConnectorVersionJson
+func createConnectorDraft(c *resty.Client, baseUrl string, connector cschema.Connector, seed ConnectorSeed) (*cschema.Connector, error) {
+	body := connectorResourceForSeed(seed)
+	body.Metadata.Name = connector.Metadata.Name
+	var created cschema.Connector
 	resp, err := c.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(body).
 		SetResult(&created).
-		Post(fmt.Sprintf("%s/api/v1/connectors/%s/versions", baseUrl, connector.Id))
+		Post(fmt.Sprintf("%s/api/v1/connectors/%s/versions", baseUrl, connector.GetId()))
 	if err != nil {
 		return nil, fmt.Errorf("POST connector seed %q version: %w", seed.Key, err)
 	}
@@ -426,16 +434,16 @@ func createConnectorDraft(c *resty.Client, baseUrl string, connector api.Connect
 	return &created, nil
 }
 
-func forceConnectorPrimary(c *resty.Client, baseUrl string, version api.ConnectorVersionJson) error {
+func forceConnectorPrimary(c *resty.Client, baseUrl string, version cschema.Connector) error {
 	resp, err := c.R().
 		SetHeader("Content-Type", "application/json").
-		SetBody(api.ForceConnectorVersionStateRequestJson{State: string(api.ConnectorVersionStatePrimary)}).
-		Put(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_forceState", baseUrl, version.Id, version.Version))
+		SetBody(api.ForceConnectorVersionStateRequestJson{State: string(cschema.ConnectorReleaseStatePrimary)}).
+		Put(fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_forceState", baseUrl, version.GetId(), version.Metadata.Generation))
 	if err != nil {
-		return fmt.Errorf("PUT connector seed %s:%d primary: %w", version.Id, version.Version, err)
+		return fmt.Errorf("PUT connector seed %s:%d primary: %w", version.GetId(), version.Metadata.Generation, err)
 	}
 	if resp.StatusCode() >= 400 {
-		return fmt.Errorf("PUT connector seed %s:%d primary returned %d: %s", version.Id, version.Version, resp.StatusCode(), resp.String())
+		return fmt.Errorf("PUT connector seed %s:%d primary returned %d: %s", version.GetId(), version.Metadata.Generation, resp.StatusCode(), resp.String())
 	}
 	return nil
 }
@@ -455,7 +463,7 @@ func upsertConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (conne
 		if err != nil {
 			return "", err
 		}
-		if created.State != api.ConnectorVersionStatePrimary {
+		if connectorObservedState(*created) != cschema.ConnectorReleaseStatePrimary {
 			if err := forceConnectorPrimary(c, baseUrl, *created); err != nil {
 				return "", err
 			}
@@ -469,9 +477,9 @@ func upsertConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (conne
 	}
 
 	if connectorDefinitionsEqual(seed.Definition, *version) &&
-		stringMapsEqual(connectorLabels(seed), version.Labels) &&
-		stringMapsEqual(seed.Annotations, version.Annotations) {
-		if version.State != api.ConnectorVersionStatePrimary {
+		stringMapsEqual(connectorLabels(seed), version.Metadata.Labels) &&
+		stringMapsEqual(seed.Annotations, version.Metadata.Annotations) {
+		if connectorObservedState(*version) != cschema.ConnectorReleaseStatePrimary {
 			if err := forceConnectorPrimary(c, baseUrl, *version); err != nil {
 				return "", err
 			}

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
 var testConnectorID = apid.MustParse("cxr_testgmail0000001")
@@ -37,16 +38,16 @@ func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
 			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("labelSelector"))
 			writeJSON(t, w, api.NewListConnectorsResponseJson(nil, ""))
 		case "POST /api/v1/connectors":
-			var req api.CreateConnectorRequestJson
+			var req cschema.Connector
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			require.Equal(t, defaultNamespace, req.Namespace)
-			require.Equal(t, "Demo NoAuth", req.Definition.DisplayName)
-			require.Equal(t, "demo-noauth", req.Labels[seedLabelKey])
-			require.Equal(t, "true", req.Labels["demo"])
-			writeJSON(t, w, connectorVersion(req.Definition, req.Labels, api.ConnectorVersionStateDraft, 1))
+			require.Equal(t, defaultNamespace, req.Metadata.Namespace)
+			require.Equal(t, "Demo NoAuth", req.Spec.Definition.DisplayName)
+			require.Equal(t, "demo-noauth", req.Metadata.Labels[seedLabelKey])
+			require.Equal(t, "true", req.Metadata.Labels["demo"])
+			writeJSON(t, w, connectorVersion(req.Spec.Definition, req.Metadata.Labels, cschema.ConnectorReleaseStateDraft, 1))
 		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/1/_forceState":
 			forcedPrimary = true
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -72,17 +73,17 @@ func TestUpsertConnectorSkipsMatchingPrimarySeed(t *testing.T) {
 		switch r.Method + " " + r.URL.Path {
 		case "GET /api/v1/connectors":
 			writeJSON(t, w, api.NewListConnectorsResponseJson(
-				[]api.ConnectorJson{
+				[]cschema.Connector{
 					connectorSummary(
 						seed,
-						api.ConnectorVersionStatePrimary,
+						cschema.ConnectorReleaseStatePrimary,
 						1, // version
 					),
 				},
 				"", // continueToken
 			))
 		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -106,22 +107,21 @@ func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
 		switch r.Method + " " + r.URL.Path {
 		case "GET /api/v1/connectors":
 			writeJSON(t, w, api.NewListConnectorsResponseJson(
-				[]api.ConnectorJson{connectorSummary(seed, api.ConnectorVersionStatePrimary, 1)},
+				[]cschema.Connector{connectorSummary(seed, cschema.ConnectorReleaseStatePrimary, 1)},
 				"",
 			))
 		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
-			writeJSON(t, w, connectorVersion(oldDefinition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(oldDefinition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
 		case "POST /api/v1/connectors/cxr_testgmail0000001/versions":
-			var req api.CreateConnectorVersionRequestJson
+			var req cschema.Connector
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			require.NotNil(t, req.Definition)
-			require.Equal(t, "New Demo NoAuth", req.Definition.DisplayName)
-			require.NotNil(t, req.Labels)
-			require.Equal(t, "demo-noauth", (*req.Labels)[seedLabelKey])
-			writeJSON(t, w, connectorVersion(*req.Definition, *req.Labels, api.ConnectorVersionStateDraft, 2))
+			require.Equal(t, "New Demo NoAuth", req.Spec.Definition.DisplayName)
+			require.NotNil(t, req.Metadata.Labels)
+			require.Equal(t, "demo-noauth", req.Metadata.Labels[seedLabelKey])
+			writeJSON(t, w, connectorVersion(req.Spec.Definition, req.Metadata.Labels, cschema.ConnectorReleaseStateDraft, 2))
 		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/2/_forceState":
 			forcedPrimary = true
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), api.ConnectorVersionStatePrimary, 2))
+			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 2))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -330,28 +330,23 @@ auth:
 	return connector
 }
 
-func connectorSummary(seed ConnectorSeed, state api.ConnectorVersionState, version uint64) api.ConnectorJson {
-	return api.ConnectorJson{
-		Id:          testConnectorID,
-		Version:     version,
-		Namespace:   connectorNamespace(seed),
-		State:       state,
-		DisplayName: seed.Definition.DisplayName,
-		Description: seed.Definition.Description,
-		Labels:      connectorLabels(seed),
-	}
+func connectorSummary(seed ConnectorSeed, state cschema.ConnectorReleaseState, version uint64) cschema.Connector {
+	return connectorVersion(seed.Definition, connectorLabels(seed), state, version)
 }
 
-func connectorVersion(def config.ConnectorDefinition, labels map[string]string, state api.ConnectorVersionState, version uint64) api.ConnectorVersionJson {
-	namespace := defaultNamespace
-	return api.ConnectorVersionJson{
-		Id:         testConnectorID,
-		Version:    version,
-		Namespace:  namespace,
-		State:      state,
-		Definition: def,
-		Labels:     labels,
+func connectorVersion(def config.ConnectorDefinition, labels map[string]string, state cschema.ConnectorReleaseState, version uint64) cschema.Connector {
+	resource := cschema.NewConnector()
+	resource.Metadata.ID = testConnectorID.String()
+	resource.Metadata.Name = "demo-noauth"
+	resource.Metadata.Namespace = defaultNamespace
+	resource.Metadata.Generation = version
+	resource.Metadata.Labels = labels
+	resource.Spec.Release.DesiredState = cschema.DesiredReleaseStateForObserved(state)
+	resource.Spec.Definition = def
+	resource.Status = &cschema.ConnectorStatus{
+		Release: cschema.ConnectorReleaseStatus{State: state},
 	}
+	return *resource
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, v any) {

--- a/internal/core/connector.go
+++ b/internal/core/connector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync"
 	"time"
 
@@ -49,6 +50,41 @@ func wrapConnector(c database.ConnectorWithDefinition, s *service) *Connector {
 	}
 }
 
+// connectorResourceFromDatabase converts a hydrated persistence row into the
+// canonical versioned Connector resource. The database state is observed
+// state; published generations retain primary desired state after they become
+// active or archived.
+func connectorResourceFromDatabase(
+	c database.ConnectorWithDefinition,
+	definition *cschema.ConnectorDefinition,
+) *cschema.Connector {
+	createdAt := c.CreatedAt
+	updatedAt := c.UpdatedAt
+	observed := cschema.ConnectorReleaseState(c.State)
+	return &cschema.Connector{
+		TypeMeta: meta.NewTypeMeta(cschema.ConnectorKind),
+		Metadata: meta.NormalizeObjectMeta(meta.ObjectMeta{
+			ID:          c.Id.String(),
+			Name:        c.Name,
+			Namespace:   c.Namespace,
+			Generation:  c.Version,
+			Labels:      maps.Clone(map[string]string(c.Labels)),
+			Annotations: maps.Clone(map[string]string(c.Annotations)),
+			CreatedAt:   &createdAt,
+			UpdatedAt:   &updatedAt,
+		}),
+		Spec: cschema.ConnectorSpec{
+			Release: cschema.ConnectorReleaseSpec{
+				DesiredState: cschema.DesiredReleaseStateForObserved(observed),
+			},
+			Definition: *definition.Clone(),
+		},
+		Status: &cschema.ConnectorStatus{
+			Release: cschema.ConnectorReleaseStatus{State: observed},
+		},
+	}
+}
+
 func (c *Connector) GetId() apid.ID {
 	return c.ConnectorWithDefinition.Id
 }
@@ -75,6 +111,13 @@ func (c *Connector) GetHash() string {
 
 func (c *Connector) GetDefinition() *cschema.ConnectorDefinition {
 	return util.Must(c.getDefinition())
+}
+
+func (c *Connector) GetResource() *cschema.Connector {
+	return connectorResourceFromDatabase(
+		c.ConnectorWithDefinition,
+		c.GetDefinition(),
+	)
 }
 
 func (c *Connector) GetCreatedAt() time.Time {

--- a/internal/core/connector_test.go
+++ b/internal/core/connector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -13,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	encryptmock "github.com/rmorlok/authproxy/internal/encrypt/mock"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,6 +101,52 @@ func TestConnector_GetDefinition(t *testing.T) {
 	// Test caching - should not call decrypt again
 	result2 := c.GetDefinition()
 	assert.Equal(t, result, result2)
+}
+
+func TestConnector_GetResource(t *testing.T) {
+	createdAt := time.Date(2026, time.September, 5, 14, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+	id := apid.MustParse("cxr_testresource00001")
+	definition := &cschema.ConnectorDefinition{
+		DisplayName: "Test Connector",
+		Description: "A test connector",
+	}
+	labels := database.Labels{"team": "platform"}
+	annotations := database.Annotations{"example.com/owner": "integrations"}
+	c := &Connector{
+		ConnectorWithDefinition: database.ConnectorWithDefinition{
+			Id:          id,
+			Name:        "test-connector",
+			Namespace:   "root.acme",
+			Version:     3,
+			State:       database.ConnectorDefinitionVersionStateArchived,
+			Labels:      labels,
+			Annotations: annotations,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+		},
+		def: definition,
+	}
+
+	resource := c.GetResource()
+	require.Equal(t, cschema.ConnectorKind, resource.Kind)
+	require.Equal(t, id.String(), resource.Metadata.ID)
+	require.Equal(t, "test-connector", string(resource.Metadata.Name))
+	require.Equal(t, "root.acme", resource.Metadata.Namespace)
+	require.Equal(t, uint64(3), resource.Metadata.Generation)
+	require.Equal(t, createdAt, *resource.Metadata.CreatedAt)
+	require.Equal(t, updatedAt, *resource.Metadata.UpdatedAt)
+	require.Equal(t, cschema.ConnectorReleaseStatePrimary, resource.Spec.Release.DesiredState)
+	require.Equal(t, cschema.ConnectorReleaseStateArchived, resource.Status.Release.State)
+	require.Equal(t, definition, &resource.Spec.Definition)
+	require.NoError(t, resource.ValidateFor(meta.ValidationModeResponse, nil))
+
+	resource.Metadata.Labels["team"] = "changed"
+	resource.Metadata.Annotations["example.com/owner"] = "changed"
+	resource.Spec.Definition.Description = "changed"
+	require.Equal(t, "platform", labels["team"])
+	require.Equal(t, "integrations", annotations["example.com/owner"])
+	require.Equal(t, "A test connector", definition.Description)
 }
 
 func TestConnector_GetHashDerivesFromEncryptedDefinition(t *testing.T) {

--- a/internal/core/iface/connector.go
+++ b/internal/core/iface/connector.go
@@ -24,5 +24,6 @@ type Connector interface {
 	GetLabels() map[string]string
 	GetAnnotations() map[string]string
 	GetDefinition() *cschema.ConnectorDefinition
+	GetResource() *cschema.Connector
 	SetState(ctx context.Context, state database.ConnectorDefinitionVersionState) error
 }

--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -143,15 +143,35 @@ type C interface {
 		cursor string,
 	) (ListConnectorVersionsExecutor, error)
 
-	// CreateConnectorVersion creates a new connector with version 1 in draft
-	// state.
+	// CreateConnector creates a logical connector and its first generation from
+	// the canonical resource envelope.
+	CreateConnector(
+		ctx context.Context,
+		resource *cschema.Connector,
+	) (Connector, error)
+
+	// UpdateConnector applies a resource patch at the logical connector
+	// boundary. Definition changes create or update the draft generation.
+	UpdateConnector(
+		ctx context.Context,
+		id apid.ID,
+		patch *cschema.ConnectorPatch,
+	) (Connector, error)
+
+	// CreateConnectorVersion creates the next sequential generation. A nil
+	// resource clones the newest generation as a draft.
 	CreateConnectorVersion(
 		ctx context.Context,
-		namespace string,
-		name scommon.ResourceName,
-		definition *cschema.ConnectorDefinition,
-		labels map[string]string,
-		annotations map[string]string,
+		id apid.ID,
+		resource *cschema.Connector,
+	) (Connector, error)
+
+	// UpdateConnectorVersion applies a resource patch to one draft generation.
+	UpdateConnectorVersion(
+		ctx context.Context,
+		id apid.ID,
+		version uint64,
+		patch *cschema.ConnectorPatch,
 	) (Connector, error)
 
 	// UpdateConnectorName renames a logical connector without changing its

--- a/internal/core/mock/connector.go
+++ b/internal/core/mock/connector.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
@@ -10,6 +11,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
 type Connector struct {
@@ -73,6 +75,34 @@ func (m *Connector) GetAnnotations() map[string]string {
 
 func (m *Connector) GetDefinition() *cschema.ConnectorDefinition {
 	return m.Definition
+}
+
+func (m *Connector) GetResource() *cschema.Connector {
+	observed := cschema.ConnectorReleaseState(m.State)
+	definition := cschema.ConnectorDefinition{}
+	if m.Definition != nil {
+		definition = *m.Definition.Clone()
+	}
+	return &cschema.Connector{
+		TypeMeta: cschema.NewConnector().TypeMeta,
+		Metadata: meta.ObjectMeta{
+			ID:          m.Id.String(),
+			Name:        m.Name,
+			Namespace:   m.Namespace,
+			Generation:  m.Version,
+			Labels:      maps.Clone(m.Labels),
+			Annotations: maps.Clone(m.Annotations),
+			CreatedAt:   &m.CreatedAt,
+			UpdatedAt:   &m.UpdatedAt,
+		},
+		Spec: cschema.ConnectorSpec{
+			Release:    cschema.ConnectorReleaseSpec{DesiredState: cschema.DesiredReleaseStateForObserved(observed)},
+			Definition: definition,
+		},
+		Status: &cschema.ConnectorStatus{
+			Release: cschema.ConnectorReleaseStatus{State: observed},
+		},
+	}
 }
 
 func (m *Connector) SetState(_ context.Context, state database.ConnectorDefinitionVersionState) error {

--- a/internal/core/service_connector_version_create.go
+++ b/internal/core/service_connector_version_create.go
@@ -11,32 +11,40 @@ import (
 	"github.com/rmorlok/authproxy/internal/database"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
 
-func (s *service) CreateConnectorVersion(
+func (s *service) CreateConnector(
 	ctx context.Context,
-	namespace string,
-	name scommon.ResourceName,
-	definition *cschema.ConnectorDefinition,
-	labels map[string]string,
-	annotations map[string]string,
+	resource *cschema.Connector,
 ) (iface.Connector, error) {
-	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnectorVersion)
+	if resource == nil {
+		return nil, fmt.Errorf("connector cannot be nil")
+	}
+	if err := resource.ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+
+	id := apctx.GetIdGenerator(ctx).New(apid.PrefixConnector)
+	normalized := resource.ApplyAPICreateDefaults(id)
+	state := database.ConnectorDefinitionVersionState(
+		normalized.Spec.Release.DesiredState,
+	)
 
 	c, err := newConnectorBuilder(s).
-		WithDefinition(definition).
+		WithDefinition(&normalized.Spec.Definition).
 		WithId(id).
 		WithVersion(1).
-		WithState(database.ConnectorDefinitionVersionStateDraft).
+		WithState(state).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build connector version: %w", err)
 	}
 
-	c.ConnectorWithDefinition.Labels = labels
-	c.ConnectorWithDefinition.Annotations = annotations
-	c.ConnectorWithDefinition.Name = name
-	c.ConnectorWithDefinition.Namespace = namespace
+	c.ConnectorWithDefinition.Labels = normalized.Metadata.Labels
+	c.ConnectorWithDefinition.Annotations = normalized.Metadata.Annotations
+	c.ConnectorWithDefinition.Name = normalized.Metadata.Name
+	c.ConnectorWithDefinition.Namespace = normalized.Metadata.Namespace
 
 	if err := s.db.UpsertConnectorDefinitionVersion(
 		ctx,
@@ -139,4 +147,57 @@ func (s *service) CreateDraftConnectorVersion(
 	}
 
 	return s.getConnectorVersion(ctx, id, newVersion)
+}
+
+// CreateConnectorVersion creates the next generation from a canonical
+// Connector request. A nil request preserves the existing blank-POST behavior
+// and clones the newest generation as a draft.
+func (s *service) CreateConnectorVersion(
+	ctx context.Context,
+	id apid.ID,
+	resource *cschema.Connector,
+) (iface.Connector, error) {
+	if resource == nil {
+		return s.CreateDraftConnectorVersion(ctx, id, nil, nil, nil)
+	}
+	if err := resource.ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+
+	currentPage := s.ListConnectorsBuilder().ForId(id).Limit(1).FetchPage(ctx)
+	if currentPage.Error != nil {
+		return nil, currentPage.Error
+	}
+	if len(currentPage.Results) == 0 {
+		return nil, ErrNotFound
+	}
+	current := currentPage.Results[0]
+	if resource.Metadata.Namespace != current.GetNamespace() {
+		return nil, fmt.Errorf("%w: metadata.namespace must match the logical connector", ErrInvalidArgument)
+	}
+	if resource.Metadata.Name != "" && resource.Metadata.Name != current.GetName() {
+		return nil, fmt.Errorf("%w: metadata.name must match the logical connector", ErrInvalidArgument)
+	}
+
+	desiredState := resource.Spec.Release.DesiredState
+	if desiredState == "" {
+		desiredState = cschema.ConnectorReleaseStateDraft
+	}
+	created, err := s.CreateDraftConnectorVersion(
+		ctx,
+		id,
+		&resource.Spec.Definition,
+		resource.Metadata.Labels,
+		resource.Metadata.Annotations,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if desiredState == cschema.ConnectorReleaseStatePrimary {
+		if err := created.SetState(ctx, database.ConnectorDefinitionVersionStatePrimary); err != nil {
+			return nil, err
+		}
+		return s.getConnectorVersion(ctx, id, created.GetVersion())
+	}
+	return created, nil
 }

--- a/internal/core/service_connector_version_create.go
+++ b/internal/core/service_connector_version_create.go
@@ -21,6 +21,7 @@ func (s *service) CreateConnector(
 	if resource == nil {
 		return nil, fmt.Errorf("connector cannot be nil")
 	}
+
 	if err := resource.ValidateFor(meta.ValidationModeCreate, nil); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	}
@@ -160,22 +161,29 @@ func (s *service) CreateConnectorVersion(
 	if resource == nil {
 		return s.CreateDraftConnectorVersion(ctx, id, nil, nil, nil)
 	}
+
 	if err := resource.ValidateFor(meta.ValidationModeCreate, nil); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	}
 
-	currentPage := s.ListConnectorsBuilder().ForId(id).Limit(1).FetchPage(ctx)
+	currentPage := s.ListConnectorsBuilder().
+		ForId(id).
+		Limit(1).
+		FetchPage(ctx)
 	if currentPage.Error != nil {
 		return nil, currentPage.Error
 	}
 	if len(currentPage.Results) == 0 {
 		return nil, ErrNotFound
 	}
+
 	current := currentPage.Results[0]
 	if resource.Metadata.Namespace != current.GetNamespace() {
 		return nil, fmt.Errorf("%w: metadata.namespace must match the logical connector", ErrInvalidArgument)
 	}
-	if resource.Metadata.Name != "" && resource.Metadata.Name != current.GetName() {
+
+	if resource.Metadata.Name != "" &&
+		resource.Metadata.Name != current.GetName() {
 		return nil, fmt.Errorf("%w: metadata.name must match the logical connector", ErrInvalidArgument)
 	}
 
@@ -183,6 +191,7 @@ func (s *service) CreateConnectorVersion(
 	if desiredState == "" {
 		desiredState = cschema.ConnectorReleaseStateDraft
 	}
+
 	created, err := s.CreateDraftConnectorVersion(
 		ctx,
 		id,
@@ -193,11 +202,17 @@ func (s *service) CreateConnectorVersion(
 	if err != nil {
 		return nil, err
 	}
+
 	if desiredState == cschema.ConnectorReleaseStatePrimary {
-		if err := created.SetState(ctx, database.ConnectorDefinitionVersionStatePrimary); err != nil {
+		if err := created.SetState(
+			ctx,
+			database.ConnectorDefinitionVersionStatePrimary,
+		); err != nil {
 			return nil, err
 		}
+
 		return s.getConnectorVersion(ctx, id, created.GetVersion())
 	}
+
 	return created, nil
 }

--- a/internal/core/service_connector_version_create_test.go
+++ b/internal/core/service_connector_version_create_test.go
@@ -34,7 +34,7 @@ func connectorResourceForMock(id apid.ID, version uint64, state database.Connect
 	}
 }
 
-func TestCreateConnectorVersion(t *testing.T) {
+func TestCreateConnector(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s, db, _, _, _, e := FullMockService(t, ctrl)
@@ -64,7 +64,12 @@ func TestCreateConnectorVersion(t *testing.T) {
 			Description: "A new connector",
 		}))
 
-		result, err := s.CreateConnectorVersion(ctx, "root", "", definition, labels, nil)
+		resource := cschema.NewConnector()
+		resource.Metadata.Namespace = "root"
+		resource.Metadata.Labels = labels
+		resource.Spec.Definition = *definition
+
+		result, err := s.CreateConnector(ctx, resource)
 		require.NoError(t, err)
 		require.Equal(t, fixedId, result.GetId())
 		require.Equal(t, uint64(1), result.GetVersion())
@@ -91,7 +96,11 @@ func TestCreateConnectorVersion(t *testing.T) {
 			UpsertConnectorDefinitionVersion(gomock.Any(), gomock.Any()).
 			Return(errors.New("db write failed"))
 
-		_, err := s.CreateConnectorVersion(ctx, "root", "", definition, nil, nil)
+		resource := cschema.NewConnector()
+		resource.Metadata.Namespace = "root"
+		resource.Spec.Definition = *definition
+
+		_, err := s.CreateConnector(ctx, resource)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to upsert connector version")
 	})

--- a/internal/core/service_connector_version_update.go
+++ b/internal/core/service_connector_version_update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/core/iface"
@@ -40,6 +41,26 @@ func (s *service) UpdateDraftConnectorVersion(
 	labels map[string]string,
 	annotations map[string]string,
 ) (iface.Connector, error) {
+	return s.updateDraftConnectorVersion(
+		ctx,
+		id,
+		version,
+		definition,
+		labels,
+		annotations,
+		database.ConnectorDefinitionVersionStateDraft,
+	)
+}
+
+func (s *service) updateDraftConnectorVersion(
+	ctx context.Context,
+	id apid.ID,
+	version uint64,
+	definition *cschema.ConnectorDefinition,
+	labels map[string]string,
+	annotations map[string]string,
+	state database.ConnectorDefinitionVersionState,
+) (iface.Connector, error) {
 	existing, err := s.db.GetConnectorDefinitionVersion(ctx, id, version)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
@@ -56,7 +77,7 @@ func (s *service) UpdateDraftConnectorVersion(
 		WithDefinition(definition).
 		WithId(id).
 		WithVersion(version).
-		WithState(database.ConnectorDefinitionVersionStateDraft).
+		WithState(state).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build connector version: %w", err)
@@ -85,6 +106,121 @@ func (s *service) UpdateDraftConnectorVersion(
 
 	s.enqueueConnectorLabelPropagation(ctx, id)
 	return s.getConnectorVersion(ctx, id, version)
+}
+
+// UpdateConnector applies logical metadata changes without manufacturing a
+// generation. Definition or release changes are applied to the existing draft,
+// or to a newly cloned draft when the selected generation is published.
+func (s *service) UpdateConnector(
+	ctx context.Context,
+	id apid.ID,
+	patch *cschema.ConnectorPatch,
+) (iface.Connector, error) {
+	if patch == nil {
+		return nil, fmt.Errorf("connector patch cannot be nil")
+	}
+	if patch.Metadata != nil && patch.Metadata.Generation != nil {
+		return nil, fmt.Errorf("%w: metadata.generation can only be addressed through a connector version endpoint", ErrInvalidArgument)
+	}
+
+	page := s.ListConnectorsBuilder().ForId(id).Limit(1).FetchPage(ctx)
+	if page.Error != nil {
+		return nil, page.Error
+	}
+	if len(page.Results) == 0 {
+		return nil, ErrNotFound
+	}
+	current := page.Results[0]
+	desired, err := patch.ApplyTo(current.GetResource(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+
+	if current.GetName() != desired.Metadata.Name {
+		if err := s.UpdateConnectorName(ctx, id, desired.Metadata.Name); err != nil {
+			return nil, err
+		}
+	}
+	if !maps.Equal(current.GetLabels(), desired.Metadata.Labels) {
+		if _, err := s.db.UpdateConnectorLabels(ctx, id, desired.Metadata.Labels); err != nil {
+			return nil, mapDatabaseError(err)
+		}
+		s.enqueueConnectorLabelPropagation(ctx, id)
+	}
+	if !maps.Equal(current.GetAnnotations(), desired.Metadata.Annotations) {
+		if _, err := s.db.UpdateConnectorAnnotations(ctx, id, desired.Metadata.Annotations); err != nil {
+			return nil, mapDatabaseError(err)
+		}
+	}
+
+	hasDefinition := patch.Spec != nil && patch.Spec.HasDefinition()
+	hasDesiredState := patch.Spec != nil &&
+		patch.Spec.Release != nil &&
+		patch.Spec.Release.HasDesiredState()
+	if !hasDefinition && !hasDesiredState {
+		return s.getConnectorVersion(ctx, id, current.GetVersion())
+	}
+	if !hasDefinition && hasDesiredState &&
+		desired.Spec.Release.DesiredState == cschema.ConnectorReleaseStatePrimary &&
+		current.GetState() == database.ConnectorDefinitionVersionStatePrimary {
+		return s.getConnectorVersion(ctx, id, current.GetVersion())
+	}
+
+	draft, err := s.GetOrCreateDraftConnectorVersion(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	desiredDraft, err := patch.ApplyTo(draft.GetResource(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+
+	return s.updateDraftConnectorVersion(
+		ctx,
+		id,
+		draft.GetVersion(),
+		&desiredDraft.Spec.Definition,
+		desired.Metadata.Labels,
+		desired.Metadata.Annotations,
+		database.ConnectorDefinitionVersionState(desiredDraft.Spec.Release.DesiredState),
+	)
+}
+
+// UpdateConnectorVersion applies a canonical patch to one draft generation.
+// Connector-level naming remains the responsibility of UpdateConnector.
+func (s *service) UpdateConnectorVersion(
+	ctx context.Context,
+	id apid.ID,
+	version uint64,
+	patch *cschema.ConnectorPatch,
+) (iface.Connector, error) {
+	if patch == nil {
+		return nil, fmt.Errorf("connector patch cannot be nil")
+	}
+	existing, err := s.GetConnectorVersion(ctx, id, version)
+	if err != nil {
+		return nil, err
+	}
+	if existing.GetState() != database.ConnectorDefinitionVersionStateDraft {
+		return nil, ErrNotDraft
+	}
+	desired, err := patch.ApplyTo(existing.GetResource(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+	if desired.Metadata.Name != existing.GetName() {
+		return nil, fmt.Errorf("%w: connector names can only be changed through the connector-level update endpoint", ErrInvalidArgument)
+	}
+
+	return s.updateDraftConnectorVersion(
+		ctx,
+		id,
+		version,
+		&desired.Spec.Definition,
+		desired.Metadata.Labels,
+		desired.Metadata.Annotations,
+		database.ConnectorDefinitionVersionState(desired.Spec.Release.DesiredState),
+	)
 }
 
 func (s *service) GetOrCreateDraftConnectorVersion(

--- a/internal/core/service_connector_version_update.go
+++ b/internal/core/service_connector_version_update.go
@@ -119,17 +119,22 @@ func (s *service) UpdateConnector(
 	if patch == nil {
 		return nil, fmt.Errorf("connector patch cannot be nil")
 	}
+
 	if patch.Metadata != nil && patch.Metadata.Generation != nil {
 		return nil, fmt.Errorf("%w: metadata.generation can only be addressed through a connector version endpoint", ErrInvalidArgument)
 	}
 
-	page := s.ListConnectorsBuilder().ForId(id).Limit(1).FetchPage(ctx)
+	page := s.ListConnectorsBuilder().
+		ForId(id).
+		Limit(1).
+		FetchPage(ctx)
 	if page.Error != nil {
 		return nil, page.Error
 	}
 	if len(page.Results) == 0 {
 		return nil, ErrNotFound
 	}
+
 	current := page.Results[0]
 	desired, err := patch.ApplyTo(current.GetResource(), nil)
 	if err != nil {
@@ -137,30 +142,40 @@ func (s *service) UpdateConnector(
 	}
 
 	if current.GetName() != desired.Metadata.Name {
-		if err := s.UpdateConnectorName(ctx, id, desired.Metadata.Name); err != nil {
+		if err := s.UpdateConnectorName(
+			ctx,
+			id,
+			desired.Metadata.Name,
+		); err != nil {
 			return nil, err
 		}
 	}
+
 	if !maps.Equal(current.GetLabels(), desired.Metadata.Labels) {
 		if _, err := s.db.UpdateConnectorLabels(ctx, id, desired.Metadata.Labels); err != nil {
 			return nil, mapDatabaseError(err)
 		}
 		s.enqueueConnectorLabelPropagation(ctx, id)
 	}
+
 	if !maps.Equal(current.GetAnnotations(), desired.Metadata.Annotations) {
 		if _, err := s.db.UpdateConnectorAnnotations(ctx, id, desired.Metadata.Annotations); err != nil {
 			return nil, mapDatabaseError(err)
 		}
 	}
 
-	hasDefinition := patch.Spec != nil && patch.Spec.HasDefinition()
+	hasDefinition := patch.Spec != nil &&
+		patch.Spec.HasDefinition()
 	hasDesiredState := patch.Spec != nil &&
 		patch.Spec.Release != nil &&
 		patch.Spec.Release.HasDesiredState()
-	if !hasDefinition && !hasDesiredState {
+
+	if !hasDefinition &&
+		!hasDesiredState {
 		return s.getConnectorVersion(ctx, id, current.GetVersion())
 	}
-	if !hasDefinition && hasDesiredState &&
+	if !hasDefinition &&
+		hasDesiredState &&
 		desired.Spec.Release.DesiredState == cschema.ConnectorReleaseStatePrimary &&
 		current.GetState() == database.ConnectorDefinitionVersionStatePrimary {
 		return s.getConnectorVersion(ctx, id, current.GetVersion())
@@ -170,6 +185,7 @@ func (s *service) UpdateConnector(
 	if err != nil {
 		return nil, err
 	}
+
 	desiredDraft, err := patch.ApplyTo(draft.GetResource(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
@@ -197,17 +213,21 @@ func (s *service) UpdateConnectorVersion(
 	if patch == nil {
 		return nil, fmt.Errorf("connector patch cannot be nil")
 	}
+
 	existing, err := s.GetConnectorVersion(ctx, id, version)
 	if err != nil {
 		return nil, err
 	}
+
 	if existing.GetState() != database.ConnectorDefinitionVersionStateDraft {
 		return nil, ErrNotDraft
 	}
+
 	desired, err := patch.ApplyTo(existing.GetResource(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	}
+
 	if desired.Metadata.Name != existing.GetName() {
 		return nil, fmt.Errorf("%w: connector names can only be changed through the connector-level update endpoint", ErrInvalidArgument)
 	}

--- a/internal/core/service_migration.go
+++ b/internal/core/service_migration.go
@@ -565,7 +565,7 @@ func (s *service) precheckConnectorForMigration(
 			}
 		}
 
-		if configConnector.HasVersion() {
+		if configConnector.HasGeneration() {
 			existingVersion, err := s.db.GetConnectorDefinitionVersion(
 				ctx,
 				configConnector.GetId(),
@@ -646,7 +646,7 @@ func (s *service) precheckConnectorForMigration(
 			return fmt.Errorf("failed to check for existing connector by name during precheck: %w", err)
 		}
 
-		if configConnector.HasVersion() {
+		if configConnector.HasGeneration() {
 			var existingVersion *database.ConnectorWithDefinition
 			if existingConnector != nil {
 				existingVersion, err = s.db.GetConnectorDefinitionVersion(
@@ -743,7 +743,7 @@ func (s *service) migrateConnector(
 	}
 
 	version := uint64(1)
-	if configConnector.HasVersion() {
+	if configConnector.HasGeneration() {
 		version = configConnector.Metadata.Generation
 	}
 
@@ -776,7 +776,7 @@ func (s *service) migrateConnector(
 		return true, nil
 	}
 
-	if configConnector.HasId() && configConnector.HasVersion() {
+	if configConnector.HasId() && configConnector.HasGeneration() {
 		existingVersion, err = s.db.GetConnectorDefinitionVersion(
 			ctx,
 			configConnector.GetId(),
@@ -861,7 +861,7 @@ func (s *service) migrateConnector(
 
 			version = existingVersion.Version + 1
 		}
-	} else if configConnector.HasVersion() {
+	} else if configConnector.HasGeneration() {
 		// Pattern C: version and name, no ID - resolve the logical connector by
 		// exact name within its namespace, then address the version by its ID.
 		existingConnector, lookupErr := s.connectorForConfigName(

--- a/internal/routes/connections.go
+++ b/internal/routes/connections.go
@@ -282,7 +282,7 @@ func (r *ConnectionsRoutes) getDataSource(gctx *gin.Context) {
 }
 
 func ConnectionToJson(conn coreIface.Connection) ConnectionJson {
-	connector := ConnectorVersionToConnectorJson(conn.GetConnector())
+	connector := *conn.GetConnector().GetResource()
 
 	return ConnectionJson{
 		Id:          conn.GetId(),

--- a/internal/routes/connections_test.go
+++ b/internal/routes/connections_test.go
@@ -387,7 +387,7 @@ func TestConnections(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 1)
 			require.Equal(t, oauthConnectionId, resp.Items[0].Id)
-			require.Equal(t, oauthConnectorId, resp.Items[0].Connector.Id)
+			require.Equal(t, oauthConnectorId, resp.Items[0].Connector.GetId())
 		})
 
 		t.Run("invalid connector id filter", func(t *testing.T) {

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -252,9 +252,12 @@ func (r *ConnectorsRoutes) list(gctx *gin.Context) {
 	}
 
 	apgin.APIJSON(gctx, http.StatusOK, schemaapi.NewListConnectorsResponseJson(
-		util.Map(auth.FilterForValidatedResources(val, result.Results), func(c connIface.Connector) cschema.Connector {
-			return *c.GetResource()
-		}),
+		util.Map(
+			auth.FilterForValidatedResources(val, result.Results),
+			func(c connIface.Connector) cschema.Connector {
+				return *c.GetResource()
+			},
+		),
 		result.Cursor,
 	))
 }

--- a/internal/routes/connectors.go
+++ b/internal/routes/connectors.go
@@ -11,7 +11,6 @@ import (
 	auth "github.com/rmorlok/authproxy/internal/apauth/service"
 	"github.com/rmorlok/authproxy/internal/apgin"
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/apserde"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/core"
 	connIface "github.com/rmorlok/authproxy/internal/core/iface"
@@ -24,63 +23,21 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	smeta "github.com/rmorlok/authproxy/internal/schema/resources/meta"
-	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/tasks"
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
-type ConnectorJson = schemaapi.ConnectorJson
-type ConnectorVersionState = schemaapi.ConnectorVersionState
-type ListConnectorsResponseJson = schemaapi.ListConnectorsResponseJson
-type ConnectorVersionJson = schemaapi.ConnectorVersionJson
-type ListConnectorVersionsResponseJson = schemaapi.ListConnectorVersionsResponseJson
-type CreateConnectorRequestJson = schemaapi.CreateConnectorRequestJson
-type UpdateConnectorRequestJson = schemaapi.UpdateConnectorRequestJson
-type CreateConnectorVersionRequestJson = schemaapi.CreateConnectorVersionRequestJson
 type ConnectorLifecycleRequestJson = schemaapi.ConnectorLifecycleRequestJson
 type ConnectorLifecycleResponseJson = schemaapi.ConnectorLifecycleResponseJson
 type ForceConnectorVersionStateRequestJson = schemaapi.ForceConnectorVersionStateRequestJson
 
 type OpenAPIListConnectorsResponseJson = schemaapiopenapi.ListConnectorsResponseJson
-type OpenAPIConnectorVersionJson = schemaapiopenapi.ConnectorVersionJson
+type OpenAPIConnectorJson = schemaapiopenapi.ConnectorJson
+type OpenAPIConnectorPatchJson = schemaapiopenapi.ConnectorPatchJson
 type OpenAPIListConnectorVersionsResponseJson = schemaapiopenapi.ListConnectorVersionsResponseJson
-type OpenAPICreateConnectorRequestJson = schemaapiopenapi.CreateConnectorRequestJson
-type OpenAPIUpdateConnectorRequestJson = schemaapiopenapi.UpdateConnectorRequestJson
-type OpenAPIUpdateConnectorVersionRequestJson = schemaapiopenapi.UpdateConnectorVersionRequestJson
-type OpenAPICreateConnectorVersionRequestJson = schemaapiopenapi.CreateConnectorVersionRequestJson
 type OpenAPIConnectorLifecycleRequestJson = schemaapiopenapi.ConnectorLifecycleRequestJson
 type OpenAPIConnectorLifecycleResponseJson = schemaapiopenapi.ConnectorLifecycleResponseJson
-
-func ConnectorToJson(c connIface.Connector) ConnectorJson {
-	return ConnectorVersionToConnectorJson(c)
-}
-
-func ConnectorVersionToConnectorJson(c connIface.Connector) ConnectorJson {
-	def := c.GetDefinition()
-	logo := ""
-	if def.Logo != nil {
-		logo = def.Logo.GetUrl()
-	}
-
-	return ConnectorJson{
-		Id:            c.GetId(),
-		Version:       c.GetVersion(),
-		Namespace:     c.GetNamespace(),
-		Name:          c.GetName(),
-		State:         schemaapi.ConnectorVersionState(c.GetState()),
-		Highlight:     def.Highlight,
-		DisplayName:   def.DisplayName,
-		Description:   def.Description,
-		StatusPageUrl: def.StatusPageUrl,
-		Logo:          logo,
-		HasConfigure:  def.SetupFlow.HasConfigure(),
-		Labels:        c.GetLabels(),
-		Annotations:   c.GetAnnotations(),
-		CreatedAt:     c.GetCreatedAt(),
-		UpdatedAt:     c.GetUpdatedAt(),
-	}
-}
 
 type ListConnectorsRequestQueryParams struct {
 	Cursor        *string                                   `form:"cursor"`
@@ -90,23 +47,6 @@ type ListConnectorsRequestQueryParams struct {
 	NameVal       *string                                   `form:"name"`
 	LabelSelector *string                                   `form:"labelSelector"`
 	OrderByVal    *string                                   `form:"orderBy"`
-}
-
-func ConnectorVersionToJson(c connIface.Connector) ConnectorVersionJson {
-	def := c.GetDefinition()
-
-	return ConnectorVersionJson{
-		Id:          c.GetId(),
-		Version:     c.GetVersion(),
-		Namespace:   c.GetNamespace(),
-		Name:        c.GetName(),
-		State:       schemaapi.ConnectorVersionState(c.GetState()),
-		Definition:  *def,
-		Labels:      c.GetLabels(),
-		Annotations: c.GetAnnotations(),
-		CreatedAt:   c.GetCreatedAt(),
-		UpdatedAt:   c.GetUpdatedAt(),
-	}
 }
 
 type ListConnectorVersionsRequestQueryParams struct {
@@ -176,7 +116,7 @@ func parseConnectorVersionID(gctx *gin.Context) (connectorVersionID, *httperr.Er
 // @Accept			json
 // @Produce		json
 // @Param			id	path		string	true	"Connector UUID"
-// @Success		200	{object}	ConnectorJson
+// @Success		200	{object}	OpenAPIConnectorJson
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		404	{object}	ErrorResponse
@@ -211,7 +151,10 @@ func (r *ConnectorsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, ConnectorToJson(c))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusOK, c.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 // @Summary		List connectors
@@ -309,7 +252,9 @@ func (r *ConnectorsRoutes) list(gctx *gin.Context) {
 	}
 
 	apgin.APIJSON(gctx, http.StatusOK, schemaapi.NewListConnectorsResponseJson(
-		util.Map(auth.FilterForValidatedResources(val, result.Results), ConnectorToJson),
+		util.Map(auth.FilterForValidatedResources(val, result.Results), func(c connIface.Connector) cschema.Connector {
+			return *c.GetResource()
+		}),
 		result.Cursor,
 	))
 }
@@ -321,7 +266,7 @@ func (r *ConnectorsRoutes) list(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string	true	"Connector UUID"
 // @Param			version	path		integer	true	"Version number"
-// @Success		200		{object}	OpenAPIConnectorVersionJson
+// @Success		200		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		404		{object}	ErrorResponse
@@ -370,7 +315,10 @@ func (r *ConnectorsRoutes) getVersion(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(c))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusOK, c.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 // @Summary		List connector versions
@@ -509,7 +457,9 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 	}
 
 	apgin.APIJSON(gctx, http.StatusOK, schemaapi.NewListConnectorVersionsResponseJson(
-		util.Map(auth.FilterForValidatedResources(val, result.Results), ConnectorVersionToJson),
+		util.Map(auth.FilterForValidatedResources(val, result.Results), func(c connIface.Connector) cschema.Connector {
+			return *c.GetResource()
+		}),
 		result.Cursor,
 	))
 }
@@ -519,8 +469,8 @@ func (r *ConnectorsRoutes) listVersions(gctx *gin.Context) {
 // @Tags			connectors
 // @Accept			json
 // @Produce		json
-// @Param			request	body		OpenAPICreateConnectorRequestJson	true	"Connector creation request"
-// @Success		201		{object}	OpenAPIConnectorVersionJson
+// @Param			request	body		OpenAPIConnectorJson	true	"Connector creation request"
+// @Success		201		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -532,58 +482,27 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	val := auth.MustGetValidatorFromGinContext(gctx)
 
-	var req CreateConnectorRequestJson
-	if err := apgin.BindJSONBody(gctx, &req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+	var req cschema.Connector
+	if err := apgin.BindResourceJSON(gctx, &req, smeta.ValidationModeCreate); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 		val.MarkErrorReturn()
 		return
 	}
 
-	if err := namespace.ValidatePath(req.Namespace); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid namespace '%s': %s", req.Namespace, err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	name, httpErr := optionalResourceName(req.Name, "connector")
-	if httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := smeta.ValidateUserLabels(req.Labels); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := database.Annotations(req.Annotations).Validate(); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := req.Definition.Validate(&common.ValidationContext{}); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector definition: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if err := val.ValidateNamespace(req.Namespace); err != nil {
+	if err := val.ValidateNamespace(req.Metadata.Namespace); err != nil {
 		apgin.WriteError(gctx, nil, httperr.Forbidden("", httperr.WithPublicErr(err)))
 		return
 	}
 
-	result, err := r.connectors.CreateConnectorVersion(ctx, req.Namespace, name, &req.Definition, req.Labels, req.Annotations)
+	result, err := r.connectors.CreateConnector(ctx, &req)
 	if err != nil {
-		if conflictErr := resourceNameConflictError(err, "connector", name, req.Namespace); conflictErr != nil {
+		if conflictErr := resourceNameConflictError(err, "connector", req.Metadata.Name, req.Metadata.Namespace); conflictErr != nil && req.Metadata.Name != "" {
 			apgin.WriteError(gctx, nil, conflictErr)
+			val.MarkErrorReturn()
+			return
+		}
+		if errors.Is(err, core.ErrInvalidArgument) {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 			val.MarkErrorReturn()
 			return
 		}
@@ -592,7 +511,10 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusCreated, ConnectorVersionToJson(result))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusCreated, result.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 // @Summary		Update connector
@@ -601,8 +523,8 @@ func (r *ConnectorsRoutes) createConnector(gctx *gin.Context) {
 // @Accept			json
 // @Produce		json
 // @Param			id		path		string							true	"Connector UUID"
-// @Param			request	body		OpenAPIUpdateConnectorRequestJson	true	"Connector update request"
-// @Success		200		{object}	OpenAPIConnectorVersionJson
+// @Param			request	body		OpenAPIConnectorPatchJson	true	"Connector update request"
+// @Success		200		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -622,32 +544,11 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 		return
 	}
 
-	var req UpdateConnectorRequestJson
-	if err := apgin.BindJSONBody(gctx, &req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+	var req cschema.ConnectorPatch
+	if err := apgin.BindResourceJSON(gctx, &req, smeta.ValidationModeUpdate); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 		val.MarkErrorReturn()
 		return
-	}
-	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if req.Labels != nil {
-		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	if req.Annotations != nil {
-		if err := database.Annotations(*req.Annotations).Validate(); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
 	}
 
 	current, err := r.loadConnectorByID(ctx, connectorId)
@@ -666,40 +567,17 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 		return
 	}
 
-	if req.Name != nil {
-		name, httpErr := optionalResourceName(req.Name, "connector")
-		if httpErr != nil {
-			apgin.WriteError(gctx, nil, httpErr)
-			val.MarkErrorReturn()
-			return
-		}
-		if err := r.connectors.UpdateConnectorName(ctx, connectorId, name); err != nil {
-			if conflictErr := resourceNameConflictError(err, "connector", name, current.GetNamespace()); conflictErr != nil {
+	result, err := r.connectors.UpdateConnector(ctx, connectorId, &req)
+	if err != nil {
+		if req.Metadata != nil && req.Metadata.Name != nil {
+			if conflictErr := resourceNameConflictError(err, "connector", *req.Metadata.Name, current.GetNamespace()); conflictErr != nil {
 				apgin.WriteError(gctx, nil, conflictErr)
 				val.MarkErrorReturn()
 				return
 			}
-			apgin.WriteErr(gctx, nil, err)
-			val.MarkErrorReturn()
-			return
 		}
-		current, err = r.connectors.GetConnectorVersion(ctx, connectorId, current.GetVersion())
-		if err != nil {
-			apgin.WriteErr(gctx, nil, err)
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	if req.Definition == nil && req.Labels == nil && req.Annotations == nil {
-		apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(current))
-		return
-	}
-
-	draft, err := r.connectors.GetOrCreateDraftConnectorVersion(ctx, connectorId)
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			apgin.WriteError(gctx, nil, httperr.NotFoundf("connector '%s' not found", connectorId))
+		if errors.Is(err, core.ErrInvalidArgument) {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 			val.MarkErrorReturn()
 			return
 		}
@@ -708,46 +586,10 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 		return
 	}
 
-	if httpErr := val.ValidateHttpStatusError(draft); httpErr != nil {
-		apgin.WriteError(gctx, nil, httpErr)
-		return
-	}
-
-	var def *cschema.ConnectorDefinition
-	if req.Definition != nil {
-		def = req.Definition
-	} else {
-		def = draft.GetDefinition()
-	}
-
-	if err := def.Validate(&common.ValidationContext{}); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector definition: %s", err.Error()))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusOK, result.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
 		val.MarkErrorReturn()
-		return
 	}
-
-	var labels map[string]string
-	if req.Labels != nil {
-		labels = *req.Labels
-	} else {
-		labels = draft.GetLabels()
-	}
-
-	var annotations map[string]string
-	if req.Annotations != nil {
-		annotations = *req.Annotations
-	} else {
-		annotations = draft.GetAnnotations()
-	}
-
-	result, err := r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, draft.GetVersion(), def, labels, annotations)
-	if err != nil {
-		apgin.WriteErr(gctx, nil, err)
-		val.MarkErrorReturn()
-		return
-	}
-
-	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(result))
 }
 
 // @Summary		Create connector version
@@ -756,8 +598,8 @@ func (r *ConnectorsRoutes) updateConnector(gctx *gin.Context) {
 // @Accept			json
 // @Produce		json
 // @Param			id		path		string									true	"Connector UUID"
-// @Param			request	body		OpenAPICreateConnectorVersionRequestJson	false	"Version creation request"
-// @Success		201		{object}	OpenAPIConnectorVersionJson
+// @Param			request	body		OpenAPIConnectorJson	false	"Version creation request; an empty body clones the newest generation as a draft"
+// @Success		201		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -794,50 +636,18 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 		return
 	}
 
-	var req CreateConnectorVersionRequestJson
+	var req *cschema.Connector
 	// Support a blank post to create a new draft version of the connector
 	if gctx.Request.ContentLength > 0 {
-		if err := apgin.BindJSONBody(gctx, &req); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
-			val.MarkErrorReturn()
-			return
-		}
-		if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		req = cschema.NewConnector()
+		if err := apgin.BindResourceJSON(gctx, req, smeta.ValidationModeCreate); err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 			val.MarkErrorReturn()
 			return
 		}
 	}
 
-	if req.Definition != nil {
-		if err := req.Definition.Validate(&common.ValidationContext{}); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector definition: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	var labels map[string]string
-	if req.Labels != nil {
-		labels = *req.Labels
-		if err := smeta.ValidateUserLabels(labels); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	var annotations map[string]string
-	if req.Annotations != nil {
-		annotations = *req.Annotations
-		if err := database.Annotations(annotations).Validate(); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	result, err := r.connectors.CreateDraftConnectorVersion(ctx, connectorId, req.Definition, labels, annotations)
+	result, err := r.connectors.CreateConnectorVersion(ctx, connectorId, req)
 	if err != nil {
 		if errors.Is(err, core.ErrDraftAlreadyExists) {
 			apgin.WriteError(gctx, nil, httperr.Conflict("a draft version already exists for this connector"))
@@ -849,12 +659,20 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 			val.MarkErrorReturn()
 			return
 		}
+		if errors.Is(err, core.ErrInvalidArgument) {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
+			val.MarkErrorReturn()
+			return
+		}
 		apgin.WriteErr(gctx, nil, err)
 		val.MarkErrorReturn()
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusCreated, ConnectorVersionToJson(result))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusCreated, result.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 // @Summary		Update connector version
@@ -864,8 +682,8 @@ func (r *ConnectorsRoutes) createVersion(gctx *gin.Context) {
 // @Produce		json
 // @Param			id		path		string							true	"Connector UUID"
 // @Param			version	path		integer							true	"Version number"
-// @Param			request	body		OpenAPIUpdateConnectorVersionRequestJson	true	"Version update request"
-// @Success		200		{object}	OpenAPIConnectorVersionJson
+// @Param			request	body		OpenAPIConnectorPatchJson	true	"Version update request"
+// @Success		200		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -887,38 +705,11 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 	connectorId := connectorVersionId.ConnectorID
 	version := connectorVersionId.Version
 
-	var req UpdateConnectorRequestJson
-	if err := apgin.BindJSONBody(gctx, &req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+	var req cschema.ConnectorPatch
+	if err := apgin.BindResourceJSON(gctx, &req, smeta.ValidationModeUpdate); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 		val.MarkErrorReturn()
 		return
-	}
-	if err := apserde.ValidateNoRedactedPlaceholders(req); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if req.Name != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequest("connector names can only be changed through the connector-level update endpoint"))
-		val.MarkErrorReturn()
-		return
-	}
-
-	if req.Labels != nil {
-		if err := smeta.ValidateUserLabels(*req.Labels); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid labels: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
-	}
-
-	if req.Annotations != nil {
-		if err := database.Annotations(*req.Annotations).Validate(); err != nil {
-			apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid annotations: %s", err.Error()))
-			val.MarkErrorReturn()
-			return
-		}
 	}
 
 	existing, err := r.connectors.GetConnectorVersion(ctx, connectorId, version)
@@ -944,37 +735,15 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 		return
 	}
 
-	var def *cschema.ConnectorDefinition
-	if req.Definition != nil {
-		def = req.Definition
-	} else {
-		def = existing.GetDefinition()
-	}
-
-	if err := def.Validate(&common.ValidationContext{}); err != nil {
-		apgin.WriteError(gctx, nil, httperr.BadRequestf("invalid connector definition: %s", err.Error()))
-		val.MarkErrorReturn()
-		return
-	}
-
-	var labels map[string]string
-	if req.Labels != nil {
-		labels = *req.Labels
-	} else {
-		labels = existing.GetLabels()
-	}
-
-	var annotations map[string]string
-	if req.Annotations != nil {
-		annotations = *req.Annotations
-	} else {
-		annotations = existing.GetAnnotations()
-	}
-
-	result, err := r.connectors.UpdateDraftConnectorVersion(ctx, connectorId, version, def, labels, annotations)
+	result, err := r.connectors.UpdateConnectorVersion(ctx, connectorId, version, &req)
 	if err != nil {
 		if errors.Is(err, core.ErrNotDraft) {
 			apgin.WriteError(gctx, nil, httperr.Conflictf("connector version '%s:%d' is not a draft", connectorId, version))
+			val.MarkErrorReturn()
+			return
+		}
+		if errors.Is(err, core.ErrInvalidArgument) {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err, httperr.WithPublicErr(err)))
 			val.MarkErrorReturn()
 			return
 		}
@@ -983,7 +752,10 @@ func (r *ConnectorsRoutes) updateVersion(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(result))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusOK, result.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 // @Summary		Get all labels for a connector
@@ -1134,7 +906,7 @@ func (r *ConnectorsRoutes) deleteVersionLabel(gctx *gin.Context) {
 // @Param			id		path		string								true	"Connector UUID"
 // @Param			version	path		integer								true	"Version number"
 // @Param			request	body		ForceConnectorVersionStateRequestJson	true	"New state"
-// @Success		200		{object}	OpenAPIConnectorVersionJson
+// @Success		200		{object}	OpenAPIConnectorJson
 // @Failure		400		{object}	ErrorResponse
 // @Failure		401		{object}	ErrorResponse
 // @Failure		403		{object}	ErrorResponse
@@ -1194,7 +966,10 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 	}
 
 	if c.GetState() == state {
-		apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(c))
+		if err := apgin.RenderResourceJSON(gctx, http.StatusOK, c.GetResource()); err != nil {
+			apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			val.MarkErrorReturn()
+		}
 		return
 	}
 
@@ -1205,7 +980,10 @@ func (r *ConnectorsRoutes) forceVersionState(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, ConnectorVersionToJson(c))
+	if err := apgin.RenderResourceJSON(gctx, http.StatusOK, c.GetResource()); err != nil {
+		apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+		val.MarkErrorReturn()
+	}
 }
 
 func (r *ConnectorsRoutes) loadConnectorByID(ctx context.Context, connectorId apid.ID) (connIface.Connector, error) {

--- a/internal/routes/connectors_test.go
+++ b/internal/routes/connectors_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/encrypt"
 	httpf2 "github.com/rmorlok/authproxy/internal/httpf"
 	"github.com/rmorlok/authproxy/internal/routes/key_value"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -37,6 +38,26 @@ import (
 	apworkflows "github.com/rmorlok/authproxy/internal/workflows"
 	"github.com/stretchr/testify/require"
 )
+
+func connectorCreateRequest(namespace string, definition cschema.ConnectorDefinition) cschema.Connector {
+	resource := cschema.NewConnector()
+	resource.Metadata.Namespace = namespace
+	resource.Spec.Definition = definition
+	return *resource
+}
+
+func connectorDefinitionPatch(definition *cschema.ConnectorDefinition) cschema.ConnectorPatch {
+	patch := cschema.NewConnectorPatch()
+	patch.Spec.Definition = definition
+	return *patch
+}
+
+func connectorNamePatch(name string) cschema.ConnectorPatch {
+	patch := cschema.NewConnectorPatch()
+	value := common.ResourceName(name)
+	patch.Metadata.Name = &value
+	return *patch
+}
 
 type fakeConnectorLifecycleCore struct {
 	connIface.C
@@ -235,10 +256,10 @@ func TestConnectors(t *testing.T) {
 		if len(root.Connectors.LoadFromList) == 0 {
 			root.Connectors.LoadFromList = []sconfig.Connector{
 				configuredConnectorResource(apid.MustParse("cxr_test0000000000001"), 0, "root", map[string]string{"type": "test-connector"}, cschema.ConnectorDefinition{
-					DisplayName: "Test ConnectorJson",
+					DisplayName: "Test Connector",
 				}),
 				configuredConnectorResource(apid.MustParse("cxr_test2000000000002"), 0, "root.child", map[string]string{"type": "test-connector-2"}, cschema.ConnectorDefinition{
-					DisplayName: "Test ConnectorJson 2",
+					DisplayName: "Test Connector 2",
 				}),
 			}
 		}
@@ -529,10 +550,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorJson
+				var resp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Id)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.GetId())
 			})
 
 			t.Run("forbidden with non-matching resource id permission", func(t *testing.T) {
@@ -582,11 +603,11 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorJson
+				var resp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Id)
-				require.Equal(t, "Test ConnectorJson", resp.DisplayName)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.GetId())
+				require.Equal(t, "Test Connector", resp.Spec.Definition.DisplayName)
 			})
 		})
 
@@ -606,7 +627,7 @@ func TestConnectors(t *testing.T) {
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors?order=id%20asc",
+					"/connectors?orderBy=id%20asc",
 					nil,
 					"root",
 					"some-actor",
@@ -622,7 +643,7 @@ func TestConnectors(t *testing.T) {
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors?order=id%20asc",
+					"/connectors?orderBy=id%20asc",
 					nil,
 					"root",
 					"some-actor",
@@ -633,21 +654,21 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorsResponseJson
+				var resp schemaapi.ListConnectorsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 2)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Items[0].Id)
-				require.Equal(t, "Test ConnectorJson", resp.Items[0].DisplayName)
-				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[1].Id)
-				require.Equal(t, "Test ConnectorJson 2", resp.Items[1].DisplayName)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Items[0].GetId())
+				require.Equal(t, "Test Connector", resp.Items[0].Spec.Definition.DisplayName)
+				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[1].GetId())
+				require.Equal(t, "Test Connector 2", resp.Items[1].Spec.Definition.DisplayName)
 			})
 
 			t.Run("namespace filter", func(t *testing.T) {
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors?order=id%20asc&namespace=root.child",
+					"/connectors?orderBy=id%20asc&namespace=root.child",
 					nil,
 					"root",
 					"some-actor",
@@ -658,19 +679,19 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorsResponseJson
+				var resp schemaapi.ListConnectorsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 1)
-				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[0].Id)
-				require.Equal(t, "Test ConnectorJson 2", resp.Items[0].DisplayName)
+				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[0].GetId())
+				require.Equal(t, "Test Connector 2", resp.Items[0].Spec.Definition.DisplayName)
 			})
 
 			t.Run("permission constrained namespace dropdown", func(t *testing.T) {
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors?order=id%20asc",
+					"/connectors?orderBy=id%20asc",
 					nil,
 					"root",
 					"some-actor",
@@ -681,11 +702,11 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorsResponseJson
+				var resp schemaapi.ListConnectorsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 1)
-				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[0].Id)
+				require.Equal(t, apid.MustParse("cxr_test2000000000002"), resp.Items[0].GetId())
 			})
 
 			t.Run("label filter", func(t *testing.T) {
@@ -718,12 +739,12 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorsResponseJson
+				var resp schemaapi.ListConnectorsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 1)
-				require.Equal(t, connectorId, resp.Items[0].Id)
-				require.Equal(t, "prod", resp.Items[0].Labels["env"])
+				require.Equal(t, connectorId, resp.Items[0].GetId())
+				require.Equal(t, "prod", resp.Items[0].Metadata.Labels["env"])
 			})
 		})
 	})
@@ -799,10 +820,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorVersionJson
+				var resp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Id)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.GetId())
 			})
 
 			t.Run("forbidden with non-matching resource id permission", func(t *testing.T) {
@@ -836,10 +857,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ConnectorVersionJson
+				var resp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Id)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.GetId())
 			})
 
 			t.Run("redacts connector secrets by default", func(t *testing.T) {
@@ -868,7 +889,8 @@ func TestConnectors(t *testing.T) {
 
 				var raw map[string]any
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
-				definition := raw["definition"].(map[string]any)
+				spec := raw["spec"].(map[string]any)
+				definition := spec["definition"].(map[string]any)
 				auth := definition["auth"].(map[string]any)
 				require.Equal(t, "*************", auth["clientSecret"])
 			})
@@ -910,7 +932,8 @@ func TestConnectors(t *testing.T) {
 
 				var raw map[string]any
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
-				definition := raw["definition"].(map[string]any)
+				spec := raw["spec"].(map[string]any)
+				definition := spec["definition"].(map[string]any)
 				auth := definition["auth"].(map[string]any)
 				require.Equal(t, "client-secret", auth["clientSecret"])
 			})
@@ -932,7 +955,7 @@ func TestConnectors(t *testing.T) {
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors/cxr_test0000000000001/versions?order=id%20asc",
+					"/connectors/cxr_test0000000000001/versions?orderBy=version%20asc",
 					nil,
 					"root",
 					"some-actor",
@@ -943,11 +966,11 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorVersionsResponseJson
+				var resp schemaapi.ListConnectorVersionsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 1)
-				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Items[0].Id)
+				require.Equal(t, apid.MustParse("cxr_test0000000000001"), resp.Items[0].GetId())
 			})
 
 			t.Run("namespace filter", func(t *testing.T) {
@@ -955,7 +978,7 @@ func TestConnectors(t *testing.T) {
 				// Namespace filter doesn't actually make sense here because versions can't change namespaces
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					"/connectors/cxr_test0000000000001/versions?order=id%20asc&namespace=root.child",
+					"/connectors/cxr_test0000000000001/versions?orderBy=version%20asc&namespace=root.child",
 					nil,
 					"root",
 					"some-actor",
@@ -966,7 +989,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var resp ListConnectorsResponseJson
+				var resp schemaapi.ListConnectorsResponseJson
 				err = json.Unmarshal(w.Body.Bytes(), &resp)
 				require.NoError(t, err)
 				require.Len(t, resp.Items, 0)
@@ -977,10 +1000,7 @@ func TestConnectors(t *testing.T) {
 	t.Run("create connector", func(t *testing.T) {
 		t.Run("unauthorized", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace:  "root",
-				Definition: cschema.ConnectorDefinition{DisplayName: "New Connector"},
-			}
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: "New Connector"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodPost, "/connectors", bytes.NewReader(jsonBody))
@@ -993,10 +1013,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("forbidden", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace:  "root",
-				Definition: cschema.ConnectorDefinition{DisplayName: "New Connector"},
-			}
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: "New Connector"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1016,10 +1033,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("invalid namespace", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace:  "!!invalid!!",
-				Definition: cschema.ConnectorDefinition{DisplayName: "New Connector"},
-			}
+			body := connectorCreateRequest("!!invalid!!", cschema.ConnectorDefinition{DisplayName: "New Connector"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1037,15 +1051,34 @@ func TestConnectors(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, w.Code)
 		})
 
+		t.Run("rejects the legacy flat request", func(t *testing.T) {
+			tu := setup(t, nil)
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors",
+				util.JsonToReader(map[string]any{
+					"namespace":  "root",
+					"definition": map[string]any{"displayName": "Legacy"},
+				}),
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "unknown field")
+		})
+
 		t.Run("invalid definition", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace: "root",
-				Definition: cschema.ConnectorDefinition{
-					DisplayName: "Bad Connector",
-					Probes:      []cschema.Probe{{}}, // Empty probe fails validation
-				},
-			}
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{
+				DisplayName: "Bad Connector",
+				Probes:      []cschema.Probe{{}}, // Empty probe fails validation
+			})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1066,10 +1099,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("rejects redacted placeholders in secret fields", func(t *testing.T) {
 			tu := setup(t, nil)
 			def := redactionTestConnectorWithSecret("***")
-			body := CreateConnectorRequestJson{
-				Namespace:  "root",
-				Definition: def,
-			}
+			body := connectorCreateRequest("root", def)
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1090,14 +1120,11 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("valid", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace: "root",
-				Definition: cschema.ConnectorDefinition{
-					DisplayName: "New Connector",
-					Description: "A brand new connector",
-				},
-				Labels: map[string]string{"env": "test"},
-			}
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{
+				DisplayName: "New Connector",
+				Description: "A brand new connector",
+			})
+			body.Metadata.Labels = map[string]string{"env": "test"}
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1114,28 +1141,53 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.NotEqual(t, apid.Nil, resp.Id)
-			require.Equal(t, uint64(1), resp.Version)
-			require.Equal(t, "root", resp.Namespace)
-			require.Equal(t, string(database.ConnectorDefinitionVersionStateDraft), string(resp.State))
-			require.Equal(t, "New Connector", resp.Definition.DisplayName)
-			require.Equal(t, "A brand new connector", resp.Definition.Description)
-			require.Equal(t, "test", resp.Labels["env"])
+			require.NotEqual(t, apid.Nil, resp.GetId())
+			require.Equal(t, uint64(1), resp.Metadata.Generation)
+			require.Equal(t, "root", resp.Metadata.Namespace)
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStateDraft, resp.Status.Release.State)
+			require.Equal(t, cschema.ConnectorReleaseStateDraft, resp.Spec.Release.DesiredState)
+			require.Equal(t, "New Connector", resp.Spec.Definition.DisplayName)
+			require.Equal(t, "A brand new connector", resp.Spec.Definition.Description)
+			require.Equal(t, "test", resp.Metadata.Labels["env"])
+		})
+
+		t.Run("valid with primary release intent", func(t *testing.T) {
+			tu := setup(t, nil)
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: "Published Connector"})
+			body.Spec.Release.DesiredState = cschema.ConnectorReleaseStatePrimary
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPost,
+				"/connectors",
+				util.JsonToReader(body),
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+			var resp cschema.Connector
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Equal(t, cschema.ConnectorReleaseStatePrimary, resp.Spec.Release.DesiredState)
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStatePrimary, resp.Status.Release.State)
 		})
 
 		t.Run("rejects apxy/-prefixed labels in request body", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := CreateConnectorRequestJson{
-				Namespace: "root",
-				Definition: cschema.ConnectorDefinition{
-					DisplayName: "New Connector",
-					Description: "A brand new connector",
-				},
-				Labels: map[string]string{"apxy/cxr/source": "config"},
-			}
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{
+				DisplayName: "New Connector",
+				Description: "A brand new connector",
+			})
+			body.Metadata.Labels = map[string]string{"apxy/cxr/source": "config"}
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1160,9 +1212,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("unauthorized", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("/connectors/%s", connectorId), bytes.NewReader(jsonBody))
@@ -1175,9 +1225,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("not found", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1197,12 +1245,10 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("invalid definition", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{
-					DisplayName: "Bad",
-					Probes:      []cschema.Probe{{}},
-				},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{
+				DisplayName: "Bad",
+				Probes:      []cschema.Probe{{}},
+			})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1222,9 +1268,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("valid - creates draft and updates", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated Connector"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated Connector"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1241,22 +1285,21 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, connectorId, resp.Id)
-			require.Equal(t, uint64(2), resp.Version) // New draft version
-			require.Equal(t, string(database.ConnectorDefinitionVersionStateDraft), string(resp.State))
-			require.Equal(t, "Updated Connector", resp.Definition.DisplayName)
+			require.Equal(t, connectorId, resp.GetId())
+			require.Equal(t, uint64(2), resp.Metadata.Generation) // New draft generation
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStateDraft, resp.Status.Release.State)
+			require.Equal(t, "Updated Connector", resp.Spec.Definition.DisplayName)
 		})
 
 		t.Run("valid - update with labels", func(t *testing.T) {
 			tu := setup(t, nil)
 			newLabels := map[string]string{"env": "staging"}
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "With Labels"},
-				Labels:     &newLabels,
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "With Labels"})
+			body.Metadata.Labels = &newLabels
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1273,10 +1316,39 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, "staging", resp.Labels["env"])
+			require.Equal(t, "staging", resp.Metadata.Labels["env"])
+		})
+
+		t.Run("valid - publishes the next generation declaratively", func(t *testing.T) {
+			tu := setup(t, nil)
+			primary := cschema.ConnectorReleaseStatePrimary
+			body := cschema.NewConnectorPatch()
+			body.Spec.Release = &cschema.ConnectorReleaseSpecPatch{DesiredState: &primary}
+			body.Spec.Definition = &cschema.ConnectorDefinition{DisplayName: "Published Update"}
+			w := httptest.NewRecorder()
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodPatch,
+				fmt.Sprintf("/connectors/%s", connectorId),
+				util.JsonToReader(body),
+				"root",
+				"some-actor",
+				aschema.AllPermissions(),
+			)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp cschema.Connector
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			require.Equal(t, uint64(2), resp.Metadata.Generation)
+			require.Equal(t, primary, resp.Spec.Release.DesiredState)
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStatePrimary, resp.Status.Release.State)
 		})
 	})
 
@@ -1326,13 +1398,14 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, connectorId, resp.Id)
-			require.Equal(t, uint64(2), resp.Version)
-			require.Equal(t, string(database.ConnectorDefinitionVersionStateDraft), string(resp.State))
-			require.Equal(t, "Test ConnectorJson", resp.Definition.DisplayName)
+			require.Equal(t, connectorId, resp.GetId())
+			require.Equal(t, uint64(2), resp.Metadata.Generation)
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStateDraft, resp.Status.Release.State)
+			require.Equal(t, "Test Connector", resp.Spec.Definition.DisplayName)
 		})
 
 		t.Run("conflict - draft already exists", func(t *testing.T) {
@@ -1372,9 +1445,7 @@ func TestConnectors(t *testing.T) {
 				DisplayName: "Bad",
 				Probes:      []cschema.Probe{{}},
 			}
-			body := CreateConnectorVersionRequestJson{
-				Definition: &def,
-			}
+			body := connectorCreateRequest("root", def)
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1395,9 +1466,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("valid - with custom definition", func(t *testing.T) {
 			tu := setup(t, nil)
 			def := cschema.ConnectorDefinition{DisplayName: "Custom Version"}
-			body := CreateConnectorVersionRequestJson{
-				Definition: &def,
-			}
+			body := connectorCreateRequest("root", def)
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1414,10 +1483,10 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, "Custom Version", resp.Definition.DisplayName)
+			require.Equal(t, "Custom Version", resp.Spec.Definition.DisplayName)
 		})
 	})
 
@@ -1426,9 +1495,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("unauthorized", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("/connectors/%s/versions/1", connectorId), bytes.NewReader(jsonBody))
@@ -1441,9 +1508,7 @@ func TestConnectors(t *testing.T) {
 
 		t.Run("not found", func(t *testing.T) {
 			tu := setup(t, nil)
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1464,9 +1529,7 @@ func TestConnectors(t *testing.T) {
 		t.Run("conflict - not a draft", func(t *testing.T) {
 			tu := setup(t, nil)
 			// Version 1 was migrated as primary, not draft
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated"})
 			jsonBody, _ := json.Marshal(body)
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1501,18 +1564,16 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var createResp ConnectorVersionJson
+			var createResp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &createResp)
 			require.NoError(t, err)
-			draftVersion := createResp.Version
+			draftVersion := createResp.Metadata.Generation
 
 			// Try to update with invalid definition
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{
-					DisplayName: "Bad",
-					Probes:      []cschema.Probe{{}},
-				},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{
+				DisplayName: "Bad",
+				Probes:      []cschema.Probe{{}},
+			})
 			jsonBody, _ := json.Marshal(body)
 			w = httptest.NewRecorder()
 			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1547,15 +1608,13 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var createResp ConnectorVersionJson
+			var createResp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &createResp)
 			require.NoError(t, err)
-			draftVersion := createResp.Version
+			draftVersion := createResp.Metadata.Generation
 
 			// Now update it
-			body := UpdateConnectorRequestJson{
-				Definition: &cschema.ConnectorDefinition{DisplayName: "Updated Draft"},
-			}
+			body := connectorDefinitionPatch(&cschema.ConnectorDefinition{DisplayName: "Updated Draft"})
 			jsonBody, _ := json.Marshal(body)
 			w = httptest.NewRecorder()
 			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -1572,13 +1631,14 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, connectorId, resp.Id)
-			require.Equal(t, draftVersion, resp.Version)
-			require.Equal(t, string(database.ConnectorDefinitionVersionStateDraft), string(resp.State))
-			require.Equal(t, "Updated Draft", resp.Definition.DisplayName)
+			require.Equal(t, connectorId, resp.GetId())
+			require.Equal(t, draftVersion, resp.Metadata.Generation)
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStateDraft, resp.Status.Release.State)
+			require.Equal(t, "Updated Draft", resp.Spec.Definition.DisplayName)
 		})
 	})
 
@@ -1795,11 +1855,11 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var versionResp ConnectorVersionJson
+				var versionResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &versionResp)
 				require.NoError(t, err)
-				require.Equal(t, "production", versionResp.Labels["env"])
-				require.Equal(t, "test-connector", versionResp.Labels["type"])
+				require.Equal(t, "production", versionResp.Metadata.Labels["env"])
+				require.Equal(t, "test-connector", versionResp.Metadata.Labels["type"])
 			})
 		})
 
@@ -1851,10 +1911,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var versionResp ConnectorVersionJson
+				var versionResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &versionResp)
 				require.NoError(t, err)
-				_, exists := versionResp.Labels["type"]
+				_, exists := versionResp.Metadata.Labels["type"]
 				require.False(t, exists)
 			})
 		})
@@ -1984,10 +2044,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var createResp ConnectorVersionJson
+				var createResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &createResp)
 				require.NoError(t, err)
-				draftVersion := createResp.Version
+				draftVersion := createResp.Metadata.Generation
 
 				// Put a label on the draft version
 				body := key_value.PutKeyValueRequestJson{Value: "staging"}
@@ -2067,10 +2127,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var createResp ConnectorVersionJson
+				var createResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &createResp)
 				require.NoError(t, err)
-				draftVersion := createResp.Version
+				draftVersion := createResp.Metadata.Generation
 
 				// Delete a label from the draft version
 				w = httptest.NewRecorder()
@@ -2173,10 +2233,11 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, string(database.ConnectorDefinitionVersionStateArchived), string(resp.State))
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStateArchived, resp.Status.Release.State)
 		})
 
 		t.Run("already in desired state", func(t *testing.T) {
@@ -2195,10 +2256,11 @@ func TestConnectors(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ConnectorVersionJson
+			var resp cschema.Connector
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
-			require.Equal(t, string(database.ConnectorDefinitionVersionStatePrimary), string(resp.State))
+			require.NotNil(t, resp.Status)
+			require.Equal(t, cschema.ConnectorReleaseStatePrimary, resp.Status.Release.State)
 		})
 	})
 
@@ -2261,11 +2323,9 @@ func TestConnectors(t *testing.T) {
 				tu := setup(t, nil)
 
 				// First create a connector with annotations via POST
-				createBody, _ := json.Marshal(CreateConnectorRequestJson{
-					Namespace:   "root",
-					Definition:  cschema.ConnectorDefinition{DisplayName: "Annotated Connector"},
-					Annotations: map[string]string{"my-annotation": "some-value"},
-				})
+				createRequest := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: "Annotated Connector"})
+				createRequest.Metadata.Annotations = map[string]string{"my-annotation": "some-value"}
+				createBody, _ := json.Marshal(createRequest)
 				w := httptest.NewRecorder()
 				req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodPost,
@@ -2280,7 +2340,7 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var created ConnectorVersionJson
+				var created cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &created)
 				require.NoError(t, err)
 
@@ -2288,7 +2348,7 @@ func TestConnectors(t *testing.T) {
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodPut,
-					fmt.Sprintf("/connectors/%s/versions/%d/_forceState", created.Id, created.Version),
+					fmt.Sprintf("/connectors/%s/versions/%d/_forceState", created.GetId(), created.Metadata.Generation),
 					util.JsonToReader(ForceConnectorVersionStateRequestJson{State: string(database.ConnectorDefinitionVersionStatePrimary)}),
 					"root",
 					"some-actor",
@@ -2302,7 +2362,7 @@ func TestConnectors(t *testing.T) {
 				w = httptest.NewRecorder()
 				req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
 					http.MethodGet,
-					fmt.Sprintf("/connectors/%s/annotations/my-annotation", created.Id),
+					fmt.Sprintf("/connectors/%s/annotations/my-annotation", created.GetId()),
 					nil,
 					"root",
 					"some-actor",
@@ -2404,10 +2464,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var versionResp ConnectorVersionJson
+				var versionResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &versionResp)
 				require.NoError(t, err)
-				require.Equal(t, "my-description", versionResp.Annotations["description"])
+				require.Equal(t, "my-description", versionResp.Metadata.Annotations["description"])
 			})
 		})
 
@@ -2497,10 +2557,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusOK, w.Code)
 
-				var versionResp ConnectorVersionJson
+				var versionResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &versionResp)
 				require.NoError(t, err)
-				_, exists := versionResp.Annotations["removeme"]
+				_, exists := versionResp.Metadata.Annotations["removeme"]
 				require.False(t, exists)
 			})
 		})
@@ -2551,10 +2611,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var createResp ConnectorVersionJson
+				var createResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &createResp)
 				require.NoError(t, err)
-				draftVersion := createResp.Version
+				draftVersion := createResp.Metadata.Generation
 
 				// Put an annotation on the draft
 				body := key_value.PutKeyValueRequestJson{Value: "draft-value"}
@@ -2631,10 +2691,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var createResp ConnectorVersionJson
+				var createResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &createResp)
 				require.NoError(t, err)
-				draftVersion := createResp.Version
+				draftVersion := createResp.Metadata.Generation
 
 				// Put an annotation on the draft version
 				body := key_value.PutKeyValueRequestJson{Value: "staging"}
@@ -2680,10 +2740,10 @@ func TestConnectors(t *testing.T) {
 				tu.Gin.ServeHTTP(w, req)
 				require.Equal(t, http.StatusCreated, w.Code)
 
-				var createResp ConnectorVersionJson
+				var createResp cschema.Connector
 				err = json.Unmarshal(w.Body.Bytes(), &createResp)
 				require.NoError(t, err)
-				draftVersion := createResp.Version
+				draftVersion := createResp.Metadata.Generation
 
 				// Put an annotation on the draft
 				body := key_value.PutKeyValueRequestJson{Value: "to-delete"}
@@ -2743,15 +2803,10 @@ func TestConnectors(t *testing.T) {
 	t.Run("resource name API", func(t *testing.T) {
 		tu := setup(t, nil)
 
-		createNamed := func(name *string, displayName string, expectedStatus int) ConnectorVersionJson {
-			body := map[string]interface{}{
-				"namespace": "root",
-				"definition": map[string]interface{}{
-					"displayName": displayName,
-				},
-			}
+		createNamed := func(name *string, displayName string, expectedStatus int) cschema.Connector {
+			body := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: displayName})
 			if name != nil {
-				body["name"] = *name
+				body.Metadata.Name = common.ResourceName(*name)
 			}
 			w := httptest.NewRecorder()
 			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2764,41 +2819,41 @@ func TestConnectors(t *testing.T) {
 			require.Equal(t, expectedStatus, w.Code, w.Body.String())
 			if expectedStatus != http.StatusCreated {
 				require.NotContains(t, w.Body.String(), "UNIQUE")
-				return ConnectorVersionJson{}
+				return cschema.Connector{}
 			}
-			var connector ConnectorVersionJson
+			var connector cschema.Connector
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &connector))
 			return connector
 		}
 
 		customName := "salesforce"
 		custom := createNamed(&customName, "Salesforce", http.StatusCreated)
-		require.Equal(t, customName, string(custom.Name))
-		require.Equal(t, customName, custom.Labels["apxy/cxr/-/name"])
+		require.Equal(t, customName, string(custom.Metadata.Name))
+		require.Equal(t, customName, custom.Metadata.Labels["apxy/cxr/-/name"])
 		defaulted := createNamed(nil, "Defaulted", http.StatusCreated)
-		require.Equal(t, defaulted.Id.String(), string(defaulted.Name))
-		require.Equal(t, defaulted.Id.String(), defaulted.Labels["apxy/cxr/-/name"])
+		require.Equal(t, defaulted.GetId().String(), string(defaulted.Metadata.Name))
+		require.Equal(t, defaulted.GetId().String(), defaulted.Metadata.Labels["apxy/cxr/-/name"])
 		createNamed(&customName, "Conflicting", http.StatusConflict)
 
 		otherName := "other-connector"
 		_ = createNamed(&otherName, "Other", http.StatusCreated)
 		w := httptest.NewRecorder()
 		req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
-			http.MethodPatch, "/connectors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": "renamed-connector"}),
+			http.MethodPatch, "/connectors/"+custom.GetId().String(), util.JsonToReader(connectorNamePatch("renamed-connector")),
 			"root", "some-actor", aschema.AllPermissions(),
 		)
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		tu.Gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		var renamed ConnectorVersionJson
+		var renamed cschema.Connector
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &renamed))
-		require.Equal(t, "renamed-connector", string(renamed.Name))
-		require.Equal(t, "renamed-connector", renamed.Labels["apxy/cxr/-/name"])
+		require.Equal(t, "renamed-connector", string(renamed.Metadata.Name))
+		require.Equal(t, "renamed-connector", renamed.Metadata.Labels["apxy/cxr/-/name"])
 
 		w = httptest.NewRecorder()
 		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
-			http.MethodPatch, "/connectors/"+custom.Id.String(), util.JsonToReader(map[string]string{"name": otherName}),
+			http.MethodPatch, "/connectors/"+custom.GetId().String(), util.JsonToReader(connectorNamePatch(otherName)),
 			"root", "some-actor", aschema.AllPermissions(),
 		)
 		require.NoError(t, err)
@@ -2807,8 +2862,8 @@ func TestConnectors(t *testing.T) {
 		require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
 
 		for _, path := range []string{
-			"/connectors/" + custom.Id.String(),
-			fmt.Sprintf("/connectors/%s/versions/%d", custom.Id, custom.Version),
+			"/connectors/" + custom.GetId().String(),
+			fmt.Sprintf("/connectors/%s/versions/%d", custom.GetId(), custom.Metadata.Generation),
 		} {
 			w = httptest.NewRecorder()
 			req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
@@ -2828,15 +2883,15 @@ func TestConnectors(t *testing.T) {
 		require.NoError(t, err)
 		tu.Gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		var listed ListConnectorsResponseJson
+		var listed schemaapi.ListConnectorsResponseJson
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
 		require.Len(t, listed.Items, 1)
-		require.Equal(t, custom.Id, listed.Items[0].Id)
+		require.Equal(t, custom.GetId(), listed.Items[0].GetId())
 
 		w = httptest.NewRecorder()
 		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
-			http.MethodPatch, fmt.Sprintf("/connectors/%s/versions/%d", custom.Id, custom.Version),
-			util.JsonToReader(map[string]string{"name": "divergent"}),
+			http.MethodPatch, fmt.Sprintf("/connectors/%s/versions/%d", custom.GetId(), custom.Metadata.Generation),
+			util.JsonToReader(connectorNamePatch("divergent")),
 			"root", "some-actor", aschema.AllPermissions(),
 		)
 		require.NoError(t, err)
@@ -2845,16 +2900,18 @@ func TestConnectors(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 
 		seededID := apid.MustParse("cxr_test0000000000001")
+		divergent := connectorCreateRequest("root", cschema.ConnectorDefinition{DisplayName: "Divergent"})
+		divergent.Metadata.Name = "divergent"
 		w = httptest.NewRecorder()
 		req, err = tu.AuthUtil.NewSignedRequestForActorExternalId(
 			http.MethodPost, "/connectors/"+seededID.String()+"/versions",
-			util.JsonToReader(map[string]string{"name": "divergent"}),
+			util.JsonToReader(divergent),
 			"root", "some-actor", aschema.AllPermissions(),
 		)
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		tu.Gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
-		require.Contains(t, w.Body.String(), "unknown field")
+		require.Contains(t, w.Body.String(), "metadata.name must match")
 	})
 }

--- a/internal/schema/api/connections.go
+++ b/internal/schema/api/connections.go
@@ -41,7 +41,7 @@ type ConnectionJson struct {
 	HealthState ConnectionHealthState `json:"healthState" yaml:"healthState" swaggertype:"string" example:"healthy"`
 	SetupStep   *cschema.SetupStep    `json:"setupStepId,omitempty" yaml:"setupStepId,omitempty" swaggertype:"string" example:"tenant"`
 	SetupError  *string               `json:"setupError,omitempty" yaml:"setupError,omitempty"`
-	Connector   ConnectorJson         `json:"connector" yaml:"connector"`
+	Connector   cschema.Connector     `json:"connector" yaml:"connector"`
 	CreatedAt   time.Time             `json:"createdAt" yaml:"createdAt"`
 	UpdatedAt   time.Time             `json:"updatedAt" yaml:"updatedAt"`
 }

--- a/internal/schema/api/connectors.go
+++ b/internal/schema/api/connectors.go
@@ -1,133 +1,43 @@
 package api
 
 import (
-	"time"
-
 	"github.com/rmorlok/authproxy/internal/apid"
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
-	"github.com/rmorlok/authproxy/internal/schema/common"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 )
 
-// ConnectorVersionState is the API-visible lifecycle state of a connector version.
-type ConnectorVersionState string
-
-const (
-	ConnectorVersionStateDraft    ConnectorVersionState = "draft"
-	ConnectorVersionStatePrimary  ConnectorVersionState = "primary"
-	ConnectorVersionStateActive   ConnectorVersionState = "active"
-	ConnectorVersionStateArchived ConnectorVersionState = "archived"
-)
-
-// ConnectorJson represents the API summary projection of a connector version.
-//
-//	@Description	Connector API summary response
-type ConnectorJson struct {
-	Id            apid.ID               `json:"id" yaml:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
-	Version       uint64                `json:"version" yaml:"version" example:"1"`
-	Namespace     string                `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Name          common.ResourceName   `json:"name" yaml:"name" swaggertype:"string" example:"salesforce"`
-	State         ConnectorVersionState `json:"state" yaml:"state" swaggertype:"string" example:"primary"`
-	DisplayName   string                `json:"displayName" yaml:"displayName" example:"Salesforce"`
-	Highlight     string                `json:"highlight,omitempty" yaml:"highlight,omitempty" example:"CRM platform"`
-	Description   string                `json:"description" yaml:"description" example:"Salesforce CRM integration"`
-	StatusPageUrl string                `json:"statusPageUrl,omitempty" yaml:"statusPageUrl,omitempty" example:"https://status.salesforce.com"`
-	Logo          string                `json:"logo" yaml:"logo" example:"https://example.com/logo.png"`
-	HasConfigure  bool                  `json:"hasConfigure" yaml:"hasConfigure" example:"false"`
-	Labels        map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations   map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt     time.Time             `json:"createdAt" yaml:"createdAt"`
-	UpdatedAt     time.Time             `json:"updatedAt" yaml:"updatedAt"`
-}
-
 type ListConnectorsResponseJson struct {
-	apiv1alpha1.ResourceList[ConnectorJson] `json:",inline" yaml:",inline"`
+	apiv1alpha1.ResourceList[cschema.Connector] `json:",inline" yaml:",inline"`
 }
 
 func NewListConnectorsResponseJson(
-	items []ConnectorJson,
+	items []cschema.Connector,
 	continueToken string,
 ) ListConnectorsResponseJson {
 	return ListConnectorsResponseJson{
 		ResourceList: apiv1alpha1.NewResourceList(
-			"Connector",
+			cschema.ConnectorKind,
 			items,
 			apiv1alpha1.ListMeta{Continue: continueToken},
 		),
 	}
 }
 
-// ConnectorVersionJson represents a single connector version returned by the API.
-//
-//	@Description	Detailed connector version information
-type ConnectorVersionJson struct {
-	Id          apid.ID                     `json:"id" yaml:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
-	Version     uint64                      `json:"version" yaml:"version" example:"1"`
-	Namespace   string                      `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Name        common.ResourceName         `json:"name" yaml:"name" swaggertype:"string" example:"salesforce"`
-	State       ConnectorVersionState       `json:"state" yaml:"state" swaggertype:"string" example:"primary"`
-	Definition  cschema.ConnectorDefinition `json:"definition" yaml:"definition"`
-	Labels      map[string]string           `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	CreatedAt   time.Time                   `json:"createdAt" yaml:"createdAt"`
-	UpdatedAt   time.Time                   `json:"updatedAt" yaml:"updatedAt"`
-}
-
 type ListConnectorVersionsResponseJson struct {
-	apiv1alpha1.ResourceList[ConnectorVersionJson] `json:",inline" yaml:",inline"`
+	apiv1alpha1.ResourceList[cschema.Connector] `json:",inline" yaml:",inline"`
 }
 
 func NewListConnectorVersionsResponseJson(
-	items []ConnectorVersionJson,
+	items []cschema.Connector,
 	continueToken string,
 ) ListConnectorVersionsResponseJson {
 	return ListConnectorVersionsResponseJson{
 		ResourceList: apiv1alpha1.NewResourceList(
-			"Connector",
+			cschema.ConnectorKind,
 			items,
 			apiv1alpha1.ListMeta{Continue: continueToken},
 		),
 	}
-}
-
-// CreateConnectorRequestJson is the request body for POST /connectors.
-//
-//	@Description	Request to create a new connector
-type CreateConnectorRequestJson struct {
-	Namespace   string                      `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Name        *common.ResourceName        `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"salesforce"`
-	Definition  cschema.ConnectorDefinition `json:"definition" yaml:"definition"`
-	Labels      map[string]string           `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-}
-
-// UpdateConnectorRequestJson is the request body for PATCH /connectors/:id.
-//
-//	@Description	Request to update a logical connector
-type UpdateConnectorRequestJson struct {
-	Name        *common.ResourceName         `json:"name,omitempty" yaml:"name,omitempty" swaggertype:"string" example:"salesforce"`
-	Definition  *cschema.ConnectorDefinition `json:"definition,omitempty" yaml:"definition,omitempty"`
-	Labels      *map[string]string           `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations *map[string]string           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-}
-
-// UpdateConnectorVersionRequestJson is the request body for PATCH /connectors/:id/versions/:version.
-// Connector-level fields such as name are intentionally excluded.
-//
-//	@Description Request to update a connector definition version
-type UpdateConnectorVersionRequestJson struct {
-	Definition  *cschema.ConnectorDefinition `json:"definition,omitempty" yaml:"definition,omitempty"`
-	Labels      *map[string]string           `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations *map[string]string           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-}
-
-// CreateConnectorVersionRequestJson is the request body for POST /connectors/:id/versions.
-//
-//	@Description	Request to create a new draft connector version
-type CreateConnectorVersionRequestJson struct {
-	Definition  *cschema.ConnectorDefinition `json:"definition,omitempty" yaml:"definition,omitempty"`
-	Labels      *map[string]string           `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations *map[string]string           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // ConnectorLifecycleRequestJson is the request body for connector-level

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -8,6 +8,7 @@ import (
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	authschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	nschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
@@ -77,29 +78,53 @@ type ListNamespacesResponseJson struct {
 	Items []nschema.Namespace `json:"items" binding:"required"`
 }
 
+// ConnectorSpecJson documents connector desired state while keeping the
+// polymorphic provider definition opaque to swaggo.
+type ConnectorSpecJson struct {
+	Release    cschema.ConnectorReleaseSpec `json:"release,omitempty"`
+	Definition map[string]interface{}       `json:"definition" swaggertype:"object"`
+}
+
+// ConnectorJson documents one logical connector generation. Every connector
+// endpoint uses this same kind; metadata.generation selects the version.
+//
+//	@Description	Kubernetes-style Connector resource
+type ConnectorJson struct {
+	APIVersion string                   `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                   `json:"kind" binding:"required" enums:"Connector" example:"Connector"`
+	Metadata   meta.ObjectMeta          `json:"metadata" binding:"required"`
+	Spec       ConnectorSpecJson        `json:"spec" binding:"required"`
+	Status     *cschema.ConnectorStatus `json:"status,omitempty"`
+}
+
+// ConnectorReleaseSpecPatchJson documents desired release-state updates.
+type ConnectorReleaseSpecPatchJson struct {
+	DesiredState *cschema.ConnectorReleaseState `json:"desiredState,omitempty" enums:"draft,primary"`
+}
+
+// ConnectorSpecPatchJson documents mutable connector desired state.
+type ConnectorSpecPatchJson struct {
+	Release    *ConnectorReleaseSpecPatchJson `json:"release,omitempty"`
+	Definition map[string]interface{}         `json:"definition,omitempty" swaggertype:"object"`
+}
+
+// ConnectorPatchJson documents a canonical Connector update.
+//
+//	@Description	Kubernetes-style Connector patch
+type ConnectorPatchJson struct {
+	APIVersion string                   `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                   `json:"kind" binding:"required" enums:"Connector" example:"Connector"`
+	Metadata   *meta.ObjectMetaPatch    `json:"metadata" binding:"required"`
+	Spec       *ConnectorSpecPatchJson  `json:"spec" binding:"required"`
+	Status     *cschema.ConnectorStatus `json:"status,omitempty"`
+}
+
 // ListConnectorsResponseJson documents the paginated connector list response.
 //
 //	@Description	Paginated list of connectors
 type ListConnectorsResponseJson struct {
 	ResourceListJson
-	// List of connectors.
-	Items []schemaapi.ConnectorJson `json:"items" binding:"required"`
-}
-
-// ConnectorVersionJson documents a connector version response.
-//
-//	@Description	Detailed connector version information
-type ConnectorVersionJson struct {
-	Id          apid.ID                         `json:"id" swaggertype:"string" example:"cxr_test550e8400abcde"`
-	Version     uint64                          `json:"version" example:"1"`
-	Namespace   string                          `json:"namespace" example:"root.acme"`
-	Name        string                          `json:"name" example:"salesforce"`
-	State       schemaapi.ConnectorVersionState `json:"state" swaggertype:"string" example:"primary"`
-	Definition  interface{}                     `json:"definition"`
-	Labels      map[string]string               `json:"labels,omitempty"`
-	Annotations map[string]string               `json:"annotations,omitempty"`
-	CreatedAt   time.Time                       `json:"createdAt"`
-	UpdatedAt   time.Time                       `json:"updatedAt"`
+	Items []ConnectorJson `json:"items" binding:"required"`
 }
 
 // ListConnectorVersionsResponseJson documents the paginated connector version list response.
@@ -107,12 +132,12 @@ type ConnectorVersionJson struct {
 //	@Description	Paginated list of connector versions
 type ListConnectorVersionsResponseJson struct {
 	ResourceListJson
-	// List of connector versions.
-	Items []ConnectorVersionJson `json:"items" binding:"required"`
+	Items []ConnectorJson `json:"items" binding:"required"`
 }
 
-// ConnectionJson documents a connection response while keeping nested
-// connector/setup definitions opaque for swaggo.
+// ConnectionJson documents a connection response while keeping setup
+// definitions opaque for swaggo. The nested connector uses the same canonical
+// envelope as connector endpoints.
 //
 //	@Description	Connection to an external service
 type ConnectionJson struct {
@@ -125,7 +150,7 @@ type ConnectionJson struct {
 	HealthState string            `json:"healthState" example:"healthy"`
 	SetupStep   string            `json:"setupStepId,omitempty" example:"tenant"`
 	SetupError  string            `json:"setupError,omitempty"`
-	Connector   interface{}       `json:"connector"`
+	Connector   ConnectorJson     `json:"connector"`
 	CreatedAt   time.Time         `json:"createdAt"`
 	UpdatedAt   time.Time         `json:"updatedAt"`
 }
@@ -199,45 +224,6 @@ type NotificationJson struct {
 type ListNotificationsResponseJson struct {
 	Items  []interface{} `json:"items"`
 	Cursor string        `json:"cursor,omitempty"`
-}
-
-// CreateConnectorRequestJson documents the connector creation body.
-//
-//	@Description	Request to create a new connector
-type CreateConnectorRequestJson struct {
-	Namespace   string            `json:"namespace" example:"root.acme"`
-	Name        *string           `json:"name,omitempty" example:"salesforce"`
-	Definition  interface{}       `json:"definition"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-}
-
-// UpdateConnectorRequestJson documents the connector update body.
-//
-//	@Description	Request to update a logical connector
-type UpdateConnectorRequestJson struct {
-	Name        *string            `json:"name,omitempty" example:"salesforce"`
-	Definition  interface{}        `json:"definition,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
-}
-
-// UpdateConnectorVersionRequestJson documents connector definition-version updates.
-//
-//	@Description Request to update a connector definition version
-type UpdateConnectorVersionRequestJson struct {
-	Definition  interface{}        `json:"definition,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
-}
-
-// CreateConnectorVersionRequestJson documents the connector version creation body.
-//
-//	@Description	Request to create a new draft connector version
-type CreateConnectorVersionRequestJson struct {
-	Definition  interface{}        `json:"definition,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
 }
 
 // ConnectorLifecycleRequestJson documents connector lifecycle operation bodies.

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -924,79 +924,7 @@
       "additionalProperties": false
     },
     "Connector": {
-      "description": "API summary projection of a connector version. This intentionally differs from the resource connector definition schema: fields such as logo are flattened for responses, while runtime fields such as state, has_configure, timestamps, version counts, and state summaries are added by the API. Request bodies and version detail responses reference the canonical resource schema under their definition fields.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "version": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
-        },
-        "state": {
-          "$ref": "#/$defs/ConnectorVersionState"
-        },
-        "displayName": {
-          "type": "string"
-        },
-        "highlight": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "statusPageUrl": {
-          "type": "string",
-          "format": "uri"
-        },
-        "logo": {
-          "type": "string"
-        },
-        "hasConfigure": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "annotations": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "versions": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "states": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ConnectorVersionState"
-          }
-        }
-      },
-      "required": [
-        "id",
-        "version",
-        "namespace",
-        "state",
-        "displayName",
-        "description",
-        "logo",
-        "hasConfigure",
-        "createdAt",
-        "updatedAt"
-      ],
-      "additionalProperties": false
+      "$ref": "../resources/connectors/schema.json"
     },
     "ListConnectorsResponse": {
       "description": "A Kubernetes-style list of connectors.",
@@ -1015,51 +943,6 @@
         }
       ]
     },
-    "ConnectorVersion": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "version": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
-        },
-        "state": {
-          "$ref": "#/$defs/ConnectorVersionState"
-        },
-        "definition": {
-          "$ref": "../resources/connectors/schema.json#/$defs/ConnectorDefinition"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "annotations": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time"
-        }
-      },
-      "required": [
-        "id",
-        "version",
-        "namespace",
-        "state",
-        "definition",
-        "createdAt",
-        "updatedAt"
-      ],
-      "additionalProperties": false
-    },
     "ListConnectorVersionsResponse": {
       "description": "A Kubernetes-style list of connector generations.",
       "allOf": [
@@ -1071,63 +954,23 @@
             "kind": { "const": "ConnectorList" },
             "items": {
               "type": "array",
-              "items": { "$ref": "#/$defs/ConnectorVersion" }
+              "items": { "$ref": "#/$defs/Connector" }
             }
           }
         }
       ]
     },
     "CreateConnectorRequest": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
-        },
-        "definition": {
-          "$ref": "../resources/connectors/schema.json#/$defs/ConnectorDefinition"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "annotations": {
-          "$ref": "#/$defs/StringMap"
-        }
-      },
-      "required": [
-        "namespace",
-        "definition"
-      ],
-      "additionalProperties": false
+      "$ref": "../resources/connectors/schema.json#/$defs/ConnectorCreate"
     },
     "UpdateConnectorRequest": {
-      "type": "object",
-      "properties": {
-        "definition": {
-          "$ref": "../resources/connectors/schema.json#/$defs/ConnectorDefinition"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "annotations": {
-          "$ref": "#/$defs/StringMap"
-        }
-      },
-      "additionalProperties": false
+      "$ref": "../resources/connectors/schema.json#/$defs/ConnectorPatch"
     },
     "CreateConnectorVersionRequest": {
-      "type": "object",
-      "properties": {
-        "definition": {
-          "$ref": "../resources/connectors/schema.json#/$defs/ConnectorDefinition"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "annotations": {
-          "$ref": "#/$defs/StringMap"
-        }
-      },
-      "additionalProperties": false
+      "$ref": "../resources/connectors/schema.json#/$defs/ConnectorCreate"
+    },
+    "UpdateConnectorVersionRequest": {
+      "$ref": "../resources/connectors/schema.json#/$defs/ConnectorPatch"
     },
     "ConnectorLifecycleRequest": {
       "type": "object",

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -92,11 +92,12 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "metrics schema", ref: "./schema.json#/$defs/MetricsSchemaResponse", file: "valid-metrics-schema.json"},
 		{name: "connector", ref: "./schema.json#/$defs/Connector", file: "valid-connector.json"},
 		{name: "list connectors", ref: "./schema.json#/$defs/ListConnectorsResponse", file: "valid-list-connectors.json"},
-		{name: "connector version", ref: "./schema.json#/$defs/ConnectorVersion", file: "valid-connector-version.json"},
+		{name: "connector generation", ref: "./schema.json#/$defs/Connector", file: "valid-connector-version.json"},
 		{name: "list connector versions", ref: "./schema.json#/$defs/ListConnectorVersionsResponse", file: "valid-list-connector-versions.json"},
 		{name: "create connector", ref: "./schema.json#/$defs/CreateConnectorRequest", file: "valid-create-connector.json"},
 		{name: "update connector", ref: "./schema.json#/$defs/UpdateConnectorRequest", file: "valid-update-connector.json"},
 		{name: "create connector version", ref: "./schema.json#/$defs/CreateConnectorVersionRequest", file: "valid-create-connector-version.json"},
+		{name: "update connector version", ref: "./schema.json#/$defs/UpdateConnectorVersionRequest", file: "valid-update-connector.json"},
 		{name: "connector lifecycle request", ref: "./schema.json#/$defs/ConnectorLifecycleRequest", file: "valid-connector-lifecycle-request.json"},
 		{name: "connector lifecycle response", ref: "./schema.json#/$defs/ConnectorLifecycleResponse", file: "valid-connector-lifecycle-response.json"},
 		{name: "force connector version state", ref: "./schema.json#/$defs/ForceConnectorVersionStateRequest", file: "valid-force-connector-version-state.json"},
@@ -145,6 +146,16 @@ func TestManagedListSchemasRejectLegacyTopLevelCursor(t *testing.T) {
 	require.Error(t, schema.Validate(map[string]any{
 		"items":  []any{},
 		"cursor": "next-page",
+	}))
+}
+
+func TestConnectorSchemasRejectLegacyFlatShape(t *testing.T) {
+	schema := compileRefSchema(t, "./schema.json#/$defs/CreateConnectorRequest")
+	require.Error(t, schema.Validate(map[string]any{
+		"namespace": "root",
+		"definition": map[string]any{
+			"displayName": "Legacy",
+		},
 	}))
 }
 

--- a/internal/schema/api/test_data/valid-connection.json
+++ b/internal/schema/api/test_data/valid-connection.json
@@ -11,18 +11,28 @@
   "healthState": "healthy",
   "setupStepId": "tenant",
   "connector": {
-    "id": "cxr_test550e8400abcde",
-    "version": 1,
-    "namespace": "root.acme",
-    "state": "primary",
-    "displayName": "Salesforce",
-    "highlight": "CRM platform",
-    "description": "Salesforce CRM integration",
-    "statusPageUrl": "https://status.salesforce.com",
-    "logo": "https://example.com/logo.png",
-    "hasConfigure": false,
-    "createdAt": "2026-05-25T12:00:00Z",
-    "updatedAt": "2026-05-25T12:30:00Z"
+    "apiVersion": "authproxy.net/v1alpha1",
+    "kind": "Connector",
+    "metadata": {
+      "id": "cxr_test550e8400abcde",
+      "name": "salesforce",
+      "namespace": "root.acme",
+      "generation": 1,
+      "createdAt": "2026-05-25T12:00:00Z",
+      "updatedAt": "2026-05-25T12:30:00Z"
+    },
+    "spec": {
+      "release": { "desiredState": "primary" },
+      "definition": {
+        "displayName": "Salesforce",
+        "logo": { "publicUrl": "https://example.com/logo.png" },
+        "description": "Salesforce CRM integration",
+        "auth": { "type": "no-auth" }
+      }
+    },
+    "status": {
+      "release": { "state": "primary" }
+    }
   },
   "createdAt": "2026-05-25T12:00:00Z",
   "updatedAt": "2026-05-25T12:30:00Z"

--- a/internal/schema/api/test_data/valid-connector-version.json
+++ b/internal/schema/api/test_data/valid-connector-version.json
@@ -1,19 +1,32 @@
 {
-  "id": "cxr_test550e8400abcde",
-  "version": 1,
-  "namespace": "root.acme",
-  "state": "primary",
-  "definition": {
-    "displayName": "Salesforce",
-    "logo": "https://example.com/logo.png",
-    "description": "Salesforce CRM integration",
-    "auth": {
-      "type": "no-auth"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Connector",
+  "metadata": {
+    "id": "cxr_test550e8400abcde",
+    "name": "salesforce",
+    "namespace": "root.acme",
+    "generation": 2,
+    "createdAt": "2026-05-25T12:00:00Z",
+    "updatedAt": "2026-05-25T12:30:00Z"
+  },
+  "spec": {
+    "release": {
+      "desiredState": "draft"
+    },
+    "definition": {
+      "displayName": "Salesforce",
+      "logo": {
+        "publicUrl": "https://example.com/logo.png"
+      },
+      "description": "Salesforce CRM integration",
+      "auth": {
+        "type": "no-auth"
+      }
     }
   },
-  "labels": {
-    "team": "platform"
-  },
-  "createdAt": "2026-05-25T12:00:00Z",
-  "updatedAt": "2026-05-25T12:30:00Z"
+  "status": {
+    "release": {
+      "state": "draft"
+    }
+  }
 }

--- a/internal/schema/api/test_data/valid-connector.json
+++ b/internal/schema/api/test_data/valid-connector.json
@@ -1,20 +1,38 @@
 {
-  "id": "cxr_test550e8400abcde",
-  "version": 1,
-  "namespace": "root.acme",
-  "state": "primary",
-  "displayName": "Salesforce",
-  "highlight": "CRM platform",
-  "description": "Salesforce CRM integration",
-  "statusPageUrl": "https://status.salesforce.com",
-  "logo": "https://example.com/logo.png",
-  "hasConfigure": false,
-  "labels": {
-    "team": "platform"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Connector",
+  "metadata": {
+    "id": "cxr_test550e8400abcde",
+    "name": "salesforce",
+    "namespace": "root.acme",
+    "generation": 1,
+    "labels": {
+      "team": "platform"
+    },
+    "annotations": {
+      "owner": "integrations"
+    },
+    "createdAt": "2026-05-25T12:00:00Z",
+    "updatedAt": "2026-05-25T12:30:00Z"
   },
-  "annotations": {
-    "owner": "integrations"
+  "spec": {
+    "release": {
+      "desiredState": "primary"
+    },
+    "definition": {
+      "displayName": "Salesforce",
+      "logo": {
+        "publicUrl": "https://example.com/logo.png"
+      },
+      "description": "Salesforce CRM integration",
+      "auth": {
+        "type": "no-auth"
+      }
+    }
   },
-  "createdAt": "2026-05-25T12:00:00Z",
-  "updatedAt": "2026-05-25T12:30:00Z"
+  "status": {
+    "release": {
+      "state": "primary"
+    }
+  }
 }

--- a/internal/schema/api/test_data/valid-create-connector-version.json
+++ b/internal/schema/api/test_data/valid-create-connector-version.json
@@ -1,13 +1,22 @@
 {
-  "definition": {
-    "displayName": "Salesforce",
-    "logo": "https://example.com/logo.png",
-    "description": "Salesforce CRM integration",
-    "auth": {
-      "type": "no-auth"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Connector",
+  "metadata": {
+    "namespace": "root.acme",
+    "labels": {
+      "team": "platform"
     }
   },
-  "labels": {
-    "team": "platform"
+  "spec": {
+    "definition": {
+      "displayName": "Salesforce",
+      "logo": {
+        "publicUrl": "https://example.com/logo.png"
+      },
+      "description": "Salesforce CRM integration",
+      "auth": {
+        "type": "no-auth"
+      }
+    }
   }
 }

--- a/internal/schema/api/test_data/valid-create-connector.json
+++ b/internal/schema/api/test_data/valid-create-connector.json
@@ -1,17 +1,25 @@
 {
-  "namespace": "root.acme",
-  "definition": {
-    "displayName": "Salesforce",
-    "logo": "https://example.com/logo.png",
-    "description": "Salesforce CRM integration",
-    "auth": {
-      "type": "no-auth"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Connector",
+  "metadata": {
+    "namespace": "root.acme",
+    "labels": {
+      "team": "platform"
+    },
+    "annotations": {
+      "owner": "integrations"
     }
   },
-  "labels": {
-    "team": "platform"
-  },
-  "annotations": {
-    "owner": "integrations"
+  "spec": {
+    "definition": {
+      "displayName": "Salesforce",
+      "logo": {
+        "publicUrl": "https://example.com/logo.png"
+      },
+      "description": "Salesforce CRM integration",
+      "auth": {
+        "type": "no-auth"
+      }
+    }
   }
 }

--- a/internal/schema/api/test_data/valid-disconnect-response.json
+++ b/internal/schema/api/test_data/valid-disconnect-response.json
@@ -6,16 +6,28 @@
     "state": "disconnecting",
     "healthState": "healthy",
     "connector": {
-      "id": "cxr_test550e8400abcde",
-      "version": 1,
-      "namespace": "root.acme",
-      "state": "primary",
-      "displayName": "Salesforce",
-      "description": "Salesforce CRM integration",
-      "logo": "https://example.com/logo.png",
-      "hasConfigure": false,
-      "createdAt": "2026-05-25T12:00:00Z",
-      "updatedAt": "2026-05-25T12:30:00Z"
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connector",
+      "metadata": {
+        "id": "cxr_test550e8400abcde",
+        "name": "salesforce",
+        "namespace": "root.acme",
+        "generation": 1,
+        "createdAt": "2026-05-25T12:00:00Z",
+        "updatedAt": "2026-05-25T12:30:00Z"
+      },
+      "spec": {
+        "release": { "desiredState": "primary" },
+        "definition": {
+          "displayName": "Salesforce",
+          "logo": { "publicUrl": "https://example.com/logo.png" },
+          "description": "Salesforce CRM integration",
+          "auth": { "type": "no-auth" }
+        }
+      },
+      "status": {
+        "release": { "state": "primary" }
+      }
     },
     "createdAt": "2026-05-25T12:00:00Z",
     "updatedAt": "2026-05-25T12:30:00Z"

--- a/internal/schema/api/test_data/valid-list-connections.json
+++ b/internal/schema/api/test_data/valid-list-connections.json
@@ -11,16 +11,28 @@
       "state": "configured",
       "healthState": "healthy",
       "connector": {
-        "id": "cxr_test550e8400abcde",
-        "version": 1,
-        "namespace": "root.acme",
-        "state": "primary",
-        "displayName": "Salesforce",
-        "description": "Salesforce CRM integration",
-        "logo": "https://example.com/logo.png",
-        "hasConfigure": false,
-        "createdAt": "2026-05-25T12:00:00Z",
-        "updatedAt": "2026-05-25T12:30:00Z"
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Connector",
+        "metadata": {
+          "id": "cxr_test550e8400abcde",
+          "name": "salesforce",
+          "namespace": "root.acme",
+          "generation": 1,
+          "createdAt": "2026-05-25T12:00:00Z",
+          "updatedAt": "2026-05-25T12:30:00Z"
+        },
+        "spec": {
+          "release": { "desiredState": "primary" },
+          "definition": {
+            "displayName": "Salesforce",
+            "logo": { "publicUrl": "https://example.com/logo.png" },
+            "description": "Salesforce CRM integration",
+            "auth": { "type": "no-auth" }
+          }
+        },
+        "status": {
+          "release": { "state": "primary" }
+        }
       },
       "createdAt": "2026-05-25T12:00:00Z",
       "updatedAt": "2026-05-25T12:30:00Z"

--- a/internal/schema/api/test_data/valid-list-connector-versions.json
+++ b/internal/schema/api/test_data/valid-list-connector-versions.json
@@ -6,20 +6,36 @@
 	},
 	"items": [
     {
-      "id": "cxr_test550e8400abcde",
-      "version": 1,
-      "namespace": "root.acme",
-      "state": "primary",
-      "definition": {
-        "displayName": "Salesforce",
-        "logo": "https://example.com/logo.png",
-        "description": "Salesforce CRM integration",
-        "auth": {
-          "type": "no-auth"
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connector",
+      "metadata": {
+        "id": "cxr_test550e8400abcde",
+        "name": "salesforce",
+        "namespace": "root.acme",
+        "generation": 2,
+        "createdAt": "2026-05-25T12:00:00Z",
+        "updatedAt": "2026-05-25T12:30:00Z"
+      },
+      "spec": {
+        "release": {
+          "desiredState": "draft"
+        },
+        "definition": {
+          "displayName": "Salesforce",
+          "logo": {
+            "publicUrl": "https://example.com/logo.png"
+          },
+          "description": "Salesforce CRM integration",
+          "auth": {
+            "type": "no-auth"
+          }
         }
       },
-      "createdAt": "2026-05-25T12:00:00Z",
-      "updatedAt": "2026-05-25T12:30:00Z"
+      "status": {
+        "release": {
+          "state": "draft"
+        }
+      }
     }
 	]
 }

--- a/internal/schema/api/test_data/valid-list-connectors.json
+++ b/internal/schema/api/test_data/valid-list-connectors.json
@@ -6,16 +6,36 @@
 	},
 	"items": [
     {
-      "id": "cxr_test550e8400abcde",
-      "version": 1,
-      "namespace": "root.acme",
-      "state": "primary",
-      "displayName": "Salesforce",
-      "description": "Salesforce CRM integration",
-      "logo": "https://example.com/logo.png",
-      "hasConfigure": false,
-      "createdAt": "2026-05-25T12:00:00Z",
-      "updatedAt": "2026-05-25T12:30:00Z"
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connector",
+      "metadata": {
+        "id": "cxr_test550e8400abcde",
+        "name": "salesforce",
+        "namespace": "root.acme",
+        "generation": 1,
+        "createdAt": "2026-05-25T12:00:00Z",
+        "updatedAt": "2026-05-25T12:30:00Z"
+      },
+      "spec": {
+        "release": {
+          "desiredState": "primary"
+        },
+        "definition": {
+          "displayName": "Salesforce",
+          "logo": {
+            "publicUrl": "https://example.com/logo.png"
+          },
+          "description": "Salesforce CRM integration",
+          "auth": {
+            "type": "no-auth"
+          }
+        }
+      },
+      "status": {
+        "release": {
+          "state": "primary"
+        }
+      }
     }
 	]
 }

--- a/internal/schema/api/test_data/valid-update-connector.json
+++ b/internal/schema/api/test_data/valid-update-connector.json
@@ -1,13 +1,21 @@
 {
-  "definition": {
-    "displayName": "Salesforce",
-    "logo": "https://example.com/logo.png",
-    "description": "Updated Salesforce integration",
-    "auth": {
-      "type": "no-auth"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Connector",
+  "metadata": {
+    "labels": {
+      "team": "integrations"
     }
   },
-  "labels": {
-    "team": "integrations"
+  "spec": {
+    "definition": {
+      "displayName": "Salesforce",
+      "logo": {
+        "publicUrl": "https://example.com/logo.png"
+      },
+      "description": "Updated Salesforce integration",
+      "auth": {
+        "type": "no-auth"
+      }
+    }
   }
 }

--- a/internal/schema/resources/connectors/README.md
+++ b/internal/schema/resources/connectors/README.md
@@ -29,6 +29,6 @@ status:
     state: primary
 ```
 
-Configuration may use `metadata.id` or `metadata.name` to identify a connector and may set `metadata.generation` explicitly. It must omit `status`, which is server-owned. API request/response wrappers that have not yet migrated to the resource envelope remain in `internal/schema/api`.
+Configuration may use `metadata.id` or `metadata.name` to identify a connector and may set `metadata.generation` explicitly. It must omit `status`, which is server-owned. Connector API create and response bodies use `Connector` directly, while updates use the presence-aware `ConnectorPatch`; only endpoint-specific lifecycle actions remain in `internal/schema/api`.
 
 Connector-author setup-flow guidance lives in [`docs/src/content/docs/integration/connector-setup-flow.md`](../../../../docs/src/content/docs/integration/connector-setup-flow.md). Shared predicate behavior for setup steps, OAuth scopes, and probes lives in [`docs/src/content/docs/integration/connector-predicates.md`](../../../../docs/src/content/docs/integration/connector-predicates.md).

--- a/internal/schema/resources/connectors/connector.go
+++ b/internal/schema/resources/connectors/connector.go
@@ -51,8 +51,62 @@ type ConnectorReleaseStatus struct {
 	State ConnectorReleaseState `json:"state" yaml:"state"`
 }
 
+// ConnectorPatch is a presence-aware update to one Connector generation.
+// Metadata and Spec are required objects so a malformed partial envelope does
+// not silently bypass resource validation.
+type ConnectorPatch struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      *meta.ObjectMetaPatch `json:"metadata" yaml:"metadata"`
+	Spec          *ConnectorSpecPatch   `json:"spec" yaml:"spec"`
+	Status        *ConnectorStatus      `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// ConnectorSpecPatch contains mutable desired-state updates. Release and
+// definition use presence tracking so explicit null values are rejected rather
+// than interpreted as omitted fields.
+type ConnectorSpecPatch struct {
+	Release    *ConnectorReleaseSpecPatch `json:"release,omitempty" yaml:"release,omitempty"`
+	Definition *ConnectorDefinition       `json:"definition,omitempty" yaml:"definition,omitempty"`
+
+	releasePresent    bool
+	definitionPresent bool
+}
+
+// ConnectorReleaseSpecPatch contains a desired release-state transition.
+type ConnectorReleaseSpecPatch struct {
+	DesiredState *ConnectorReleaseState `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
+
+	desiredStatePresent bool
+}
+
 func NewConnector() *Connector {
 	return &Connector{TypeMeta: meta.NewTypeMeta(ConnectorKind)}
+}
+
+// NewConnectorPatch returns an empty Connector update envelope.
+func NewConnectorPatch() *ConnectorPatch {
+	return &ConnectorPatch{
+		TypeMeta: meta.NewTypeMeta(ConnectorKind),
+		Metadata: &meta.ObjectMetaPatch{},
+		Spec:     &ConnectorSpecPatch{},
+	}
+}
+
+// ApplyAPICreateDefaults returns a copy with server-assigned identity and
+// generation. API-created connectors default to draft so publishing remains an
+// explicit release decision; configuration retains its existing primary
+// default during reconciliation.
+func (c *Connector) ApplyAPICreateDefaults(id apid.ID) *Connector {
+	clone := c.Clone()
+	clone.Metadata.ID = id.String()
+	clone.Metadata.Generation = 1
+	if clone.Metadata.Name == "" {
+		clone.Metadata.Name = common.ResourceName(id.String())
+	}
+	if clone.Spec.Release.DesiredState == "" {
+		clone.Spec.Release.DesiredState = ConnectorReleaseStateDraft
+	}
+	return clone
 }
 
 func (c *Connector) Clone() *Connector {
@@ -87,6 +141,10 @@ func (c *Connector) ValidateFor(
 		vc = &common.ValidationContext{Path: "$"}
 	}
 
+	requireStoredIdentity := mode == meta.ValidationModePersistence ||
+		mode == meta.ValidationModeResponse
+	requireNamespace := mode != meta.ValidationModeConfig
+
 	var result *multierror.Error
 	if err := meta.ValidateResource(
 		c.TypeMeta,
@@ -96,20 +154,17 @@ func (c *Connector) ValidateFor(
 			Path:               vc,
 			ExpectedAPIVersion: meta.APIVersionV1Alpha1,
 			ExpectedKind:       ConnectorKind,
-			IDValidator: func(value string) error {
-				id, err := apid.Parse(value)
-				if err != nil {
-					return err
-				}
-				if id.Prefix() != apid.PrefixConnector {
-					return fmt.Errorf("must be a connector id")
-				}
-				return nil
-			},
+			RequireID:          requireStoredIdentity,
+			RequireName:        requireStoredIdentity,
+			RequireNamespace:   requireNamespace,
+			IDValidator:        ValidateID,
 			NamespaceValidator: nschema.ValidatePath,
 		},
 	); err != nil {
 		result = multierror.Append(result, err)
+	}
+	if requireStoredIdentity && c.Metadata.Generation == 0 {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.generation", "is required"))
 	}
 
 	switch c.Spec.Release.DesiredState {
@@ -137,7 +192,181 @@ func (c *Connector) ValidateFor(
 			result = multierror.Append(result, vc.NewErrorfForField("status.release.state", "is not a recognized connector release state"))
 		}
 	}
+	if requireStoredIdentity && c.Status == nil {
+		result = multierror.Append(result, vc.NewErrorForField("status", "is required"))
+	}
+	if requireStoredIdentity && c.Spec.Release.DesiredState == "" {
+		result = multierror.Append(result, vc.NewErrorForField("spec.release.desiredState", "is required"))
+	}
+	if requireStoredIdentity && c.Status != nil {
+		observed := c.Status.Release.State
+		switch c.Spec.Release.DesiredState {
+		case ConnectorReleaseStateDraft:
+			if observed != ConnectorReleaseStateDraft {
+				result = multierror.Append(result, vc.NewErrorForField("status.release.state", "must be draft when desiredState is draft"))
+			}
+		case ConnectorReleaseStatePrimary:
+			if observed != ConnectorReleaseStatePrimary &&
+				observed != ConnectorReleaseStateActive &&
+				observed != ConnectorReleaseStateArchived {
+				result = multierror.Append(result, vc.NewErrorForField("status.release.state", "must be primary, active, or archived when desiredState is primary"))
+			}
+		}
+	}
 
+	return result.ErrorOrNil()
+}
+
+// ValidateID validates the stable logical connector identifier.
+func ValidateID(value string) error {
+	id, err := apid.Parse(value)
+	if err != nil {
+		return err
+	}
+	if id.Prefix() != apid.PrefixConnector {
+		return fmt.Errorf("must be a connector id")
+	}
+	return nil
+}
+
+// DesiredReleaseStateForObserved maps the database's observed lifecycle state
+// back to declarative intent. Draft generations remain draft; every published
+// generation retains primary intent even after it becomes active or archived.
+func DesiredReleaseStateForObserved(state ConnectorReleaseState) ConnectorReleaseState {
+	if state == ConnectorReleaseStateDraft {
+		return ConnectorReleaseStateDraft
+	}
+	return ConnectorReleaseStatePrimary
+}
+
+// ValidateFor validates a partial Connector at the API update boundary.
+func (c *ConnectorPatch) ValidateFor(
+	mode meta.ValidationMode,
+	vc *common.ValidationContext,
+) error {
+	if c == nil {
+		return fmt.Errorf("connector patch is required")
+	}
+	if vc == nil {
+		vc = &common.ValidationContext{Path: "$"}
+	}
+
+	var result *multierror.Error
+	if err := meta.ValidateTypeMeta(c.TypeMeta, meta.APIVersionV1Alpha1, ConnectorKind, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if c.Metadata == nil {
+		result = multierror.Append(result, vc.NewErrorForField("metadata", "is required and must not be null"))
+	} else if err := meta.ValidateObjectMetaPatch(*c.Metadata, meta.ValidationOptions{
+		Mode:               mode,
+		Path:               vc,
+		IDValidator:        ValidateID,
+		NamespaceValidator: nschema.ValidatePath,
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if c.Spec == nil {
+		result = multierror.Append(result, vc.NewErrorForField("spec", "is required and must not be null"))
+	} else if err := c.Spec.validate(vc.PushField("spec")); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := meta.ValidateStatus(c.Status, mode, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (c *ConnectorSpecPatch) validate(vc *common.ValidationContext) error {
+	var result *multierror.Error
+	if c.releasePresent && c.Release == nil {
+		result = multierror.Append(result, vc.NewErrorForField("release", "must not be null"))
+	} else if c.Release != nil {
+		if c.Release.desiredStatePresent && c.Release.DesiredState == nil {
+			result = multierror.Append(result, vc.NewErrorForField("release.desiredState", "must not be null"))
+		} else if c.Release.DesiredState != nil {
+			switch *c.Release.DesiredState {
+			case ConnectorReleaseStateDraft, ConnectorReleaseStatePrimary:
+			default:
+				result = multierror.Append(result, vc.NewErrorfForField("release.desiredState", "must be either %q or %q", ConnectorReleaseStateDraft, ConnectorReleaseStatePrimary))
+			}
+		}
+	}
+	if c.definitionPresent && c.Definition == nil {
+		result = multierror.Append(result, vc.NewErrorForField("definition", "must not be null"))
+	} else if c.Definition != nil {
+		if err := c.Definition.Validate(vc.PushField("definition")); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+	return result.ErrorOrNil()
+}
+
+// HasRelease reports whether the patch contains a release object, including an
+// explicit null value.
+func (c *ConnectorSpecPatch) HasRelease() bool {
+	return c != nil && (c.releasePresent || c.Release != nil)
+}
+
+// HasDefinition reports whether the patch contains a definition, including an
+// explicit null value.
+func (c *ConnectorSpecPatch) HasDefinition() bool {
+	return c != nil && (c.definitionPresent || c.Definition != nil)
+}
+
+// HasDesiredState reports whether desiredState was provided, including null.
+func (c *ConnectorReleaseSpecPatch) HasDesiredState() bool {
+	return c != nil && (c.desiredStatePresent || c.DesiredState != nil)
+}
+
+// ApplyTo applies this patch to a copy of current and enforces immutable
+// connector identity and generation fields.
+func (c *ConnectorPatch) ApplyTo(
+	current *Connector,
+	vc *common.ValidationContext,
+) (*Connector, error) {
+	if current == nil {
+		return nil, fmt.Errorf("current connector is required")
+	}
+	if vc == nil {
+		vc = &common.ValidationContext{Path: "$"}
+	}
+	if err := c.ValidateFor(meta.ValidationModeUpdate, vc); err != nil {
+		return nil, err
+	}
+
+	updated := current.Clone()
+	updated.Metadata = meta.ApplyObjectMetaPatch(updated.Metadata, *c.Metadata)
+	if c.Spec.Release != nil && c.Spec.Release.DesiredState != nil {
+		updated.Spec.Release.DesiredState = *c.Spec.Release.DesiredState
+	}
+	if c.Spec.Definition != nil {
+		updated.Spec.Definition = *c.Spec.Definition.Clone()
+	}
+	if err := ValidateUpdate(current, updated, vc); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// ValidateUpdate rejects changes to stable connector identity. Names, labels,
+// annotations, provider definitions, and desired release state are mutable;
+// namespace and generation are not.
+func ValidateUpdate(before, after *Connector, vc *common.ValidationContext) error {
+	if before == nil || after == nil {
+		return fmt.Errorf("before and after connectors are required")
+	}
+	if vc == nil {
+		vc = &common.ValidationContext{Path: "$"}
+	}
+
+	var result *multierror.Error
+	if err := meta.ValidateTypeMetaUpdate(before.TypeMeta, after.TypeMeta, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if err := meta.ValidateMetadataUpdate(before.Metadata, after.Metadata, meta.UpdateOptions{ImmutableNamespace: true}, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
 	return result.ErrorOrNil()
 }
 
@@ -164,7 +393,7 @@ func (c *Connector) HasName() bool {
 	return c != nil && c.Metadata.Name != ""
 }
 
-func (c *Connector) HasVersion() bool {
+func (c *Connector) HasGeneration() bool {
 	return c != nil && c.Metadata.Generation > 0
 }
 

--- a/internal/schema/resources/connectors/connector_test.go
+++ b/internal/schema/resources/connectors/connector_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
@@ -111,4 +112,149 @@ func TestConnectorValidation(t *testing.T) {
 
 	connector = testConnectorResource()
 	require.ErrorContains(t, connector.Validate(nil), "status: is server-owned")
+}
+
+func TestConnectorValidationModesAndCreateDefaults(t *testing.T) {
+	create := testConnectorResource()
+	create.Metadata.ID = ""
+	create.Metadata.Name = ""
+	create.Metadata.Generation = 0
+	create.Status = nil
+	create.Spec.Release.DesiredState = ""
+	require.NoError(t, create.ValidateFor(meta.ValidationModeCreate, nil))
+
+	id := apid.MustParse("cxr_testcreate0000001")
+	normalized := create.ApplyAPICreateDefaults(id)
+	require.Equal(t, id, normalized.GetId())
+	require.Equal(t, common.ResourceName(id.String()), normalized.Metadata.Name)
+	require.Equal(t, uint64(1), normalized.Metadata.Generation)
+	require.Equal(t, ConnectorReleaseStateDraft, normalized.Spec.Release.DesiredState)
+	require.Empty(t, create.Metadata.ID, "defaulting must not mutate the request")
+
+	normalized.Status = &ConnectorStatus{Release: ConnectorReleaseStatus{State: ConnectorReleaseStateDraft}}
+	require.NoError(t, normalized.ValidateFor(meta.ValidationModeResponse, nil))
+
+	normalized.Status.Release.State = ConnectorReleaseStatePrimary
+	require.ErrorContains(t, normalized.ValidateFor(meta.ValidationModeResponse, nil), "must be draft")
+
+	normalized.Spec.Release.DesiredState = ConnectorReleaseStatePrimary
+	require.NoError(t, normalized.ValidateFor(meta.ValidationModeResponse, nil))
+	normalized.Status.Release.State = ConnectorReleaseStateArchived
+	require.NoError(t, normalized.ValidateFor(meta.ValidationModeResponse, nil))
+}
+
+func TestConnectorDesiredReleaseStateForObserved(t *testing.T) {
+	require.Equal(t, ConnectorReleaseStateDraft, DesiredReleaseStateForObserved(ConnectorReleaseStateDraft))
+	for _, state := range []ConnectorReleaseState{
+		ConnectorReleaseStatePrimary,
+		ConnectorReleaseStateActive,
+		ConnectorReleaseStateArchived,
+	} {
+		require.Equal(t, ConnectorReleaseStatePrimary, DesiredReleaseStateForObserved(state))
+	}
+}
+
+func TestConnectorPatchRoundtripAndApply(t *testing.T) {
+	current := testConnectorResource()
+	labels := map[string]string{"environment": "staging"}
+	annotations := map[string]string{}
+	name := common.ResourceName("renamed-connector")
+	primary := ConnectorReleaseStatePrimary
+	definition := current.Spec.Definition
+	definition.Description = "updated"
+
+	patch := NewConnectorPatch()
+	patch.Metadata.Name = &name
+	patch.Metadata.Labels = &labels
+	patch.Metadata.Annotations = &annotations
+	patch.Spec.Release = &ConnectorReleaseSpecPatch{DesiredState: &primary}
+	patch.Spec.Definition = &definition
+
+	data, err := json.Marshal(patch)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"Connector",
+      "metadata":{
+        "name":"renamed-connector",
+        "labels":{"environment":"staging"},
+        "annotations":{}
+      },
+      "spec":{
+        "release":{"desiredState":"primary"},
+        "definition":`+mustJSON(t, definition)+`
+      }
+    }`, string(data))
+
+	var decoded ConnectorPatch
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	updated, err := decoded.ApplyTo(&current, nil)
+	require.NoError(t, err)
+	require.Equal(t, name, updated.Metadata.Name)
+	require.Equal(t, labels, updated.Metadata.Labels)
+	require.Empty(t, updated.Metadata.Annotations)
+	require.NotNil(t, updated.Metadata.Annotations)
+	require.Equal(t, primary, updated.Spec.Release.DesiredState)
+	require.Equal(t, "updated", updated.Spec.Definition.Description)
+	require.Equal(t, current.Metadata.ID, updated.Metadata.ID)
+	require.Equal(t, current.Metadata.Generation, updated.Metadata.Generation)
+}
+
+func TestConnectorPatchRejectsNullAndImmutableFields(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		json string
+		yaml string
+		want string
+	}{
+		{
+			name: "definition",
+			json: `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{},"spec":{"definition":null}}`,
+			yaml: "apiVersion: authproxy.net/v1alpha1\nkind: Connector\nmetadata: {}\nspec:\n  definition: null\n",
+			want: "spec.definition: must not be null",
+		},
+		{
+			name: "release",
+			json: `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{},"spec":{"release":null}}`,
+			yaml: "apiVersion: authproxy.net/v1alpha1\nkind: Connector\nmetadata: {}\nspec:\n  release: null\n",
+			want: "spec.release: must not be null",
+		},
+		{
+			name: "desired state",
+			json: `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{},"spec":{"release":{"desiredState":null}}}`,
+			yaml: "apiVersion: authproxy.net/v1alpha1\nkind: Connector\nmetadata: {}\nspec:\n  release:\n    desiredState: null\n",
+			want: "spec.release.desiredState: must not be null",
+		},
+	} {
+		t.Run(tc.name+" JSON", func(t *testing.T) {
+			var patch ConnectorPatch
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &patch))
+			require.ErrorContains(t, patch.ValidateFor(meta.ValidationModeUpdate, nil), tc.want)
+		})
+		t.Run(tc.name+" YAML", func(t *testing.T) {
+			var patch ConnectorPatch
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &patch))
+			require.ErrorContains(t, patch.ValidateFor(meta.ValidationModeUpdate, nil), tc.want)
+		})
+	}
+
+	current := testConnectorResource()
+	patch := NewConnectorPatch()
+	generation := current.Metadata.Generation + 1
+	patch.Metadata.Generation = &generation
+	_, err := patch.ApplyTo(&current, nil)
+	require.ErrorContains(t, err, "metadata.generation: is immutable")
+
+	namespace := "root.other"
+	patch = NewConnectorPatch()
+	patch.Metadata.Namespace = &namespace
+	_, err = patch.ApplyTo(&current, nil)
+	require.ErrorContains(t, err, "metadata.namespace: is immutable")
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/internal/schema/resources/connectors/connectors.go
+++ b/internal/schema/resources/connectors/connectors.go
@@ -117,7 +117,7 @@ func (c *Connectors) ValidateIdentities(vc *common.ValidationContext) error {
 			logicalDetails = &identityDetails{versions: make(map[uint64]int), unversioned: make(map[string]int)}
 			byLogical[lk] = logicalDetails
 		}
-		if connector.HasVersion() {
+		if connector.HasGeneration() {
 			logicalDetails.versions[connector.Metadata.Generation]++
 		} else {
 			state := string(connector.Spec.Release.DesiredState)

--- a/internal/schema/resources/connectors/patch_serialization.go
+++ b/internal/schema/resources/connectors/patch_serialization.go
@@ -1,0 +1,128 @@
+package connectors
+
+import (
+	"encoding/json"
+
+	"github.com/rmorlok/authproxy/internal/util"
+	"gopkg.in/yaml.v3"
+)
+
+type connectorSpecPatchWire struct {
+	Release    *ConnectorReleaseSpecPatch `json:"release,omitempty" yaml:"release,omitempty"`
+	Definition *ConnectorDefinition       `json:"definition,omitempty" yaml:"definition,omitempty"`
+}
+
+func (c ConnectorSpecPatch) MarshalJSON() ([]byte, error) {
+	value := map[string]any{}
+	if c.HasRelease() {
+		value["release"] = c.Release
+	}
+	if c.HasDefinition() {
+		value["definition"] = c.Definition
+	}
+	return json.Marshal(value)
+}
+
+func (c *ConnectorSpecPatch) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	var wire connectorSpecPatchWire
+	if err := util.DecodeJSONStrict(data, &wire); err != nil {
+		return err
+	}
+	*c = ConnectorSpecPatch{Release: wire.Release, Definition: wire.Definition}
+	_, c.releasePresent = fields["release"]
+	_, c.definitionPresent = fields["definition"]
+	return nil
+}
+
+func (c ConnectorSpecPatch) MarshalYAML() (any, error) {
+	value := map[string]any{}
+	if c.HasRelease() {
+		value["release"] = c.Release
+	}
+	if c.HasDefinition() {
+		value["definition"] = c.Definition
+	}
+	return value, nil
+}
+
+func (c *ConnectorSpecPatch) UnmarshalYAML(value *yaml.Node) error {
+	var wire connectorSpecPatchWire
+	if err := util.DecodeYAMLNodeStrict(value, &wire); err != nil {
+		return err
+	}
+	*c = ConnectorSpecPatch{Release: wire.Release, Definition: wire.Definition}
+	node := value
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			switch node.Content[i].Value {
+			case "release":
+				c.releasePresent = true
+			case "definition":
+				c.definitionPresent = true
+			}
+		}
+	}
+	return nil
+}
+
+func (c ConnectorReleaseSpecPatch) MarshalJSON() ([]byte, error) {
+	value := map[string]any{}
+	if c.HasDesiredState() {
+		value["desiredState"] = c.DesiredState
+	}
+	return json.Marshal(value)
+}
+
+func (c *ConnectorReleaseSpecPatch) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	var wire struct {
+		DesiredState *ConnectorReleaseState `json:"desiredState,omitempty"`
+	}
+	if err := util.DecodeJSONStrict(data, &wire); err != nil {
+		return err
+	}
+	*c = ConnectorReleaseSpecPatch{DesiredState: wire.DesiredState}
+	_, c.desiredStatePresent = fields["desiredState"]
+	return nil
+}
+
+func (c ConnectorReleaseSpecPatch) MarshalYAML() (any, error) {
+	value := map[string]any{}
+	if c.HasDesiredState() {
+		value["desiredState"] = c.DesiredState
+	}
+	return value, nil
+}
+
+func (c *ConnectorReleaseSpecPatch) UnmarshalYAML(value *yaml.Node) error {
+	var wire struct {
+		DesiredState *ConnectorReleaseState `yaml:"desiredState,omitempty"`
+	}
+	if err := util.DecodeYAMLNodeStrict(value, &wire); err != nil {
+		return err
+	}
+	*c = ConnectorReleaseSpecPatch{DesiredState: wire.DesiredState}
+	node := value
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == "desiredState" {
+				c.desiredStatePresent = true
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/schema/resources/connectors/schema.json
+++ b/internal/schema/resources/connectors/schema.json
@@ -458,6 +458,79 @@
       },
       "required": ["release"],
       "additionalProperties": false
+    },
+    "ConnectorCreate": {
+      "allOf": [
+        { "$ref": "../meta/schema.json#/$defs/Resource" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Connector" },
+            "metadata": {
+              "allOf": [
+                { "$ref": "../meta/schema.json#/$defs/ObjectMeta" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^cxr_" },
+                    "namespace": { "$ref": "../namespace/schema.json#/$defs/NamespacePath" }
+                  },
+                  "required": ["namespace"]
+                }
+              ]
+            },
+            "spec": { "$ref": "#/$defs/ConnectorSpec" },
+            "status": { "$ref": "#/$defs/ConnectorStatus" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "ConnectorReleaseSpecPatch": {
+      "type": "object",
+      "properties": {
+        "desiredState": {
+          "type": "string",
+          "enum": ["draft", "primary"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConnectorSpecPatch": {
+      "type": "object",
+      "properties": {
+        "release": { "$ref": "#/$defs/ConnectorReleaseSpecPatch" },
+        "definition": { "$ref": "#/$defs/ConnectorDefinition" }
+      },
+      "additionalProperties": false
+    },
+    "ConnectorPatch": {
+      "allOf": [
+        { "$ref": "../meta/schema.json#/$defs/Resource" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Connector" },
+            "metadata": {
+              "allOf": [
+                { "$ref": "../meta/schema.json#/$defs/ObjectMetaPatch" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^cxr_" },
+                    "namespace": { "$ref": "../namespace/schema.json#/$defs/NamespacePath" }
+                  }
+                }
+              ]
+            },
+            "spec": { "$ref": "#/$defs/ConnectorSpecPatch" },
+            "status": { "$ref": "#/$defs/ConnectorStatus" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     }
   },
   "allOf": [

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -2870,7 +2870,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -2878,7 +2878,7 @@ const docTemplateadmin_api = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2945,7 +2945,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3005,7 +3005,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -3013,7 +3013,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3891,11 +3891,11 @@ const docTemplateadmin_api = `{
                         "required": true
                     },
                     {
-                        "description": "Version creation request",
+                        "description": "Version creation request; an empty body clones the newest generation as a draft",
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -3903,7 +3903,7 @@ const docTemplateadmin_api = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3983,7 +3983,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4050,7 +4050,7 @@ const docTemplateadmin_api = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -4058,7 +4058,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4147,7 +4147,7 @@ const docTemplateadmin_api = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -8177,74 +8177,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "api.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
@@ -8301,6 +8233,30 @@ const docTemplateadmin_api = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "connectors.ConnectorReleaseSpec": {
+            "type": "object",
+            "properties": {
+                "desiredState": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorReleaseStatus": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorStatus": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseStatus"
                 }
             }
         },
@@ -8600,7 +8556,9 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -8642,48 +8600,72 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "openapi.ConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "openapi.ConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
+        "openapi.ConnectorReleaseSpecPatchJson": {
             "type": "object",
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "desiredState": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "draft",
+                        "primary"
+                    ]
+                }
+            }
+        },
+        "openapi.ConnectorSpecJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseSpec"
+                }
+            }
+        },
+        "openapi.ConnectorSpecPatchJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
+                "release": {
+                    "$ref": "#/definitions/openapi.ConnectorReleaseSpecPatchJson"
                 }
             }
         },
@@ -9408,74 +9390,6 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
             "type": "object",
@@ -9595,7 +9509,9 @@ const docTemplateadmin_api = `{
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -9637,6 +9553,41 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "routes.OpenAPIConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
         "routes.OpenAPIConnectorLifecycleRequestJson": {
             "description": "Request to run a connector lifecycle operation",
             "type": "object",
@@ -9660,94 +9611,38 @@ const docTemplateadmin_api = `{
                 }
             }
         },
-        "routes.OpenAPIConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "routes.OpenAPIConnectorPatchJson": {
+            "description": "Kubernetes-style Connector patch",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
+                "kind": {
                     "type": "string",
-                    "example": "salesforce"
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMetaPatch"
                 },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecPatchJson"
                 },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorRequestJson": {
-            "description": "Request to create a new connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorVersionRequestJson": {
-            "description": "Request to create a new draft connector version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
                 }
             }
         },
@@ -9820,10 +9715,9 @@ const docTemplateadmin_api = `{
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connector versions.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/openapi.ConnectorVersionJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -9852,10 +9746,9 @@ const docTemplateadmin_api = `{
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/api.ConnectorJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -10131,48 +10024,6 @@ const docTemplateadmin_api = `{
                 },
                 "updatedAt": {
                     "type": "string"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a logical connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
-            "description": "Request to update a connector definition version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -2864,7 +2864,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -2872,7 +2872,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2939,7 +2939,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2999,7 +2999,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -3007,7 +3007,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3885,11 +3885,11 @@
                         "required": true
                     },
                     {
-                        "description": "Version creation request",
+                        "description": "Version creation request; an empty body clones the newest generation as a draft",
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -3897,7 +3897,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3977,7 +3977,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4044,7 +4044,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -4052,7 +4052,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4141,7 +4141,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -8171,74 +8171,6 @@
                 }
             }
         },
-        "api.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
@@ -8295,6 +8227,30 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "connectors.ConnectorReleaseSpec": {
+            "type": "object",
+            "properties": {
+                "desiredState": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorReleaseStatus": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorStatus": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseStatus"
                 }
             }
         },
@@ -8594,7 +8550,9 @@
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -8636,48 +8594,72 @@
                 }
             }
         },
-        "openapi.ConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "openapi.ConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
+        "openapi.ConnectorReleaseSpecPatchJson": {
             "type": "object",
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "desiredState": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "draft",
+                        "primary"
+                    ]
+                }
+            }
+        },
+        "openapi.ConnectorSpecJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseSpec"
+                }
+            }
+        },
+        "openapi.ConnectorSpecPatchJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
+                "release": {
+                    "$ref": "#/definitions/openapi.ConnectorReleaseSpecPatchJson"
                 }
             }
         },
@@ -9402,74 +9384,6 @@
                 }
             }
         },
-        "routes.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
             "type": "object",
@@ -9589,7 +9503,9 @@
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -9631,6 +9547,41 @@
                 }
             }
         },
+        "routes.OpenAPIConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
         "routes.OpenAPIConnectorLifecycleRequestJson": {
             "description": "Request to run a connector lifecycle operation",
             "type": "object",
@@ -9654,94 +9605,38 @@
                 }
             }
         },
-        "routes.OpenAPIConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "routes.OpenAPIConnectorPatchJson": {
+            "description": "Kubernetes-style Connector patch",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
+                "kind": {
                     "type": "string",
-                    "example": "salesforce"
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMetaPatch"
                 },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecPatchJson"
                 },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorRequestJson": {
-            "description": "Request to create a new connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorVersionRequestJson": {
-            "description": "Request to create a new draft connector version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
                 }
             }
         },
@@ -9814,10 +9709,9 @@
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connector versions.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/openapi.ConnectorVersionJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -9846,10 +9740,9 @@
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/api.ConnectorJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -10125,48 +10018,6 @@
                 },
                 "updatedAt": {
                     "type": "string"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a logical connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
-            "description": "Request to update a connector definition version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -5,55 +5,6 @@ definitions:
       signingKeyConfigured:
         type: boolean
     type: object
-  api.ConnectorJson:
-    description: Connector API summary response
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
-        type: string
-      description:
-        example: Salesforce CRM integration
-        type: string
-      displayName:
-        example: Salesforce
-        type: string
-      hasConfigure:
-        example: false
-        type: boolean
-      highlight:
-        example: CRM platform
-        type: string
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      logo:
-        example: https://example.com/logo.png
-        type: string
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      statusPageUrl:
-        example: https://status.salesforce.com
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
   api.MetricsSchemaMetricJson:
     description: Supported metric definition
     properties:
@@ -93,6 +44,21 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  connectors.ConnectorReleaseSpec:
+    properties:
+      desiredState:
+        type: string
+    type: object
+  connectors.ConnectorReleaseStatus:
+    properties:
+      state:
+        type: string
+    type: object
+  connectors.ConnectorStatus:
+    properties:
+      release:
+        $ref: '#/definitions/connectors.ConnectorReleaseStatus'
     type: object
   key.KeyStatus:
     properties:
@@ -294,7 +260,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      connector: {}
+      connector:
+        $ref: '#/definitions/openapi.ConnectorJson'
       createdAt:
         type: string
       healthState:
@@ -324,37 +291,52 @@ definitions:
       updatedAt:
         type: string
     type: object
-  openapi.ConnectorVersionJson:
-    description: Detailed connector version information
+  openapi.ConnectorJson:
+    description: Kubernetes-style Connector resource
     properties:
-      annotations:
-        additionalProperties:
-          type: string
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  openapi.ConnectorReleaseSpecPatchJson:
+    properties:
+      desiredState:
+        enum:
+        - draft
+        - primary
+        type: string
+    type: object
+  openapi.ConnectorSpecJson:
+    properties:
+      definition:
         type: object
-      createdAt:
-        type: string
-      definition: {}
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
+      release:
+        $ref: '#/definitions/connectors.ConnectorReleaseSpec'
+    type: object
+  openapi.ConnectorSpecPatchJson:
+    properties:
+      definition:
         type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
+      release:
+        $ref: '#/definitions/openapi.ConnectorReleaseSpecPatchJson'
     type: object
   openapi.DryRunRequestJson:
     description: 'Dry-run input: a proxy-shaped request + request type + the identity
@@ -873,55 +855,6 @@ definitions:
         example: redirect
         type: string
     type: object
-  routes.ConnectorJson:
-    description: Connector API summary response
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
-        type: string
-      description:
-        example: Salesforce CRM integration
-        type: string
-      displayName:
-        example: Salesforce
-        type: string
-      hasConfigure:
-        example: false
-        type: boolean
-      highlight:
-        example: CRM platform
-        type: string
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      logo:
-        example: https://example.com/logo.png
-        type: string
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      statusPageUrl:
-        example: https://status.salesforce.com
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
     properties:
@@ -1012,7 +945,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      connector: {}
+      connector:
+        $ref: '#/definitions/openapi.ConnectorJson'
       createdAt:
         type: string
       healthState:
@@ -1042,6 +976,31 @@ definitions:
       updatedAt:
         type: string
     type: object
+  routes.OpenAPIConnectorJson:
+    description: Kubernetes-style Connector resource
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
   routes.OpenAPIConnectorLifecycleRequestJson:
     description: Request to run a connector lifecycle operation
     properties:
@@ -1058,69 +1017,30 @@ definitions:
       taskId:
         type: string
     type: object
-  routes.OpenAPIConnectorVersionJson:
-    description: Detailed connector version information
+  routes.OpenAPIConnectorPatchJson:
+    description: Kubernetes-style Connector patch
     properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
-      definition: {}
-      id:
-        example: cxr_test550e8400abcde
+      kind:
+        enum:
+        - Connector
+        example: Connector
         type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
-  routes.OpenAPICreateConnectorRequestJson:
-    description: Request to create a new connector
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-    type: object
-  routes.OpenAPICreateConnectorVersionRequestJson:
-    description: Request to create a new draft connector version
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
+      metadata:
+        $ref: '#/definitions/meta.ObjectMetaPatch'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecPatchJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPIDisconnectConnectionRequestJson:
     description: Request body for connection disconnect operations
@@ -1167,9 +1087,8 @@ definitions:
         example: authproxy.net/v1alpha1
         type: string
       items:
-        description: List of connector versions.
         items:
-          $ref: '#/definitions/openapi.ConnectorVersionJson'
+          $ref: '#/definitions/openapi.ConnectorJson'
         type: array
       kind:
         type: string
@@ -1190,9 +1109,8 @@ definitions:
         example: authproxy.net/v1alpha1
         type: string
       items:
-        description: List of connectors.
         items:
-          $ref: '#/definitions/api.ConnectorJson'
+          $ref: '#/definitions/openapi.ConnectorJson'
         type: array
       kind:
         type: string
@@ -1392,35 +1310,6 @@ definitions:
         type: string
       updatedAt:
         type: string
-    type: object
-  routes.OpenAPIUpdateConnectorRequestJson:
-    description: Request to update a logical connector
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-    type: object
-  routes.OpenAPIUpdateConnectorVersionRequestJson:
-    description: Request to update a connector definition version
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
     type: object
   routes.ProxyRequest:
     description: Request to proxy or simulate an HTTP request
@@ -3383,14 +3272,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPICreateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorJson'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -3433,7 +3322,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -3470,14 +3359,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorPatchJson'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4048,18 +3937,19 @@ paths:
         name: id
         required: true
         type: string
-      - description: Version creation request
+      - description: Version creation request; an empty body clones the newest generation
+          as a draft
         in: body
         name: request
         schema:
-          $ref: '#/definitions/routes.OpenAPICreateConnectorVersionRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorJson'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4111,7 +4001,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4153,14 +4043,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorPatchJson'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4218,7 +4108,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -2870,7 +2870,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -2878,7 +2878,7 @@ const docTemplateApi = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2945,7 +2945,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3005,7 +3005,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -3013,7 +3013,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3891,11 +3891,11 @@ const docTemplateApi = `{
                         "required": true
                     },
                     {
-                        "description": "Version creation request",
+                        "description": "Version creation request; an empty body clones the newest generation as a draft",
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -3903,7 +3903,7 @@ const docTemplateApi = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3983,7 +3983,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4050,7 +4050,7 @@ const docTemplateApi = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -4058,7 +4058,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4147,7 +4147,7 @@ const docTemplateApi = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -8177,74 +8177,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "api.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
@@ -8301,6 +8233,30 @@ const docTemplateApi = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "connectors.ConnectorReleaseSpec": {
+            "type": "object",
+            "properties": {
+                "desiredState": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorReleaseStatus": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorStatus": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseStatus"
                 }
             }
         },
@@ -8600,7 +8556,9 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -8642,48 +8600,72 @@ const docTemplateApi = `{
                 }
             }
         },
-        "openapi.ConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "openapi.ConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
+        "openapi.ConnectorReleaseSpecPatchJson": {
             "type": "object",
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "desiredState": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "draft",
+                        "primary"
+                    ]
+                }
+            }
+        },
+        "openapi.ConnectorSpecJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseSpec"
+                }
+            }
+        },
+        "openapi.ConnectorSpecPatchJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
+                "release": {
+                    "$ref": "#/definitions/openapi.ConnectorReleaseSpecPatchJson"
                 }
             }
         },
@@ -9408,74 +9390,6 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
             "type": "object",
@@ -9595,7 +9509,9 @@ const docTemplateApi = `{
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -9637,6 +9553,41 @@ const docTemplateApi = `{
                 }
             }
         },
+        "routes.OpenAPIConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
         "routes.OpenAPIConnectorLifecycleRequestJson": {
             "description": "Request to run a connector lifecycle operation",
             "type": "object",
@@ -9660,94 +9611,38 @@ const docTemplateApi = `{
                 }
             }
         },
-        "routes.OpenAPIConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "routes.OpenAPIConnectorPatchJson": {
+            "description": "Kubernetes-style Connector patch",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
+                "kind": {
                     "type": "string",
-                    "example": "salesforce"
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMetaPatch"
                 },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecPatchJson"
                 },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorRequestJson": {
-            "description": "Request to create a new connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorVersionRequestJson": {
-            "description": "Request to create a new draft connector version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
                 }
             }
         },
@@ -9820,10 +9715,9 @@ const docTemplateApi = `{
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connector versions.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/openapi.ConnectorVersionJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -9852,10 +9746,9 @@ const docTemplateApi = `{
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/api.ConnectorJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -10131,48 +10024,6 @@ const docTemplateApi = `{
                 },
                 "updatedAt": {
                     "type": "string"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a logical connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
-            "description": "Request to update a connector definition version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -2864,7 +2864,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -2872,7 +2872,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2939,7 +2939,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.ConnectorJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -2999,7 +2999,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -3007,7 +3007,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3885,11 +3885,11 @@
                         "required": true
                     },
                     {
-                        "description": "Version creation request",
+                        "description": "Version creation request; an empty body clones the newest generation as a draft",
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPICreateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     }
                 ],
@@ -3897,7 +3897,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -3977,7 +3977,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4044,7 +4044,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorPatchJson"
                         }
                     }
                 ],
@@ -4052,7 +4052,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -4141,7 +4141,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/routes.OpenAPIConnectorVersionJson"
+                            "$ref": "#/definitions/routes.OpenAPIConnectorJson"
                         }
                     },
                     "400": {
@@ -8171,74 +8171,6 @@
                 }
             }
         },
-        "api.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "api.MetricsSchemaMetricJson": {
             "description": "Supported metric definition",
             "type": "object",
@@ -8295,6 +8227,30 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "connectors.ConnectorReleaseSpec": {
+            "type": "object",
+            "properties": {
+                "desiredState": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorReleaseStatus": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "connectors.ConnectorStatus": {
+            "type": "object",
+            "properties": {
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseStatus"
                 }
             }
         },
@@ -8594,7 +8550,9 @@
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -8636,48 +8594,72 @@
                 }
             }
         },
-        "openapi.ConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "openapi.ConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
+        "openapi.ConnectorReleaseSpecPatchJson": {
             "type": "object",
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "desiredState": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "draft",
+                        "primary"
+                    ]
+                }
+            }
+        },
+        "openapi.ConnectorSpecJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "release": {
+                    "$ref": "#/definitions/connectors.ConnectorReleaseSpec"
+                }
+            }
+        },
+        "openapi.ConnectorSpecPatchJson": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "object"
                 },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
+                "release": {
+                    "$ref": "#/definitions/openapi.ConnectorReleaseSpecPatchJson"
                 }
             }
         },
@@ -9402,74 +9384,6 @@
                 }
             }
         },
-        "routes.ConnectorJson": {
-            "description": "Connector API summary response",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Salesforce CRM integration"
-                },
-                "displayName": {
-                    "type": "string",
-                    "example": "Salesforce"
-                },
-                "hasConfigure": {
-                    "type": "boolean",
-                    "example": false
-                },
-                "highlight": {
-                    "type": "string",
-                    "example": "CRM platform"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "cxr_test550e8400abcde"
-                },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "logo": {
-                    "type": "string",
-                    "example": "https://example.com/logo.png"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
-                },
-                "statusPageUrl": {
-                    "type": "string",
-                    "example": "https://status.salesforce.com"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
         "routes.DataSourceOptionJson": {
             "description": "Data source option for form select fields",
             "type": "object",
@@ -9589,7 +9503,9 @@
                         "type": "string"
                     }
                 },
-                "connector": {},
+                "connector": {
+                    "$ref": "#/definitions/openapi.ConnectorJson"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -9631,6 +9547,41 @@
                 }
             }
         },
+        "routes.OpenAPIConnectorJson": {
+            "description": "Kubernetes-style Connector resource",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
+                }
+            }
+        },
         "routes.OpenAPIConnectorLifecycleRequestJson": {
             "description": "Request to run a connector lifecycle operation",
             "type": "object",
@@ -9654,94 +9605,38 @@
                 }
             }
         },
-        "routes.OpenAPIConnectorVersionJson": {
-            "description": "Detailed connector version information",
+        "routes.OpenAPIConnectorPatchJson": {
+            "description": "Kubernetes-style Connector patch",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "definition": {},
-                "id": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "cxr_test550e8400abcde"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
+                "kind": {
                     "type": "string",
-                    "example": "salesforce"
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMetaPatch"
                 },
-                "state": {
-                    "type": "string",
-                    "example": "primary"
+                "spec": {
+                    "$ref": "#/definitions/openapi.ConnectorSpecPatchJson"
                 },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorRequestJson": {
-            "description": "Request to create a new connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
-                }
-            }
-        },
-        "routes.OpenAPICreateConnectorVersionRequestJson": {
-            "description": "Request to create a new draft connector version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                "status": {
+                    "$ref": "#/definitions/connectors.ConnectorStatus"
                 }
             }
         },
@@ -9814,10 +9709,9 @@
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connector versions.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/openapi.ConnectorVersionJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -9846,10 +9740,9 @@
                     "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "List of connectors.",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/api.ConnectorJson"
+                        "$ref": "#/definitions/openapi.ConnectorJson"
                     }
                 },
                 "kind": {
@@ -10125,48 +10018,6 @@
                 },
                 "updatedAt": {
                     "type": "string"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorRequestJson": {
-            "description": "Request to update a logical connector",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string",
-                    "example": "salesforce"
-                }
-            }
-        },
-        "routes.OpenAPIUpdateConnectorVersionRequestJson": {
-            "description": "Request to update a connector definition version",
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "definition": {},
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -5,55 +5,6 @@ definitions:
       signingKeyConfigured:
         type: boolean
     type: object
-  api.ConnectorJson:
-    description: Connector API summary response
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
-        type: string
-      description:
-        example: Salesforce CRM integration
-        type: string
-      displayName:
-        example: Salesforce
-        type: string
-      hasConfigure:
-        example: false
-        type: boolean
-      highlight:
-        example: CRM platform
-        type: string
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      logo:
-        example: https://example.com/logo.png
-        type: string
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      statusPageUrl:
-        example: https://status.salesforce.com
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
   api.MetricsSchemaMetricJson:
     description: Supported metric definition
     properties:
@@ -93,6 +44,21 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  connectors.ConnectorReleaseSpec:
+    properties:
+      desiredState:
+        type: string
+    type: object
+  connectors.ConnectorReleaseStatus:
+    properties:
+      state:
+        type: string
+    type: object
+  connectors.ConnectorStatus:
+    properties:
+      release:
+        $ref: '#/definitions/connectors.ConnectorReleaseStatus'
     type: object
   key.KeyStatus:
     properties:
@@ -294,7 +260,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      connector: {}
+      connector:
+        $ref: '#/definitions/openapi.ConnectorJson'
       createdAt:
         type: string
       healthState:
@@ -324,37 +291,52 @@ definitions:
       updatedAt:
         type: string
     type: object
-  openapi.ConnectorVersionJson:
-    description: Detailed connector version information
+  openapi.ConnectorJson:
+    description: Kubernetes-style Connector resource
     properties:
-      annotations:
-        additionalProperties:
-          type: string
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  openapi.ConnectorReleaseSpecPatchJson:
+    properties:
+      desiredState:
+        enum:
+        - draft
+        - primary
+        type: string
+    type: object
+  openapi.ConnectorSpecJson:
+    properties:
+      definition:
         type: object
-      createdAt:
-        type: string
-      definition: {}
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
+      release:
+        $ref: '#/definitions/connectors.ConnectorReleaseSpec'
+    type: object
+  openapi.ConnectorSpecPatchJson:
+    properties:
+      definition:
         type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
+      release:
+        $ref: '#/definitions/openapi.ConnectorReleaseSpecPatchJson'
     type: object
   openapi.DryRunRequestJson:
     description: 'Dry-run input: a proxy-shaped request + request type + the identity
@@ -873,55 +855,6 @@ definitions:
         example: redirect
         type: string
     type: object
-  routes.ConnectorJson:
-    description: Connector API summary response
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
-        type: string
-      description:
-        example: Salesforce CRM integration
-        type: string
-      displayName:
-        example: Salesforce
-        type: string
-      hasConfigure:
-        example: false
-        type: boolean
-      highlight:
-        example: CRM platform
-        type: string
-      id:
-        example: cxr_test550e8400abcde
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      logo:
-        example: https://example.com/logo.png
-        type: string
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      statusPageUrl:
-        example: https://status.salesforce.com
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
   routes.DataSourceOptionJson:
     description: Data source option for form select fields
     properties:
@@ -1012,7 +945,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      connector: {}
+      connector:
+        $ref: '#/definitions/openapi.ConnectorJson'
       createdAt:
         type: string
       healthState:
@@ -1042,6 +976,31 @@ definitions:
       updatedAt:
         type: string
     type: object
+  routes.OpenAPIConnectorJson:
+    description: Kubernetes-style Connector resource
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
   routes.OpenAPIConnectorLifecycleRequestJson:
     description: Request to run a connector lifecycle operation
     properties:
@@ -1058,69 +1017,30 @@ definitions:
       taskId:
         type: string
     type: object
-  routes.OpenAPIConnectorVersionJson:
-    description: Detailed connector version information
+  routes.OpenAPIConnectorPatchJson:
+    description: Kubernetes-style Connector patch
     properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      createdAt:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
-      definition: {}
-      id:
-        example: cxr_test550e8400abcde
+      kind:
+        enum:
+        - Connector
+        example: Connector
         type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      state:
-        example: primary
-        type: string
-      updatedAt:
-        type: string
-      version:
-        example: 1
-        type: integer
-    type: object
-  routes.OpenAPICreateConnectorRequestJson:
-    description: Request to create a new connector
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-    type: object
-  routes.OpenAPICreateConnectorVersionRequestJson:
-    description: Request to create a new draft connector version
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
+      metadata:
+        $ref: '#/definitions/meta.ObjectMetaPatch'
+      spec:
+        $ref: '#/definitions/openapi.ConnectorSpecPatchJson'
+      status:
+        $ref: '#/definitions/connectors.ConnectorStatus'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPIDisconnectConnectionRequestJson:
     description: Request body for connection disconnect operations
@@ -1167,9 +1087,8 @@ definitions:
         example: authproxy.net/v1alpha1
         type: string
       items:
-        description: List of connector versions.
         items:
-          $ref: '#/definitions/openapi.ConnectorVersionJson'
+          $ref: '#/definitions/openapi.ConnectorJson'
         type: array
       kind:
         type: string
@@ -1190,9 +1109,8 @@ definitions:
         example: authproxy.net/v1alpha1
         type: string
       items:
-        description: List of connectors.
         items:
-          $ref: '#/definitions/api.ConnectorJson'
+          $ref: '#/definitions/openapi.ConnectorJson'
         type: array
       kind:
         type: string
@@ -1392,35 +1310,6 @@ definitions:
         type: string
       updatedAt:
         type: string
-    type: object
-  routes.OpenAPIUpdateConnectorRequestJson:
-    description: Request to update a logical connector
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        example: salesforce
-        type: string
-    type: object
-  routes.OpenAPIUpdateConnectorVersionRequestJson:
-    description: Request to update a connector definition version
-    properties:
-      annotations:
-        additionalProperties:
-          type: string
-        type: object
-      definition: {}
-      labels:
-        additionalProperties:
-          type: string
-        type: object
     type: object
   routes.ProxyRequest:
     description: Request to proxy or simulate an HTTP request
@@ -3383,14 +3272,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPICreateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorJson'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -3433,7 +3322,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.ConnectorJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -3470,14 +3359,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorPatchJson'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4048,18 +3937,19 @@ paths:
         name: id
         required: true
         type: string
-      - description: Version creation request
+      - description: Version creation request; an empty body clones the newest generation
+          as a draft
         in: body
         name: request
         schema:
-          $ref: '#/definitions/routes.OpenAPICreateConnectorVersionRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorJson'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4111,7 +4001,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4153,14 +4043,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.OpenAPIUpdateConnectorVersionRequestJson'
+          $ref: '#/definitions/routes.OpenAPIConnectorPatchJson'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:
@@ -4218,7 +4108,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/routes.OpenAPIConnectorVersionJson'
+            $ref: '#/definitions/routes.OpenAPIConnectorJson'
         "400":
           description: Bad Request
           schema:


### PR DESCRIPTION
Closes #839

## Summary

- migrate connector and connector-generation endpoints to canonical `authproxy.net/v1alpha1` `Connector` resources and `ConnectorPatch` updates
- represent desired release state in `spec.release`, observed lifecycle state in `status.release`, and connector versions with stable `metadata.id` plus sequential `metadata.generation`
- add shared connector resource validation, defaulting, patch presence tracking, normalization, and core/resource conversion helpers
- update automatic and explicit generation reconciliation, including draft/primary transitions, renames, and ordered generation lists
- update JSON schemas, fixtures, generated Swagger, CLI/demo consumers, and nested connector responses
- intentionally provide no legacy-format compatibility or data migration; existing non-production environments may be recreated

## Verification

- `env AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite GOCACHE=/tmp/authproxy1-go-cache go test ./internal/core ./internal/routes ./internal/schema/api ./internal/schema/config ./internal/schema/resources/connectors ./demos/seed/backend -count=1`
- `env GOCACHE=/tmp/authproxy1-go-cache go test ./... -run "^$"`
- `./scripts/preflight.sh`