### PR TITLE
Migrate notification and search projections to v1alpha1

### DIFF
--- a/docs/src/content/docs/operations/connector-version-migrations.md
+++ b/docs/src/content/docs/operations/connector-version-migrations.md
@@ -194,9 +194,62 @@ POST /api/v1/notifications/{id}/_viewed
 POST /api/v1/notifications/_viewed
 ```
 
-`GET /notifications` returns actor-filtered active notifications with `viewed`,
-`canAction`, and `actionUrl` when the actor is allowed to perform the action.
-Clients should only follow `actionUrl` when `canAction` is true.
+`GET /notifications` returns a `NotificationList`. Each item is a read-only,
+resource-shaped projection of a durable notification row. It is not a
+client-managed desired resource: `status.viewed` is specific to the
+authenticated actor, and `status.action` is present only when that actor can
+perform the suggested action.
+
+```json
+{
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "Notification",
+  "metadata": {
+    "id": "ntf_01example",
+    "namespace": "root.acme",
+    "createdAt": "2026-08-16T12:00:00Z",
+    "updatedAt": "2026-08-16T12:00:00Z"
+  },
+  "spec": {
+    "key": "connection:cxn_01example:auth_required",
+    "level": "warning",
+    "resourceRef": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connection",
+      "id": "cxn_01example"
+    },
+    "title": "Connection requires re-authentication",
+    "message": "Reconnect to refresh credentials."
+  },
+  "status": {
+    "state": "active",
+    "viewed": false,
+    "action": {"url": "/connections/cxn_01example?action=reauth"}
+  }
+}
+```
+
+Marking one notification viewed uses a typed action and returns the same action
+with `status.viewed: true`:
+
+```json
+{
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "NotificationView",
+  "metadata": {
+    "target": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Notification",
+      "id": "ntf_01example"
+    }
+  },
+  "spec": {}
+}
+```
+
+The batch endpoint uses `kind: NotificationBatchView`, with Notification
+references in `metadata.targets` and an empty `spec`. Its response reports
+`status.viewedCount`.
 
 ## API
 

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -187,12 +187,45 @@ The Admin cross-resource endpoint searches names directly and also searches
 user-label values:
 
 ```http
