### PR TITLE
Migrate request events to v1alpha1 projections

### DIFF
--- a/docs/src/content/docs/operations/app-metrics.md
+++ b/docs/src/content/docs/operations/app-metrics.md
@@ -47,10 +47,77 @@ include namespace, connector, connection, method, status range, path, response
 source, rate-limit id, label selector, and timestamp range. Fetch one event at
 `GET /api/v1/metrics/request-events/{id}`.
 
+Request events use the `authproxy.net/v1alpha1` envelope, but they are immutable
+observations rather than resources with client-managed desired state. Event
+identity, namespace, the frozen label snapshot, and timestamp are in
+`metadata`; observed request and response facts are in `spec`. Resource
+attribution uses typed references. In particular, `connectorRef.generation`
+records the connector generation used for the request.
+
+```yaml
+apiVersion: authproxy.net/v1alpha1
+kind: RequestEvent
+metadata:
+  id: req_01example
+  namespace: root.acme
+  labels:
+    team: payments
+  createdAt: 2026-09-06T17:30:00Z
+spec:
+  requestType: proxy
+  correlationId: corr-123
+  durationMilliseconds: 150
+  namespaceRef:
+    apiVersion: authproxy.net/v1alpha1
+    kind: Namespace
+    id: root.acme
+  actorRef:
+    apiVersion: authproxy.net/v1alpha1
+    kind: Actor
+    id: act_01example
+    name: billing-service
+    namespace: root.acme
+  connectionRef:
+    apiVersion: authproxy.net/v1alpha1
+    kind: Connection
+    id: cxn_01example
+    name: production
+    namespace: root.acme
+  connectorRef:
+    apiVersion: authproxy.net/v1alpha1
+    kind: Connector
+    id: cxr_01example
+    name: provider
+    namespace: root.integrations
+    generation: 3
+  request:
+    method: GET
+    host: api.example.com
+    scheme: https
+    path: /v1/items
+  response:
+    statusCode: 200
+    source: upstream
+  captureAvailable: false
+```
+
+List responses use `kind: RequestEventList`; pagination is returned in
+`metadata.continue`, and the exact match count (when available) is returned in
+`metadata.total`. Existing request-event filters retain their current query
+parameter names, including `connectorVersion` for generation-specific queries.
+
 Full request and response payloads are separate encrypted blobs and exist only
 when `fullRequestRecording` is `always`. Keep recording at `never` unless the
 debugging or audit requirement justifies the additional sensitive data,
 storage, access control, and retention burden.
+
+When capture is present, `spec.capture` contains the original URL, headers, and
+request/response bodies; body values use base64 on the wire. These fields are
+not metadata and are redacted by default. AuthProxy returns unredacted capture
+only when the authenticated actor has `secrets:replay`; otherwise the response
+includes `X-AuthProxy-Data-Redacted: true` when capture fields were masked.
+Treat replayed data as sensitive even when a particular request appears
+harmless.
 
 ## Query API
 

--- a/internal/app_metrics/full_log.go
+++ b/internal/app_metrics/full_log.go
@@ -104,6 +104,11 @@ type FullLog struct {
 	RequestCancelled    bool                `json:"rc,omitempty"`
 	Request             FullLogRequest      `json:"req"`
 	Response            FullLogResponse     `json:"res"`
+
+	// Record is attached by StorageService after loading the searchable row.
+	// It is not persisted in the encrypted blob. API conversion uses it to
+	// preserve typed resource attribution alongside captured protocol data.
+	Record *LogRecord `json:"-"`
 }
 
 func (e *FullLog) GetId() apid.ID {

--- a/internal/app_metrics/log_record.go
+++ b/internal/app_metrics/log_record.go
@@ -8,13 +8,10 @@ import (
 	"github.com/rmorlok/authproxy/internal/httpf"
 )
 
-// LogRecord represents a record of an HTTP request as is stored in the request events. This
-// data is redacted to avoid containing sensitive information like information in headers. For a given
-// record, the full request may be stored as well, which would correspond to the data in the
-// Entry struct.
-//
-// JSON tagging on this struct is used so the same data structure can be passed directly to endpoint
-// responses. It is not use for internal storage.
+// LogRecord is the searchable, non-payload record stored for an HTTP request.
+// It contains no captured URL, headers, or body; those may be stored separately
+// in an encrypted FullLog. API routes convert this storage model to the public
+// RequestEvent projection rather than serializing it directly.
 type LogRecord struct {
 	Namespace           string              `json:"namespace"`
 	Type                httpf.RequestType   `json:"type"`

--- a/internal/app_metrics/storage_service.go
+++ b/internal/app_metrics/storage_service.go
@@ -121,6 +121,7 @@ func (ss *StorageService) GetFullLog(ctx context.Context, id apid.ID) (*FullLog,
 		}
 		return nil, err
 	}
+	fullLog.Record = log
 
 	return fullLog, nil
 }

