### PR TITLE
Migrate Terraform provider to v1alpha1 resources

### DIFF
--- a/integration_tests/terraform/connector_test.go
+++ b/integration_tests/terraform/connector_test.go
@@ -25,8 +25,9 @@ const updatedConnectorDefinition = `{
   }
 }`
 
-// TestAccConnector_publishTrue tests: create with publish=true -> version 1 is primary,
-// then update definition -> version 2 is primary.
+// TestAccConnector_publishTrue tests: create with publish=true -> generation 1 is primary,
+// then update definition -> generation 2 is primary. The provider retains its
+// established `version` HCL name while mapping it to API metadata.generation.
 func TestAccConnector_publishTrue(t *testing.T) {
 	env := testSetup(t)
 	providerCfg := testProviderConfig(env)
@@ -89,7 +90,7 @@ resource "authproxy_connector" "test" {
 	})
 }
 
-// TestAccConnector_publishFalse tests: create with publish=false -> version stays draft.
+// TestAccConnector_publishFalse tests creation and in-place updates of a draft generation.
 func TestAccConnector_publishFalse(t *testing.T) {
 	env := testSetup(t)
 	providerCfg := testProviderConfig(env)
@@ -97,7 +98,6 @@ func TestAccConnector_publishFalse(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
-			// Create connector with publish=false -> stays draft
 			{
 				Config: providerCfg + `
 resource "authproxy_namespace" "test" {
@@ -121,6 +121,30 @@ resource "authproxy_connector" "test" {
 					resource.TestCheckResourceAttr("authproxy_connector.test", "version", "1"),
 					resource.TestCheckResourceAttr("authproxy_connector.test", "state", "draft"),
 					resource.TestCheckResourceAttr("authproxy_connector.test", "publish", "false"),
+				),
+			},
+			{
+				Config: providerCfg + `
+resource "authproxy_namespace" "test" {
+  path = "root.tf-test-connector-draft"
+}
+
+resource "authproxy_connector" "test" {
+  namespace  = authproxy_namespace.test.path
+  publish    = false
+  definition = jsonencode({
+    displayName = "Draft Connector Updated"
+    description = "An updated draft connector"
+    auth = {
+      type = "no-auth"
+    }
+  })
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("authproxy_connector.test", "version", "1"),
+					resource.TestCheckResourceAttr("authproxy_connector.test", "state", "draft"),
+					resource.TestCheckResourceAttr("authproxy_connector.test", "display_name", "Draft Connector Updated"),
 				),
 			},
 		},
@@ -245,7 +269,8 @@ resource "authproxy_connector" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("authproxy_connector.test", "labels.env", "production"),
 					resource.TestCheckResourceAttr("authproxy_connector.test", "labels.team", "platform"),
-					// The API creates a new version for any update on a published connector
+					// Resource metadata changes do not manufacture a new generation.
+					resource.TestCheckResourceAttr("authproxy_connector.test", "version", "1"),
 					resource.TestCheckResourceAttr("authproxy_connector.test", "state", "primary"),
 				),
 			},