-GET /api/v1/search/resources?q=production&resourceType=connection
+GET /api/v1/search/resources?q=production&kind=Connection
 ```
 
 Exact name matches rank before name prefixes, which rank before name
 substrings and matching label values. Namespace and resource-ID permissions are
-applied before results are returned.
+applied before results are returned. Search results are heterogeneous
+projections, not partial resource objects. Each item carries one typed
+`resourceRef`; partial-result observations live in the list metadata:
+
+```json
+{
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "SearchResultList",
+  "metadata": {
+    "truncatedKinds": ["Connection"],
+    "incompleteKinds": []
+  },
+  "items": [
+    {
+      "resourceRef": {
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Connection",
+        "id": "cxn_01example",
+        "name": "production-salesforce",
+        "namespace": "root.acme"
+      },
+      "labels": {"team": "payments"},
+      "matchedLabels": [],
+      "updatedAt": "2026-08-16T12:00:00Z"
+    }
+  ]
+}
+```
+
+Namespace results use the immutable namespace path as an ID-only reference;
+clients can derive the display segment from that path. Search never returns
+request events, task history, or other operational projections as if they were
+durable resources. See [connector migration notifications](/operations/connector-version-migrations/#notifications)
+for the separate actor-specific notification projection and its view actions.
 
 ## Actor resource shape
 

--- a/internal/database/object_reference.go
+++ b/internal/database/object_reference.go
@@ -42,21 +42,21 @@ var objectReferenceTargets = map[meta.Kind]objectReferenceTarget{
 		idColumn:    "id",
 		newRow:      func() objectReferenceRow { return &Actor{} },
 		rowID:       func(row objectReferenceRow) string { return row.(*Actor).Id.String() },
-		idValidator: idValidatorForPrefix(apid.PrefixActor),
+		idValidator: meta.IdValidatorForPrefix(apid.PrefixActor),
 	},
 	connectionschema.ConnectionKind: {
 		table:       ConnectionsTable,
 		idColumn:    "id",
 		newRow:      func() objectReferenceRow { return &Connection{} },
 		rowID:       func(row objectReferenceRow) string { return row.(*Connection).Id.String() },
-		idValidator: idValidatorForPrefix(apid.PrefixConnection),
+		idValidator: meta.IdValidatorForPrefix(apid.PrefixConnection),
 	},
 	connectorschema.ConnectorKind: {
 		table:           ConnectorsTable,
 		idColumn:        "id",
 		newRow:          func() objectReferenceRow { return &Connector{} },
 		rowID:           func(row objectReferenceRow) string { return row.(*Connector).Id.String() },
-		idValidator:     idValidatorForPrefix(apid.PrefixConnector),
+		idValidator:     meta.IdValidatorForPrefix(apid.PrefixConnector),
 		allowGeneration: true,
 	},
 	keyschema.KeyKind: {
@@ -64,7 +64,7 @@ var objectReferenceTargets = map[meta.Kind]objectReferenceTarget{
 		idColumn:    "id",
 		newRow:      func() objectReferenceRow { return &Key{} },
 		rowID:       func(row objectReferenceRow) string { return row.(*Key).Id.String() },
-		idValidator: idValidatorForPrefix(apid.PrefixKey),
+		idValidator: meta.IdValidatorForPrefix(apid.PrefixKey),
 	},
 	namespaceschema.NamespaceKind: {
 		table:                   NamespacesTable,
@@ -79,18 +79,8 @@ var objectReferenceTargets = map[meta.Kind]objectReferenceTarget{
 		idColumn:    "id",
 		newRow:      func() objectReferenceRow { return &RateLimit{} },
 		rowID:       func(row objectReferenceRow) string { return row.(*RateLimit).Id.String() },
-		idValidator: idValidatorForPrefix(apid.PrefixRateLimit),
+		idValidator: meta.IdValidatorForPrefix(apid.PrefixRateLimit),
 	},
-}
-
-func idValidatorForPrefix(prefix apid.Prefix) func(string) error {
-	return func(value string) error {
-		id, err := apid.Parse(value)
-		if err != nil {
-			return err
-		}
-		return id.ValidatePrefix(prefix)
-	}
 }
 
 func namespaceNamespacedNameCondition(reference meta.ObjectReference) (sq.Sqlizer, error) {

--- a/internal/routes/notifications.go
+++ b/internal/routes/notifications.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"fmt"
+	"maps"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -12,6 +14,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/httperr"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
@@ -22,8 +25,9 @@ type NotificationsRoutes struct {
 
 type NotificationJson = schemaapi.NotificationJson
 type ListNotificationsResponseJson = schemaapi.ListNotificationsResponseJson
-type MarkNotificationsViewedRequestJson = schemaapi.MarkNotificationsViewedRequestJson
 type OpenAPIListNotificationsResponseJson = schemaapiopenapi.ListNotificationsResponseJson
+type OpenAPINotificationViewActionJson = schemaapiopenapi.NotificationViewActionJson
+type OpenAPINotificationBatchViewActionJson = schemaapiopenapi.NotificationBatchViewActionJson
 
 type ListNotificationsRequestQuery struct {
 	LimitVal      *uint64 `form:"limit"`
@@ -110,10 +114,15 @@ func (r *NotificationsRoutes) list(gctx *gin.Context) {
 
 	items := make([]NotificationJson, 0, len(notifications))
 	for _, n := range notifications {
-		items = append(items, notificationToJSON(n))
+		item, err := notificationToJSON(n)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			return
+		}
+		items = append(items, item)
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, ListNotificationsResponseJson{Items: items})
+	apgin.APIJSON(gctx, http.StatusOK, schemaapi.NewListNotificationsResponseJson(items, ""))
 }
 
 // @Summary		Mark notifications viewed
@@ -121,8 +130,8 @@ func (r *NotificationsRoutes) list(gctx *gin.Context) {
 // @Tags			notifications
 // @Accept			json
 // @Produce		json
-// @Param			request	body	MarkNotificationsViewedRequestJson	true	"Notification IDs"
-// @Success		204
+// @Param			request	body	OpenAPINotificationBatchViewActionJson	true	"Notification batch view action"
+// @Success		200	{object}	OpenAPINotificationBatchViewActionJson
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		403	{object}	ErrorResponse
@@ -134,25 +143,39 @@ func (r *NotificationsRoutes) markViewedBatch(gctx *gin.Context) {
 	ctx := gctx.Request.Context()
 	ra := auth.MustGetAuthFromGinContext(gctx)
 
-	var req MarkNotificationsViewedRequestJson
-	if err := apgin.BindJSONBody(gctx, &req); err != nil {
+	var req schemaapi.NotificationBatchViewAction
+	if err := apgin.BindActionJSON(gctx, &req, schemaapi.NotificationBatchViewActionKind); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
 		return
 	}
 
-	if err := r.core.MarkActorNotificationsViewed(ctx, ra, req.Ids); err != nil {
+	ids := make([]apid.ID, 0, len(req.Metadata.Targets))
+	for _, target := range req.Metadata.Targets {
+		id, err := apid.Parse(target.ID)
+		if err != nil {
+			apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+			return
+		}
+		ids = append(ids, id)
+	}
+	if err := r.core.MarkActorNotificationsViewed(ctx, ra, ids); err != nil {
 		apgin.WriteErr(gctx, nil, err)
 		return
 	}
-	gctx.Status(http.StatusNoContent)
+	response := schemaapi.NewNotificationBatchViewResponse(req.Metadata.Targets)
+	if err := apgin.RenderActionJSON(gctx, http.StatusOK, &response, schemaapi.NotificationBatchViewActionKind); err != nil {
+		apgin.WriteErr(gctx, nil, err)
+	}
 }
 
 // @Summary		Mark notification viewed
 // @Description	Mark a notification viewed for the authenticated actor
 // @Tags			notifications
+// @Accept		json
 // @Produce		json
 // @Param			id	path	string	true	"Notification ID"
-// @Success		204
+// @Param			request	body	OpenAPINotificationViewActionJson	true	"Notification view action"
+// @Success		200	{object}	OpenAPINotificationViewActionJson
 // @Failure		400	{object}	ErrorResponse
 // @Failure		401	{object}	ErrorResponse
 // @Failure		403	{object}	ErrorResponse
@@ -177,42 +200,70 @@ func (r *NotificationsRoutes) markViewed(gctx *gin.Context) {
 		apgin.WriteError(gctx, nil, httperr.BadRequest("invalid notification id", httperr.WithInternalErr(err)))
 		return
 	}
+	var req schemaapi.NotificationViewAction
+	if err := apgin.BindActionJSON(gctx, &req, schemaapi.NotificationViewActionKind); err != nil {
+		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
+		return
+	}
+	if req.Metadata.Target.ID != id.String() {
+		apgin.WriteError(gctx, nil, httperr.BadRequest("metadata.target.id does not match the notification path"))
+		return
+	}
 
 	if err := r.core.MarkActorNotificationViewed(ctx, ra, id); err != nil {
 		apgin.WriteErr(gctx, nil, err)
 		return
 	}
-	gctx.Status(http.StatusNoContent)
+	response := schemaapi.NewNotificationViewResponse(req.Metadata.Target)
+	if err := apgin.RenderActionJSON(gctx, http.StatusOK, &response, schemaapi.NotificationViewActionKind); err != nil {
+		apgin.WriteErr(gctx, nil, err)
+	}
 }
 
-func notificationToJSON(actorNotification coreIface.ActorNotification) NotificationJson {
+func notificationToJSON(actorNotification coreIface.ActorNotification) (NotificationJson, error) {
 	n := actorNotification.Notification
-	actionURL := ""
+	resourceKind, err := resourceKindForStoredType(n.ResourceType)
+	if err != nil {
+		return NotificationJson{}, fmt.Errorf("build notification resource reference: %w", err)
+	}
+	var action *schemaapi.NotificationActionStatusJson
 	if actorNotification.CanAction && n.ActionUrl != nil {
-		actionURL = *n.ActionUrl
+		action = &schemaapi.NotificationActionStatusJson{URL: *n.ActionUrl}
 	}
-	metadata := map[string]any(n.Metadata)
-	if len(metadata) == 0 {
-		metadata = nil
+	contextData := map[string]any(n.Metadata)
+	if len(contextData) == 0 {
+		contextData = nil
 	}
+	createdAt := n.CreatedAt
+	updatedAt := n.UpdatedAt
 	return NotificationJson{
-		Id:           n.Id,
-		Key:          n.Key,
-		Level:        schemaapi.NotificationLevel(n.Level),
-		State:        schemaapi.NotificationState(n.State),
-		ResourceType: n.ResourceType,
-		ResourceId:   n.ResourceId,
-		Namespace:    n.Namespace,
-		Title:        n.Title,
-		Message:      n.Message,
-		ActionUrl:    actionURL,
-		CanAction:    actorNotification.CanAction,
-		Viewed:       actorNotification.Viewed,
-		Metadata:     metadata,
-		CreatedAt:    n.CreatedAt,
-		UpdatedAt:    n.UpdatedAt,
-		ResolvedAt:   n.ResolvedAt,
-	}
+		TypeMeta: meta.NewTypeMeta(schemaapi.NotificationKind),
+		Metadata: meta.NormalizeObjectMeta(meta.ObjectMeta{
+			ID:        n.Id.String(),
+			Namespace: n.Namespace,
+			Labels:    maps.Clone(map[string]string(n.Labels)),
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		}),
+		Spec: schemaapi.NotificationSpecJson{
+			Key:   n.Key,
+			Level: schemaapi.NotificationLevel(n.Level),
+			ResourceRef: meta.ObjectReference{
+				APIVersion: meta.APIVersionV1Alpha1,
+				Kind:       resourceKind,
+				ID:         n.ResourceId.String(),
+			},
+			Title:   n.Title,
+			Message: n.Message,
+			Context: contextData,
+		},
+		Status: schemaapi.NotificationStatusJson{
+			State:      schemaapi.NotificationState(n.State),
+			Viewed:     actorNotification.Viewed,
+			Action:     action,
+			ResolvedAt: n.ResolvedAt,
+		},
+	}, nil
 }
 
 func (r *NotificationsRoutes) Register(g gin.IRouter) {

--- a/internal/routes/notifications.go
+++ b/internal/routes/notifications.go
@@ -144,7 +144,11 @@ func (r *NotificationsRoutes) markViewedBatch(gctx *gin.Context) {
 	ra := auth.MustGetAuthFromGinContext(gctx)
 
 	var req schemaapi.NotificationBatchViewAction
-	if err := apgin.BindActionJSON(gctx, &req, schemaapi.NotificationBatchViewActionKind); err != nil {
+	if err := apgin.BindActionJSON(
+		gctx,
+		&req,
+		schemaapi.NotificationBatchViewActionKind,
+	); err != nil {
 		apgin.WriteError(gctx, nil, httperr.BadRequestErr(err))
 		return
 	}
@@ -163,7 +167,12 @@ func (r *NotificationsRoutes) markViewedBatch(gctx *gin.Context) {
 		return
 	}
 	response := schemaapi.NewNotificationBatchViewResponse(req.Metadata.Targets)
-	if err := apgin.RenderActionJSON(gctx, http.StatusOK, &response, schemaapi.NotificationBatchViewActionKind); err != nil {
+	if err := apgin.RenderActionJSON(
+		gctx,
+		http.StatusOK,
+		&response,
+		schemaapi.NotificationBatchViewActionKind,
+	); err != nil {
 		apgin.WriteErr(gctx, nil, err)
 	}
 }

--- a/internal/routes/notifications_test.go
+++ b/internal/routes/notifications_test.go
@@ -1,0 +1,275 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	authcore "github.com/rmorlok/authproxy/internal/apauth/core"
+	authservice "github.com/rmorlok/authproxy/internal/apauth/service"
+	"github.com/rmorlok/authproxy/internal/apgin"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/config"
+	coreiface "github.com/rmorlok/authproxy/internal/core/iface"
+	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+)
+
+type notificationsRouteTestCore struct {
+	coreiface.C
+	list      func(context.Context, *authcore.RequestAuth, database.ListNotificationsOptions) ([]coreiface.ActorNotification, error)
+	mark      func(context.Context, *authcore.RequestAuth, apid.ID) error
+	markBatch func(context.Context, *authcore.RequestAuth, []apid.ID) error
+}
+
+func (c notificationsRouteTestCore) ListActorNotifications(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	opts database.ListNotificationsOptions,
+) ([]coreiface.ActorNotification, error) {
+	return c.list(ctx, ra, opts)
+}
+
+func (c notificationsRouteTestCore) MarkActorNotificationViewed(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	id apid.ID,
+) error {
+	return c.mark(ctx, ra, id)
+}
+
+func (c notificationsRouteTestCore) MarkActorNotificationsViewed(
+	ctx context.Context,
+	ra *authcore.RequestAuth,
+	ids []apid.ID,
+) error {
+	return c.markBatch(ctx, ra, ids)
+}
+
+type notificationsRouteSetup struct {
+	router   *gin.Engine
+	authUtil *authservice.AuthTestUtil
+}
+
+func setupNotificationsRoute(t *testing.T, core coreiface.C) notificationsRouteSetup {
+	t.Helper()
+	cfg, db := database.MustApplyBlankTestDbConfig(t, config.FromRoot(&sconfig.Root{}))
+	_, auth, authUtil := authservice.TestAuthServiceWithDb(sconfig.ServiceIdAdminApi, cfg, db)
+	router := apgin.ForTest(nil)
+	NewNotificationsRoutes(auth, core).Register(router)
+	return notificationsRouteSetup{router: router, authUtil: authUtil}
+}
+
+func signedNotificationRequest(
+	t *testing.T,
+	setup notificationsRouteSetup,
+	method, url string,
+	body any,
+) *http.Request {
+	t.Helper()
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		data, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(data)
+	}
+	req, err := setup.authUtil.NewSignedRequestForActorExternalId(
+		method,
+		url,
+		reader,
+		"root",
+		"notification-caller",
+		aschema.AllPermissions(),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestNotificationToJSONBuildsActorProjection(t *testing.T) {
+	now := time.Now().UTC()
+	actionURL := "/connections/cxn_test0000000000001?action=reauth"
+	item, err := notificationToJSON(coreiface.ActorNotification{
+		Notification: database.Notification{
+			Id:           apid.New(apid.PrefixNotification),
+			Key:          "connection:reauth",
+			Level:        database.NotificationLevelWarning,
+			State:        database.NotificationStateActive,
+			ResourceType: string(database.SearchResourceTypeConnection),
+			ResourceId:   apid.MustParse("cxn_test0000000000001"),
+			Namespace:    "root.acme",
+			Labels:       database.Labels{"team": "payments"},
+			Title:        "Reauthenticate",
+			Message:      "Credentials must be refreshed.",
+			ActionUrl:    &actionURL,
+			Metadata:     database.NotificationMetadata{"targetVersion": 2},
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		},
+		Viewed:    true,
+		CanAction: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, meta.NewTypeMeta(schemaapi.NotificationKind), item.TypeMeta)
+	require.Equal(t, "root.acme", item.Metadata.Namespace)
+	require.Equal(t, map[string]string{"team": "payments"}, item.Metadata.Labels)
+	require.Equal(t, connectionschema.ConnectionKind, item.Spec.ResourceRef.Kind)
+	require.Equal(t, "cxn_test0000000000001", item.Spec.ResourceRef.ID)
+	require.Equal(t, map[string]any{"targetVersion": 2}, item.Spec.Context)
+	require.True(t, item.Status.Viewed)
+	require.Equal(t, actionURL, item.Status.Action.URL)
+}
+
+func TestNotificationToJSONOmitsUnauthorizedAction(t *testing.T) {
+	actionURL := "/connections/cxn_test0000000000001?action=reauth"
+	item, err := notificationToJSON(coreiface.ActorNotification{
+		Notification: database.Notification{
+			Id:           apid.New(apid.PrefixNotification),
+			ResourceType: string(database.SearchResourceTypeConnection),
+			ResourceId:   apid.MustParse("cxn_test0000000000001"),
+			ActionUrl:    &actionURL,
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, item.Status.Action)
+}
+
+func TestNotificationToJSONRejectsUnsupportedResourceType(t *testing.T) {
+	_, err := notificationToJSON(coreiface.ActorNotification{Notification: database.Notification{
+		ResourceType: "request_event",
+	}})
+	require.ErrorContains(t, err, "unsupported resource type")
+}
+
+func TestNotificationsRouteReturnsResourceList(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	notificationID := apid.New(apid.PrefixNotification)
+	core := notificationsRouteTestCore{
+		list: func(_ context.Context, _ *authcore.RequestAuth, opts database.ListNotificationsOptions) ([]coreiface.ActorNotification, error) {
+			require.Equal(t, uint64(100), opts.Limit)
+			return []coreiface.ActorNotification{{Notification: database.Notification{
+				Id:           notificationID,
+				Key:          "connection:reauth",
+				Level:        database.NotificationLevelWarning,
+				State:        database.NotificationStateActive,
+				ResourceType: string(database.SearchResourceTypeConnection),
+				ResourceId:   apid.MustParse("cxn_test0000000000001"),
+				Namespace:    "root.acme",
+				Title:        "Reauthenticate",
+				Message:      "Credentials must be refreshed.",
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}}}, nil
+		},
+	}
+	setup := setupNotificationsRoute(t, core)
+	w := httptest.NewRecorder()
+	setup.router.ServeHTTP(w, signedNotificationRequest(t, setup, http.MethodGet, "/notifications", nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var response schemaapi.ListNotificationsResponseJson
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, meta.NewTypeMeta("NotificationList"), response.TypeMeta)
+	require.Len(t, response.Items, 1)
+	require.Equal(t, notificationID.String(), response.Items[0].Metadata.ID)
+	require.Equal(t, connectionschema.ConnectionKind, response.Items[0].Spec.ResourceRef.Kind)
+}
+
+func TestNotificationsRouteViewActions(t *testing.T) {
+	first := apid.New(apid.PrefixNotification)
+	second := apid.New(apid.PrefixNotification)
+	var marked apid.ID
+	var markedBatch []apid.ID
+	core := notificationsRouteTestCore{
+		mark: func(_ context.Context, _ *authcore.RequestAuth, id apid.ID) error {
+			marked = id
+			return nil
+		},
+		markBatch: func(_ context.Context, _ *authcore.RequestAuth, ids []apid.ID) error {
+			markedBatch = append([]apid.ID(nil), ids...)
+			return nil
+		},
+	}
+	setup := setupNotificationsRoute(t, core)
+
+	t.Run("single", func(t *testing.T) {
+		request := schemaapi.NewNotificationViewRequest(schemaapi.NewNotificationReference(first))
+		w := httptest.NewRecorder()
+		setup.router.ServeHTTP(w, signedNotificationRequest(
+			t,
+			setup,
+			http.MethodPost,
+			"/notifications/"+first.String()+"/_viewed",
+			request,
+		))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Equal(t, first, marked)
+		var response schemaapi.NotificationViewAction
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.NoError(t, response.ValidateResponse(schemaapi.NotificationViewActionKind))
+	})
+
+	t.Run("target must match path", func(t *testing.T) {
+		marked = apid.Nil
+		request := schemaapi.NewNotificationViewRequest(schemaapi.NewNotificationReference(second))
+		w := httptest.NewRecorder()
+		setup.router.ServeHTTP(w, signedNotificationRequest(
+			t,
+			setup,
+			http.MethodPost,
+			"/notifications/"+first.String()+"/_viewed",
+			request,
+		))
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		require.Equal(t, apid.Nil, marked)
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		targets := []meta.ObjectReference{
+			schemaapi.NewNotificationReference(first),
+			schemaapi.NewNotificationReference(second),
+		}
+		request := schemaapi.NotificationBatchViewAction{
+			TypeMeta: meta.NewTypeMeta(schemaapi.NotificationBatchViewActionKind),
+			Metadata: &schemaapi.NotificationBatchViewMetadata{Targets: targets},
+			Spec:     &schemaapi.NotificationBatchViewSpec{},
+		}
+		w := httptest.NewRecorder()
+		setup.router.ServeHTTP(w, signedNotificationRequest(
+			t,
+			setup,
+			http.MethodPost,
+			"/notifications/_viewed",
+			request,
+		))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Equal(t, []apid.ID{first, second}, markedBatch)
+		var response schemaapi.NotificationBatchViewAction
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.NoError(t, response.ValidateResponse(schemaapi.NotificationBatchViewActionKind))
+	})
+
+	t.Run("legacy ids body is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		setup.router.ServeHTTP(w, signedNotificationRequest(
+			t,
+			setup,
+			http.MethodPost,
+			"/notifications/_viewed",
+			map[string]any{"ids": []string{first.String()}},
+		))
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	})
+}

--- a/internal/routes/resource_references.go
+++ b/internal/routes/resource_references.go
@@ -1,0 +1,65 @@
+package routes
+
+import (
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	namespaceschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	ratelimitschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+)
+
+var searchResourceTypeByKind = map[meta.Kind]database.SearchResourceType{
+	actorschema.ActorKind:           database.SearchResourceTypeActor,
+	connectionschema.ConnectionKind: database.SearchResourceTypeConnection,
+	connectorschema.ConnectorKind:   database.SearchResourceTypeConnector,
+	namespaceschema.NamespaceKind:   database.SearchResourceTypeNamespace,
+	keyschema.KeyKind:               database.SearchResourceTypeKey,
+	ratelimitschema.RateLimitKind:   database.SearchResourceTypeRateLimit,
+}
+
+var searchResourceKindByType = func() map[database.SearchResourceType]meta.Kind {
+	result := make(map[database.SearchResourceType]meta.Kind, len(searchResourceTypeByKind))
+	for kind, resourceType := range searchResourceTypeByKind {
+		result[resourceType] = kind
+	}
+	return result
+}()
+
+func resourceKindForStoredType(resourceType string) (meta.Kind, error) {
+	kind, ok := searchResourceKindByType[database.SearchResourceType(resourceType)]
+	if !ok {
+		return "", fmt.Errorf("unsupported resource type %q", resourceType)
+	}
+	return kind, nil
+}
+
+func searchResourceReference(resource database.SearchResource) (meta.ObjectReference, error) {
+	kind, err := resourceKindForStoredType(string(resource.ResourceType))
+	if err != nil {
+		return meta.ObjectReference{}, err
+	}
+
+	metadata := meta.ObjectMeta{
+		ID:        resource.ResourceID,
+		Name:      common.ResourceName(resource.Name),
+		Namespace: resource.Namespace,
+	}
+	if kind == namespaceschema.NamespaceKind {
+		if err := namespaceschema.ValidatePath(resource.ResourceID); err != nil {
+			return meta.ObjectReference{}, fmt.Errorf("build namespace reference: %w", err)
+		}
+		// Namespace names permit values that the shared ResourceName primitive
+		// does not. Its immutable path is already the complete identity, so keep
+		// the heterogeneous reference ID-only instead of emitting an invalid or
+		// duplicated display identity.
+		metadata = meta.ObjectMeta{ID: resource.ResourceID}
+	}
+
+	return meta.NewObjectReference(meta.NewTypeMeta(kind), metadata), nil
+}

--- a/internal/routes/resource_references.go
+++ b/internal/routes/resource_references.go
@@ -39,7 +39,9 @@ func resourceKindForStoredType(resourceType string) (meta.Kind, error) {
 	return kind, nil
 }
 
-func searchResourceReference(resource database.SearchResource) (meta.ObjectReference, error) {
+func searchResourceReference(
+	resource database.SearchResource,
+) (meta.ObjectReference, error) {
 	kind, err := resourceKindForStoredType(string(resource.ResourceType))
 	if err != nil {
 		return meta.ObjectReference{}, err
@@ -50,6 +52,7 @@ func searchResourceReference(resource database.SearchResource) (meta.ObjectRefer
 		Name:      common.ResourceName(resource.Name),
 		Namespace: resource.Namespace,
 	}
+	
 	if kind == namespaceschema.NamespaceKind {
 		if err := namespaceschema.ValidatePath(resource.ResourceID); err != nil {
 			return meta.ObjectReference{}, fmt.Errorf("build namespace reference: %w", err)

--- a/internal/routes/resource_references_test.go
+++ b/internal/routes/resource_references_test.go
@@ -1,0 +1,65 @@
+package routes
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	keyschema "github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	namespaceschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	ratelimitschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchResourceReferenceSupportsEverySearchKind(t *testing.T) {
+	tests := []struct {
+		resourceType database.SearchResourceType
+		kind         meta.Kind
+		id           string
+	}{
+		{database.SearchResourceTypeActor, actorschema.ActorKind, "act_test0000000000001"},
+		{database.SearchResourceTypeConnection, connectionschema.ConnectionKind, "cxn_test0000000000001"},
+		{database.SearchResourceTypeConnector, connectorschema.ConnectorKind, "cxr_test0000000000001"},
+		{database.SearchResourceTypeKey, keyschema.KeyKind, "key_test0000000000001"},
+		{database.SearchResourceTypeRateLimit, ratelimitschema.RateLimitKind, "rl_test00000000000001"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			ref, err := searchResourceReference(database.SearchResource{
+				ResourceType: tt.resourceType,
+				ResourceID:   tt.id,
+				Name:         "example",
+				Namespace:    "root.acme",
+			})
+			require.NoError(t, err)
+			require.Equal(t, meta.APIVersionV1Alpha1, ref.APIVersion)
+			require.Equal(t, tt.kind, ref.Kind)
+			require.Equal(t, tt.id, ref.ID)
+			require.Equal(t, common.ResourceName("example"), ref.Name)
+			require.Equal(t, "root.acme", ref.Namespace)
+		})
+	}
+}
+
+func TestSearchResourceReferenceUsesNamespacePathIdentity(t *testing.T) {
+	ref, err := searchResourceReference(database.SearchResource{
+		ResourceType: database.SearchResourceTypeNamespace,
+		ResourceID:   "root.acme.team",
+		Name:         "team",
+		Namespace:    "root.acme.team",
+	})
+	require.NoError(t, err)
+	require.Equal(t, namespaceschema.NamespaceKind, ref.Kind)
+	require.Equal(t, "root.acme.team", ref.ID)
+	require.Empty(t, ref.Name)
+	require.Empty(t, ref.Namespace)
+}
+
+func TestSearchResourceReferenceRejectsUnknownType(t *testing.T) {
+	_, err := searchResourceReference(database.SearchResource{ResourceType: "request_event"})
+	require.ErrorContains(t, err, "unsupported resource type")
+}

--- a/internal/routes/resource_search.go
+++ b/internal/routes/resource_search.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/httperr"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 )
 
@@ -40,7 +41,7 @@ type ResourceSearchRoutes struct {
 
 type SearchResourcesRequestQuery struct {
 	Mode          string   `form:"mode"`
-	ResourceTypes []string `form:"resourceType"`
+	Kinds         []string `form:"kind"`
 	Query         string   `form:"q"`
 	LabelSelector string   `form:"labelSelector"`
 	Namespace     string   `form:"namespace"`
@@ -69,7 +70,7 @@ var searchPermissionResources = map[database.SearchResourceType]string{
 // @Tags         search
 // @Produce      json
 // @Param        mode            query string false "Search mode: query or seed"
-// @Param        resourceType   query []string false "Resource types; may be repeated" collectionFormat(multi)
+// @Param        kind           query []string false "Resource kinds; may be repeated" collectionFormat(multi)
 // @Param        q               query string false "Case-insensitive literal resource-name or label-value substring (minimum 3 characters)"
 // @Param        labelSelector  query string false "Exact Kubernetes-style label selector"
 // @Param        namespace       query string false "Namespace matcher"
@@ -88,6 +89,10 @@ func (r *ResourceSearchRoutes) search(gctx *gin.Context) {
 	var req SearchResourcesRequestQuery
 	if err := gctx.ShouldBindQuery(&req); err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
+		return
+	}
+	if _, legacyResourceTypePresent := gctx.GetQuery("resourceType"); legacyResourceTypePresent {
+		apgin.WriteError(gctx, r.logger, httperr.BadRequest("resourceType is no longer supported; use kind"))
 		return
 	}
 
@@ -131,7 +136,7 @@ func (r *ResourceSearchRoutes) search(gctx *gin.Context) {
 		}
 	}
 
-	resourceTypes, explicitTypes, err := parseSearchResourceTypes(req.ResourceTypes)
+	resourceTypes, explicitTypes, err := parseSearchResourceKinds(req.Kinds)
 	if err != nil {
 		apgin.WriteError(gctx, r.logger, httperr.BadRequest(err.Error(), httperr.WithInternalErr(err)))
 		return
@@ -276,12 +281,13 @@ collectionComplete:
 		resources = resources[:limit]
 	}
 
-	response := schemaapi.SearchResourcesResponseJson{
-		Items:           make([]schemaapi.SearchResourceSummaryJson, 0, len(resources)),
-		TruncatedTypes:  schemaSearchTypes(truncated),
-		IncompleteTypes: schemaSearchTypes(incomplete),
-	}
+	items := make([]schemaapi.SearchResourceSummaryJson, 0, len(resources))
 	for _, resource := range resources {
+		resourceRef, err := searchResourceReference(resource)
+		if err != nil {
+			apgin.WriteError(gctx, r.logger, httperr.InternalServerError(httperr.WithInternalErr(err)))
+			return
+		}
 		labels := map[string]string{}
 		for key, value := range resource.Labels {
 			labels[key] = value
@@ -290,38 +296,41 @@ collectionComplete:
 		for _, match := range resource.MatchedLabels {
 			matches = append(matches, schemaapi.SearchLabelMatchJson{Key: match.Key, Value: match.Value})
 		}
-		response.Items = append(response.Items, schemaapi.SearchResourceSummaryJson{
-			ResourceType:  schemaapi.SearchResourceType(resource.ResourceType),
-			ResourceId:    resource.ResourceID,
-			Name:          resource.Name,
-			Namespace:     resource.Namespace,
+		items = append(items, schemaapi.SearchResourceSummaryJson{
+			ResourceRef:   resourceRef,
 			Labels:        labels,
 			MatchedLabels: matches,
 			UpdatedAt:     resource.UpdatedAt,
 		})
 	}
+	response := schemaapi.NewSearchResourcesResponseJson(
+		items,
+		schemaSearchKinds(truncated),
+		schemaSearchKinds(incomplete),
+	)
 
 	r.logger.Info("admin resource search completed",
 		"mode", mode,
-		"resource_type_count", len(resourceTypes),
+		"resource_kind_count", len(resourceTypes),
 		"result_count", len(response.Items),
-		"truncated_type_count", len(response.TruncatedTypes),
-		"incomplete_type_count", len(response.IncompleteTypes),
+		"truncated_kind_count", len(response.Metadata.TruncatedKinds),
+		"incomplete_kind_count", len(response.Metadata.IncompleteKinds),
 		"duration", time.Since(startedAt),
 	)
 	apgin.APIJSON(gctx, http.StatusOK, response)
 }
 
-func parseSearchResourceTypes(rawTypes []string) ([]database.SearchResourceType, bool, error) {
-	if len(rawTypes) == 0 {
+func parseSearchResourceKinds(rawKinds []string) ([]database.SearchResourceType, bool, error) {
+	if len(rawKinds) == 0 {
 		return database.SearchResourceTypes(), false, nil
 	}
-	seen := make(map[database.SearchResourceType]struct{}, len(rawTypes))
-	result := make([]database.SearchResourceType, 0, len(rawTypes))
-	for _, rawType := range rawTypes {
-		resourceType := database.SearchResourceType(strings.TrimSpace(rawType))
-		if !database.IsValidSearchResourceType(resourceType) {
-			return nil, true, httperr.BadRequestf("invalid resource_type %q", rawType)
+	seen := make(map[database.SearchResourceType]struct{}, len(rawKinds))
+	result := make([]database.SearchResourceType, 0, len(rawKinds))
+	for _, rawKind := range rawKinds {
+		kind := meta.Kind(strings.TrimSpace(rawKind))
+		resourceType, ok := searchResourceTypeByKind[kind]
+		if !ok {
+			return nil, true, httperr.BadRequestf("invalid kind %q", rawKind)
 		}
 		if _, ok := seen[resourceType]; ok {
 			continue
@@ -363,10 +372,10 @@ func intersectNamespaceMatchers(left, right []string) []string {
 	return result
 }
 
-func schemaSearchTypes(values map[database.SearchResourceType]struct{}) []schemaapi.SearchResourceType {
-	result := make([]schemaapi.SearchResourceType, 0, len(values))
+func schemaSearchKinds(values map[database.SearchResourceType]struct{}) []meta.Kind {
+	result := make([]meta.Kind, 0, len(values))
 	for resourceType := range values {
-		result = append(result, schemaapi.SearchResourceType(resourceType))
+		result = append(result, searchResourceKindByType[resourceType])
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
 	return result

--- a/internal/routes/resource_search_test.go
+++ b/internal/routes/resource_search_test.go
@@ -23,6 +23,11 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	scommon "github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	namespaceschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/test_utils"
 	"github.com/stretchr/testify/require"
 )
@@ -97,7 +102,7 @@ func TestResourceSearchRouteQueryAndPermissions(t *testing.T) {
 
 	t.Run("requires authentication", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/search/resources?q=payments&resourceType=actor", nil)
+		req, err := http.NewRequest(http.MethodGet, "/search/resources?q=payments&kind=Actor", nil)
 		require.NoError(t, err)
 		setup.gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusUnauthorized, w.Code)
@@ -111,15 +116,20 @@ func TestResourceSearchRouteQueryAndPermissions(t *testing.T) {
 			ResourceIds: []string{allowed.Id.String()},
 			Verbs:       []string{"list", "get"},
 		}}
-		req := signedSearchRequest(t, setup, "/search/resources?q=payments&resourceType=actor&namespace=root.team.**", permissions)
+		req := signedSearchRequest(t, setup, "/search/resources?q=payments&kind=Actor&namespace=root.team.**", permissions)
 		setup.gin.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
 		var response schemaapi.SearchResourcesResponseJson
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 		require.Len(t, response.Items, 1)
-		require.Equal(t, allowed.Id.String(), response.Items[0].ResourceId)
-		require.Equal(t, "payments-service", response.Items[0].Name)
+		require.Equal(t, meta.NewTypeMeta(actorschema.ActorKind), meta.TypeMeta{
+			APIVersion: response.Items[0].ResourceRef.APIVersion,
+			Kind:       response.Items[0].ResourceRef.Kind,
+		})
+		require.Equal(t, allowed.Id.String(), response.Items[0].ResourceRef.ID)
+		require.Equal(t, scommon.ResourceName("payments-service"), response.Items[0].ResourceRef.Name)
+		require.Equal(t, "root.team", response.Items[0].ResourceRef.Namespace)
 		require.Equal(t, map[string]string{"env": "prod"}, response.Items[0].Labels)
 	})
 }
@@ -200,29 +210,31 @@ func TestResourceNamesEndToEndAcrossVersionsAndAuthorization(t *testing.T) {
 	setup.gin.ServeHTTP(w, signedSearchRequest(
 		t,
 		setup,
-		"/search/resources?q=billing-provider&resourceType=connector&namespace=root.**",
+		"/search/resources?q=billing-provider&kind=Connector&namespace=root.**",
 		permissions,
 	))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var response schemaapi.SearchResourcesResponseJson
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Len(t, response.Items, 1, "the hidden duplicate and extra connector version must not leak")
-	require.Equal(t, allowedConnectorID.String(), response.Items[0].ResourceId)
-	require.Equal(t, "billing-provider", response.Items[0].Name)
-	require.Equal(t, "root.allowed", response.Items[0].Namespace)
+	require.Equal(t, connectorschema.ConnectorKind, response.Items[0].ResourceRef.Kind)
+	require.Equal(t, allowedConnectorID.String(), response.Items[0].ResourceRef.ID)
+	require.Equal(t, scommon.ResourceName("billing-provider"), response.Items[0].ResourceRef.Name)
+	require.Equal(t, "root.allowed", response.Items[0].ResourceRef.Namespace)
 
 	w = httptest.NewRecorder()
 	setup.gin.ServeHTTP(w, signedSearchRequest(
 		t,
 		setup,
-		"/search/resources?q=billing-live&resourceType=connection&namespace=root.**",
+		"/search/resources?q=billing-live&kind=Connection&namespace=root.**",
 		permissions,
 	))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Len(t, response.Items, 1)
-	require.Equal(t, connectionID.String(), response.Items[0].ResourceId)
-	require.Equal(t, "billing-live", response.Items[0].Name)
+	require.Equal(t, connectionschema.ConnectionKind, response.Items[0].ResourceRef.Kind)
+	require.Equal(t, connectionID.String(), response.Items[0].ResourceRef.ID)
+	require.Equal(t, scommon.ResourceName("billing-live"), response.Items[0].ResourceRef.Name)
 }
 
 func TestResourceSearchRouteValidation(t *testing.T) {
@@ -233,7 +245,8 @@ func TestResourceSearchRouteValidation(t *testing.T) {
 		"/search/resources?q=ab",
 		"/search/resources?mode=invalid&q=valid",
 		"/search/resources?mode=seed&q=invalid",
-		"/search/resources?q=valid&resourceType=unknown",
+		"/search/resources?q=valid&resourceType=actor",
+		"/search/resources?q=valid&kind=Unknown",
 		"/search/resources?labelSelector=" + url.QueryEscape("bad key=value"),
 		"/search/resources?labelSelector=" + url.QueryEscape(","),
 		"/search/resources?labelSelector=" + url.QueryEscape("env=prod,"),
@@ -279,7 +292,7 @@ func TestResourceSearchRouteSeedCoversRemainingTypes(t *testing.T) {
 	setup.gin.ServeHTTP(w, signedSearchRequest(
 		t,
 		setup,
-		"/search/resources?mode=seed&resourceType=namespace&resourceType=key&resourceType=rate_limit&limit=50",
+		"/search/resources?mode=seed&kind=Namespace&kind=Key&kind=RateLimit&limit=50",
 		aschema.AllPermissions(),
 	))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
@@ -288,10 +301,15 @@ func TestResourceSearchRouteSeedCoversRemainingTypes(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Len(t, response.Items, 3)
 	for _, item := range response.Items {
-		require.Equal(t, "seed", item.Name)
+		if item.ResourceRef.Kind == namespaceschema.NamespaceKind {
+			require.Equal(t, "root.seed", item.ResourceRef.ID)
+			require.Empty(t, item.ResourceRef.Name)
+		} else {
+			require.Equal(t, scommon.ResourceName("seed"), item.ResourceRef.Name)
+		}
 	}
-	require.Empty(t, response.TruncatedTypes)
-	require.Empty(t, response.IncompleteTypes)
+	require.Empty(t, response.Metadata.TruncatedKinds)
+	require.Empty(t, response.Metadata.IncompleteKinds)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -319,11 +337,11 @@ func TestResourceSearchRouteReturnsIncompleteTypes(t *testing.T) {
 		}
 	})
 	w := httptest.NewRecorder()
-	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&resourceType=actor", aschema.AllPermissions()))
+	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&kind=Actor", aschema.AllPermissions()))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var response schemaapi.SearchResourcesResponseJson
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	require.Equal(t, []schemaapi.SearchResourceType{schemaapi.SearchResourceTypeActor}, response.IncompleteTypes)
+	require.Equal(t, []meta.Kind{actorschema.ActorKind}, response.Metadata.IncompleteKinds)
 	require.Empty(t, response.Items)
 }
 
@@ -345,13 +363,13 @@ func TestResourceSearchRouteOverallDeadlineDoesNotWaitForIgnoredCancellation(t *
 	setup.routes.overallTimeout = 20 * time.Millisecond
 
 	w := httptest.NewRecorder()
-	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&resourceType=actor", aschema.AllPermissions()))
+	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&kind=Actor", aschema.AllPermissions()))
 	close(release)
 
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	var response schemaapi.SearchResourcesResponseJson
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	require.Equal(t, []schemaapi.SearchResourceType{schemaapi.SearchResourceTypeActor}, response.IncompleteTypes)
+	require.Equal(t, []meta.Kind{actorschema.ActorKind}, response.Metadata.IncompleteKinds)
 }
 
 func TestResourceSearchRouteUnexpectedDatabaseFailure(t *testing.T) {
@@ -364,6 +382,6 @@ func TestResourceSearchRouteUnexpectedDatabaseFailure(t *testing.T) {
 		}
 	})
 	w := httptest.NewRecorder()
-	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&resourceType=actor", aschema.AllPermissions()))
+	setup.gin.ServeHTTP(w, signedSearchRequest(t, setup, "/search/resources?q=payments&kind=Actor", aschema.AllPermissions()))
 	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
 }

--- a/internal/schema/api/README.md
+++ b/internal/schema/api/README.md
@@ -1,12 +1,20 @@
 # API Schema
 
-This package contains endpoint-specific API request and response DTOs plus shared API transports. These types describe wire contracts at AuthProxy route boundaries that are not already canonical resource contracts.
+This package contains endpoint-specific API request and response DTOs plus 
+shared API transports. These types describe wire contracts at AuthProxy route 
+boundaries that are not already canonical resource contracts.
 
-Canonical resources and their resource-specific patches live in `internal/schema/resources/...`; routes use those types directly when the entire body is the resource or patch. Do not add aliases here merely to rename a resource for a particular endpoint. API models may compose shared primitives from `internal/schema/common` and resource models from `internal/schema/resources/...`. Resource packages must not import this package.
+Canonical resources and their resource-specific patches live in 
+`internal/schema/resources/...`; routes use those types directly when the entire
+body is the resource or patch. Do not add aliases here merely to rename a 
+resource for a particular endpoint. API models may compose shared primitives 
+from `internal/schema/common` and resource models from 
+`internal/schema/resources/...`. Resource packages must not import this package.
 
-Rate-limit resources and patches live in `internal/schema/resources/rate_limit`; this package owns only the rate-limit list transport and dry-run DTOs. Encryption-key API DTOs live here too; key material syntax composes `internal/schema/resources/key.KeyData`, and the API exposes its own state enum rather than database storage types.
-
-Auxiliary route DTOs also belong here: session initiation, request-events list envelopes, task status and monitoring responses, and shared label/annotation key-value bodies. Keep route packages focused on binding, validation, authorization, and conversion to/from service-layer types.
+Auxiliary route DTOs also belong here: session initiation, request-events list
+envelopes, task status and monitoring responses, and shared label/annotation 
+key-value bodies. Keep route packages focused on binding, validation, 
+authorization, and conversion to/from service-layer types.
 
 Notifications and search make their non-resource semantics explicit here.
 `NotificationJson` is a read-only, resource-shaped projection of a durable
@@ -17,6 +25,12 @@ resource. Search items are heterogeneous summaries, not partial resources.
 truncation/incompleteness observations in projection metadata. Notification
 view mutations use typed action contracts.
 
-OpenAPI-only generator adapters live under `internal/schema/api/openapi`. Keep those adapters thin: they may compose API DTOs and canonical resources for documentation, but no runtime contract or behavior may depend on them.
+OpenAPI-only generator adapters live under `internal/schema/api/openapi`. Keep
+those adapters thin: they may compose API DTOs and canonical resources for 
+documentation, but no runtime contract or behavior may depend on them.
 
-Route handlers should import endpoint-specific DTOs from this package and canonical resources from their resource package, or convert those contracts to runtime/core/database models. Do not add new endpoint-specific `*RequestJson` or `*ResponseJson` structs under `internal/routes`; preflight rejects that so contract ownership stays clear.
+Route handlers should import endpoint-specific DTOs from this package and 
+canonical resources from their resource package, or convert those contracts to 
+runtime/core/database models. Do not add new endpoint-specific `*RequestJson` 
+or `*ResponseJson` structs under `internal/routes`; preflight rejects that so 
+contract ownership stays clear.

--- a/internal/schema/api/README.md
+++ b/internal/schema/api/README.md
@@ -8,6 +8,15 @@ Rate-limit resources and patches live in `internal/schema/resources/rate_limit`;
 
 Auxiliary route DTOs also belong here: session initiation, request-events list envelopes, task status and monitoring responses, and shared label/annotation key-value bodies. Keep route packages focused on binding, validation, authorization, and conversion to/from service-layer types.
 
+Notifications and search make their non-resource semantics explicit here.
+`NotificationJson` is a read-only, resource-shaped projection of a durable
+notification row because its `status.viewed` and `status.action` values are
+calculated for the authenticated actor; it is not a client-managed desired
+resource. Search items are heterogeneous summaries, not partial resources.
+`SearchResultList` therefore carries typed `resourceRef` values and puts
+truncation/incompleteness observations in projection metadata. Notification
+view mutations use typed action contracts.
+
 OpenAPI-only generator adapters live under `internal/schema/api/openapi`. Keep those adapters thin: they may compose API DTOs and canonical resources for documentation, but no runtime contract or behavior may depend on them.
 
 Route handlers should import endpoint-specific DTOs from this package and canonical resources from their resource package, or convert those contracts to runtime/core/database models. Do not add new endpoint-specific `*RequestJson` or `*ResponseJson` structs under `internal/routes`; preflight rejects that so contract ownership stays clear.

--- a/internal/schema/api/list_test.go
+++ b/internal/schema/api/list_test.go
@@ -21,6 +21,7 @@ func TestManagedListConstructorsUseV1Alpha1Envelope(t *testing.T) {
 		{name: "connections", expectedKind: "ConnectionList", value: NewListConnectionResponseJson(nil, "next")},
 		{name: "keys", expectedKind: "KeyList", value: NewListKeysResponseJson(nil, "next")},
 		{name: "rate limits", expectedKind: "RateLimitList", value: NewListRateLimitsResponseJson(nil, "next")},
+		{name: "notifications", expectedKind: "NotificationList", value: NewListNotificationsResponseJson(nil, "next")},
 	}
 
 	for _, tt := range tests {

--- a/internal/schema/api/notifications.go
+++ b/internal/schema/api/notifications.go
@@ -1,10 +1,20 @@
 package api
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rmorlok/authproxy/internal/apid"
-	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+)
+
+const (
+	NotificationKind                meta.Kind = "Notification"
+	NotificationViewActionKind      meta.Kind = "NotificationView"
+	NotificationBatchViewActionKind meta.Kind = "NotificationBatchView"
 )
 
 type NotificationLevel string
@@ -22,49 +32,221 @@ const (
 	NotificationStateResolved NotificationState = "resolved"
 )
 
-// NotificationJson is the actor-specific API projection of a notification.
+// NotificationJson is an actor-specific, read-only projection of a durable
+// notification. The underlying notification is shared, while Status.Viewed
+// and Status.Action are calculated for the authenticated actor.
 //
-//	@Description	Actor-visible notification
+//	@Description	Actor-visible, resource-shaped notification projection
 type NotificationJson struct {
-	Id           apid.ID           `json:"id" yaml:"id" swaggertype:"string" example:"ntf_test550e8400abcde"`
-	Key          string            `json:"key" yaml:"key"`
-	Level        NotificationLevel `json:"level" yaml:"level" swaggertype:"string" example:"warning"`
-	State        NotificationState `json:"state" yaml:"state" swaggertype:"string" example:"active"`
-	ResourceType string            `json:"resourceType" yaml:"resourceType" example:"connection"`
-	ResourceId   apid.ID           `json:"resourceId" yaml:"resourceId" swaggertype:"string" example:"cxn_test550e8400abcde"`
-	Namespace    string            `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Title        string            `json:"title" yaml:"title"`
-	Message      string            `json:"message" yaml:"message"`
-	ActionUrl    string            `json:"actionUrl,omitempty" yaml:"actionUrl,omitempty"`
-	CanAction    bool              `json:"canAction" yaml:"canAction"`
-	Viewed       bool              `json:"viewed" yaml:"viewed"`
-	Metadata     map[string]any    `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	CreatedAt    time.Time         `json:"createdAt" yaml:"createdAt"`
-	UpdatedAt    time.Time         `json:"updatedAt" yaml:"updatedAt"`
-	ResolvedAt   *time.Time        `json:"resolvedAt,omitempty" yaml:"resolvedAt,omitempty"`
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      meta.ObjectMeta        `json:"metadata" yaml:"metadata"`
+	Spec          NotificationSpecJson   `json:"spec" yaml:"spec"`
+	Status        NotificationStatusJson `json:"status" yaml:"status"`
 }
 
+// NotificationSpecJson contains the notification content and the typed
+// reference to the resource whose condition produced it.
+type NotificationSpecJson struct {
+	Key         string               `json:"key" yaml:"key"`
+	Level       NotificationLevel    `json:"level" yaml:"level" swaggertype:"string" example:"warning"`
+	ResourceRef meta.ObjectReference `json:"resourceRef" yaml:"resourceRef"`
+	Title       string               `json:"title" yaml:"title"`
+	Message     string               `json:"message" yaml:"message"`
+	Context     map[string]any       `json:"context,omitempty" yaml:"context,omitempty"`
+}
+
+// NotificationStatusJson combines the shared notification lifecycle with
+// observations specific to the authenticated actor.
+type NotificationStatusJson struct {
+	State      NotificationState             `json:"state" yaml:"state" swaggertype:"string" example:"active"`
+	Viewed     bool                          `json:"viewed" yaml:"viewed"`
+	Action     *NotificationActionStatusJson `json:"action,omitempty" yaml:"action,omitempty"`
+	ResolvedAt *time.Time                    `json:"resolvedAt,omitempty" yaml:"resolvedAt,omitempty"`
+}
+
+// NotificationActionStatusJson is present only when the authenticated actor
+// is authorized to perform the notification's suggested action.
+type NotificationActionStatusJson struct {
+	URL string `json:"url" yaml:"url"`
+}
+
+// ListNotificationsResponseJson is the Kubernetes-style list of actor-visible
+// Notification projections.
 type ListNotificationsResponseJson struct {
-	Items  []NotificationJson `json:"items" yaml:"items"`
-	Cursor string             `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+	apiv1alpha1.ResourceList[NotificationJson] `json:",inline" yaml:",inline"`
 }
 