--- a/internal/app_metrics/storage_service_test.go
+++ b/internal/app_metrics/storage_service_test.go
@@ -347,6 +347,15 @@ func TestGetFullLog_BlobStore(t *testing.T) {
 	require.Equal(t, original.Request.URL, result.Request.URL)
 	require.Equal(t, original.Request.Method, result.Request.Method)
 	require.Equal(t, original.Response.StatusCode, result.Response.StatusCode)
+	require.Nil(t, result.Record, "the encrypted blob does not duplicate the searchable record")
+
+	record := original.ToRecord()
+	serviceResult, err := (&StorageService{
+		retriever: &recordRetrieverStub{record: record},
+		fullStore: fullStore,
+	}).GetFullLog(context.Background(), testId)
+	require.NoError(t, err)
+	require.Same(t, record, serviceResult.Record)
 }
 
 func TestBlobStoreStore_ReturnsEncryptError(t *testing.T) {

--- a/internal/routes/request_event_conversion.go
+++ b/internal/routes/request_event_conversion.go
@@ -18,7 +18,10 @@ import (
 	ratelimitschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 )
 
-func requestEventToJSON(record *app_metrics.LogRecord, full *app_metrics.FullLog) *schemaapi.RequestEventJson {
+func requestEventToJSON(
+	record *app_metrics.LogRecord,
+	full *app_metrics.FullLog,
+) *schemaapi.RequestEventJson {
 	if record == nil {
 		return nil
 	}
@@ -130,6 +133,10 @@ func requestEventActorReference(labels database.Labels) *meta.ObjectReference {
 	return requestEventResourceReference(actorschema.ActorKind, id, 0, labels, "")
 }
 
+// requestEventResourceReference creates an object reference for the specified
+// id. The reference will always contain the id, and it will use best-effort
+// to extract the name/namespace from the labels of the request. For namespace
+// it will use the fallbackNamespace if no namespace is found.
 func requestEventResourceReference(
 	kind meta.Kind,
 	id apid.ID,
@@ -156,7 +163,11 @@ func requestEventResourceReference(
 	}
 }
 
-func requestEventRateLimit(id apid.ID, mode string, bucket map[string]string) *schemaapi.RequestEventRateLimitJson {
+func requestEventRateLimit(
+	id apid.ID,
+	mode string,
+	bucket map[string]string,
+) *schemaapi.RequestEventRateLimitJson {
 	return &schemaapi.RequestEventRateLimitJson{
 		RateLimitRef: meta.ObjectReference{
 			APIVersion: meta.APIVersionV1Alpha1,

--- a/internal/routes/request_event_conversion.go
+++ b/internal/routes/request_event_conversion.go
@@ -1,0 +1,196 @@
+package routes
+
+import (
+	"encoding/base64"
+	"fmt"
+	"maps"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/app_metrics"
+	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	namespaceschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	ratelimitschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+)
+
+func requestEventToJSON(record *app_metrics.LogRecord, full *app_metrics.FullLog) *schemaapi.RequestEventJson {
+	if record == nil {
+		return nil
+	}
+
+	_, systemLabels := database.SplitUserAndApxyLabels(record.Labels)
+	createdAt := record.Timestamp.UTC()
+	responseSource := record.ResponseSource
+	if responseSource == "" {
+		responseSource = app_metrics.ResponseSourceUpstream
+	}
+
+	resource := &schemaapi.RequestEventJson{
+		TypeMeta: meta.NewTypeMeta(schemaapi.RequestEventKind),
+		Metadata: meta.NormalizeObjectMeta(meta.ObjectMeta{
+			ID:        record.RequestId.String(),
+			Namespace: record.Namespace,
+			Labels:    maps.Clone(map[string]string(record.Labels)),
+			CreatedAt: &createdAt,
+		}),
+		Spec: schemaapi.RequestEventSpecJson{
+			RequestType:          record.Type,
+			CorrelationID:        record.CorrelationId,
+			DurationMilliseconds: record.MillisecondDuration.Duration().Milliseconds(),
+			NamespaceRef: meta.ObjectReference{
+				APIVersion: meta.APIVersionV1Alpha1,
+				Kind:       namespaceschema.NamespaceKind,
+				ID:         record.Namespace,
+			},
+			ActorRef: requestEventActorReference(systemLabels),
+			ConnectionRef: requestEventResourceReference(
+				connectionschema.ConnectionKind,
+				record.ConnectionId,
+				0,
+				systemLabels,
+				record.Namespace,
+			),
+			ConnectorRef: requestEventResourceReference(
+				connectorschema.ConnectorKind,
+				record.ConnectorId,
+				record.ConnectorVersion,
+				systemLabels,
+				record.Namespace,
+			),
+			Request: schemaapi.RequestEventRequestJson{
+				Method:      record.Method,
+				Host:        record.Host,
+				Scheme:      record.Scheme,
+				Path:        record.Path,
+				HTTPVersion: record.RequestHttpVersion,
+				SizeBytes:   record.RequestSizeBytes,
+				MIMEType:    record.RequestMimeType,
+				BodySkipped: string(record.RequestBodySkipped),
+			},
+			Response: schemaapi.RequestEventResponseJson{
+				StatusCode:  record.ResponseStatusCode,
+				Error:       record.ResponseError,
+				HTTPVersion: record.ResponseHttpVersion,
+				SizeBytes:   record.ResponseSizeBytes,
+				MIMEType:    record.ResponseMimeType,
+				BodySkipped: string(record.ResponseBodySkipped),
+				Source:      string(responseSource),
+			},
+			CaptureAvailable: record.FullRequestRecorded,
+			InternalTimeout:  record.InternalTimeout,
+			RequestCancelled: record.RequestCancelled,
+		},
+	}
+
+	if !record.RateLimitId.IsNil() {
+		resource.Spec.RateLimit = requestEventRateLimit(
+			record.RateLimitId,
+			record.RateLimitMode,
+			record.RateLimitBucket,
+		)
+	}
+	if len(record.RateLimitMatched) > 0 {
+		resource.Spec.RateLimitsMatched = make([]schemaapi.RequestEventRateLimitJson, 0, len(record.RateLimitMatched))
+		for _, match := range record.RateLimitMatched {
+			resource.Spec.RateLimitsMatched = append(resource.Spec.RateLimitsMatched, *requestEventRateLimit(
+				match.Id,
+				match.Mode,
+				match.Bucket,
+			))
+		}
+	}
+	if full != nil && full.Full {
+		resource.Spec.Capture = &schemaapi.RequestEventCaptureJson{
+			Request: schemaapi.RequestEventCapturedRequestJson{
+				URL:     full.Request.URL,
+				Headers: cloneHeader(full.Request.Headers),
+				Body:    encodeRequestEventBody(full.Request.Body),
+			},
+			Response: schemaapi.RequestEventCapturedResponseJson{
+				Headers: cloneHeader(full.Response.Headers),
+				Body:    encodeRequestEventBody(full.Response.Body),
+			},
+		}
+	}
+
+	return resource
+}
+
+func requestEventActorReference(labels database.Labels) *meta.ObjectReference {
+	actorID := labels[implicitResourceLabel(apid.PrefixActor, "id")]
+	id, err := apid.Parse(actorID)
+	if err != nil || id.ValidatePrefix(apid.PrefixActor) != nil {
+		return nil
+	}
+	return requestEventResourceReference(actorschema.ActorKind, id, 0, labels, "")
+}
+
+func requestEventResourceReference(
+	kind meta.Kind,
+	id apid.ID,
+	generation uint64,
+	labels database.Labels,
+	fallbackNamespace string,
+) *meta.ObjectReference {
+	if id.IsNil() {
+		return nil
+	}
+	token := database.ApidPrefixToLabelToken(id.Prefix())
+	name := labels[fmt.Sprintf("%s%s/-/name", meta.SystemLabelPrefix, token)]
+	namespace := labels[fmt.Sprintf("%s%s/-/ns", meta.SystemLabelPrefix, token)]
+	if namespace == "" {
+		namespace = fallbackNamespace
+	}
+	return &meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       kind,
+		ID:         id.String(),
+		Name:       common.ResourceName(name),
+		Namespace:  namespace,
+		Generation: generation,
+	}
+}
+
+func requestEventRateLimit(id apid.ID, mode string, bucket map[string]string) *schemaapi.RequestEventRateLimitJson {
+	return &schemaapi.RequestEventRateLimitJson{
+		RateLimitRef: meta.ObjectReference{
+			APIVersion: meta.APIVersionV1Alpha1,
+			Kind:       ratelimitschema.RateLimitKind,
+			ID:         id.String(),
+		},
+		Mode:   mode,
+		Bucket: maps.Clone(bucket),
+	}
+}
+
+func implicitResourceLabel(prefix apid.Prefix, field string) string {
+	return fmt.Sprintf(
+		"%s%s/-/%s",
+		meta.SystemLabelPrefix,
+		database.ApidPrefixToLabelToken(prefix),
+		field,
+	)
+}
+
+func encodeRequestEventBody(value []byte) string {
+	if len(value) == 0 {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(value)
+}
+
+func cloneHeader(value map[string][]string) map[string][]string {
+	if value == nil {
+		return make(map[string][]string)
+	}
+	result := make(map[string][]string, len(value))
+	for key, values := range value {
+		result[key] = append([]string(nil), values...)
+	}
+	return result
+}

--- a/internal/routes/request_event_conversion_test.go
+++ b/internal/routes/request_event_conversion_test.go
@@ -1,0 +1,145 @@
+package routes
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/app_metrics"
+	"github.com/rmorlok/authproxy/internal/apserde"
+	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/httpf"
+	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	namespaceschema "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	ratelimitschema "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestEventToJSONBuildsImmutableProjectionAndReferences(t *testing.T) {
+	requestID := apid.MustParse("req_test550e8400abcde")
+	actorID := apid.MustParse("act_test550e8400abcde")
+	connectionID := apid.MustParse("cxn_test550e8400abcde")
+	connectorID := apid.MustParse("cxr_test550e8400abcde")
+	rateLimitID := apid.MustParse("rl_test550e8400abcde")
+	timestamp := time.Date(2026, 9, 6, 12, 30, 0, 0, time.FixedZone("offset", -5*60*60))
+	record := &app_metrics.LogRecord{
+		Namespace:           "root.acme",
+		Type:                httpf.RequestTypeProxy,
+		RequestId:           requestID,
+		CorrelationId:       "corr-123",
+		Timestamp:           timestamp,
+		MillisecondDuration: app_metrics.MillisecondDuration(150 * time.Millisecond),
+		ConnectionId:        connectionID,
+		ConnectorId:         connectorID,
+		ConnectorVersion:    3,
+		Method:              "POST",
+		Host:                "api.example.com",
+		Scheme:              "https",
+		Path:                "/v1/items",
+		ResponseStatusCode:  429,
+		FullRequestRecorded: true,
+		Labels: database.Labels{
+			"team":            "payments",
+			"apxy/act/-/id":   actorID.String(),
+			"apxy/act/-/name": "service-actor",
+			"apxy/act/-/ns":   "root.acme",
+			"apxy/cxn/-/id":   connectionID.String(),
+			"apxy/cxn/-/name": "production",
+			"apxy/cxn/-/ns":   "root.acme",
+			"apxy/cxr/-/id":   connectorID.String(),
+			"apxy/cxr/-/name": "provider",
+			"apxy/cxr/-/ns":   "root.integrations",
+		},
+		ResponseSource:  app_metrics.ResponseSourceRateLimit,
+		RateLimitId:     rateLimitID,
+		RateLimitMode:   "enforce",
+		RateLimitBucket: map[string]string{"actor": actorID.String()},
+		RateLimitMatched: []app_metrics.RateLimitMatch{{
+			Id:   rateLimitID,
+			Mode: "enforce",
+		}},
+	}
+
+	event := requestEventToJSON(record, nil)
+	require.Equal(t, meta.NewTypeMeta("RequestEvent"), event.TypeMeta)
+	require.Equal(t, requestID.String(), event.Metadata.ID)
+	require.Equal(t, "root.acme", event.Metadata.Namespace)
+	require.Equal(t, map[string]string(record.Labels), event.Metadata.Labels)
+	require.Equal(t, timestamp.UTC(), *event.Metadata.CreatedAt)
+	require.Equal(t, namespaceschema.NamespaceKind, event.Spec.NamespaceRef.Kind)
+	require.Equal(t, "root.acme", event.Spec.NamespaceRef.ID)
+	require.Equal(t, actorschema.ActorKind, event.Spec.ActorRef.Kind)
+	require.Equal(t, actorID.String(), event.Spec.ActorRef.ID)
+	require.Equal(t, connectionschema.ConnectionKind, event.Spec.ConnectionRef.Kind)
+	require.Equal(t, "production", string(event.Spec.ConnectionRef.Name))
+	require.Equal(t, connectorschema.ConnectorKind, event.Spec.ConnectorRef.Kind)
+	require.Equal(t, uint64(3), event.Spec.ConnectorRef.Generation)
+	require.Equal(t, "root.integrations", event.Spec.ConnectorRef.Namespace)
+	require.Equal(t, ratelimitschema.RateLimitKind, event.Spec.RateLimit.RateLimitRef.Kind)
+	require.Equal(t, rateLimitID.String(), event.Spec.RateLimit.RateLimitRef.ID)
+	require.Len(t, event.Spec.RateLimitsMatched, 1)
+	require.True(t, event.Spec.CaptureAvailable)
+	require.Nil(t, event.Spec.Capture)
+}
+
+func TestRequestEventCaptureUsesSecretReplayRedaction(t *testing.T) {
+	record := &app_metrics.LogRecord{
+		Namespace:           "root",
+		Type:                httpf.RequestTypeProxy,
+		RequestId:           apid.MustParse("req_test550e8400abcde"),
+		Timestamp:           time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC),
+		MillisecondDuration: app_metrics.MillisecondDuration(time.Millisecond),
+		Method:              "POST",
+		Host:                "api.example.com",
+		Scheme:              "https",
+		Path:                "/token",
+		FullRequestRecorded: true,
+	}
+	full := &app_metrics.FullLog{
+		Full: true,
+		Request: app_metrics.FullLogRequest{
+			URL:     "https://api.example.com/token?api_key=secret",
+			Headers: map[string][]string{"Authorization": {"Bearer secret"}},
+			Body:    []byte(`{"client_secret":"secret"}`),
+		},
+		Response: app_metrics.FullLogResponse{
+			Headers: map[string][]string{"Set-Cookie": {"session=secret"}},
+			Body:    []byte(`{"access_token":"secret"}`),
+		},
+	}
+	event := requestEventToJSON(record, full)
+	require.NotNil(t, event.Spec.Capture)
+	require.Equal(t, base64.StdEncoding.EncodeToString(full.Request.Body), event.Spec.Capture.Request.Body)
+	require.Equal(t, base64.StdEncoding.EncodeToString(full.Response.Body), event.Spec.Capture.Response.Body)
+
+	redacted, report, err := apserde.MarshalJSONForAPI(context.Background(), event)
+	require.NoError(t, err)
+	require.True(t, report.Redacted)
+	require.NotContains(t, string(redacted), "secret")
+	require.Contains(t, string(redacted), "***")
+
+	replayed, report, err := apserde.MarshalJSONForAPI(
+		apserde.WithSecretReplay(context.Background(), true),
+		event,
+	)
+	require.NoError(t, err)
+	require.False(t, report.Redacted)
+	require.Contains(t, string(replayed), "Bearer secret")
+	require.Contains(t, string(replayed), "api_key=secret")
+}
+
+func TestRequestEventToJSONOmitsUnavailableReferences(t *testing.T) {
+	event := requestEventToJSON(&app_metrics.LogRecord{
+		Namespace: "root",
+		RequestId: apid.MustParse("req_test550e8400abcde"),
+	}, nil)
+	require.Nil(t, event.Spec.ActorRef)
+	require.Nil(t, event.Spec.ConnectionRef)
+	require.Nil(t, event.Spec.ConnectorRef)
+	require.Nil(t, event.Spec.RateLimit)
+}

--- a/internal/routes/request_events.go
+++ b/internal/routes/request_events.go
@@ -18,7 +18,6 @@ import (
 	sapi "github.com/rmorlok/authproxy/internal/schema/api"
 	schemaapiopenapi "github.com/rmorlok/authproxy/internal/schema/api/openapi"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
-	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/rmorlok/authproxy/internal/util/pagination"
 )
 
@@ -150,58 +149,6 @@ func (q *ListRequestEventsQuery) ApplyToBuilder(
 	}
 
 	return b, nil
-}
-
-type ListRequestEventsResponseJson = sapi.ListRequestEventsResponseJson
-
-func requestEventToJson(r *app_metrics.LogRecord) *sapi.RequestEventJson {
-	if r == nil {
-		return nil
-	}
-
-	matches := make([]sapi.RequestEventRateLimit, len(r.RateLimitMatched))
-	for i, m := range r.RateLimitMatched {
-		matches[i] = sapi.RequestEventRateLimit{
-			Id:     m.Id,
-			Mode:   m.Mode,
-			Bucket: m.Bucket,
-		}
-	}
-
-	return &sapi.RequestEventJson{
-		Namespace:           r.Namespace,
-		Type:                string(r.Type),
-		RequestId:           r.RequestId,
-		CorrelationId:       r.CorrelationId,
-		Timestamp:           r.Timestamp,
-		MillisecondDuration: int64(r.MillisecondDuration.Duration() / time.Millisecond),
-		ConnectionId:        r.ConnectionId,
-		ConnectorId:         r.ConnectorId,
-		ConnectorVersion:    r.ConnectorVersion,
-		Method:              r.Method,
-		Host:                r.Host,
-		Scheme:              r.Scheme,
-		Path:                r.Path,
-		RequestHttpVersion:  r.RequestHttpVersion,
-		RequestSizeBytes:    r.RequestSizeBytes,
-		RequestMimeType:     r.RequestMimeType,
-		RequestBodySkipped:  string(r.RequestBodySkipped),
-		ResponseStatusCode:  r.ResponseStatusCode,
-		ResponseError:       r.ResponseError,
-		ResponseHttpVersion: r.ResponseHttpVersion,
-		ResponseSizeBytes:   r.ResponseSizeBytes,
-		ResponseMimeType:    r.ResponseMimeType,
-		ResponseBodySkipped: string(r.ResponseBodySkipped),
-		InternalTimeout:     r.InternalTimeout,
-		RequestCancelled:    r.RequestCancelled,
-		FullRequestRecorded: r.FullRequestRecorded,
-		Labels:              r.Labels,
-		ResponseSource:      string(r.ResponseSource),
-		RateLimitId:         r.RateLimitId,
-		RateLimitMode:       r.RateLimitMode,
-		RateLimitBucket:     r.RateLimitBucket,
-		RateLimitMatched:    matches,
-	}
 }
 
 func metricsQueryToRequestEventQuery(
@@ -516,7 +463,7 @@ func metricsSeriesGroupKey(labels map[string]string) string {
 }
 
 // @Summary		Get request events entry
-// @Description	Get a specific request events entry by its UUID
+// @Description	Get a specific immutable request event by its ID
 // @Tags			request-events
 // @Accept			json
 // @Produce		json
@@ -572,11 +519,15 @@ func (r *RequestEventsRoutes) get(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, http.StatusOK, entry)
+	record := entry.Record
+	if record == nil {
+		record = entry.ToRecord()
+	}
+	apgin.APIJSON(gctx, http.StatusOK, requestEventToJSON(record, entry))
 }
 
 // @Summary		List request events entries
-// @Description	List request events entries with optional filtering and pagination
+// @Description	List immutable request-event projections with optional filtering and pagination
 // @Tags			request-events
 // @Accept			json
 // @Produce		json
@@ -668,11 +619,13 @@ func (r *RequestEventsRoutes) list(gctx *gin.Context) {
 		return
 	}
 
-	apgin.APIJSON(gctx, 200, &ListRequestEventsResponseJson{
-		Items:  util.Map(auth.FilterForValidatedResources(val, result.Results), requestEventToJson),
-		Cursor: result.Cursor,
-		Total:  result.Total,
-	})
+	filtered := auth.FilterForValidatedResources(val, result.Results)
+	items := make([]sapi.RequestEventJson, 0, len(filtered))
+	for _, record := range filtered {
+		items = append(items, *requestEventToJSON(record, nil))
+	}
+	response := sapi.NewListRequestEventsResponseJson(items, result.Cursor, result.Total)
+	apgin.APIJSON(gctx, http.StatusOK, &response)
 }
 
 // @Summary		Query application metrics

--- a/internal/routes/request_events_test.go
+++ b/internal/routes/request_events_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/app_metrics"
 	"github.com/rmorlok/authproxy/internal/app_metrics/mock"
+	"github.com/rmorlok/authproxy/internal/apserde"
 	"github.com/rmorlok/authproxy/internal/config"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/httpf"
@@ -101,7 +102,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ListRequestEventsResponseJson
+			var resp sapi.ListRequestEventsResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 0)
@@ -189,11 +190,11 @@ func TestRequestEventsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ListRequestEventsResponseJson
+			var resp sapi.ListRequestEventsResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 1)
-			require.Equal(t, resp.Items[0].RequestId, id)
+			require.Equal(t, id.String(), resp.Items[0].Metadata.ID)
 		})
 
 		t.Run("multiple pages of results", func(t *testing.T) {
@@ -232,11 +233,11 @@ func TestRequestEventsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ListRequestEventsResponseJson
+			var resp sapi.ListRequestEventsResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 1)
-			require.Equal(t, resp.Cursor, "next-cursor")
+			require.Equal(t, "next-cursor", resp.Metadata.Continue)
 		})
 
 		t.Run("from cursor", func(t *testing.T) {
@@ -274,7 +275,7 @@ func TestRequestEventsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ListRequestEventsResponseJson
+			var resp sapi.ListRequestEventsResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 1)
@@ -414,6 +415,16 @@ func TestRequestEventsRoutes(t *testing.T) {
 				Id:        testId,
 				Namespace: "root",
 				Timestamp: time.Now().UTC(),
+				Full:      true,
+				Request: app_metrics.FullLogRequest{
+					URL:     "https://api.example.com/items?api_key=secret",
+					Headers: map[string][]string{"Authorization": {"Bearer secret"}},
+					Body:    []byte("secret request body"),
+				},
+				Response: app_metrics.FullLogResponse{
+					Headers: map[string][]string{"Set-Cookie": {"session=secret"}},
+					Body:    []byte("secret response body"),
+				},
 			}
 
 			tu.MockRetriever.EXPECT().
@@ -422,6 +433,51 @@ func TestRequestEventsRoutes(t *testing.T) {
 
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, "true", w.Header().Get(apserde.RedactedHeader))
+			require.NotContains(t, w.Body.String(), "Bearer secret")
+
+			var response sapi.RequestEventJson
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.Equal(t, testId.String(), response.Metadata.ID)
+			require.NotNil(t, response.Spec.Capture)
+		})
+
+		t.Run("valid with secret replay", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			permissions := append(
+				aschema.PermissionsSingle("root.**", "request-events", "get"),
+				aschema.PermissionsSingle("root.**", apserde.SecretResource, apserde.SecretReplayVerb)...,
+			)
+			req, err := tu.AuthUtil.NewSignedRequestForActorExternalId(
+				http.MethodGet,
+				"/metrics/request-events/"+testId.String(),
+				nil,
+				"root",
+				"some-actor",
+				permissions,
+			)
+			require.NoError(t, err)
+
+			entry := &app_metrics.FullLog{
+				Id:        testId,
+				Namespace: "root",
+				Timestamp: time.Now().UTC(),
+				Full:      true,
+				Request: app_metrics.FullLogRequest{
+					URL:     "https://api.example.com/items?api_key=secret",
+					Headers: map[string][]string{"Authorization": {"Bearer secret"}},
+				},
+			}
+
+			tu.MockRetriever.EXPECT().
+				GetFullLog(gomock.Any(), testId).
+				Return(entry, nil)
+
+			tu.Gin.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Empty(t, w.Header().Get(apserde.RedactedHeader))
+			require.Contains(t, w.Body.String(), "Bearer secret")
+			require.Contains(t, w.Body.String(), "api_key=secret")
 		})
 	})
 
