### PR TITLE
Migrate JavaScript SDK to v1alpha1 resources

### DIFF
--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -2,8 +2,46 @@
 
 Package source for AuthProxy's JavaScript/TypeScript SDK. The canonical usage guide, including authentication and proxy examples, is in [the SDK documentation](../../docs/src/content/docs/sdks/javascript.md).
 
+## Contract model
+
+The SDK contains handwritten types for the API's `authproxy.net/v1alpha1`
+contract. Managed resources and read-only operational projections use
+Kubernetes-style envelopes with `apiVersion`, `kind`, `metadata`, `spec`, and,
+where applicable, server-owned `status`. List results use `<Kind>List` with
+pagination under `metadata`; imperative operations use typed action envelopes.
+
+Shared transport primitives and constructors live in `src/common.ts`. Resource
+modules own their resource-specific metadata, spec, status, patch, list, and
+action types alongside their endpoint functions. Do not add flat compatibility
+models when the server contract changes—update the canonical SDK type and its
+serialization tests together.
+
+Connector generations are not a separate resource type. Each generation is a
+`Connector` with the same `metadata.id` and a distinct
+`metadata.generation`. A connector reference without a generation resolves to
+the primary generation; connection bindings and migration targets use an exact
+generation.
+
+Actor signing keys and key provider configuration are write-only inputs. Actor
+responses omit signing material, and key responses contain only the server's
+redacted provider configuration plus `status.keyDataConfigured`. The SDK types
+and fixtures preserve these boundaries but do not perform client-side secret
+redaction. `createActorClaim` and `actorResourceToClaim` build the restricted
+Actor shape allowed inside AuthProxy JWTs; the helpers deliberately omit
+database identity, timestamps, status, and signing material.
+
+## Development
+
 Build from the repository root:
 
 ```bash
 yarn workspace @authproxy/api build
+```
+
+Run the package checks with:
+
+```bash
+yarn workspace @authproxy/api typecheck
+yarn workspace @authproxy/api test
+yarn workspace @authproxy/api lint
 ```

--- a/sdks/js/src/actionSerialization.test.ts
+++ b/sdks/js/src/actionSerialization.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const postMock = vi.hoisted(() => vi.fn());
+const putMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./client', () => ({
+  client: { post: postMock, put: putMock },
+}));
+
+import { API_VERSION, objectReference } from './common';
+import {
+  abortConnection,
+  ConnectionState,
+  disconnectConnection,
+  forceConnectionState,
+  initiateConnection,
+  migrateConnectionVersion,
+  submitConnection,
+} from './connections';
+import { markNotificationViewed, markNotificationsViewed } from './notifications';
+
+describe('v1alpha1 action serialization', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    putMock.mockReset();
+  });
+
+  it('targets a connector reference when initiating a connection', () => {
+    initiateConnection(objectReference('Connector', { id: 'cxr_test' }), {
+      intoNamespace: 'root.acme',
+      name: 'production',
+      returnToUrl: 'https://example.com/callback',
+    });
+
+    expect(postMock).toHaveBeenCalledWith('/api/v1/connections/_initiate', {
+      apiVersion: API_VERSION,
+      kind: 'ConnectionInitiate',
+      metadata: {
+        target: { apiVersion: API_VERSION, kind: 'Connector', id: 'cxr_test' },
+      },
+      spec: {
+        intoNamespace: 'root.acme',
+        name: 'production',
+        returnToUrl: 'https://example.com/callback',
+      },
+    });
+  });
+
+  it('builds connection-targeted setup and lifecycle actions', () => {
+    submitConnection('cxn_test', {
+      stepId: 'preconnect:0',
+      data: { workspace: 'ws-123' },
+    });
+    disconnectConnection('cxn_test', { timeoutSeconds: 600 });
+    abortConnection('cxn_test');
+
+    const target = {
+      apiVersion: API_VERSION,
+      kind: 'Connection',
+      id: 'cxn_test',
+    };
+    expect(postMock).toHaveBeenNthCalledWith(1, '/api/v1/connections/cxn_test/_submit', {
+      apiVersion: API_VERSION,
+      kind: 'ConnectionSetupSubmit',
+      metadata: { target },
+      spec: { stepId: 'preconnect:0', data: { workspace: 'ws-123' } },
+    });
+    expect(postMock).toHaveBeenNthCalledWith(2, '/api/v1/connections/cxn_test/_disconnect', {
+      apiVersion: API_VERSION,
+      kind: 'ConnectionDisconnect',
+      metadata: { target },
+      spec: { timeoutSeconds: 600 },
+    });
+    expect(postMock).toHaveBeenNthCalledWith(3, '/api/v1/connections/cxn_test/_abort', {
+      apiVersion: API_VERSION,
+      kind: 'ConnectionSetupAbort',
+      metadata: { target },
+      spec: {},
+    });
+  });
+
+  it('requires an exact connector generation for migration actions', () => {
+    migrateConnectionVersion('cxn_test', {
+      connectorRef: objectReference('Connector', { id: 'cxr_test', generation: 3 }),
+      timeoutSeconds: 600,
+    });
+    forceConnectionState('cxn_test', ConnectionState.CONFIGURED);
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/v1/connections/cxn_test/_migrateVersion',
+      expect.objectContaining({
+        apiVersion: API_VERSION,
+        kind: 'ConnectionVersionMigration',
+        spec: {
+          connectorRef: {
+            apiVersion: API_VERSION,
+            kind: 'Connector',
+            id: 'cxr_test',
+            generation: 3,
+          },
+          timeoutSeconds: 600,
+        },
+      }),
+    );
+    expect(putMock).toHaveBeenCalledWith(
+      '/api/v1/connections/cxn_test/_forceState',
+      expect.objectContaining({
+        apiVersion: API_VERSION,
+        kind: 'ConnectionForceState',
+        spec: { state: ConnectionState.CONFIGURED },
+      }),
+    );
+  });
+
+  it('serializes single and batch notification targets as references', () => {
+    markNotificationViewed('ntf_one');
+    markNotificationsViewed(['ntf_one', 'ntf_two']);
+
+    expect(postMock).toHaveBeenNthCalledWith(1, '/api/v1/notifications/ntf_one/_viewed', {
+      apiVersion: API_VERSION,
+      kind: 'NotificationView',
+      metadata: {
+        target: { apiVersion: API_VERSION, kind: 'Notification', id: 'ntf_one' },
+      },
+      spec: {},
+    });
+    expect(postMock).toHaveBeenNthCalledWith(2, '/api/v1/notifications/_viewed', {
+      apiVersion: API_VERSION,
+      kind: 'NotificationBatchView',
+      metadata: {
+        targets: [
+          { apiVersion: API_VERSION, kind: 'Notification', id: 'ntf_one' },
+          { apiVersion: API_VERSION, kind: 'Notification', id: 'ntf_two' },
+        ],
+      },
+      spec: {},
+    });
+  });
+});

--- a/sdks/js/src/actors.ts
+++ b/sdks/js/src/actors.ts
@@ -1,9 +1,15 @@
 import { client } from './client';
-import { ListResponse } from './common';
+import {
+  API_VERSION,
+  MutableResourceMetadata,
+  NamespacedCreateMetadata,
+  ObjectMetadata,
+  ResourceList,
+  TypeMeta,
+} from './common';
 
 // Actor models mirror the canonical authproxy.net/v1alpha1 resource.
 