-type MarkNotificationsViewedRequestJson struct {
-	Ids []apid.ID `json:"ids" yaml:"ids" swaggertype:"array,string" example:"ntf_test550e8400abcde"`
+func NewListNotificationsResponseJson(
+	items []NotificationJson,
+	continueToken string,
+) ListNotificationsResponseJson {
+	return ListNotificationsResponseJson{ResourceList: apiv1alpha1.NewResourceList(
+		NotificationKind,
+		items,
+		apiv1alpha1.ListMeta{Continue: continueToken},
+	)}
 }
 
-// NotificationUpsertJson is an internal service shape used by migration hooks
-// and core code when creating deterministic notifications.
-type NotificationUpsertJson struct {
-	Key               string               `json:"key" yaml:"key"`
-	Level             NotificationLevel    `json:"level" yaml:"level"`
-	ResourceType      string               `json:"resourceType" yaml:"resourceType"`
-	ResourceId        apid.ID              `json:"resourceId" yaml:"resourceId"`
-	Namespace         string               `json:"namespace" yaml:"namespace"`
-	Title             string               `json:"title" yaml:"title"`
-	Message           string               `json:"message" yaml:"message"`
-	ActionUrl         string               `json:"actionUrl,omitempty" yaml:"actionUrl,omitempty"`
-	ViewPermissions   []aschema.Permission `json:"viewPermissions,omitempty" yaml:"viewPermissions,omitempty"`
-	ActionPermissions []aschema.Permission `json:"actionPermissions,omitempty" yaml:"actionPermissions,omitempty"`
-	Metadata          map[string]any       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+type NotificationViewSpec struct{}
+
+type NotificationViewStatus struct {
+	Viewed bool `json:"viewed" yaml:"viewed"`
+}
+
+type NotificationViewAction struct {
+	apiv1alpha1.Action[NotificationViewSpec, NotificationViewStatus] `json:",inline" yaml:",inline"`
+}
+
+func NewNotificationViewRequest(target meta.ObjectReference) NotificationViewAction {
+	return NotificationViewAction{Action: apiv1alpha1.Action[NotificationViewSpec, NotificationViewStatus]{
+		TypeMeta: meta.NewTypeMeta(NotificationViewActionKind),
+		Metadata: apiv1alpha1.ActionMeta{Target: target},
+		Spec:     NotificationViewSpec{},
+	}}
+}
+
+func (a *NotificationViewAction) ValidateRequest(expectedKind meta.Kind) error {
+	if err := a.Action.ValidateRequest(expectedKind); err != nil {
+		return err
+	}
+	return validateNotificationReference(a.Metadata.Target, &common.ValidationContext{Path: "$.metadata.target"})
+}
+
+func (a *NotificationViewAction) ValidateResponse(expectedKind meta.Kind) error {
+	if err := a.Action.ValidateResponse(expectedKind); err != nil {
+		return err
+	}
+	if err := validateNotificationReference(a.Metadata.Target, &common.ValidationContext{Path: "$.metadata.target"}); err != nil {
+		return err
+	}
+	if a.Status == nil {
+		return fmt.Errorf("$.status: is required")
+	}
+	if !a.Status.Viewed {
+		return fmt.Errorf("$.status.viewed: must be true")
+	}
+	return nil
+}
+
+func NewNotificationViewResponse(target meta.ObjectReference) NotificationViewAction {
+	return NotificationViewAction{Action: apiv1alpha1.NewActionResponse(
+		NotificationViewActionKind,
+		target,
+		NotificationViewSpec{},
+		NotificationViewStatus{Viewed: true},
+	)}
+}
+
+// NotificationBatchViewMetadata identifies every Notification projection to
+// mark viewed. Targets are references because the batch has no single action
+// target suitable for the shared action transport.
+type NotificationBatchViewMetadata struct {
+	Targets []meta.ObjectReference `json:"targets" yaml:"targets"`
+}
+
+type NotificationBatchViewSpec struct{}
+
+type NotificationBatchViewStatus struct {
+	ViewedCount int `json:"viewedCount" yaml:"viewedCount"`
+}
+
+type NotificationBatchViewAction struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      *NotificationBatchViewMetadata `json:"metadata" yaml:"metadata"`
+	Spec          *NotificationBatchViewSpec     `json:"spec" yaml:"spec"`
+	Status        *NotificationBatchViewStatus   `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+func (a *NotificationBatchViewAction) ValidateRequest(expectedKind meta.Kind) error {
+	return a.validate(expectedKind, false)
+}
+
+func (a *NotificationBatchViewAction) ValidateResponse(expectedKind meta.Kind) error {
+	return a.validate(expectedKind, true)
+}
+
+func (a *NotificationBatchViewAction) validate(expectedKind meta.Kind, response bool) error {
+	if a == nil {
+		return fmt.Errorf("notification batch view action is required")
+	}
+	vc := &common.ValidationContext{Path: "$"}
+	var result *multierror.Error
+	if err := meta.ValidateTypeMeta(a.TypeMeta, meta.APIVersionV1Alpha1, expectedKind, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if a.Metadata == nil {
+		result = multierror.Append(result, vc.NewErrorForField("metadata", "is required"))
+	} else if len(a.Metadata.Targets) == 0 {
+		result = multierror.Append(result, vc.NewErrorForField("metadata.targets", "must not be empty"))
+	} else {
+		seen := make(map[string]struct{}, len(a.Metadata.Targets))
+		for i, target := range a.Metadata.Targets {
+			if err := validateNotificationReference(target, &common.ValidationContext{Path: fmt.Sprintf("$.metadata.targets[%d]", i)}); err != nil {
+				result = multierror.Append(result, err)
+			}
+			if _, found := seen[target.ID]; found {
+				result = multierror.Append(result, vc.NewErrorfForField("metadata.targets", "contains duplicate id %q", target.ID))
+			}
+			seen[target.ID] = struct{}{}
+		}
+	}
+	if a.Spec == nil {
+		result = multierror.Append(result, vc.NewErrorForField("spec", "is required"))
+	}
+	if response {
+		if a.Status == nil {
+			result = multierror.Append(result, vc.NewErrorForField("status", "is required"))
+		} else if a.Metadata != nil && a.Status.ViewedCount != len(a.Metadata.Targets) {
+			result = multierror.Append(result, vc.NewErrorForField("status.viewedCount", "must match the number of targets"))
+		}
+	} else if a.Status != nil {
+		result = multierror.Append(result, vc.NewErrorForField("status", "is server-owned"))
+	}
+	return result.ErrorOrNil()
+}
+
+func NewNotificationBatchViewResponse(
+	targets []meta.ObjectReference,
+) NotificationBatchViewAction {
+	return NotificationBatchViewAction{
+		TypeMeta: meta.NewTypeMeta(NotificationBatchViewActionKind),
+		Metadata: &NotificationBatchViewMetadata{Targets: targets},
+		Spec:     &NotificationBatchViewSpec{},
+		Status:   &NotificationBatchViewStatus{ViewedCount: len(targets)},
+	}
+}
+
+func NewNotificationReference(id apid.ID) meta.ObjectReference {
+	return meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       NotificationKind,
+		ID:         id.String(),
+	}
+}
+
+func validateNotificationReference(ref meta.ObjectReference, vc *common.ValidationContext) error {
+	var result *multierror.Error
+	if err := meta.ValidateObjectReferenceWithOptions(ref, meta.ObjectReferenceValidationOptions{
+		ExpectedAPIVersion: meta.APIVersionV1Alpha1,
+		ExpectedKind:       NotificationKind,
+		IDValidator: func(value string) error {
+			id, err := apid.Parse(value)
+			if err != nil {
+				return err
+			}
+			return id.ValidatePrefix(apid.PrefixNotification)
+		},
+	}, vc); err != nil {
+		result = multierror.Append(result, err)
+	}
+	if ref.ID == "" {
+		result = multierror.Append(result, vc.NewErrorForField("id", "is required for Notification references"))
+	}
+	if ref.Name != "" || ref.Namespace != "" {
+		result = multierror.Append(result, vc.NewError("Notification references support id only"))
+	}
+	if ref.Generation != 0 {
+		result = multierror.Append(result, vc.NewErrorForField("generation", "does not apply to Notification references"))
+	}
+	return result.ErrorOrNil()
 }

--- a/internal/schema/api/notifications.go
+++ b/internal/schema/api/notifications.go
@@ -80,11 +80,13 @@ func NewListNotificationsResponseJson(
 	items []NotificationJson,
 	continueToken string,
 ) ListNotificationsResponseJson {
-	return ListNotificationsResponseJson{ResourceList: apiv1alpha1.NewResourceList(
-		NotificationKind,
-		items,
-		apiv1alpha1.ListMeta{Continue: continueToken},
-	)}
+	return ListNotificationsResponseJson{
+		ResourceList: apiv1alpha1.NewResourceList(
+			NotificationKind,
+			items,
+			apiv1alpha1.ListMeta{Continue: continueToken},
+		),
+	}
 }
 
 type NotificationViewSpec struct{}
@@ -98,25 +100,37 @@ type NotificationViewAction struct {
 }
 
 func NewNotificationViewRequest(target meta.ObjectReference) NotificationViewAction {
-	return NotificationViewAction{Action: apiv1alpha1.Action[NotificationViewSpec, NotificationViewStatus]{
-		TypeMeta: meta.NewTypeMeta(NotificationViewActionKind),
-		Metadata: apiv1alpha1.ActionMeta{Target: target},
-		Spec:     NotificationViewSpec{},
-	}}
+	return NotificationViewAction{
+		Action: apiv1alpha1.Action[NotificationViewSpec, NotificationViewStatus]{
+			TypeMeta: meta.NewTypeMeta(NotificationViewActionKind),
+			Metadata: apiv1alpha1.ActionMeta{Target: target},
+			Spec:     NotificationViewSpec{},
+		},
+	}
 }
 
 func (a *NotificationViewAction) ValidateRequest(expectedKind meta.Kind) error {
 	if err := a.Action.ValidateRequest(expectedKind); err != nil {
 		return err
 	}
-	return validateNotificationReference(a.Metadata.Target, &common.ValidationContext{Path: "$.metadata.target"})
+	return validateNotificationReference(
+		a.Metadata.Target,
+		&common.ValidationContext{
+			Path: "$.metadata.target",
+		},
+	)
 }
 
 func (a *NotificationViewAction) ValidateResponse(expectedKind meta.Kind) error {
 	if err := a.Action.ValidateResponse(expectedKind); err != nil {
 		return err
 	}
-	if err := validateNotificationReference(a.Metadata.Target, &common.ValidationContext{Path: "$.metadata.target"}); err != nil {
+	if err := validateNotificationReference(
+		a.Metadata.Target,
+		&common.ValidationContext{
+			Path: "$.metadata.target",
+		},
+	); err != nil {
 		return err
 	}
 	if a.Status == nil {
@@ -224,29 +238,35 @@ func NewNotificationReference(id apid.ID) meta.ObjectReference {
 	}
 }
 
-func validateNotificationReference(ref meta.ObjectReference, vc *common.ValidationContext) error {
+func validateNotificationReference(
+	ref meta.ObjectReference,
+	vc *common.ValidationContext,
+) error {
 	var result *multierror.Error
-	if err := meta.ValidateObjectReferenceWithOptions(ref, meta.ObjectReferenceValidationOptions{
-		ExpectedAPIVersion: meta.APIVersionV1Alpha1,
-		ExpectedKind:       NotificationKind,
-		IDValidator: func(value string) error {
-			id, err := apid.Parse(value)
-			if err != nil {
-				return err
-			}
-			return id.ValidatePrefix(apid.PrefixNotification)
+
+	if err := meta.ValidateObjectReferenceWithOptions(
+		ref,
+		meta.ObjectReferenceValidationOptions{
+			ExpectedAPIVersion: meta.APIVersionV1Alpha1,
+			ExpectedKind:       NotificationKind,
+			IDValidator:        meta.IdValidatorForPrefix(apid.PrefixNotification),
 		},
-	}, vc); err != nil {
+		vc,
+	); err != nil {
 		result = multierror.Append(result, err)
 	}
+
 	if ref.ID == "" {
 		result = multierror.Append(result, vc.NewErrorForField("id", "is required for Notification references"))
 	}
+
 	if ref.Name != "" || ref.Namespace != "" {
 		result = multierror.Append(result, vc.NewError("Notification references support id only"))
 	}
+
 	if ref.Generation != 0 {
 		result = multierror.Append(result, vc.NewErrorForField("generation", "does not apply to Notification references"))
 	}
+
 	return result.ErrorOrNil()
 }

--- a/internal/schema/api/notifications_test.go
+++ b/internal/schema/api/notifications_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationListAndViewActions(t *testing.T) {
+	id := apid.New(apid.PrefixNotification)
+	target := NewNotificationReference(id)
+
+	list := NewListNotificationsResponseJson(nil, "next")
+	require.Equal(t, meta.NewTypeMeta("NotificationList"), list.TypeMeta)
+	require.Empty(t, list.Items)
+	require.Equal(t, "next", list.Metadata.Continue)
+
+	request := NewNotificationViewRequest(target)
+	require.NoError(t, request.ValidateRequest(NotificationViewActionKind))
+
+	response := NewNotificationViewResponse(target)
+	require.NoError(t, response.ValidateResponse(NotificationViewActionKind))
+	require.True(t, response.Status.Viewed)
+}
+
+func TestNotificationViewActionRejectsInvalidTarget(t *testing.T) {
+	request := NewNotificationViewRequest(meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       NotificationKind,
+		Namespace:  "root",
+		Name:       "notice",
+	})
+	require.ErrorContains(t, request.ValidateRequest(NotificationViewActionKind), "support id only")
+}
+
+func TestNotificationBatchViewActionValidation(t *testing.T) {
+	first := NewNotificationReference(apid.New(apid.PrefixNotification))
+	second := NewNotificationReference(apid.New(apid.PrefixNotification))
+	request := NotificationBatchViewAction{
+		TypeMeta: meta.NewTypeMeta(NotificationBatchViewActionKind),
+		Metadata: &NotificationBatchViewMetadata{Targets: []meta.ObjectReference{first, second}},
+		Spec:     &NotificationBatchViewSpec{},
+	}
+	require.NoError(t, request.ValidateRequest(NotificationBatchViewActionKind))
+
+	response := NewNotificationBatchViewResponse(request.Metadata.Targets)
+	require.NoError(t, response.ValidateResponse(NotificationBatchViewActionKind))
+
+	request.Metadata.Targets = append(request.Metadata.Targets, first)
+	require.ErrorContains(t, request.ValidateRequest(NotificationBatchViewActionKind), "duplicate id")
+}
+
+func TestNotificationBatchViewActionStrictJSON(t *testing.T) {
+	var action NotificationBatchViewAction
+	err := util.DecodeJSONStrict([]byte(`{
+		"apiVersion":"authproxy.net/v1alpha1",
+		"kind":"NotificationBatchView",
+		"metadata":{"targets":[]},
+		"spec":{}
+	}`), &action)
+	require.NoError(t, err)
+	require.ErrorContains(t, action.ValidateRequest(NotificationBatchViewActionKind), "must not be empty")
+}

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -292,34 +292,73 @@ type ConnectionForceStateActionJson struct {
 	Status     *ConnectionForceStateStatusJson `json:"status,omitempty"`
 }
 
-// NotificationJson documents actor-visible notifications.
+type NotificationSpecJson struct {
+	Key         string                 `json:"key" binding:"required"`
+	Level       string                 `json:"level" binding:"required" enums:"info,warning,error" example:"warning"`
+	ResourceRef meta.ObjectReference   `json:"resourceRef" binding:"required"`
+	Title       string                 `json:"title" binding:"required"`
+	Message     string                 `json:"message" binding:"required"`
+	Context     map[string]interface{} `json:"context,omitempty" swaggertype:"object"`
+}
+
+type NotificationActionStatusJson struct {
+	URL string `json:"url" binding:"required"`
+}
+
+type NotificationStatusJson struct {
+	State      string                        `json:"state" binding:"required" enums:"active,resolved" example:"active"`
+	Viewed     bool                          `json:"viewed"`
+	Action     *NotificationActionStatusJson `json:"action,omitempty"`
+	ResolvedAt *time.Time                    `json:"resolvedAt,omitempty"`
+}
+
+// NotificationJson documents an actor-visible resource-shaped projection.
 //
-//	@Description	Actor-visible notification
+//	@Description	Actor-visible, resource-shaped notification projection
 type NotificationJson struct {
-	Id           apid.ID                `json:"id" swaggertype:"string" example:"ntf_test550e8400abcde"`
-	Key          string                 `json:"key"`
-	Level        string                 `json:"level" example:"warning"`
-	State        string                 `json:"state" example:"active"`
-	ResourceType string                 `json:"resourceType" example:"connection"`
-	ResourceId   apid.ID                `json:"resourceId" swaggertype:"string" example:"cxn_test550e8400abcde"`
-	Namespace    string                 `json:"namespace" example:"root.acme"`
-	Title        string                 `json:"title"`
-	Message      string                 `json:"message"`
-	ActionUrl    string                 `json:"actionUrl,omitempty"`
-	CanAction    bool                   `json:"canAction"`
-	Viewed       bool                   `json:"viewed"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
-	CreatedAt    time.Time              `json:"createdAt"`
-	UpdatedAt    time.Time              `json:"updatedAt"`
-	ResolvedAt   *time.Time             `json:"resolvedAt,omitempty"`
+	APIVersion string                 `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                 `json:"kind" binding:"required" enums:"Notification" example:"Notification"`
+	Metadata   meta.ObjectMeta        `json:"metadata" binding:"required"`
+	Spec       NotificationSpecJson   `json:"spec" binding:"required"`
+	Status     NotificationStatusJson `json:"status" binding:"required"`
 }
 
 // ListNotificationsResponseJson documents the paginated notification list response.
 //
 //	@Description	Paginated list of actor-visible notifications
 type ListNotificationsResponseJson struct {
-	Items  []interface{} `json:"items"`
-	Cursor string        `json:"cursor,omitempty"`
+	ResourceListJson
+	Items []NotificationJson `json:"items" binding:"required"`
+}
+
+type NotificationViewSpecJson struct{}
+
+type NotificationViewStatusJson struct {
+	Viewed bool `json:"viewed"`
+}
+
+type NotificationViewActionJson struct {
+	APIVersion string                      `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                      `json:"kind" binding:"required" enums:"NotificationView" example:"NotificationView"`
+	Metadata   apiv1alpha1.ActionMeta      `json:"metadata" binding:"required"`
+	Spec       NotificationViewSpecJson    `json:"spec" binding:"required"`
+	Status     *NotificationViewStatusJson `json:"status,omitempty"`
+}
+
+type NotificationBatchViewMetadataJson struct {
+	Targets []meta.ObjectReference `json:"targets" binding:"required"`
+}
+
+type NotificationBatchViewStatusJson struct {
+	ViewedCount int `json:"viewedCount"`
+}
+
+type NotificationBatchViewActionJson struct {
+	APIVersion string                            `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                            `json:"kind" binding:"required" enums:"NotificationBatchView" example:"NotificationBatchView"`
+	Metadata   NotificationBatchViewMetadataJson `json:"metadata" binding:"required"`
+	Spec       NotificationViewSpecJson          `json:"spec" binding:"required"`
+	Status     *NotificationBatchViewStatusJson  `json:"status,omitempty"`
 }
 
 // ConnectorLifecycleRequestJson documents connector lifecycle operation bodies.

--- a/internal/schema/api/openapi/search.go
+++ b/internal/schema/api/openapi/search.go
@@ -1,23 +1,30 @@
 package openapi
 
-import "time"
+import (
+	"time"
 
-// SearchResourcesResponseJson documents the bounded resource-search response.
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+)
+
+type SearchResultListMetaJson struct {
+	TruncatedKinds  []string `json:"truncatedKinds"`
+	IncompleteKinds []string `json:"incompleteKinds"`
+}
+
+// SearchResourcesResponseJson documents the heterogeneous resource-search
+// projection. Each result carries one typed ObjectReference rather than a
+// second flat identity envelope.
 type SearchResourcesResponseJson struct {
-	// This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while
-	// avoiding swaggo's inability to resolve same-package nested named types.
-	Items []struct {
-		ResourceType  string            `json:"resourceType" example:"connection"`
-		ResourceId    string            `json:"resourceId" example:"cxn_test550e8400abcde"`
-		Name          string            `json:"name" example:"production-crm"`
-		Namespace     string            `json:"namespace" example:"root.acme"`
-		Labels        map[string]string `json:"labels"`
+	APIVersion string                   `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                   `json:"kind" binding:"required" enums:"SearchResultList" example:"SearchResultList"`
+	Metadata   SearchResultListMetaJson `json:"metadata" binding:"required"`
+	Items      []struct {
+		ResourceRef   meta.ObjectReference `json:"resourceRef" binding:"required"`
+		Labels        map[string]string    `json:"labels"`
 		MatchedLabels []struct {
-			Key   string `json:"key" example:"name"`
-			Value string `json:"value" example:"payments-production"`
+			Key   string `json:"key" example:"team"`
+			Value string `json:"value" example:"payments"`
 		} `json:"matchedLabels"`
 		UpdatedAt time.Time `json:"updatedAt"`
-	} `json:"items"`
-	TruncatedTypes  []string `json:"truncatedTypes"`
-	IncompleteTypes []string `json:"incompleteTypes"`
+	} `json:"items" binding:"required"`
 }

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -32,15 +32,15 @@
         "type": "string"
       }
     },