@@ -464,11 +520,11 @@ func TestRequestEventsRoutes(t *testing.T) {
 			tu.Gin.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 
-			var resp ListRequestEventsResponseJson
+			var resp sapi.ListRequestEventsResponseJson
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err)
 			require.Len(t, resp.Items, 1)
-			require.Equal(t, id, resp.Items[0].RequestId)
+			require.Equal(t, id.String(), resp.Items[0].Metadata.ID)
 
 			// Verify the label_selector was passed to the builder
 			require.NotNil(t, b.LabelSelector)
@@ -520,7 +576,8 @@ func TestRequestEventsRoutes(t *testing.T) {
 			require.Len(t, items, 1)
 
 			item := items[0].(map[string]interface{})
-			labels := item["labels"].(map[string]interface{})
+			metadata := item["metadata"].(map[string]interface{})
+			labels := metadata["labels"].(map[string]interface{})
 			require.Equal(t, "prod", labels["env"])
 			require.Equal(t, "us-east", labels["region"])
 		})
@@ -569,7 +626,8 @@ func TestRequestEventsRoutes(t *testing.T) {
 			require.Len(t, items, 1)
 
 			item := items[0].(map[string]interface{})
-			_, hasLabels := item["labels"]
+			metadata := item["metadata"].(map[string]interface{})
+			_, hasLabels := metadata["labels"]
 			require.False(t, hasLabels, "labels should be omitted from JSON when nil")
 		})
 	})

--- a/internal/schema/api/README.md
+++ b/internal/schema/api/README.md
@@ -25,6 +25,14 @@ resource. Search items are heterogeneous summaries, not partial resources.
 truncation/incompleteness observations in projection metadata. Notification
 view mutations use typed action contracts.
 
+Request events are immutable, resource-shaped observations rather than
+client-managed desired resources. `RequestEventJson` uses resource metadata for
+the event identity, namespace, label snapshot, and creation time. Its `spec`
+contains the observed exchange, typed references to attributed resources, and
+optional captured protocol data. Capture fields remain explicitly tagged for
+the API secret-replay policy. `RequestEventList` uses list metadata for its
+opaque continuation token and exact result total.
+
 OpenAPI-only generator adapters live under `internal/schema/api/openapi`. Keep
 those adapters thin: they may compose API DTOs and canonical resources for 
 documentation, but no runtime contract or behavior may depend on them.

--- a/internal/schema/api/auxiliary.go
+++ b/internal/schema/api/auxiliary.go
@@ -43,54 +43,6 @@ type PutKeyValueRequestJson struct {
 	Value string `json:"value" yaml:"value" example:"production"`
 }
 
