### PR TITLE
Resolve generationless connector references to primary

### DIFF
--- a/internal/core/iface/service.go
+++ b/internal/core/iface/service.go
@@ -79,7 +79,7 @@ type C interface {
 	ResolveConnectionReference(ctx context.Context, reference meta.ObjectReference) (Connection, error)
 
 	// ResolveConnectorReference resolves and hydrates a Connector. An explicit
-	// generation selects that definition version; otherwise the newest version
+	// generation selects that definition version; otherwise the primary version
 	// is returned.
 	ResolveConnectorReference(ctx context.Context, reference meta.ObjectReference) (Connector, error)
 

--- a/internal/core/service_object_reference.go
+++ b/internal/core/service_object_reference.go
@@ -48,23 +48,41 @@ func (s *service) ResolveConnectionReference(
 	return s.getConnectionForDb(ctx, connection)
 }
 
+// resolveLogicalConnectorReference resolves a connector reference without
+// selecting or hydrating a definition version. Use this for relationships that
+// apply to the logical connector across all generations.
+func (s *service) resolveLogicalConnectorReference(
+	ctx context.Context,
+	reference meta.ObjectReference,
+) (*database.Connector, error) {
+	connector, err := s.db.ResolveConnectorReference(ctx, reference)
+	if err != nil {
+		return nil, coreObjectReferenceError(reference.Kind, err)
+	}
+	return connector, nil
+}
+
 // ResolveConnectorReference resolves the logical connector first, then uses
 // generation to choose the requested definition version. An omitted
-// generation selects the newest version.
+// generation selects the primary version.
 func (s *service) ResolveConnectorReference(
 	ctx context.Context,
 	reference meta.ObjectReference,
 ) (iface.Connector, error) {
-	connector, err := s.db.ResolveConnectorReference(ctx, reference)
+	connector, err := s.resolveLogicalConnectorReference(ctx, reference)
 	if err != nil {
-		return nil, coreObjectReferenceError(reference.Kind, err)
+		return nil, err
 	}
 
 	if reference.Generation != 0 {
 		return s.getConnectorVersion(ctx, connector.Id, reference.Generation)
 	}
 
-	version, err := s.db.NewestConnectorDefinitionVersionForId(ctx, connector.Id)
+	version, err := s.db.GetConnectorDefinitionVersionForState(
+		ctx,
+		connector.Id,
+		database.ConnectorDefinitionVersionStatePrimary,
+	)
 	if err != nil {
 		return nil, coreObjectReferenceError(reference.Kind, err)
 	}

--- a/internal/core/service_object_reference_test.go
+++ b/internal/core/service_object_reference_test.go
@@ -136,7 +136,7 @@ func TestResolveConnectorReferenceHydratesDefinitionVersion(t *testing.T) {
 		require.Equal(t, "Billing", resolved.GetDefinition().DisplayName)
 	})
 
-	t.Run("omitted generation uses newest", func(t *testing.T) {
+	t.Run("omitted generation uses primary", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s, db, _, _, _, encrypt := FullMockService(t, ctrl)
 		ref := coreReference(connectorschema.ConnectorKind, connectorID.String())
@@ -145,13 +145,17 @@ func TestResolveConnectorReferenceHydratesDefinitionVersion(t *testing.T) {
 		require.NoError(t, err)
 
 		db.EXPECT().ResolveConnectorReference(ctx, ref).Return(logicalConnector, nil)
-		db.EXPECT().NewestConnectorDefinitionVersionForId(ctx, connectorID).Return(
+		db.EXPECT().GetConnectorDefinitionVersionForState(
+			ctx,
+			connectorID,
+			database.ConnectorDefinitionVersionStatePrimary,
+		).Return(
 			&database.ConnectorWithDefinition{
 				Id:                  connectorID,
 				Namespace:           logicalConnector.Namespace,
 				Name:                logicalConnector.Name,
-				Version:             3,
-				State:               database.ConnectorDefinitionVersionStateDraft,
+				Version:             2,
+				State:               database.ConnectorDefinitionVersionStatePrimary,
 				EncryptedDefinition: encryptedDefinition,
 			},
 			nil,
@@ -160,7 +164,8 @@ func TestResolveConnectorReferenceHydratesDefinitionVersion(t *testing.T) {
 
 		resolved, err := s.ResolveConnectorReference(ctx, ref)
 		require.NoError(t, err)
-		require.Equal(t, uint64(3), resolved.GetVersion())
+		require.Equal(t, uint64(2), resolved.GetVersion())
+		require.Equal(t, database.ConnectorDefinitionVersionStatePrimary, resolved.GetState())
 		require.Equal(t, logicalConnector.Name, resolved.GetName())
 	})
 }
@@ -294,7 +299,11 @@ func TestResolveConnectorReferenceReturnsNotFoundWithoutDefinitionVersion(t *tes
 	connector := &database.Connector{Id: apid.New(apid.PrefixConnector)}
 	ref := coreReference(connectorschema.ConnectorKind, connector.Id.String())
 	db.EXPECT().ResolveConnectorReference(ctx, ref).Return(connector, nil)
-	db.EXPECT().NewestConnectorDefinitionVersionForId(ctx, connector.Id).Return(nil, database.ErrNotFound)
+	db.EXPECT().GetConnectorDefinitionVersionForState(
+		ctx,
+		connector.Id,
+		database.ConnectorDefinitionVersionStatePrimary,
+	).Return(nil, database.ErrNotFound)
 
 	resolved, err := s.ResolveConnectorReference(ctx, ref)
 	require.Nil(t, resolved)

--- a/internal/core/service_rate_limit.go
+++ b/internal/core/service_rate_limit.go
@@ -175,7 +175,7 @@ func (s *service) normalizeRateLimitScope(
 	}
 
 	if resource.Spec.Scope.ConnectorRef != nil {
-		connector, err := s.ResolveConnectorReference(
+		connector, err := s.resolveLogicalConnectorReference(
 			ctx,
 			*resource.Spec.Scope.ConnectorRef,
 		)
@@ -186,7 +186,7 @@ func (s *service) normalizeRateLimitScope(
 		if err := validateRateLimitScopeTargetNamespace(
 			"connector",
 			resource.Metadata.Namespace,
-			connector.GetNamespace(),
+			connector.Namespace,
 		); err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func (s *service) normalizeRateLimitScope(
 		resource.Spec.Scope.ConnectorRef = &meta.ObjectReference{
 			APIVersion: meta.APIVersionV1Alpha1,
 			Kind:       cschema.ConnectorKind,
-			ID:         connector.GetId().String(),
+			ID:         connector.Id.String(),
 		}
 	}
 

--- a/internal/core/service_rate_limit_scope_test.go
+++ b/internal/core/service_rate_limit_scope_test.go
@@ -1,8 +1,15 @@
 package core
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/database"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	rlschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +41,36 @@ func TestValidateRateLimitScopeTargetNamespace(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidArgument)
 		require.ErrorContains(t, err, "outside rate-limit namespace")
 	}
+}
+
+func TestNormalizeRateLimitConnectorScopeResolvesLogicalConnector(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s, db, _, _, _, _ := FullMockService(t, ctrl)
+	ctx := context.Background()
+	connectorID := apid.New(apid.PrefixConnector)
+	ref := meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       cschema.ConnectorKind,
+		Namespace:  "root.acme",
+		Name:       "billing",
+	}
+	resource := &rlschema.RateLimit{
+		Metadata: meta.ObjectMeta{Namespace: "root.acme"},
+		Spec: rlschema.RateLimitSpec{Scope: &rlschema.RateLimitScope{
+			ConnectorRef: &ref,
+		}},
+	}
+
+	db.EXPECT().ResolveConnectorReference(ctx, ref).Return(&database.Connector{
+		Id:        connectorID,
+		Namespace: "root.acme.payments",
+		Name:      "billing",
+	}, nil)
+
+	require.NoError(t, s.normalizeRateLimitScope(ctx, resource))
+	require.Equal(t, &meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       cschema.ConnectorKind,
+		ID:         connectorID.String(),
+	}, resource.Spec.Scope.ConnectorRef)
 }


### PR DESCRIPTION
## Summary

- resolve connector references without `generation` to the primary definition version instead of the newest version
- preserve exact-version resolution when `generation` is specified
- resolve rate-limit connector scopes against the logical connector so their cross-generation semantics do not depend on a primary version
- document and test both resolution paths

## Rationale

A generationless connector reference should select the published version suitable for normal use, not a newer draft. Rate-limit connector references are intentionally generation-independent, so their normalization only needs the logical connector identity and namespace.

## Verification

- `go test ./internal/core -run 'TestResolveConnectorReference|TestNormalizeRateLimitConnectorScope|TestValidateRateLimitScopeTargetNamespace' -count=1`\n- `go test ./internal/core -count=1`\n- `./scripts/preflight.sh`