-    "SearchResourceType": {
+    "SearchResourceKind": {
       "type": "string",
       "enum": [
-        "actor",
-        "connection",
-        "connector",
-        "namespace",
-        "key",
-        "rate_limit"
+        "Actor",
+        "Connection",
+        "Connector",
+        "Namespace",
+        "Key",
+        "RateLimit"
       ]
     },
     "SearchLabelMatch": {
@@ -62,24 +62,18 @@
     "SearchResourceSummary": {
       "type": "object",
       "properties": {
-        "resourceType": {
-          "$ref": "#/$defs/SearchResourceType"
-        },
-        "resourceId": {
-          "type": "string"
-        },
-        "name": {
-          "anyOf": [
+        "resourceRef": {
+          "allOf": [
+            { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
             {
-              "$ref": "../common/schema.json#/$defs/ResourceName"
-            },
-            {
-              "$ref": "../resources/namespace/schema.json#/$defs/NamespaceName"
+              "type": "object",
+              "properties": {
+                "apiVersion": { "const": "authproxy.net/v1alpha1" },
+                "kind": { "$ref": "#/$defs/SearchResourceKind" },
+                "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+              }
             }
           ]
-        },
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
         },
         "labels": {
           "$ref": "#/$defs/StringMap"
@@ -96,44 +90,54 @@
         }
       },
       "required": [
-        "resourceType",
-        "resourceId",
-        "name",
-        "namespace",
+        "resourceRef",
         "labels",
         "matchedLabels",
         "updatedAt"
       ],
       "additionalProperties": false
     },
-    "SearchResourcesResponse": {
+    "SearchResultListMeta": {
       "type": "object",
       "properties": {
-        "items": {
+        "truncatedKinds": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/SearchResourceSummary"
+            "$ref": "#/$defs/SearchResourceKind"
           }
         },
-        "truncatedTypes": {
+        "incompleteKinds": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/SearchResourceType"
-          }
-        },
-        "incompleteTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SearchResourceType"
+            "$ref": "#/$defs/SearchResourceKind"
           }
         }
       },
       "required": [
-        "items",
-        "truncatedTypes",
-        "incompleteTypes"
+        "truncatedKinds",
+        "incompleteKinds"
       ],
       "additionalProperties": false
+    },
+    "SearchResourcesResponse": {
+      "description": "A heterogeneous search projection whose items identify resources through typed references.",
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "items"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "SearchResultList" },
+            "metadata": { "$ref": "#/$defs/SearchResultListMeta" },
+            "items": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/SearchResourceSummary" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "HeadersVal": {
       "oneOf": [
@@ -600,95 +604,208 @@
       ],
       "additionalProperties": false
     },
-    "Notification": {
+    "NotificationResourceReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "$ref": "#/$defs/SearchResourceKind" }
+          }
+        }
+      ]
+    },
+    "NotificationSpec": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
-        },
         "key": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "level": {
           "$ref": "#/$defs/NotificationLevel"
         },