-// RequestEventJson documents the public request-event record projection.
-type RequestEventJson struct {
-	Namespace           string                  `json:"namespace" yaml:"namespace" example:"root.acme"`
-	Type                string                  `json:"type" yaml:"type" example:"proxy"`
-	RequestId           apid.ID                 `json:"requestId" yaml:"requestId" swaggertype:"string" example:"req_test550e8400abcde"`
-	CorrelationId       string                  `json:"correlationId,omitempty" yaml:"correlationId,omitempty"`
-	Timestamp           time.Time               `json:"timestamp" yaml:"timestamp"`
-	MillisecondDuration int64                   `json:"duration" yaml:"duration" example:"150"`
-	ConnectionId        apid.ID                 `json:"connectionId,omitempty" yaml:"connectionId,omitempty" swaggertype:"string"`
-	ConnectorId         apid.ID                 `json:"connectorId,omitempty" yaml:"connectorId,omitempty" swaggertype:"string"`
-	ConnectorVersion    uint64                  `json:"connectorVersion,omitempty" yaml:"connectorVersion,omitempty"`
-	Method              string                  `json:"method" yaml:"method" example:"GET"`
-	Host                string                  `json:"host" yaml:"host" example:"api.example.com"`
-	Scheme              string                  `json:"scheme" yaml:"scheme" example:"https"`
-	Path                string                  `json:"path" yaml:"path" example:"/v1/users"`
-	RequestHttpVersion  string                  `json:"requestHttpVersion,omitempty" yaml:"requestHttpVersion,omitempty"`
-	RequestSizeBytes    int64                   `json:"requestSizeBytes,omitempty" yaml:"requestSizeBytes,omitempty"`
-	RequestMimeType     string                  `json:"requestMimeType,omitempty" yaml:"requestMimeType,omitempty"`
-	RequestBodySkipped  string                  `json:"requestBodySkipped,omitempty" yaml:"requestBodySkipped,omitempty"`
-	ResponseStatusCode  int                     `json:"responseStatusCode,omitempty" yaml:"responseStatusCode,omitempty" example:"200"`
-	ResponseError       string                  `json:"responseError,omitempty" yaml:"responseError,omitempty"`
-	ResponseHttpVersion string                  `json:"responseHttpVersion,omitempty" yaml:"responseHttpVersion,omitempty"`
-	ResponseSizeBytes   int64                   `json:"responseSizeBytes,omitempty" yaml:"responseSizeBytes,omitempty"`
-	ResponseMimeType    string                  `json:"responseMimeType,omitempty" yaml:"responseMimeType,omitempty"`
-	ResponseBodySkipped string                  `json:"responseBodySkipped,omitempty" yaml:"responseBodySkipped,omitempty"`
-	InternalTimeout     bool                    `json:"internalTimeout,omitempty" yaml:"internalTimeout,omitempty"`
-	RequestCancelled    bool                    `json:"requestCancelled,omitempty" yaml:"requestCancelled,omitempty"`
-	FullRequestRecorded bool                    `json:"fullRequestRecorded,omitempty" yaml:"fullRequestRecorded,omitempty"`
-	Labels              map[string]string       `json:"labels,omitempty" yaml:"labels,omitempty"`
-	ResponseSource      string                  `json:"responseSource,omitempty" yaml:"responseSource,omitempty" example:"upstream"`
-	RateLimitId         apid.ID                 `json:"rateLimitId,omitempty" yaml:"rateLimitId,omitempty" swaggertype:"string"`
-	RateLimitMode       string                  `json:"rateLimitMode,omitempty" yaml:"rateLimitMode,omitempty"`
-	RateLimitBucket     map[string]string       `json:"rateLimitBucket,omitempty" yaml:"rateLimitBucket,omitempty"`
-	RateLimitMatched    []RequestEventRateLimit `json:"rateLimitMatched,omitempty" yaml:"rateLimitMatched,omitempty"`
-}
-
-type RequestEventRateLimit struct {
-	Id     apid.ID           `json:"id" yaml:"id" swaggertype:"string" example:"rl_test550e8400abcde"`
-	Mode   string            `json:"mode" yaml:"mode" example:"enforce"`
-	Bucket map[string]string `json:"bucket,omitempty" yaml:"bucket,omitempty"`
-}
-
-type ListRequestEventsResponseJson struct {
-	Items  []*RequestEventJson `json:"items" yaml:"items"`
-	Cursor string              `json:"cursor,omitempty" yaml:"cursor,omitempty"`
-	Total  *int64              `json:"total,omitempty" yaml:"total,omitempty"`
-}
-
 type TaskState string
 
 const (

--- a/internal/schema/api/list_test.go
+++ b/internal/schema/api/list_test.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestManagedListConstructorsUseV1Alpha1Envelope(t *testing.T) {
+func TestListConstructorsUseV1Alpha1Envelope(t *testing.T) {
 	tests := []struct {
 		name         string
 		expectedKind string
@@ -22,6 +22,7 @@ func TestManagedListConstructorsUseV1Alpha1Envelope(t *testing.T) {
 		{name: "keys", expectedKind: "KeyList", value: NewListKeysResponseJson(nil, "next")},
 		{name: "rate limits", expectedKind: "RateLimitList", value: NewListRateLimitsResponseJson(nil, "next")},
 		{name: "notifications", expectedKind: "NotificationList", value: NewListNotificationsResponseJson(nil, "next")},
+		{name: "request events", expectedKind: "RequestEventList", value: NewListRequestEventsResponseJson(nil, "next", nil)},
 	}
 
 	for _, tt := range tests {

--- a/internal/schema/api/openapi/list_responses.go
+++ b/internal/schema/api/openapi/list_responses.go
@@ -405,46 +405,11 @@ type ListKeysResponseJson struct {
 	Items []KeyJson `json:"items" binding:"required"`
 }
 
-// ListRequestEventsResponseJson documents the paginated request-events list response.
-//
-//	@Description	Paginated list of request events entries
-type ListRequestEventsResponseJson struct {
-	Items  []interface{} `json:"items"`
-	Cursor string        `json:"cursor,omitempty"`
-	Total  *int64        `json:"total,omitempty"`
-}
-
 // MetricsSchemaResponseJson documents the metrics schema response.
 //
 //	@Description	Application metrics schema response
 type MetricsSchemaResponseJson struct {
 	Metrics []schemaapi.MetricsSchemaMetricJson `json:"metrics"`
-}
-
-// RequestEventJson documents the public request-event record projection.
-//
-//	@Description	HTTP request events entry
-type RequestEventJson struct {
-	Namespace           string            `json:"namespace" example:"root.acme"`
-	Type                string            `json:"type" example:"proxy"`
-	RequestId           string            `json:"requestId" swaggertype:"string" example:"req_test550e8400abcde"`
-	CorrelationId       string            `json:"correlationId,omitempty"`
-	Timestamp           time.Time         `json:"timestamp"`
-	MillisecondDuration int64             `json:"duration" example:"150"`
-	ConnectionId        string            `json:"connectionId,omitempty" swaggertype:"string"`
-	ConnectorId         string            `json:"connectorId,omitempty" swaggertype:"string"`
-	ConnectorVersion    uint64            `json:"connectorVersion,omitempty"`
-	Method              string            `json:"method" example:"GET"`
-	Host                string            `json:"host" example:"api.example.com"`
-	Scheme              string            `json:"scheme" example:"https"`
-	Path                string            `json:"path" example:"/v1/users"`
-	ResponseStatusCode  int               `json:"responseStatusCode,omitempty" example:"200"`
-	Labels              map[string]string `json:"labels,omitempty"`
-	ResponseSource      string            `json:"responseSource,omitempty" example:"upstream"`
-	RateLimitId         string            `json:"rateLimitId,omitempty" swaggertype:"string"`
-	RateLimitMode       string            `json:"rateLimitMode,omitempty"`
-	RateLimitBucket     map[string]string `json:"rateLimitBucket,omitempty"`
-	RateLimitMatched    []interface{}     `json:"rateLimitMatched,omitempty"`
 }
 
 // TaskInfoJson documents public background task status.

--- a/internal/schema/api/openapi/request_events.go
+++ b/internal/schema/api/openapi/request_events.go
@@ -1,0 +1,126 @@
+package openapi
+
+import "github.com/rmorlok/authproxy/internal/schema/resources/meta"
+
+type RequestEventNamespaceReferenceJson struct {
+	APIVersion string `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string `json:"kind" binding:"required" enums:"Namespace" example:"Namespace"`
+	ID         string `json:"id" binding:"required" example:"root.acme"`
+}
+
+type RequestEventActorReferenceJson struct {
+	APIVersion string `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string `json:"kind" binding:"required" enums:"Actor" example:"Actor"`
+	ID         string `json:"id" binding:"required" example:"act_01example"`
+	Name       string `json:"name,omitempty" example:"billing-service"`
+	Namespace  string `json:"namespace,omitempty" example:"root.acme"`
+}
+
+type RequestEventConnectionReferenceJson struct {
+	APIVersion string `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string `json:"kind" binding:"required" enums:"Connection" example:"Connection"`
+	ID         string `json:"id" binding:"required" example:"cxn_01example"`
+	Name       string `json:"name,omitempty" example:"production"`
+	Namespace  string `json:"namespace,omitempty" example:"root.acme"`
+}
+
+type RequestEventConnectorReferenceJson struct {
+	APIVersion string `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string `json:"kind" binding:"required" enums:"Connector" example:"Connector"`
+	ID         string `json:"id" binding:"required" example:"cxr_01example"`
+	Name       string `json:"name,omitempty" example:"provider"`
+	Namespace  string `json:"namespace,omitempty" example:"root.integrations"`
+	Generation uint64 `json:"generation,omitempty" example:"3"`
+}
+
+type RequestEventRateLimitReferenceJson struct {
+	APIVersion string `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string `json:"kind" binding:"required" enums:"RateLimit" example:"RateLimit"`
+	ID         string `json:"id" binding:"required" example:"rl_01example"`
+}
+
+type RequestEventRequestJson struct {
+	Method      string `json:"method" binding:"required" example:"GET"`
+	Host        string `json:"host" binding:"required" example:"api.example.com"`
+	Scheme      string `json:"scheme" binding:"required" example:"https"`
+	Path        string `json:"path" binding:"required" example:"/v1/users"`
+	HTTPVersion string `json:"httpVersion,omitempty" example:"HTTP/2.0"`
+	SizeBytes   int64  `json:"sizeBytes,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty" example:"application/json"`
+	BodySkipped string `json:"bodySkipped,omitempty" enums:"streaming,too_large"`
+}
+
+type RequestEventResponseJson struct {
+	StatusCode  int    `json:"statusCode,omitempty" example:"200"`
+	Error       string `json:"error,omitempty"`
+	HTTPVersion string `json:"httpVersion,omitempty" example:"HTTP/2.0"`
+	SizeBytes   int64  `json:"sizeBytes,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty" example:"application/json"`
+	BodySkipped string `json:"bodySkipped,omitempty" enums:"streaming,too_large"`
+	Source      string `json:"source,omitempty" enums:"upstream,connector_rate_limiter,rate_limit" example:"upstream"`
+}
+
+type RequestEventCapturedRequestJson struct {
+	URL     string              `json:"url" binding:"required" example:"https://api.example.com/v1/users"`
+	Headers map[string][]string `json:"headers" binding:"required"`
+	Body    []byte              `json:"body,omitempty" swaggertype:"string" format:"byte"`
+}
+
+type RequestEventCapturedResponseJson struct {
+	Headers map[string][]string `json:"headers" binding:"required"`
+	Body    []byte              `json:"body,omitempty" swaggertype:"string" format:"byte"`
+}
+
+type RequestEventCaptureJson struct {
+	Request  RequestEventCapturedRequestJson  `json:"request" binding:"required"`
+	Response RequestEventCapturedResponseJson `json:"response" binding:"required"`
+}
+
+type RequestEventRateLimitJson struct {
+	RateLimitRef RequestEventRateLimitReferenceJson `json:"rateLimitRef" binding:"required"`
+	Mode         string                             `json:"mode" binding:"required" enums:"enforce,observe" example:"enforce"`
+	Bucket       map[string]string                  `json:"bucket,omitempty"`
+}
+
+type RequestEventSpecJson struct {
+	RequestType          string                               `json:"requestType" binding:"required" enums:"global,proxy,oauth,public,probe" example:"proxy"`
+	CorrelationID        string                               `json:"correlationId,omitempty"`
+	DurationMilliseconds int64                                `json:"durationMilliseconds" binding:"required" example:"150"`
+	NamespaceRef         RequestEventNamespaceReferenceJson   `json:"namespaceRef" binding:"required"`
+	ActorRef             *RequestEventActorReferenceJson      `json:"actorRef,omitempty"`
+	ConnectionRef        *RequestEventConnectionReferenceJson `json:"connectionRef,omitempty"`
+	ConnectorRef         *RequestEventConnectorReferenceJson  `json:"connectorRef,omitempty"`
+	Request              RequestEventRequestJson              `json:"request" binding:"required"`
+	Response             RequestEventResponseJson             `json:"response" binding:"required"`
+	CaptureAvailable     bool                                 `json:"captureAvailable"`
+	Capture              *RequestEventCaptureJson             `json:"capture,omitempty"`
+	RateLimit            *RequestEventRateLimitJson           `json:"rateLimit,omitempty"`
+	RateLimitsMatched    []RequestEventRateLimitJson          `json:"rateLimitsMatched,omitempty"`
+	InternalTimeout      bool                                 `json:"internalTimeout,omitempty"`
+	RequestCancelled     bool                                 `json:"requestCancelled,omitempty"`
+}
+
+// RequestEventJson documents an immutable, resource-shaped event projection.
+//
+//	@Description	Immutable, resource-shaped HTTP request event projection
+type RequestEventJson struct {
+	APIVersion string               `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string               `json:"kind" binding:"required" enums:"RequestEvent" example:"RequestEvent"`
+	Metadata   meta.ObjectMeta      `json:"metadata" binding:"required"`
+	Spec       RequestEventSpecJson `json:"spec" binding:"required"`
+}
+
+type RequestEventListMetaJson struct {
+	Continue string `json:"continue,omitempty"`
+	Total    *int64 `json:"total,omitempty"`
+}
+
+// ListRequestEventsResponseJson documents the request-event projection list.
+//
+//	@Description	Paginated list of immutable request-event projections
+type ListRequestEventsResponseJson struct {
+	APIVersion string                   `json:"apiVersion" binding:"required" enums:"authproxy.net/v1alpha1" example:"authproxy.net/v1alpha1"`
+	Kind       string                   `json:"kind" binding:"required" enums:"RequestEventList" example:"RequestEventList"`
+	Metadata   RequestEventListMetaJson `json:"metadata" binding:"required"`
+	Items      []RequestEventJson       `json:"items" binding:"required"`
+}

--- a/internal/schema/api/request_events.go
+++ b/internal/schema/api/request_events.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+)
+
+const RequestEventKind meta.Kind = "RequestEvent"
+
+// RequestEventJson is an immutable, resource-shaped observation of one HTTP
+// exchange. It is an event projection, not a client-managed desired resource.
+// Captured protocol data remains in Spec.Capture and is always subject to the
+// API secret-replay policy.
+//
+//	@Description	Immutable, resource-shaped HTTP request event projection
+type RequestEventJson struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      meta.ObjectMeta      `json:"metadata" yaml:"metadata"`
+	Spec          RequestEventSpecJson `json:"spec" yaml:"spec"`
+}
+
+type RequestEventSpecJson struct {
+	RequestType          common.RequestType          `json:"requestType" yaml:"requestType"`
+	CorrelationID        string                      `json:"correlationId,omitempty" yaml:"correlationId,omitempty"`
+	DurationMilliseconds int64                       `json:"durationMilliseconds" yaml:"durationMilliseconds"`
+	NamespaceRef         meta.ObjectReference        `json:"namespaceRef" yaml:"namespaceRef"`
+	ActorRef             *meta.ObjectReference       `json:"actorRef,omitempty" yaml:"actorRef,omitempty"`
+	ConnectionRef        *meta.ObjectReference       `json:"connectionRef,omitempty" yaml:"connectionRef,omitempty"`
+	ConnectorRef         *meta.ObjectReference       `json:"connectorRef,omitempty" yaml:"connectorRef,omitempty"`
+	Request              RequestEventRequestJson     `json:"request" yaml:"request"`
+	Response             RequestEventResponseJson    `json:"response" yaml:"response"`
+	CaptureAvailable     bool                        `json:"captureAvailable" yaml:"captureAvailable"`
+	Capture              *RequestEventCaptureJson    `json:"capture,omitempty" yaml:"capture,omitempty"`
+	RateLimit            *RequestEventRateLimitJson  `json:"rateLimit,omitempty" yaml:"rateLimit,omitempty"`
+	RateLimitsMatched    []RequestEventRateLimitJson `json:"rateLimitsMatched,omitempty" yaml:"rateLimitsMatched,omitempty"`
+	InternalTimeout      bool                        `json:"internalTimeout,omitempty" yaml:"internalTimeout,omitempty"`
+	RequestCancelled     bool                        `json:"requestCancelled,omitempty" yaml:"requestCancelled,omitempty"`
+}
+
+type RequestEventRequestJson struct {
+	Method      string `json:"method" yaml:"method"`
+	Host        string `json:"host" yaml:"host"`
+	Scheme      string `json:"scheme" yaml:"scheme"`
+	Path        string `json:"path" yaml:"path"`
+	HTTPVersion string `json:"httpVersion,omitempty" yaml:"httpVersion,omitempty"`
+	SizeBytes   int64  `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty" yaml:"mimeType,omitempty"`
+	BodySkipped string `json:"bodySkipped,omitempty" yaml:"bodySkipped,omitempty"`
+}
+
+type RequestEventResponseJson struct {
+	StatusCode  int    `json:"statusCode,omitempty" yaml:"statusCode,omitempty"`
+	Error       string `json:"error,omitempty" yaml:"error,omitempty"`
+	HTTPVersion string `json:"httpVersion,omitempty" yaml:"httpVersion,omitempty"`
+	SizeBytes   int64  `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty" yaml:"mimeType,omitempty"`
+	BodySkipped string `json:"bodySkipped,omitempty" yaml:"bodySkipped,omitempty"`
+	Source      string `json:"source,omitempty" yaml:"source,omitempty"`
+}
+
+// RequestEventCaptureJson contains the optional encrypted full-log material.
+// Its sensitive members are redacted unless the caller has secrets/replay.
+type RequestEventCaptureJson struct {
+	Request  RequestEventCapturedRequestJson  `json:"request" yaml:"request"`
+	Response RequestEventCapturedResponseJson `json:"response" yaml:"response"`
+}
+
+type RequestEventCapturedRequestJson struct {
+	URL     string              `json:"url" yaml:"url" apiredact:"secret"`
+	Headers map[string][]string `json:"headers" yaml:"headers" apiredact:"secret"`
+	// Body is the captured body encoded as base64 for the JSON/YAML wire format.
+	Body string `json:"body,omitempty" yaml:"body,omitempty" apiredact:"secret"`
+}
+
+type RequestEventCapturedResponseJson struct {
+	Headers map[string][]string `json:"headers" yaml:"headers" apiredact:"secret"`
+	// Body is the captured body encoded as base64 for the JSON/YAML wire format.
+	Body string `json:"body,omitempty" yaml:"body,omitempty" apiredact:"secret"`
+}
+
+type RequestEventRateLimitJson struct {
+	RateLimitRef meta.ObjectReference `json:"rateLimitRef" yaml:"rateLimitRef"`
+	Mode         string               `json:"mode" yaml:"mode"`
+	Bucket       map[string]string    `json:"bucket,omitempty" yaml:"bucket,omitempty"`
+}
+
+// RequestEventListMetaJson keeps the existing exact total while moving the
+// opaque cursor into Kubernetes-style list metadata.
+type RequestEventListMetaJson struct {
+	Continue string `json:"continue,omitempty" yaml:"continue,omitempty"`
+	Total    *int64 `json:"total,omitempty" yaml:"total,omitempty"`
+}
+
+type ListRequestEventsResponseJson struct {
+	meta.TypeMeta `json:",inline" yaml:",inline"`
+	Metadata      RequestEventListMetaJson `json:"metadata" yaml:"metadata"`
+	Items         []RequestEventJson       `json:"items" yaml:"items"`
+}
+
+func NewListRequestEventsResponseJson(
+	items []RequestEventJson,
+	continueToken string,
+	total *int64,
+) ListRequestEventsResponseJson {
+	if items == nil {
+		items = make([]RequestEventJson, 0)
+	}
+	return ListRequestEventsResponseJson{
+		TypeMeta: meta.NewTypeMeta(meta.Kind(string(RequestEventKind) + "List")),
+		Metadata: RequestEventListMetaJson{Continue: continueToken, Total: total},
+		Items:    items,
+	}
+}

--- a/internal/schema/api/request_events_test.go
+++ b/internal/schema/api/request_events_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewListRequestEventsResponseJson(t *testing.T) {
+	total := int64(12)
+	response := NewListRequestEventsResponseJson(nil, "next", &total)
+	require.Equal(t, meta.NewTypeMeta("RequestEventList"), response.TypeMeta)
+	require.Empty(t, response.Items)
+	require.Equal(t, "next", response.Metadata.Continue)
+	require.Equal(t, total, *response.Metadata.Total)
+
+	data, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"apiVersion":"authproxy.net/v1alpha1",
+		"kind":"RequestEventList",
+		"metadata":{"continue":"next","total":12},
+		"items":[]
+	}`, string(data))
+}

--- a/internal/schema/api/schema.json
+++ b/internal/schema/api/schema.json
@@ -1451,182 +1451,252 @@
       ],
       "additionalProperties": false
     },
+    "RequestEventNamespaceReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Namespace" },
+            "id": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+          },
+          "not": {
+            "anyOf": [
+              { "required": ["name"] },
+              { "required": ["namespace"] },
+              { "required": ["generation"] }
+            ]
+          }
+        }
+      ]
+    },
+    "RequestEventActorReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Actor" },
+            "id": { "type": "string", "pattern": "^act_" },
+            "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+          }
+        }
+      ]
+    },
+    "RequestEventConnectionReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Connection" },
+            "id": { "type": "string", "pattern": "^cxn_" },
+            "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+          },
+          "not": { "required": ["generation"] }
+        }
+      ]
+    },
+    "RequestEventConnectorReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "Connector" },
+            "id": { "type": "string", "pattern": "^cxr_" },
+            "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+          }
+        }
+      ]
+    },
+    "RequestEventRateLimitReference": {
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/ObjectReference" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "RateLimit" },
+            "id": { "type": "string", "pattern": "^rl_" }
+          },
+          "not": { "required": ["generation"] }
+        }
+      ]
+    },
+    "RequestEventRequest": {
+      "type": "object",
+      "properties": {
+        "method": { "$ref": "../resources/rate_limit/schema.json#/$defs/HttpMethod" },
+        "host": { "type": "string" },
+        "scheme": { "type": "string" },
+        "path": { "type": "string" },
+        "httpVersion": { "type": "string" },
+        "sizeBytes": { "type": "integer", "minimum": 0 },
+        "mimeType": { "type": "string" },
+        "bodySkipped": { "type": "string", "enum": ["streaming", "too_large"] }
+      },
+      "required": ["method", "host", "scheme", "path"],
+      "additionalProperties": false
+    },
+    "RequestEventResponse": {
+      "type": "object",
+      "properties": {
+        "statusCode": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "error": { "type": "string" },
+        "httpVersion": { "type": "string" },
+        "sizeBytes": { "type": "integer", "minimum": 0 },
+        "mimeType": { "type": "string" },
+        "bodySkipped": { "type": "string", "enum": ["streaming", "too_large"] },
+        "source": {
+          "type": "string",
+          "enum": ["upstream", "connector_rate_limiter", "rate_limit"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "RequestEventCapturedRequest": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "body": { "type": "string", "contentEncoding": "base64" }
+      },
+      "required": ["url", "headers"],
+      "additionalProperties": false
+    },
+    "RequestEventCapturedResponse": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "body": { "type": "string", "contentEncoding": "base64" }
+      },
+      "required": ["headers"],
+      "additionalProperties": false
+    },
+    "RequestEventCapture": {
+      "type": "object",
+      "properties": {
+        "request": { "$ref": "#/$defs/RequestEventCapturedRequest" },
+        "response": { "$ref": "#/$defs/RequestEventCapturedResponse" }
+      },
+      "required": ["request", "response"],
+      "additionalProperties": false
+    },
     "RequestEventRateLimit": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "rateLimitRef": { "$ref": "#/$defs/RequestEventRateLimitReference" },
+        "mode": { "$ref": "../resources/rate_limit/schema.json#/$defs/Mode" },
+        "bucket": { "$ref": "#/$defs/StringMap" }
+      },
+      "required": ["rateLimitRef", "mode"],
+      "additionalProperties": false
+    },
+    "RequestEventSpec": {
+      "type": "object",
+      "properties": {
+        "requestType": { "$ref": "../common/schema.json#/$defs/RequestType" },
+        "correlationId": { "type": "string" },
+        "durationMilliseconds": { "type": "integer", "minimum": 0 },
+        "namespaceRef": { "$ref": "#/$defs/RequestEventNamespaceReference" },
+        "actorRef": { "$ref": "#/$defs/RequestEventActorReference" },
+        "connectionRef": { "$ref": "#/$defs/RequestEventConnectionReference" },
+        "connectorRef": { "$ref": "#/$defs/RequestEventConnectorReference" },
+        "request": { "$ref": "#/$defs/RequestEventRequest" },
+        "response": { "$ref": "#/$defs/RequestEventResponse" },
+        "captureAvailable": { "type": "boolean" },
+        "capture": { "$ref": "#/$defs/RequestEventCapture" },
+        "rateLimit": { "$ref": "#/$defs/RequestEventRateLimit" },
+        "rateLimitsMatched": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RequestEventRateLimit" }
         },
-        "mode": {
-          "$ref": "../resources/rate_limit/schema.json#/$defs/Mode"
-        },
-        "bucket": {
-          "$ref": "#/$defs/StringMap"
-        }
+        "internalTimeout": { "type": "boolean" },
+        "requestCancelled": { "type": "boolean" }
       },
       "required": [
-        "id",
-        "mode"
+        "requestType",
+        "durationMilliseconds",
+        "namespaceRef",
+        "request",
+        "response",
+        "captureAvailable"
       ],
       "additionalProperties": false
     },
     "RequestEvent": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath"
-        },
-        "type": {
-          "$ref": "../common/schema.json#/$defs/RequestType"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "correlationId": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "duration": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "connectionId": {
-          "type": "string"
-        },
-        "connectorId": {
-          "type": "string"
-        },
-        "connectorVersion": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "method": {
-          "$ref": "../resources/rate_limit/schema.json#/$defs/HttpMethod"
-        },
-        "host": {
-          "type": "string"
-        },
-        "scheme": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "requestHttpVersion": {
-          "type": "string"
-        },
-        "requestSizeBytes": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "requestMimeType": {
-          "type": "string"
-        },
-        "requestBodySkipped": {
-          "type": "string",
-          "enum": [
-            "streaming",
-            "too_large"
-          ]
-        },
-        "responseStatusCode": {
-          "type": "integer",
-          "minimum": 100,
-          "maximum": 599
-        },
-        "responseError": {
-          "type": "string"
-        },
-        "responseHttpVersion": {
-          "type": "string"
-        },
-        "responseSizeBytes": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "responseMimeType": {
-          "type": "string"
-        },
-        "responseBodySkipped": {
-          "type": "string",
-          "enum": [
-            "streaming",
-            "too_large"
-          ]
-        },
-        "internalTimeout": {
-          "type": "boolean"
-        },
-        "requestCancelled": {
-          "type": "boolean"
-        },
-        "fullRequestRecorded": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "responseSource": {
-          "type": "string",
-          "enum": [
-            "upstream",
-            "connector_rate_limiter",
-            "rate_limit"
-          ]
-        },
-        "rateLimitId": {
-          "type": "string"
-        },
-        "rateLimitMode": {
-          "$ref": "../resources/rate_limit/schema.json#/$defs/Mode"
-        },
-        "rateLimitBucket": {
-          "$ref": "#/$defs/StringMap"
-        },
-        "rateLimitMatched": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RequestEventRateLimit"
+      "description": "An immutable, resource-shaped HTTP event projection; it is not a client-managed desired resource.",
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/Resource" },
+        {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "RequestEvent" },
+            "metadata": {
+              "allOf": [
+                { "$ref": "../resources/meta/schema.json#/$defs/ObjectMeta" },
+                {
+                  "type": "object",
+                  "required": ["id", "namespace", "createdAt"],
+                  "properties": {
+                    "id": { "type": "string", "pattern": "^req_" },
+                    "namespace": { "$ref": "../resources/namespace/schema.json#/$defs/NamespacePath" }
+                  }
+                }
+              ]
+            },
+            "spec": { "$ref": "#/$defs/RequestEventSpec" }
           }
         }
-      },
-      "required": [
-        "namespace",
-        "type",
-        "requestId",
-        "timestamp",
-        "duration",
-        "method",
-        "host",
-        "scheme",
-        "path"
       ],
+      "unevaluatedProperties": false
+    },
+    "RequestEventListMeta": {
+      "type": "object",
+      "properties": {
+        "continue": { "type": "string" },
+        "total": { "type": "integer", "minimum": 0 }
+      },
       "additionalProperties": false
     },
     "ListRequestEventsResponse": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/RequestEvent"
+      "description": "A paginated list of immutable RequestEvent projections.",
+      "allOf": [
+        { "$ref": "../resources/meta/schema.json#/$defs/TypeMeta" },
+        {
+          "type": "object",
+          "required": ["metadata", "items"],
+          "properties": {
+            "apiVersion": { "const": "authproxy.net/v1alpha1" },
+            "kind": { "const": "RequestEventList" },
+            "metadata": { "$ref": "#/$defs/RequestEventListMeta" },
+            "items": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/RequestEvent" }
+            }
           }
-        },
-        "cursor": {
-          "type": "string"
-        },
-        "total": {
-          "type": "integer",
-          "minimum": 0
         }
-      },
-      "required": [
-        "items"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TaskState": {
       "type": "string",

--- a/internal/schema/api/schema_test.go
+++ b/internal/schema/api/schema_test.go
@@ -155,6 +155,26 @@ func TestManagedListSchemasRejectLegacyTopLevelCursor(t *testing.T) {
 	}))
 }
 
+func TestRequestEventSchemasRejectLegacyFlatShape(t *testing.T) {
+	event := compileRefSchema(t, "./schema.json#/$defs/RequestEvent")
+	require.Error(t, event.Validate(map[string]any{
+		"namespace": "root.acme",
+		"requestId": "req_test550e8400abcde",
+		"timestamp": "2026-01-02T03:04:05Z",
+		"method":    "GET",
+		"host":      "api.example.com",
+		"scheme":    "https",
+		"path":      "/v1/users",
+	}))
+
+	list := compileRefSchema(t, "./schema.json#/$defs/ListRequestEventsResponse")
+	require.Error(t, list.Validate(map[string]any{
+		"items":  []any{},
+		"cursor": "next-page",
+		"total":  1,
+	}))
+}
+
 func TestNotificationAndSearchSchemasRejectLegacyFlatIdentity(t *testing.T) {
 	notifications := compileRefSchema(t, "./schema.json#/$defs/ListNotificationsResponse")
 	require.Error(t, notifications.Validate(map[string]any{

--- a/internal/schema/api/test_data/valid-list-request-events.json
+++ b/internal/schema/api/test_data/valid-list-request-events.json
@@ -1,17 +1,36 @@
 {
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "RequestEventList",
+  "metadata": {
+    "continue": "next",
+    "total": 1
+  },
   "items": [
     {
-      "namespace": "root.acme",
-      "type": "proxy",
-      "requestId": "req_test550e8400abcde",
-      "timestamp": "2026-01-02T03:04:05Z",
-      "duration": 150,
-      "method": "GET",
-      "host": "api.example.com",
-      "scheme": "https",
-      "path": "/v1/users"
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "RequestEvent",
+      "metadata": {
+        "id": "req_test550e8400abcde",
+        "namespace": "root.acme",
+        "createdAt": "2026-01-02T03:04:05Z"
+      },
+      "spec": {
+        "requestType": "proxy",
+        "durationMilliseconds": 150,
+        "namespaceRef": {
+          "apiVersion": "authproxy.net/v1alpha1",
+          "kind": "Namespace",
+          "id": "root.acme"
+        },
+        "request": {
+          "method": "GET",
+          "host": "api.example.com",
+          "scheme": "https",
+          "path": "/v1/users"
+        },
+        "response": {},
+        "captureAvailable": false
+      }
     }
-  ],
-  "cursor": "next",
-  "total": 1
+  ]
 }

--- a/internal/schema/api/test_data/valid-request-event.json
+++ b/internal/schema/api/test_data/valid-request-event.json
@@ -1,29 +1,85 @@
 {
-  "namespace": "root.acme",
-  "type": "proxy",
-  "requestId": "req_test550e8400abcde",
-  "correlationId": "corr-123",
-  "timestamp": "2026-01-02T03:04:05Z",
-  "duration": 150,
-  "connectionId": "cxn_test550e8400abcde",
-  "connectorId": "cxr_test550e8400abcde",
-  "connectorVersion": 2,
-  "method": "GET",
-  "host": "api.example.com",
-  "scheme": "https",
-  "path": "/v1/users",
-  "responseStatusCode": 200,
-  "labels": {
-    "team": "api"
+  "apiVersion": "authproxy.net/v1alpha1",
+  "kind": "RequestEvent",
+  "metadata": {
+    "id": "req_test550e8400abcde",
+    "namespace": "root.acme",
+    "labels": {
+      "team": "api"
+    },
+    "createdAt": "2026-01-02T03:04:05Z"
   },
-  "responseSource": "upstream",
-  "rateLimitMatched": [
-    {
-      "id": "rl_test550e8400abcde",
-      "mode": "observe",
-      "bucket": {
-        "actor": "act_test550e8400abcde"
+  "spec": {
+    "requestType": "proxy",
+    "correlationId": "corr-123",
+    "durationMilliseconds": 150,
+    "namespaceRef": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Namespace",
+      "id": "root.acme"
+    },
+    "actorRef": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Actor",
+      "id": "act_test550e8400abcde",
+      "name": "service-actor",
+      "namespace": "root.acme"
+    },
+    "connectionRef": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connection",
+      "id": "cxn_test550e8400abcde",
+      "name": "production",
+      "namespace": "root.acme"
+    },
+    "connectorRef": {
+      "apiVersion": "authproxy.net/v1alpha1",
+      "kind": "Connector",
+      "id": "cxr_test550e8400abcde",
+      "name": "provider",
+      "namespace": "root.integrations",
+      "generation": 2
+    },
+    "request": {
+      "method": "GET",
+      "host": "api.example.com",
+      "scheme": "https",
+      "path": "/v1/users",
+      "httpVersion": "HTTP/2.0"
+    },
+    "response": {
+      "statusCode": 200,
+      "httpVersion": "HTTP/2.0",
+      "source": "upstream"
+    },
+    "captureAvailable": true,
+    "capture": {
+      "request": {
+        "url": "https://api.example.com/v1/users?cursor=next",
+        "headers": {
+          "Authorization": ["Bearer example"]
+        },
+        "body": "e30="
+      },
+      "response": {
+        "headers": {
+          "Content-Type": ["application/json"]
+        },
+        "body": "e30="
       }
-    }
-  ]
+    },
+    "rateLimitsMatched": [
+      {
+        "rateLimitRef": {
+          "apiVersion": "authproxy.net/v1alpha1",
+          "kind": "RateLimit",
+          "id": "rl_test550e8400abcde"
+        },
+        "mode": "observe",
+        "bucket": {
+          "actor": "act_test550e8400abcde"
+        }
+      }
+    ]
+  }
 }

--- a/internal/service/admin_api/swagger/docs.go
+++ b/internal/service/admin_api/swagger/docs.go
@@ -5786,7 +5786,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "List request events entries with optional filtering and pagination",
+                "description": "List immutable request-event projections with optional filtering and pagination",
                 "consumes": [
                     "application/json"
                 ],
@@ -5936,7 +5936,7 @@ const docTemplateadmin_api = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a specific request events entry by its UUID",
+                "description": "Get a specific immutable request event by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -9724,6 +9724,458 @@ const docTemplateadmin_api = `{
                 }
             }
         },
+        "openapi.RequestEventActorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "act_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Actor"
+                    ],
+                    "example": "Actor"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventCaptureJson": {
+            "type": "object",
+            "required": [
+                "request",
+                "response"
+            ],
+            "properties": {
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedRequestJson"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedResponseJson"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedRequestJson": {
+            "type": "object",
+            "required": [
+                "headers",
+                "url"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://api.example.com/v1/users"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedResponseJson": {
+            "type": "object",
+            "required": [
+                "headers"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "openapi.RequestEventConnectionReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxn_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connection"
+                    ],
+                    "example": "Connection"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventConnectorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "generation": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxr_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "provider"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.integrations"
+                }
+            }
+        },
+        "openapi.RequestEventJson": {
+            "description": "Immutable, resource-shaped HTTP request event projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
+                }
+            }
+        },
+        "openapi.RequestEventListMetaJson": {
+            "type": "object",
+            "properties": {
+                "continue": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventNamespaceReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Namespace"
+                    ],
+                    "example": "Namespace"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitJson": {
+            "type": "object",
+            "required": [
+                "mode",
+                "rateLimitRef"
+            ],
+            "properties": {
+                "bucket": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "enforce",
+                        "observe"
+                    ],
+                    "example": "enforce"
+                },
+                "rateLimitRef": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitReferenceJson"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "rl_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RateLimit"
+                    ],
+                    "example": "RateLimit"
+                }
+            }
+        },
+        "openapi.RequestEventRequestJson": {
+            "type": "object",
+            "required": [
+                "host",
+                "method",
+                "path",
+                "scheme"
+            ],
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "host": {
+                    "type": "string",
+                    "example": "api.example.com"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "method": {
+                    "type": "string",
+                    "example": "GET"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "path": {
+                    "type": "string",
+                    "example": "/v1/users"
+                },
+                "scheme": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventResponseJson": {
+            "type": "object",
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "error": {
+                    "type": "string"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "upstream",
+                        "connector_rate_limiter",
+                        "rate_limit"
+                    ],
+                    "example": "upstream"
+                },
+                "statusCode": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
+        "openapi.RequestEventSpecJson": {
+            "type": "object",
+            "required": [
+                "durationMilliseconds",
+                "namespaceRef",
+                "request",
+                "requestType",
+                "response"
+            ],
+            "properties": {
+                "actorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventActorReferenceJson"
+                },
+                "capture": {
+                    "$ref": "#/definitions/openapi.RequestEventCaptureJson"
+                },
+                "captureAvailable": {
+                    "type": "boolean"
+                },
+                "connectionRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectionReferenceJson"
+                },
+                "connectorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectorReferenceJson"
+                },
+                "correlationId": {
+                    "type": "string"
+                },
+                "durationMilliseconds": {
+                    "type": "integer",
+                    "example": 150
+                },
+                "internalTimeout": {
+                    "type": "boolean"
+                },
+                "namespaceRef": {
+                    "$ref": "#/definitions/openapi.RequestEventNamespaceReferenceJson"
+                },
+                "rateLimit": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                },
+                "rateLimitsMatched": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventRequestJson"
+                },
+                "requestCancelled": {
+                    "type": "boolean"
+                },
+                "requestType": {
+                    "type": "string",
+                    "enum": [
+                        "global",
+                        "proxy",
+                        "oauth",
+                        "public",
+                        "probe"
+                    ],
+                    "example": "proxy"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventResponseJson"
+                }
+            }
+        },
         "openapi.SearchResultListMetaJson": {
             "type": "object",
             "properties": {
@@ -10358,18 +10810,37 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.OpenAPIListRequestEventsResponse": {
-            "description": "Paginated list of request events entries",
+            "description": "Paginated list of immutable request-event projections",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventJson"
+                    }
                 },