@@ -380,8 +405,8 @@ resource "authproxy_connector" "test" {
 			},
 			{
 				ResourceName:      "authproxy_connector.test",
-				ImportState:        true,
-				ImportStateVerify:  true,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/integration_tests/terraform/rate_limit_test.go
+++ b/integration_tests/terraform/rate_limit_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccRateLimit_createUpdateImport(t *testing.T) {
+	env := testSetup(t)
+	providerCfg := testProviderConfig(env)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + `
+resource "authproxy_namespace" "test" {
+  path = "root.tf-test-rate-limit"
+}
+
+resource "authproxy_rate_limit" "test" {
+  namespace = authproxy_namespace.test.path
+  mode      = "observe"
+
+  selector {
+    methods = ["GET"]
+  }
+
+  bucket {
+    dimensions = ["actor"]
+  }
+
+  algorithm {
+    fixed_window {
+      window = "1m"
+      limit  = 10
+    }
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("authproxy_rate_limit.test", "id"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "namespace", "root.tf-test-rate-limit"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "mode", "observe"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "selector.methods.0", "GET"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "algorithm.fixed_window.limit", "10"),
+				),
+			},
+			{
+				Config: providerCfg + `
+resource "authproxy_namespace" "test" {
+  path = "root.tf-test-rate-limit"
+}
+
+resource "authproxy_rate_limit" "test" {
+  namespace = authproxy_namespace.test.path
+  mode      = "enforce"
+  labels = {
+    team = "platform"
+  }
+
+  scope {
+    namespace_matcher = "root.tf-test-rate-limit.**"
+  }
+
+  selector {
+    methods = ["GET", "POST"]
+  }
+
+  bucket {
+    dimensions = ["actor"]
+  }
+
+  algorithm {
+    fixed_window {
+      window = "1m"
+      limit  = 20
+    }
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "mode", "enforce"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "labels.team", "platform"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "scope.namespace_matcher", "root.tf-test-rate-limit.**"),
+					resource.TestCheckResourceAttr("authproxy_rate_limit.test", "algorithm.fixed_window.limit", "20"),
+				),
+			},
+			{
+				ResourceName:      "authproxy_rate_limit.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/terraform/provider/docs/README.md
+++ b/terraform/provider/docs/README.md
@@ -33,6 +33,7 @@ provider "authproxy" {
 - `authproxy_key` - Manages keys
 - `authproxy_actor` - Manages actors (users/entities that own connections)
 - `authproxy_connector` - Manages connectors with automatic version lifecycle
+- `authproxy_rate_limit` - Manages namespace-scoped rate-limit policies
 
 ## Data Sources
 
@@ -40,6 +41,37 @@ provider "authproxy" {
 - `data.authproxy_key` - Reads an existing key
 - `data.authproxy_actor` - Reads an existing actor
 - `data.authproxy_connector` - Reads an existing connector
+
+## API Resource Mapping
+
+The provider keeps its idiomatic HCL interface while communicating with the
+admin API using `authproxy.net/v1alpha1` resources. Users do not write the API
+envelope in HCL; the provider maps fields as follows:
+
+| Terraform value | API field |
+|---|---|
+| Resource or namespace ID/path | `metadata.id` |
+| Namespace ownership | `metadata.namespace` |
+| Labels and annotations | `metadata.labels` and `metadata.annotations` |
+| Connector `version` | `metadata.generation` |
+| Desired configuration | `spec` |
+| Observed lifecycle state | `status` |
+
+Connector `definition` maps only to `spec.definition`; connector identity,
+labels, annotations, generation, and release state are never mixed into that
+document. Connector definitions are sensitive because they may contain OAuth
+client secrets. Terraform still stores sensitive values in state, so use an
+encrypted state backend with appropriately restricted access. When the API
+redacts a connector secret on read, the provider retains the prior state value
+at that field and continues detecting drift in non-secret fields.
+
+Managed key material and actor signing material are write-only API values and
+are not exposed by this provider's HCL schema or copied into Terraform state.
+
+The HCL attribute names and types did not change for this API migration, so no
+Terraform state upgrader is required. The first refresh maps existing state to
+the v1alpha1 response fields; connector `version` continues to hold the numeric
+generation.
 
 ## Building
 

--- a/terraform/provider/docs/data-sources/authproxy_actor.md
+++ b/terraform/provider/docs/data-sources/authproxy_actor.md
@@ -19,5 +19,6 @@ data "authproxy_actor" "existing" {
 - `namespace` - The namespace.
 - `external_id` - The external identifier.
 - `labels` - Labels map.
+- `annotations` - Annotations map.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.

--- a/terraform/provider/docs/data-sources/authproxy_connector.md
+++ b/terraform/provider/docs/data-sources/authproxy_connector.md
@@ -17,11 +17,12 @@ data "authproxy_connector" "gmail" {
 ## Attribute Reference
 
 - `namespace` - The namespace.
-- `version` - The current version number.
+- `version` - The selected connector generation (`metadata.generation`).
 - `state` - The current version state.
 - `display_name` - The display name.
 - `description` - The description.
-- `logo` - The logo.
+- `logo` - The public URL or data URL from `spec.definition.logo`.
 - `labels` - Labels map.
+- `annotations` - Annotations map.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.

--- a/terraform/provider/docs/data-sources/authproxy_key.md
+++ b/terraform/provider/docs/data-sources/authproxy_key.md
@@ -19,5 +19,6 @@ data "authproxy_key" "main" {
 - `namespace` - The namespace.
 - `state` - The current state.
 - `labels` - Labels map.
+- `annotations` - Annotations map.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.

--- a/terraform/provider/docs/data-sources/authproxy_namespace.md
+++ b/terraform/provider/docs/data-sources/authproxy_namespace.md
@@ -19,5 +19,6 @@ data "authproxy_namespace" "production" {
 - `state` - The namespace state.
 - `key_id` - The key ID, if set.
 - `labels` - Labels map.
+- `annotations` - Annotations map.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.

--- a/terraform/provider/docs/resources/authproxy_actor.md
+++ b/terraform/provider/docs/resources/authproxy_actor.md
@@ -20,12 +20,16 @@ resource "authproxy_actor" "service_account" {
 - `namespace` - (Required, ForceNew) The namespace this actor belongs to.
 - `external_id` - (Required, ForceNew) The external identifier for this actor.
 - `labels` - (Optional) A map of labels.
+- `annotations` - (Optional) A map of annotations.
 
 ## Attribute Reference
 
 - `id` - The actor ID.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.
+
+Actor signing material is write-only and is not exposed by this provider or
+stored in Terraform state.
 
 ## Import
 

--- a/terraform/provider/docs/resources/authproxy_connector.md
+++ b/terraform/provider/docs/resources/authproxy_connector.md
@@ -1,6 +1,6 @@
 # authproxy_connector
 
-Manages an AuthProxy connector with automatic version lifecycle. When the definition changes, a new version is created and optionally promoted to primary.
+Manages an AuthProxy connector with automatic generation lifecycle. The established Terraform attribute is named `version`, but its value comes from API `metadata.generation`.
 
 ## Example Usage
 
@@ -9,15 +9,22 @@ resource "authproxy_connector" "gmail" {
   namespace = "root.production"
 
   definition = jsonencode({
-    display_name = "Gmail"
+    displayName = "Gmail"
     description  = "Google Gmail integration"
     auth = {
-      type          = "oauth2"
-      client_id     = "your-client-id"
-      client_secret = "your-client-secret"
-      auth_url      = "https://accounts.google.com/o/oauth2/v2/auth"
-      token_url     = "https://oauth2.googleapis.com/token"
-      scopes        = ["https://www.googleapis.com/auth/gmail.readonly"]
+      type         = "OAuth2"
+      clientId     = "your-client-id"
+      clientSecret = "your-client-secret"
+      authorization = {
+        endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+      }
+      token = {
+        endpoint = "https://oauth2.googleapis.com/token"
+      }
+      scopes = [{
+        id     = "https://www.googleapis.com/auth/gmail.readonly"
+        reason = "Read Gmail messages"
+      }]
     }
   })
 
@@ -36,10 +43,10 @@ resource "authproxy_connector" "gmail_staging" {
   publish   = false
 
   definition = jsonencode({
-    display_name = "Gmail (Staging)"
+    displayName = "Gmail (Staging)"
     description  = "Gmail connector under review"
     auth = {
-      type = "no_auth"
+      type = "no-auth"
     }
   })
 }
@@ -48,14 +55,15 @@ resource "authproxy_connector" "gmail_staging" {
 ## Argument Reference
 
 - `namespace` - (Required, ForceNew) The namespace this connector belongs to.
-- `definition` - (Required) The connector definition as JSON. Use `jsonencode()` for readable HCL. Includes auth configuration, probes, rate limiting, etc.
+- `definition` - (Required, Sensitive) The connector provider definition as JSON. Use `jsonencode()` for readable HCL. This maps exclusively to API `spec.definition`; resource metadata and release state are separate. Because definitions can contain credentials, secure access to Terraform state.
 - `labels` - (Optional) A map of labels.
-- `publish` - (Optional, default `true`) Whether to promote new versions to primary state. When `false`, versions remain in draft state.
+- `annotations` - (Optional) A map of annotations.
+- `publish` - (Optional, default `true`) Whether to publish newly created or currently managed draft generations. Changing it from true to false does not demote an already published generation; it controls what happens when the next definition change creates a generation.
 
 ## Attribute Reference
 
 - `id` - The stable connector ID (persists across version changes).
-- `version` - The current version number.
+- `version` - The selected connector generation (`metadata.generation`).
 - `state` - The current version state (`draft`, `primary`, `active`, `archived`).
 - `display_name` - Display name extracted from the definition.
 - `created_at` - Timestamp of creation.
@@ -65,11 +73,14 @@ resource "authproxy_connector" "gmail_staging" {
 
 The connector resource abstracts version management:
 
-- **Create**: Creates version 1. If `publish = true`, promotes to `primary`.
-- **Update (definition changed)**: Creates a new version. If `publish = true`, promotes to `primary` (previous primary becomes `active`).
-- **Update (labels only)**: Updates labels on the current version without creating a new one.
-- **Update (publish false -> true)**: Promotes the current draft version to `primary`.
-- **Destroy**: Archives all non-archived versions.
+- **Create**: Creates generation 1 with desired release state `primary` when `publish = true`, or `draft` when false.
+- **Update a published definition**: Creates a new generation. With `publish = true`, the new generation becomes primary and the previous primary becomes active.
+- **Update a draft definition**: Updates that draft generation in place.
+- **Update labels or annotations**: Updates resource metadata without changing a published generation.
+- **Update `publish` from false to true**: Promotes the managed draft generation to primary.
+- **Destroy**: Archives all non-archived generations.
+
+The API redacts connector credentials unless the caller can replay secrets. On a redacted read, the provider preserves prior values only at masked fields so credentials remain stable while non-secret drift is still detected.
 
 ## Import
 

--- a/terraform/provider/docs/resources/authproxy_key.md
+++ b/terraform/provider/docs/resources/authproxy_key.md
@@ -16,8 +16,9 @@ resource "authproxy_key" "main" {
 ## Argument Reference
 
 - `namespace` - (Required, ForceNew) The namespace this key belongs to.
-- `state` - (Optional) The desired state of the key.
+- `state` - (Optional) The desired key state (`spec.desiredState`). The computed value reflects observed `status.state`.
 - `labels` - (Optional) A map of labels.
+- `annotations` - (Optional) A map of annotations.
 
 ## Attribute Reference
 
@@ -25,6 +26,10 @@ resource "authproxy_key" "main" {
 - `state` - The current state.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.
+
+The provider creates keys with server-managed random key material. Provider
+configuration and key material are write-only and are never stored in
+Terraform state.
 
 ## Import
 

--- a/terraform/provider/docs/resources/authproxy_namespace.md
+++ b/terraform/provider/docs/resources/authproxy_namespace.md
@@ -18,11 +18,12 @@ resource "authproxy_namespace" "production" {
 
 - `path` - (Required, ForceNew) The namespace path. Must start with "root".
 - `labels` - (Optional) A map of labels for the namespace.
+- `annotations` - (Optional) A map of annotations for the namespace.
 
 ## Attribute Reference
 
 - `state` - The namespace state.
-- `key_id` - The ID of the key associated with this namespace.
+- `key_id` - The ID from `spec.encryptionKeyRef`, if configured.
 - `created_at` - Timestamp of creation.
 - `updated_at` - Timestamp of last update.
 

--- a/terraform/provider/docs/resources/authproxy_rate_limit.md
+++ b/terraform/provider/docs/resources/authproxy_rate_limit.md
@@ -2,6 +2,8 @@
 
 Manages an AuthProxy rate-limit resource. Every field maps to a typed HCL attribute so authors get plan-time validation and field-level diffs — no `jsonencode` required.
 
+The provider serializes these attributes into the `authproxy.net/v1alpha1` resource envelope: ownership and user metadata live under `metadata`, the policy lives under `spec`, and observed effective mode is read from `status`.
+
 ## Example Usage
 
 ```hcl

--- a/terraform/provider/examples/resources/authproxy_connector/main.tf
+++ b/terraform/provider/examples/resources/authproxy_connector/main.tf
@@ -2,15 +2,22 @@ resource "authproxy_connector" "gmail" {
   namespace = "root.production"
 
   definition = jsonencode({
-    display_name = "Gmail"
-    description  = "Google Gmail integration"
+    displayName = "Gmail"
+    description = "Google Gmail integration"
     auth = {
-      type          = "oauth2"
-      client_id     = var.gmail_client_id
-      client_secret = var.gmail_client_secret
-      auth_url      = "https://accounts.google.com/o/oauth2/v2/auth"
-      token_url     = "https://oauth2.googleapis.com/token"
-      scopes        = ["https://www.googleapis.com/auth/gmail.readonly"]
+      type         = "OAuth2"
+      clientId     = var.gmail_client_id
+      clientSecret = var.gmail_client_secret
+      authorization = {
+        endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+      }
+      token = {
+        endpoint = "https://oauth2.googleapis.com/token"
+      }
+      scopes = [{
+        id     = "https://www.googleapis.com/auth/gmail.readonly"
+        reason = "Read Gmail messages"
+      }]
     }
   })
 
@@ -26,10 +33,10 @@ resource "authproxy_connector" "gmail_staging" {
   publish   = false
 
   definition = jsonencode({
-    display_name = "Gmail (Staging)"
-    description  = "Gmail connector under review"
+    displayName = "Gmail (Staging)"
+    description = "Gmail connector under review"
     auth = {
-      type = "no_auth"
+      type = "no-auth"
     }
   })
 }

--- a/terraform/provider/internal/client/actors.go
+++ b/terraform/provider/internal/client/actors.go
@@ -3,32 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 )
 
-const (
-	ActorAPIVersion = "authproxy.net/v1alpha1"
-	ActorKind       = "Actor"
-)
+const ActorKind = "Actor"
 
 // These local wire models keep the Terraform provider independent from the
 // server's internal packages while mirroring its canonical resource contract.
-type ActorMetadata struct {
-	ID          string            `json:"id,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"createdAt,omitempty"`
-	UpdatedAt   time.Time         `json:"updatedAt,omitempty"`
-}
-
-type ActorMetadataPatch struct {
-	Name        *string            `json:"name,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
-}
-
 type ActorSpec struct {
 	ExternalID string `json:"externalId"`
 }
@@ -36,24 +16,21 @@ type ActorSpec struct {
 type ActorSpecPatch struct{}
 
 type Actor struct {
-	APIVersion string        `json:"apiVersion"`
-	Kind       string        `json:"kind"`
-	Metadata   ActorMetadata `json:"metadata"`
-	Spec       ActorSpec     `json:"spec"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     ActorSpec      `json:"spec"`
 }
 
 type CreateActorRequest struct {
-	APIVersion string        `json:"apiVersion"`
-	Kind       string        `json:"kind"`
-	Metadata   ActorMetadata `json:"metadata"`
-	Spec       ActorSpec     `json:"spec"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     ActorSpec      `json:"spec"`
 }
 
 type UpdateActorRequest struct {
-	APIVersion string              `json:"apiVersion"`
-	Kind       string              `json:"kind"`
-	Metadata   *ActorMetadataPatch `json:"metadata"`
-	Spec       *ActorSpecPatch     `json:"spec"`
+	TypeMeta
+	Metadata *ObjectMetadataPatch `json:"metadata"`
+	Spec     *ActorSpecPatch      `json:"spec"`
 }
 
 func (c *Client) CreateActor(ctx context.Context, req CreateActorRequest) (*Actor, error) {

--- a/terraform/provider/internal/client/actors_test.go
+++ b/terraform/provider/internal/client/actors_test.go
@@ -7,9 +7,8 @@ import (
 
 func TestCreateActorRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 	req := CreateActorRequest{
-		APIVersion: ActorAPIVersion,
-		Kind:       ActorKind,
-		Metadata: ActorMetadata{
+		TypeMeta: NewTypeMeta(ActorKind),
+		Metadata: ObjectMetadata{
 			Namespace: "root.acme",
 			Labels:    map[string]string{"team": "platform"},
 		},
@@ -24,7 +23,7 @@ func TestCreateActorRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 	if err := json.Unmarshal(data, &body); err != nil {
 		t.Fatal(err)
 	}
-	if body["apiVersion"] != ActorAPIVersion || body["kind"] != ActorKind {
+	if body["apiVersion"] != APIVersion || body["kind"] != ActorKind {
 		t.Fatalf("type metadata: %s", data)
 	}
 	if _, exists := body["externalId"]; exists {
@@ -41,10 +40,9 @@ func TestCreateActorRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 func TestUpdateActorRequestIncludesRequiredPatchSections(t *testing.T) {
 	labels := map[string]string{"team": "security"}
 	req := UpdateActorRequest{
-		APIVersion: ActorAPIVersion,
-		Kind:       ActorKind,
-		Metadata:   &ActorMetadataPatch{Labels: &labels},
-		Spec:       &ActorSpecPatch{},
+		TypeMeta: NewTypeMeta(ActorKind),
+		Metadata: &ObjectMetadataPatch{Labels: &labels},
+		Spec:     &ActorSpecPatch{},
 	}
 
 	data, err := json.Marshal(req)

--- a/terraform/provider/internal/client/connectors.go
+++ b/terraform/provider/internal/client/connectors.go
@@ -2,56 +2,66 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
-type Connector struct {
-	Id          string            `json:"id"`
-	Version     uint64            `json:"version"`
-	Namespace   string            `json:"namespace"`
-	State       string            `json:"state"`
-	DisplayName string            `json:"displayName"`
-	Highlight   string            `json:"highlight,omitempty"`
-	Description string            `json:"description"`
-	Logo        string            `json:"logo"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"createdAt"`
-	UpdatedAt   time.Time         `json:"updatedAt"`
-	Versions    int64             `json:"versions,omitempty"`
+const ConnectorKind = "Connector"
+
+type ConnectorReleaseSpec struct {
+	DesiredState string `json:"desiredState,omitempty"`
 }
 
-type ConnectorVersion struct {
-	Id          string            `json:"id"`
-	Version     uint64            `json:"version"`
-	Namespace   string            `json:"namespace"`
-	State       string            `json:"state"`
-	Definition  json.RawMessage   `json:"definition"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"createdAt"`
-	UpdatedAt   time.Time         `json:"updatedAt"`
+type ConnectorSpec struct {
+	Release    ConnectorReleaseSpec `json:"release,omitempty"`
+	Definition json.RawMessage      `json:"definition"`
+}
+
+type ConnectorReleaseStatus struct {
+	State string `json:"state"`
+}
+
+type ConnectorStatus struct {
+	Release ConnectorReleaseStatus `json:"release"`
+}
+
+type Connector struct {
+	TypeMeta
+	Metadata ObjectMetadata   `json:"metadata"`
+	Spec     ConnectorSpec    `json:"spec"`
+	Status   *ConnectorStatus `json:"status,omitempty"`
+
+	// DataRedacted is transport metadata derived from the response header. It
+	// is not part of the resource JSON contract.
+	DataRedacted bool `json:"-"`
 }
 
 type CreateConnectorRequest struct {
-	Namespace   string            `json:"namespace"`
-	Definition  json.RawMessage   `json:"definition"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     ConnectorSpec  `json:"spec"`
+}
+
+type ConnectorReleaseSpecPatch struct {
+	DesiredState *string `json:"desiredState,omitempty"`
+}
+
+type ConnectorSpecPatch struct {
+	Release    *ConnectorReleaseSpecPatch `json:"release,omitempty"`
+	Definition *json.RawMessage           `json:"definition,omitempty"`
 }
 
 type UpdateConnectorRequest struct {
-	Definition  *json.RawMessage   `json:"definition,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata *ObjectMetadataPatch `json:"metadata"`
+	Spec     *ConnectorSpecPatch  `json:"spec"`
 }
 
 type CreateConnectorVersionRequest struct {
-	Definition  *json.RawMessage   `json:"definition,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     ConnectorSpec  `json:"spec"`
 }
 
 type ForceStateRequest struct {
@@ -59,44 +69,96 @@ type ForceStateRequest struct {
 }
 
 type ListConnectorVersionsResponse struct {
-	Items  []ConnectorVersion `json:"items"`
-	Cursor string             `json:"cursor,omitempty"`
+	ResourceList[Connector]
 }
 
-func (c *Client) CreateConnector(ctx context.Context, req CreateConnectorRequest) (*ConnectorVersion, error) {
-	var cv ConnectorVersion
-	err := c.post(ctx, "/api/v1/connectors", req, &cv)
-	return &cv, err
+// ConnectorDefinitionSummary contains the definition fields surfaced by the
+// Terraform data source in addition to its opaque definition document.
+type ConnectorDefinitionSummary struct {
+	DisplayName string
+	Description string
+	Logo        string
+}
+
+// DecodeConnectorDefinitionSummary extracts display fields without treating
+// resource metadata as part of spec.definition. Logo supports both public URL
+// and base64 image representations accepted by the connector schema.
+func DecodeConnectorDefinitionSummary(definition json.RawMessage) (ConnectorDefinitionSummary, error) {
+	var value struct {
+		DisplayName string          `json:"displayName"`
+		Description string          `json:"description"`
+		Logo        json.RawMessage `json:"logo"`
+	}
+	if err := json.Unmarshal(definition, &value); err != nil {
+		return ConnectorDefinitionSummary{}, err
+	}
+
+	result := ConnectorDefinitionSummary{
+		DisplayName: value.DisplayName,
+		Description: value.Description,
+	}
+	if len(value.Logo) == 0 || string(value.Logo) == "null" {
+		return result, nil
+	}
+	if value.Logo[0] == '"' {
+		if err := json.Unmarshal(value.Logo, &result.Logo); err != nil {
+			return ConnectorDefinitionSummary{}, err
+		}
+		return result, nil
+	}
+	var image struct {
+		PublicURL string `json:"publicUrl"`
+		MimeType  string `json:"mimeType"`
+		Base64    string `json:"base64"`
+	}
+	if err := json.Unmarshal(value.Logo, &image); err != nil {
+		return ConnectorDefinitionSummary{}, err
+	}
+	if image.PublicURL != "" {
+		result.Logo = image.PublicURL
+	} else if image.Base64 != "" {
+		if _, err := base64.StdEncoding.DecodeString(image.Base64); err != nil {
+			return ConnectorDefinitionSummary{}, fmt.Errorf("decode connector logo: %w", err)
+		}
+		result.Logo = fmt.Sprintf("data:%s;base64,%s", image.MimeType, image.Base64)
+	}
+	return result, nil
+}
+
+func (c *Client) CreateConnector(ctx context.Context, req CreateConnectorRequest) (*Connector, error) {
+	var connector Connector
+	err := c.writeConnector(ctx, "POST", "/api/v1/connectors", req, &connector)
+	return &connector, err
 }
 
 func (c *Client) GetConnector(ctx context.Context, id string) (*Connector, error) {
-	var conn Connector
-	err := c.get(ctx, fmt.Sprintf("/api/v1/connectors/%s", id), &conn)
-	return &conn, err
+	var connector Connector
+	err := c.readConnector(ctx, fmt.Sprintf("/api/v1/connectors/%s", id), &connector)
+	return &connector, err
 }
 
-func (c *Client) GetConnectorVersion(ctx context.Context, id string, version uint64) (*ConnectorVersion, error) {
-	var cv ConnectorVersion
-	err := c.get(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions/%d", id, version), &cv)
-	return &cv, err
+func (c *Client) GetConnectorVersion(ctx context.Context, id string, version uint64) (*Connector, error) {
+	var connector Connector
+	err := c.readConnector(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions/%d", id, version), &connector)
+	return &connector, err
 }
 
-func (c *Client) UpdateConnector(ctx context.Context, id string, req UpdateConnectorRequest) (*ConnectorVersion, error) {
-	var cv ConnectorVersion
-	err := c.patch(ctx, fmt.Sprintf("/api/v1/connectors/%s", id), req, &cv)
-	return &cv, err
+func (c *Client) UpdateConnector(ctx context.Context, id string, req UpdateConnectorRequest) (*Connector, error) {
+	var connector Connector
+	err := c.writeConnector(ctx, "PATCH", fmt.Sprintf("/api/v1/connectors/%s", id), req, &connector)
+	return &connector, err
 }
 
-func (c *Client) UpdateConnectorVersion(ctx context.Context, id string, version uint64, req UpdateConnectorRequest) (*ConnectorVersion, error) {
-	var cv ConnectorVersion
-	err := c.patch(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions/%d", id, version), req, &cv)
-	return &cv, err
+func (c *Client) UpdateConnectorVersion(ctx context.Context, id string, version uint64, req UpdateConnectorRequest) (*Connector, error) {
+	var connector Connector
+	err := c.writeConnector(ctx, "PATCH", fmt.Sprintf("/api/v1/connectors/%s/versions/%d", id, version), req, &connector)
+	return &connector, err
 }
 
-func (c *Client) CreateConnectorVersion(ctx context.Context, id string, req CreateConnectorVersionRequest) (*ConnectorVersion, error) {
-	var cv ConnectorVersion
-	err := c.post(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions", id), req, &cv)
-	return &cv, err
+func (c *Client) CreateConnectorVersion(ctx context.Context, id string, req CreateConnectorVersionRequest) (*Connector, error) {
+	var connector Connector
+	err := c.writeConnector(ctx, "POST", fmt.Sprintf("/api/v1/connectors/%s/versions", id), req, &connector)
+	return &connector, err
 }
 
 func (c *Client) ForceConnectorVersionState(ctx context.Context, id string, version uint64, state string) error {
@@ -104,7 +166,34 @@ func (c *Client) ForceConnectorVersionState(ctx context.Context, id string, vers
 }
 
 func (c *Client) ListConnectorVersions(ctx context.Context, id string) (*ListConnectorVersionsResponse, error) {
-	var resp ListConnectorVersionsResponse
-	err := c.get(ctx, fmt.Sprintf("/api/v1/connectors/%s/versions", id), &resp)
-	return &resp, err
+	var response ListConnectorVersionsResponse
+	resp, err := c.http.R().SetContext(ctx).SetResult(&response).
+		Get(fmt.Sprintf("/api/v1/connectors/%s/versions", id))
+	if err != nil {
+		return &response, err
+	}
+	redacted := resp.Header().Get("X-AuthProxy-Data-Redacted") == "true"
+	for i := range response.Items {
+		response.Items[i].DataRedacted = redacted
+	}
+	err = checkResponse(resp)
+	return &response, err
+}
+
+func (c *Client) readConnector(ctx context.Context, path string, result *Connector) error {
+	resp, err := c.http.R().SetContext(ctx).SetResult(result).Get(path)
+	if err != nil {
+		return err
+	}
+	result.DataRedacted = resp.Header().Get("X-AuthProxy-Data-Redacted") == "true"
+	return checkResponse(resp)
+}
+
+func (c *Client) writeConnector(ctx context.Context, method, path string, body any, result *Connector) error {
+	resp, err := c.http.R().SetContext(ctx).SetBody(body).SetResult(result).Execute(method, path)
+	if err != nil {
+		return err
+	}
+	result.DataRedacted = resp.Header().Get("X-AuthProxy-Data-Redacted") == "true"
+	return checkResponse(resp)
 }

--- a/terraform/provider/internal/client/connectors_test.go
+++ b/terraform/provider/internal/client/connectors_test.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConnectorRequestsKeepDefinitionInsideSpec(t *testing.T) {
+	definition := json.RawMessage(`{"displayName":"Example","logo":{"publicUrl":"https://example.com/logo.png"},"description":"example","auth":{"type":"no-auth"}}`)
+	request := CreateConnectorRequest{
+		TypeMeta: NewTypeMeta(ConnectorKind),
+		Metadata: ObjectMetadata{
+			Namespace: "root.acme",
+			Labels:    map[string]string{"team": "platform"},
+		},
+		Spec: ConnectorSpec{
+			Release:    ConnectorReleaseSpec{DesiredState: "primary"},
+			Definition: definition,
+		},
+	}
+	body := assertCanonicalRequest(t, request, ConnectorKind)
+	if _, exists := body["definition"]; exists {
+		t.Fatalf("legacy top-level definition present: %+v", body)
+	}
+	spec := body["spec"].(map[string]any)
+	if spec["definition"] == nil {
+		t.Fatalf("spec.definition missing: %+v", spec)
+	}
+	metadata := body["metadata"].(map[string]any)
+	definitionBody := spec["definition"].(map[string]any)
+	for _, field := range []string{"namespace", "labels", "generation", "state"} {
+		if _, exists := definitionBody[field]; exists {
+			t.Errorf("resource metadata %q leaked into definition: %+v", field, definitionBody)
+		}
+	}
+	if metadata["namespace"] != "root.acme" {
+		t.Fatalf("metadata.namespace: %+v", metadata)
+	}
+}
+
+func TestGetConnectorTracksRedactedResponseHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/connectors/cxr_test" {
+			t.Errorf("path: %s", request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		response.Header().Set("X-AuthProxy-Data-Redacted", "true")
+		_, _ = response.Write([]byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{"id":"cxr_test","generation":1},"spec":{"definition":{}},"status":{"release":{"state":"primary"}}}`))
+	}))
+	defer server.Close()
+
+	api, err := New(Config{Endpoint: server.URL, BearerToken: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector, err := api.GetConnector(t.Context(), "cxr_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !connector.DataRedacted {
+		t.Fatal("redaction response header was not retained")
+	}
+}
+
+func TestConnectorPatchIncludesRequiredEmptySections(t *testing.T) {
+	request := UpdateConnectorRequest{
+		TypeMeta: NewTypeMeta(ConnectorKind),
+		Metadata: &ObjectMetadataPatch{},
+		Spec:     &ConnectorSpecPatch{},
+	}
+	assertCanonicalRequest(t, request, ConnectorKind)
+}
+
+func TestConnectorVersionListUsesCanonicalEnvelope(t *testing.T) {
+	data := []byte(`{
+		"apiVersion":"authproxy.net/v1alpha1",
+		"kind":"ConnectorList",
+		"metadata":{"continue":"next"},
+		"items":[{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{"id":"cxr_test","generation":2},"spec":{"definition":{}},"status":{"release":{"state":"draft"}}}]
+	}`)
+	var response ListConnectorVersionsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Kind != "ConnectorList" || response.Metadata.Continue != "next" || len(response.Items) != 1 {
+		t.Fatalf("list response: %+v", response)
+	}
+	if response.Items[0].Metadata.Generation != 2 {
+		t.Fatalf("generation: %+v", response.Items[0].Metadata)
+	}
+}
+
+func TestDecodeConnectorDefinitionSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		logo string
+		want string
+	}{
+		{name: "string", logo: `"https://example.com/logo.png"`, want: "https://example.com/logo.png"},
+		{name: "object", logo: `{"publicUrl":"https://example.com/logo.png"}`, want: "https://example.com/logo.png"},
+		{name: "base64", logo: `{"mimeType":"image/png","base64":"aGVsbG8="}`, want: "data:image/png;base64,aGVsbG8="},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			summary, err := DecodeConnectorDefinitionSummary(json.RawMessage(`{"displayName":"Example","description":"Description","logo":` + test.logo + `}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if summary.DisplayName != "Example" || summary.Description != "Description" || summary.Logo != test.want {
+				t.Fatalf("summary: %+v", summary)
+			}
+		})
+	}
+}

--- a/terraform/provider/internal/client/keys.go
+++ b/terraform/provider/internal/client/keys.go
@@ -3,48 +3,61 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 )
 
+const KeyKind = "Key"
+
+type KeySpec struct {
+	Usage        string         `json:"usage,omitempty"`
+	MaterialType string         `json:"materialType,omitempty"`
+	DesiredState string         `json:"desiredState,omitempty"`
+	KeyData      map[string]any `json:"keyData,omitempty"`
+}
+
+type KeyStatus struct {
+	State             string `json:"state"`
+	KeyDataConfigured bool   `json:"keyDataConfigured"`
+}
+
 type Key struct {
-	Id          string            `json:"id"`
-	Namespace   string            `json:"namespace"`
-	State       string            `json:"state"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"createdAt"`
-	UpdatedAt   time.Time         `json:"updatedAt"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     KeySpec        `json:"spec"`
+	Status   *KeyStatus     `json:"status,omitempty"`
 }
 
 type CreateKeyRequest struct {
-	Namespace   string                 `json:"namespace"`
-	Labels      map[string]string      `json:"labels,omitempty"`
-	Annotations map[string]string      `json:"annotations,omitempty"`
-	KeyData     map[string]interface{} `json:"keyData"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     KeySpec        `json:"spec"`
+}
+
+type KeySpecPatch struct {
+	DesiredState *string `json:"desiredState,omitempty"`
 }
 
 type UpdateKeyRequest struct {
-	State       *string            `json:"state,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata *ObjectMetadataPatch `json:"metadata"`
+	Spec     *KeySpecPatch        `json:"spec"`
 }
 
 func (c *Client) CreateKey(ctx context.Context, req CreateKeyRequest) (*Key, error) {
-	var ek Key
-	err := c.post(ctx, "/api/v1/keys", req, &ek)
-	return &ek, err
+	var key Key
+	err := c.post(ctx, "/api/v1/keys", req, &key)
+	return &key, err
 }
 
 func (c *Client) GetKey(ctx context.Context, id string) (*Key, error) {
-	var ek Key
-	err := c.get(ctx, fmt.Sprintf("/api/v1/keys/%s", id), &ek)
-	return &ek, err
+	var key Key
+	err := c.get(ctx, fmt.Sprintf("/api/v1/keys/%s", id), &key)
+	return &key, err
 }
 
 func (c *Client) UpdateKey(ctx context.Context, id string, req UpdateKeyRequest) (*Key, error) {
-	var ek Key
-	err := c.patch(ctx, fmt.Sprintf("/api/v1/keys/%s", id), req, &ek)
-	return &ek, err
+	var key Key
+	err := c.patch(ctx, fmt.Sprintf("/api/v1/keys/%s", id), req, &key)
+	return &key, err
 }
 
 func (c *Client) DeleteKey(ctx context.Context, id string) error {

--- a/terraform/provider/internal/client/keys_test.go
+++ b/terraform/provider/internal/client/keys_test.go
@@ -1,0 +1,32 @@
+package client
+
+import "testing"
+
+func TestKeyRequestsPutDesiredStateAndKeyDataInSpec(t *testing.T) {
+	create := CreateKeyRequest{
+		TypeMeta: NewTypeMeta(KeyKind),
+		Metadata: ObjectMetadata{
+			Namespace: "root.acme",
+		},
+		Spec: KeySpec{
+			DesiredState: "active",
+			KeyData:      map[string]any{"numBytes": float64(32)},
+		},
+	}
+	body := assertCanonicalRequest(t, create, KeyKind)
+	if _, exists := body["keyData"]; exists {
+		t.Fatalf("legacy top-level keyData present: %+v", body)
+	}
+	spec := body["spec"].(map[string]any)
+	if spec["desiredState"] != "active" || spec["keyData"] == nil {
+		t.Fatalf("key spec: %+v", spec)
+	}
+
+	disabled := "disabled"
+	update := UpdateKeyRequest{
+		TypeMeta: NewTypeMeta(KeyKind),
+		Metadata: &ObjectMetadataPatch{},
+		Spec:     &KeySpecPatch{DesiredState: &disabled},
+	}
+	assertCanonicalRequest(t, update, KeyKind)
+}

--- a/terraform/provider/internal/client/namespaces.go
+++ b/terraform/provider/internal/client/namespaces.go
@@ -3,28 +3,48 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
+	"strings"
 )
 
+const NamespaceKind = "Namespace"
+
+type NamespaceSpec struct {
+	EncryptionKeyRef *ObjectReference `json:"encryptionKeyRef,omitempty"`
+}
+
+type NamespaceStatus struct {
+	State string `json:"state"`
+}
+
 type Namespace struct {
-	Path        string            `json:"path"`
-	State       string            `json:"state"`
-	KeyId       *string           `json:"keyId,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   time.Time         `json:"createdAt"`
-	UpdatedAt   time.Time         `json:"updatedAt"`
+	TypeMeta
+	Metadata ObjectMetadata   `json:"metadata"`
+	Spec     NamespaceSpec    `json:"spec"`
+	Status   *NamespaceStatus `json:"status,omitempty"`
 }
 
 type CreateNamespaceRequest struct {
-	Path        string            `json:"path"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     NamespaceSpec  `json:"spec"`
 }
 
+type NamespaceSpecPatch struct{}
+
 type UpdateNamespaceRequest struct {
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	TypeMeta
+	Metadata *ObjectMetadataPatch `json:"metadata"`
+	Spec     *NamespaceSpecPatch  `json:"spec"`
+}
+
+// NamespaceMetadataForPath maps Terraform's stable path attribute onto the
+// API's Kubernetes-style name and parent namespace identity.
+func NamespaceMetadataForPath(path string) ObjectMetadata {
+	index := strings.LastIndex(path, ".")
+	if index < 0 {
+		return ObjectMetadata{Name: path}
+	}
+	return ObjectMetadata{Name: path[index+1:], Namespace: path[:index]}
 }
 
 func (c *Client) CreateNamespace(ctx context.Context, req CreateNamespaceRequest) (*Namespace, error) {

--- a/terraform/provider/internal/client/namespaces_test.go
+++ b/terraform/provider/internal/client/namespaces_test.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNamespaceMetadataForPath(t *testing.T) {
+	tests := []struct {
+		path      string
+		name      string
+		namespace string
+	}{
+		{path: "root", name: "root"},
+		{path: "root.acme", name: "acme", namespace: "root"},
+		{path: "root.acme.prod", name: "prod", namespace: "root.acme"},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			metadata := NamespaceMetadataForPath(test.path)
+			if metadata.Name != test.name || metadata.Namespace != test.namespace {
+				t.Fatalf("metadata: %+v", metadata)
+			}
+		})
+	}
+}
+
+func TestNamespaceRequestsUseCanonicalResourceEnvelopes(t *testing.T) {
+	create := CreateNamespaceRequest{
+		TypeMeta: NewTypeMeta(NamespaceKind),
+		Metadata: ObjectMetadata{
+			Name:      "acme",
+			Namespace: "root",
+		},
+		Spec: NamespaceSpec{},
+	}
+	assertCanonicalRequest(t, create, NamespaceKind)
+
+	labels := map[string]string{"team": "platform"}
+	update := UpdateNamespaceRequest{
+		TypeMeta: NewTypeMeta(NamespaceKind),
+		Metadata: &ObjectMetadataPatch{Labels: &labels},
+		Spec:     &NamespaceSpecPatch{},
+	}
+	assertCanonicalRequest(t, update, NamespaceKind)
+}
+
+func assertCanonicalRequest(t *testing.T, value any, kind string) map[string]any {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["apiVersion"] != APIVersion || body["kind"] != kind {
+		t.Fatalf("type metadata: %s", data)
+	}
+	if body["metadata"] == nil || body["spec"] == nil {
+		t.Fatalf("metadata and spec must be non-null: %s", data)
+	}
+	return body
+}

--- a/terraform/provider/internal/client/rate_limits.go
+++ b/terraform/provider/internal/client/rate_limits.go
@@ -3,13 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 )
 
-const (
-	RateLimitAPIVersion = "authproxy.net/v1alpha1"
-	RateLimitKind       = "RateLimit"
-)
+const RateLimitKind = "RateLimit"
 
 // These local wire models keep the Terraform provider independent from the
 // server's internal packages while mirroring its canonical resource contract.
@@ -51,14 +47,6 @@ type RateLimitAlgorithm struct {
 	TokenBucket   *RateLimitTokenBucket   `json:"tokenBucket,omitempty"`
 }
 
-type ObjectReference struct {
-	APIVersion string `json:"apiVersion"`
-	Kind       string `json:"kind"`
-	ID         string `json:"id,omitempty"`
-	Name       string `json:"name,omitempty"`
-	Namespace  string `json:"namespace,omitempty"`
-}
-
 type RateLimitScope struct {
 	NamespaceMatcher string           `json:"namespaceMatcher,omitempty"`
 	ConnectorRef     *ObjectReference `json:"connectorRef,omitempty"`
@@ -73,39 +61,21 @@ type RateLimitSpec struct {
 	Algorithm RateLimitAlgorithm `json:"algorithm"`
 }
 
-type RateLimitMetadata struct {
-	ID          string            `json:"id,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	CreatedAt   *time.Time        `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time        `json:"updatedAt,omitempty"`
-}
-
-type RateLimitMetadataPatch struct {
-	Name        *string            `json:"name,omitempty"`
-	Labels      *map[string]string `json:"labels,omitempty"`
-	Annotations *map[string]string `json:"annotations,omitempty"`
-}
-
 type RateLimitStatus struct {
 	EffectiveMode string `json:"effectiveMode"`
 }
 
 type RateLimit struct {
-	APIVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   RateLimitMetadata `json:"metadata"`
-	Spec       RateLimitSpec     `json:"spec"`
-	Status     *RateLimitStatus  `json:"status,omitempty"`
+	TypeMeta
+	Metadata ObjectMetadata   `json:"metadata"`
+	Spec     RateLimitSpec    `json:"spec"`
+	Status   *RateLimitStatus `json:"status,omitempty"`
 }
 
 type CreateRateLimitRequest struct {
-	APIVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   RateLimitMetadata `json:"metadata"`
-	Spec       RateLimitSpec     `json:"spec"`
+	TypeMeta
+	Metadata ObjectMetadata `json:"metadata"`
+	Spec     RateLimitSpec  `json:"spec"`
 }
 
 type RateLimitSpecPatch struct {
@@ -120,10 +90,9 @@ type RateLimitSpecPatch struct {
 }
 
 type UpdateRateLimitRequest struct {
-	APIVersion string                  `json:"apiVersion"`
-	Kind       string                  `json:"kind"`
-	Metadata   *RateLimitMetadataPatch `json:"metadata"`
-	Spec       *RateLimitSpecPatch     `json:"spec"`
+	TypeMeta
+	Metadata *ObjectMetadataPatch `json:"metadata"`
+	Spec     *RateLimitSpecPatch  `json:"spec"`
 }
 
 func (c *Client) CreateRateLimit(ctx context.Context, req CreateRateLimitRequest) (*RateLimit, error) {

--- a/terraform/provider/internal/client/rate_limits_test.go
+++ b/terraform/provider/internal/client/rate_limits_test.go
@@ -7,18 +7,13 @@ import (
 
 func TestCreateRateLimitRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 	req := CreateRateLimitRequest{
-		APIVersion: RateLimitAPIVersion,
-		Kind:       RateLimitKind,
-		Metadata: RateLimitMetadata{
+		TypeMeta: NewTypeMeta(RateLimitKind),
+		Metadata: ObjectMetadata{
 			Name:      "salesforce-v3",
 			Namespace: "root.acme",
 		},
 		Spec: RateLimitSpec{
-			Scope: &RateLimitScope{ConnectorRef: &ObjectReference{
-				APIVersion: RateLimitAPIVersion,
-				Kind:       "Connector",
-				ID:         "cxr_salesforce",
-			}},
+			Scope:    &RateLimitScope{ConnectorRef: NewIDReference(ConnectorKind, "cxr_salesforce")},
 			Selector: RateLimitSelector{},
 			Bucket:   RateLimitBucket{},
 			Algorithm: RateLimitAlgorithm{
@@ -35,7 +30,7 @@ func TestCreateRateLimitRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 	if err := json.Unmarshal(data, &body); err != nil {
 		t.Fatal(err)
 	}
-	if body["apiVersion"] != RateLimitAPIVersion || body["kind"] != RateLimitKind {
+	if body["apiVersion"] != APIVersion || body["kind"] != RateLimitKind {
 		t.Fatalf("type metadata: %s", data)
 	}
 	if _, exists := body["definition"]; exists {
@@ -48,10 +43,9 @@ func TestCreateRateLimitRequestUsesCanonicalResourceEnvelope(t *testing.T) {
 
 func TestUpdateRateLimitRequestEncodesNilScopeAsNull(t *testing.T) {
 	req := UpdateRateLimitRequest{
-		APIVersion: RateLimitAPIVersion,
-		Kind:       RateLimitKind,
-		Metadata:   &RateLimitMetadataPatch{},
-		Spec:       &RateLimitSpecPatch{},
+		TypeMeta: NewTypeMeta(RateLimitKind),
+		Metadata: &ObjectMetadataPatch{},
+		Spec:     &RateLimitSpecPatch{},
 	}
 
 	data, err := json.Marshal(req)

--- a/terraform/provider/internal/client/resources.go
+++ b/terraform/provider/internal/client/resources.go
@@ -1,0 +1,70 @@
+package client
+
+import "time"
+
+// APIVersion is the resource schema understood by this provider. The REST
+// route remains /api/v1; apiVersion describes the JSON resource contract.
+const APIVersion = "authproxy.net/v1alpha1"
+
+// TypeMeta identifies the schema used to decode a resource.
+type TypeMeta struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+}
+
+// NewTypeMeta returns the canonical type metadata for a resource kind.
+func NewTypeMeta(kind string) TypeMeta {
+	return TypeMeta{APIVersion: APIVersion, Kind: kind}
+}
+
+// ObjectMetadata contains the identity and common metadata shared by
+// AuthProxy resources. Pointer timestamps allow create requests to omit
+// server-owned fields while using the same shape for responses.
+type ObjectMetadata struct {
+	ID          string            `json:"id,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Generation  uint64            `json:"generation,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	CreatedAt   *time.Time        `json:"createdAt,omitempty"`
+	UpdatedAt   *time.Time        `json:"updatedAt,omitempty"`
+}
+
+// ObjectMetadataPatch is the common metadata merge-patch shape. A non-nil
+// pointer to an empty map clears that map.
+type ObjectMetadataPatch struct {
+	Name        *string            `json:"name,omitempty"`
+	Labels      *map[string]string `json:"labels,omitempty"`
+	Annotations *map[string]string `json:"annotations,omitempty"`
+}
+
+// ObjectReference identifies another resource without copying its spec or
+// status. Generation is only populated for versioned resource kinds.
+type ObjectReference struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	ID         string `json:"id,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Generation uint64 `json:"generation,omitempty"`
+}
+
+// NewIDReference creates a canonical ID-based object reference.
+func NewIDReference(kind, id string) *ObjectReference {
+	return &ObjectReference{APIVersion: APIVersion, Kind: kind, ID: id}
+}
+
+// ListMetadata contains resource-list pagination state.
+type ListMetadata struct {
+	ResourceVersion    string `json:"resourceVersion,omitempty"`
+	Continue           string `json:"continue,omitempty"`
+	RemainingItemCount *int64 `json:"remainingItemCount,omitempty"`
+}
+
+// ResourceList is the common Kubernetes-style list envelope.
+type ResourceList[T any] struct {
+	TypeMeta
+	Metadata ListMetadata `json:"metadata"`
+	Items    []T          `json:"items"`
+}

--- a/terraform/provider/internal/client/resources_test.go
+++ b/terraform/provider/internal/client/resources_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewTypeMetaUsesV1Alpha1(t *testing.T) {
+	meta := NewTypeMeta(ConnectorKind)
+	if meta.APIVersion != "authproxy.net/v1alpha1" || meta.Kind != ConnectorKind {
+		t.Fatalf("type metadata: %+v", meta)
+	}
+}
+
+func TestCreateMetadataOmitsServerOwnedFields(t *testing.T) {
+	data, err := json.Marshal(ObjectMetadata{Namespace: "root.acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"id", "generation", "createdAt", "updatedAt"} {
+		if _, exists := metadata[field]; exists {
+			t.Errorf("server-owned field %q present in create metadata: %s", field, data)
+		}
+	}
+}
+
+func TestNewIDReferenceUsesCanonicalIdentity(t *testing.T) {
+	reference := NewIDReference(KeyKind, "key_test")
+	if reference.APIVersion != APIVersion || reference.Kind != KeyKind || reference.ID != "key_test" {
+		t.Fatalf("object reference: %+v", reference)
+	}
+}

--- a/terraform/provider/internal/datasources/actor.go
+++ b/terraform/provider/internal/datasources/actor.go
@@ -72,8 +72,8 @@ func (d *ActorDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	config.ExternalId = types.StringValue(a.Spec.ExternalID)
 	config.Labels = labelsToMap(a.Metadata.Labels)
 	config.Annotations = annotationsToMap(a.Metadata.Annotations)
-	config.CreatedAt = types.StringValue(a.Metadata.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	config.UpdatedAt = types.StringValue(a.Metadata.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	config.CreatedAt = timestampToString(a.Metadata.CreatedAt)
+	config.UpdatedAt = timestampToString(a.Metadata.UpdatedAt)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/terraform/provider/internal/datasources/connector.go
+++ b/terraform/provider/internal/datasources/connector.go
@@ -43,7 +43,7 @@ func (d *ConnectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"id":           schema.StringAttribute{Required: true},
 			"namespace":    schema.StringAttribute{Computed: true},
-			"version":      schema.Int64Attribute{Computed: true},
+			"version":      schema.Int64Attribute{Computed: true, Description: "The selected connector metadata.generation."},
 			"state":        schema.StringAttribute{Computed: true},
 			"display_name": schema.StringAttribute{Computed: true},
 			"description":  schema.StringAttribute{Computed: true},
@@ -76,16 +76,25 @@ func (d *ConnectorDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	config.Namespace = types.StringValue(conn.Namespace)
-	config.Version = types.Int64Value(int64(conn.Version))
-	config.State = types.StringValue(conn.State)
-	config.DisplayName = types.StringValue(conn.DisplayName)
-	config.Description = types.StringValue(conn.Description)
-	config.Logo = types.StringValue(conn.Logo)
-	config.Labels = labelsToMap(conn.Labels)
-	config.Annotations = annotationsToMap(conn.Annotations)
-	config.CreatedAt = types.StringValue(conn.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	config.UpdatedAt = types.StringValue(conn.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	config.Namespace = types.StringValue(conn.Metadata.Namespace)
+	config.Version = types.Int64Value(int64(conn.Metadata.Generation))
+	if conn.Status != nil {
+		config.State = types.StringValue(conn.Status.Release.State)
+	} else {
+		config.State = types.StringNull()
+	}
+	if summary, err := client.DecodeConnectorDefinitionSummary(conn.Spec.Definition); err == nil {
+		config.DisplayName = types.StringValue(summary.DisplayName)
+		config.Description = types.StringValue(summary.Description)
+		config.Logo = types.StringValue(summary.Logo)
+	} else {
+		resp.Diagnostics.AddError("Failed to decode connector definition", err.Error())
+		return
+	}
+	config.Labels = labelsToMap(conn.Metadata.Labels)
+	config.Annotations = annotationsToMap(conn.Metadata.Annotations)
+	config.CreatedAt = timestampToString(conn.Metadata.CreatedAt)
+	config.UpdatedAt = timestampToString(conn.Metadata.UpdatedAt)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/terraform/provider/internal/datasources/helpers.go
+++ b/terraform/provider/internal/datasources/helpers.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -53,4 +54,11 @@ func labelsToMap(labels map[string]string) types.Map {
 	}
 	m, _ := types.MapValueFrom(context.Background(), types.StringType, elements)
 	return m
+}
+
+func timestampToString(value *time.Time) types.String {
+	if value == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(value.Format(time.RFC3339))
 }

--- a/terraform/provider/internal/datasources/key.go
+++ b/terraform/provider/internal/datasources/key.go
@@ -68,12 +68,16 @@ func (d *KeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	config.Namespace = types.StringValue(ek.Namespace)
-	config.State = types.StringValue(ek.State)
-	config.Labels = labelsToMap(ek.Labels)
-	config.Annotations = annotationsToMap(ek.Annotations)
-	config.CreatedAt = types.StringValue(ek.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	config.UpdatedAt = types.StringValue(ek.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	config.Namespace = types.StringValue(ek.Metadata.Namespace)
+	if ek.Status != nil {
+		config.State = types.StringValue(ek.Status.State)
+	} else {
+		config.State = types.StringValue(ek.Spec.DesiredState)
+	}
+	config.Labels = labelsToMap(ek.Metadata.Labels)
+	config.Annotations = annotationsToMap(ek.Metadata.Annotations)
+	config.CreatedAt = timestampToString(ek.Metadata.CreatedAt)
+	config.UpdatedAt = timestampToString(ek.Metadata.UpdatedAt)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/terraform/provider/internal/datasources/namespace.go
+++ b/terraform/provider/internal/datasources/namespace.go
@@ -68,16 +68,20 @@ func (d *NamespaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	config.State = types.StringValue(ns.State)
-	if ns.KeyId != nil {
-		config.KeyId = types.StringValue(*ns.KeyId)
+	if ns.Status != nil {
+		config.State = types.StringValue(ns.Status.State)
+	} else {
+		config.State = types.StringNull()
+	}
+	if ns.Spec.EncryptionKeyRef != nil && ns.Spec.EncryptionKeyRef.ID != "" {
+		config.KeyId = types.StringValue(ns.Spec.EncryptionKeyRef.ID)
 	} else {
 		config.KeyId = types.StringNull()
 	}
-	config.Labels = labelsToMap(ns.Labels)
-	config.Annotations = annotationsToMap(ns.Annotations)
-	config.CreatedAt = types.StringValue(ns.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	config.UpdatedAt = types.StringValue(ns.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	config.Labels = labelsToMap(ns.Metadata.Labels)
+	config.Annotations = annotationsToMap(ns.Metadata.Annotations)
+	config.CreatedAt = timestampToString(ns.Metadata.CreatedAt)
+	config.UpdatedAt = timestampToString(ns.Metadata.UpdatedAt)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }

--- a/terraform/provider/internal/resources/actor.go
+++ b/terraform/provider/internal/resources/actor.go
@@ -104,9 +104,8 @@ func (r *ActorResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	a, err := r.client.CreateActor(ctx, client.CreateActorRequest{
-		APIVersion: client.ActorAPIVersion,
-		Kind:       client.ActorKind,
-		Metadata: client.ActorMetadata{
+		TypeMeta: client.NewTypeMeta(client.ActorKind),
+		Metadata: client.ObjectMetadata{
 			Namespace:   plan.Namespace.ValueString(),
 			Labels:      labels,
 			Annotations: annotations,
@@ -161,9 +160,8 @@ func (r *ActorResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	a, err := r.client.UpdateActor(ctx, plan.Id.ValueString(), client.UpdateActorRequest{
-		APIVersion: client.ActorAPIVersion,
-		Kind:       client.ActorKind,
-		Metadata: &client.ActorMetadataPatch{
+		TypeMeta: client.NewTypeMeta(client.ActorKind),
+		Metadata: &client.ObjectMetadataPatch{
 			Labels:      &labels,
 			Annotations: &annotations,
 		},
@@ -201,6 +199,6 @@ func setActorState(model *ActorResourceModel, a *client.Actor) {
 	model.ExternalId = types.StringValue(a.Spec.ExternalID)
 	model.Labels = labelsToMap(a.Metadata.Labels)
 	model.Annotations = annotationsToMap(a.Metadata.Annotations)
-	model.CreatedAt = types.StringValue(a.Metadata.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	model.UpdatedAt = types.StringValue(a.Metadata.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	model.CreatedAt = timestampToString(a.Metadata.CreatedAt)
+	model.UpdatedAt = timestampToString(a.Metadata.UpdatedAt)
 }

--- a/terraform/provider/internal/resources/connector.go
+++ b/terraform/provider/internal/resources/connector.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -45,7 +47,7 @@ func (r *ConnectorResource) Metadata(_ context.Context, req resource.MetadataReq
 
 func (r *ConnectorResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages an AuthProxy connector. Automatically handles version lifecycle: when the definition changes, a new version is created and optionally promoted to primary.",
+		Description: "Manages an AuthProxy connector and its generation lifecycle. Published definition changes create a new generation; draft definition changes update that draft in place.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The stable connector ID (persists across version changes).",
@@ -64,6 +66,7 @@ func (r *ConnectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"definition": schema.StringAttribute{
 				Description: "The connector definition as JSON (auth config, probes, rate limiting, etc.).",
 				Required:    true,
+				Sensitive:   true,
 				CustomType:  jsontypes.NormalizedType{},
 			},
 			"labels": schema.MapAttribute{
@@ -79,13 +82,13 @@ func (r *ConnectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				ElementType: types.StringType,
 			},
 			"publish": schema.BoolAttribute{
-				Description: "Whether to promote new versions to primary state. When true (default), new versions are automatically set as primary. When false, versions remain in draft state.",
+				Description: "Whether to publish newly created or currently managed draft generations. Changing this from true to false does not demote an already published generation.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
 			},
 			"version": schema.Int64Attribute{
-				Description: "The current version number.",
+				Description: "The current API metadata.generation, exposed under the provider's established version attribute.",
 				Computed:    true,
 			},
 			"state": schema.StringAttribute{
@@ -129,29 +132,20 @@ func (r *ConnectorResource) Create(ctx context.Context, req resource.CreateReque
 	defJSON := json.RawMessage(plan.Definition.ValueString())
 
 	cv, err := r.client.CreateConnector(ctx, client.CreateConnectorRequest{
-		Namespace:   plan.Namespace.ValueString(),
-		Definition:  defJSON,
-		Labels:      labels,
-		Annotations: annotations,
+		TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+		Metadata: client.ObjectMetadata{
+			Namespace:   plan.Namespace.ValueString(),
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: client.ConnectorSpec{
+			Release:    client.ConnectorReleaseSpec{DesiredState: desiredConnectorReleaseState(plan.Publish.ValueBool())},
+			Definition: defJSON,
+		},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create connector", err.Error())
 		return
-	}
-
-	// If publish is true, promote to primary
-	if plan.Publish.ValueBool() {
-		err = r.client.ForceConnectorVersionState(ctx, cv.Id, cv.Version, "primary")
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to promote connector to primary", err.Error())
-			return
-		}
-		// Re-read to get updated state
-		cv, err = r.client.GetConnectorVersion(ctx, cv.Id, cv.Version)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to read connector after promotion", err.Error())
-			return
-		}
 	}
 
 	setConnectorState(&plan, cv)
@@ -167,8 +161,17 @@ func (r *ConnectorResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	id := state.Id.ValueString()
 
-	// Read the connector to get the latest version
-	conn, err := r.client.GetConnector(ctx, id)
+	var connector *client.Connector
+	var err error
+	// A draft is not the logical connector's primary generation. Preserve the
+	// exact generation managed by Terraform; published resources deliberately
+	// follow the API's primary generation so out-of-band promotion is detected.
+	if !state.Publish.IsNull() && !state.Publish.IsUnknown() && !state.Publish.ValueBool() &&
+		!state.Version.IsNull() && !state.Version.IsUnknown() && state.Version.ValueInt64() > 0 {
+		connector, err = r.client.GetConnectorVersion(ctx, id, uint64(state.Version.ValueInt64()))
+	} else {
+		connector, err = r.client.GetConnector(ctx, id)
+	}
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -178,14 +181,7 @@ func (r *ConnectorResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	// Get the full version details (with definition)
-	cv, err := r.client.GetConnectorVersion(ctx, id, conn.Version)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read connector version", err.Error())
-		return
-	}
-
-	setConnectorState(&state, cv)
+	setConnectorState(&state, connector)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -211,71 +207,68 @@ func (r *ConnectorResource) Update(ctx context.Context, req resource.UpdateReque
 	definitionChanged := !plan.Definition.Equal(state.Definition)
 	publishChanged := !plan.Publish.Equal(state.Publish)
 
-	var cv *client.ConnectorVersion
+	var cv *client.Connector
 	var err error
 
 	if definitionChanged {
-		// Definition changed: create a new version
 		defJSON := json.RawMessage(plan.Definition.ValueString())
-		labelsPtr := &labels
-		annotationsPtr := &annotations
-
-		cv, err = r.client.CreateConnectorVersion(ctx, id, client.CreateConnectorVersionRequest{
-			Definition:  &defJSON,
-			Labels:      labelsPtr,
-			Annotations: annotationsPtr,
-		})
+		if state.State.ValueString() == "draft" {
+			desiredState := desiredConnectorReleaseState(plan.Publish.ValueBool())
+			cv, err = r.client.UpdateConnectorVersion(ctx, id, uint64(state.Version.ValueInt64()), client.UpdateConnectorRequest{
+				TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+				Metadata: connectorMetadataPatch(labels, annotations),
+				Spec: &client.ConnectorSpecPatch{
+					Release:    &client.ConnectorReleaseSpecPatch{DesiredState: &desiredState},
+					Definition: &defJSON,
+				},
+			})
+		} else {
+			cv, err = r.client.CreateConnectorVersion(ctx, id, client.CreateConnectorVersionRequest{
+				TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+				Metadata: client.ObjectMetadata{
+					Namespace:   plan.Namespace.ValueString(),
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: client.ConnectorSpec{
+					Release:    client.ConnectorReleaseSpec{DesiredState: desiredConnectorReleaseState(plan.Publish.ValueBool())},
+					Definition: defJSON,
+				},
+			})
+		}
 		if err != nil {
-			resp.Diagnostics.AddError("Failed to create new connector version", err.Error())
+			resp.Diagnostics.AddError("Failed to update connector definition", err.Error())
 			return
 		}
-
-		if plan.Publish.ValueBool() {
-			err = r.client.ForceConnectorVersionState(ctx, id, cv.Version, "primary")
-			if err != nil {
-				resp.Diagnostics.AddError("Failed to promote new version to primary", err.Error())
-				return
-			}
-			cv, err = r.client.GetConnectorVersion(ctx, id, cv.Version)
-			if err != nil {
-				resp.Diagnostics.AddError("Failed to read connector version after promotion", err.Error())
-				return
-			}
-		}
 	} else if publishChanged && plan.Publish.ValueBool() {
-		// Publish changed from false to true: promote current draft version
+		// Publish changed from false to true: promote the exact draft generation.
 		currentVersion := uint64(state.Version.ValueInt64())
-		err = r.client.ForceConnectorVersionState(ctx, id, currentVersion, "primary")
+		desiredState := "primary"
+		cv, err = r.client.UpdateConnectorVersion(ctx, id, currentVersion, client.UpdateConnectorRequest{
+			TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+			Metadata: connectorMetadataPatch(labels, annotations),
+			Spec: &client.ConnectorSpecPatch{Release: &client.ConnectorReleaseSpecPatch{
+				DesiredState: &desiredState,
+			}},
+		})
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to promote version to primary", err.Error())
 			return
 		}
-		cv, err = r.client.GetConnectorVersion(ctx, id, currentVersion)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to read connector version after promotion", err.Error())
-			return
-		}
 	} else {
-		// Only labels/annotations changed: use connector-level PATCH which handles
-		// draft creation internally (version-level PATCH requires draft state).
-		updateReq := client.UpdateConnectorRequest{Labels: &labels, Annotations: &annotations}
-		cv, err = r.client.UpdateConnector(ctx, id, updateReq)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to update connector labels", err.Error())
-			return
+		updateReq := client.UpdateConnectorRequest{
+			TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+			Metadata: connectorMetadataPatch(labels, annotations),
+			Spec:     &client.ConnectorSpecPatch{},
 		}
-
-		if plan.Publish.ValueBool() && cv.State == "draft" {
-			err = r.client.ForceConnectorVersionState(ctx, id, cv.Version, "primary")
-			if err != nil {
-				resp.Diagnostics.AddError("Failed to promote version after label update", err.Error())
-				return
-			}
-			cv, err = r.client.GetConnectorVersion(ctx, id, cv.Version)
-			if err != nil {
-				resp.Diagnostics.AddError("Failed to read connector version after promotion", err.Error())
-				return
-			}
+		if state.State.ValueString() == "draft" {
+			cv, err = r.client.UpdateConnectorVersion(ctx, id, uint64(state.Version.ValueInt64()), updateReq)
+		} else {
+			cv, err = r.client.UpdateConnector(ctx, id, updateReq)
+		}
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to update connector metadata", err.Error())
+			return
 		}
 	}
 
@@ -303,8 +296,8 @@ func (r *ConnectorResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	for _, v := range versions.Items {
-		if v.State != "archived" {
-			err = r.client.ForceConnectorVersionState(ctx, id, v.Version, "archived")
+		if v.Status != nil && v.Status.Release.State != "archived" {
+			err = r.client.ForceConnectorVersionState(ctx, id, v.Metadata.Generation, "archived")
 			if err != nil {
 				resp.Diagnostics.AddError("Failed to archive connector version", err.Error())
 				return
@@ -319,49 +312,92 @@ func (r *ConnectorResource) ImportState(ctx context.Context, req resource.Import
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, pathAttr("publish"), true)...)
 }
 
-// connectorMetadataFields are fields the API adds to the definition response
-// that are not part of the user-provided definition. These must be stripped
-// before storing the definition in state to avoid "inconsistent result" errors.
-var connectorMetadataFields = []string{
-	"id", "version", "namespace", "state", "logo",
-	"labels", "annotations", "createdAt", "updatedAt",
+func setConnectorState(model *ConnectorResourceModel, connector *client.Connector) {
+	model.Id = types.StringValue(connector.Metadata.ID)
+	model.Namespace = types.StringValue(connector.Metadata.Namespace)
+	model.Version = types.Int64Value(int64(connector.Metadata.Generation))
+	model.Labels = labelsToMap(connector.Metadata.Labels)
+	model.Annotations = annotationsToMap(connector.Metadata.Annotations)
+	model.CreatedAt = timestampToString(connector.Metadata.CreatedAt)
+	model.UpdatedAt = timestampToString(connector.Metadata.UpdatedAt)
+	if connector.Status != nil {
+		model.State = types.StringValue(connector.Status.Release.State)
+	} else {
+		model.State = types.StringNull()
+	}
+
+	if len(connector.Spec.Definition) > 0 {
+		definition := connector.Spec.Definition
+		if connector.DataRedacted && !model.Definition.IsNull() && !model.Definition.IsUnknown() {
+			if merged, err := preserveRedactedJSON(definition, []byte(model.Definition.ValueString())); err == nil {
+				definition = merged
+			}
+		}
+		model.Definition = jsontypes.NewNormalizedValue(string(definition))
+		if summary, err := client.DecodeConnectorDefinitionSummary(connector.Spec.Definition); err == nil {
+			model.DisplayName = types.StringValue(summary.DisplayName)
+		}
+	}
 }
 
-func setConnectorState(model *ConnectorResourceModel, cv *client.ConnectorVersion) {
-	model.Id = types.StringValue(cv.Id)
-	model.Namespace = types.StringValue(cv.Namespace)
-	model.Version = types.Int64Value(int64(cv.Version))
-	model.State = types.StringValue(cv.State)
-	model.Labels = labelsToMap(cv.Labels)
-	model.Annotations = annotationsToMap(cv.Annotations)
-	model.CreatedAt = types.StringValue(cv.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	model.UpdatedAt = types.StringValue(cv.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+// preserveRedactedJSON keeps prior Terraform state at fields the API explicitly
+// masked in a response. This prevents write-only connector secrets from being
+// replaced with asterisks after apply while leaving all observable fields
+// available for drift detection.
+func preserveRedactedJSON(observed, prior []byte) (json.RawMessage, error) {
+	var observedValue any
+	if err := json.Unmarshal(observed, &observedValue); err != nil {
+		return nil, err
+	}
+	var priorValue any
+	if err := json.Unmarshal(prior, &priorValue); err != nil {
+		return nil, err
+	}
+	merged := preserveRedactedValue(observedValue, priorValue)
+	return json.Marshal(merged)
+}
 
-	if cv.Definition != nil {
-		// Strip metadata fields that the API adds but aren't part of the
-		// user-provided definition.
-		var defMap map[string]json.RawMessage
-		if err := json.Unmarshal(cv.Definition, &defMap); err == nil {
-			for _, field := range connectorMetadataFields {
-				delete(defMap, field)
+func preserveRedactedValue(observed, prior any) any {
+	switch value := observed.(type) {
+	case string:
+		if value != "" && strings.Trim(value, "*") == "" {
+			if priorString, ok := prior.(string); ok &&
+				utf8.RuneCountInString(priorString) == utf8.RuneCountInString(value) {
+				return priorString
 			}
-			if cleaned, err := json.Marshal(defMap); err == nil {
-				model.Definition = jsontypes.NewNormalizedValue(string(cleaned))
-			} else {
-				model.Definition = jsontypes.NewNormalizedValue(string(cv.Definition))
+		}
+	case map[string]any:
+		priorMap, _ := prior.(map[string]any)
+		for key, item := range value {
+			value[key] = preserveRedactedValue(item, priorMap[key])
+		}
+	case []any:
+		priorSlice, _ := prior.([]any)
+		for index, item := range value {
+			var priorItem any
+			if index < len(priorSlice) {
+				priorItem = priorSlice[index]
 			}
-		} else {
-			model.Definition = jsontypes.NewNormalizedValue(string(cv.Definition))
+			value[index] = preserveRedactedValue(item, priorItem)
 		}
 	}
+	return observed
+}
 
-	// Extract display_name from definition
-	var def struct {
-		DisplayName string `json:"displayName"`
+func desiredConnectorReleaseState(publish bool) string {
+	if publish {
+		return "primary"
 	}
-	if cv.Definition != nil {
-		if err := json.Unmarshal(cv.Definition, &def); err == nil {
-			model.DisplayName = types.StringValue(def.DisplayName)
-		}
+	return "draft"
+}
+
+func connectorMetadataPatch(labels, annotations map[string]string) *client.ObjectMetadataPatch {
+	patch := &client.ObjectMetadataPatch{}
+	if labels != nil {
+		patch.Labels = &labels
 	}
+	if annotations != nil {
+		patch.Annotations = &annotations
+	}
+	return patch
 }

--- a/terraform/provider/internal/resources/connector_test.go
+++ b/terraform/provider/internal/resources/connector_test.go
@@ -1,0 +1,169 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rmorlok/authproxy/terraform/provider/internal/client"
+)
+
+func TestSetConnectorStateMapsCanonicalResourceWithoutDefinitionStripping(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	definition := json.RawMessage(`{
+		"displayName":"Example",
+		"logo":{"publicUrl":"https://example.com/logo.png"},
+		"description":"Example connector",
+		"auth":{"type":"no-auth"}
+	}`)
+	connector := &client.Connector{
+		TypeMeta: client.NewTypeMeta(client.ConnectorKind),
+		Metadata: client.ObjectMetadata{
+			ID:          "cxr_test",
+			Namespace:   "root.acme",
+			Generation:  3,
+			Labels:      map[string]string{"team": "platform"},
+			Annotations: map[string]string{"owner": "integrations"},
+			CreatedAt:   &now,
+			UpdatedAt:   &now,
+		},
+		Spec: client.ConnectorSpec{
+			Release:    client.ConnectorReleaseSpec{DesiredState: "primary"},
+			Definition: definition,
+		},
+		Status: &client.ConnectorStatus{Release: client.ConnectorReleaseStatus{State: "primary"}},
+	}
+
+	model := ConnectorResourceModel{Publish: types.BoolValue(true)}
+	setConnectorState(&model, connector)
+
+	if model.Id.ValueString() != "cxr_test" || model.Version.ValueInt64() != 3 || !model.Publish.ValueBool() {
+		t.Fatalf("identity/release mapping: %+v", model)
+	}
+	if model.State.ValueString() != "primary" || model.DisplayName.ValueString() != "Example" {
+		t.Fatalf("status/definition mapping: %+v", model)
+	}
+	if !model.Definition.Equal(jsontypes.NewNormalizedValue(string(definition))) {
+		t.Fatalf("definition changed while mapping to state: %s", model.Definition.ValueString())
+	}
+	var stateDefinition map[string]any
+	if err := json.Unmarshal([]byte(model.Definition.ValueString()), &stateDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := stateDefinition["logo"]; !exists {
+		t.Fatalf("provider-owned logo removed from spec.definition: %+v", stateDefinition)
+	}
+	var labels map[string]string
+	model.Labels.ElementsAs(context.Background(), &labels, false)
+	if labels["team"] != "platform" {
+		t.Fatalf("labels: %+v", labels)
+	}
+}
+
+func TestConnectorDefinitionAttributeIsSensitive(t *testing.T) {
+	var response resource.SchemaResponse
+	(&ConnectorResource{}).Schema(t.Context(), resource.SchemaRequest{}, &response)
+	definition, ok := response.Schema.Attributes["definition"].(resourceschema.StringAttribute)
+	if !ok || !definition.Sensitive {
+		t.Fatalf("connector definition must be a sensitive string attribute: %#v", response.Schema.Attributes["definition"])
+	}
+}
+
+func TestSetConnectorStatePreservesDraftPublishPreference(t *testing.T) {
+	connector := &client.Connector{
+		Metadata: client.ObjectMetadata{ID: "cxr_test", Namespace: "root", Generation: 1},
+		Spec: client.ConnectorSpec{
+			Release:    client.ConnectorReleaseSpec{DesiredState: "draft"},
+			Definition: json.RawMessage(`{"displayName":"Draft"}`),
+		},
+		Status: &client.ConnectorStatus{Release: client.ConnectorReleaseStatus{State: "draft"}},
+	}
+	model := ConnectorResourceModel{Publish: types.BoolValue(false)}
+	setConnectorState(&model, connector)
+	if model.Publish.ValueBool() || model.State.ValueString() != "draft" {
+		t.Fatalf("draft release mapping: %+v", model)
+	}
+}
+
+func TestSetConnectorStatePreservesProviderPublishPreference(t *testing.T) {
+	connector := &client.Connector{
+		Metadata: client.ObjectMetadata{ID: "cxr_test", Namespace: "root", Generation: 1},
+		Spec: client.ConnectorSpec{
+			Release:    client.ConnectorReleaseSpec{DesiredState: "primary"},
+			Definition: json.RawMessage(`{"displayName":"Published"}`),
+		},
+		Status: &client.ConnectorStatus{Release: client.ConnectorReleaseStatus{State: "primary"}},
+	}
+	model := ConnectorResourceModel{Publish: types.BoolValue(false)}
+	setConnectorState(&model, connector)
+	if model.Publish.ValueBool() {
+		t.Fatal("API release state must not overwrite the provider-local publish preference")
+	}
+}
+
+func TestConnectorMetadataPatchPreservesClearAndOmission(t *testing.T) {
+	empty := map[string]string{}
+	patch := connectorMetadataPatch(empty, nil)
+	if patch.Labels == nil || len(*patch.Labels) != 0 {
+		t.Fatalf("empty labels must remain an explicit clear: %+v", patch)
+	}
+	if patch.Annotations != nil {
+		t.Fatalf("nil annotations must be omitted: %+v", patch)
+	}
+}
+
+func TestPreserveRedactedJSONRetainsPriorSecrets(t *testing.T) {
+	observed := []byte(`{"auth":{"clientSecret":"*************"},"description":"updated","scopes":[{"token":"*****"}]}`)
+	prior := []byte(`{"auth":{"clientSecret":"client-secret"},"description":"old","scopes":[{"token":"token"}]}`)
+	merged, err := preserveRedactedJSON(observed, prior)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(merged, &value); err != nil {
+		t.Fatal(err)
+	}
+	auth := value["auth"].(map[string]any)
+	if auth["clientSecret"] != "client-secret" {
+		t.Fatalf("secret was not retained: %s", merged)
+	}
+	if value["description"] != "updated" {
+		t.Fatalf("observable drift was lost: %s", merged)
+	}
+	scopes := value["scopes"].([]any)
+	if scopes[0].(map[string]any)["token"] != "token" {
+		t.Fatalf("nested secret was not retained: %s", merged)
+	}
+}
+
+func TestSetConnectorStateRetainsSecretFromPriorStateOnRedactedRead(t *testing.T) {
+	model := ConnectorResourceModel{
+		Definition: jsontypes.NewNormalizedValue(`{"displayName":"Example","auth":{"type":"OAuth2","clientSecret":"client-secret"}}`),
+	}
+	connector := &client.Connector{
+		Metadata: client.ObjectMetadata{ID: "cxr_test", Namespace: "root", Generation: 1},
+		Spec: client.ConnectorSpec{
+			Release:    client.ConnectorReleaseSpec{DesiredState: "primary"},
+			Definition: json.RawMessage(`{"displayName":"Example","auth":{"type":"OAuth2","clientSecret":"*************"}}`),
+		},
+		Status:       &client.ConnectorStatus{Release: client.ConnectorReleaseStatus{State: "primary"}},
+		DataRedacted: true,
+	}
+	setConnectorState(&model, connector)
+	var definition struct {
+		Auth struct {
+			ClientSecret string `json:"clientSecret"`
+		} `json:"auth"`
+	}
+	if err := json.Unmarshal([]byte(model.Definition.ValueString()), &definition); err != nil {
+		t.Fatal(err)
+	}
+	if definition.Auth.ClientSecret != "client-secret" {
+		t.Fatalf("redacted response replaced prior secret: %q", definition.Auth.ClientSecret)
+	}
+}

--- a/terraform/provider/internal/resources/helpers.go
+++ b/terraform/provider/internal/resources/helpers.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -77,6 +78,13 @@ func annotationsToMap(annotations map[string]string) types.Map {
 	}
 	m, _ := types.MapValueFrom(context.Background(), types.StringType, elements)
 	return m
+}
+
+func timestampToString(value *time.Time) types.String {
+	if value == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(value.Format(time.RFC3339))
 }
 
 // pathAttr returns a path.Path for the given attribute name.

--- a/terraform/provider/internal/resources/key.go
+++ b/terraform/provider/internal/resources/key.go
@@ -101,11 +101,18 @@ func (r *KeyResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	spec := client.KeySpec{KeyData: map[string]any{"numBytes": 32}}
+	if !plan.State.IsNull() && !plan.State.IsUnknown() {
+		spec.DesiredState = plan.State.ValueString()
+	}
 	ek, err := r.client.CreateKey(ctx, client.CreateKeyRequest{
-		Namespace:   plan.Namespace.ValueString(),
-		Labels:      labels,
-		Annotations: annotations,
-		KeyData:     map[string]interface{}{"numBytes": 32},
+		TypeMeta: client.NewTypeMeta(client.KeyKind),
+		Metadata: client.ObjectMetadata{
+			Namespace:   plan.Namespace.ValueString(),
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: spec,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create key", err.Error())
@@ -154,16 +161,20 @@ func (r *KeyResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
-	updateReq := client.UpdateKeyRequest{}
+	updateReq := client.UpdateKeyRequest{
+		TypeMeta: client.NewTypeMeta(client.KeyKind),
+		Metadata: &client.ObjectMetadataPatch{},
+		Spec:     &client.KeySpecPatch{},
+	}
 	if !plan.State.IsNull() && !plan.State.IsUnknown() {
 		s := plan.State.ValueString()
-		updateReq.State = &s
+		updateReq.Spec.DesiredState = &s
 	}
 	if labels != nil {
-		updateReq.Labels = &labels
+		updateReq.Metadata.Labels = &labels
 	}
 	if annotations != nil {
-		updateReq.Annotations = &annotations
+		updateReq.Metadata.Annotations = &annotations
 	}
 
 	ek, err := r.client.UpdateKey(ctx, plan.Id.ValueString(), updateReq)
@@ -194,11 +205,15 @@ func (r *KeyResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func setKeyState(model *KeyResourceModel, ek *client.Key) {
-	model.Id = types.StringValue(ek.Id)
-	model.Namespace = types.StringValue(ek.Namespace)
-	model.State = types.StringValue(ek.State)
-	model.Labels = labelsToMap(ek.Labels)
-	model.Annotations = annotationsToMap(ek.Annotations)
-	model.CreatedAt = types.StringValue(ek.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	model.UpdatedAt = types.StringValue(ek.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	model.Id = types.StringValue(ek.Metadata.ID)
+	model.Namespace = types.StringValue(ek.Metadata.Namespace)
+	if ek.Status != nil {
+		model.State = types.StringValue(ek.Status.State)
+	} else {
+		model.State = types.StringValue(ek.Spec.DesiredState)
+	}
+	model.Labels = labelsToMap(ek.Metadata.Labels)
+	model.Annotations = annotationsToMap(ek.Metadata.Annotations)
+	model.CreatedAt = timestampToString(ek.Metadata.CreatedAt)
+	model.UpdatedAt = timestampToString(ek.Metadata.UpdatedAt)
 }

--- a/terraform/provider/internal/resources/namespace.go
+++ b/terraform/provider/internal/resources/namespace.go
@@ -101,10 +101,13 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	metadata := client.NamespaceMetadataForPath(plan.Path.ValueString())
+	metadata.Labels = labels
+	metadata.Annotations = annotations
 	ns, err := r.client.CreateNamespace(ctx, client.CreateNamespaceRequest{
-		Path:        plan.Path.ValueString(),
-		Labels:      labels,
-		Annotations: annotations,
+		TypeMeta: client.NewTypeMeta(client.NamespaceKind),
+		Metadata: metadata,
+		Spec:     client.NamespaceSpec{},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create namespace", err.Error())
@@ -153,9 +156,17 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	metadata := &client.ObjectMetadataPatch{}
+	if labels != nil {
+		metadata.Labels = &labels
+	}
+	if annotations != nil {
+		metadata.Annotations = &annotations
+	}
 	ns, err := r.client.UpdateNamespace(ctx, plan.Path.ValueString(), client.UpdateNamespaceRequest{
-		Labels:      labels,
-		Annotations: annotations,
+		TypeMeta: client.NewTypeMeta(client.NamespaceKind),
+		Metadata: metadata,
+		Spec:     &client.NamespaceSpecPatch{},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update namespace", err.Error())
@@ -184,15 +195,19 @@ func (r *NamespaceResource) ImportState(ctx context.Context, req resource.Import
 }
 
 func setNamespaceState(model *NamespaceResourceModel, ns *client.Namespace) {
-	model.Path = types.StringValue(ns.Path)
-	model.State = types.StringValue(ns.State)
-	if ns.KeyId != nil {
-		model.KeyId = types.StringValue(*ns.KeyId)
+	model.Path = types.StringValue(ns.Metadata.ID)
+	if ns.Status != nil {
+		model.State = types.StringValue(ns.Status.State)
+	} else {
+		model.State = types.StringNull()
+	}
+	if ns.Spec.EncryptionKeyRef != nil && ns.Spec.EncryptionKeyRef.ID != "" {
+		model.KeyId = types.StringValue(ns.Spec.EncryptionKeyRef.ID)
 	} else {
 		model.KeyId = types.StringNull()
 	}
-	model.Labels = labelsToMap(ns.Labels)
-	model.Annotations = annotationsToMap(ns.Annotations)
-	model.CreatedAt = types.StringValue(ns.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	model.UpdatedAt = types.StringValue(ns.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	model.Labels = labelsToMap(ns.Metadata.Labels)
+	model.Annotations = annotationsToMap(ns.Metadata.Annotations)
+	model.CreatedAt = timestampToString(ns.Metadata.CreatedAt)
+	model.UpdatedAt = timestampToString(ns.Metadata.UpdatedAt)
 }

--- a/terraform/provider/internal/resources/rate_limit.go
+++ b/terraform/provider/internal/resources/rate_limit.go
@@ -292,9 +292,8 @@ func (r *RateLimitResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	rl, err := r.client.CreateRateLimit(ctx, client.CreateRateLimitRequest{
-		APIVersion: client.RateLimitAPIVersion,
-		Kind:       client.RateLimitKind,
-		Metadata: client.RateLimitMetadata{
+		TypeMeta: client.NewTypeMeta(client.RateLimitKind),
+		Metadata: client.ObjectMetadata{
 			Namespace:   plan.Namespace.ValueString(),
 			Labels:      labels,
 			Annotations: annotations,
@@ -351,9 +350,8 @@ func (r *RateLimitResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	updateReq := client.UpdateRateLimitRequest{
-		APIVersion: client.RateLimitAPIVersion,
-		Kind:       client.RateLimitKind,
-		Metadata:   &client.RateLimitMetadataPatch{},
+		TypeMeta: client.NewTypeMeta(client.RateLimitKind),
+		Metadata: &client.ObjectMetadataPatch{},
 		Spec: &client.RateLimitSpecPatch{
 			Scope:     spec.Scope,
 			Mode:      &spec.Mode,
@@ -406,18 +404,10 @@ func buildRateLimitSpec(ctx context.Context, plan *RateLimitResourceModel) (clie
 		def.Scope = &client.RateLimitScope{}
 		def.Scope.NamespaceMatcher = plan.Scope.NamespaceMatcher.ValueString()
 		if plan.Scope.ConnectorRef != nil {
-			def.Scope.ConnectorRef = &client.ObjectReference{
-				APIVersion: client.RateLimitAPIVersion,
-				Kind:       "Connector",
-				ID:         plan.Scope.ConnectorRef.ID.ValueString(),
-			}
+			def.Scope.ConnectorRef = client.NewIDReference(client.ConnectorKind, plan.Scope.ConnectorRef.ID.ValueString())
 		}
 		if plan.Scope.ConnectionRef != nil {
-			def.Scope.ConnectionRef = &client.ObjectReference{
-				APIVersion: client.RateLimitAPIVersion,
-				Kind:       "Connection",
-				ID:         plan.Scope.ConnectionRef.ID.ValueString(),
-			}
+			def.Scope.ConnectionRef = client.NewIDReference("Connection", plan.Scope.ConnectionRef.ID.ValueString())
 		}
 	}
 
@@ -487,12 +477,8 @@ func setRateLimitState(model *RateLimitResourceModel, rl *client.RateLimit) {
 	}
 	model.Labels = labelsToMap(rl.Metadata.Labels)
 	model.Annotations = annotationsToMap(rl.Metadata.Annotations)
-	if rl.Metadata.CreatedAt != nil {
-		model.CreatedAt = types.StringValue(rl.Metadata.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	}
-	if rl.Metadata.UpdatedAt != nil {
-		model.UpdatedAt = types.StringValue(rl.Metadata.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	}
+	model.CreatedAt = timestampToString(rl.Metadata.CreatedAt)
+	model.UpdatedAt = timestampToString(rl.Metadata.UpdatedAt)
 	model.Scope = nil
 	if rl.Spec.Scope != nil {
 		model.Scope = &rateLimitScopeModel{NamespaceMatcher: types.StringNull()}

--- a/terraform/provider/internal/resources/rate_limit_test.go
+++ b/terraform/provider/internal/resources/rate_limit_test.go
@@ -149,7 +149,7 @@ func TestBuildRateLimitSpec_ConnectorScope(t *testing.T) {
 	if spec.Scope == nil || spec.Scope.ConnectorRef == nil {
 		t.Fatalf("connector scope: %+v", spec.Scope)
 	}
-	if got := spec.Scope.ConnectorRef; got.APIVersion != client.RateLimitAPIVersion || got.Kind != "Connector" || got.ID != "cxr_salesforce" {
+	if got := spec.Scope.ConnectorRef; got.APIVersion != client.APIVersion || got.Kind != "Connector" || got.ID != "cxr_salesforce" {
 		t.Errorf("connector ref: %+v", got)
 	}
 }
@@ -186,7 +186,7 @@ func TestBuildRateLimitSpec_ConnectionScope(t *testing.T) {
 	if spec.Scope == nil || spec.Scope.ConnectionRef == nil {
 		t.Fatalf("connection scope: %+v", spec.Scope)
 	}
-	if got := spec.Scope.ConnectionRef; got.APIVersion != client.RateLimitAPIVersion || got.Kind != "Connection" || got.ID != "cxn_customer" {
+	if got := spec.Scope.ConnectionRef; got.APIVersion != client.APIVersion || got.Kind != "Connection" || got.ID != "cxn_customer" {
 		t.Errorf("connection ref: %+v", got)
 	}
 }
@@ -196,9 +196,8 @@ func TestBuildRateLimitSpec_ConnectionScope(t *testing.T) {
 func TestSetRateLimitState_PopulatesAllFields(t *testing.T) {
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	rl := &client.RateLimit{
-		APIVersion: client.RateLimitAPIVersion,
-		Kind:       client.RateLimitKind,
-		Metadata: client.RateLimitMetadata{
+		TypeMeta: client.NewTypeMeta(client.RateLimitKind),
+		Metadata: client.ObjectMetadata{
 			ID:          "rl_test123",
 			Namespace:   "root.acme",
 			Labels:      map[string]string{"team": "acme", "apxy/rl/-/id": "rl_test123"},
@@ -208,7 +207,7 @@ func TestSetRateLimitState_PopulatesAllFields(t *testing.T) {
 		},
 		Spec: client.RateLimitSpec{
 			Scope: &client.RateLimitScope{ConnectorRef: &client.ObjectReference{
-				APIVersion: client.RateLimitAPIVersion,
+				APIVersion: client.APIVersion,
 				Kind:       "Connector",
 				ID:         "cxr_salesforce",
 			}},
@@ -266,7 +265,7 @@ func TestSetRateLimitState_PopulatesAllFields(t *testing.T) {
 
 func TestSetRateLimitState_NamespaceMatcherScope(t *testing.T) {
 	rl := &client.RateLimit{
-		Metadata: client.RateLimitMetadata{ID: "rl_test123", Namespace: "root.acme"},
+		Metadata: client.ObjectMetadata{ID: "rl_test123", Namespace: "root.acme"},
 		Spec: client.RateLimitSpec{
 			Scope:     &client.RateLimitScope{NamespaceMatcher: "root.acme.payments.**"},
 			Algorithm: client.RateLimitAlgorithm{TokenBucket: &client.RateLimitTokenBucket{Capacity: 1, RefillRate: 1}},
@@ -284,10 +283,9 @@ func TestSetRateLimitState_EmptyModeDefaultsToEnforce(t *testing.T) {
 	// The server stores Mode="" for the default ("enforce"); the
 	// provider surfaces it explicitly so plan/apply consistency holds.
 	rl := &client.RateLimit{
-		APIVersion: client.RateLimitAPIVersion,
-		Kind:       client.RateLimitKind,
-		Metadata:   client.RateLimitMetadata{ID: "rl_x", Namespace: "root"},
-		Spec:       client.RateLimitSpec{Algorithm: client.RateLimitAlgorithm{TokenBucket: &client.RateLimitTokenBucket{Capacity: 1, RefillRate: 1}}},
+		TypeMeta: client.NewTypeMeta(client.RateLimitKind),
+		Metadata: client.ObjectMetadata{ID: "rl_x", Namespace: "root"},
+		Spec:     client.RateLimitSpec{Algorithm: client.RateLimitAlgorithm{TokenBucket: &client.RateLimitTokenBucket{Capacity: 1, RefillRate: 1}}},
 	}
 	var m RateLimitResourceModel
 	setRateLimitState(&m, rl)

--- a/terraform/provider/internal/resources/resource_state_test.go
+++ b/terraform/provider/internal/resources/resource_state_test.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/terraform/provider/internal/client"
+)
+
+func TestSetNamespaceStateMapsMetadataSpecAndStatus(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	namespace := &client.Namespace{
+		TypeMeta: client.NewTypeMeta(client.NamespaceKind),
+		Metadata: client.ObjectMetadata{
+			ID:        "root.acme",
+			Name:      "acme",
+			Namespace: "root",
+			CreatedAt: &now,
+			UpdatedAt: &now,
+		},
+		Spec:   client.NamespaceSpec{EncryptionKeyRef: client.NewIDReference(client.KeyKind, "key_test")},
+		Status: &client.NamespaceStatus{State: "active"},
+	}
+	var model NamespaceResourceModel
+	setNamespaceState(&model, namespace)
+	if model.Path.ValueString() != "root.acme" || model.State.ValueString() != "active" || model.KeyId.ValueString() != "key_test" {
+		t.Fatalf("namespace state: %+v", model)
+	}
+}
+
+func TestSetKeyStateUsesObservedStateWithoutExposingKeyData(t *testing.T) {
+	key := &client.Key{
+		TypeMeta: client.NewTypeMeta(client.KeyKind),
+		Metadata: client.ObjectMetadata{
+			ID:        "key_test",
+			Namespace: "root.acme",
+		},
+		Spec: client.KeySpec{
+			DesiredState: "disabled",
+			KeyData:      map[string]any{"value": "********"},
+		},
+		Status: &client.KeyStatus{State: "active", KeyDataConfigured: true},
+	}
+	var model KeyResourceModel
+	setKeyState(&model, key)
+	if model.Id.ValueString() != "key_test" || model.Namespace.ValueString() != "root.acme" || model.State.ValueString() != "active" {
+		t.Fatalf("key state: %+v", model)
+	}
+}
+
+func TestSetActorStateMapsMetadataAndSpec(t *testing.T) {
+	actor := &client.Actor{
+		TypeMeta: client.NewTypeMeta(client.ActorKind),
+		Metadata: client.ObjectMetadata{
+			ID:        "act_test",
+			Namespace: "root.acme",
+		},
+		Spec: client.ActorSpec{ExternalID: "user-123"},
+	}
+	var model ActorResourceModel
+	setActorState(&model, actor)
+	if model.Id.ValueString() != "act_test" || model.Namespace.ValueString() != "root.acme" || model.ExternalId.ValueString() != "user-123" {
+		t.Fatalf("actor state: %+v", model)
+	}
+}


### PR DESCRIPTION
Closes #847

## Summary

- add shared, provider-local v1alpha1 wire primitives for type metadata, object metadata, references, and resource lists while keeping the provider independent of server-internal schema packages
- migrate namespaces, keys, connectors, actors, rate limits, and their data sources to explicit `apiVersion` / `kind` / `metadata` / `spec` / `status` mappings
- map connector `version` to `metadata.generation`, update drafts in place, follow primary generations for published-resource drift, and remove definition metadata stripping
- mark connector definitions sensitive and preserve prior secret values only when the API marks a response as redacted; key material and actor signing material remain outside Terraform state
- retain the existing HCL schema, so no Terraform state upgrader is required
- update provider examples/docs and extend connector plus rate-limit acceptance coverage

## Verification

- `go test ./...` from `terraform/provider`
- `terraform fmt -check -recursive terraform/provider/examples integration_tests/terraform`
- `./scripts/preflight.sh`

The tagged Terraform acceptance package cannot yet be compiled in isolation because the feature branch shared integration helpers still reference the removed flat connector DTOs; migrating those helpers is explicitly tracked by dependent issue #848. The Terraform acceptance cases in this PR are ready for that follow-on migration.