-        "state": {
-          "$ref": "#/$defs/NotificationState"
-        },
-        "resourceType": {
-          "type": "string"
-        },
-        "resourceId": {
-          "type": "string"
-        },
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
+        "resourceRef": {
+          "$ref": "#/$defs/NotificationResourceReference"
         },
         "title": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
-        "actionUrl": {
-          "type": "string"
-        },
-        "canAction": {
-          "type": "boolean"
-        },
-        "viewed": {
-          "type": "boolean"
-        },
-        "metadata": {
+        "context": {
           "type": "object"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time"
-        },
+        }
+      },
+      "required": ["key", "level", "resourceRef", "title", "message"],
+      "additionalProperties": false
+    },
+    "NotificationActionStatus": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string", "minLength": 1 }
+      },
+      "required": ["url"],
+      "additionalProperties": false
+    },
+    "NotificationStatus": {
+      "type": "object",
+      "properties": {
+        "state": { "$ref": "#/$defs/NotificationState" },
+        "viewed": { "type": "boolean" },
+        "action": { "$ref": "#/$defs/NotificationActionStatus" },
         "resolvedAt": {
           "type": "string",
           "format": "date-time"
         }
       },
-      "required": [
-        "id",
-        "key",
-        "level",
-        "state",
-        "resourceType",
-        "resourceId",
-        "namespace",
-        "title",
-        "message",
-        "canAction",
-        "viewed",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["state", "viewed"],
       "additionalProperties": false
     },
-    "ListNotificationsResponse": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Notification"
+    "Notification": {
+      "description": "A read-only actor-specific projection of a durable notification record.",
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/Resource" },
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Notification" },
+            "metadata": {
+              "allOf": [
+                { "$ref": "../resources/meta/schema.json#/$defs/ObjectMeta" },
+                {
+                  "type": "object",
+                  "required": ["id", "namespace", "createdAt", "updatedAt"],
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^ntf_" },
+                    "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+                  }
+                }
+              ]
+            },
+            "spec": { "$ref": "#/$defs/NotificationSpec" },
+            "status": { "$ref": "#/$defs/NotificationStatus" }
           }
-        },
-        "cursor": {
-          "type": "string"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "ListNotificationsResponse": {
+      "description": "A Kubernetes-style list of actor-visible Notification projections.",
+      "allOf": [
+        { "$ref": "./v1alpha1/schema.json#/$defs/ResourceList" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "NotificationList" },
+            "items": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/Notification" }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "NotificationReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Notification" },
+            "id": { "type": "string", "pattern": "^ntf_" }
+          },
+          "not": {
+            "anyOf": [
+              { "required": ["name"] },
+              { "required": ["namespace"] },
+              { "required": ["generation"] }
+            ]
+          }
+        }
+      ]
+    },
+    "NotificationViewSpec": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "NotificationViewStatus": {
+      "type": "object",
+      "required": ["viewed"],
+      "properties": {
+        "viewed": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "NotificationViewAction": {
+      "allOf": [
+        { "$ref": "./v1alpha1/schema.json#/$defs/Action" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "NotificationView" },
+            "metadata": {
+              "type": "object",
+              "required": ["target"],
+              "properties": {
+                "target": { "$ref": "#/$defs/NotificationReference" }
+              },
+              "additionalProperties": false
+            },
+            "spec": { "$ref": "#/$defs/NotificationViewSpec" },
+            "status": { "$ref": "#/$defs/NotificationViewStatus" }
+          }
+        }
+      ]
+    },
+    "NotificationBatchViewMetadata": {
+      "type": "object",
+      "required": ["targets"],
+      "properties": {
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/NotificationReference" }
         }
       },