-                "total": {
-                    "type": "integer"
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEventList"
+                    ],
+                    "example": "RequestEventList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.RequestEventListMetaJson"
                 }
             }
         },
@@ -10477,85 +10948,34 @@ const docTemplateadmin_api = `{
             }
         },
         "routes.OpenAPIRequestEventsEntry": {
-            "description": "HTTP request events entry",
+            "description": "Immutable, resource-shaped HTTP request event projection",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "connectionId": {
-                    "type": "string"
-                },
-                "connectorId": {
-                    "type": "string"
-                },
-                "connectorVersion": {
-                    "type": "integer"
-                },
-                "correlationId": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "integer",
-                    "example": 150
-                },
-                "host": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "api.example.com"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "method": {
+                "kind": {
                     "type": "string",
-                    "example": "GET"
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
                 },
-                "path": {
-                    "type": "string",
-                    "example": "/v1/users"
-                },
-                "rateLimitBucket": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "rateLimitId": {
-                    "type": "string"
-                },
-                "rateLimitMatched": {
-                    "type": "array",
-                    "items": {}
-                },
-                "rateLimitMode": {
-                    "type": "string"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "responseSource": {
-                    "type": "string",
-                    "example": "upstream"
-                },
-                "responseStatusCode": {
-                    "type": "integer",
-                    "example": 200
-                },
-                "scheme": {
-                    "type": "string",
-                    "example": "https"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "example": "proxy"
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.json
+++ b/internal/service/admin_api/swagger/docs.json
@@ -5780,7 +5780,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List request events entries with optional filtering and pagination",
+                "description": "List immutable request-event projections with optional filtering and pagination",
                 "consumes": [
                     "application/json"
                 ],
@@ -5930,7 +5930,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a specific request events entry by its UUID",
+                "description": "Get a specific immutable request event by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -9718,6 +9718,458 @@
                 }
             }
         },
+        "openapi.RequestEventActorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "act_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Actor"
+                    ],
+                    "example": "Actor"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventCaptureJson": {
+            "type": "object",
+            "required": [
+                "request",
+                "response"
+            ],
+            "properties": {
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedRequestJson"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedResponseJson"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedRequestJson": {
+            "type": "object",
+            "required": [
+                "headers",
+                "url"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://api.example.com/v1/users"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedResponseJson": {
+            "type": "object",
+            "required": [
+                "headers"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "openapi.RequestEventConnectionReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxn_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connection"
+                    ],
+                    "example": "Connection"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventConnectorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "generation": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxr_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "provider"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.integrations"
+                }
+            }
+        },
+        "openapi.RequestEventJson": {
+            "description": "Immutable, resource-shaped HTTP request event projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
+                }
+            }
+        },
+        "openapi.RequestEventListMetaJson": {
+            "type": "object",
+            "properties": {
+                "continue": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventNamespaceReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Namespace"
+                    ],
+                    "example": "Namespace"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitJson": {
+            "type": "object",
+            "required": [
+                "mode",
+                "rateLimitRef"
+            ],
+            "properties": {
+                "bucket": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "enforce",
+                        "observe"
+                    ],
+                    "example": "enforce"
+                },
+                "rateLimitRef": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitReferenceJson"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "rl_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RateLimit"
+                    ],
+                    "example": "RateLimit"
+                }
+            }
+        },
+        "openapi.RequestEventRequestJson": {
+            "type": "object",
+            "required": [
+                "host",
+                "method",
+                "path",
+                "scheme"
+            ],
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "host": {
+                    "type": "string",
+                    "example": "api.example.com"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "method": {
+                    "type": "string",
+                    "example": "GET"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "path": {
+                    "type": "string",
+                    "example": "/v1/users"
+                },
+                "scheme": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventResponseJson": {
+            "type": "object",
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "error": {
+                    "type": "string"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "upstream",
+                        "connector_rate_limiter",
+                        "rate_limit"
+                    ],
+                    "example": "upstream"
+                },
+                "statusCode": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
+        "openapi.RequestEventSpecJson": {
+            "type": "object",
+            "required": [
+                "durationMilliseconds",
+                "namespaceRef",
+                "request",
+                "requestType",
+                "response"
+            ],
+            "properties": {
+                "actorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventActorReferenceJson"
+                },
+                "capture": {
+                    "$ref": "#/definitions/openapi.RequestEventCaptureJson"
+                },
+                "captureAvailable": {
+                    "type": "boolean"
+                },
+                "connectionRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectionReferenceJson"
+                },
+                "connectorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectorReferenceJson"
+                },
+                "correlationId": {
+                    "type": "string"
+                },
+                "durationMilliseconds": {
+                    "type": "integer",
+                    "example": 150
+                },
+                "internalTimeout": {
+                    "type": "boolean"
+                },
+                "namespaceRef": {
+                    "$ref": "#/definitions/openapi.RequestEventNamespaceReferenceJson"
+                },
+                "rateLimit": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                },
+                "rateLimitsMatched": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventRequestJson"
+                },
+                "requestCancelled": {
+                    "type": "boolean"
+                },
+                "requestType": {
+                    "type": "string",
+                    "enum": [
+                        "global",
+                        "proxy",
+                        "oauth",
+                        "public",
+                        "probe"
+                    ],
+                    "example": "proxy"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventResponseJson"
+                }
+            }
+        },
         "openapi.SearchResultListMetaJson": {
             "type": "object",
             "properties": {
@@ -10352,18 +10804,37 @@
             }
         },
         "routes.OpenAPIListRequestEventsResponse": {
-            "description": "Paginated list of request events entries",
+            "description": "Paginated list of immutable request-event projections",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventJson"
+                    }
                 },
-                "total": {
-                    "type": "integer"
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEventList"
+                    ],
+                    "example": "RequestEventList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.RequestEventListMetaJson"
                 }
             }
         },
@@ -10471,85 +10942,34 @@
             }
         },
         "routes.OpenAPIRequestEventsEntry": {
-            "description": "HTTP request events entry",
+            "description": "Immutable, resource-shaped HTTP request event projection",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "connectionId": {
-                    "type": "string"
-                },
-                "connectorId": {
-                    "type": "string"
-                },
-                "connectorVersion": {
-                    "type": "integer"
-                },
-                "correlationId": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "integer",
-                    "example": 150
-                },
-                "host": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "api.example.com"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "method": {
+                "kind": {
                     "type": "string",
-                    "example": "GET"
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
                 },
-                "path": {
-                    "type": "string",
-                    "example": "/v1/users"
-                },
-                "rateLimitBucket": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "rateLimitId": {
-                    "type": "string"
-                },
-                "rateLimitMatched": {
-                    "type": "array",
-                    "items": {}
-                },
-                "rateLimitMode": {
-                    "type": "string"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "responseSource": {
-                    "type": "string",
-                    "example": "upstream"
-                },
-                "responseStatusCode": {
-                    "type": "integer",
-                    "example": 200
-                },
-                "scheme": {
-                    "type": "string",
-                    "example": "https"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "example": "proxy"
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
                 }
             }
         },

--- a/internal/service/admin_api/swagger/docs.yaml
+++ b/internal/service/admin_api/swagger/docs.yaml
@@ -1032,6 +1032,327 @@ definitions:
         example: 1
         type: number
     type: object
+  openapi.RequestEventActorReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: act_01example
+        type: string
+      kind:
+        enum:
+        - Actor
+        example: Actor
+        type: string
+      name:
+        example: billing-service
+        type: string
+      namespace:
+        example: root.acme
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventCaptureJson:
+    properties:
+      request:
+        $ref: '#/definitions/openapi.RequestEventCapturedRequestJson'
+      response:
+        $ref: '#/definitions/openapi.RequestEventCapturedResponseJson'
+    required:
+    - request
+    - response
+    type: object
+  openapi.RequestEventCapturedRequestJson:
+    properties:
+      body:
+        format: byte
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      url:
+        example: https://api.example.com/v1/users
+        type: string
+    required:
+    - headers
+    - url
+    type: object
+  openapi.RequestEventCapturedResponseJson:
+    properties:
+      body:
+        format: byte
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+    required:
+    - headers
+    type: object
+  openapi.RequestEventConnectionReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: cxn_01example
+        type: string
+      kind:
+        enum:
+        - Connection
+        example: Connection
+        type: string
+      name:
+        example: production
+        type: string
+      namespace:
+        example: root.acme
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventConnectorReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      generation:
+        example: 3
+        type: integer
+      id:
+        example: cxr_01example
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      name:
+        example: provider
+        type: string
+      namespace:
+        example: root.integrations
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventJson:
+    description: Immutable, resource-shaped HTTP request event projection
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - RequestEvent
+        example: RequestEvent
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.RequestEventSpecJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  openapi.RequestEventListMetaJson:
+    properties:
+      continue:
+        type: string
+      total:
+        type: integer
+    type: object
+  openapi.RequestEventNamespaceReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: root.acme
+        type: string
+      kind:
+        enum:
+        - Namespace
+        example: Namespace
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventRateLimitJson:
+    properties:
+      bucket:
+        additionalProperties:
+          type: string
+        type: object
+      mode:
+        enum:
+        - enforce
+        - observe
+        example: enforce
+        type: string
+      rateLimitRef:
+        $ref: '#/definitions/openapi.RequestEventRateLimitReferenceJson'
+    required:
+    - mode
+    - rateLimitRef
+    type: object
+  openapi.RequestEventRateLimitReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: rl_01example
+        type: string
+      kind:
+        enum:
+        - RateLimit
+        example: RateLimit
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventRequestJson:
+    properties:
+      bodySkipped:
+        enum:
+        - streaming
+        - too_large
+        type: string
+      host:
+        example: api.example.com
+        type: string
+      httpVersion:
+        example: HTTP/2.0
+        type: string
+      method:
+        example: GET
+        type: string
+      mimeType:
+        example: application/json
+        type: string
+      path:
+        example: /v1/users
+        type: string
+      scheme:
+        example: https
+        type: string
+      sizeBytes:
+        type: integer
+    required:
+    - host
+    - method
+    - path
+    - scheme
+    type: object
+  openapi.RequestEventResponseJson:
+    properties:
+      bodySkipped:
+        enum:
+        - streaming
+        - too_large
+        type: string
+      error:
+        type: string
+      httpVersion:
+        example: HTTP/2.0
+        type: string
+      mimeType:
+        example: application/json
+        type: string
+      sizeBytes:
+        type: integer
+      source:
+        enum:
+        - upstream
+        - connector_rate_limiter
+        - rate_limit
+        example: upstream
+        type: string
+      statusCode:
+        example: 200
+        type: integer
+    type: object
+  openapi.RequestEventSpecJson:
+    properties:
+      actorRef:
+        $ref: '#/definitions/openapi.RequestEventActorReferenceJson'
+      capture:
+        $ref: '#/definitions/openapi.RequestEventCaptureJson'
+      captureAvailable:
+        type: boolean
+      connectionRef:
+        $ref: '#/definitions/openapi.RequestEventConnectionReferenceJson'
+      connectorRef:
+        $ref: '#/definitions/openapi.RequestEventConnectorReferenceJson'
+      correlationId:
+        type: string
+      durationMilliseconds:
+        example: 150
+        type: integer
+      internalTimeout:
+        type: boolean
+      namespaceRef:
+        $ref: '#/definitions/openapi.RequestEventNamespaceReferenceJson'
+      rateLimit:
+        $ref: '#/definitions/openapi.RequestEventRateLimitJson'
+      rateLimitsMatched:
+        items:
+          $ref: '#/definitions/openapi.RequestEventRateLimitJson'
+        type: array
+      request:
+        $ref: '#/definitions/openapi.RequestEventRequestJson'
+      requestCancelled:
+        type: boolean
+      requestType:
+        enum:
+        - global
+        - proxy
+        - oauth
+        - public
+        - probe
+        example: proxy
+        type: string
+      response:
+        $ref: '#/definitions/openapi.RequestEventResponseJson'
+    required:
+    - durationMilliseconds
+    - namespaceRef
+    - request
+    - requestType
+    - response
+    type: object
   openapi.SearchResultListMetaJson:
     properties:
       incompleteKinds:
@@ -1481,15 +1802,29 @@ definitions:
     - metadata
     type: object
   routes.OpenAPIListRequestEventsResponse:
-    description: Paginated list of request events entries
+    description: Paginated list of immutable request-event projections
     properties:
-      cursor:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
       items:
-        items: {}
+        items:
+          $ref: '#/definitions/openapi.RequestEventJson'
         type: array
-      total:
-        type: integer
+      kind:
+        enum:
+        - RequestEventList
+        example: RequestEventList
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.RequestEventListMetaJson'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPIMetricsSchemaResponse:
     description: Application metrics schema response
@@ -1564,63 +1899,27 @@ definitions:
         type: integer
     type: object
   routes.OpenAPIRequestEventsEntry:
-    description: HTTP request events entry
+    description: Immutable, resource-shaped HTTP request event projection
     properties:
-      connectionId:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
-      connectorId:
+      kind:
+        enum:
+        - RequestEvent
+        example: RequestEvent
         type: string
-      connectorVersion:
-        type: integer
-      correlationId:
-        type: string
-      duration:
-        example: 150
-        type: integer
-      host:
-        example: api.example.com
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      method:
-        example: GET
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      path:
-        example: /v1/users
-        type: string
-      rateLimitBucket:
-        additionalProperties:
-          type: string
-        type: object
-      rateLimitId:
-        type: string
-      rateLimitMatched:
-        items: {}
-        type: array
-      rateLimitMode:
-        type: string
-      requestId:
-        example: req_test550e8400abcde
-        type: string
-      responseSource:
-        example: upstream
-        type: string
-      responseStatusCode:
-        example: 200
-        type: integer
-      scheme:
-        example: https
-        type: string
-      timestamp:
-        type: string
-      type:
-        example: proxy
-        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.RequestEventSpecJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPISearchResourcesResponseJson:
     properties:
@@ -5512,7 +5811,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: List request events entries with optional filtering and pagination
+      description: List immutable request-event projections with optional filtering
+        and pagination
       parameters:
       - description: Pagination cursor
         in: query
@@ -5610,7 +5910,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get a specific request events entry by its UUID
+      description: Get a specific immutable request event by its ID
       parameters:
       - description: Request events entry UUID
         in: path

--- a/internal/service/api/swagger/docs.go
+++ b/internal/service/api/swagger/docs.go
@@ -5786,7 +5786,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "List request events entries with optional filtering and pagination",
+                "description": "List immutable request-event projections with optional filtering and pagination",
                 "consumes": [
                     "application/json"
                 ],
@@ -5936,7 +5936,7 @@ const docTemplateApi = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a specific request events entry by its UUID",
+                "description": "Get a specific immutable request event by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -9724,6 +9724,458 @@ const docTemplateApi = `{
                 }
             }
         },