-export const ACTOR_API_VERSION = 'authproxy.net/v1alpha1' as const;
 export const ACTOR_KIND = 'Actor' as const;
 
 export interface ActorPermission {
@@ -15,12 +21,10 @@ export interface ActorPermission {
 
 export type ActorSigningKey = Record<string, unknown>;
 
-export interface ActorMetadata {
+export interface ActorMetadata extends ObjectMetadata {
   id: string;
   name: string;
   namespace: string;
-  labels?: Record<string, string>;
-  annotations?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 }
@@ -34,44 +38,92 @@ export interface ActorStatus {
   signingKeyConfigured: boolean;
 }
 
-export interface Actor {
-  apiVersion: typeof ACTOR_API_VERSION;
-  kind: typeof ACTOR_KIND;
+export interface Actor extends TypeMeta<typeof ACTOR_KIND> {
   metadata: ActorMetadata;
   spec: ActorSpec;
   status: ActorStatus;
 }
 
-export interface CreateActorRequest {
-  apiVersion: typeof ACTOR_API_VERSION;
-  kind: typeof ACTOR_KIND;
-  metadata: {
-    namespace: string;
-    name?: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-  };
-  spec: {
-    externalId: string;
-    permissions?: ActorPermission[];
+export interface CreateActorRequest extends TypeMeta<typeof ACTOR_KIND> {
+  metadata: NamespacedCreateMetadata;
+  spec: ActorSpec & {
+    /** Write-only signing material; it is never returned on Actor resources. */
     signingKey?: ActorSigningKey;
   };
 }
 
-export interface UpdateActorRequest {
-  apiVersion: typeof ACTOR_API_VERSION;
-  kind: typeof ACTOR_KIND;
-  metadata: {
-    name?: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-  };
+export interface UpdateActorRequest extends TypeMeta<typeof ACTOR_KIND> {
+  metadata: MutableResourceMetadata;
   spec: {
+    externalId?: string;
     permissions?: ActorPermission[];
     /** Explicit null removes actor-specific signing material. */
     signingKey?: ActorSigningKey | null;
   };
 }
+
+export type ActorList = ResourceList<Actor>;
+
+/** Restricted Actor resource permitted in an AuthProxy JWT actor claim. */
+export interface ActorClaim extends TypeMeta<typeof ACTOR_KIND> {
+  metadata: {
+    name?: string;
+    namespace: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+    id?: never;
+    generation?: never;
+    createdAt?: never;
+    updatedAt?: never;
+  };
+  spec: ActorSpec;
+  status?: never;
+}
+
+export interface ActorClaimInput {
+  externalId: string;
+  namespace: string;
+  name?: string;
+  permissions?: ActorPermission[];
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+}
+
+/** Builds the restricted resource shape accepted in a JWT's actor claim. */
+export const createActorClaim = (input: ActorClaimInput): ActorClaim => ({
+  apiVersion: API_VERSION,
+  kind: ACTOR_KIND,
+  metadata: {
+    ...(input.name ? { name: input.name } : {}),
+    namespace: input.namespace,
+    ...(input.labels ? { labels: { ...input.labels } } : {}),
+    ...(input.annotations ? { annotations: { ...input.annotations } } : {}),
+  },
+  spec: {
+    externalId: input.externalId,
+    ...(input.permissions
+      ? {
+          permissions: input.permissions.map((permission) => ({
+            ...permission,
+            resources: [...permission.resources],
+            ...(permission.resourceIds ? { resourceIds: [...permission.resourceIds] } : {}),
+            verbs: [...permission.verbs],
+          })),
+        }
+      : {}),
+  },
+});
+
+/** Removes database identity, timestamps, status, and signing data from an Actor. */
+export const actorResourceToClaim = (actor: Actor): ActorClaim =>
+  createActorClaim({
+    externalId: actor.spec.externalId,
+    namespace: actor.metadata.namespace,
+    name: actor.metadata.name,
+    permissions: actor.spec.permissions,
+    labels: actor.metadata.labels,
+    annotations: actor.metadata.annotations,
+  });
 
 export interface PutActorLabelRequest {
   value: string;
@@ -108,8 +160,8 @@ export interface ListActorsParams {
  * Get a list of all actors
  * @param params The parameters for filtering and pagination
  */
-export const listActors = (params: ListActorsParams) => {
-  return client.get<ListResponse<Actor>>('/api/v1/actors', { params });
+export const listActors = (params?: ListActorsParams) => {
+  return client.get<ActorList>('/api/v1/actors', { params });
 };
 
 /**

--- a/sdks/js/src/common.ts
+++ b/sdks/js/src/common.ts
@@ -1,6 +1,160 @@
-// ListResponse is a generic response for list endpoints.
-export interface ListResponse<T> {
-  items: T[];
-  cursor?: string;
-  total?: number; // Total is not returned for all endpoints and should not be assumed.
+/** The schema version used by every v1 API resource and transport object. */
+export const API_VERSION = 'authproxy.net/v1alpha1' as const;
+
+export type ApiVersion = typeof API_VERSION;
+
+/** Kinds that identify durable, client-managed AuthProxy resources. */
+export type ManagedResourceKind =
+  | 'Actor'
+  | 'Connection'
+  | 'Connector'
+  | 'Key'
+  | 'Namespace'
+  | 'RateLimit';
+
+/** Read-only resource-shaped projections returned by operational APIs. */
+export type ProjectionKind =
+  | 'Notification'
+  | 'RequestEvent'
+  | 'Task'
+  | 'TaskExecution'
+  | 'TaskQueue'
+  | 'TaskQueueHistory'
+  | 'TaskSchedule'
+  | 'TaskServer'
+  | 'WorkflowHistoryEvent'
+  | 'WorkflowInstance';
+
+export type ResourceKind = ManagedResourceKind | ProjectionKind;
+
+/** Identifies the concrete schema used by a resource or transport object. */
+export interface TypeMeta<K extends string = string> {
+  apiVersion: ApiVersion;
+  kind: K;
 }
+
+/** Common resource metadata. Individual resources narrow required fields. */
+export interface ObjectMetadata {
+  id?: string;
+  name?: string;
+  namespace?: string;
+  generation?: number;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export enum ConditionStatus {
+  TRUE = 'True',
+  FALSE = 'False',
+  UNKNOWN = 'Unknown',
+}
+
+export interface Condition {
+  type: string;
+  status: ConditionStatus;
+  observedGeneration?: number;
+  lastTransitionTime: string;
+  reason?: string;
+  message?: string;
+}
+
+/** Common metadata fields accepted by mutable, namespaced resources. */
+export interface NamespacedCreateMetadata {
+  name?: string;
+  namespace: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+}
+
+/** Common metadata fields accepted by resource merge patches. */
+export interface MutableResourceMetadata {
+  name?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+}
+
+/**
+ * Stable resource identity. References use either id or namespace/name.
+ * Connector references may additionally select a generation.
+ */
+export interface ObjectReference<K extends string = ResourceKind> extends TypeMeta<K> {
+  id?: string;
+  name?: string;
+  namespace?: string;
+  generation?: number;
+}
+
+export type VersionedConnectorReference = ObjectReference<'Connector'> & {
+  generation: number;
+};
+
+export type GenerationlessObjectReference<K extends string> = Omit<
+  ObjectReference<K>,
+  'generation'
+> & {
+  generation?: never;
+};
+
+export interface ListMetadata {
+  resourceVersion?: string;
+  continue?: string;
+  remainingItemCount?: number;
+}
+
+/** Kubernetes-style list transport for a homogeneous resource kind. */
+export type ResourceList<T extends TypeMeta<string>> = TypeMeta<`${T['kind']}List`> & {
+  metadata: ListMetadata;
+  items: T[];
+};
+
+export interface ActionMetadata<TTargetKind extends string = ResourceKind> {
+  target: ObjectReference<TTargetKind>;
+}
+
+/** Imperative action sent to the API. Status is always server-owned. */
+export type ActionRequest<
+  K extends string,
+  TTargetKind extends string,
+  TSpec,
+> = TypeMeta<K> & {
+  metadata: ActionMetadata<TTargetKind>;
+  spec: TSpec;
+  status?: never;
+};
+
+/** Typed action result returned by the API. */
+export type ActionResponse<
+  K extends string,
+  TTargetKind extends string,
+  TSpec,
+  TStatus,
+> = TypeMeta<K> & {
+  metadata: ActionMetadata<TTargetKind>;
+  spec: TSpec;
+  status: TStatus;
+};
+
+export const objectReference = <
+  K extends string,
+  I extends Omit<ObjectReference<K>, 'apiVersion' | 'kind'>,
+>(
+  kind: K,
+  identity: I,
+): TypeMeta<K> & I => ({
+  apiVersion: API_VERSION,
+  kind,
+  ...identity,
+});
+
+export const actionRequest = <K extends string, TTargetKind extends string, TSpec>(
+  kind: K,
+  target: ObjectReference<TTargetKind>,
+  spec: TSpec,
+): ActionRequest<K, TTargetKind, TSpec> => ({
+  apiVersion: API_VERSION,
+  kind,
+  metadata: { target },
+  spec,
+});

--- a/sdks/js/src/connections.ts
+++ b/sdks/js/src/connections.ts
@@ -1,448 +1,499 @@
-import {client} from './client';
-import {Connector} from './connectors';
-import {ListResponse} from './common';
+import { client } from './client';
+import {
+  ActionRequest,
+  ActionResponse,
+  MutableResourceMetadata,
+  ObjectMetadata,
+  ObjectReference,
+  ResourceList,
+  TypeMeta,
+  VersionedConnectorReference,
+  actionRequest,
+  objectReference,
+} from './common';
 
-// Connection models
-//
-// SETUP: connection is persisted and one or more setup steps are in progress.
-// CONFIGURED: setup is complete. The connection may or may not be currently
-// usable; the orthogonal ConnectionHealthState axis carries that signal.
+export const CONNECTION_KIND = 'Connection' as const;
+
 export enum ConnectionState {
-    SETUP = 'setup',
-    CONFIGURED = 'configured',
-    DISABLED = 'disabled',
-    DISCONNECTING = 'disconnecting',
-    DISCONNECTED = 'disconnected',
+  SETUP = 'setup',
+  CONFIGURED = 'configured',
+  DISABLED = 'disabled',
+  DISCONNECTING = 'disconnecting',
+  DISCONNECTED = 'disconnected',
 }
 
-// Operational health signal for a connection. Distinct from ConnectionState:
-// a Configured connection whose credentials have stopped working flips to
-// UNHEALTHY without leaving the Configured lifecycle state. UIs surface this
-// to drive the unified re-authentication action.
 export enum ConnectionHealthState {
-    HEALTHY = 'healthy',
-    UNHEALTHY = 'unhealthy',
+  HEALTHY = 'healthy',
+  UNHEALTHY = 'unhealthy',
 }
 
-export interface UpdateConnectionRequest {
-    name?: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
+export interface ConnectionMetadata extends ObjectMetadata {
+  id: string;
+  name: string;
+  namespace: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
-export interface PutConnectionLabelRequest {
-    value: string;
+export interface ConnectionSpec {
+  connectorRef: VersionedConnectorReference;
+  /** Connector-defined desired configuration. Auth credentials are stored separately. */
+  configuration?: Record<string, unknown>;
 }
 
-export interface ConnectionLabel {
-    key: string;
-    value: string;
-}
-
-export interface PutConnectionAnnotationRequest {
-    value: string;
-}
-
-export interface ConnectionAnnotation {
-    key: string;
-    value: string;
-}
-
-export interface Connection {
-    id: string;
-    name: string;
-    namespace: string;
-    connector: Connector;
+export interface ConnectionStatus {
+  lifecycle: {
     state: ConnectionState;
-    healthState: ConnectionHealthState;
-    setupStepId?: string;
-    setupError?: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-    createdAt: string;
-    updatedAt: string;
+  };
+  health: {
+    state: ConnectionHealthState;
+  };
+  setup?: {
+    stepId?: string;
+    error?: string;
+  };
+  configuration: {
+    configured: boolean;
+    /** JSON Schema derived from the exact connector generation. */
+    schema: Record<string, unknown>;
+  };
 }
+
+export interface Connection extends TypeMeta<typeof CONNECTION_KIND> {
+  metadata: ConnectionMetadata;
+  spec: ConnectionSpec;
+  status: ConnectionStatus;
+}
+
+export interface UpdateConnectionRequest extends TypeMeta<typeof CONNECTION_KIND> {
+  metadata: MutableResourceMetadata;
+  /** Connection bindings/configuration are changed through typed actions. */
+  spec: Record<string, never>;
+}
+
+export type ConnectionList = ResourceList<Connection>;
 
 export function canBeDisconnected(connection: Connection): boolean {
-    return (
-        connection.state !== ConnectionState.DISCONNECTING &&
-        connection.state !== ConnectionState.DISCONNECTED
-    );
+  return (
+    connection.status.lifecycle.state !== ConnectionState.DISCONNECTING &&
+    connection.status.lifecycle.state !== ConnectionState.DISCONNECTED
+  );
 }
 
-// Request models
-export interface InitiateConnectionRequest {
-    connectorId: string;
-    name?: string;
-    returnToUrl: string;
-    labels?: Record<string, string>;
+export const CONNECTION_INITIATE_KIND = 'ConnectionInitiate' as const;
+export const CONNECTION_SETUP_KIND = 'ConnectionSetup' as const;
+export const CONNECTION_SETUP_SUBMIT_KIND = 'ConnectionSetupSubmit' as const;
+export const CONNECTION_SETUP_ABORT_KIND = 'ConnectionSetupAbort' as const;
+export const CONNECTION_RECONFIGURE_KIND = 'ConnectionReconfigure' as const;
+export const CONNECTION_SETUP_CANCEL_KIND = 'ConnectionSetupCancel' as const;
+export const CONNECTION_SETUP_RETRY_KIND = 'ConnectionSetupRetry' as const;
+export const CONNECTION_REAUTHENTICATE_KIND = 'ConnectionReauthenticate' as const;
+export const CONNECTION_DISCONNECT_KIND = 'ConnectionDisconnect' as const;
+export const CONNECTION_VERSION_MIGRATION_KIND = 'ConnectionVersionMigration' as const;
+export const CONNECTION_FORCE_STATE_KIND = 'ConnectionForceState' as const;
+
+export interface ConnectionInitiateSpec {
+  intoNamespace?: string;
+  name?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  returnToUrl: string;
 }
+
+export type ConnectionInitiateRequest = ActionRequest<
+  typeof CONNECTION_INITIATE_KIND,
+  'Connector',
+  ConnectionInitiateSpec
+>;
 
 export enum ConnectionSetupResponseType {
-    REDIRECT = 'redirect',
-    FORM = 'form',
-    COMPLETE = 'complete',
-    VERIFYING = 'verifying',
-    ERROR = 'error',
+  REDIRECT = 'redirect',
+  FORM = 'form',
+  COMPLETE = 'complete',
+  VERIFYING = 'verifying',
+  ERROR = 'error',
 }
 
-export interface ConnectionSetupResponse {
-    id: string;
-    type: ConnectionSetupResponseType;
+export interface ConnectionSetupRedirectStatus {
+  type: ConnectionSetupResponseType.REDIRECT;
+  redirectUrl: string;
 }
 
-export interface ConnectionSetupRedirectResponse extends ConnectionSetupResponse {
-    type: ConnectionSetupResponseType.REDIRECT;
-    redirectUrl: string;
+export interface ConnectionSetupFormStatus {
+  type: ConnectionSetupResponseType.FORM;
+  stepId: string;
+  stepTitle?: string;
+  stepDescription?: string;
+  jsonSchema: Record<string, unknown>;
+  uiSchema: Record<string, unknown>;
+  /** Previously submitted values are always returned irreversibly redacted. */
+  data?: Record<string, unknown>;
 }
 
-export interface ConnectionSetupFormResponse extends ConnectionSetupResponse {
-    type: ConnectionSetupResponseType.FORM;
-    stepId: string;
-    stepTitle?: string;
-    stepDescription?: string;
-    jsonSchema: Record<string, unknown>;
-    uiSchema: Record<string, unknown>;
-    data?: Record<string, unknown>;
+export interface ConnectionSetupCompleteStatus {
+  type: ConnectionSetupResponseType.COMPLETE;
 }
 
-export interface ConnectionSetupCompleteResponse extends ConnectionSetupResponse {
-    type: ConnectionSetupResponseType.COMPLETE;
+export interface ConnectionSetupVerifyingStatus {
+  type: ConnectionSetupResponseType.VERIFYING;
 }
 
-export interface ConnectionSetupVerifyingResponse extends ConnectionSetupResponse {
-    type: ConnectionSetupResponseType.VERIFYING;
+export interface ConnectionSetupErrorStatus {
+  type: ConnectionSetupResponseType.ERROR;
+  error: string;
+  canRetry?: boolean;
 }
 
-export interface ConnectionSetupErrorResponse extends ConnectionSetupResponse {
-    type: ConnectionSetupResponseType.ERROR;
-    error: string;
-    canRetry: boolean;
+export type ConnectionSetupStatus =
+  | ConnectionSetupRedirectStatus
+  | ConnectionSetupFormStatus
+  | ConnectionSetupCompleteStatus
+  | ConnectionSetupVerifyingStatus
+  | ConnectionSetupErrorStatus;
+
+export type ConnectionSetupResponse = ActionResponse<
+  typeof CONNECTION_SETUP_KIND,
+  typeof CONNECTION_KIND,
+  Record<string, never>,
+  ConnectionSetupStatus
+>;
+
+export type ConnectionSetupRedirectResponse = ConnectionSetupResponse & {
+  status: ConnectionSetupRedirectStatus;
+};
+export type ConnectionSetupFormResponse = ConnectionSetupResponse & {
+  status: ConnectionSetupFormStatus;
+};
+export type ConnectionSetupCompleteResponse = ConnectionSetupResponse & {
+  status: ConnectionSetupCompleteStatus;
+};
+export type ConnectionSetupVerifyingResponse = ConnectionSetupResponse & {
+  status: ConnectionSetupVerifyingStatus;
+};
+export type ConnectionSetupErrorResponse = ConnectionSetupResponse & {
+  status: ConnectionSetupErrorStatus;
+};
+
+export function isRedirectResponse(
+  response: ConnectionSetupResponse,
+): response is ConnectionSetupRedirectResponse {
+  return response.status.type === ConnectionSetupResponseType.REDIRECT;
 }
 
-export function isRedirectResponse(response: ConnectionSetupResponse): response is ConnectionSetupRedirectResponse {
-    return response.type === ConnectionSetupResponseType.REDIRECT;
+export function isFormResponse(
+  response: ConnectionSetupResponse,
+): response is ConnectionSetupFormResponse {
+  return response.status.type === ConnectionSetupResponseType.FORM;
 }
 
-export function isFormResponse(response: ConnectionSetupResponse): response is ConnectionSetupFormResponse {
-    return response.type === ConnectionSetupResponseType.FORM;
+export function isCompleteResponse(
+  response: ConnectionSetupResponse,
+): response is ConnectionSetupCompleteResponse {
+  return response.status.type === ConnectionSetupResponseType.COMPLETE;
 }
 
-export function isCompleteResponse(response: ConnectionSetupResponse): response is ConnectionSetupCompleteResponse {
-    return response.type === ConnectionSetupResponseType.COMPLETE;
+export function isVerifyingResponse(
+  response: ConnectionSetupResponse,
+): response is ConnectionSetupVerifyingResponse {
+  return response.status.type === ConnectionSetupResponseType.VERIFYING;
 }
 
-export function isVerifyingResponse(response: ConnectionSetupResponse): response is ConnectionSetupVerifyingResponse {
-    return response.type === ConnectionSetupResponseType.VERIFYING;
+export function isErrorResponse(
+  response: ConnectionSetupResponse,
+): response is ConnectionSetupErrorResponse {
+  return response.status.type === ConnectionSetupResponseType.ERROR;
 }
 
-export function isErrorResponse(response: ConnectionSetupResponse): response is ConnectionSetupErrorResponse {
-    return response.type === ConnectionSetupResponseType.ERROR;
+export interface ConnectionSetupSubmitSpec {
+  stepId: string;
+  data: unknown;
+  returnToUrl?: string;
 }
 
-export interface SubmitConnectionRequest {
-    stepId: string;
-    data: unknown;
-    returnToUrl?: string;
+export type ConnectionSetupSubmitRequest = ActionRequest<
+  typeof CONNECTION_SETUP_SUBMIT_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionSetupSubmitSpec
+>;
+
+export interface ConnectionSetupControlSpec {
+  returnToUrl?: string;
 }
 
-export interface RetryConnectionRequest {
-    returnToUrl?: string;
+export type ConnectionSetupRetryRequest = ActionRequest<
+  typeof CONNECTION_SETUP_RETRY_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionSetupControlSpec
+>;
+
+export type ConnectionReauthenticateRequest = ActionRequest<
+  typeof CONNECTION_REAUTHENTICATE_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionSetupControlSpec
+>;
+
+export type EmptyConnectionActionKind =
+  | typeof CONNECTION_SETUP_ABORT_KIND
+  | typeof CONNECTION_RECONFIGURE_KIND
+  | typeof CONNECTION_SETUP_CANCEL_KIND;
+
+export type EmptyConnectionActionRequest<K extends EmptyConnectionActionKind> = ActionRequest<
+  K,
+  typeof CONNECTION_KIND,
+  Record<string, never>
+>;
+
+export interface ConnectionDisconnectSpec {
+  timeoutSeconds?: number;
 }
 
-export interface ReauthConnectionRequest {
-    returnToUrl?: string;
+export interface ConnectionDisconnectStatus {
+  taskId: string;
+  connection: Connection;
 }
+
+export type ConnectionDisconnectRequest = ActionRequest<
+  typeof CONNECTION_DISCONNECT_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionDisconnectSpec
+>;
+export type ConnectionDisconnectResponse = ActionResponse<
+  typeof CONNECTION_DISCONNECT_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionDisconnectSpec,
+  ConnectionDisconnectStatus
+>;
+
+export interface ConnectionVersionMigrationSpec {
+  connectorRef: VersionedConnectorReference;
+  timeoutSeconds?: number;
+}
+
+export interface ConnectionVersionMigrationStatus {
+  taskId: string;
+  sourceConnectorRef: VersionedConnectorReference;
+  targetConnectorRef: VersionedConnectorReference;
+}
+
+export type ConnectionVersionMigrationRequest = ActionRequest<
+  typeof CONNECTION_VERSION_MIGRATION_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionVersionMigrationSpec
+>;
+export type ConnectionVersionMigrationResponse = ActionResponse<
+  typeof CONNECTION_VERSION_MIGRATION_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionVersionMigrationSpec,
+  ConnectionVersionMigrationStatus
+>;
+
+export interface ConnectionForceStateSpec {
+  state: ConnectionState;
+}
+
+export type ConnectionForceStateRequest = ActionRequest<
+  typeof CONNECTION_FORCE_STATE_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionForceStateSpec
+>;
+export type ConnectionForceStateResponse = ActionResponse<
+  typeof CONNECTION_FORCE_STATE_KIND,
+  typeof CONNECTION_KIND,
+  ConnectionForceStateSpec,
+  { connection: Connection }
+>;
 
 export interface DataSourceOption {
-    value: string;
-    label: string;
+  value: string;
+  label: string;
 }
 
-// Disconnect models
-export interface DisconnectConnectionRequest {
-    timeoutSeconds?: number;
-}
-
-export interface DisconnectResponseJson {
-    taskId: string;
-    connection: Connection;
-}
-
-export interface MigrateConnectionVersionRequest {
-    targetVersion: number;
-    timeoutSeconds?: number;
-}
-
-export interface MigrateConnectionVersionResponseJson {
-    taskId: string;
-    connectionId: string;
-    sourceVersion: number;
-    targetVersion: number;
-}
-
-export interface ForceConnectionStateRequest {
-    state: ConnectionState;
-}
-
-export type ForceConnectionStateResponse = Connection;
-
-/**
- * Parameters used for listing connections.
- */
 export interface ListConnectionsParams {
-    name?: string;
-    state?: ConnectionState;
-    namespace?: string;
-    labelSelector?: string;
-    cursor?: string;
-    limit?: number;
-    orderBy?: string;
+  name?: string;
+  state?: ConnectionState;
+  namespace?: string;
+  labelSelector?: string;
+  cursor?: string;
+  limit?: number;
+  orderBy?: string;
 }
 
-/**
- * Get a list of all connections
- */
-export const listConnections = (params: ListConnectionsParams) => {
-    return client.get<ListResponse<Connection>>('/api/v1/connections', {params});
-};
+const connectionTarget = (id: string): ObjectReference<typeof CONNECTION_KIND> =>
+  objectReference(CONNECTION_KIND, { id });
 
-/**
- * Get a specific connection by ID
- */
-export const getConnection = (id: string) => {
-    return client.get<Connection>(`/api/v1/connections/${id}`);
-};
+export const listConnections = (params?: ListConnectionsParams) =>
+  client.get<ConnectionList>('/api/v1/connections', { params });
 
-/**
- * Initiate a new connection
- */
+export const getConnection = (id: string) =>
+  client.get<Connection>(`/api/v1/connections/${id}`);
+
 export const initiateConnection = (
-    connectorId: string,
-    returnToUrl: string,
-    labels?: Record<string, string>,
-    name?: string,
+  connectorRef: ObjectReference<'Connector'>,
+  spec: ConnectionInitiateSpec,
 ) => {
-    const request: InitiateConnectionRequest = {
-        connectorId: connectorId,
-        name,
-        returnToUrl: returnToUrl,
-        labels,
-    };
-
-    return client.post<ConnectionSetupResponse>(
-        '/api/v1/connections/_initiate',
-        request
-    );
+  const request: ConnectionInitiateRequest = actionRequest(
+    CONNECTION_INITIATE_KIND,
+    connectorRef,
+    spec,
+  );
+  return client.post<ConnectionSetupResponse>('/api/v1/connections/_initiate', request);
 };
 
-/**
- * Submit form data for a connection setup step
- */
-export const submitConnection = (
-    connectionId: string,
-    stepId: string,
-    data: unknown,
-    returnToUrl?: string
-) => {
-    const request: SubmitConnectionRequest = {
-        stepId: stepId,
-        data,
-        returnToUrl: returnToUrl,
-    };
-
-    return client.post<ConnectionSetupResponse>(
-        `/api/v1/connections/${connectionId}/_submit`,
-        request
-    );
+export const submitConnection = (connectionId: string, spec: ConnectionSetupSubmitSpec) => {
+  const request: ConnectionSetupSubmitRequest = actionRequest(
+    CONNECTION_SETUP_SUBMIT_KIND,
+    connectionTarget(connectionId),
+    spec,
+  );
+  return client.post<ConnectionSetupResponse>(
+    `/api/v1/connections/${connectionId}/_submit`,
+    request,
+  );
 };
 
-/**
- * Disconnect a connection
- */
-export const disconnectConnection = (id: string, request?: DisconnectConnectionRequest) => {
-    return client.post<DisconnectResponseJson>(
-        `/api/v1/connections/${id}/_disconnect`,
-        request
-    );
+export const disconnectConnection = (id: string, spec: ConnectionDisconnectSpec = {}) => {
+  const request: ConnectionDisconnectRequest = actionRequest(
+    CONNECTION_DISCONNECT_KIND,
+    connectionTarget(id),
+    spec,
+  );
+  return client.post<ConnectionDisconnectResponse>(
+    `/api/v1/connections/${id}/_disconnect`,
+    request,
+  );
 };
 
-/**
- * Migrate a connection to another version of the same connector.
- */
-export const migrateConnectionVersion = (id: string, request: MigrateConnectionVersionRequest) => {
-    return client.post<MigrateConnectionVersionResponseJson>(
-        `/api/v1/connections/${id}/_migrateVersion`,
-        request
-    );
+export const migrateConnectionVersion = (id: string, spec: ConnectionVersionMigrationSpec) => {
+  const request: ConnectionVersionMigrationRequest = actionRequest(
+    CONNECTION_VERSION_MIGRATION_KIND,
+    connectionTarget(id),
+    spec,
+  );
+  return client.post<ConnectionVersionMigrationResponse>(
+    `/api/v1/connections/${id}/_migrateVersion`,
+    request,
+  );
 };
 
-/**
- * Force the state of a connection. Requires admin permissions.
- */
 export const forceConnectionState = (id: string, state: ConnectionState) => {
-    const request: ForceConnectionStateRequest = {
-        state: state,
-    };
-    return client.put<ForceConnectionStateResponse>(
-        `/api/v1/connections/${id}/_forceState`,
-        request
-    );
+  const request: ConnectionForceStateRequest = actionRequest(
+    CONNECTION_FORCE_STATE_KIND,
+    connectionTarget(id),
+    { state },
+  );
+  return client.put<ConnectionForceStateResponse>(
+    `/api/v1/connections/${id}/_forceState`,
+    request,
+  );
 };
 
-/**
- * Update a connection's labels
- */
-export const updateConnection = (id: string, request: UpdateConnectionRequest) => {
-    return client.patch<Connection>(`/api/v1/connections/${id}`, request);
+export const updateConnection = (id: string, request: UpdateConnectionRequest) =>
+  client.patch<Connection>(`/api/v1/connections/${id}`, request);
+
+export const getConnectionLabels = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/connections/${id}/labels`);
+
+export const getConnectionLabel = (id: string, labelKey: string) =>
+  client.get<{ key: string; value: string }>(`/api/v1/connections/${id}/labels/${labelKey}`);
+
+export const putConnectionLabel = (id: string, labelKey: string, value: string) =>
+  client.put<{ key: string; value: string }>(
+    `/api/v1/connections/${id}/labels/${labelKey}`,
+    { value },
+  );
+
+export const deleteConnectionLabel = (id: string, labelKey: string) =>
+  client.delete(`/api/v1/connections/${id}/labels/${labelKey}`);
+
+export const getConnectionAnnotations = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/connections/${id}/annotations`);
+
+export const getConnectionAnnotation = (id: string, annotationKey: string) =>
+  client.get<{ key: string; value: string }>(
+    `/api/v1/connections/${id}/annotations/${annotationKey}`,
+  );
+
+export const putConnectionAnnotation = (id: string, annotationKey: string, value: string) =>
+  client.put<{ key: string; value: string }>(
+    `/api/v1/connections/${id}/annotations/${annotationKey}`,
+    { value },
+  );
+
+export const deleteConnectionAnnotation = (id: string, annotationKey: string) =>
+  client.delete(`/api/v1/connections/${id}/annotations/${annotationKey}`);
+
+const emptyConnectionAction = <K extends EmptyConnectionActionKind>(id: string, kind: K) =>
+  actionRequest(kind, connectionTarget(id), {});
+
+export const abortConnection = (id: string) =>
+  client.post<void>(
+    `/api/v1/connections/${id}/_abort`,
+    emptyConnectionAction(id, CONNECTION_SETUP_ABORT_KIND),
+  );
+
+export const getSetupStep = (connectionId: string, returnToUrl?: string) =>
+  client.get<ConnectionSetupResponse>(
+    `/api/v1/connections/${connectionId}/_setupStep`,
+    returnToUrl ? { params: { returnToUrl } } : undefined,
+  );
+
+export const getDataSource = (connectionId: string, sourceId: string) =>
+  client.get<DataSourceOption[]>(
+    `/api/v1/connections/${connectionId}/_dataSource/${sourceId}`,
+  );
+
+export const reconfigureConnection = (id: string) =>
+  client.post<ConnectionSetupResponse>(
+    `/api/v1/connections/${id}/_reconfigure`,
+    emptyConnectionAction(id, CONNECTION_RECONFIGURE_KIND),
+  );
+
+export const cancelSetupConnection = (id: string) =>
+  client.post<void>(
+    `/api/v1/connections/${id}/_cancelSetup`,
+    emptyConnectionAction(id, CONNECTION_SETUP_CANCEL_KIND),
+  );
+
+export const retryConnection = (id: string, spec: ConnectionSetupControlSpec = {}) => {
+  const request: ConnectionSetupRetryRequest = actionRequest(
+    CONNECTION_SETUP_RETRY_KIND,
+    connectionTarget(id),
+    spec,
+  );
+  return client.post<ConnectionSetupResponse>(`/api/v1/connections/${id}/_retry`, request);
 };
 
-/**
- * Get all labels for a specific connection by ID (uuid)
- */
-export const getConnectionLabels = (id: string) => {
-    return client.get<Record<string, string>>(`/api/v1/connections/${id}/labels`);
-};
-
-/**
- * Get a specific label for a connection by ID (uuid) and label key
- */
-export const getConnectionLabel = (id: string, labelKey: string) => {
-    return client.get<ConnectionLabel>(`/api/v1/connections/${id}/labels/${labelKey}`);
-};
-
-/**
- * Set a specific label for a connection by ID (uuid) and label key
- */
-export const putConnectionLabel = (id: string, labelKey: string, value: string) => {
-    return client.put<ConnectionLabel>(`/api/v1/connections/${id}/labels/${labelKey}`, { value });
-};
-
-/**
- * Delete a specific label for a connection by ID (uuid) and label key
- */
-export const deleteConnectionLabel = (id: string, labelKey: string) => {
-    return client.delete(`/api/v1/connections/${id}/labels/${labelKey}`);
-};
-
-/**
- * Get all annotations for a specific connection by ID (uuid)
- */
-export const getConnectionAnnotations = (id: string) => {
-    return client.get<Record<string, string>>(`/api/v1/connections/${id}/annotations`);
-};
-
-/**
- * Get a specific annotation for a connection by ID (uuid) and annotation key
- */
-export const getConnectionAnnotation = (id: string, annotationKey: string) => {
-    return client.get<ConnectionAnnotation>(`/api/v1/connections/${id}/annotations/${annotationKey}`);
-};
-
-/**
- * Set a specific annotation for a connection by ID (uuid) and annotation key
- */
-export const putConnectionAnnotation = (id: string, annotationKey: string, value: string) => {
-    return client.put<ConnectionAnnotation>(`/api/v1/connections/${id}/annotations/${annotationKey}`, { value });
-};
-
-/**
- * Delete a specific annotation for a connection by ID (uuid) and annotation key
- */
-export const deleteConnectionAnnotation = (id: string, annotationKey: string) => {
-    return client.delete(`/api/v1/connections/${id}/annotations/${annotationKey}`);
-};
-
-/**
- * Abort a connection that is still in setup
- */
-export const abortConnection = (id: string) => {
-    return client.post<void>(`/api/v1/connections/${id}/_abort`);
-};
-
-/**
- * Get the current setup step for a connection
- */
-export const getSetupStep = (connectionId: string, returnToUrl?: string) => {
-    return client.get<ConnectionSetupResponse>(
-        `/api/v1/connections/${connectionId}/_setupStep`,
-        returnToUrl ? {params: {returnToUrl: returnToUrl}} : undefined
-    );
-};
-
-/**
- * Get data source options for a connection setup step
- */
-export const getDataSource = (connectionId: string, sourceId: string) => {
-    return client.get<DataSourceOption[]>(`/api/v1/connections/${connectionId}/_dataSource/${sourceId}`);
-};
-
-/**
- * Reconfigure a completed connection by restarting its configure phase
- */
-export const reconfigureConnection = (id: string) => {
-    return client.post<ConnectionSetupResponse>(`/api/v1/connections/${id}/_reconfigure`);
-};
-
-/**
- * Cancel an in-flight reconfigure on a ready connection by clearing setup_step_id and setup_error.
- * The connection remains ready and its previously stored configuration continues to apply.
- */
-export const cancelSetupConnection = (id: string) => {
-    return client.post<void>(`/api/v1/connections/${id}/_cancelSetup`);
-};
-
-/**
- * Retry a connection that failed during setup, including auth-phase failures and probe
- * verification failures. For connectors with preconnect steps, returns to preconnect:0 so the
- * user can correct inputs. For connectors without preconnect steps, re-initiates OAuth
- * (returnToUrl is required in that case).
- */
-export const retryConnection = (id: string, returnToUrl?: string) => {
-    const request: RetryConnectionRequest = { returnToUrl: returnToUrl };
-    return client.post<ConnectionSetupResponse>(
-        `/api/v1/connections/${id}/_retry`,
-        request
-    );
-};
-
-/**
- * Re-authenticate a Ready connection. Used both for user-driven credential rotation and as the
- * recovery action when a connection has flipped to unhealthy. For api-key connectors, returns the
- * credentials form (no prior values pre-filled); on submit the existing credential is rotated
- * atomically. For OAuth2 connectors, restarts at preconnect:0 if defined, otherwise re-initiates
- * the OAuth redirect (returnToUrl is required in that case).
- */
-export const reauthConnection = (id: string, returnToUrl?: string) => {
-    const request: ReauthConnectionRequest = { returnToUrl: returnToUrl };
-    return client.post<ConnectionSetupResponse>(
-        `/api/v1/connections/${id}/_reauth`,
-        request
-    );
+export const reauthConnection = (id: string, spec: ConnectionSetupControlSpec = {}) => {
+  const request: ConnectionReauthenticateRequest = actionRequest(
+    CONNECTION_REAUTHENTICATE_KIND,
+    connectionTarget(id),
+    spec,
+  );
+  return client.post<ConnectionSetupResponse>(`/api/v1/connections/${id}/_reauth`, request);
 };
 
 export const connections = {
-    list: listConnections,
-    get: getConnection,
-    initiate: initiateConnection,
-    submit: submitConnection,
-    disconnect: disconnectConnection,
-    migrateVersion: migrateConnectionVersion,
-    abort: abortConnection,
-    forceState: forceConnectionState,
-    update: updateConnection,
-    getSetupStep: getSetupStep,
-    getDataSource: getDataSource,
-    reconfigure: reconfigureConnection,
-    cancelSetup: cancelSetupConnection,
-    retry: retryConnection,
-    reauth: reauthConnection,
-    getLabels: getConnectionLabels,
-    getLabel: getConnectionLabel,
-    putLabel: putConnectionLabel,
-    deleteLabel: deleteConnectionLabel,
-    getAnnotations: getConnectionAnnotations,
-    getAnnotation: getConnectionAnnotation,
-    putAnnotation: putConnectionAnnotation,
-    deleteAnnotation: deleteConnectionAnnotation,
+  list: listConnections,
+  get: getConnection,
+  initiate: initiateConnection,
+  submit: submitConnection,
+  disconnect: disconnectConnection,
+  migrateVersion: migrateConnectionVersion,
+  abort: abortConnection,
+  forceState: forceConnectionState,
+  update: updateConnection,
+  getSetupStep,
+  getDataSource,
+  reconfigure: reconfigureConnection,
+  cancelSetup: cancelSetupConnection,
+  retry: retryConnection,
+  reauth: reauthConnection,
+  getLabels: getConnectionLabels,
+  getLabel: getConnectionLabel,
+  putLabel: putConnectionLabel,
+  deleteLabel: deleteConnectionLabel,
+  getAnnotations: getConnectionAnnotations,
+  getAnnotation: getConnectionAnnotation,
+  putAnnotation: putConnectionAnnotation,
+  deleteAnnotation: deleteConnectionAnnotation,
 };

--- a/sdks/js/src/connectors.ts
+++ b/sdks/js/src/connectors.ts
@@ -1,238 +1,287 @@
-import {client} from './client';
-import {ListResponse} from './common';
+import { client } from './client';
+import {
+  MutableResourceMetadata,
+  NamespacedCreateMetadata,
+  ObjectMetadata,
+  ResourceList,
+  TypeMeta,
+} from './common';
 
-// Connector models
-export interface ConnectorVersion {
-    id: string;
-    name: string;
-    version: number;
-    namespace: string;
-    state: ConnectorVersionState;
-    definition: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-    createdAt: string;
-    updatedAt: string;
+export const CONNECTOR_KIND = 'Connector' as const;
+
+export enum ConnectorReleaseState {
+  DRAFT = 'draft',
+  PRIMARY = 'primary',
+  ACTIVE = 'active',
+  ARCHIVED = 'archived',
 }
 
-export interface Connector {
-    id: string;
-    name: string;
-    version: number;
-    namespace: string;
-    state: ConnectorVersionState;
-    displayName: string;
-    description: string;
-    highlight?: string;
-    statusPageUrl?: string;
-    logo: string;
-    hasConfigure: boolean;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-    createdAt: string;
-    updatedAt: string;
+/**
+ * Connector definitions are open, connector-authored documents validated by
+ * the server's connector schema. The SDK preserves every definition field.
+ */
+export type ConnectorDefinition = Record<string, unknown>;
+
+export interface ConnectorMetadata extends ObjectMetadata {
+  id: string;
+  name: string;
+  namespace: string;
+  generation: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
-export interface PutConnectorAnnotationRequest {
-    value: string;
+export interface ConnectorReleaseSpec {
+  desiredState?: ConnectorReleaseState.DRAFT | ConnectorReleaseState.PRIMARY;
 }
 
-export interface ConnectorAnnotation {
-    key: string;
-    value: string;
+export interface ConnectorSpec {
+  release?: ConnectorReleaseSpec;
+  definition: ConnectorDefinition;
 }
 
-export enum ConnectorVersionState {
-    DRAFT = 'draft',
-    PRIMARY = 'primary',
-    ACTIVE = 'active',
-    ARCHIVED = 'archived',
+export interface ConnectorStatus {
+  release: {
+    state: ConnectorReleaseState;
+  };
 }
 
-export interface ListConnectorsParams {
-    name?: string;
-    state?: ConnectorVersionState;
-    namespace?: string;
-    labelSelector?: string;
-    cursor?: string;
-    limit?: number;
-    orderBy?: string;
+/**
+ * Every connector generation is a Connector resource. The logical connector
+ * is metadata.id; metadata.generation selects a specific version.
+ */
+export interface Connector extends TypeMeta<typeof CONNECTOR_KIND> {
+  metadata: ConnectorMetadata;
+  spec: ConnectorSpec;
+  status: ConnectorStatus;
 }
 
-export interface ListConnectorVersionsParams {
-    state?: ConnectorVersionState;
-    namespace?: string;
-    labelSelector?: string;
-    cursor?: string;
-    limit?: number;
-    orderBy?: string;
+export interface CreateConnectorRequest extends TypeMeta<typeof CONNECTOR_KIND> {
+  metadata: NamespacedCreateMetadata;
+  spec: ConnectorSpec;
 }
+
+export interface UpdateConnectorRequest extends TypeMeta<typeof CONNECTOR_KIND> {
+  metadata: MutableResourceMetadata;
+  spec: {
+    release?: {
+      desiredState?: ConnectorReleaseState.DRAFT | ConnectorReleaseState.PRIMARY;
+    };
+    definition?: ConnectorDefinition;
+  };
+}
+
+export type ConnectorList = ResourceList<Connector>;
 
 export interface ConnectorLifecycleRequest {
-    timeoutSeconds?: number;
+  timeoutSeconds?: number;
 }
 
 export interface ConnectorLifecycleResponse {
-    taskId: string;
-    connectorId: string;
+  taskId: string;
+  connectorId: string;
 }
 
-export interface UpdateConnectorRequest {
-    name?: string;
-    definition?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
+export interface ForceConnectorGenerationStateRequest {
+  state: ConnectorReleaseState;
 }
 
-/**
- * Get a list of all available connectors
- */
-export const listConnectors = (params: ListConnectorsParams) => {
-    return client.get<ListResponse<Connector>>('/api/v1/connectors', {params});
-};
+export interface ListConnectorsParams {
+  name?: string;
+  state?: ConnectorReleaseState;
+  namespace?: string;
+  labelSelector?: string;
+  cursor?: string;
+  limit?: number;
+  orderBy?: string;
+}
 
-/**
- * Get a specific connector by ID
- */
-export const getConnector = (id: string) => {
-    return client.get<Connector>(`/api/v1/connectors/${id}`);
-};
+export interface ListConnectorGenerationsParams {
+  state?: ConnectorReleaseState;
+  namespace?: string;
+  labelSelector?: string;
+  cursor?: string;
+  limit?: number;
+  orderBy?: string;
+}
 
-/**
- * Update a connector name and/or its draft-version metadata.
- */
-export const updateConnector = (id: string, request: UpdateConnectorRequest) => {
-    return client.patch<ConnectorVersion>(`/api/v1/connectors/${id}`, request);
-};
+export interface ConnectorLabel {
+  key: string;
+  value: string;
+}
 
-/**
- * Get versions for a specific connector by ID
- */
-export const listConnectorVersions = (
-    id: string,
-    params: ListConnectorVersionsParams
+export interface ConnectorAnnotation {
+  key: string;
+  value: string;
+}
+
+export const listConnectors = (params?: ListConnectorsParams) =>
+  client.get<ConnectorList>('/api/v1/connectors', { params });
+
+export const createConnector = (request: CreateConnectorRequest) =>
+  client.post<Connector>('/api/v1/connectors', request);
+
+export const getConnector = (id: string) =>
+  client.get<Connector>(`/api/v1/connectors/${id}`);
+
+/** Updates connector-level metadata and the current draft generation. */
+export const updateConnector = (id: string, request: UpdateConnectorRequest) =>
+  client.patch<Connector>(`/api/v1/connectors/${id}`, request);
+
+export const listConnectorGenerations = (
+  id: string,
+  params?: ListConnectorGenerationsParams,
+) =>
+  client.get<ConnectorList>(`/api/v1/connectors/${id}/versions`, { params });
+
+export const createConnectorGeneration = (
+  id: string,
+  request?: CreateConnectorRequest,
+) => client.post<Connector>(`/api/v1/connectors/${id}/versions`, request);
+
+export const getConnectorGeneration = (id: string, generation: number) =>
+  client.get<Connector>(`/api/v1/connectors/${id}/versions/${generation}`);
+
+export const updateConnectorGeneration = (
+  id: string,
+  generation: number,
+  request: UpdateConnectorRequest,
+) => client.patch<Connector>(`/api/v1/connectors/${id}/versions/${generation}`, request);
+
+export const forceConnectorGenerationState = (
+  id: string,
+  generation: number,
+  state: ConnectorReleaseState,
 ) => {
-    return client.get<ListResponse<ConnectorVersion>>(
-        `/api/v1/connectors/${id}/versions`,
-        {params}
-    );
+  const request: ForceConnectorGenerationStateRequest = { state };
+  return client.put<Connector>(
+    `/api/v1/connectors/${id}/versions/${generation}/_forceState`,
+    request,
+  );
 };
 
-/**
- * Get a specific connector version by ID and version number
- */
-export const getConnectorVersion = (id: string, version: number) => {
-    return client.get<ConnectorVersion>(`/api/v1/connectors/${id}/versions/${version}`);
-};
+export const disconnectAllConnectorConnections = (
+  id: string,
+  request?: ConnectorLifecycleRequest,
+) => client.post<ConnectorLifecycleResponse>(`/api/v1/connectors/${id}/_disconnectAll`, request);
 
-export interface ForceConnectorVersionStateRequest {
-    state: ConnectorVersionState;
-}
+export const archiveConnector = (id: string, request?: ConnectorLifecycleRequest) =>
+  client.post<ConnectorLifecycleResponse>(`/api/v1/connectors/${id}/_archive`, request);
 
-export type ForceConnectorVersionStateResponse = ConnectorVersion;
+export const getConnectorLabels = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/connectors/${id}/labels`);
 
-/**
- * Force a connector version into a specific state (admin operation)
- */
-export const forceConnectorVersionState = (id: string, version: number, state: ConnectorVersionState) => {
-    const request: ForceConnectorVersionStateRequest = { state };
-    return client.put<ForceConnectorVersionStateResponse>(
-        `/api/v1/connectors/${id}/versions/${version}/_forceState`,
-        request
-    );
-};
+export const getConnectorLabel = (id: string, labelKey: string) =>
+  client.get<ConnectorLabel>(`/api/v1/connectors/${id}/labels/${labelKey}`);
 
-/**
- * Disconnect all connections for a connector.
- */
-export const disconnectAllConnectorConnections = (id: string, request?: ConnectorLifecycleRequest) => {
-    return client.post<ConnectorLifecycleResponse>(
-        `/api/v1/connectors/${id}/_disconnectAll`,
-        request
-    );
-};
+export const putConnectorLabel = (id: string, labelKey: string, value: string) =>
+  client.put<ConnectorLabel>(`/api/v1/connectors/${id}/labels/${labelKey}`, { value });
 
-/**
- * Archive a connector after disconnecting its connections.
- */
-export const archiveConnector = (id: string, request?: ConnectorLifecycleRequest) => {
-    return client.post<ConnectorLifecycleResponse>(
-        `/api/v1/connectors/${id}/_archive`,
-        request
-    );
-};
+export const deleteConnectorLabel = (id: string, labelKey: string) =>
+  client.delete(`/api/v1/connectors/${id}/labels/${labelKey}`);
 
-/**
- * Get all annotations for a specific connector
- */
-export const getConnectorAnnotations = (id: string) => {
-    return client.get<Record<string, string>>(`/api/v1/connectors/${id}/annotations`);
-};
+export const getConnectorAnnotations = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/connectors/${id}/annotations`);
 
-/**
- * Get a specific annotation for a connector
- */
-export const getConnectorAnnotation = (id: string, annotationKey: string) => {
-    return client.get<ConnectorAnnotation>(`/api/v1/connectors/${id}/annotations/${annotationKey}`);
-};
+export const getConnectorAnnotation = (id: string, annotationKey: string) =>
+  client.get<ConnectorAnnotation>(`/api/v1/connectors/${id}/annotations/${annotationKey}`);
 
-/**
- * Set a specific annotation for a connector
- */
-export const putConnectorAnnotation = (id: string, annotationKey: string, value: string) => {
-    return client.put<ConnectorAnnotation>(`/api/v1/connectors/${id}/annotations/${annotationKey}`, { value });
-};
+export const putConnectorAnnotation = (id: string, annotationKey: string, value: string) =>
+  client.put<ConnectorAnnotation>(`/api/v1/connectors/${id}/annotations/${annotationKey}`, {
+    value,
+  });
 
-/**
- * Delete a specific annotation from a connector
- */
-export const deleteConnectorAnnotation = (id: string, annotationKey: string) => {
-    return client.delete(`/api/v1/connectors/${id}/annotations/${annotationKey}`);
-};
+export const deleteConnectorAnnotation = (id: string, annotationKey: string) =>
+  client.delete(`/api/v1/connectors/${id}/annotations/${annotationKey}`);
 
-/**
- * Get all annotations for a specific connector version
- */
-export const getConnectorVersionAnnotations = (id: string, version: number) => {
-    return client.get<Record<string, string>>(`/api/v1/connectors/${id}/versions/${version}/annotations`);
-};
+export const getConnectorGenerationLabels = (id: string, generation: number) =>
+  client.get<Record<string, string>>(
+    `/api/v1/connectors/${id}/versions/${generation}/labels`,
+  );
 
-/**
- * Get a specific annotation for a connector version
- */
-export const getConnectorVersionAnnotation = (id: string, version: number, annotationKey: string) => {
-    return client.get<ConnectorAnnotation>(`/api/v1/connectors/${id}/versions/${version}/annotations/${annotationKey}`);
-};
+export const getConnectorGenerationLabel = (
+  id: string,
+  generation: number,
+  labelKey: string,
+) =>
+  client.get<ConnectorLabel>(
+    `/api/v1/connectors/${id}/versions/${generation}/labels/${labelKey}`,
+  );
 
-/**
- * Set a specific annotation for a connector version
- */
-export const putConnectorVersionAnnotation = (id: string, version: number, annotationKey: string, value: string) => {
-    return client.put<ConnectorAnnotation>(`/api/v1/connectors/${id}/versions/${version}/annotations/${annotationKey}`, { value });
-};
+export const putConnectorGenerationLabel = (
+  id: string,
+  generation: number,
+  labelKey: string,
+  value: string,
+) =>
+  client.put<ConnectorLabel>(
+    `/api/v1/connectors/${id}/versions/${generation}/labels/${labelKey}`,
+    { value },
+  );
 
-/**
- * Delete a specific annotation from a connector version
- */
-export const deleteConnectorVersionAnnotation = (id: string, version: number, annotationKey: string) => {
-    return client.delete(`/api/v1/connectors/${id}/versions/${version}/annotations/${annotationKey}`);
-};
+export const deleteConnectorGenerationLabel = (
+  id: string,
+  generation: number,
+  labelKey: string,
+) => client.delete(`/api/v1/connectors/${id}/versions/${generation}/labels/${labelKey}`);
+
+export const getConnectorGenerationAnnotations = (id: string, generation: number) =>
+  client.get<Record<string, string>>(
+    `/api/v1/connectors/${id}/versions/${generation}/annotations`,
+  );
+
+export const getConnectorGenerationAnnotation = (
+  id: string,
+  generation: number,
+  annotationKey: string,
+) =>
+  client.get<ConnectorAnnotation>(
+    `/api/v1/connectors/${id}/versions/${generation}/annotations/${annotationKey}`,
+  );
+
+export const putConnectorGenerationAnnotation = (
+  id: string,
+  generation: number,
+  annotationKey: string,
+  value: string,
+) =>
+  client.put<ConnectorAnnotation>(
+    `/api/v1/connectors/${id}/versions/${generation}/annotations/${annotationKey}`,
+    { value },
+  );
+
+export const deleteConnectorGenerationAnnotation = (
+  id: string,
+  generation: number,
+  annotationKey: string,
+) => client.delete(`/api/v1/connectors/${id}/versions/${generation}/annotations/${annotationKey}`);
 
 export const connectors = {
-    list: listConnectors,
-    get: getConnector,
-    update: updateConnector,
-    listVersions: listConnectorVersions,
-    getVersion: getConnectorVersion,
-    forceVersionState: forceConnectorVersionState,
-    disconnectAll: disconnectAllConnectorConnections,
-    archive: archiveConnector,
-    getAnnotations: getConnectorAnnotations,
-    getAnnotation: getConnectorAnnotation,
-    putAnnotation: putConnectorAnnotation,
-    deleteAnnotation: deleteConnectorAnnotation,
-    getVersionAnnotations: getConnectorVersionAnnotations,
-    getVersionAnnotation: getConnectorVersionAnnotation,
-    putVersionAnnotation: putConnectorVersionAnnotation,
-    deleteVersionAnnotation: deleteConnectorVersionAnnotation,
+  list: listConnectors,
+  create: createConnector,
+  get: getConnector,
+  update: updateConnector,
+  listGenerations: listConnectorGenerations,
+  createGeneration: createConnectorGeneration,
+  getGeneration: getConnectorGeneration,
+  updateGeneration: updateConnectorGeneration,
+  forceGenerationState: forceConnectorGenerationState,
+  disconnectAll: disconnectAllConnectorConnections,
+  archive: archiveConnector,
+  getLabels: getConnectorLabels,
+  getLabel: getConnectorLabel,
+  putLabel: putConnectorLabel,
+  deleteLabel: deleteConnectorLabel,
+  getAnnotations: getConnectorAnnotations,
+  getAnnotation: getConnectorAnnotation,
+  putAnnotation: putConnectorAnnotation,
+  deleteAnnotation: deleteConnectorAnnotation,
+  getGenerationLabels: getConnectorGenerationLabels,
+  getGenerationLabel: getConnectorGenerationLabel,
+  putGenerationLabel: putConnectorGenerationLabel,
+  deleteGenerationLabel: deleteConnectorGenerationLabel,
+  getGenerationAnnotations: getConnectorGenerationAnnotations,
+  getGenerationAnnotation: getConnectorGenerationAnnotation,
+  putGenerationAnnotation: putConnectorGenerationAnnotation,
+  deleteGenerationAnnotation: deleteConnectorGenerationAnnotation,
 };

--- a/sdks/js/src/contracts.test.ts
+++ b/sdks/js/src/contracts.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  Actor,
+  ActorSpec,
+  CreateActorRequest,
+  actorResourceToClaim,
+  createActorClaim,
+} from './actors';
+import { API_VERSION, ManagedResourceKind, objectReference } from './common';
+import {
+  Connection,
+  ConnectionHealthState,
+  ConnectionSetupResponse,
+  ConnectionSetupResponseType,
+  ConnectionState,
+} from './connections';
+import { Connector, ConnectorReleaseState } from './connectors';
+import { Key, KeyMaterialType, KeyState, KeyUsage } from './keys';
+import { Namespace, NamespaceState } from './namespaces';
+import { Notification, NotificationLevel, NotificationState } from './notifications';
+import { RateLimit, RateLimitMode } from './rateLimits';
+import { RequestEvent, RequestType } from './requestEvents';
+import { SearchResultList } from './search';
+import {
+  TaskExecution,
+  TaskQueue,
+  TaskQueueHistory,
+  TaskSchedule,
+  TaskServer,
+} from './taskMonitoring';
+import { Task, TaskState } from './tasks';
+import { WorkflowHistoryEvent, WorkflowInstance } from './workflowMonitoring';
+
+const connectorRef = objectReference('Connector', {
+  id: 'cxr_test',
+  namespace: 'root.acme',
+  name: 'provider',
+  generation: 2,
+});
+
+const actor = {
+  apiVersion: API_VERSION,
+  kind: 'Actor',
+  metadata: {
+    id: 'act_test',
+    name: 'service',
+    namespace: 'root.acme',
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: { externalId: 'subject-1', permissions: [] },
+  status: { signingKeyConfigured: true },
+} satisfies Actor;
+
+const connector = {
+  apiVersion: API_VERSION,
+  kind: 'Connector',
+  metadata: {
+    id: 'cxr_test',
+    name: 'provider',
+    namespace: 'root.acme',
+    generation: 2,
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: {
+    release: { desiredState: ConnectorReleaseState.PRIMARY },
+    definition: { displayName: 'Provider', auth: { type: 'no-auth' } },
+  },
+  status: { release: { state: ConnectorReleaseState.PRIMARY } },
+} satisfies Connector;
+
+const connection = {
+  apiVersion: API_VERSION,
+  kind: 'Connection',
+  metadata: {
+    id: 'cxn_test',
+    name: 'production',
+    namespace: 'root.acme',
+    labels: { team: 'platform' },
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: {
+    connectorRef,
+    configuration: { tenant: 'acme' },
+  },
+  status: {
+    lifecycle: { state: ConnectionState.CONFIGURED },
+    health: { state: ConnectionHealthState.HEALTHY },
+    configuration: {
+      configured: true,
+      schema: { type: 'object', properties: { tenant: { type: 'string' } } },
+    },
+  },
+} satisfies Connection;
+
+const key = {
+  apiVersion: API_VERSION,
+  kind: 'Key',
+  metadata: {
+    id: 'key_test',
+    name: 'primary',
+    namespace: 'root.acme',
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: {
+    usage: KeyUsage.DATA_ENCRYPTION,
+    materialType: KeyMaterialType.SYMMETRIC,
+    desiredState: KeyState.ACTIVE,
+    keyData: { value: '****************' },
+  },
+  status: { state: KeyState.ACTIVE, keyDataConfigured: true },
+} satisfies Key;
+
+const namespace = {
+  apiVersion: API_VERSION,
+  kind: 'Namespace',
+  metadata: {
+    id: 'root.acme',
+    name: 'acme',
+    namespace: 'root',
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: { encryptionKeyRef: objectReference('Key', { id: 'key_test' }) },
+  status: { state: NamespaceState.ACTIVE },
+} satisfies Namespace;
+
+const rateLimit = {
+  apiVersion: API_VERSION,
+  kind: 'RateLimit',
+  metadata: {
+    id: 'rl_test',
+    name: 'writes',
+    namespace: 'root.acme',
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: {
+    scope: { connectorRef: objectReference('Connector', { id: 'cxr_test' }) },
+    mode: RateLimitMode.ENFORCE,
+    selector: { methods: ['POST'] },
+    bucket: { dimensions: ['actor'] },
+    algorithm: { fixedWindow: { window: '1m', limit: 100 } },
+  },
+  status: { effectiveMode: RateLimitMode.ENFORCE },
+} satisfies RateLimit;
+
+describe('v1alpha1 managed resource contracts', () => {
+  it('uses one discriminated envelope for every managed kind', () => {
+    const resources: Array<Actor | Connector | Connection | Key | Namespace | RateLimit> = [
+      actor,
+      connector,
+      connection,
+      key,
+      namespace,
+      rateLimit,
+    ];
+
+    expect(resources.map(({ kind }) => kind)).toEqual([
+      'Actor',
+      'Connector',
+      'Connection',
+      'Key',
+      'Namespace',
+      'RateLimit',
+    ] satisfies ManagedResourceKind[]);
+    expect(resources.every(({ apiVersion }) => apiVersion === API_VERSION)).toBe(true);
+    expect(connection.spec.connectorRef.generation).toBe(2);
+    expect(connector.metadata.generation).toBe(2);
+  });
+
+  it('round trips optional metadata and status without flattening them', () => {
+    const decoded = JSON.parse(JSON.stringify(connection)) as Connection;
+    expect(decoded).toEqual(connection);
+    expect(decoded.metadata.labels).toEqual({ team: 'platform' });
+    expect(decoded.status.configuration.schema).toEqual(
+      expect.objectContaining({ type: 'object' }),
+    );
+    expect(decoded).not.toHaveProperty('state');
+  });
+
+  it('keeps actor signing keys write-only and key provider data redacted', () => {
+    const createActor = {
+      apiVersion: API_VERSION,
+      kind: 'Actor',
+      metadata: { namespace: 'root.acme' },
+      spec: {
+        externalId: 'subject-1',
+        signingKey: { raw: 'write-only' },
+      },
+    } satisfies CreateActorRequest;
+
+    expect(JSON.parse(JSON.stringify(createActor)).spec.signingKey).toEqual({ raw: 'write-only' });
+    expect(JSON.parse(JSON.stringify(actor)).spec).not.toHaveProperty('signingKey');
+    expect(JSON.parse(JSON.stringify(key)).spec.keyData.value).toBe('****************');
+    expectTypeOf<ActorSpec>().not.toHaveProperty('signingKey');
+  });
+
+  it('builds the restricted Actor resource allowed in JWT claims', () => {
+    const claim = actorResourceToClaim(actor);
+    const created = createActorClaim({
+      externalId: 'subject-2',
+      namespace: 'root.acme',
+      permissions: [
+        { namespace: 'root.acme', resources: ['connections'], verbs: ['get'] },
+      ],
+    });
+
+    expect(claim).toEqual({
+      apiVersion: API_VERSION,
+      kind: 'Actor',
+      metadata: { name: 'service', namespace: 'root.acme' },
+      spec: { externalId: 'subject-1', permissions: [] },
+    });
+    expect(claim).not.toHaveProperty('metadata.id');
+    expect(claim).not.toHaveProperty('metadata.createdAt');
+    expect(claim).not.toHaveProperty('status');
+    expect(created.spec.externalId).toBe('subject-2');
+  });
+});
+
+const notification = {
+  apiVersion: API_VERSION,
+  kind: 'Notification',
+  metadata: {
+    id: 'ntf_test',
+    namespace: 'root.acme',
+    createdAt: '2026-01-02T03:04:05Z',
+    updatedAt: '2026-01-02T03:05:06Z',
+  },
+  spec: {
+    key: 'connection:reauth',
+    level: NotificationLevel.WARNING,
+    resourceRef: objectReference('Connection', { id: 'cxn_test' }),
+    title: 'Reauthenticate',
+    message: 'Credentials need attention.',
+  },
+  status: { state: NotificationState.ACTIVE, viewed: false },
+} satisfies Notification;
+
+const requestEvent = {
+  apiVersion: API_VERSION,
+  kind: 'RequestEvent',
+  metadata: {
+    id: 'req_test',
+    namespace: 'root.acme',
+    createdAt: '2026-01-02T03:04:05Z',
+  },
+  spec: {
+    requestType: RequestType.PROXY,
+    durationMilliseconds: 12,
+    namespaceRef: objectReference('Namespace', { id: 'root.acme' }),
+    request: { method: 'GET', host: 'api.example.com', scheme: 'https', path: '/v1' },
+    response: { statusCode: 200 },
+    captureAvailable: false,
+  },
+} satisfies RequestEvent;
+
+const task = {
+  apiVersion: API_VERSION,
+  kind: 'Task',
+  metadata: { id: 'task-token' },
+  spec: { type: 'sync' },
+  status: { state: TaskState.COMPLETED },
+} satisfies Task;
+
+const taskQueue = {
+  apiVersion: API_VERSION,
+  kind: 'TaskQueue',
+  metadata: { id: 'default' },
+  spec: {},
+  status: {
+    memoryUsage: 1,
+    latencySeconds: 0,
+    size: 1,
+    groups: 0,
+    pending: 1,
+    active: 0,
+    scheduled: 0,
+    retry: 0,
+    archived: 0,
+    completed: 0,
+    aggregating: 0,
+    processed: 0,
+    failed: 0,
+    processedTotal: 0,
+    failedTotal: 0,
+    paused: false,
+  },
+} satisfies TaskQueue;
+
+const taskExecution = {
+  apiVersion: API_VERSION,
+  kind: 'TaskExecution',
+  metadata: { id: 'task-1' },
+  spec: { queue: 'default', type: 'sync', payload: '{}', maxRetry: 3 },
+  status: { state: 'pending', retried: 0 },
+} satisfies TaskExecution;
+
+const taskQueueHistory = {
+  apiVersion: API_VERSION,
+  kind: 'TaskQueueHistory',
+  metadata: { id: 'default' },
+  spec: { days: 30 },
+  status: { items: [{ date: '2026-01-02', processed: 2, failed: 0 }] },
+} satisfies TaskQueueHistory;
+
+const taskServer = {
+  apiVersion: API_VERSION,
+  kind: 'TaskServer',
+  metadata: { id: 'server-1' },
+  spec: { host: 'worker', pid: 42, concurrency: 10, queues: { default: 1 }, strictPriority: false },
+  status: { state: 'active', activeWorkers: [] },
+} satisfies TaskServer;
+
+const taskSchedule = {
+  apiVersion: API_VERSION,
+  kind: 'TaskSchedule',
+  metadata: { id: 'schedule-1' },
+  spec: { schedule: '@every 1m', taskType: 'sync' },
+  status: { nextRunAt: '2026-01-02T03:04:05Z' },
+} satisfies TaskSchedule;
+
+const historyEvent = {
+  apiVersion: API_VERSION,
+  kind: 'WorkflowHistoryEvent',
+  metadata: { id: 'event-1', createdAt: '2026-01-02T03:04:05Z' },
+  spec: { sequenceId: 1, type: 'WorkflowExecutionStarted' },
+} satisfies WorkflowHistoryEvent;
+
+const workflow = {
+  apiVersion: API_VERSION,
+  kind: 'WorkflowInstance',
+  metadata: { id: 'execution-1' },
+  spec: { instanceId: 'workflow-1', queue: 'default' },
+  status: { state: 'active', history: [historyEvent] },
+} satisfies WorkflowInstance;
+
+const searchResults = {
+  apiVersion: API_VERSION,
+  kind: 'SearchResultList',
+  metadata: { truncatedKinds: ['Connection'], incompleteKinds: [] },
+  items: [
+    {
+      resourceRef: objectReference('Connection', { id: 'cxn_test', name: 'production', namespace: 'root.acme' }),
+      labels: {},
+      matchedLabels: [],
+      updatedAt: '2026-01-02T03:05:06Z',
+    },
+  ],
+} satisfies SearchResultList;
+
+describe('v1alpha1 read-only projections', () => {
+  it('keeps projection identity, observations, and list metadata nested', () => {
+    const projections = [
+      notification,
+      requestEvent,
+      task,
+      taskQueue,
+      taskExecution,
+      taskQueueHistory,
+      taskServer,
+      taskSchedule,
+      workflow,
+      historyEvent,
+    ];
+
+    expect(projections.map(({ kind }) => kind)).toEqual([
+      'Notification',
+      'RequestEvent',
+      'Task',
+      'TaskQueue',
+      'TaskExecution',
+      'TaskQueueHistory',
+      'TaskServer',
+      'TaskSchedule',
+      'WorkflowInstance',
+      'WorkflowHistoryEvent',
+    ]);
+    expect(searchResults.metadata.truncatedKinds).toEqual(['Connection']);
+    expect(searchResults.items[0].resourceRef.kind).toBe('Connection');
+  });
+
+  it('discriminates setup action status under status', () => {
+    const response = {
+      apiVersion: API_VERSION,
+      kind: 'ConnectionSetup',
+      metadata: { target: objectReference('Connection', { id: 'cxn_test' }) },
+      spec: {},
+      status: { type: ConnectionSetupResponseType.REDIRECT, redirectUrl: 'https://example.com' },
+    } satisfies ConnectionSetupResponse;
+
+    expect(response.status.type).toBe(ConnectionSetupResponseType.REDIRECT);
+    expect(response).not.toHaveProperty('type');
+  });
+});

--- a/sdks/js/src/error.ts
+++ b/sdks/js/src/error.ts
@@ -1,3 +1,4 @@
 export type ApiError = {
   error: string;
+  stackTrace?: string;
 };

--- a/sdks/js/src/keys.ts
+++ b/sdks/js/src/keys.ts
@@ -1,42 +1,81 @@
 import { client } from './client';
-import { ListResponse } from './common';
+import {
+  MutableResourceMetadata,
+  NamespacedCreateMetadata,
+  ObjectMetadata,
+  ResourceList,
+  TypeMeta,
+} from './common';
 
-// Key models
+export const KEY_KIND = 'Key' as const;
 
-export enum KeyState {
-    ACTIVE = 'active',
-    DISABLED = 'disabled',
+export enum KeyUsage {
+  DATA_ENCRYPTION = 'data_encryption',
 }
 
-export interface Key {
-  id: string;
-  name: string;
-  namespace: string;
-  state: KeyState;
-  keyData?: KeyData;
-  labels?: Record<string, string>;
-  annotations?: Record<string, string>;
-  createdAt: string;
-  updatedAt: string;
+export enum KeyMaterialType {
+  SYMMETRIC = 'symmetric',
+  PUBLIC = 'public',
+  PRIVATE = 'private',
+  EXTERNAL = 'external',
+}
+
+export enum KeyState {
+  ACTIVE = 'active',
+  DISABLED = 'disabled',
 }
 
 export type KeyData = Record<string, unknown>;
 
-export interface CreateKeyRequest {
-    namespace: string;
-    name?: string;
-    keyData?: KeyData;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
+export interface KeyMetadata extends ObjectMetadata {
+  id: string;
+  name: string;
+  namespace: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
-export interface UpdateKeyRequest {
-    name?: string;
-    state?: KeyState;
-    keyData?: KeyData;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
+export interface KeySpec {
+  usage: KeyUsage;
+  materialType: KeyMaterialType;
+  desiredState: KeyState;
+  /** Provider configuration is always returned with secret fields redacted. */
+  keyData?: KeyData;
 }
+
+export interface KeyStatus {
+  state: KeyState;
+  keyDataConfigured: boolean;
+}
+
+export interface Key extends TypeMeta<typeof KEY_KIND> {
+  metadata: KeyMetadata;
+  spec: KeySpec;
+  status: KeyStatus;
+}
+
+export interface CreateKeyRequest extends TypeMeta<typeof KEY_KIND> {
+  metadata: NamespacedCreateMetadata;
+  spec: {
+    usage?: KeyUsage;
+    materialType?: KeyMaterialType;
+    desiredState?: KeyState;
+    /** Write-only provider configuration; responses contain only redacted values. */
+    keyData: KeyData;
+  };
+}
+
+export interface UpdateKeyRequest extends TypeMeta<typeof KEY_KIND> {
+  metadata: MutableResourceMetadata;
+  spec: {
+    usage?: KeyUsage;
+    materialType?: KeyMaterialType;
+    desiredState?: KeyState;
+    keyData?: KeyData;
+  };
+}
+
+export type KeyList = ResourceList<Key>;
 
 export interface ListKeysParams {
   name?: string;
@@ -53,109 +92,47 @@ export interface KeyLabel {
   value: string;
 }
 
-export interface PutKeyLabelRequest {
-  value: string;
-}
-
-export interface PutKeyAnnotationRequest {
-  value: string;
-}
-
 export interface KeyAnnotation {
   key: string;
   value: string;
 }
 
-/**
- * List keys with optional filtering and pagination
- */
-export const listKeys = (params: ListKeysParams) => {
-  return client.get<ListResponse<Key>>('/api/v1/keys', { params });
-};
+export const listKeys = (params?: ListKeysParams) =>
+  client.get<KeyList>('/api/v1/keys', { params });
 
-/**
- * Create a new key
- */
-export const createKey = (request: CreateKeyRequest) => {
-    return client.post<Key>('/api/v1/keys', request);
-};
+export const createKey = (request: CreateKeyRequest) =>
+  client.post<Key>('/api/v1/keys', request);
 
-/**
- * Get a specific key by ID
- */
-export const getKey = (id: string) => {
-  return client.get<Key>(`/api/v1/keys/${id}`);
-};
+export const getKey = (id: string) => client.get<Key>(`/api/v1/keys/${id}`);
 
-/**
- * Update a key's state and/or labels
- */
-export const updateKey = (id: string, request: UpdateKeyRequest) => {
-  return client.patch<Key>(`/api/v1/keys/${id}`, request);
-};
+export const updateKey = (id: string, request: UpdateKeyRequest) =>
+  client.patch<Key>(`/api/v1/keys/${id}`, request);
 
-/**
- * Delete a key (soft delete)
- */
-export const deleteKey = (id: string) => {
-  return client.delete(`/api/v1/keys/${id}`);
-};
+export const deleteKey = (id: string) => client.delete(`/api/v1/keys/${id}`);
 
-/**
- * Get all labels for a specific key
- */
-export const getKeyLabels = (id: string) => {
-  return client.get<Record<string, string>>(`/api/v1/keys/${id}/labels`);
-};
+export const getKeyLabels = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/keys/${id}/labels`);
 
-/**
- * Get a specific label for a key
- */
-export const getKeyLabel = (id: string, labelKey: string) => {
-  return client.get<KeyLabel>(`/api/v1/keys/${id}/labels/${labelKey}`);
-};
+export const getKeyLabel = (id: string, labelKey: string) =>
+  client.get<KeyLabel>(`/api/v1/keys/${id}/labels/${labelKey}`);
 
-/**
- * Set a specific label for a key
- */
-export const putKeyLabel = (id: string, labelKey: string, value: string) => {
-  return client.put<KeyLabel>(`/api/v1/keys/${id}/labels/${labelKey}`, { value });
-};
+export const putKeyLabel = (id: string, labelKey: string, value: string) =>
+  client.put<KeyLabel>(`/api/v1/keys/${id}/labels/${labelKey}`, { value });
 
-/**
- * Delete a specific label from a key
- */
-export const deleteKeyLabel = (id: string, labelKey: string) => {
-  return client.delete(`/api/v1/keys/${id}/labels/${labelKey}`);
-};
+export const deleteKeyLabel = (id: string, labelKey: string) =>
+  client.delete(`/api/v1/keys/${id}/labels/${labelKey}`);
 
-/**
- * Get all annotations for a specific key
- */
-export const getKeyAnnotations = (id: string) => {
-  return client.get<Record<string, string>>(`/api/v1/keys/${id}/annotations`);
-};
+export const getKeyAnnotations = (id: string) =>
+  client.get<Record<string, string>>(`/api/v1/keys/${id}/annotations`);
 
-/**
- * Get a specific annotation for a key
- */
-export const getKeyAnnotation = (id: string, annotationKey: string) => {
-  return client.get<KeyAnnotation>(`/api/v1/keys/${id}/annotations/${annotationKey}`);
-};
+export const getKeyAnnotation = (id: string, annotationKey: string) =>
+  client.get<KeyAnnotation>(`/api/v1/keys/${id}/annotations/${annotationKey}`);
 
-/**
- * Set a specific annotation for a key
- */
-export const putKeyAnnotation = (id: string, annotationKey: string, value: string) => {
-  return client.put<KeyAnnotation>(`/api/v1/keys/${id}/annotations/${annotationKey}`, { value });
-};
+export const putKeyAnnotation = (id: string, annotationKey: string, value: string) =>
+  client.put<KeyAnnotation>(`/api/v1/keys/${id}/annotations/${annotationKey}`, { value });
 
-/**
- * Delete a specific annotation from a key
- */
-export const deleteKeyAnnotation = (id: string, annotationKey: string) => {
-  return client.delete(`/api/v1/keys/${id}/annotations/${annotationKey}`);
-};
+export const deleteKeyAnnotation = (id: string, annotationKey: string) =>
+  client.delete(`/api/v1/keys/${id}/annotations/${annotationKey}`);
 
 export const keys = {
   list: listKeys,

--- a/sdks/js/src/namespaces.ts
+++ b/sdks/js/src/namespaces.ts
@@ -1,69 +1,70 @@
 import { client } from './client';
-import { ListResponse } from './common';
+import {
+  API_VERSION,
+  GenerationlessObjectReference,
+  ObjectMetadata,
+  ResourceList,
+  TypeMeta,
+} from './common';
 
-// Namespace models
-
-// The predefined root namespace path
+export const NAMESPACE_KIND = 'Namespace' as const;
 export const ROOT_NAMESPACE_PATH = 'root';
 export const NAMESPACE_PATH_SEPARATOR = '.';
 
 export enum NamespaceState {
-    ACTIVE = 'active',
-    DISCONNECTING = 'disconnecting',
-    DISCONNECTED = 'disconnected',
+  ACTIVE = 'active',
+  DESTROYING = 'destroying',
+  DESTROYED = 'destroyed',
 }
 
-export interface UpdateNamespaceRequest {
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-}
-
-export interface PutNamespaceLabelRequest {
-    value: string;
-}
-
-export interface NamespaceLabel {
-    key: string;
-    value: string;
-}
-
-export interface PutNamespaceAnnotationRequest {
-    value: string;
-}
-
-export interface NamespaceAnnotation {
-    key: string;
-    value: string;
-}
-
-export interface Namespace {
-  path: string;
+export interface NamespaceMetadata extends ObjectMetadata {
+  /** Immutable canonical namespace path. */
+  id: string;
+  /** Final path segment. */
   name: string;
-  state: NamespaceState;
-  keyId?: string;
-  labels?: Record<string, string>;
-  annotations?: Record<string, string>;
+  /** Parent path; omitted only for root. */
+  namespace?: string;
   createdAt: string;
   updatedAt: string;
 }
 
-export interface NamespaceKeyResponse {
-  keyId: string;
+export interface NamespaceSpec {
+  encryptionKeyRef?: GenerationlessObjectReference<'Key'>;
 }
 
-export interface SetNamespaceKeyRequest {
-  keyId: string;
+export interface NamespaceStatus {
+  state: NamespaceState;
 }
 
-export interface CreateNamespaceRequest {
-    path: string;
+export interface Namespace extends TypeMeta<typeof NAMESPACE_KIND> {
+  metadata: NamespaceMetadata;
+  spec: NamespaceSpec;
+  status: NamespaceStatus;
+}
+
+export interface CreateNamespaceRequest extends TypeMeta<typeof NAMESPACE_KIND> {
+  metadata: {
+    name: string;
+    namespace?: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
+  };
+  spec: NamespaceSpec;
 }
 
-/**
- * Parameters used for listing namespaces.
- */
+export interface UpdateNamespaceRequest extends TypeMeta<typeof NAMESPACE_KIND> {
+  metadata: {
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    /** Null clears the key; omission leaves the current value unchanged. */
+    encryptionKeyRef?: GenerationlessObjectReference<'Key'> | null;
+  };
+}
+
+export type NamespaceList = ResourceList<Namespace>;
+
 export interface ListNamespaceParams {
   name?: string;
   state?: NamespaceState;
@@ -75,129 +76,76 @@ export interface ListNamespaceParams {
   childrenOf?: string;
 }
 
-/**
- * Returns a matcher that will match for the specified namespace path and all its children. This value can be used
- * in the namespace filter param for listing resources. If no path is specified, the matcher will match for all namespaces.
- */
-export const namespaceAndChildren = (path: string | null | undefined): string => {
-    if( !path ) {
-        return ROOT_NAMESPACE_PATH + NAMESPACE_PATH_SEPARATOR +  "**";
-    }
-
-    if (path.endsWith("**")) {
-        return path;
-    } else {
-        return path + NAMESPACE_PATH_SEPARATOR + "**";
-    }
-}
-
-/**
- * Get a list of all namespaces
- * @param params The parameters for filtering and pagination
- */
-export const listNamespaces = (params: ListNamespaceParams) => {
-  return client.get<ListResponse<Namespace>>('/api/v1/namespaces', { params });
+/** Matches a namespace path and every descendant in list filters. */
+export const namespaceAndChildren = (path?: string | null): string => {
+  if (!path) {
+    return `${ROOT_NAMESPACE_PATH}${NAMESPACE_PATH_SEPARATOR}**`;
+  }
+  return path.endsWith('**') ? path : `${path}${NAMESPACE_PATH_SEPARATOR}**`;
 };
 
-/**
- * Create a new namespace
- * @param request The namespace to create
- */
-export const createNamespace = (request: CreateNamespaceRequest) => {
-    return client.post<Namespace>('/api/v1/namespaces', request);
-};
+export const listNamespaces = (params?: ListNamespaceParams) =>
+  client.get<NamespaceList>('/api/v1/namespaces', { params });
 
-/**
- * Get a specific namespace by path
- */
-export const getNamespaceByPath = (path: string) => {
-  return client.get<Namespace>(`/api/v1/namespaces/${path}`);
-};
+export const createNamespace = (request: CreateNamespaceRequest) =>
+  client.post<Namespace>('/api/v1/namespaces', request);
 
-/**
- * Update a namespace's labels
- */
-export const updateNamespace = (path: string, request: UpdateNamespaceRequest) => {
-  return client.patch<Namespace>(`/api/v1/namespaces/${path}`, request);
-};
+export const getNamespaceByPath = (path: string) =>
+  client.get<Namespace>(`/api/v1/namespaces/${path}`);
 
-/**
- * Get all labels for a specific namespace by path
- */
-export const getNamespaceLabels = (path: string) => {
-  return client.get<Record<string, string>>(`/api/v1/namespaces/${path}/labels`);
-};
+export const updateNamespace = (path: string, request: UpdateNamespaceRequest) =>
+  client.patch<Namespace>(`/api/v1/namespaces/${path}`, request);
 
-/**
- * Get a specific label for a namespace by path and label key
- */
-export const getNamespaceLabel = (path: string, labelKey: string) => {
-  return client.get<NamespaceLabel>(`/api/v1/namespaces/${path}/labels/${labelKey}`);
-};
+export const getNamespaceLabels = (path: string) =>
+  client.get<Record<string, string>>(`/api/v1/namespaces/${path}/labels`);
 
-/**
- * Set a specific label for a namespace by path and label key
- */
-export const putNamespaceLabel = (path: string, labelKey: string, value: string) => {
-  return client.put<NamespaceLabel>(`/api/v1/namespaces/${path}/labels/${labelKey}`, { value });
-};
+export const getNamespaceLabel = (path: string, labelKey: string) =>
+  client.get<{ key: string; value: string }>(`/api/v1/namespaces/${path}/labels/${labelKey}`);
 
-/**
- * Delete a specific label for a namespace by path and label key
- */
-export const deleteNamespaceLabel = (path: string, labelKey: string) => {
-  return client.delete(`/api/v1/namespaces/${path}/labels/${labelKey}`);
-};
+export const putNamespaceLabel = (path: string, labelKey: string, value: string) =>
+  client.put<{ key: string; value: string }>(`/api/v1/namespaces/${path}/labels/${labelKey}`, {
+    value,
+  });
 
-/**
- * Get the key assigned to a namespace
- */
-export const getNamespaceKey = (path: string) => {
-  return client.get<NamespaceKeyResponse>(`/api/v1/namespaces/${path}/key`);
-};
+export const deleteNamespaceLabel = (path: string, labelKey: string) =>
+  client.delete(`/api/v1/namespaces/${path}/labels/${labelKey}`);
 
-/**
- * Set the key for a namespace
- */
-export const setNamespaceKey = (path: string, keyId: string) => {
-  const request: SetNamespaceKeyRequest = { keyId: keyId };
+/** Returns the Namespace resource whose spec contains the assigned key. */
+export const getNamespaceKey = (path: string) =>
+  client.get<Namespace>(`/api/v1/namespaces/${path}/key`);
+
+export const setNamespaceKey = (
+  path: string,
+  encryptionKeyRef: GenerationlessObjectReference<'Key'>,
+) => {
+  const request: UpdateNamespaceRequest = {
+    apiVersion: API_VERSION,
+    kind: NAMESPACE_KIND,
+    metadata: {},
+    spec: { encryptionKeyRef },
+  };
   return client.put<Namespace>(`/api/v1/namespaces/${path}/key`, request);
 };
 
-/**
- * Clear the key for a namespace (falls back to parent)
- */
-export const clearNamespaceKey = (path: string) => {
-  return client.delete(`/api/v1/namespaces/${path}/key`);
-};
+export const clearNamespaceKey = (path: string) =>
+  client.delete(`/api/v1/namespaces/${path}/key`);
 
-/**
- * Get all annotations for a specific namespace by path
- */
-export const getNamespaceAnnotations = (path: string) => {
-  return client.get<Record<string, string>>(`/api/v1/namespaces/${path}/annotations`);
-};
+export const getNamespaceAnnotations = (path: string) =>
+  client.get<Record<string, string>>(`/api/v1/namespaces/${path}/annotations`);
 
-/**
- * Get a specific annotation for a namespace by path and annotation key
- */
-export const getNamespaceAnnotation = (path: string, annotationKey: string) => {
-  return client.get<NamespaceAnnotation>(`/api/v1/namespaces/${path}/annotations/${annotationKey}`);
-};
+export const getNamespaceAnnotation = (path: string, annotationKey: string) =>
+  client.get<{ key: string; value: string }>(
+    `/api/v1/namespaces/${path}/annotations/${annotationKey}`,
+  );
 
-/**
- * Set a specific annotation for a namespace by path and annotation key
- */
-export const putNamespaceAnnotation = (path: string, annotationKey: string, value: string) => {
-  return client.put<NamespaceAnnotation>(`/api/v1/namespaces/${path}/annotations/${annotationKey}`, { value });
-};
+export const putNamespaceAnnotation = (path: string, annotationKey: string, value: string) =>
+  client.put<{ key: string; value: string }>(
+    `/api/v1/namespaces/${path}/annotations/${annotationKey}`,
+    { value },
+  );
 
-/**
- * Delete a specific annotation for a namespace by path and annotation key
- */
-export const deleteNamespaceAnnotation = (path: string, annotationKey: string) => {
-  return client.delete(`/api/v1/namespaces/${path}/annotations/${annotationKey}`);
-};
+export const deleteNamespaceAnnotation = (path: string, annotationKey: string) =>
+  client.delete(`/api/v1/namespaces/${path}/annotations/${annotationKey}`);
 
 export const namespaces = {
   list: listNamespaces,

--- a/sdks/js/src/notifications.ts
+++ b/sdks/js/src/notifications.ts
@@ -1,63 +1,139 @@
-import {client} from './client';
-import {ListResponse} from './common';
+import { client } from './client';
+import {
+  API_VERSION,
+  ActionRequest,
+  ActionResponse,
+  ManagedResourceKind,
+  ObjectMetadata,
+  ObjectReference,
+  ResourceList,
+  TypeMeta,
+  actionRequest,
+  objectReference,
+} from './common';
+
+export const NOTIFICATION_KIND = 'Notification' as const;
+export const NOTIFICATION_VIEW_KIND = 'NotificationView' as const;
+export const NOTIFICATION_BATCH_VIEW_KIND = 'NotificationBatchView' as const;
 
 export enum NotificationLevel {
-    INFO = 'info',
-    WARNING = 'warning',
-    ERROR = 'error',
+  INFO = 'info',
+  WARNING = 'warning',
+  ERROR = 'error',
 }
 
 export enum NotificationState {
-    ACTIVE = 'active',
-    RESOLVED = 'resolved',
+  ACTIVE = 'active',
+  RESOLVED = 'resolved',
 }
 
-export interface Notification {
-    id: string;
-    key: string;
-    level: NotificationLevel;
-    state: NotificationState;
-    resourceType: string;
-    resourceId: string;
-    namespace: string;
-    title: string;
-    message: string;
-    actionUrl?: string;
-    canAction: boolean;
-    viewed: boolean;
-    metadata?: Record<string, unknown>;
-    createdAt: string;
-    updatedAt: string;
-    resolvedAt?: string;
+export interface NotificationMetadata extends ObjectMetadata {
+  id: string;
+  namespace: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NotificationSpec {
+  key: string;
+  level: NotificationLevel;
+  resourceRef: ObjectReference<ManagedResourceKind>;
+  title: string;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+export interface NotificationStatus {
+  state: NotificationState;
+  viewed: boolean;
+  action?: {
+    url: string;
+  };
+  resolvedAt?: string;
+}
+
+export interface Notification extends TypeMeta<typeof NOTIFICATION_KIND> {
+  metadata: NotificationMetadata;
+  spec: NotificationSpec;
+  status: NotificationStatus;
+}
+
+export type NotificationList = ResourceList<Notification>;
+
+export type NotificationReference = ObjectReference<typeof NOTIFICATION_KIND> & {
+  id: string;
+  name?: never;
+  namespace?: never;
+  generation?: never;
+};
+
+export type NotificationViewRequest = ActionRequest<
+  typeof NOTIFICATION_VIEW_KIND,
+  typeof NOTIFICATION_KIND,
+  Record<string, never>
+>;
+
+export type NotificationViewResponse = ActionResponse<
+  typeof NOTIFICATION_VIEW_KIND,
+  typeof NOTIFICATION_KIND,
+  Record<string, never>,
+  { viewed: true }
+>;
+
+export interface NotificationBatchViewRequest extends TypeMeta<typeof NOTIFICATION_BATCH_VIEW_KIND> {
+  metadata: {
+    targets: NotificationReference[];
+  };
+  spec: Record<string, never>;
+  status?: never;
+}
+
+export interface NotificationBatchViewResponse
+  extends TypeMeta<typeof NOTIFICATION_BATCH_VIEW_KIND> {
+  metadata: {
+    targets: NotificationReference[];
+  };
+  spec: Record<string, never>;
+  status: {
+    viewedCount: number;
+  };
 }
 
 export interface ListNotificationsParams {
-    limit?: number;
-    includeViewed?: boolean;
-    state?: NotificationState;
-    namespace?: string;
-    labelSelector?: string;
+  limit?: number;
+  includeViewed?: boolean;
+  state?: NotificationState;
+  namespace?: string;
+  labelSelector?: string;
 }
 
-export interface MarkNotificationsViewedRequest {
-    ids: string[];
-}
+const notificationReference = (id: string): NotificationReference =>
+  objectReference(NOTIFICATION_KIND, { id }) as NotificationReference;
 
-export const listNotifications = (params?: ListNotificationsParams) => {
-    return client.get<ListResponse<Notification>>('/api/v1/notifications', {params});
-};
+export const listNotifications = (params?: ListNotificationsParams) =>
+  client.get<NotificationList>('/api/v1/notifications', { params });
 
 export const markNotificationViewed = (id: string) => {
-    return client.post<void>(`/api/v1/notifications/${id}/_viewed`);
+  const request: NotificationViewRequest = actionRequest(
+    NOTIFICATION_VIEW_KIND,
+    notificationReference(id),
+    {},
+  );
+  return client.post<NotificationViewResponse>(`/api/v1/notifications/${id}/_viewed`, request);
 };
 
 export const markNotificationsViewed = (ids: string[]) => {
-    const request: MarkNotificationsViewedRequest = {ids};
-    return client.post<void>('/api/v1/notifications/_viewed', request);
+  const request: NotificationBatchViewRequest = {
+    apiVersion: API_VERSION,
+    kind: NOTIFICATION_BATCH_VIEW_KIND,
+    metadata: { targets: ids.map(notificationReference) },
+    spec: {},
+  };
+  return client.post<NotificationBatchViewResponse>('/api/v1/notifications/_viewed', request);
 };
 
 export const notifications = {
-    list: listNotifications,
-    markViewed: markNotificationViewed,
-    markBatchViewed: markNotificationsViewed,
+  list: listNotifications,
+  markViewed: markNotificationViewed,
+  markBatchViewed: markNotificationsViewed,
 };

--- a/sdks/js/src/rateLimits.ts
+++ b/sdks/js/src/rateLimits.ts
@@ -1,10 +1,16 @@
 import { client } from './client';
-import { ListResponse } from './common';
+import {
+    GenerationlessObjectReference,
+    MutableResourceMetadata,
+    NamespacedCreateMetadata,
+    ObjectMetadata,
+    ResourceList,
+    TypeMeta,
+} from './common';
 import { ProxyRequest } from './proxy';
 
 // Rate-limit models mirror the canonical authproxy.net/v1alpha1 resource.
 
-export const RATE_LIMIT_API_VERSION = 'authproxy.net/v1alpha1' as const;
 export const RATE_LIMIT_KIND = 'RateLimit' as const;
 
 export enum RateLimitMode {
@@ -70,27 +76,14 @@ export interface RateLimitTokenBucket {
  * Tagged union — exactly one variant must be set. The server (and the
  * Terraform provider) validate this at write time.
  */
-export interface RateLimitAlgorithm {
-    fixedWindow?: RateLimitFixedWindow;
-    slidingWindow?: RateLimitSlidingWindow;
-    tokenBucket?: RateLimitTokenBucket;
-}
+export type RateLimitAlgorithm =
+    | {fixedWindow: RateLimitFixedWindow; slidingWindow?: never; tokenBucket?: never}
+    | {slidingWindow: RateLimitSlidingWindow; fixedWindow?: never; tokenBucket?: never}
+    | {tokenBucket: RateLimitTokenBucket; fixedWindow?: never; slidingWindow?: never};
 
-export interface RateLimitConnectorReference {
-    apiVersion: typeof RATE_LIMIT_API_VERSION;
-    kind: 'Connector';
-    id?: string;
-    name?: string;
-    namespace?: string;
-}
+export type RateLimitConnectorReference = GenerationlessObjectReference<'Connector'>;
 
-export interface RateLimitConnectionReference {
-    apiVersion: typeof RATE_LIMIT_API_VERSION;
-    kind: 'Connection';
-    id?: string;
-    name?: string;
-    namespace?: string;
-}
+export type RateLimitConnectionReference = GenerationlessObjectReference<'Connection'>;
 
 export type RateLimitScope =
     | {namespaceMatcher: string; connectorRef?: never; connectionRef?: never}
@@ -106,12 +99,10 @@ export interface RateLimitSpec {
     algorithm: RateLimitAlgorithm;
 }
 
-export interface RateLimitMetadata {
+export interface RateLimitMetadata extends ObjectMetadata {
     id: string;
     name: string;
     namespace: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
     createdAt: string;
     updatedAt: string;
 }
@@ -120,34 +111,19 @@ export interface RateLimitStatus {
     effectiveMode: RateLimitMode;
 }
 
-export interface RateLimit {
-    apiVersion: typeof RATE_LIMIT_API_VERSION;
-    kind: typeof RATE_LIMIT_KIND;
+export interface RateLimit extends TypeMeta<typeof RATE_LIMIT_KIND> {
     metadata: RateLimitMetadata;
     spec: RateLimitSpec;
     status: RateLimitStatus;
 }
 
-export interface CreateRateLimitRequest {
-    apiVersion: typeof RATE_LIMIT_API_VERSION;
-    kind: typeof RATE_LIMIT_KIND;
-    metadata: {
-        namespace: string;
-        name?: string;
-        labels?: Record<string, string>;
-        annotations?: Record<string, string>;
-    };
+export interface CreateRateLimitRequest extends TypeMeta<typeof RATE_LIMIT_KIND> {
+    metadata: NamespacedCreateMetadata;
     spec: RateLimitSpec;
 }
 
-export interface UpdateRateLimitRequest {
-    apiVersion: typeof RATE_LIMIT_API_VERSION;
-    kind: typeof RATE_LIMIT_KIND;
-    metadata: {
-        name?: string;
-        labels?: Record<string, string>;
-        annotations?: Record<string, string>;
-    };
+export interface UpdateRateLimitRequest extends TypeMeta<typeof RATE_LIMIT_KIND> {
+    metadata: MutableResourceMetadata;
     spec: {
         scope?: RateLimitScope | null;
         mode?: RateLimitMode;
@@ -156,6 +132,8 @@ export interface UpdateRateLimitRequest {
         algorithm?: RateLimitAlgorithm;
     };
 }
+
+export type RateLimitList = ResourceList<RateLimit>;
 
 export interface ListRateLimitsParams {
     name?: string;
@@ -169,8 +147,8 @@ export interface ListRateLimitsParams {
 /**
  * List rate limits with optional filtering and pagination.
  */
-export const listRateLimits = (params: ListRateLimitsParams) => {
-    return client.get<ListResponse<RateLimit>>('/api/v1/rate-limits', { params });
+export const listRateLimits = (params?: ListRateLimitsParams) => {
+    return client.get<RateLimitList>('/api/v1/rate-limits', { params });
 };
 
 /**

--- a/sdks/js/src/requestEvents.ts
+++ b/sdks/js/src/requestEvents.ts
@@ -1,151 +1,135 @@
-import {client} from './client';
-import {ListResponse} from './common';
+import { client } from './client';
+import {
+  ListMetadata,
+  ObjectMetadata,
+  ObjectReference,
+  ResourceList,
+  TypeMeta,
+} from './common';
+import { RateLimitMode } from './rateLimits';
 
-// Request events models
+export const REQUEST_EVENT_KIND = 'RequestEvent' as const;
 
 export enum RequestType {
-    GLOBAL = 'global',
-    PROXY = 'proxy',
-    OAUTH = 'oauth',
-    PUBLIC = 'public',
+  GLOBAL = 'global',
+  PROXY = 'proxy',
+  OAUTH = 'oauth',
+  PUBLIC = 'public',
+  PROBE = 'probe',
 }
 
-// Identifies who produced the response captured by a RequestEventRecord.
-// "upstream" is the historical default and means the response (including
-// any 429) came from the 3rd-party. "connector_rate_limiter" means the
-// connector-level reactive 429 limiter short-circuited the request before
-// reaching the 3rd party. "rate_limit" means a proxy-side RateLimit
-// resource matched and rejected the request.
 export enum ResponseSource {
-    UPSTREAM = 'upstream',
-    CONNECTOR_RATE_LIMITER = 'connector_rate_limiter',
-    RATE_LIMIT = 'rate_limit',
+  UPSTREAM = 'upstream',
+  CONNECTOR_RATE_LIMITER = 'connector_rate_limiter',
+  RATE_LIMIT = 'rate_limit',
 }
 
-// A single rate-limit rule that matched a request. The full set of
-// matches is stored on RequestEventRecord.rateLimitMatched so observers
-// can see every rule that contributed to the decision, not just the one
-// that ultimately rejected the request.
-export interface RateLimitMatch {
-    id: string; // The ID of the rate-limit resource that matched
-    mode: string; // 'enforce' or 'observe'
-    bucket?: Record<string, string>; // Resolved bucket dimensions (dimension name → value)
+export interface RequestEventMetadata extends ObjectMetadata {
+  id: string;
+  namespace: string;
+  createdAt: string;
 }
 
-// RequestEventRecord is the log data recorded for every request event. It does not contain header and body data,
-// which is only conditionally recorded.
-export interface RequestEventRecord {
-    namespace: string; // The namespace of the request
-    type: RequestType; // The type of request (global, proxy, oauth, public)
-    requestId: string; // The ID of the request (randomly generated UUID)
-    correlationId: string; // Correlation ID for the request as supplied by the proxy caller
-    timestamp: string; // Timestamp of the request
-    duration: number; // Duration of the request in milliseconds
-    connectionId: string; // The ID of the connection that handled the request, if applicable
-    connectorId: string; // The ID of the connector that handled the request, if applicable
-    connectorVersion: number; // The version of the connector that handled the request, if applicable
-    method: string; // The HTTP method of the request
-    host: string; // The host of the request
-    scheme: string; // The scheme of the request (http, https)
-    path: string; // The path of the request
-    requestHttpVersion?: string; // The HTTP version of the request
-    requestSizeBytes?: number; // The size of the request in bytes
-    requestMimeType?: string; // The MIME type of the request
-    responseStatusCode?: number; // The HTTP status code of the response
-    responseError?: string; // The error message if the response was an error (could not make HTTP call)
-    responseHttpVersion?: string; // The HTTP version of the response
-    responseSizeBytes?: number; // The size of the response in bytes
-    responseMimeType?: string; // The MIME type of the response
-    internalTimeout?: boolean; // If there was an internal timeout while capture full response size/body
-    requestCancelled?: boolean; // If the caller cancelled the request before the full body was consumed
-    fullRequestRecorded?: boolean; // If the full request body was recorded; This means you may be able to get the full request
-    labels?: Record<string, string>; // Labels associated with the request (merged from connection and per-request labels)
-
-    // Rate-limit attribution. Defaults to ResponseSource.UPSTREAM for any
-    // request that was not short-circuited by a rate limiter. The
-    // rate_limit_* fields are populated when a proxy-side RateLimit
-    // resource matched the request — they remain empty for upstream and
-    // connector_rate_limiter responses.
-    responseSource?: ResponseSource;
-    rateLimitId?: string; // ID of the RateLimit resource that fired (when response_source = rate_limit)
-    rateLimitMode?: string; // 'enforce' or 'observe' (when response_source = rate_limit)
-    rateLimitBucket?: Record<string, string>; // Resolved bucket dimensions for the firing rule
-    rateLimitMatched?: RateLimitMatch[]; // Full set of rate-limit rules that matched this request
+export interface RequestEventRequest {
+  method: string;
+  host: string;
+  scheme: string;
+  path: string;
+  httpVersion?: string;
+  sizeBytes?: number;
+  mimeType?: string;
+  bodySkipped?: string;
 }
 
-// RequestEvent is the full data for a single request event. It contains header and body data.
-export interface RequestEvent {
-    id: string; // Request ID
-    ns: string; // Namespace
-    cid: string; // Correlation ID
-    ts: string; // Timestamp
-    dur: number; // Duration
-    full: boolean; // Full data present
-    req: {
-        // -- Request data --
-        u: string; // URL
-        v: string; // HTTP version
-        m: string; // Method
-        h: Record<string, string[]>; // Headers
-        cl?: number; // Content length
-        b: string; // Body; base64 encoded string
-    }; // Request
-    res: {
-        // -- Response data --
-        v: string; // HTTP version
-        sc: number; // HTTP status code
-        h: Record<string, string[]>; // Headers
-        b?: string; // Body; base64 encoded string
-        cl?: number; // Content length
-        err?: string; // Error message
-    }; // Response
+export interface RequestEventResponse {
+  statusCode?: number;
+  error?: string;
+  httpVersion?: string;
+  sizeBytes?: number;
+  mimeType?: string;
+  bodySkipped?: string;
+  source?: ResponseSource;
 }
 
-/**
- * Parameters used for listing request events.
- */
+export interface RequestEventCapture {
+  request: {
+    url: string;
+    headers: Record<string, string[]>;
+    /** Captured bytes encoded as base64. Subject to API secret-replay policy. */
+    body?: string;
+  };
+  response: {
+    headers: Record<string, string[]>;
+    /** Captured bytes encoded as base64. Subject to API secret-replay policy. */
+    body?: string;
+  };
+}
+
+export interface RequestEventRateLimit {
+  rateLimitRef: ObjectReference<'RateLimit'>;
+  mode: RateLimitMode;
+  bucket?: Record<string, string>;
+}
+
+export interface RequestEventSpec {
+  requestType: RequestType;
+  correlationId?: string;
+  durationMilliseconds: number;
+  namespaceRef: ObjectReference<'Namespace'>;
+  actorRef?: ObjectReference<'Actor'>;
+  connectionRef?: ObjectReference<'Connection'>;
+  connectorRef?: ObjectReference<'Connector'>;
+  request: RequestEventRequest;
+  response: RequestEventResponse;
+  captureAvailable: boolean;
+  capture?: RequestEventCapture;
+  rateLimit?: RequestEventRateLimit;
+  rateLimitsMatched?: RequestEventRateLimit[];
+  internalTimeout?: boolean;
+  requestCancelled?: boolean;
+}
+
+/** Immutable projection used by both list and get request-event endpoints. */
+export interface RequestEvent extends TypeMeta<typeof REQUEST_EVENT_KIND> {
+  metadata: RequestEventMetadata;
+  spec: RequestEventSpec;
+}
+
+export type RequestEventList = ResourceList<RequestEvent> & {
+  metadata: ListMetadata & {
+    total?: number;
+  };
+};
+
 export interface ListRequestEventsParams {
-    cursor?: string;
-    limit?: number;
-    orderBy?: string;
-
-    /*
-     * Filters
-     */
-
-    namespace?: string;
-    requestType?: RequestType;
-    labelSelector?: string;
-    correlationId?: string;
-    connectionId?: string;
-    connectorType?: string;
-    connectorId?: string;
-    connectorVersion?: number;
-    method?: string;
-    statusCode?: number;
-    statusCodeRange?: string; // Changed to string to match Go's format (e.g., "200-299")
-    timestampRange?: string;
-    path?: string;
-    pathRegex?: string; // Changed to string to match Go's format
-    responseSource?: ResponseSource; // Filter by who produced the response
-    rateLimitId?: string; // Filter for entries that fired a specific RateLimit resource
+  cursor?: string;
+  limit?: number;
+  orderBy?: string;
+  namespace?: string;
+  requestType?: RequestType;
+  labelSelector?: string;
+  correlationId?: string;
+  connectionId?: string;
+  connectorType?: string;
+  connectorId?: string;
+  connectorVersion?: number;
+  method?: string;
+  statusCode?: number;
+  statusCodeRange?: string;
+  timestampRange?: string;
+  path?: string;
+  pathRegex?: string;
+  responseSource?: ResponseSource;
+  rateLimitId?: string;
 }
 
-/**
- * Get a list of request events
- */
-export const listRequestEvents = (params: ListRequestEventsParams) => {
-    return client.get<ListResponse<RequestEventRecord>>('/api/v1/metrics/request-events', {params});
-};
+export const listRequestEvents = (params?: ListRequestEventsParams) =>
+  client.get<RequestEventList>('/api/v1/metrics/request-events', { params });
 
-/**
- * Get a specific request event by ID (uuid)
- */
-export const getRequestEvent = (id: string) => {
-    return client.get<RequestEvent>(`/api/v1/metrics/request-events/${id}`);
-};
+export const getRequestEvent = (id: string) =>
+  client.get<RequestEvent>(`/api/v1/metrics/request-events/${id}`);
 
 export const requestEvents = {
-    list: listRequestEvents,
-    get: getRequestEvent,
+  list: listRequestEvents,
+  get: getRequestEvent,
 };

--- a/sdks/js/src/resourceNames.test.ts
+++ b/sdks/js/src/resourceNames.test.ts
@@ -8,14 +8,14 @@ vi.mock('./client', () => ({
     client: {get: getMock, post: postMock, patch: patchMock},
 }));
 
-import {ACTOR_API_VERSION, ACTOR_KIND, createActor, updateActor} from './actors';
+import {ACTOR_KIND, createActor, updateActor} from './actors';
+import {API_VERSION, objectReference} from './common';
 import {initiateConnection, updateConnection} from './connections';
-import {updateConnector} from './connectors';
-import {createKey, listKeys, updateKey} from './keys';
+import {CONNECTOR_KIND, updateConnector} from './connectors';
+import {createKey, KeyState, listKeys, updateKey} from './keys';
 import {listNamespaces} from './namespaces';
 import {
     createRateLimit,
-    RATE_LIMIT_API_VERSION,
     RATE_LIMIT_KIND,
     RateLimitMode,
     updateRateLimit,
@@ -30,15 +30,24 @@ describe('resource name contracts', () => {
 
     it('sends optional names on create requests', () => {
         createActor({
-            apiVersion: ACTOR_API_VERSION,
+            apiVersion: API_VERSION,
             kind: ACTOR_KIND,
             metadata: {namespace: 'root', name: 'customer'},
             spec: {externalId: 'customer-1'},
         });
-        initiateConnection('cxr_test', '/return', {env: 'prod'}, 'production-crm');
-        createKey({namespace: 'root', name: 'primary-key'});
+        initiateConnection(objectReference(CONNECTOR_KIND, {id: 'cxr_test'}), {
+            returnToUrl: '/return',
+            labels: {env: 'prod'},
+            name: 'production-crm',
+        });
+        createKey({
+            apiVersion: API_VERSION,
+            kind: 'Key',
+            metadata: {namespace: 'root', name: 'primary-key'},
+            spec: {keyData: {numBytes: 32}},
+        });
         createRateLimit({
-            apiVersion: RATE_LIMIT_API_VERSION,
+            apiVersion: API_VERSION,
             kind: RATE_LIMIT_KIND,
             metadata: {namespace: 'root', name: 'public-api'},
             spec: {
@@ -50,14 +59,20 @@ describe('resource name contracts', () => {
         });
 
         expect(postMock).toHaveBeenCalledWith('/api/v1/actors', expect.objectContaining({
-            apiVersion: ACTOR_API_VERSION,
+            apiVersion: API_VERSION,
             kind: ACTOR_KIND,
             metadata: expect.objectContaining({name: 'customer'}),
         }));
-        expect(postMock).toHaveBeenCalledWith('/api/v1/connections/_initiate', expect.objectContaining({name: 'production-crm'}));
-        expect(postMock).toHaveBeenCalledWith('/api/v1/keys', expect.objectContaining({name: 'primary-key'}));
+        expect(postMock).toHaveBeenCalledWith('/api/v1/connections/_initiate', expect.objectContaining({
+            apiVersion: API_VERSION,
+            kind: 'ConnectionInitiate',
+            spec: expect.objectContaining({name: 'production-crm'}),
+        }));
+        expect(postMock).toHaveBeenCalledWith('/api/v1/keys', expect.objectContaining({
+            metadata: expect.objectContaining({name: 'primary-key'}),
+        }));
         expect(postMock).toHaveBeenCalledWith('/api/v1/rate-limits', expect.objectContaining({
-            apiVersion: RATE_LIMIT_API_VERSION,
+            apiVersion: API_VERSION,
             kind: RATE_LIMIT_KIND,
             metadata: expect.objectContaining({name: 'public-api'}),
         }));
@@ -65,32 +80,61 @@ describe('resource name contracts', () => {
 
     it('renames resources by immutable id', () => {
         updateActor('act_test', {
-            apiVersion: ACTOR_API_VERSION,
+            apiVersion: API_VERSION,
             kind: ACTOR_KIND,
             metadata: {name: 'actor-name'},
             spec: {},
         });
-        updateConnection('cxn_test', {name: 'connection-name'});
-        updateConnector('cxr_test', {name: 'connector-name'});
-        updateKey('key_test', {name: 'key-name'});
+        updateConnection('cxn_test', {
+            apiVersion: API_VERSION,
+            kind: 'Connection',
+            metadata: {name: 'connection-name'},
+            spec: {},
+        });
+        updateConnector('cxr_test', {
+            apiVersion: API_VERSION,
+            kind: CONNECTOR_KIND,
+            metadata: {name: 'connector-name'},
+            spec: {},
+        });
+        updateKey('key_test', {
+            apiVersion: API_VERSION,
+            kind: 'Key',
+            metadata: {name: 'key-name'},
+            spec: {desiredState: KeyState.ACTIVE},
+        });
         updateRateLimit('rl_test', {
-            apiVersion: RATE_LIMIT_API_VERSION,
+            apiVersion: API_VERSION,
             kind: RATE_LIMIT_KIND,
             metadata: {name: 'limit-name'},
             spec: {},
         });
 
         expect(patchMock).toHaveBeenCalledWith('/api/v1/actors/act_test', {
-            apiVersion: ACTOR_API_VERSION,
+            apiVersion: API_VERSION,
             kind: ACTOR_KIND,
             metadata: {name: 'actor-name'},
             spec: {},
         });
-        expect(patchMock).toHaveBeenCalledWith('/api/v1/connections/cxn_test', {name: 'connection-name'});
-        expect(patchMock).toHaveBeenCalledWith('/api/v1/connectors/cxr_test', {name: 'connector-name'});
-        expect(patchMock).toHaveBeenCalledWith('/api/v1/keys/key_test', {name: 'key-name'});
+        expect(patchMock).toHaveBeenCalledWith('/api/v1/connections/cxn_test', expect.objectContaining({
+            apiVersion: API_VERSION,
+            kind: 'Connection',
+            metadata: {name: 'connection-name'},
+            spec: {},
+        }));
+        expect(patchMock).toHaveBeenCalledWith('/api/v1/connectors/cxr_test', expect.objectContaining({
+            apiVersion: API_VERSION,
+            kind: CONNECTOR_KIND,
+            metadata: {name: 'connector-name'},
+            spec: {},
+        }));
+        expect(patchMock).toHaveBeenCalledWith('/api/v1/keys/key_test', expect.objectContaining({
+            apiVersion: API_VERSION,
+            kind: 'Key',
+            metadata: {name: 'key-name'},
+        }));
         expect(patchMock).toHaveBeenCalledWith('/api/v1/rate-limits/rl_test', {
-            apiVersion: RATE_LIMIT_API_VERSION,
+            apiVersion: API_VERSION,
             kind: RATE_LIMIT_KIND,
             metadata: {name: 'limit-name'},
             spec: {},

--- a/sdks/js/src/search.ts
+++ b/sdks/js/src/search.ts
@@ -1,57 +1,58 @@
-import {AxiosRequestConfig} from 'axios';
-import {client} from './client';
+import { AxiosRequestConfig } from 'axios';
+import { client } from './client';
+import { ManagedResourceKind, ObjectReference, TypeMeta } from './common';
+
+export const SEARCH_RESULT_LIST_KIND = 'SearchResultList' as const;
 
 export type SearchResourceType =
-    | 'actor'
-    | 'connection'
-    | 'connector'
-    | 'namespace'
-    | 'key'
-    | 'rate_limit';
+  | 'actor'
+  | 'connection'
+  | 'connector'
+  | 'namespace'
+  | 'key'
+  | 'rate_limit';
 
 export type SearchMode = 'query' | 'seed';
 
 export interface SearchLabelMatch {
-    key: string;
-    value: string;
+  key: string;
+  value: string;
 }
 
-export interface SearchResourceSummary {
-    resourceType: SearchResourceType;
-    resourceId: string;
-    name: string;
-    namespace: string;
-    labels: Record<string, string>;
-    matchedLabels: SearchLabelMatch[];
-    updatedAt: string;
+export interface SearchResult {
+  resourceRef: ObjectReference<ManagedResourceKind>;
+  labels: Record<string, string>;
+  matchedLabels: SearchLabelMatch[];
+  updatedAt: string;
 }
 
-export interface SearchResourcesResponse {
-    items: SearchResourceSummary[];
-    truncatedTypes: SearchResourceType[];
-    incompleteTypes: SearchResourceType[];
+export interface SearchResultList extends TypeMeta<typeof SEARCH_RESULT_LIST_KIND> {
+  metadata: {
+    truncatedKinds: ManagedResourceKind[];
+    incompleteKinds: ManagedResourceKind[];
+  };
+  items: SearchResult[];
 }
 
 export interface SearchResourcesParams {
-    mode?: SearchMode;
-    resourceType?: SearchResourceType[];
-    q?: string;
-    labelSelector?: string;
-    namespace?: string;
-    limit?: number;
+  mode?: SearchMode;
+  resourceType?: SearchResourceType[];
+  q?: string;
+  labelSelector?: string;
+  namespace?: string;
+  limit?: number;
 }
 
 export const searchResources = (
-    params: SearchResourcesParams,
-    config?: AxiosRequestConfig,
-) => {
-    return client.get<SearchResourcesResponse>('/api/v1/search/resources', {
-        ...config,
-        params,
-        paramsSerializer: config?.paramsSerializer ?? {indexes: null},
-    });
-};
+  params: SearchResourcesParams,
+  config?: AxiosRequestConfig,
+) =>
+  client.get<SearchResultList>('/api/v1/search/resources', {
+    ...config,
+    params,
+    paramsSerializer: config?.paramsSerializer ?? { indexes: null },
+  });
 
 export const resourceSearch = {
-    search: searchResources,
+  search: searchResources,
 };

--- a/sdks/js/src/taskMonitoring.ts
+++ b/sdks/js/src/taskMonitoring.ts
@@ -1,90 +1,154 @@
 import { client } from './client';
-import { ListResponse } from './common';
+import { ActionResponse, ObjectMetadata, ResourceList, TypeMeta } from './common';
 
-// Queue info
-export interface QueueInfo {
-  queue: string;
-  memoryUsage: number;
-  latencySeconds: number;
-  size: number;
-  groups: number;
-  pending: number;
-  active: number;
-  scheduled: number;
-  retry: number;
-  archived: number;
-  completed: number;
-  aggregating: number;
-  processed: number;
-  failed: number;
-  processedTotal: number;
-  failedTotal: number;
-  paused: boolean;
-  timestamp: string;
+export const TASK_QUEUE_KIND = 'TaskQueue' as const;
+export const TASK_QUEUE_HISTORY_KIND = 'TaskQueueHistory' as const;
+export const TASK_EXECUTION_KIND = 'TaskExecution' as const;
+export const TASK_SERVER_KIND = 'TaskServer' as const;
+export const TASK_SCHEDULE_KIND = 'TaskSchedule' as const;
+
+export const TASK_EXECUTION_RUN_KIND = 'TaskExecutionRun' as const;
+export const TASK_EXECUTION_ARCHIVE_KIND = 'TaskExecutionArchive' as const;
+export const TASK_EXECUTION_CANCEL_KIND = 'TaskExecutionCancel' as const;
+export const TASK_EXECUTION_DELETE_KIND = 'TaskExecutionDelete' as const;
+export const TASK_QUEUE_PAUSE_KIND = 'TaskQueuePause' as const;
+export const TASK_QUEUE_UNPAUSE_KIND = 'TaskQueueUnpause' as const;
+export const TASK_QUEUE_RUN_ALL_KIND = 'TaskQueueRunAll' as const;
+export const TASK_QUEUE_DELETE_ALL_KIND = 'TaskQueueDeleteAll' as const;
+
+export interface TaskQueue extends TypeMeta<typeof TASK_QUEUE_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: Record<string, never>;
+  status: {
+    memoryUsage: number;
+    latencySeconds: number;
+    size: number;
+    groups: number;
+    pending: number;
+    active: number;
+    scheduled: number;
+    retry: number;
+    archived: number;
+    completed: number;
+    aggregating: number;
+    processed: number;
+    failed: number;
+    processedTotal: number;
+    failedTotal: number;
+    paused: boolean;
+  };
 }
 
-// Task info
-export interface MonitoringTaskInfo {
-  id: string;
-  queue: string;
-  type: string;
-  payload: string;
-  state: string;
-  maxRetry: number;
-  retried: number;
-  lastErr?: string;
-  lastFailedAt?: string;
-  nextProcessAt?: string;
-  completedAt?: string;
-  isOrphaned?: boolean;
-  group?: string;
+export type TaskQueueList = ResourceList<TaskQueue>;
+
+export interface TaskExecution extends TypeMeta<typeof TASK_EXECUTION_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    queue: string;
+    type: string;
+    payload: string;
+    maxRetry: number;
+    group?: string;
+  };
+  status: {
+    state: string;
+    retried: number;
+    lastError?: string;
+    lastFailedAt?: string;
+    nextProcessAt?: string;
+    completedAt?: string;
+    orphaned?: boolean;
+  };
 }
 
-// Daily stats
-export interface DailyStats {
-  queue: string;
-  processed: number;
-  failed: number;
+export type TaskExecutionList = ResourceList<TaskExecution>;
+
+export interface TaskQueueDailyStats {
   date: string;
+  processed: number;
+  failed: number;
 }
 
-// Worker info
-export interface WorkerInfo {
+export interface TaskQueueHistory extends TypeMeta<typeof TASK_QUEUE_HISTORY_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    days: number;
+  };
+  status: {
+    items: TaskQueueDailyStats[];
+  };
+}
+
+export interface TaskWorker {
   taskId: string;
   taskType: string;
   queue: string;
-  started: string;
+  startedAt: string;
   deadline: string;
 }
 
-// Server info
-export interface ServerInfo {
-  id: string;
-  host: string;
-  pid: number;
-  concurrency: number;
-  queues: Record<string, number>;
-  strictPriority: boolean;
-  started: string;
-  status: string;
-  activeWorkers: WorkerInfo[];
+export interface TaskServer extends TypeMeta<typeof TASK_SERVER_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    host: string;
+    pid: number;
+    concurrency: number;
+    queues: Record<string, number>;
+    strictPriority: boolean;
+  };
+  status: {
+    state: string;
+    activeWorkers: TaskWorker[];
+  };
 }
 
-// Scheduler entry
-export interface SchedulerEntry {
-  id: string;
-  spec: string;
-  taskType: string;
-  next: string;
-  prev?: string;
+export type TaskServerList = ResourceList<TaskServer>;
+
+export interface TaskSchedule extends TypeMeta<typeof TASK_SCHEDULE_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    schedule: string;
+    taskType: string;
+  };
+  status: {
+    nextRunAt: string;
+    previousRunAt?: string;
+  };
 }
 
-// Bulk action response
-export interface BulkActionResponse {
+export type TaskScheduleList = ResourceList<TaskSchedule>;
+
+export interface OperationActionStatus {
+  succeeded: boolean;
   affectedCount: number;
 }
 
-// Query params
+export type TaskExecutionActionKind =
+  | typeof TASK_EXECUTION_RUN_KIND
+  | typeof TASK_EXECUTION_ARCHIVE_KIND
+  | typeof TASK_EXECUTION_CANCEL_KIND
+  | typeof TASK_EXECUTION_DELETE_KIND;
+
+export type TaskExecutionAction<K extends TaskExecutionActionKind> = ActionResponse<
+  K,
+  typeof TASK_EXECUTION_KIND,
+  { queue: string },
+  OperationActionStatus
+>;
+
+export type TaskQueueActionKind =
+  | typeof TASK_QUEUE_PAUSE_KIND
+  | typeof TASK_QUEUE_UNPAUSE_KIND
+  | typeof TASK_QUEUE_RUN_ALL_KIND
+  | typeof TASK_QUEUE_DELETE_ALL_KIND;
+
+export type TaskQueueAction<K extends TaskQueueActionKind> = ActionResponse<
+  K,
+  typeof TASK_QUEUE_KIND,
+  { state?: string },
+  OperationActionStatus
+>;
+
 export interface ListTasksParams {
   cursor?: string;
   limit?: number;
@@ -94,158 +158,92 @@ export interface HistoryParams {
   days?: number;
 }
 
-export type MonitoringTaskState = 'pending' | 'active' | 'scheduled' | 'retry' | 'archived' | 'completed';
+export type MonitoringTaskState =
+  | 'pending'
+  | 'active'
+  | 'scheduled'
+  | 'retry'
+  | 'archived'
+  | 'completed';
 
-/**
- * List all queues with their info
- */
-export const listQueues = () => {
-  return client.get<ListResponse<QueueInfo>>('/api/v1/task-monitoring/queues');
-};
+export const listQueues = () =>
+  client.get<TaskQueueList>('/api/v1/task-monitoring/queues');
 
-/**
- * Get info for a specific queue
- */
-export const getQueueInfo = (queue: string) => {
-  return client.get<QueueInfo>(`/api/v1/task-monitoring/queues/${queue}`);
-};
+export const getQueueInfo = (queue: string) =>
+  client.get<TaskQueue>(`/api/v1/task-monitoring/queues/${queue}`);
 
-/**
- * Get daily stats history for a queue
- */
-export const getQueueHistory = (queue: string, params?: HistoryParams) => {
-  return client.get<ListResponse<DailyStats>>(
-    `/api/v1/task-monitoring/queues/${queue}/history`,
-    { params }
-  );
-};
+export const getQueueHistory = (queue: string, params?: HistoryParams) =>
+  client.get<TaskQueueHistory>(`/api/v1/task-monitoring/queues/${queue}/history`, { params });
 
-/**
- * List tasks by state in a queue
- */
 export const listTasksByState = (
   queue: string,
   state: MonitoringTaskState,
-  params?: ListTasksParams
-) => {
-  return client.get<ListResponse<MonitoringTaskInfo>>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${state}`,
-    { params }
+  params?: ListTasksParams,
+) =>
+  client.get<TaskExecutionList>(`/api/v1/task-monitoring/queues/${queue}/tasks/${state}`, {
+    params,
+  });
+
+export const getTaskInfo = (queue: string, state: MonitoringTaskState, taskId: string) =>
+  client.get<TaskExecution>(
+    `/api/v1/task-monitoring/queues/${queue}/tasks/${state}/${taskId}`,
   );
-};
 
-/**
- * Get a specific task
- */
-export const getTaskInfo = (queue: string, state: MonitoringTaskState, taskId: string) => {
-  return client.get<MonitoringTaskInfo>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${state}/${taskId}`
+export const listServers = () =>
+  client.get<TaskServerList>('/api/v1/task-monitoring/servers');
+
+export const listSchedulerEntries = () =>
+  client.get<TaskScheduleList>('/api/v1/task-monitoring/scheduler-entries');
+
+export const runTask = (queue: string, taskId: string) =>
+  client.post<TaskExecutionAction<typeof TASK_EXECUTION_RUN_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_run`,
   );
-};
 
-/**
- * List connected servers
- */
-export const listServers = () => {
-  return client.get<ListResponse<ServerInfo>>('/api/v1/task-monitoring/servers');
-};
-
-/**
- * List scheduler entries
- */
-export const listSchedulerEntries = () => {
-  return client.get<ListResponse<SchedulerEntry>>('/api/v1/task-monitoring/scheduler-entries');
-};
-
-/**
- * Run a task (move from scheduled/retry/archived to pending)
- */
-export const runTask = (queue: string, taskId: string) => {
-  return client.post<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_run`
+export const archiveTask = (queue: string, taskId: string) =>
+  client.post<TaskExecutionAction<typeof TASK_EXECUTION_ARCHIVE_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_archive`,
   );
-};
 
-/**
- * Archive a task
- */
-export const archiveTask = (queue: string, taskId: string) => {
-  return client.post<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_archive`
+export const cancelTask = (queue: string, taskId: string) =>
+  client.post<TaskExecutionAction<typeof TASK_EXECUTION_CANCEL_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_cancel`,
   );
-};
 
-/**
- * Cancel a task that is currently being processed
- */
-export const cancelTask = (queue: string, taskId: string) => {
-  return client.post<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}/_cancel`
+export const deleteTask = (queue: string, taskId: string) =>
+  client.delete<TaskExecutionAction<typeof TASK_EXECUTION_DELETE_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}`,
   );
-};
 
-/**
- * Delete a task
- */
-export const deleteTask = (queue: string, taskId: string) => {
-  return client.delete<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/tasks/${taskId}`
+export const pauseQueue = (queue: string) =>
+  client.post<TaskQueueAction<typeof TASK_QUEUE_PAUSE_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/_pause`,
   );
-};
 
-/**
- * Pause a queue
- */
-export const pauseQueue = (queue: string) => {
-  return client.post<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/_pause`
+export const unpauseQueue = (queue: string) =>
+  client.post<TaskQueueAction<typeof TASK_QUEUE_UNPAUSE_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/_unpause`,
   );
-};
 
-/**
- * Unpause a queue
- */
-export const unpauseQueue = (queue: string) => {
-  return client.post<{ ok: boolean }>(
-    `/api/v1/task-monitoring/queues/${queue}/_unpause`
+export const runAllArchivedTasks = (queue: string) =>
+  client.post<TaskQueueAction<typeof TASK_QUEUE_RUN_ALL_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/archived/_runAll`,
   );
-};
 
-/**
- * Run all archived tasks in a queue
- */
-export const runAllArchivedTasks = (queue: string) => {
-  return client.post<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/archived/_runAll`
+export const runAllRetryTasks = (queue: string) =>
+  client.post<TaskQueueAction<typeof TASK_QUEUE_RUN_ALL_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/retry/_runAll`,
   );
-};
 
-/**
- * Run all retry tasks in a queue
- */
-export const runAllRetryTasks = (queue: string) => {
-  return client.post<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/retry/_runAll`
+export const deleteAllArchivedTasks = (queue: string) =>
+  client.delete<TaskQueueAction<typeof TASK_QUEUE_DELETE_ALL_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/archived`,
   );
-};
 
-/**
- * Delete all archived tasks in a queue
- */
-export const deleteAllArchivedTasks = (queue: string) => {
-  return client.delete<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/archived`
+export const deleteAllCompletedTasks = (queue: string) =>
+  client.delete<TaskQueueAction<typeof TASK_QUEUE_DELETE_ALL_KIND>>(
+    `/api/v1/task-monitoring/queues/${queue}/completed`,
   );
-};
-
-/**
- * Delete all completed tasks in a queue
- */
-export const deleteAllCompletedTasks = (queue: string) => {
-  return client.delete<BulkActionResponse>(
-    `/api/v1/task-monitoring/queues/${queue}/completed`
-  );
-};
 
 export const taskMonitoring = {
   listQueues,

--- a/sdks/js/src/tasks.ts
+++ b/sdks/js/src/tasks.ts
@@ -1,7 +1,9 @@
-import { client } from './client';
 import { BackoffConfig } from './backoff';
+import { client } from './client';
+import { ObjectMetadata, TypeMeta } from './common';
 
-// Task models
+export const TASK_KIND = 'Task' as const;
+
 export enum TaskState {
   UNKNOWN = 'unknown',
   ACTIVE = 'active',
@@ -12,59 +14,49 @@ export enum TaskState {
   COMPLETED = 'completed',
 }
 
-export interface TaskInfoJson {
-  id: string;
-  type: string;
-  state: TaskState;
-  updatedAt?: string;
+export interface Task extends TypeMeta<typeof TASK_KIND> {
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    type: string;
+  };
+  status: {
+    state: TaskState;
+  };
 }
 
-/**
- * Get task information
- */
-export const getTask = (id: string) => {
-  return client.get<TaskInfoJson>(`/api/v1/tasks/${id}`);
-};
+export const getTask = (id: string) => client.get<Task>(`/api/v1/tasks/${id}`);
 
-// Default configuration
 const defaultBackoffConfig: BackoffConfig = {
-  initialDelay: 1000, // Start with 1 second
-  maxDelay: 120_000, // Max delay of 20 minutes
-  maxAttempts: 10, // Try up to 10 times
-  backoffFactor: 2, // Double the delay each time
+  initialDelay: 1_000,
+  maxDelay: 120_000,
+  maxAttempts: 10,
+  backoffFactor: 2,
 };
 
-/**
- * The final state of a call to poll for a task to be finalized.
- */
 export enum PollForTaskResult {
   FINALIZED = 'finalized',
   RETRIES_EXHAUSTED = 'retries_exhausted',
   ERROR = 'error',
 }
 
-/**
- * Poll for a task to reach a final state (COMPLETED or FAILED), with exponential backoff.
- */
+export interface PollForTaskFinalizedResult {
+  result: PollForTaskResult;
+  task?: Task;
+}
+
+/** Polls until the task is completed/failed or the configured backoff is exhausted. */
 export const pollForTaskFinalized = async (
   taskId: string,
-  config = defaultBackoffConfig
-): Promise<{
-  result: PollForTaskResult;
-  taskInfo?: TaskInfoJson;
-}> => {
-  // Merge provided config with defaults
+  config: BackoffConfig = defaultBackoffConfig,
+): Promise<PollForTaskFinalizedResult> => {
   const fullConfig = { ...defaultBackoffConfig, ...config };
   const { initialDelay, maxDelay, maxAttempts, backoffFactor } = fullConfig;
 
   let attempts = 0;
   let delay = initialDelay;
 
-  const poll = async (): Promise<{
-    result: PollForTaskResult;
-    taskInfo?: TaskInfoJson;
-  }> => {
-    attempts++;
+  const poll = async (): Promise<PollForTaskFinalizedResult> => {
+    attempts += 1;
 
     try {
       const response = await getTask(taskId);
@@ -72,13 +64,9 @@ export const pollForTaskFinalized = async (
         return { result: PollForTaskResult.ERROR };
       }
 
-      const taskInfo = response.data;
-
-      if (
-        taskInfo.state === TaskState.COMPLETED ||
-        taskInfo.state === TaskState.FAILED
-      ) {
-        return { result: PollForTaskResult.FINALIZED, taskInfo };
+      const task = response.data;
+      if (task.status.state === TaskState.COMPLETED || task.status.state === TaskState.FAILED) {
+        return { result: PollForTaskResult.FINALIZED, task };
       }
 
       if (attempts >= maxAttempts) {
@@ -88,7 +76,7 @@ export const pollForTaskFinalized = async (
       await new Promise((resolve) => setTimeout(resolve, delay));
       delay = Math.min(delay * backoffFactor, maxDelay);
       return poll();
-    } catch (error) {
+    } catch (_error) {
       if (attempts >= maxAttempts) {
         return { result: PollForTaskResult.ERROR };
       }

--- a/sdks/js/src/workflowMonitoring.ts
+++ b/sdks/js/src/workflowMonitoring.ts
@@ -1,50 +1,69 @@
 import { AxiosRequestConfig } from 'axios';
 import { client } from './client';
+import {
+  ActionResponse,
+  ObjectMetadata,
+  ObjectReference,
+  ResourceList,
+  TypeMeta,
+} from './common';
+import { OperationActionStatus } from './taskMonitoring';
 
-export interface WorkflowInstance {
+export const WORKFLOW_INSTANCE_KIND = 'WorkflowInstance' as const;
+export const WORKFLOW_HISTORY_EVENT_KIND = 'WorkflowHistoryEvent' as const;
+export const WORKFLOW_INSTANCE_CANCEL_KIND = 'WorkflowInstanceCancel' as const;
+export const WORKFLOW_INSTANCE_DELETE_KIND = 'WorkflowInstanceDelete' as const;
+
+export interface WorkflowInstanceReference {
+  target: ObjectReference<typeof WORKFLOW_INSTANCE_KIND>;
   instanceId: string;
-  executionId: string;
-  parent?: WorkflowInstance;
 }
 
 export type WorkflowInstanceState = 'active' | 'continued_as_new' | 'finished' | string;
 
-export interface WorkflowInstanceRef {
-  instance?: WorkflowInstance;
-  createdAt?: string;
-  completedAt?: string;
-  state: WorkflowInstanceState;
-  queue: string;
+export interface WorkflowInstance extends TypeMeta<typeof WORKFLOW_INSTANCE_KIND> {
+  /** metadata.id is the unique execution ID. */
+  metadata: ObjectMetadata & { id: string };
+  spec: {
+    /** Logical workflow instance ID, required together with metadata.id for addressing. */
+    instanceId: string;
+    queue: string;
+    parentRef?: WorkflowInstanceReference;
+    workflowName?: string;
+  };
+  status: {
+    state: WorkflowInstanceState;
+    completedAt?: string;
+    error?: boolean;
+    history?: WorkflowHistoryEvent[];
+    children?: WorkflowInstance[];
+  };
 }
 
-export interface WorkflowHistoryEvent {
-  id?: string;
-  sequenceId?: number;
-  type?: string;
-  timestamp?: string;
-  scheduleEventId?: number;
-  attributes?: unknown;
-  visibleAt?: string;
+export interface WorkflowHistoryEvent extends TypeMeta<typeof WORKFLOW_HISTORY_EVENT_KIND> {
+  metadata: ObjectMetadata;
+  spec: {
+    sequenceId?: number;
+    type?: string;
+    scheduleEventId?: number;
+    attributes?: unknown;
+    visibleAt?: string;
+  };
 }
 
-export interface WorkflowInstanceInfo extends WorkflowInstanceRef {
-  history?: WorkflowHistoryEvent[];
-}
+export type WorkflowInstanceList = ResourceList<WorkflowInstance>;
+export type WorkflowHistoryEventList = ResourceList<WorkflowHistoryEvent>;
 
-export interface WorkflowInstanceTree extends WorkflowInstanceRef {
-  workflowName?: string;
-  error?: boolean;
-  children?: WorkflowInstanceTree[];
-}
+export type WorkflowInstanceActionKind =
+  | typeof WORKFLOW_INSTANCE_CANCEL_KIND
+  | typeof WORKFLOW_INSTANCE_DELETE_KIND;
 
-export interface ListWorkflowInstancesResponse {
-  items: WorkflowInstanceRef[];
-  cursor?: string;
-}
-
-export interface ListWorkflowHistoryResponse {
-  items: WorkflowHistoryEvent[];
-}
+export type WorkflowInstanceAction<K extends WorkflowInstanceActionKind> = ActionResponse<
+  K,
+  typeof WORKFLOW_INSTANCE_KIND,
+  { instanceId: string },
+  OperationActionStatus
+>;
 
 export interface ListWorkflowInstancesParams {
   cursor?: string;
@@ -56,33 +75,31 @@ const instancePath = (instanceId: string, executionId: string) =>
 
 export const listWorkflowInstances = (
   params?: ListWorkflowInstancesParams,
-  config?: AxiosRequestConfig
-) => {
-  return client.get<ListWorkflowInstancesResponse>('/api/v1/workflow-monitoring/instances', {
+  config?: AxiosRequestConfig,
+) =>
+  client.get<WorkflowInstanceList>('/api/v1/workflow-monitoring/instances', {
     ...config,
     params,
   });
-};
 
-export const getWorkflowInstance = (instanceId: string, executionId: string) => {
-  return client.get<WorkflowInstanceInfo>(instancePath(instanceId, executionId));
-};
+export const getWorkflowInstance = (instanceId: string, executionId: string) =>
+  client.get<WorkflowInstance>(instancePath(instanceId, executionId));
 
-export const listWorkflowHistory = (instanceId: string, executionId: string) => {
-  return client.get<ListWorkflowHistoryResponse>(`${instancePath(instanceId, executionId)}/history`);
-};
+export const listWorkflowHistory = (instanceId: string, executionId: string) =>
+  client.get<WorkflowHistoryEventList>(`${instancePath(instanceId, executionId)}/history`);
 
-export const getWorkflowTree = (instanceId: string, executionId: string) => {
-  return client.get<WorkflowInstanceTree>(`${instancePath(instanceId, executionId)}/tree`);
-};
+export const getWorkflowTree = (instanceId: string, executionId: string) =>
+  client.get<WorkflowInstance>(`${instancePath(instanceId, executionId)}/tree`);
 
-export const cancelWorkflowInstance = (instanceId: string, executionId: string) => {
-  return client.post<{ ok: boolean }>(`${instancePath(instanceId, executionId)}/_cancel`);
-};
+export const cancelWorkflowInstance = (instanceId: string, executionId: string) =>
+  client.post<WorkflowInstanceAction<typeof WORKFLOW_INSTANCE_CANCEL_KIND>>(
+    `${instancePath(instanceId, executionId)}/_cancel`,
+  );
 
-export const removeWorkflowInstance = (instanceId: string, executionId: string) => {
-  return client.delete<{ ok: boolean }>(instancePath(instanceId, executionId));
-};
+export const removeWorkflowInstance = (instanceId: string, executionId: string) =>
+  client.delete<WorkflowInstanceAction<typeof WORKFLOW_INSTANCE_DELETE_KIND>>(
+    instancePath(instanceId, executionId),
+  );
 
 export const workflowMonitoring = {
   listWorkflowInstances,


### PR DESCRIPTION
Closes #844

## Summary

- replace the JavaScript SDK's flat managed-resource models with shared authproxy.net/v1alpha1 type metadata, object metadata, references, resource lists, and typed actions
- model actors, connectors, connections, keys, namespaces, rate limits, notifications, search, request events, tasks, queues, and workflows using the backend wire contracts
- represent every connector generation as Connector with metadata.generation; require exact generations for connection bindings/migrations and prohibit generations on rate-limit references
- add restricted Actor JWT-claim helpers and document write-only/redacted actor and key configuration
- update endpoint serialization, pagination, error types, exports, package documentation, and compile-time/runtime contract coverage

The Admin and Marketplace consumers intentionally remain for #845 and #846. This PR changes only the SDK layer and does not retain parallel flat compatibility aliases.

## Verification

- yarn workspace @authproxy/api typecheck
- yarn workspace @authproxy/api test
- yarn workspace @authproxy/api lint
- yarn workspace @authproxy/api build
- ./scripts/preflight.sh