-      "required": [
-        "items"
-      ],
       "additionalProperties": false
+    },
+    "NotificationBatchViewStatus": {
+      "type": "object",
+      "required": ["viewedCount"],
+      "properties": {
+        "viewedCount": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "NotificationBatchViewAction": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "spec"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "NotificationBatchView" },
+            "metadata": { "$ref": "#/$defs/NotificationBatchViewMetadata" },
+            "spec": { "$ref": "#/$defs/NotificationViewSpec" },
+            "status": { "$ref": "#/$defs/NotificationBatchViewStatus" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "ListNamespacesResponse": {
       "description": "A Kubernetes-style list of namespaces.",

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -86,6 +86,8 @@ func TestSchemaSamples(t *testing.T) {
 		{name: "update connection", ref: "./schema.json#/$defs/ConnectionPatch", file: "valid-update-connection.json"},
 		{name: "proxy response", ref: "./schema.json#/$defs/ProxyResponse", file: "valid-proxy-response.json"},
 		{name: "list notifications", ref: "./schema.json#/$defs/ListNotificationsResponse", file: "valid-list-notifications.json"},
+		{name: "view notification", ref: "./schema.json#/$defs/NotificationViewAction", file: "valid-view-notification.json"},
+		{name: "batch view notifications", ref: "./schema.json#/$defs/NotificationBatchViewAction", file: "valid-batch-view-notifications.json"},
 		{name: "search resources", ref: "./schema.json#/$defs/SearchResourcesResponse", file: "valid-search-resources.json"},
 		{name: "list namespaces", ref: "./schema.json#/$defs/ListNamespacesResponse", file: "valid-list-namespaces.json"},
 		{name: "actor", ref: "./schema.json#/$defs/Actor", file: "valid-actor.json"},
@@ -150,6 +152,27 @@ func TestManagedListSchemasRejectLegacyTopLevelCursor(t *testing.T) {
 	require.Error(t, schema.Validate(map[string]any{
 		"items":  []any{},
 		"cursor": "next-page",
+	}))
+}
+
+func TestNotificationAndSearchSchemasRejectLegacyFlatIdentity(t *testing.T) {
+	notifications := compileRefSchema(t, "./schema.json#/$defs/ListNotificationsResponse")
+	require.Error(t, notifications.Validate(map[string]any{
+		"items": []any{map[string]any{
+			"id":           "ntf_test550e8400abcde",
+			"resourceType": "connection",
+			"resourceId":   "cxn_test550e8400abcde",
+		}},
+	}))
+
+	search := compileRefSchema(t, "./schema.json#/$defs/SearchResourcesResponse")
+	require.Error(t, search.Validate(map[string]any{
+		"items": []any{map[string]any{
+			"resourceType": "connection",
+			"resourceId":   "cxn_test550e8400abcde",
+			"name":         "production",
+			"namespace":    "root.acme",
+		}},
 	}))
 }
 

--- a/internal/schema/api/search.go
+++ b/internal/schema/api/search.go
@@ -1,35 +1,62 @@
 package api
 
-import "time"
+import (
+	"time"
 
-type SearchResourceType string
-
-const (
-	SearchResourceTypeActor      SearchResourceType = "actor"
-	SearchResourceTypeConnection SearchResourceType = "connection"
-	SearchResourceTypeConnector  SearchResourceType = "connector"
-	SearchResourceTypeNamespace  SearchResourceType = "namespace"
-	SearchResourceTypeKey        SearchResourceType = "key"
-	SearchResourceTypeRateLimit  SearchResourceType = "rate_limit"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 )
+
+const SearchResultListKind meta.Kind = "SearchResultList"
 
 type SearchLabelMatchJson struct {
 	Key   string `json:"key" yaml:"key"`
 	Value string `json:"value" yaml:"value"`
 }
 
+// SearchResourceSummaryJson is a heterogeneous resource projection. Its
+// ResourceRef owns identity; the remaining fields contain search-only display
+// and match information rather than a partial resource envelope.
 type SearchResourceSummaryJson struct {
-	ResourceType  SearchResourceType     `json:"resourceType" yaml:"resourceType" swaggertype:"string" example:"connection"`
-	ResourceId    string                 `json:"resourceId" yaml:"resourceId" example:"cxn_test550e8400abcde"`
-	Name          string                 `json:"name" yaml:"name" example:"production-crm"`
-	Namespace     string                 `json:"namespace" yaml:"namespace" example:"root.acme"`
+	ResourceRef   meta.ObjectReference   `json:"resourceRef" yaml:"resourceRef"`
 	Labels        map[string]string      `json:"labels" yaml:"labels"`
 	MatchedLabels []SearchLabelMatchJson `json:"matchedLabels" yaml:"matchedLabels"`
 	UpdatedAt     time.Time              `json:"updatedAt" yaml:"updatedAt"`
 }
 
+// SearchResultListMetaJson reports partial-result state for the heterogeneous
+// search projection. It is not resource pagination metadata.
+type SearchResultListMetaJson struct {
+	TruncatedKinds  []meta.Kind `json:"truncatedKinds" yaml:"truncatedKinds"`
+	IncompleteKinds []meta.Kind `json:"incompleteKinds" yaml:"incompleteKinds"`
+}
+
+// SearchResourcesResponseJson is a typed list projection rather than a list
+// of partial canonical resources.
 type SearchResourcesResponseJson struct {
-	Items           []SearchResourceSummaryJson `json:"items" yaml:"items"`
-	TruncatedTypes  []SearchResourceType        `json:"truncatedTypes" yaml:"truncatedTypes"`
-	IncompleteTypes []SearchResourceType        `json:"incompleteTypes" yaml:"incompleteTypes"`
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      SearchResultListMetaJson    `json:"metadata" yaml:"metadata"`
+	Items         []SearchResourceSummaryJson `json:"items" yaml:"items"`
+}
+
+func NewSearchResourcesResponseJson(
+	items []SearchResourceSummaryJson,
+	truncatedKinds, incompleteKinds []meta.Kind,
+) SearchResourcesResponseJson {
+	if items == nil {
+		items = make([]SearchResourceSummaryJson, 0)
+	}
+	if truncatedKinds == nil {
+		truncatedKinds = make([]meta.Kind, 0)
+	}
+	if incompleteKinds == nil {
+		incompleteKinds = make([]meta.Kind, 0)
+	}
+	return SearchResourcesResponseJson{
+		TypeMeta: meta.NewTypeMeta(SearchResultListKind),
+		Metadata: SearchResultListMetaJson{
+			TruncatedKinds:  truncatedKinds,
+			IncompleteKinds: incompleteKinds,
+		},
+		Items: items,
+	}
 }

--- a/internal/schema/api/search_test.go
+++ b/internal/schema/api/search_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewSearchResourcesResponseJson(t *testing.T) {
+	response := NewSearchResourcesResponseJson(nil, nil, []meta.Kind{"Actor"})
+	require.Equal(t, meta.NewTypeMeta(SearchResultListKind), response.TypeMeta)
+	require.Empty(t, response.Items)
+	require.Empty(t, response.Metadata.TruncatedKinds)
+	require.Equal(t, []meta.Kind{"Actor"}, response.Metadata.IncompleteKinds)
+
+	jsonData, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"apiVersion":"authproxy.net/v1alpha1",
+		"kind":"SearchResultList",
+		"metadata":{"truncatedKinds":[],"incompleteKinds":["Actor"]},
+		"items":[]
+	}`, string(jsonData))
+
+	yamlData, err := yaml.Marshal(response)
+	require.NoError(t, err)
+	require.Contains(t, string(yamlData), "kind: SearchResultList")
+}

--- a/internal/schema/api/test_data/valid-batch-view-notifications.json
+++ b/internal/schema/api/test_data/valid-batch-view-notifications.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "NotificationBatchView",
+  "metadata": {
+    "targets": [
+      {
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Notification",
+        "id": "ntf_test550e8400abcde"
+      },
+      {
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Notification",
+        "id": "ntf_test550e8400abcdef"
+      }
+    ]
+  },
+  "spec": {},
+  "status": {
+    "viewedCount": 2
+  }
+}

--- a/internal/schema/api/test_data/valid-list-notifications.json
+++ b/internal/schema/api/test_data/valid-list-notifications.json
@@ -1,23 +1,38 @@
 {
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "NotificationList",
+  "metadata": {},
   "items": [
     {
-      "id": "ntf_test550e8400abcde",
-      "key": "connector_migration:cxn_test550e8400abcde:reauth",
-      "level": "warning",
-      "state": "active",
-      "resourceType": "connection",
-      "resourceId": "cxn_test550e8400abcde",
-      "namespace": "root.acme",
-      "title": "Connection requires re-authentication",
-      "message": "The target connector version requires the user to re-authenticate.",
-      "actionUrl": "/connections/cxn_test550e8400abcde?action=reauth",
-      "canAction": true,
-      "viewed": false,
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Notification",
       "metadata": {
-        "targetVersion": 3
+        "id": "ntf_test550e8400abcde",
+        "namespace": "root.acme",
+        "createdAt": "2026-07-03T12:00:00Z",
+        "updatedAt": "2026-07-03T12:00:00Z"
       },
-      "createdAt": "2026-07-03T12:00:00Z",
-      "updatedAt": "2026-07-03T12:00:00Z"
+      "spec": {
+        "key": "connector_migration:cxn_test550e8400abcde:reauth",
+        "level": "warning",
+        "resourceRef": {
+          "apiVersion": "authproxy.net/v1alpha1",
+          "kind": "Connection",
+          "id": "cxn_test550e8400abcde"
+        },
+        "title": "Connection requires re-authentication",
+        "message": "The target connector version requires the user to re-authenticate.",
+        "context": {
+          "targetVersion": 3
+        }
+      },
+      "status": {
+        "state": "active",
+        "viewed": false,
+        "action": {
+          "url": "/connections/cxn_test550e8400abcde?action=reauth"
+        }
+      }
     }
   ]
 }

--- a/internal/schema/api/test_data/valid-search-resources.json
+++ b/internal/schema/api/test_data/valid-search-resources.json
@@ -1,10 +1,19 @@
 {
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "SearchResultList",
+  "metadata": {
+    "truncatedKinds": ["Connection"],
+    "incompleteKinds": []
+  },
   "items": [
     {
-      "resourceType": "connection",
-      "resourceId": "cxn_test550e8400abcde",
-      "name": "production-crm",
-      "namespace": "root.acme",
+      "resourceRef": {
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Connection",
+        "id": "cxn_test550e8400abcde",
+        "name": "production-crm",
+        "namespace": "root.acme"
+      },
       "labels": {
         "team": "payments"
       },
@@ -17,17 +26,14 @@
       "updatedAt": "2026-07-12T12:00:00Z"
     },
     {
-      "resourceType": "namespace",
-      "resourceId": "root._billing-",
-      "name": "_billing-",
-      "namespace": "root._billing-",
+      "resourceRef": {
+        "apiVersion": "authproxy.net/v1alpha1",
+        "kind": "Namespace",
+        "id": "root._billing-"
+      },
       "labels": {},
       "matchedLabels": [],
       "updatedAt": "2026-07-12T12:00:00Z"
     }
-  ],
-  "truncatedTypes": [
-    "connection"
-  ],
-  "incompleteTypes": []
+  ]
 }

--- a/internal/schema/api/test_data/valid-view-notification.json
+++ b/internal/schema/api/test_data/valid-view-notification.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "NotificationView",
+  "metadata": {
+    "target": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Notification",
+      "id": "ntf_test550e8400abcde"
+    }
+  },
+  "spec": {},
+  "status": {
+    "viewed": true
+  }
+}

--- a/internal/schema/resources/meta/validation.go
+++ b/internal/schema/resources/meta/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/util"
 )
@@ -131,7 +132,11 @@ func ValidateObjectReference(
 	value ObjectReference,
 	path *common.ValidationContext,
 ) error {
-	return ValidateObjectReferenceWithOptions(value, ObjectReferenceValidationOptions{}, path)
+	return ValidateObjectReferenceWithOptions(
+		value,
+		ObjectReferenceValidationOptions{},
+		path,
+	)
 }
 
 // ValidateObjectReferenceWithOptions validates the common object-reference
@@ -271,7 +276,10 @@ func ValidateObjectMeta(value ObjectMeta, options ValidationOptions) error {
 // ValidateObjectMetaPatch validates the fields that are present in a metadata
 // patch. Resource packages supply validators for their ID and namespace
 // formats, just as they do for complete ObjectMeta values.
-func ValidateObjectMetaPatch(value ObjectMetaPatch, options ValidationOptions) error {
+func ValidateObjectMetaPatch(
+	value ObjectMetaPatch,
+	options ValidationOptions,
+) error {
 	vc := validationPath(options.Path).PushField("metadata")
 	var result *multierror.Error
 
@@ -410,4 +418,17 @@ func ValidateTypeMetaUpdate(
 		result = multierror.Append(result, vc.NewErrorForField("kind", "is immutable"))
 	}
 	return result.ErrorOrNil()
+}
+
+// IdValidatorForPrefix returns a validator that checks that the given ID is
+// valid for the given prefix. It is intened to be used with the
+// `ValidationOptions.IDValidator` option.
+func IdValidatorForPrefix(prefix apid.Prefix) func(string) error {
+	return func(value string) error {
+		id, err := apid.Parse(value)
+		if err != nil {
+			return err
+		}
+		return id.ValidatePrefix(prefix)
+	}
 }

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -6936,18 +6936,21 @@ const docTemplateadmin_api = `{
                 "summary": "Mark notifications viewed",
                 "parameters": [
                     {
-                        "description": "Notification IDs",
+                        "description": "Notification batch view action",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
                         }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -6990,6 +6993,9 @@ const docTemplateadmin_api = `{
                     }
                 ],
                 "description": "Mark a notification viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -7004,11 +7010,23 @@ const docTemplateadmin_api = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Notification view action",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -7998,8 +8016,8 @@ const docTemplateadmin_api = `{
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Resource types; may be repeated",
-                        "name": "resourceType",
+                        "description": "Resource kinds; may be repeated",
+                        "name": "kind",
                         "in": "query"
                     },
                     {
@@ -9228,6 +9246,147 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "openapi.NotificationActionStatusJson": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationBatchViewMetadataJson": {
+            "type": "object",
+            "required": [
+                "targets"
+            ],
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meta.ObjectReference"
+                    }
+                }
+            }
+        },
+        "openapi.NotificationBatchViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewedCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.NotificationJson": {
+            "description": "Actor-visible, resource-shaped notification projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec",
+                "status"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Notification"
+                    ],
+                    "example": "Notification"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationStatusJson"
+                }
+            }
+        },
+        "openapi.NotificationSpecJson": {
+            "type": "object",
+            "required": [
+                "key",
+                "level",
+                "message",
+                "resourceRef",
+                "title"
+            ],
+            "properties": {
+                "context": {
+                    "type": "object"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "info",
+                        "warning",
+                        "error"
+                    ],
+                    "example": "warning"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "resourceRef": {
+                    "$ref": "#/definitions/meta.ObjectReference"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationStatusJson": {
+            "type": "object",
+            "required": [
+                "state"
+            ],
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/openapi.NotificationActionStatusJson"
+                },
+                "resolvedAt": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "resolved"
+                    ],
+                    "example": "active"
+                },
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "openapi.NotificationViewSpecJson": {
+            "type": "object"
+        },
+        "openapi.NotificationViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "openapi.RateLimitAlgorithmJson": {
             "type": "object",
             "properties": {
@@ -9565,6 +9724,23 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "openapi.SearchResultListMetaJson": {
+            "type": "object",
+            "properties": {
+                "incompleteKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "truncatedKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.ConnectionScopesJson": {
             "type": "object",
             "properties": {
@@ -9630,20 +9806,6 @@ const docTemplateadmin_api = `{
                 "value": {
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.MarkNotificationsViewedRequestJson": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ntf_test550e8400abcde"
-                    ]
                 }
             }
         },
@@ -10167,13 +10329,31 @@ const docTemplateadmin_api = `{
         "routes.OpenAPIListNotificationsResponseJson": {
             "description": "Paginated list of actor-visible notifications",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.NotificationJson"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ListMeta"
                 }
             }
         },
@@ -10202,6 +10382,74 @@ const docTemplateadmin_api = `{
                     "items": {
                         "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
+                }
+            }
+        },
+        "routes.OpenAPINotificationBatchViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationBatchView"
+                    ],
+                    "example": "NotificationBatchView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewMetadataJson"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewStatusJson"
+                }
+            }
+        },
+        "routes.OpenAPINotificationViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationView"
+                    ],
+                    "example": "NotificationView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ActionMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationViewStatusJson"
                 }
             }
         },
@@ -10313,18 +10561,27 @@ const docTemplateadmin_api = `{
         },
         "routes.OpenAPISearchResourcesResponseJson": {
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "incompleteTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while\navoiding swaggo's inability to resolve same-package nested named types.",
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "required": [
+                            "resourceRef"
+                        ],
                         "properties": {
                             "labels": {
                                 "type": "object",
@@ -10339,30 +10596,17 @@ const docTemplateadmin_api = `{
                                     "properties": {
                                         "key": {
                                             "type": "string",
-                                            "example": "name"
+                                            "example": "team"
                                         },
                                         "value": {
                                             "type": "string",
-                                            "example": "payments-production"
+                                            "example": "payments"
                                         }
                                     }
                                 }
                             },
-                            "name": {
-                                "type": "string",
-                                "example": "production-crm"
-                            },
-                            "namespace": {
-                                "type": "string",
-                                "example": "root.acme"
-                            },
-                            "resourceId": {
-                                "type": "string",
-                                "example": "cxn_test550e8400abcde"
-                            },
-                            "resourceType": {
-                                "type": "string",
-                                "example": "connection"
+                            "resourceRef": {
+                                "$ref": "#/definitions/meta.ObjectReference"
                             },
                             "updatedAt": {
                                 "type": "string"
@@ -10370,11 +10614,15 @@ const docTemplateadmin_api = `{
                         }
                     }
                 },
-                "truncatedTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "SearchResultList"
+                    ],
+                    "example": "SearchResultList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.SearchResultListMetaJson"
                 }
             }
         },
@@ -10460,6 +10708,14 @@ const docTemplateadmin_api = `{
                 "actorId": {
                     "type": "string",
                     "example": "act_test550e8400abcde"
+                }
+            }
+        },
+        "v1alpha1.ActionMeta": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "$ref": "#/definitions/meta.ObjectReference"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -6930,18 +6930,21 @@
                 "summary": "Mark notifications viewed",
                 "parameters": [
                     {
-                        "description": "Notification IDs",
+                        "description": "Notification batch view action",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
                         }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -6984,6 +6987,9 @@
                     }
                 ],
                 "description": "Mark a notification viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -6998,11 +7004,23 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Notification view action",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -7992,8 +8010,8 @@
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Resource types; may be repeated",
-                        "name": "resourceType",
+                        "description": "Resource kinds; may be repeated",
+                        "name": "kind",
                         "in": "query"
                     },
                     {
@@ -9222,6 +9240,147 @@
                 }
             }
         },
+        "openapi.NotificationActionStatusJson": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationBatchViewMetadataJson": {
+            "type": "object",
+            "required": [
+                "targets"
+            ],
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meta.ObjectReference"
+                    }
+                }
+            }
+        },
+        "openapi.NotificationBatchViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewedCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.NotificationJson": {
+            "description": "Actor-visible, resource-shaped notification projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec",
+                "status"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Notification"
+                    ],
+                    "example": "Notification"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationStatusJson"
+                }
+            }
+        },
+        "openapi.NotificationSpecJson": {
+            "type": "object",
+            "required": [
+                "key",
+                "level",
+                "message",
+                "resourceRef",
+                "title"
+            ],
+            "properties": {
+                "context": {
+                    "type": "object"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "info",
+                        "warning",
+                        "error"
+                    ],
+                    "example": "warning"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "resourceRef": {
+                    "$ref": "#/definitions/meta.ObjectReference"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationStatusJson": {
+            "type": "object",
+            "required": [
+                "state"
+            ],
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/openapi.NotificationActionStatusJson"
+                },
+                "resolvedAt": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "resolved"
+                    ],
+                    "example": "active"
+                },
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "openapi.NotificationViewSpecJson": {
+            "type": "object"
+        },
+        "openapi.NotificationViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "openapi.RateLimitAlgorithmJson": {
             "type": "object",
             "properties": {
@@ -9559,6 +9718,23 @@
                 }
             }
         },
+        "openapi.SearchResultListMetaJson": {
+            "type": "object",
+            "properties": {
+                "incompleteKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "truncatedKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.ConnectionScopesJson": {
             "type": "object",
             "properties": {
@@ -9624,20 +9800,6 @@
                 "value": {
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.MarkNotificationsViewedRequestJson": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ntf_test550e8400abcde"
-                    ]
                 }
             }
         },
@@ -10161,13 +10323,31 @@
         "routes.OpenAPIListNotificationsResponseJson": {
             "description": "Paginated list of actor-visible notifications",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.NotificationJson"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ListMeta"
                 }
             }
         },
@@ -10196,6 +10376,74 @@
                     "items": {
                         "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
+                }
+            }
+        },
+        "routes.OpenAPINotificationBatchViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationBatchView"
+                    ],
+                    "example": "NotificationBatchView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewMetadataJson"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewStatusJson"
+                }
+            }
+        },
+        "routes.OpenAPINotificationViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationView"
+                    ],
+                    "example": "NotificationView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ActionMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationViewStatusJson"
                 }
             }
         },
@@ -10307,18 +10555,27 @@
         },
         "routes.OpenAPISearchResourcesResponseJson": {
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "incompleteTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while\navoiding swaggo's inability to resolve same-package nested named types.",
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "required": [
+                            "resourceRef"
+                        ],
                         "properties": {
                             "labels": {
                                 "type": "object",
@@ -10333,30 +10590,17 @@
                                     "properties": {
                                         "key": {
                                             "type": "string",
-                                            "example": "name"
+                                            "example": "team"
                                         },
                                         "value": {
                                             "type": "string",
-                                            "example": "payments-production"
+                                            "example": "payments"
                                         }
                                     }
                                 }
                             },
-                            "name": {
-                                "type": "string",
-                                "example": "production-crm"
-                            },
-                            "namespace": {
-                                "type": "string",
-                                "example": "root.acme"
-                            },
-                            "resourceId": {
-                                "type": "string",
-                                "example": "cxn_test550e8400abcde"
-                            },
-                            "resourceType": {
-                                "type": "string",
-                                "example": "connection"
+                            "resourceRef": {
+                                "$ref": "#/definitions/meta.ObjectReference"
                             },
                             "updatedAt": {
                                 "type": "string"
@@ -10364,11 +10608,15 @@
                         }
                     }
                 },
-                "truncatedTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "SearchResultList"
+                    ],
+                    "example": "SearchResultList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.SearchResultListMetaJson"
                 }
             }
         },
@@ -10454,6 +10702,14 @@
                 "actorId": {
                     "type": "string",
                     "example": "act_test550e8400abcde"
+                }
+            }
+        },
+        "v1alpha1.ActionMeta": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "$ref": "#/definitions/meta.ObjectReference"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -700,6 +700,103 @@ definitions:
     - kind
     - metadata
     type: object
+  openapi.NotificationActionStatusJson:
+    properties:
+      url:
+        type: string
+    required:
+    - url
+    type: object
+  openapi.NotificationBatchViewMetadataJson:
+    properties:
+      targets:
+        items:
+          $ref: '#/definitions/meta.ObjectReference'
+        type: array
+    required:
+    - targets
+    type: object
+  openapi.NotificationBatchViewStatusJson:
+    properties:
+      viewedCount:
+        type: integer
+    type: object
+  openapi.NotificationJson:
+    description: Actor-visible, resource-shaped notification projection
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Notification
+        example: Notification
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.NotificationSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    - status
+    type: object
+  openapi.NotificationSpecJson:
+    properties:
+      context:
+        type: object
+      key:
+        type: string
+      level:
+        enum:
+        - info
+        - warning
+        - error
+        example: warning
+        type: string
+      message:
+        type: string
+      resourceRef:
+        $ref: '#/definitions/meta.ObjectReference'
+      title:
+        type: string
+    required:
+    - key
+    - level
+    - message
+    - resourceRef
+    - title
+    type: object
+  openapi.NotificationStatusJson:
+    properties:
+      action:
+        $ref: '#/definitions/openapi.NotificationActionStatusJson'
+      resolvedAt:
+        type: string
+      state:
+        enum:
+        - active
+        - resolved
+        example: active
+        type: string
+      viewed:
+        type: boolean
+    required:
+    - state
+    type: object
+  openapi.NotificationViewSpecJson:
+    type: object
+  openapi.NotificationViewStatusJson:
+    properties:
+      viewed:
+        type: boolean
+    type: object
   openapi.RateLimitAlgorithmJson:
     properties:
       fixedWindow:
@@ -935,6 +1032,17 @@ definitions:
         example: 1
         type: number
     type: object
+  openapi.SearchResultListMetaJson:
+    properties:
+      incompleteKinds:
+        items:
+          type: string
+        type: array
+      truncatedKinds:
+        items:
+          type: string
+        type: array
+    type: object
   routes.ConnectionScopesJson:
     properties:
       granted:
@@ -981,15 +1089,6 @@ definitions:
       value:
         example: production
         type: string
-    type: object
-  routes.MarkNotificationsViewedRequestJson:
-    properties:
-      ids:
-        example:
-        - ntf_test550e8400abcde
-        items:
-          type: string
-        type: array
     type: object
   routes.OpenAPIConnectionDisconnectActionJson:
     properties:
@@ -1362,11 +1461,24 @@ definitions:
   routes.OpenAPIListNotificationsResponseJson:
     description: Paginated list of actor-visible notifications
     properties:
-      cursor:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
       items:
-        items: {}
+        items:
+          $ref: '#/definitions/openapi.NotificationJson'
         type: array
+      kind:
+        type: string
+      metadata:
+        $ref: '#/definitions/v1alpha1.ListMeta'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPIListRequestEventsResponse:
     description: Paginated list of request events entries
@@ -1386,6 +1498,54 @@ definitions:
         items:
           $ref: '#/definitions/api.MetricsSchemaMetricJson'
         type: array
+    type: object
+  routes.OpenAPINotificationBatchViewActionJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - NotificationBatchView
+        example: NotificationBatchView
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.NotificationBatchViewMetadataJson'
+      spec:
+        $ref: '#/definitions/openapi.NotificationViewSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationBatchViewStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  routes.OpenAPINotificationViewActionJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - NotificationView
+        example: NotificationView
+        type: string
+      metadata:
+        $ref: '#/definitions/v1alpha1.ActionMeta'
+      spec:
+        $ref: '#/definitions/openapi.NotificationViewSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationViewStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPIProxyResponseJson:
     description: Response from a proxied HTTP request
@@ -1464,14 +1624,12 @@ definitions:
     type: object
   routes.OpenAPISearchResourcesResponseJson:
     properties:
-      incompleteTypes:
-        items:
-          type: string
-        type: array
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
       items:
-        description: |-
-          This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while
-          avoiding swaggo's inability to resolve same-package nested named types.
         items:
           properties:
             labels:
@@ -1482,33 +1640,33 @@ definitions:
               items:
                 properties:
                   key:
-                    example: name
+                    example: team
                     type: string
                   value:
-                    example: payments-production
+                    example: payments
                     type: string
                 type: object
               type: array
-            name:
-              example: production-crm
-              type: string
-            namespace:
-              example: root.acme
-              type: string
-            resourceId:
-              example: cxn_test550e8400abcde
-              type: string
-            resourceType:
-              example: connection
-              type: string
+            resourceRef:
+              $ref: '#/definitions/meta.ObjectReference'
             updatedAt:
               type: string
+          required:
+          - resourceRef
           type: object
         type: array
-      truncatedTypes:
-        items:
-          type: string
-        type: array
+      kind:
+        enum:
+        - SearchResultList
+        example: SearchResultList
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.SearchResultListMetaJson'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPITaskInfoJson:
     description: Background task status
@@ -1567,6 +1725,11 @@ definitions:
       actorId:
         example: act_test550e8400abcde
         type: string
+    type: object
+  v1alpha1.ActionMeta:
+    properties:
+      target:
+        $ref: '#/definitions/meta.ObjectReference'
     type: object
   v1alpha1.ListMeta:
     properties:
@@ -6088,17 +6251,19 @@ paths:
       - application/json
       description: Mark multiple notifications viewed for the authenticated actor
       parameters:
-      - description: Notification IDs
+      - description: Notification batch view action
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.MarkNotificationsViewedRequestJson'
+          $ref: '#/definitions/routes.OpenAPINotificationBatchViewActionJson'
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPINotificationBatchViewActionJson'
         "400":
           description: Bad Request
           schema:
@@ -6126,6 +6291,8 @@ paths:
       - notifications
   /notifications/{id}/_viewed:
     post:
+      consumes:
+      - application/json
       description: Mark a notification viewed for the authenticated actor
       parameters:
       - description: Notification ID
@@ -6133,11 +6300,19 @@ paths:
         name: id
         required: true
         type: string
+      - description: Notification view action
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.OpenAPINotificationViewActionJson'
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPINotificationViewActionJson'
         "400":
           description: Bad Request
           schema:
@@ -6774,11 +6949,11 @@ paths:
         name: mode
         type: string
       - collectionFormat: multi
-        description: Resource types; may be repeated
+        description: Resource kinds; may be repeated
         in: query
         items:
           type: string
-        name: resourceType
+        name: kind
         type: array
       - description: Case-insensitive literal resource-name or label-value substring
           (minimum 3 characters)

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -6936,18 +6936,21 @@ const docTemplateApi = `{
                 "summary": "Mark notifications viewed",
                 "parameters": [
                     {
-                        "description": "Notification IDs",
+                        "description": "Notification batch view action",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
                         }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -6990,6 +6993,9 @@ const docTemplateApi = `{
                     }
                 ],
                 "description": "Mark a notification viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -7004,11 +7010,23 @@ const docTemplateApi = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Notification view action",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -7998,8 +8016,8 @@ const docTemplateApi = `{
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Resource types; may be repeated",
-                        "name": "resourceType",
+                        "description": "Resource kinds; may be repeated",
+                        "name": "kind",
                         "in": "query"
                     },
                     {
@@ -9228,6 +9246,147 @@ const docTemplateApi = `{
                 }
             }
         },
+        "openapi.NotificationActionStatusJson": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationBatchViewMetadataJson": {
+            "type": "object",
+            "required": [
+                "targets"
+            ],
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meta.ObjectReference"
+                    }
+                }
+            }
+        },
+        "openapi.NotificationBatchViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewedCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.NotificationJson": {
+            "description": "Actor-visible, resource-shaped notification projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec",
+                "status"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Notification"
+                    ],
+                    "example": "Notification"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationStatusJson"
+                }
+            }
+        },
+        "openapi.NotificationSpecJson": {
+            "type": "object",
+            "required": [
+                "key",
+                "level",
+                "message",
+                "resourceRef",
+                "title"
+            ],
+            "properties": {
+                "context": {
+                    "type": "object"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "info",
+                        "warning",
+                        "error"
+                    ],
+                    "example": "warning"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "resourceRef": {
+                    "$ref": "#/definitions/meta.ObjectReference"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationStatusJson": {
+            "type": "object",
+            "required": [
+                "state"
+            ],
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/openapi.NotificationActionStatusJson"
+                },
+                "resolvedAt": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "resolved"
+                    ],
+                    "example": "active"
+                },
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "openapi.NotificationViewSpecJson": {
+            "type": "object"
+        },
+        "openapi.NotificationViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "openapi.RateLimitAlgorithmJson": {
             "type": "object",
             "properties": {
@@ -9565,6 +9724,23 @@ const docTemplateApi = `{
                 }
             }
         },
+        "openapi.SearchResultListMetaJson": {
+            "type": "object",
+            "properties": {
+                "incompleteKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "truncatedKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.ConnectionScopesJson": {
             "type": "object",
             "properties": {
@@ -9630,20 +9806,6 @@ const docTemplateApi = `{
                 "value": {
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.MarkNotificationsViewedRequestJson": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ntf_test550e8400abcde"
-                    ]
                 }
             }
         },
@@ -10167,13 +10329,31 @@ const docTemplateApi = `{
         "routes.OpenAPIListNotificationsResponseJson": {
             "description": "Paginated list of actor-visible notifications",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.NotificationJson"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ListMeta"
                 }
             }
         },
@@ -10202,6 +10382,74 @@ const docTemplateApi = `{
                     "items": {
                         "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
+                }
+            }
+        },
+        "routes.OpenAPINotificationBatchViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationBatchView"
+                    ],
+                    "example": "NotificationBatchView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewMetadataJson"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewStatusJson"
+                }
+            }
+        },
+        "routes.OpenAPINotificationViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationView"
+                    ],
+                    "example": "NotificationView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ActionMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationViewStatusJson"
                 }
             }
         },
@@ -10313,18 +10561,27 @@ const docTemplateApi = `{
         },
         "routes.OpenAPISearchResourcesResponseJson": {
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "incompleteTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while\navoiding swaggo's inability to resolve same-package nested named types.",
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "required": [
+                            "resourceRef"
+                        ],
                         "properties": {
                             "labels": {
                                 "type": "object",
@@ -10339,30 +10596,17 @@ const docTemplateApi = `{
                                     "properties": {
                                         "key": {
                                             "type": "string",
-                                            "example": "name"
+                                            "example": "team"
                                         },
                                         "value": {
                                             "type": "string",
-                                            "example": "payments-production"
+                                            "example": "payments"
                                         }
                                     }
                                 }
                             },
-                            "name": {
-                                "type": "string",
-                                "example": "production-crm"
-                            },
-                            "namespace": {
-                                "type": "string",
-                                "example": "root.acme"
-                            },
-                            "resourceId": {
-                                "type": "string",
-                                "example": "cxn_test550e8400abcde"
-                            },
-                            "resourceType": {
-                                "type": "string",
-                                "example": "connection"
+                            "resourceRef": {
+                                "$ref": "#/definitions/meta.ObjectReference"
                             },
                             "updatedAt": {
                                 "type": "string"
@@ -10370,11 +10614,15 @@ const docTemplateApi = `{
                         }
                     }
                 },
-                "truncatedTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "SearchResultList"
+                    ],
+                    "example": "SearchResultList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.SearchResultListMetaJson"
                 }
             }
         },
@@ -10460,6 +10708,14 @@ const docTemplateApi = `{
                 "actorId": {
                     "type": "string",
                     "example": "act_test550e8400abcde"
+                }
+            }
+        },
+        "v1alpha1.ActionMeta": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "$ref": "#/definitions/meta.ObjectReference"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -6930,18 +6930,21 @@
                 "summary": "Mark notifications viewed",
                 "parameters": [
                     {
-                        "description": "Notification IDs",
+                        "description": "Notification batch view action",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/routes.MarkNotificationsViewedRequestJson"
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
                         }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationBatchViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -6984,6 +6987,9 @@
                     }
                 ],
                 "description": "Mark a notification viewed for the authenticated actor",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -6998,11 +7004,23 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Notification view action",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.OpenAPINotificationViewActionJson"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -7992,8 +8010,8 @@
                             "type": "string"
                         },
                         "collectionFormat": "multi",
-                        "description": "Resource types; may be repeated",
-                        "name": "resourceType",
+                        "description": "Resource kinds; may be repeated",
+                        "name": "kind",
                         "in": "query"
                     },
                     {
@@ -9222,6 +9240,147 @@
                 }
             }
         },
+        "openapi.NotificationActionStatusJson": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationBatchViewMetadataJson": {
+            "type": "object",
+            "required": [
+                "targets"
+            ],
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meta.ObjectReference"
+                    }
+                }
+            }
+        },
+        "openapi.NotificationBatchViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewedCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.NotificationJson": {
+            "description": "Actor-visible, resource-shaped notification projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec",
+                "status"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Notification"
+                    ],
+                    "example": "Notification"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationStatusJson"
+                }
+            }
+        },
+        "openapi.NotificationSpecJson": {
+            "type": "object",
+            "required": [
+                "key",
+                "level",
+                "message",
+                "resourceRef",
+                "title"
+            ],
+            "properties": {
+                "context": {
+                    "type": "object"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "info",
+                        "warning",
+                        "error"
+                    ],
+                    "example": "warning"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "resourceRef": {
+                    "$ref": "#/definitions/meta.ObjectReference"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "openapi.NotificationStatusJson": {
+            "type": "object",
+            "required": [
+                "state"
+            ],
+            "properties": {
+                "action": {
+                    "$ref": "#/definitions/openapi.NotificationActionStatusJson"
+                },
+                "resolvedAt": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "resolved"
+                    ],
+                    "example": "active"
+                },
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "openapi.NotificationViewSpecJson": {
+            "type": "object"
+        },
+        "openapi.NotificationViewStatusJson": {
+            "type": "object",
+            "properties": {
+                "viewed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "openapi.RateLimitAlgorithmJson": {
             "type": "object",
             "properties": {
@@ -9559,6 +9718,23 @@
                 }
             }
         },
+        "openapi.SearchResultListMetaJson": {
+            "type": "object",
+            "properties": {
+                "incompleteKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "truncatedKinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "routes.ConnectionScopesJson": {
             "type": "object",
             "properties": {
@@ -9624,20 +9800,6 @@
                 "value": {
                     "type": "string",
                     "example": "production"
-                }
-            }
-        },
-        "routes.MarkNotificationsViewedRequestJson": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "ntf_test550e8400abcde"
-                    ]
                 }
             }
         },
@@ -10161,13 +10323,31 @@
         "routes.OpenAPIListNotificationsResponseJson": {
             "description": "Paginated list of actor-visible notifications",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.NotificationJson"
+                    }
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ListMeta"
                 }
             }
         },
@@ -10196,6 +10376,74 @@
                     "items": {
                         "$ref": "#/definitions/api.MetricsSchemaMetricJson"
                     }
+                }
+            }
+        },
+        "routes.OpenAPINotificationBatchViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationBatchView"
+                    ],
+                    "example": "NotificationBatchView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewMetadataJson"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationBatchViewStatusJson"
+                }
+            }
+        },
+        "routes.OpenAPINotificationViewActionJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "NotificationView"
+                    ],
+                    "example": "NotificationView"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/v1alpha1.ActionMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.NotificationViewSpecJson"
+                },
+                "status": {
+                    "$ref": "#/definitions/openapi.NotificationViewStatusJson"
                 }
             }
         },
@@ -10307,18 +10555,27 @@
         },
         "routes.OpenAPISearchResourcesResponseJson": {
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "incompleteTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
-                    "description": "This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while\navoiding swaggo's inability to resolve same-package nested named types.",
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "required": [
+                            "resourceRef"
+                        ],
                         "properties": {
                             "labels": {
                                 "type": "object",
@@ -10333,30 +10590,17 @@
                                     "properties": {
                                         "key": {
                                             "type": "string",
-                                            "example": "name"
+                                            "example": "team"
                                         },
                                         "value": {
                                             "type": "string",
-                                            "example": "payments-production"
+                                            "example": "payments"
                                         }
                                     }
                                 }
                             },
-                            "name": {
-                                "type": "string",
-                                "example": "production-crm"
-                            },
-                            "namespace": {
-                                "type": "string",
-                                "example": "root.acme"
-                            },
-                            "resourceId": {
-                                "type": "string",
-                                "example": "cxn_test550e8400abcde"
-                            },
-                            "resourceType": {
-                                "type": "string",
-                                "example": "connection"
+                            "resourceRef": {
+                                "$ref": "#/definitions/meta.ObjectReference"
                             },
                             "updatedAt": {
                                 "type": "string"
@@ -10364,11 +10608,15 @@
                         }
                     }
                 },
-                "truncatedTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "SearchResultList"
+                    ],
+                    "example": "SearchResultList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.SearchResultListMetaJson"
                 }
             }
         },
@@ -10454,6 +10702,14 @@
                 "actorId": {
                     "type": "string",
                     "example": "act_test550e8400abcde"
+                }
+            }
+        },
+        "v1alpha1.ActionMeta": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "$ref": "#/definitions/meta.ObjectReference"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -700,6 +700,103 @@ definitions:
     - kind
     - metadata
     type: object
+  openapi.NotificationActionStatusJson:
+    properties:
+      url:
+        type: string
+    required:
+    - url
+    type: object
+  openapi.NotificationBatchViewMetadataJson:
+    properties:
+      targets:
+        items:
+          $ref: '#/definitions/meta.ObjectReference'
+        type: array
+    required:
+    - targets
+    type: object
+  openapi.NotificationBatchViewStatusJson:
+    properties:
+      viewedCount:
+        type: integer
+    type: object
+  openapi.NotificationJson:
+    description: Actor-visible, resource-shaped notification projection
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - Notification
+        example: Notification
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.NotificationSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    - status
+    type: object
+  openapi.NotificationSpecJson:
+    properties:
+      context:
+        type: object
+      key:
+        type: string
+      level:
+        enum:
+        - info
+        - warning
+        - error
+        example: warning
+        type: string
+      message:
+        type: string
+      resourceRef:
+        $ref: '#/definitions/meta.ObjectReference'
+      title:
+        type: string
+    required:
+    - key
+    - level
+    - message
+    - resourceRef
+    - title
+    type: object
+  openapi.NotificationStatusJson:
+    properties:
+      action:
+        $ref: '#/definitions/openapi.NotificationActionStatusJson'
+      resolvedAt:
+        type: string
+      state:
+        enum:
+        - active
+        - resolved
+        example: active
+        type: string
+      viewed:
+        type: boolean
+    required:
+    - state
+    type: object
+  openapi.NotificationViewSpecJson:
+    type: object
+  openapi.NotificationViewStatusJson:
+    properties:
+      viewed:
+        type: boolean
+    type: object
   openapi.RateLimitAlgorithmJson:
     properties:
       fixedWindow:
@@ -935,6 +1032,17 @@ definitions:
         example: 1
         type: number
     type: object
+  openapi.SearchResultListMetaJson:
+    properties:
+      incompleteKinds:
+        items:
+          type: string
+        type: array
+      truncatedKinds:
+        items:
+          type: string
+        type: array
+    type: object
   routes.ConnectionScopesJson:
     properties:
       granted:
@@ -981,15 +1089,6 @@ definitions:
       value:
         example: production
         type: string
-    type: object
-  routes.MarkNotificationsViewedRequestJson:
-    properties:
-      ids:
-        example:
-        - ntf_test550e8400abcde
-        items:
-          type: string
-        type: array
     type: object
   routes.OpenAPIConnectionDisconnectActionJson:
     properties:
@@ -1362,11 +1461,24 @@ definitions:
   routes.OpenAPIListNotificationsResponseJson:
     description: Paginated list of actor-visible notifications
     properties:
-      cursor:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
       items:
-        items: {}
+        items:
+          $ref: '#/definitions/openapi.NotificationJson'
         type: array
+      kind:
+        type: string
+      metadata:
+        $ref: '#/definitions/v1alpha1.ListMeta'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPIListRequestEventsResponse:
     description: Paginated list of request events entries
@@ -1386,6 +1498,54 @@ definitions:
         items:
           $ref: '#/definitions/api.MetricsSchemaMetricJson'
         type: array
+    type: object
+  routes.OpenAPINotificationBatchViewActionJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - NotificationBatchView
+        example: NotificationBatchView
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.NotificationBatchViewMetadataJson'
+      spec:
+        $ref: '#/definitions/openapi.NotificationViewSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationBatchViewStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  routes.OpenAPINotificationViewActionJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - NotificationView
+        example: NotificationView
+        type: string
+      metadata:
+        $ref: '#/definitions/v1alpha1.ActionMeta'
+      spec:
+        $ref: '#/definitions/openapi.NotificationViewSpecJson'
+      status:
+        $ref: '#/definitions/openapi.NotificationViewStatusJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPIProxyResponseJson:
     description: Response from a proxied HTTP request
@@ -1464,14 +1624,12 @@ definitions:
     type: object
   routes.OpenAPISearchResourcesResponseJson:
     properties:
-      incompleteTypes:
-        items:
-          type: string
-        type: array
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
       items:
-        description: |-
-          This anonymous shape mirrors schemaapi.SearchResourceSummaryJson while
-          avoiding swaggo's inability to resolve same-package nested named types.
         items:
           properties:
             labels:
@@ -1482,33 +1640,33 @@ definitions:
               items:
                 properties:
                   key:
-                    example: name
+                    example: team
                     type: string
                   value:
-                    example: payments-production
+                    example: payments
                     type: string
                 type: object
               type: array
-            name:
-              example: production-crm
-              type: string
-            namespace:
-              example: root.acme
-              type: string
-            resourceId:
-              example: cxn_test550e8400abcde
-              type: string
-            resourceType:
-              example: connection
-              type: string
+            resourceRef:
+              $ref: '#/definitions/meta.ObjectReference'
             updatedAt:
               type: string
+          required:
+          - resourceRef
           type: object
         type: array
-      truncatedTypes:
-        items:
-          type: string
-        type: array
+      kind:
+        enum:
+        - SearchResultList
+        example: SearchResultList
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.SearchResultListMetaJson'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPITaskInfoJson:
     description: Background task status
@@ -1567,6 +1725,11 @@ definitions:
       actorId:
         example: act_test550e8400abcde
         type: string
+    type: object
+  v1alpha1.ActionMeta:
+    properties:
+      target:
+        $ref: '#/definitions/meta.ObjectReference'
     type: object
   v1alpha1.ListMeta:
     properties:
@@ -6088,17 +6251,19 @@ paths:
       - application/json
       description: Mark multiple notifications viewed for the authenticated actor
       parameters:
-      - description: Notification IDs
+      - description: Notification batch view action
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/routes.MarkNotificationsViewedRequestJson'
+          $ref: '#/definitions/routes.OpenAPINotificationBatchViewActionJson'
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPINotificationBatchViewActionJson'
         "400":
           description: Bad Request
           schema:
@@ -6126,6 +6291,8 @@ paths:
       - notifications
   /notifications/{id}/_viewed:
     post:
+      consumes:
+      - application/json
       description: Mark a notification viewed for the authenticated actor
       parameters:
       - description: Notification ID
@@ -6133,11 +6300,19 @@ paths:
         name: id
         required: true
         type: string
+      - description: Notification view action
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/routes.OpenAPINotificationViewActionJson'
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.OpenAPINotificationViewActionJson'
         "400":
           description: Bad Request
           schema:
@@ -6774,11 +6949,11 @@ paths:
         name: mode
         type: string
       - collectionFormat: multi
-        description: Resource types; may be repeated
+        description: Resource kinds; may be repeated
         in: query
         items:
           type: string
-        name: resourceType
+        name: kind
         type: array
       - description: Case-insensitive literal resource-name or label-value substring
           (minimum 3 characters)


### PR DESCRIPTION
Closes #841

## Summary

- classify notifications as actor-specific, read-only resource-shaped projections and return `NotificationList`
- replace notification viewed mutations with typed `NotificationView` and `NotificationBatchView` actions
- return heterogeneous search results as `SearchResultList` projections with typed `resourceRef` identity and typed partial-result metadata
- replace the search `resourceType` query parameter with resource `kind`, explicitly rejecting the legacy parameter to avoid broadening old requests
- document the resource/projection boundary and regenerate the static schema and Swagger contracts

## Authorization and safety

- retain existing per-kind list/get permission filtering for search
- retain actor-specific notification visibility and action authorization in core
- omit notification action URLs unless the authenticated actor can perform the action

## Verification

- `go test ./...`
- `go test ./internal/routes ./internal/schema/api`
- `yarn docs:build`
- `./scripts/preflight.sh`