+        "openapi.RequestEventActorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "act_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Actor"
+                    ],
+                    "example": "Actor"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventCaptureJson": {
+            "type": "object",
+            "required": [
+                "request",
+                "response"
+            ],
+            "properties": {
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedRequestJson"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedResponseJson"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedRequestJson": {
+            "type": "object",
+            "required": [
+                "headers",
+                "url"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://api.example.com/v1/users"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedResponseJson": {
+            "type": "object",
+            "required": [
+                "headers"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "openapi.RequestEventConnectionReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxn_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connection"
+                    ],
+                    "example": "Connection"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventConnectorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "generation": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxr_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "provider"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.integrations"
+                }
+            }
+        },
+        "openapi.RequestEventJson": {
+            "description": "Immutable, resource-shaped HTTP request event projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
+                }
+            }
+        },
+        "openapi.RequestEventListMetaJson": {
+            "type": "object",
+            "properties": {
+                "continue": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventNamespaceReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Namespace"
+                    ],
+                    "example": "Namespace"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitJson": {
+            "type": "object",
+            "required": [
+                "mode",
+                "rateLimitRef"
+            ],
+            "properties": {
+                "bucket": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "enforce",
+                        "observe"
+                    ],
+                    "example": "enforce"
+                },
+                "rateLimitRef": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitReferenceJson"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "rl_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RateLimit"
+                    ],
+                    "example": "RateLimit"
+                }
+            }
+        },
+        "openapi.RequestEventRequestJson": {
+            "type": "object",
+            "required": [
+                "host",
+                "method",
+                "path",
+                "scheme"
+            ],
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "host": {
+                    "type": "string",
+                    "example": "api.example.com"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "method": {
+                    "type": "string",
+                    "example": "GET"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "path": {
+                    "type": "string",
+                    "example": "/v1/users"
+                },
+                "scheme": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventResponseJson": {
+            "type": "object",
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "error": {
+                    "type": "string"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "upstream",
+                        "connector_rate_limiter",
+                        "rate_limit"
+                    ],
+                    "example": "upstream"
+                },
+                "statusCode": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
+        "openapi.RequestEventSpecJson": {
+            "type": "object",
+            "required": [
+                "durationMilliseconds",
+                "namespaceRef",
+                "request",
+                "requestType",
+                "response"
+            ],
+            "properties": {
+                "actorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventActorReferenceJson"
+                },
+                "capture": {
+                    "$ref": "#/definitions/openapi.RequestEventCaptureJson"
+                },
+                "captureAvailable": {
+                    "type": "boolean"
+                },
+                "connectionRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectionReferenceJson"
+                },
+                "connectorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectorReferenceJson"
+                },
+                "correlationId": {
+                    "type": "string"
+                },
+                "durationMilliseconds": {
+                    "type": "integer",
+                    "example": 150
+                },
+                "internalTimeout": {
+                    "type": "boolean"
+                },
+                "namespaceRef": {
+                    "$ref": "#/definitions/openapi.RequestEventNamespaceReferenceJson"
+                },
+                "rateLimit": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                },
+                "rateLimitsMatched": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventRequestJson"
+                },
+                "requestCancelled": {
+                    "type": "boolean"
+                },
+                "requestType": {
+                    "type": "string",
+                    "enum": [
+                        "global",
+                        "proxy",
+                        "oauth",
+                        "public",
+                        "probe"
+                    ],
+                    "example": "proxy"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventResponseJson"
+                }
+            }
+        },
         "openapi.SearchResultListMetaJson": {
             "type": "object",
             "properties": {
@@ -10358,18 +10810,37 @@ const docTemplateApi = `{
             }
         },
         "routes.OpenAPIListRequestEventsResponse": {
-            "description": "Paginated list of request events entries",
+            "description": "Paginated list of immutable request-event projections",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventJson"
+                    }
                 },
-                "total": {
-                    "type": "integer"
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEventList"
+                    ],
+                    "example": "RequestEventList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.RequestEventListMetaJson"
                 }
             }
         },
@@ -10477,85 +10948,34 @@ const docTemplateApi = `{
             }
         },
         "routes.OpenAPIRequestEventsEntry": {
-            "description": "HTTP request events entry",
+            "description": "Immutable, resource-shaped HTTP request event projection",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "connectionId": {
-                    "type": "string"
-                },
-                "connectorId": {
-                    "type": "string"
-                },
-                "connectorVersion": {
-                    "type": "integer"
-                },
-                "correlationId": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "integer",
-                    "example": 150
-                },
-                "host": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "api.example.com"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "method": {
+                "kind": {
                     "type": "string",
-                    "example": "GET"
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
                 },
-                "path": {
-                    "type": "string",
-                    "example": "/v1/users"
-                },
-                "rateLimitBucket": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "rateLimitId": {
-                    "type": "string"
-                },
-                "rateLimitMatched": {
-                    "type": "array",
-                    "items": {}
-                },
-                "rateLimitMode": {
-                    "type": "string"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "responseSource": {
-                    "type": "string",
-                    "example": "upstream"
-                },
-                "responseStatusCode": {
-                    "type": "integer",
-                    "example": 200
-                },
-                "scheme": {
-                    "type": "string",
-                    "example": "https"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "example": "proxy"
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.json
+++ b/internal/service/api/swagger/docs.json
@@ -5780,7 +5780,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List request events entries with optional filtering and pagination",
+                "description": "List immutable request-event projections with optional filtering and pagination",
                 "consumes": [
                     "application/json"
                 ],
@@ -5930,7 +5930,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a specific request events entry by its UUID",
+                "description": "Get a specific immutable request event by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -9718,6 +9718,458 @@
                 }
             }
         },
+        "openapi.RequestEventActorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "act_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Actor"
+                    ],
+                    "example": "Actor"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "billing-service"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventCaptureJson": {
+            "type": "object",
+            "required": [
+                "request",
+                "response"
+            ],
+            "properties": {
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedRequestJson"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventCapturedResponseJson"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedRequestJson": {
+            "type": "object",
+            "required": [
+                "headers",
+                "url"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://api.example.com/v1/users"
+                }
+            }
+        },
+        "openapi.RequestEventCapturedResponseJson": {
+            "type": "object",
+            "required": [
+                "headers"
+            ],
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "format": "byte"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "openapi.RequestEventConnectionReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxn_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connection"
+                    ],
+                    "example": "Connection"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "production"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.acme"
+                }
+            }
+        },
+        "openapi.RequestEventConnectorReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "generation": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "id": {
+                    "type": "string",
+                    "example": "cxr_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Connector"
+                    ],
+                    "example": "Connector"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "provider"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "root.integrations"
+                }
+            }
+        },
+        "openapi.RequestEventJson": {
+            "description": "Immutable, resource-shaped HTTP request event projection",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
+                },
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
+                }
+            }
+        },
+        "openapi.RequestEventListMetaJson": {
+            "type": "object",
+            "properties": {
+                "continue": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventNamespaceReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "root.acme"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Namespace"
+                    ],
+                    "example": "Namespace"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitJson": {
+            "type": "object",
+            "required": [
+                "mode",
+                "rateLimitRef"
+            ],
+            "properties": {
+                "bucket": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "enforce",
+                        "observe"
+                    ],
+                    "example": "enforce"
+                },
+                "rateLimitRef": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitReferenceJson"
+                }
+            }
+        },
+        "openapi.RequestEventRateLimitReferenceJson": {
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "id",
+                "kind"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "rl_01example"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RateLimit"
+                    ],
+                    "example": "RateLimit"
+                }
+            }
+        },
+        "openapi.RequestEventRequestJson": {
+            "type": "object",
+            "required": [
+                "host",
+                "method",
+                "path",
+                "scheme"
+            ],
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "host": {
+                    "type": "string",
+                    "example": "api.example.com"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "method": {
+                    "type": "string",
+                    "example": "GET"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "path": {
+                    "type": "string",
+                    "example": "/v1/users"
+                },
+                "scheme": {
+                    "type": "string",
+                    "example": "https"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "openapi.RequestEventResponseJson": {
+            "type": "object",
+            "properties": {
+                "bodySkipped": {
+                    "type": "string",
+                    "enum": [
+                        "streaming",
+                        "too_large"
+                    ]
+                },
+                "error": {
+                    "type": "string"
+                },
+                "httpVersion": {
+                    "type": "string",
+                    "example": "HTTP/2.0"
+                },
+                "mimeType": {
+                    "type": "string",
+                    "example": "application/json"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "upstream",
+                        "connector_rate_limiter",
+                        "rate_limit"
+                    ],
+                    "example": "upstream"
+                },
+                "statusCode": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
+        "openapi.RequestEventSpecJson": {
+            "type": "object",
+            "required": [
+                "durationMilliseconds",
+                "namespaceRef",
+                "request",
+                "requestType",
+                "response"
+            ],
+            "properties": {
+                "actorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventActorReferenceJson"
+                },
+                "capture": {
+                    "$ref": "#/definitions/openapi.RequestEventCaptureJson"
+                },
+                "captureAvailable": {
+                    "type": "boolean"
+                },
+                "connectionRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectionReferenceJson"
+                },
+                "connectorRef": {
+                    "$ref": "#/definitions/openapi.RequestEventConnectorReferenceJson"
+                },
+                "correlationId": {
+                    "type": "string"
+                },
+                "durationMilliseconds": {
+                    "type": "integer",
+                    "example": 150
+                },
+                "internalTimeout": {
+                    "type": "boolean"
+                },
+                "namespaceRef": {
+                    "$ref": "#/definitions/openapi.RequestEventNamespaceReferenceJson"
+                },
+                "rateLimit": {
+                    "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                },
+                "rateLimitsMatched": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventRateLimitJson"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/openapi.RequestEventRequestJson"
+                },
+                "requestCancelled": {
+                    "type": "boolean"
+                },
+                "requestType": {
+                    "type": "string",
+                    "enum": [
+                        "global",
+                        "proxy",
+                        "oauth",
+                        "public",
+                        "probe"
+                    ],
+                    "example": "proxy"
+                },
+                "response": {
+                    "$ref": "#/definitions/openapi.RequestEventResponseJson"
+                }
+            }
+        },
         "openapi.SearchResultListMetaJson": {
             "type": "object",
             "properties": {
@@ -10352,18 +10804,37 @@
             }
         },
         "routes.OpenAPIListRequestEventsResponse": {
-            "description": "Paginated list of request events entries",
+            "description": "Paginated list of immutable request-event projections",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "items",
+                "kind",
+                "metadata"
+            ],
             "properties": {
-                "cursor": {
-                    "type": "string"
+                "apiVersion": {
+                    "type": "string",
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
                 "items": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "$ref": "#/definitions/openapi.RequestEventJson"
+                    }
                 },
-                "total": {
-                    "type": "integer"
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "RequestEventList"
+                    ],
+                    "example": "RequestEventList"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/openapi.RequestEventListMetaJson"
                 }
             }
         },
@@ -10471,85 +10942,34 @@
             }
         },
         "routes.OpenAPIRequestEventsEntry": {
-            "description": "HTTP request events entry",
+            "description": "Immutable, resource-shaped HTTP request event projection",
             "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ],
             "properties": {
-                "connectionId": {
-                    "type": "string"
-                },
-                "connectorId": {
-                    "type": "string"
-                },
-                "connectorVersion": {
-                    "type": "integer"
-                },
-                "correlationId": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "integer",
-                    "example": 150
-                },
-                "host": {
+                "apiVersion": {
                     "type": "string",
-                    "example": "api.example.com"
+                    "enum": [
+                        "authproxy.net/v1alpha1"
+                    ],
+                    "example": "authproxy.net/v1alpha1"
                 },
-                "labels": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "method": {
+                "kind": {
                     "type": "string",
-                    "example": "GET"
+                    "enum": [
+                        "RequestEvent"
+                    ],
+                    "example": "RequestEvent"
                 },
-                "namespace": {
-                    "type": "string",
-                    "example": "root.acme"
+                "metadata": {
+                    "$ref": "#/definitions/meta.ObjectMeta"
                 },
-                "path": {
-                    "type": "string",
-                    "example": "/v1/users"
-                },
-                "rateLimitBucket": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "rateLimitId": {
-                    "type": "string"
-                },
-                "rateLimitMatched": {
-                    "type": "array",
-                    "items": {}
-                },
-                "rateLimitMode": {
-                    "type": "string"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": "req_test550e8400abcde"
-                },
-                "responseSource": {
-                    "type": "string",
-                    "example": "upstream"
-                },
-                "responseStatusCode": {
-                    "type": "integer",
-                    "example": 200
-                },
-                "scheme": {
-                    "type": "string",
-                    "example": "https"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "example": "proxy"
+                "spec": {
+                    "$ref": "#/definitions/openapi.RequestEventSpecJson"
                 }
             }
         },

--- a/internal/service/api/swagger/docs.yaml
+++ b/internal/service/api/swagger/docs.yaml
@@ -1032,6 +1032,327 @@ definitions:
         example: 1
         type: number
     type: object
+  openapi.RequestEventActorReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: act_01example
+        type: string
+      kind:
+        enum:
+        - Actor
+        example: Actor
+        type: string
+      name:
+        example: billing-service
+        type: string
+      namespace:
+        example: root.acme
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventCaptureJson:
+    properties:
+      request:
+        $ref: '#/definitions/openapi.RequestEventCapturedRequestJson'
+      response:
+        $ref: '#/definitions/openapi.RequestEventCapturedResponseJson'
+    required:
+    - request
+    - response
+    type: object
+  openapi.RequestEventCapturedRequestJson:
+    properties:
+      body:
+        format: byte
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      url:
+        example: https://api.example.com/v1/users
+        type: string
+    required:
+    - headers
+    - url
+    type: object
+  openapi.RequestEventCapturedResponseJson:
+    properties:
+      body:
+        format: byte
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+    required:
+    - headers
+    type: object
+  openapi.RequestEventConnectionReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: cxn_01example
+        type: string
+      kind:
+        enum:
+        - Connection
+        example: Connection
+        type: string
+      name:
+        example: production
+        type: string
+      namespace:
+        example: root.acme
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventConnectorReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      generation:
+        example: 3
+        type: integer
+      id:
+        example: cxr_01example
+        type: string
+      kind:
+        enum:
+        - Connector
+        example: Connector
+        type: string
+      name:
+        example: provider
+        type: string
+      namespace:
+        example: root.integrations
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventJson:
+    description: Immutable, resource-shaped HTTP request event projection
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      kind:
+        enum:
+        - RequestEvent
+        example: RequestEvent
+        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.RequestEventSpecJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
+    type: object
+  openapi.RequestEventListMetaJson:
+    properties:
+      continue:
+        type: string
+      total:
+        type: integer
+    type: object
+  openapi.RequestEventNamespaceReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: root.acme
+        type: string
+      kind:
+        enum:
+        - Namespace
+        example: Namespace
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventRateLimitJson:
+    properties:
+      bucket:
+        additionalProperties:
+          type: string
+        type: object
+      mode:
+        enum:
+        - enforce
+        - observe
+        example: enforce
+        type: string
+      rateLimitRef:
+        $ref: '#/definitions/openapi.RequestEventRateLimitReferenceJson'
+    required:
+    - mode
+    - rateLimitRef
+    type: object
+  openapi.RequestEventRateLimitReferenceJson:
+    properties:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
+        type: string
+      id:
+        example: rl_01example
+        type: string
+      kind:
+        enum:
+        - RateLimit
+        example: RateLimit
+        type: string
+    required:
+    - apiVersion
+    - id
+    - kind
+    type: object
+  openapi.RequestEventRequestJson:
+    properties:
+      bodySkipped:
+        enum:
+        - streaming
+        - too_large
+        type: string
+      host:
+        example: api.example.com
+        type: string
+      httpVersion:
+        example: HTTP/2.0
+        type: string
+      method:
+        example: GET
+        type: string
+      mimeType:
+        example: application/json
+        type: string
+      path:
+        example: /v1/users
+        type: string
+      scheme:
+        example: https
+        type: string
+      sizeBytes:
+        type: integer
+    required:
+    - host
+    - method
+    - path
+    - scheme
+    type: object
+  openapi.RequestEventResponseJson:
+    properties:
+      bodySkipped:
+        enum:
+        - streaming
+        - too_large
+        type: string
+      error:
+        type: string
+      httpVersion:
+        example: HTTP/2.0
+        type: string
+      mimeType:
+        example: application/json
+        type: string
+      sizeBytes:
+        type: integer
+      source:
+        enum:
+        - upstream
+        - connector_rate_limiter
+        - rate_limit
+        example: upstream
+        type: string
+      statusCode:
+        example: 200
+        type: integer
+    type: object
+  openapi.RequestEventSpecJson:
+    properties:
+      actorRef:
+        $ref: '#/definitions/openapi.RequestEventActorReferenceJson'
+      capture:
+        $ref: '#/definitions/openapi.RequestEventCaptureJson'
+      captureAvailable:
+        type: boolean
+      connectionRef:
+        $ref: '#/definitions/openapi.RequestEventConnectionReferenceJson'
+      connectorRef:
+        $ref: '#/definitions/openapi.RequestEventConnectorReferenceJson'
+      correlationId:
+        type: string
+      durationMilliseconds:
+        example: 150
+        type: integer
+      internalTimeout:
+        type: boolean
+      namespaceRef:
+        $ref: '#/definitions/openapi.RequestEventNamespaceReferenceJson'
+      rateLimit:
+        $ref: '#/definitions/openapi.RequestEventRateLimitJson'
+      rateLimitsMatched:
+        items:
+          $ref: '#/definitions/openapi.RequestEventRateLimitJson'
+        type: array
+      request:
+        $ref: '#/definitions/openapi.RequestEventRequestJson'
+      requestCancelled:
+        type: boolean
+      requestType:
+        enum:
+        - global
+        - proxy
+        - oauth
+        - public
+        - probe
+        example: proxy
+        type: string
+      response:
+        $ref: '#/definitions/openapi.RequestEventResponseJson'
+    required:
+    - durationMilliseconds
+    - namespaceRef
+    - request
+    - requestType
+    - response
+    type: object
   openapi.SearchResultListMetaJson:
     properties:
       incompleteKinds:
@@ -1481,15 +1802,29 @@ definitions:
     - metadata
     type: object
   routes.OpenAPIListRequestEventsResponse:
-    description: Paginated list of request events entries
+    description: Paginated list of immutable request-event projections
     properties:
-      cursor:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
       items:
-        items: {}
+        items:
+          $ref: '#/definitions/openapi.RequestEventJson'
         type: array
-      total:
-        type: integer
+      kind:
+        enum:
+        - RequestEventList
+        example: RequestEventList
+        type: string
+      metadata:
+        $ref: '#/definitions/openapi.RequestEventListMetaJson'
+    required:
+    - apiVersion
+    - items
+    - kind
+    - metadata
     type: object
   routes.OpenAPIMetricsSchemaResponse:
     description: Application metrics schema response
@@ -1564,63 +1899,27 @@ definitions:
         type: integer
     type: object
   routes.OpenAPIRequestEventsEntry:
-    description: HTTP request events entry
+    description: Immutable, resource-shaped HTTP request event projection
     properties:
-      connectionId:
+      apiVersion:
+        enum:
+        - authproxy.net/v1alpha1
+        example: authproxy.net/v1alpha1
         type: string
-      connectorId:
+      kind:
+        enum:
+        - RequestEvent
+        example: RequestEvent
         type: string
-      connectorVersion:
-        type: integer
-      correlationId:
-        type: string
-      duration:
-        example: 150
-        type: integer
-      host:
-        example: api.example.com
-        type: string
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      method:
-        example: GET
-        type: string
-      namespace:
-        example: root.acme
-        type: string
-      path:
-        example: /v1/users
-        type: string
-      rateLimitBucket:
-        additionalProperties:
-          type: string
-        type: object
-      rateLimitId:
-        type: string
-      rateLimitMatched:
-        items: {}
-        type: array
-      rateLimitMode:
-        type: string
-      requestId:
-        example: req_test550e8400abcde
-        type: string
-      responseSource:
-        example: upstream
-        type: string
-      responseStatusCode:
-        example: 200
-        type: integer
-      scheme:
-        example: https
-        type: string
-      timestamp:
-        type: string
-      type:
-        example: proxy
-        type: string
+      metadata:
+        $ref: '#/definitions/meta.ObjectMeta'
+      spec:
+        $ref: '#/definitions/openapi.RequestEventSpecJson'
+    required:
+    - apiVersion
+    - kind
+    - metadata
+    - spec
     type: object
   routes.OpenAPISearchResourcesResponseJson:
     properties:
@@ -5512,7 +5811,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: List request events entries with optional filtering and pagination
+      description: List immutable request-event projections with optional filtering
+        and pagination
       parameters:
       - description: Pagination cursor
         in: query
@@ -5610,7 +5910,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get a specific request events entry by its UUID
+      description: Get a specific immutable request event by its ID
       parameters:
       - description: Request events entry UUID
         in: path


### PR DESCRIPTION
Closes #842

## Summary

- classify RequestEvent as an immutable, resource-shaped event projection with apiVersion, kind, metadata, and spec
- expose typed namespace, actor, connection, connector-generation, and rate-limit references while preserving the complete frozen label snapshot
- move pagination to RequestEventList metadata.continue and metadata.total without changing query/filter parameters
- combine the searchable event row with encrypted full capture on reads, keeping URLs, headers, and base64 bodies under the API secret-replay redaction policy
- update JSON Schema, OpenAPI/Swagger output, fixtures, package guidance, route/storage tests, and application-metrics documentation

The JavaScript SDK and Admin UI are intentionally left for dependent issues #844 and #845, which will consume this contract after the backend resource migrations are complete.

## Verification

- ./scripts/preflight.sh
- yarn docs:build
- focused schema, storage, conversion, and route tests with SQLite
- RequestEvents provider suite with SQLite
- RequestEvents provider suite with PostgreSQL