### PR TITLE
Migrate CLI, demos, and integration fixtures to v1alpha1

### DIFF
--- a/cmd/cli/list_resource_names_test.go
+++ b/cmd/cli/list_resource_names_test.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
-	scommon "github.com/rmorlok/authproxy/internal/schema/common"
-	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
-	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,22 +24,4 @@ func TestResourceListCommandsExposeExactNameFilter(t *testing.T) {
 	require.Equal(t, "salesforce", connectorRequest.QueryParam.Get("name"))
 	require.Equal(t, "crm", connectorRequest.QueryParam.Get("type"))
 	require.Equal(t, "cursor-2", connectorRequest.QueryParam.Get("cursor"))
-}
-
-func TestResourceListJSONKeepsNameAndImmutableID(t *testing.T) {
-	resource := connectionschema.Connection{
-		TypeMeta: meta.NewTypeMeta(connectionschema.ConnectionKind),
-		Metadata: meta.ObjectMeta{
-			ID:   "cxn_test1234567890ab",
-			Name: scommon.ResourceName("production-crm"),
-		},
-	}
-
-	encoded, err := json.Marshal(resource)
-	require.NoError(t, err)
-	var projected map[string]any
-	require.NoError(t, json.Unmarshal(encoded, &projected))
-	metadata := projected["metadata"].(map[string]any)
-	require.Equal(t, "cxn_test1234567890ab", metadata["id"])
-	require.Equal(t, "production-crm", metadata["name"])
 }

--- a/cmd/cli/output.go
+++ b/cmd/cli/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ type Output[T any] interface {
 type output[T any] struct {
 	isSingle    bool
 	hasPrevious bool
+	writer      io.Writer
 }
 
 func (o *output[T]) EmitAll(vs []T) {
@@ -33,14 +35,14 @@ func (o *output[T]) Emit(v T) {
 	if !o.isSingle {
 		indent = "  "
 		if !o.hasPrevious {
-			fmt.Print("[\n")
+			fmt.Fprint(o.writer, "[\n")
 		} else {
-			fmt.Print(",\n")
+			fmt.Fprint(o.writer, ",\n")
 		}
 	}
 
 	formatted, _ := json.MarshalIndent(v, indent, "  ")
-	fmt.Print(indent + string(formatted))
+	fmt.Fprint(o.writer, indent+string(formatted))
 	o.hasPrevious = true
 }
 
@@ -59,7 +61,7 @@ func (o *output[T]) ErrorResponse(resp *resty.Response) error {
 	}
 
 	prettyJSON, _ := json.MarshalIndent(errorJson, "", "  ")
-	fmt.Println(string(prettyJSON))
+	fmt.Fprintln(o.writer, string(prettyJSON))
 
 	return errors.New("error from API")
 }
@@ -71,9 +73,9 @@ func (o *output[T]) ShouldStop() bool {
 func (o *output[T]) Done() {
 	if !o.isSingle {
 		if o.hasPrevious {
-			fmt.Print("\n]")
+			fmt.Fprint(o.writer, "\n]")
 		} else {
-			fmt.Println("[]")
+			fmt.Fprintln(o.writer, "[]")
 		}
 	}
 }
@@ -81,11 +83,13 @@ func (o *output[T]) Done() {
 func OutputSingle[T any](cmd *cobra.Command) Output[T] {
 	return &output[T]{
 		isSingle: true,
+		writer:   cmd.OutOrStdout(),
 	}
 }
 
 func OutputMultiple[T any](cmd *cobra.Command) Output[T] {
 	return &output[T]{
 		isSingle: false,
+		writer:   cmd.OutOrStdout(),
 	}
 }

--- a/cmd/cli/output_test.go
+++ b/cmd/cli/output_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceOutputRetainsV1Alpha1Envelope(t *testing.T) {
+	connector := connectorschema.NewConnector()
+	connector.Metadata = meta.ObjectMeta{
+		ID:         "cxr_testconnector0001",
+		Name:       common.ResourceName("test-connector"),
+		Namespace:  "root.testing",
+		Generation: 3,
+	}
+	connector.Spec.Definition.DisplayName = "Test connector"
+	connector.Status = &connectorschema.ConnectorStatus{
+		Release: connectorschema.ConnectorReleaseStatus{State: connectorschema.ConnectorReleaseStateActive},
+	}
+
+	var buffer bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buffer)
+	out := OutputMultiple[connectorschema.Connector](cmd)
+	out.Emit(*connector)
+	out.Done()
+
+	var resources []map[string]any
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &resources))
+	require.Len(t, resources, 1)
+	require.Equal(t, "authproxy.net/v1alpha1", resources[0]["apiVersion"])
+	require.Equal(t, "Connector", resources[0]["kind"])
+	require.NotContains(t, resources[0], "id")
+	require.NotContains(t, resources[0], "name")
+
+	metadata, ok := resources[0]["metadata"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "cxr_testconnector0001", metadata["id"])
+	require.Equal(t, "test-connector", metadata["name"])
+	require.Equal(t, "root.testing", metadata["namespace"])
+	require.Equal(t, float64(3), metadata["generation"])
+	require.Contains(t, resources[0], "spec")
+	require.Contains(t, resources[0], "status")
+}

--- a/demos/seed/backend/main.go
+++ b/demos/seed/backend/main.go
@@ -4,7 +4,7 @@
 //
 // Idempotency model: for each desired actor, first GET it by
 // external_id; if AuthProxy returns 404, POST it. For each desired
-// connector, list by the stable demo seed label, create it when absent,
+// connector, list by its namespace/name identity, create it when absent,
 // or publish a new version when the definition changes. Re-running the
 // seed job is a no-op once the state matches.
 //
@@ -37,27 +37,9 @@ import (
 
 // SeedConfig is the YAML shape the binary consumes.
 type SeedConfig struct {
-	Actors             []ActorSeed             `yaml:"actors"`
+	Actors             []actorschema.Actor     `yaml:"actors"`
 	OAuth2TestProvider *OAuth2TestProviderSeed `yaml:"oauth2TestProvider"`
-	Connectors         []ConnectorSeed         `yaml:"connectors"`
-}
-
-type ActorSeed struct {
-	ExternalId  string            `yaml:"externalId"`
-	Namespace   string            `yaml:"namespace,omitempty"`
-	Labels      map[string]string `yaml:"labels,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty"`
-}
-
-type ConnectorSeed struct {
-	// Key is the stable seed identity. AuthProxy generates connector IDs
-	// for API-created connectors, so the seed job stores this key as an
-	// API label and uses it for future idempotent upgrades.
-	Key         string                     `yaml:"key"`
-	Namespace   string                     `yaml:"namespace,omitempty"`
-	Definition  config.ConnectorDefinition `yaml:"definition"`
-	Labels      map[string]string          `yaml:"labels,omitempty"`
-	Annotations map[string]string          `yaml:"annotations,omitempty"`
+	Connectors         []cschema.Connector     `yaml:"connectors"`
 }
 
 type OAuth2TestProviderSeed struct {
@@ -109,8 +91,6 @@ type settings struct {
 const (
 	seedRetryTimeout  = 5 * time.Minute
 	seedRetryInterval = 5 * time.Second
-	seedLabelKey      = "demo.authproxy.net/seed-key"
-	defaultNamespace  = "root"
 )
 
 type seedAction string
@@ -147,6 +127,19 @@ func loadConfig(path string) (*SeedConfig, error) {
 	if err := util.DecodeYAMLStrict(data, &c); err != nil {
 		return nil, fmt.Errorf("parse seed config %q: %w", path, err)
 	}
+	for i := range c.Actors {
+		if err := c.Actors[i].ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+			return nil, fmt.Errorf("validate seed actor %d: %w", i, err)
+		}
+	}
+	for i := range c.Connectors {
+		if err := c.Connectors[i].ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+			return nil, fmt.Errorf("validate seed connector %d: %w", i, err)
+		}
+		if c.Connectors[i].Metadata.Name == "" {
+			return nil, fmt.Errorf("validate seed connector %d: metadata.name is required for idempotent seeding", i)
+		}
+	}
 	return &c, nil
 }
 
@@ -175,15 +168,15 @@ func newSignedClient(s settings) (*resty.Client, error) {
 // upsertActor creates the actor if it doesn't already exist by
 // external_id. Returns true when a create was performed, false on
 // no-op.
-func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, err error) {
+func upsertActor(c *resty.Client, baseUrl string, a actorschema.Actor) (created bool, err error) {
 	// GET by external_id (with optional namespace).
 	getReq := c.R().SetHeader("Accept", "application/json")
-	if a.Namespace != "" {
-		getReq.SetQueryParam("namespace", a.Namespace)
+	if a.Metadata.Namespace != "" {
+		getReq.SetQueryParam("namespace", a.Metadata.Namespace)
 	}
-	getResp, err := getReq.Get(fmt.Sprintf("%s/api/v1/actors/external-id/%s", baseUrl, a.ExternalId))
+	getResp, err := getReq.Get(fmt.Sprintf("%s/api/v1/actors/external-id/%s", baseUrl, a.Spec.ExternalId))
 	if err != nil {
-		return false, fmt.Errorf("GET actor %q: %w", a.ExternalId, err)
+		return false, fmt.Errorf("GET actor %q: %w", a.Spec.ExternalId, err)
 	}
 
 	switch getResp.StatusCode() {
@@ -192,27 +185,18 @@ func upsertActor(c *resty.Client, baseUrl string, a ActorSeed) (created bool, er
 	case http.StatusNotFound:
 		// fall through to create
 	default:
-		return false, fmt.Errorf("GET actor %q returned %d: %s", a.ExternalId, getResp.StatusCode(), getResp.String())
+		return false, fmt.Errorf("GET actor %q returned %d: %s", a.Spec.ExternalId, getResp.StatusCode(), getResp.String())
 	}
 
-	body := actorschema.Actor{
-		TypeMeta: meta.NewTypeMeta(actorschema.ActorKind),
-		Metadata: meta.ObjectMeta{
-			Namespace:   a.Namespace,
-			Labels:      a.Labels,
-			Annotations: a.Annotations,
-		},
-		Spec: actorschema.ActorSpec{ExternalId: a.ExternalId},
-	}
 	postResp, err := c.R().
 		SetHeader("Content-Type", "application/json").
-		SetBody(body).
+		SetBody(a).
 		Post(fmt.Sprintf("%s/api/v1/actors", baseUrl))
 	if err != nil {
-		return false, fmt.Errorf("POST actor %q: %w", a.ExternalId, err)
+		return false, fmt.Errorf("POST actor %q: %w", a.Spec.ExternalId, err)
 	}
 	if postResp.StatusCode() >= 400 {
-		return false, fmt.Errorf("POST actor %q returned %d: %s", a.ExternalId, postResp.StatusCode(), postResp.String())
+		return false, fmt.Errorf("POST actor %q returned %d: %s", a.Spec.ExternalId, postResp.StatusCode(), postResp.String())
 	}
 	return true, nil
 }
@@ -301,32 +285,17 @@ const (
 	connectorUpdated        connectorAction = "updated"
 )
 
-func connectorNamespace(seed ConnectorSeed) string {
-	if seed.Namespace != "" {
-		return seed.Namespace
-	}
-	return defaultNamespace
-}
-
-func connectorLabels(seed ConnectorSeed) map[string]string {
-	labels := make(map[string]string, len(seed.Labels)+1)
-	for k, v := range seed.Labels {
-		labels[k] = v
-	}
-	labels[seedLabelKey] = seed.Key
-	return labels
-}
-
-func connectorDefinitionsEqual(want config.ConnectorDefinition, got cschema.Connector) bool {
+func connectorDefinitionsEqual(want cschema.ConnectorDefinition, got cschema.Connector) bool {
 	return reflect.DeepEqual(normalizeForJSON(want), normalizeForJSON(got.Spec.Definition))
 }
 
-func connectorResourceForSeed(seed ConnectorSeed) cschema.Connector {
-	resource := cschema.NewConnector()
-	resource.Metadata.Namespace = connectorNamespace(seed)
-	resource.Metadata.Labels = connectorLabels(seed)
-	resource.Metadata.Annotations = seed.Annotations
-	resource.Spec.Definition = seed.Definition
+func connectorRequestForSeed(seed cschema.Connector) cschema.Connector {
+	resource := seed.Clone()
+	resource.Metadata.ID = ""
+	resource.Metadata.Generation = 0
+	resource.Metadata.CreatedAt = nil
+	resource.Metadata.UpdatedAt = nil
+	resource.Status = nil
 	return *resource
 }
 
@@ -363,23 +332,26 @@ func normalizeForJSON(v any) any {
 	return out
 }
 
-func listSeededConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*cschema.Connector, error) {
+func listSeededConnector(c *resty.Client, baseUrl string, seed cschema.Connector) (*cschema.Connector, error) {
 	var list api.ListConnectorsResponseJson
 	resp, err := c.R().
 		SetHeader("Accept", "application/json").
-		SetQueryParam("namespace", connectorNamespace(seed)).
-		SetQueryParam("labelSelector", fmt.Sprintf("%s=%s", seedLabelKey, seed.Key)).
-		SetQueryParam("limit", "1").
+		SetQueryParam("namespace", seed.Metadata.Namespace).
+		SetQueryParam("name", string(seed.Metadata.Name)).
+		SetQueryParam("limit", "2").
 		SetResult(&list).
 		Get(fmt.Sprintf("%s/api/v1/connectors", baseUrl))
 	if err != nil {
-		return nil, fmt.Errorf("GET connector seed %q: %w", seed.Key, err)
+		return nil, fmt.Errorf("GET connector seed %q: %w", seed.Metadata.Name, err)
 	}
 	if resp.StatusCode() >= 400 {
-		return nil, fmt.Errorf("GET connector seed %q returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("GET connector seed %q returned %d: %s", seed.Metadata.Name, resp.StatusCode(), resp.String())
 	}
 	if len(list.Items) == 0 {
 		return nil, nil
+	}
+	if len(list.Items) > 1 {
+		return nil, fmt.Errorf("GET connector seed %q returned %d exact-name matches", seed.Metadata.Name, len(list.Items))
 	}
 	return &list.Items[0], nil
 }
@@ -399,8 +371,8 @@ func getConnectorVersion(c *resty.Client, baseUrl string, connector cschema.Conn
 	return &version, nil
 }
 
-func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*cschema.Connector, error) {
-	body := connectorResourceForSeed(seed)
+func createConnector(c *resty.Client, baseUrl string, seed cschema.Connector) (*cschema.Connector, error) {
+	body := connectorRequestForSeed(seed)
 	var created cschema.Connector
 	resp, err := c.R().
 		SetHeader("Content-Type", "application/json").
@@ -408,16 +380,16 @@ func createConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (*csch
 		SetResult(&created).
 		Post(fmt.Sprintf("%s/api/v1/connectors", baseUrl))
 	if err != nil {
-		return nil, fmt.Errorf("POST connector seed %q: %w", seed.Key, err)
+		return nil, fmt.Errorf("POST connector seed %q: %w", seed.Metadata.Name, err)
 	}
 	if resp.StatusCode() >= 400 {
-		return nil, fmt.Errorf("POST connector seed %q returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("POST connector seed %q returned %d: %s", seed.Metadata.Name, resp.StatusCode(), resp.String())
 	}
 	return &created, nil
 }
 
-func createConnectorDraft(c *resty.Client, baseUrl string, connector cschema.Connector, seed ConnectorSeed) (*cschema.Connector, error) {
-	body := connectorResourceForSeed(seed)
+func createConnectorDraft(c *resty.Client, baseUrl string, connector cschema.Connector, seed cschema.Connector) (*cschema.Connector, error) {
+	body := connectorRequestForSeed(seed)
 	body.Metadata.Name = connector.Metadata.Name
 	var created cschema.Connector
 	resp, err := c.R().
@@ -426,10 +398,10 @@ func createConnectorDraft(c *resty.Client, baseUrl string, connector cschema.Con
 		SetResult(&created).
 		Post(fmt.Sprintf("%s/api/v1/connectors/%s/versions", baseUrl, connector.GetId()))
 	if err != nil {
-		return nil, fmt.Errorf("POST connector seed %q version: %w", seed.Key, err)
+		return nil, fmt.Errorf("POST connector seed %q version: %w", seed.Metadata.Name, err)
 	}
 	if resp.StatusCode() >= 400 {
-		return nil, fmt.Errorf("POST connector seed %q version returned %d: %s", seed.Key, resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("POST connector seed %q version returned %d: %s", seed.Metadata.Name, resp.StatusCode(), resp.String())
 	}
 	return &created, nil
 }
@@ -448,9 +420,9 @@ func forceConnectorPrimary(c *resty.Client, baseUrl string, version cschema.Conn
 	return nil
 }
 
-func upsertConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (connectorAction, error) {
-	if seed.Key == "" {
-		return "", fmt.Errorf("connector seed key is required")
+func upsertConnector(c *resty.Client, baseUrl string, seed cschema.Connector) (connectorAction, error) {
+	if seed.Metadata.Name == "" {
+		return "", fmt.Errorf("connector seed metadata.name is required")
 	}
 
 	existing, err := listSeededConnector(c, baseUrl, seed)
@@ -476,9 +448,9 @@ func upsertConnector(c *resty.Client, baseUrl string, seed ConnectorSeed) (conne
 		return "", err
 	}
 
-	if connectorDefinitionsEqual(seed.Definition, *version) &&
-		stringMapsEqual(connectorLabels(seed), version.Metadata.Labels) &&
-		stringMapsEqual(seed.Annotations, version.Metadata.Annotations) {
+	if connectorDefinitionsEqual(seed.Spec.Definition, *version) &&
+		stringMapsEqual(seed.Metadata.Labels, version.Metadata.Labels) &&
+		stringMapsEqual(seed.Metadata.Annotations, version.Metadata.Annotations) {
 		if connectorObservedState(*version) != cschema.ConnectorReleaseStatePrimary {
 			if err := forceConnectorPrimary(c, baseUrl, *version); err != nil {
 				return "", err
@@ -519,20 +491,20 @@ func run(logger *slog.Logger) error {
 				break
 			}
 			if time.Now().After(deadline) {
-				return fmt.Errorf("upsert actor %q after %s: %w", a.ExternalId, seedRetryTimeout, err)
+				return fmt.Errorf("upsert actor %q after %s: %w", a.Spec.ExternalId, seedRetryTimeout, err)
 			}
 			logger.Warn("actor seed attempt failed; retrying",
-				"external_id", a.ExternalId,
-				"namespace", a.Namespace,
+				"external_id", a.Spec.ExternalId,
+				"namespace", a.Metadata.Namespace,
 				"attempt", attempt,
 				"err", err,
 			)
 			time.Sleep(seedRetryInterval)
 		}
 		if created {
-			logger.Info("actor created", "external_id", a.ExternalId, "namespace", a.Namespace)
+			logger.Info("actor created", "external_id", a.Spec.ExternalId, "namespace", a.Metadata.Namespace)
 		} else {
-			logger.Info("actor already present", "external_id", a.ExternalId, "namespace", a.Namespace)
+			logger.Info("actor already present", "external_id", a.Spec.ExternalId, "namespace", a.Metadata.Namespace)
 		}
 	}
 
@@ -571,11 +543,11 @@ func run(logger *slog.Logger) error {
 				break
 			}
 			if time.Now().After(deadline) {
-				return fmt.Errorf("upsert connector %q after %s: %w", connector.Key, seedRetryTimeout, err)
+				return fmt.Errorf("upsert connector %q after %s: %w", connector.Metadata.Name, seedRetryTimeout, err)
 			}
 			logger.Warn("connector seed attempt failed; retrying",
-				"key", connector.Key,
-				"namespace", connectorNamespace(connector),
+				"name", connector.Metadata.Name,
+				"namespace", connector.Metadata.Namespace,
 				"attempt", attempt,
 				"err", err,
 			)
@@ -584,11 +556,11 @@ func run(logger *slog.Logger) error {
 
 		switch action {
 		case connectorCreated:
-			logger.Info("connector created", "key", connector.Key, "namespace", connectorNamespace(connector))
+			logger.Info("connector created", "name", connector.Metadata.Name, "namespace", connector.Metadata.Namespace)
 		case connectorUpdated:
-			logger.Info("connector updated", "key", connector.Key, "namespace", connectorNamespace(connector))
+			logger.Info("connector updated", "name", connector.Metadata.Name, "namespace", connector.Metadata.Namespace)
 		case connectorAlreadyPresent:
-			logger.Info("connector already present", "key", connector.Key, "namespace", connectorNamespace(connector))
+			logger.Info("connector already present", "name", connector.Metadata.Name, "namespace", connector.Metadata.Namespace)
 		}
 	}
 	return nil

--- a/demos/seed/backend/main_test.go
+++ b/demos/seed/backend/main_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -15,6 +17,7 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
 var testConnectorID = apid.MustParse("cxr_testgmail0000001")
@@ -22,32 +25,26 @@ var testConnectorID = apid.MustParse("cxr_testgmail0000001")
 const testBaseURL = "http://seed.test"
 
 func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
-	seed := ConnectorSeed{
-		Key:        "demo-noauth",
-		Definition: mustConnector(t, "Demo NoAuth"),
-		Labels: map[string]string{
-			"demo": "true",
-		},
-	}
+	seed := seedConnector(t, "demo-noauth", "Demo NoAuth")
 
 	forcedPrimary := false
 	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
 		case "GET /api/v1/connectors":
-			require.Equal(t, defaultNamespace, r.URL.Query().Get("namespace"))
-			require.Equal(t, seedLabelKey+"=demo-noauth", r.URL.Query().Get("labelSelector"))
+			require.Equal(t, "root", r.URL.Query().Get("namespace"))
+			require.Equal(t, "demo-noauth", r.URL.Query().Get("name"))
 			writeJSON(t, w, api.NewListConnectorsResponseJson(nil, ""))
 		case "POST /api/v1/connectors":
 			var req cschema.Connector
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			require.Equal(t, defaultNamespace, req.Metadata.Namespace)
+			require.Equal(t, "root", req.Metadata.Namespace)
+			require.Equal(t, "demo-noauth", string(req.Metadata.Name))
 			require.Equal(t, "Demo NoAuth", req.Spec.Definition.DisplayName)
-			require.Equal(t, "demo-noauth", req.Metadata.Labels[seedLabelKey])
 			require.Equal(t, "true", req.Metadata.Labels["demo"])
 			writeJSON(t, w, connectorVersion(req.Spec.Definition, req.Metadata.Labels, cschema.ConnectorReleaseStateDraft, 1))
 		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/1/_forceState":
 			forcedPrimary = true
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(seed.Spec.Definition, seed.Metadata.Labels, cschema.ConnectorReleaseStatePrimary, 1))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -60,14 +57,7 @@ func TestUpsertConnectorCreatesAndPublishesMissingSeed(t *testing.T) {
 }
 
 func TestUpsertConnectorSkipsMatchingPrimarySeed(t *testing.T) {
-	seed := ConnectorSeed{
-		Key:        "demo-noauth",
-		Namespace:  "root",
-		Definition: mustConnector(t, "Demo NoAuth"),
-		Labels: map[string]string{
-			"demo": "true",
-		},
-	}
+	seed := seedConnector(t, "demo-noauth", "Demo NoAuth")
 
 	client := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
@@ -83,7 +73,7 @@ func TestUpsertConnectorSkipsMatchingPrimarySeed(t *testing.T) {
 				"", // continueToken
 			))
 		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(seed.Spec.Definition, seed.Metadata.Labels, cschema.ConnectorReleaseStatePrimary, 1))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -95,11 +85,7 @@ func TestUpsertConnectorSkipsMatchingPrimarySeed(t *testing.T) {
 }
 
 func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
-	seed := ConnectorSeed{
-		Key:        "demo-noauth",
-		Namespace:  "root",
-		Definition: mustConnector(t, "New Demo NoAuth"),
-	}
+	seed := seedConnector(t, "demo-noauth", "New Demo NoAuth")
 	oldDefinition := mustConnector(t, "Old Demo NoAuth")
 	forcedPrimary := false
 
@@ -111,17 +97,16 @@ func TestUpsertConnectorPublishesNewVersionWhenDefinitionChanges(t *testing.T) {
 				"",
 			))
 		case "GET /api/v1/connectors/cxr_testgmail0000001/versions/1":
-			writeJSON(t, w, connectorVersion(oldDefinition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 1))
+			writeJSON(t, w, connectorVersion(oldDefinition, seed.Metadata.Labels, cschema.ConnectorReleaseStatePrimary, 1))
 		case "POST /api/v1/connectors/cxr_testgmail0000001/versions":
 			var req cschema.Connector
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			require.Equal(t, "New Demo NoAuth", req.Spec.Definition.DisplayName)
 			require.NotNil(t, req.Metadata.Labels)
-			require.Equal(t, "demo-noauth", req.Metadata.Labels[seedLabelKey])
 			writeJSON(t, w, connectorVersion(req.Spec.Definition, req.Metadata.Labels, cschema.ConnectorReleaseStateDraft, 2))
 		case "PUT /api/v1/connectors/cxr_testgmail0000001/versions/2/_forceState":
 			forcedPrimary = true
-			writeJSON(t, w, connectorVersion(seed.Definition, connectorLabels(seed), cschema.ConnectorReleaseStatePrimary, 2))
+			writeJSON(t, w, connectorVersion(seed.Spec.Definition, seed.Metadata.Labels, cschema.ConnectorReleaseStatePrimary, 2))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
 		}
@@ -219,6 +204,63 @@ func TestPostOAuth2TestProviderTreatsDuplicateAsAlreadyPresent(t *testing.T) {
 	}
 }
 
+func TestDeploymentSeedConfigsContainCanonicalResources(t *testing.T) {
+	for _, overlay := range []string{"demo", "dev"} {
+		t.Run(overlay, func(t *testing.T) {
+			manifestData, err := os.ReadFile(filepath.Join(
+				"..", "..", "..", "deploy", "kustomize", "authproxy-demo", "overlays", overlay, "seed", "seed-config.yaml",
+			))
+			require.NoError(t, err)
+
+			var manifest struct {
+				APIVersion string `yaml:"apiVersion"`
+				Kind       string `yaml:"kind"`
+				Metadata   struct {
+					Name string `yaml:"name"`
+				} `yaml:"metadata"`
+				Data map[string]string `yaml:"data"`
+			}
+			require.NoError(t, util.DecodeYAMLStrict(manifestData, &manifest))
+			require.Equal(t, "v1", manifest.APIVersion)
+			require.Equal(t, "ConfigMap", manifest.Kind)
+
+			seedPath := filepath.Join(t.TempDir(), "seed.yaml")
+			require.NoError(t, os.WriteFile(seedPath, []byte(manifest.Data["seed.yaml"]), 0o600))
+			cfg, err := loadConfig(seedPath)
+			require.NoError(t, err)
+			require.NotEmpty(t, cfg.Actors)
+			require.NotEmpty(t, cfg.Connectors)
+			for _, actor := range cfg.Actors {
+				require.Equal(t, "authproxy.net/v1alpha1", string(actor.APIVersion))
+				require.Equal(t, "Actor", string(actor.Kind))
+			}
+			for _, connector := range cfg.Connectors {
+				require.Equal(t, "authproxy.net/v1alpha1", string(connector.APIVersion))
+				require.Equal(t, "Connector", string(connector.Kind))
+			}
+		})
+	}
+}
+
+func TestLoadConfigRejectsLegacyFlatResources(t *testing.T) {
+	seedPath := filepath.Join(t.TempDir(), "seed.yaml")
+	require.NoError(t, os.WriteFile(seedPath, []byte(`
+actors:
+  - externalId: demo-admin
+    namespace: root
+connectors:
+  - key: demo-noauth
+    namespace: root
+    definition:
+      displayName: Demo NoAuth
+      auth:
+        type: no-auth
+`), 0o600))
+
+	_, err := loadConfig(seedPath)
+	require.ErrorContains(t, err, "parse seed config")
+}
+
 func TestSeedConfigParsesOAuthConnectorSetupVariants(t *testing.T) {
 	data := []byte(`
 oauth2TestProvider:
@@ -233,51 +275,57 @@ oauth2TestProvider:
     - username: demo-oauth-user@example.test
       password: demo-password
 connectors:
-  - key: demo-oauth-tenant
-    namespace: root
-    definition:
-      displayName: Demo OAuth Tenant
-      description: Demo OAuth connector with pre-connect config
+  - apiVersion: authproxy.net/v1alpha1
+    kind: Connector
+    metadata:
+      name: demo-oauth-tenant
+      namespace: root
       labels:
         type: demo-oauth-tenant
-      auth:
-        type: OAuth2
-        clientId: demo-oauth-tenant
-        clientSecret: demo-oauth-tenant-secret
-        authorization:
-          endpoint: https://example.test/oauth2/web/authorize
-          queryOverrides:
-            tenant: "{{cfg.tenant}}"
-        token:
-          endpoint: http://go-oauth2-server/v1/oauth/tokens
-        scopes:
-          - id: read
-            reason: Read demo data
-      setupFlow:
-        preconnect:
-          steps:
-            - id: tenant
-              title: Choose tenant
-              jsonSchema:
-                type: object
-                required:
-                  - tenant
-                properties:
-                  tenant:
-                    type: string
-              uiSchema:
-                type: VerticalLayout
-                elements:
-                  - type: Control
-                    scope: "#/properties/tenant"
+    spec:
+      release:
+        desiredState: primary
+      definition:
+        displayName: Demo OAuth Tenant
+        description: Demo OAuth connector with pre-connect config
+        auth:
+          type: OAuth2
+          clientId: demo-oauth-tenant
+          clientSecret: demo-oauth-tenant-secret
+          authorization:
+            endpoint: https://example.test/oauth2/web/authorize
+            queryOverrides:
+              tenant: "{{cfg.tenant}}"
+          token:
+            endpoint: http://go-oauth2-server/v1/oauth/tokens
+          scopes:
+            - id: read
+              reason: Read demo data
+        setupFlow:
+          preconnect:
+            steps:
+              - id: tenant
+                title: Choose tenant
+                jsonSchema:
+                  type: object
+                  required:
+                    - tenant
+                  properties:
+                    tenant:
+                      type: string
+                uiSchema:
+                  type: VerticalLayout
+                  elements:
+                    - type: Control
+                      scope: "#/properties/tenant"
 `)
 	var cfg SeedConfig
 	require.NoError(t, yaml.Unmarshal(data, &cfg))
 	require.NotNil(t, cfg.OAuth2TestProvider)
 	require.Len(t, cfg.OAuth2TestProvider.Clients, 1)
 	require.Len(t, cfg.Connectors, 1)
-	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
-	require.True(t, cfg.Connectors[0].Definition.SetupFlow.HasPreconnect())
+	require.NoError(t, cfg.Connectors[0].Spec.Definition.Validate(&common.ValidationContext{}))
+	require.True(t, cfg.Connectors[0].Spec.Definition.SetupFlow.HasPreconnect())
 }
 
 func TestSeedConfigParsesAPIKeyConnector(t *testing.T) {
@@ -289,29 +337,35 @@ oauth2TestProvider:
       key: demo-api-key
       placement: bearer
 connectors:
-  - key: demo-api-key
-    namespace: root
-    definition:
-      displayName: Demo API Key
-      description: Demo API key connector
+  - apiVersion: authproxy.net/v1alpha1
+    kind: Connector
+    metadata:
+      name: demo-api-key
+      namespace: root
       labels:
         type: demo-api-key
-      auth:
-        type: api-key
-        placement:
-          type: bearer
-      probes:
-        - id: verify-api-key
-          proxyHttp:
-            method: GET
-            url: http://go-oauth2-server/test/api-key-resource/demo-api-key
+    spec:
+      release:
+        desiredState: primary
+      definition:
+        displayName: Demo API Key
+        description: Demo API key connector
+        auth:
+          type: api-key
+          placement:
+            type: bearer
+        probes:
+          - id: verify-api-key
+            proxyHttp:
+              method: GET
+              url: http://go-oauth2-server/test/api-key-resource/demo-api-key
 `)
 	var cfg SeedConfig
 	require.NoError(t, yaml.Unmarshal(data, &cfg))
 	require.NotNil(t, cfg.OAuth2TestProvider)
 	require.Len(t, cfg.OAuth2TestProvider.APIKeyResourcePolicies, 1)
 	require.Len(t, cfg.Connectors, 1)
-	require.NoError(t, cfg.Connectors[0].Definition.Validate(&common.ValidationContext{}))
+	require.NoError(t, cfg.Connectors[0].Spec.Definition.Validate(&common.ValidationContext{}))
 }
 
 func mustConnector(t *testing.T, displayName string) config.ConnectorDefinition {
@@ -330,15 +384,26 @@ auth:
 	return connector
 }
 
-func connectorSummary(seed ConnectorSeed, state cschema.ConnectorReleaseState, version uint64) cschema.Connector {
-	return connectorVersion(seed.Definition, connectorLabels(seed), state, version)
+func seedConnector(t *testing.T, name, displayName string) cschema.Connector {
+	t.Helper()
+	resource := cschema.NewConnector()
+	resource.Metadata.Name = common.ResourceName(name)
+	resource.Metadata.Namespace = "root"
+	resource.Metadata.Labels = map[string]string{"demo": "true"}
+	resource.Spec.Release.DesiredState = cschema.ConnectorReleaseStatePrimary
+	resource.Spec.Definition = mustConnector(t, displayName)
+	return *resource
+}
+
+func connectorSummary(seed cschema.Connector, state cschema.ConnectorReleaseState, version uint64) cschema.Connector {
+	return connectorVersion(seed.Spec.Definition, seed.Metadata.Labels, state, version)
 }
 
 func connectorVersion(def config.ConnectorDefinition, labels map[string]string, state cschema.ConnectorReleaseState, version uint64) cschema.Connector {
 	resource := cschema.NewConnector()
 	resource.Metadata.ID = testConnectorID.String()
 	resource.Metadata.Name = "demo-noauth"
-	resource.Metadata.Namespace = defaultNamespace
+	resource.Metadata.Namespace = "root"
 	resource.Metadata.Generation = version
 	resource.Metadata.Labels = labels
 	resource.Spec.Release.DesiredState = cschema.DesiredReleaseStateForObserved(state)

--- a/deploy/kustomize/authproxy-demo/README.md
+++ b/deploy/kustomize/authproxy-demo/README.md
@@ -66,3 +66,14 @@ Seeding is intentionally not part of the Kustomize deployment apply. Run the
 on demand; it renders `overlays/demo/seed` and applies the resulting Job.
 Dev seeding will be run by the per-branch deploy workflow after the environment
 is applied.
+
+The seed ConfigMaps contain complete `authproxy.net/v1alpha1` `Actor` and
+`Connector` resources. Connector seed identity is its exact
+`metadata.namespace` and `metadata.name`; labels are ordinary resource
+metadata. The seed binary rejects the former flat actor and connector forms.
+
+There is deliberately no conversion job for environments populated with the
+former connector-definition format. At this pre-production API boundary,
+delete the disposable demo/dev environment and its data, redeploy it, and then
+run the seed workflow. Do not run the new seed job against legacy persisted
+data.

--- a/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/demo/seed/seed-config.yaml
@@ -5,145 +5,183 @@ metadata:
 data:
   seed.yaml: |
     actors:
-      - externalId: demo-admin
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: demo-admin
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: admin
-      - externalId: demo-user
+      spec:
+        externalId: demo-admin
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: demo-user
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: user
-      - externalId: fresh-user
+      spec:
+        externalId: demo-user
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: fresh-user
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: user
-      - externalId: grafana
+      spec:
+        externalId: fresh-user
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: grafana
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: datasource
+      spec:
+        externalId: grafana
     oauth2TestProvider:
       apiKeyResourcePolicies:
-        - key: demo-api-key
-          path: /test/api-key-resource/demo-api-key
-          placement: bearer
+      - key: demo-api-key
+        path: "/test/api-key-resource/demo-api-key"
+        placement: bearer
       baseUrl: http://demo-go-oauth2-server
       clients:
-        - key: demo-oauth-simple
-          redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-simple-secret
-          tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-tenant
-          redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-tenant-secret
-          tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-configure
-          redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-configure-secret
-          tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-simple
+        redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-simple-secret
+        tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-tenant
+        redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-tenant-secret
+        tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-configure
+        redirectUri: https://marketplace.demo.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-configure-secret
+        tokenEndpointAuthMethod: client_secret_post
       resourcePolicies:
-        - path: /test/resource/demo-resources
-          requiredScope: resources
+      - path: "/test/resource/demo-resources"
+        requiredScope: resources
       users:
-        - displayName: Demo OAuth User
-          email: demo-oauth-user@example.test
-          password: demo-password
-          sub: demo-oauth-user
-          username: demo-oauth-user@example.test
+      - displayName: Demo OAuth User
+        email: demo-oauth-user@example.test
+        password: demo-password
+        sub: demo-oauth-user
+        username: demo-oauth-user@example.test
     connectors:
-      - definition:
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-readme-noauth
+        namespace: root
+        labels:
+          auth_method: no_auth
+          demo: 'true'
+          showcase: catalog
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             type: no-auth
-          description: "This connector is intentionally simple: it demonstrates that the
-            demo-seed job can publish connector definitions into the Marketplace
-            catalog during install and upgrade. Follow-up demo connectors show
-            OAuth, API key auth, pre-connect tenant selection, and post-connect
-            configuration."
+          description: 'This connector is intentionally simple: it demonstrates that the
+            demo-seed job can publish connector definitions into the Marketplace catalog
+            during install and upgrade. Follow-up demo connectors show OAuth, API key
+            auth, pre-connect tenant selection, and post-connect configuration.'
           displayName: Demo README Resource
           highlight: A no-auth catalog entry used to verify demo seeding.
-          labels:
-            demo: "true"
-            type: demo-readme-noauth
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJEZW1vIFJFQURNRSBSZXNvdXJjZSBsb2dvIj48cmVjdCB3aWR0aD0iMjgwIiBoZWlnaHQ9IjE0MCIgcng9IjEyIiBmaWxsPSIjMEIzRDJFIi8+PHBhdGggZD0iTTYyIDk2VjQ0aDM1YzE3IDAgMjggMTAgMjggMjZzLTExIDI2LTI4IDI2SDYyWm0yMC0xN2gxNGM2IDAgMTAtMyAxMC05cy00LTktMTAtOUg4MnYxOFptNjQgMTdWNDRoMjB2MzVoMzV2MTdoLTU1WiIgZmlsbD0iI0ZGRkZGRiIvPjwvc3ZnPg==
             mimeType: image/svg+xml
-        key: demo-readme-noauth
-        labels:
-          auth_method: no_auth
-          demo: "true"
-          showcase: catalog
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-api-key-bearer
         namespace: root
-      - definition:
+        labels:
+          auth_method: api-key
+          demo: 'true'
+          showcase: api-key
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             placement:
               type: bearer
             type: api-key
-          description: "This connector demonstrates AuthProxy API-key setup and proxying.
-            Enter `demo-api-key` when prompted; it is an intentionally fake key
-            accepted only by the demo provider. AuthProxy stores the key as an
-            encrypted credential, injects it as `Authorization: Bearer demo-api-key`
-            on proxy requests, and verifies it with a probe so wrong keys are easy
-            to spot."
-          displayName: "Demo API Key: Bearer Token"
+          description: 'This connector demonstrates AuthProxy API-key setup and proxying.
+            Enter `demo-api-key` when prompted; it is an intentionally fake key accepted
+            only by the demo provider. AuthProxy stores the key as an encrypted credential,
+            injects it as `Authorization: Bearer demo-api-key` on proxy requests, and
+            verifies it with a probe so wrong keys are easy to spot.'
+          displayName: 'Demo API Key: Bearer Token'
           highlight: Creates a connection from a static demo API key.
-          labels:
-            demo: "true"
-            type: demo-api-key-bearer
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJBUEkgS2V5IERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iI0M4NDYzMCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTExNiA3MGg3NG0tMjAtMTYgMTYgMTYtMTYgMTYiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5BSzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           probes:
-            - failureThreshold: 1
-              id: verify-api-key
-              proxyHttp:
-                method: GET
-                url: http://demo-go-oauth2-server/test/api-key-resource/demo-api-key
-        key: demo-api-key-bearer
-        labels:
-          auth_method: api-key
-          demo: "true"
-          showcase: api-key
+          - failureThreshold: 1
+            id: verify-api-key
+            proxyHttp:
+              method: GET
+              url: http://demo-go-oauth2-server/test/api-key-resource/demo-api-key
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-simple
         namespace: root
-      - definition:
+        labels:
+          auth_method: oauth2
+          demo: 'true'
+          showcase: simple-oauth
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
             clientId: demo-oauth-simple
             clientSecret: demo-oauth-simple-secret
             scopes:
-              - id: read
-                reason: Read basic profile information from the demo provider.
-              - id: profile
-                reason: Show how connectors explain why each requested OAuth scope is needed.
+            - id: read
+              reason: Read basic profile information from the demo provider.
+            - id: profile
+              reason: Show how connectors explain why each requested OAuth scope is needed.
             token:
               endpoint: http://demo-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
-          description: "This connector demonstrates AuthProxy's simplest OAuth path: the
-            user clicks Connect, approves access in the demo OAuth provider, and
-            AuthProxy stores the resulting tokens for proxy requests. Use provider
-            username `demo-oauth-user@example.test` and password `demo-password`
-            when the consent screen asks you to sign in."
-          displayName: "Demo OAuth: Basic Authorization"
+          description: 'This connector demonstrates AuthProxy''s simplest OAuth path:
+            the user clicks Connect, approves access in the demo OAuth provider, and AuthProxy
+            stores the resulting tokens for proxy requests. Use provider username `demo-oauth-user@example.test`
+            and password `demo-password` when the consent screen asks you to sign in.'
+          displayName: 'Demo OAuth: Basic Authorization'
           highlight: A plain OAuth authorization-code connection with no extra setup.
-          labels:
-            demo: "true"
-            type: demo-oauth-simple
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJTdHJhaWdodCBPQXV0aCBEZW1vIGxvZ28iPjxyZWN0IHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiByeD0iMTIiIGZpbGw9IiMxNjVERkYiLz48Y2lyY2xlIGN4PSI3NiIgY3k9IjcwIiByPSIzNCIgZmlsbD0icmdiYSgyNTUsMjU1LDI1NSwwLjE4KSIvPjxwYXRoIGQ9Ik0xOTAgNDhjMTIgMCAyMiAxMCAyMiAyMnMtMTAgMjItMjIgMjJoLTQ4Yy0xMiAwLTIyLTEwLTIyLTIyczEwLTIyIDIyLTIyaDQ4Wm0tNDggMTZhNiA2IDAgMCAwIDAgMTJoNDhhNiA2IDAgMCAwIDAtMTJoLTQ4WiIgZmlsbD0iI2ZmZiIgb3BhY2l0eT0iMC45NSIvPjx0ZXh0IHg9Ijc2IiB5PSI4MiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iI2ZmZiIgZm9udC1mYW1pbHk9IkludGVyLCBBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIzNCIgZm9udC13ZWlnaHQ9IjgwMCI+U088L3RleHQ+PC9zdmc+
             mimeType: image/svg+xml
-        key: demo-oauth-simple
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-tenant
+        namespace: root
         labels:
           auth_method: oauth2
-          demo: "true"
-          showcase: simple-oauth
-        namespace: root
-      - definition:
+          demo: 'true'
+          showcase: preconnect
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
@@ -152,125 +190,120 @@ data:
             clientId: demo-oauth-tenant
             clientSecret: demo-oauth-tenant-secret
             scopes:
-              - id: read
-                reason: Read access after the selected tenant has authorized the app.
-              - id: profile
-                reason: Display which demo user approved the tenant-scoped connection.
+            - id: read
+              reason: Read access after the selected tenant has authorized the app.
+            - id: profile
+              reason: Display which demo user approved the tenant-scoped connection.
             token:
               endpoint: http://demo-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
-          description: This connector demonstrates pre-connect setup. AuthProxy asks for a
-            pretend tenant before redirecting to OAuth, then makes that value
-            available to OAuth endpoint templates. In a real connector this pattern
-            selects the customer's regional login host or tenant-specific
-            authorization parameters before credentials are requested.
-          displayName: "Demo OAuth: Tenant Selection"
+          description: This connector demonstrates pre-connect setup. AuthProxy asks for
+            a pretend tenant before redirecting to OAuth, then makes that value available
+            to OAuth endpoint templates. In a real connector this pattern selects the
+            customer's regional login host or tenant-specific authorization parameters
+            before credentials are requested.
+          displayName: 'Demo OAuth: Tenant Selection'
           highlight: Collects a pretend tenant before starting OAuth.
-          labels:
-            demo: "true"
-            type: demo-oauth-tenant
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJUZW5hbnQgU2VsZWN0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzdBM0U5RCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5UUzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           setupFlow:
             preconnect:
               steps:
-                - description: This pre-connect step runs before OAuth. The value is saved into
-                    connection configuration and can be used to shape
-                    provider-specific OAuth URLs.
-                  id: tenant
-                  jsonSchema:
-                    properties:
-                      tenant:
-                        description: Try `northwind`, `globex`, or any short tenant slug. The demo
-                          provider accepts all values; the field exists to show
-                          pre-auth configuration.
-                        minLength: 2
-                        title: Demo tenant
-                        type: string
-                    required:
-                      - tenant
-                    type: object
-                  title: Choose a pretend tenant
-                  uiSchema:
-                    elements:
-                      - scope: "#/properties/tenant"
-                        type: Control
-                    type: VerticalLayout
-        key: demo-oauth-tenant
+              - description: This pre-connect step runs before OAuth. The value is saved
+                  into connection configuration and can be used to shape provider-specific
+                  OAuth URLs.
+                id: tenant
+                jsonSchema:
+                  properties:
+                    tenant:
+                      description: Try `northwind`, `globex`, or any short tenant slug.
+                        The demo provider accepts all values; the field exists to show
+                        pre-auth configuration.
+                      minLength: 2
+                      title: Demo tenant
+                      type: string
+                  required:
+                  - tenant
+                  type: object
+                title: Choose a pretend tenant
+                uiSchema:
+                  elements:
+                  - scope: "#/properties/tenant"
+                    type: Control
+                  type: VerticalLayout
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-configure
+        namespace: root
         labels:
           auth_method: oauth2
-          demo: "true"
-          showcase: preconnect
-        namespace: root
-      - definition:
+          demo: 'true'
+          showcase: postconnect-configure
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.demo.authproxy.net/web/authorize
             clientId: demo-oauth-configure
             clientSecret: demo-oauth-configure-secret
             scopes:
-              - id: read
-                reason: Complete the OAuth flow against the demo provider.
-              - id: resources
-                reason: Fetch the pretend resource list used by the post-connect configuration
-                  step.
+            - id: read
+              reason: Complete the OAuth flow against the demo provider.
+            - id: resources
+              reason: Fetch the pretend resource list used by the post-connect configuration
+                step.
             token:
               endpoint: http://demo-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
           description: This connector demonstrates post-connect configuration. After OAuth
-            succeeds, AuthProxy calls a demo provider resource endpoint through the
-            new connection and turns the response into selectable pretend resources.
-            This is the pattern for connectors that must discover workspaces,
-            projects, calendars, or folders after credentials exist.
-          displayName: "Demo OAuth: Resource Configuration"
-          highlight: Uses OAuth first, then fetches configuration choices through the proxy.
-          labels:
-            demo: "true"
-            type: demo-oauth-configure
+            succeeds, AuthProxy calls a demo provider resource endpoint through the new
+            connection and turns the response into selectable pretend resources. This
+            is the pattern for connectors that must discover workspaces, projects, calendars,
+            or folders after credentials exist.
+          displayName: 'Demo OAuth: Resource Configuration'
+          highlight: Uses OAuth first, then fetches configuration choices through the
+            proxy.
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJSZXNvdXJjZSBDb25maWd1cmF0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzBCN0E1QSIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5SQzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           setupFlow:
             configure:
               steps:
-                - dataSources:
-                    demoResources:
-                      proxyRequest:
-                        headers:
-                          Accept: application/json
-                        method: GET
-                        url: http://demo-go-oauth2-server/test/resource/demo-resources
-                      transform: "Array.isArray(data.resources) ? data.resources.map(r => ({ value:
-                        r.id || r.value, label: r.name || r.label || r.id || r.value
-                        })) : [{ value: 'project-alpha', label: 'Project Alpha
-                        (demo)' }, { value: 'workspace-north', label: 'North
-                        Workspace (demo)' }, { value: 'reports-folder', label:
-                        'Reports Folder (demo)' }]"
-                  description: This post-connect step is populated by a data source request
-                    through the authenticated proxy. The options stand in for
-                    provider resources such as projects, calendars, or workspaces.
-                  id: select_resource
-                  jsonSchema:
-                    properties:
-                      resource_id:
-                        description: Options are loaded after OAuth using the new connection's
-                          credentials.
-                        title: Demo resource
-                        type: string
-                        x-data-source: demo_resources
-                    required:
-                      - resource_id
-                    type: object
-                  title: Select a pretend resource
-                  uiSchema:
-                    elements:
-                      - scope: "#/properties/resource_id"
-                        type: Control
-                    type: VerticalLayout
-        key: demo-oauth-configure
-        labels:
-          auth_method: oauth2
-          demo: "true"
-          showcase: postconnect-configure
-        namespace: root
+              - dataSources:
+                  demoResources:
+                    proxyRequest:
+                      headers:
+                        Accept: application/json
+                      method: GET
+                      url: http://demo-go-oauth2-server/test/resource/demo-resources
+                    transform: 'Array.isArray(data.resources) ? data.resources.map(r =>
+                      ({ value: r.id || r.value, label: r.name || r.label || r.id || r.value
+                      })) : [{ value: ''project-alpha'', label: ''Project Alpha (demo)''
+                      }, { value: ''workspace-north'', label: ''North Workspace (demo)''
+                      }, { value: ''reports-folder'', label: ''Reports Folder (demo)''
+                      }]'
+                description: This post-connect step is populated by a data source request
+                  through the authenticated proxy. The options stand in for provider resources
+                  such as projects, calendars, or workspaces.
+                id: select_resource
+                jsonSchema:
+                  properties:
+                    resource_id:
+                      description: Options are loaded after OAuth using the new connection's
+                        credentials.
+                      title: Demo resource
+                      type: string
+                      x-data-source: demo_resources
+                  required:
+                  - resource_id
+                  type: object
+                title: Select a pretend resource
+                uiSchema:
+                  elements:
+                  - scope: "#/properties/resource_id"
+                    type: Control
+                  type: VerticalLayout

--- a/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
+++ b/deploy/kustomize/authproxy-demo/overlays/dev/seed/seed-config.yaml
@@ -5,145 +5,183 @@ metadata:
 data:
   seed.yaml: |
     actors:
-      - externalId: demo-admin
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: demo-admin
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: admin
-      - externalId: demo-user
+      spec:
+        externalId: demo-admin
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: demo-user
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: user
-      - externalId: fresh-user
+      spec:
+        externalId: demo-user
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: fresh-user
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: user
-      - externalId: grafana
+      spec:
+        externalId: fresh-user
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Actor
+      metadata:
+        name: grafana
         namespace: root
         labels:
-          demo: "true"
+          demo: 'true'
           role: datasource
+      spec:
+        externalId: grafana
     oauth2TestProvider:
       apiKeyResourcePolicies:
-        - key: demo-api-key
-          path: /test/api-key-resource/demo-api-key
-          placement: bearer
+      - key: demo-api-key
+        path: "/test/api-key-resource/demo-api-key"
+        placement: bearer
       baseUrl: http://dev-go-oauth2-server
       clients:
-        - key: demo-oauth-simple
-          redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-simple-secret
-          tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-tenant
-          redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-tenant-secret
-          tokenEndpointAuthMethod: client_secret_post
-        - key: demo-oauth-configure
-          redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
-          scope: read profile resources
-          secret: demo-oauth-configure-secret
-          tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-simple
+        redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-simple-secret
+        tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-tenant
+        redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-tenant-secret
+        tokenEndpointAuthMethod: client_secret_post
+      - key: demo-oauth-configure
+        redirectUri: https://marketplace.branch.dev.authproxy.net/oauth2/callback
+        scope: read profile resources
+        secret: demo-oauth-configure-secret
+        tokenEndpointAuthMethod: client_secret_post
       resourcePolicies:
-        - path: /test/resource/demo-resources
-          requiredScope: resources
+      - path: "/test/resource/demo-resources"
+        requiredScope: resources
       users:
-        - displayName: Demo OAuth User
-          email: demo-oauth-user@example.test
-          password: demo-password
-          sub: demo-oauth-user
-          username: demo-oauth-user@example.test
+      - displayName: Demo OAuth User
+        email: demo-oauth-user@example.test
+        password: demo-password
+        sub: demo-oauth-user
+        username: demo-oauth-user@example.test
     connectors:
-      - definition:
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-readme-noauth
+        namespace: root
+        labels:
+          auth_method: no_auth
+          demo: 'true'
+          showcase: catalog
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             type: no-auth
-          description: "This connector is intentionally simple: it demonstrates that the
-            demo-seed job can publish connector definitions into the Marketplace
-            catalog during install and upgrade. Follow-up demo connectors show
-            OAuth, API key auth, pre-connect tenant selection, and post-connect
-            configuration."
+          description: 'This connector is intentionally simple: it demonstrates that the
+            demo-seed job can publish connector definitions into the Marketplace catalog
+            during install and upgrade. Follow-up demo connectors show OAuth, API key
+            auth, pre-connect tenant selection, and post-connect configuration.'
           displayName: Demo README Resource
           highlight: A no-auth catalog entry used to verify demo seeding.
-          labels:
-            demo: "true"
-            type: demo-readme-noauth
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJEZW1vIFJFQURNRSBSZXNvdXJjZSBsb2dvIj48cmVjdCB3aWR0aD0iMjgwIiBoZWlnaHQ9IjE0MCIgcng9IjEyIiBmaWxsPSIjMEIzRDJFIi8+PHBhdGggZD0iTTYyIDk2VjQ0aDM1YzE3IDAgMjggMTAgMjggMjZzLTExIDI2LTI4IDI2SDYyWm0yMC0xN2gxNGM2IDAgMTAtMyAxMC05cy00LTktMTAtOUg4MnYxOFptNjQgMTdWNDRoMjB2MzVoMzV2MTdoLTU1WiIgZmlsbD0iI0ZGRkZGRiIvPjwvc3ZnPg==
             mimeType: image/svg+xml
-        key: demo-readme-noauth
-        labels:
-          auth_method: no_auth
-          demo: "true"
-          showcase: catalog
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-api-key-bearer
         namespace: root
-      - definition:
+        labels:
+          auth_method: api-key
+          demo: 'true'
+          showcase: api-key
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             placement:
               type: bearer
             type: api-key
-          description: "This connector demonstrates AuthProxy API-key setup and proxying.
-            Enter `demo-api-key` when prompted; it is an intentionally fake key
-            accepted only by the demo provider. AuthProxy stores the key as an
-            encrypted credential, injects it as `Authorization: Bearer demo-api-key`
-            on proxy requests, and verifies it with a probe so wrong keys are easy
-            to spot."
-          displayName: "Demo API Key: Bearer Token"
+          description: 'This connector demonstrates AuthProxy API-key setup and proxying.
+            Enter `demo-api-key` when prompted; it is an intentionally fake key accepted
+            only by the demo provider. AuthProxy stores the key as an encrypted credential,
+            injects it as `Authorization: Bearer demo-api-key` on proxy requests, and
+            verifies it with a probe so wrong keys are easy to spot.'
+          displayName: 'Demo API Key: Bearer Token'
           highlight: Creates a connection from a static demo API key.
-          labels:
-            demo: "true"
-            type: demo-api-key-bearer
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJBUEkgS2V5IERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iI0M4NDYzMCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTExNiA3MGg3NG0tMjAtMTYgMTYgMTYtMTYgMTYiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIxNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5BSzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           probes:
-            - failureThreshold: 1
-              id: verify-api-key
-              proxyHttp:
-                method: GET
-                url: http://dev-go-oauth2-server/test/api-key-resource/demo-api-key
-        key: demo-api-key-bearer
-        labels:
-          auth_method: api-key
-          demo: "true"
-          showcase: api-key
+          - failureThreshold: 1
+            id: verify-api-key
+            proxyHttp:
+              method: GET
+              url: http://dev-go-oauth2-server/test/api-key-resource/demo-api-key
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-simple
         namespace: root
-      - definition:
+        labels:
+          auth_method: oauth2
+          demo: 'true'
+          showcase: simple-oauth
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
             clientId: demo-oauth-simple
             clientSecret: demo-oauth-simple-secret
             scopes:
-              - id: read
-                reason: Read basic profile information from the demo provider.
-              - id: profile
-                reason: Show how connectors explain why each requested OAuth scope is needed.
+            - id: read
+              reason: Read basic profile information from the demo provider.
+            - id: profile
+              reason: Show how connectors explain why each requested OAuth scope is needed.
             token:
               endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
-          description: "This connector demonstrates AuthProxy's simplest OAuth path: the
-            user clicks Connect, approves access in the demo OAuth provider, and
-            AuthProxy stores the resulting tokens for proxy requests. Use provider
-            username `demo-oauth-user@example.test` and password `demo-password`
-            when the consent screen asks you to sign in."
-          displayName: "Demo OAuth: Basic Authorization"
+          description: 'This connector demonstrates AuthProxy''s simplest OAuth path:
+            the user clicks Connect, approves access in the demo OAuth provider, and AuthProxy
+            stores the resulting tokens for proxy requests. Use provider username `demo-oauth-user@example.test`
+            and password `demo-password` when the consent screen asks you to sign in.'
+          displayName: 'Demo OAuth: Basic Authorization'
           highlight: A plain OAuth authorization-code connection with no extra setup.
-          labels:
-            demo: "true"
-            type: demo-oauth-simple
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJTdHJhaWdodCBPQXV0aCBEZW1vIGxvZ28iPjxyZWN0IHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiByeD0iMTIiIGZpbGw9IiMxNjVERkYiLz48Y2lyY2xlIGN4PSI3NiIgY3k9IjcwIiByPSIzNCIgZmlsbD0icmdiYSgyNTUsMjU1LDI1NSwwLjE4KSIvPjxwYXRoIGQ9Ik0xOTAgNDhjMTIgMCAyMiAxMCAyMiAyMnMtMTAgMjItMjIgMjJoLTQ4Yy0xMiAwLTIyLTEwLTIyLTIyczEwLTIyIDIyLTIyaDQ4Wm0tNDggMTZhNiA2IDAgMCAwIDAgMTJoNDhhNiA2IDAgMCAwIDAtMTJoLTQ4WiIgZmlsbD0iI2ZmZiIgb3BhY2l0eT0iMC45NSIvPjx0ZXh0IHg9Ijc2IiB5PSI4MiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iI2ZmZiIgZm9udC1mYW1pbHk9IkludGVyLCBBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIzNCIgZm9udC13ZWlnaHQ9IjgwMCI+U088L3RleHQ+PC9zdmc+
             mimeType: image/svg+xml
-        key: demo-oauth-simple
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-tenant
+        namespace: root
         labels:
           auth_method: oauth2
-          demo: "true"
-          showcase: simple-oauth
-        namespace: root
-      - definition:
+          demo: 'true'
+          showcase: preconnect
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
@@ -152,125 +190,120 @@ data:
             clientId: demo-oauth-tenant
             clientSecret: demo-oauth-tenant-secret
             scopes:
-              - id: read
-                reason: Read access after the selected tenant has authorized the app.
-              - id: profile
-                reason: Display which demo user approved the tenant-scoped connection.
+            - id: read
+              reason: Read access after the selected tenant has authorized the app.
+            - id: profile
+              reason: Display which demo user approved the tenant-scoped connection.
             token:
               endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
-          description: This connector demonstrates pre-connect setup. AuthProxy asks for a
-            pretend tenant before redirecting to OAuth, then makes that value
-            available to OAuth endpoint templates. In a real connector this pattern
-            selects the customer's regional login host or tenant-specific
-            authorization parameters before credentials are requested.
-          displayName: "Demo OAuth: Tenant Selection"
+          description: This connector demonstrates pre-connect setup. AuthProxy asks for
+            a pretend tenant before redirecting to OAuth, then makes that value available
+            to OAuth endpoint templates. In a real connector this pattern selects the
+            customer's regional login host or tenant-specific authorization parameters
+            before credentials are requested.
+          displayName: 'Demo OAuth: Tenant Selection'
           highlight: Collects a pretend tenant before starting OAuth.
-          labels:
-            demo: "true"
-            type: demo-oauth-tenant
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJUZW5hbnQgU2VsZWN0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzdBM0U5RCIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5UUzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           setupFlow:
             preconnect:
               steps:
-                - description: This pre-connect step runs before OAuth. The value is saved into
-                    connection configuration and can be used to shape
-                    provider-specific OAuth URLs.
-                  id: tenant
-                  jsonSchema:
-                    properties:
-                      tenant:
-                        description: Try `northwind`, `globex`, or any short tenant slug. The demo
-                          provider accepts all values; the field exists to show
-                          pre-auth configuration.
-                        minLength: 2
-                        title: Demo tenant
-                        type: string
-                    required:
-                      - tenant
-                    type: object
-                  title: Choose a pretend tenant
-                  uiSchema:
-                    elements:
-                      - scope: "#/properties/tenant"
-                        type: Control
-                    type: VerticalLayout
-        key: demo-oauth-tenant
+              - description: This pre-connect step runs before OAuth. The value is saved
+                  into connection configuration and can be used to shape provider-specific
+                  OAuth URLs.
+                id: tenant
+                jsonSchema:
+                  properties:
+                    tenant:
+                      description: Try `northwind`, `globex`, or any short tenant slug.
+                        The demo provider accepts all values; the field exists to show
+                        pre-auth configuration.
+                      minLength: 2
+                      title: Demo tenant
+                      type: string
+                  required:
+                  - tenant
+                  type: object
+                title: Choose a pretend tenant
+                uiSchema:
+                  elements:
+                  - scope: "#/properties/tenant"
+                    type: Control
+                  type: VerticalLayout
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: demo-oauth-configure
+        namespace: root
         labels:
           auth_method: oauth2
-          demo: "true"
-          showcase: preconnect
-        namespace: root
-      - definition:
+          demo: 'true'
+          showcase: postconnect-configure
+      spec:
+        release:
+          desiredState: primary
+        definition:
           auth:
             authorization:
               endpoint: https://oauth2.branch.dev.authproxy.net/web/authorize
             clientId: demo-oauth-configure
             clientSecret: demo-oauth-configure-secret
             scopes:
-              - id: read
-                reason: Complete the OAuth flow against the demo provider.
-              - id: resources
-                reason: Fetch the pretend resource list used by the post-connect configuration
-                  step.
+            - id: read
+              reason: Complete the OAuth flow against the demo provider.
+            - id: resources
+              reason: Fetch the pretend resource list used by the post-connect configuration
+                step.
             token:
               endpoint: http://dev-go-oauth2-server/v1/oauth/tokens
             type: OAuth2
           description: This connector demonstrates post-connect configuration. After OAuth
-            succeeds, AuthProxy calls a demo provider resource endpoint through the
-            new connection and turns the response into selectable pretend resources.
-            This is the pattern for connectors that must discover workspaces,
-            projects, calendars, or folders after credentials exist.
-          displayName: "Demo OAuth: Resource Configuration"
-          highlight: Uses OAuth first, then fetches configuration choices through the proxy.
-          labels:
-            demo: "true"
-            type: demo-oauth-configure
+            succeeds, AuthProxy calls a demo provider resource endpoint through the new
+            connection and turns the response into selectable pretend resources. This
+            is the pattern for connectors that must discover workspaces, projects, calendars,
+            or folders after credentials exist.
+          displayName: 'Demo OAuth: Resource Configuration'
+          highlight: Uses OAuth first, then fetches configuration choices through the
+            proxy.
           logo:
             base64: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTQwIiB2aWV3Qm94PSIwIDAgMjgwIDE0MCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJSZXNvdXJjZSBDb25maWd1cmF0aW9uIE9BdXRoIERlbW8gbG9nbyI+PHJlY3Qgd2lkdGg9IjI4MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0iIzBCN0E1QSIvPjxjaXJjbGUgY3g9Ijc2IiBjeT0iNzAiIHI9IjM0IiBmaWxsPSJyZ2JhKDI1NSwyNTUsMjU1LDAuMTgpIi8+PHBhdGggZD0iTTE5MCA0OGMxMiAwIDIyIDEwIDIyIDIycy0xMCAyMi0yMiAyMmgtNDhjLTEyIDAtMjItMTAtMjItMjJzMTAtMjIgMjItMjJoNDhabS00OCAxNmE2IDYgMCAwIDAgMCAxMmg0OGE2IDYgMCAwIDAgMC0xMmgtNDhaIiBmaWxsPSIjZmZmIiBvcGFjaXR5PSIwLjk1Ii8+PHRleHQgeD0iNzYiIHk9IjgyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjZmZmIiBmb250LWZhbWlseT0iSW50ZXIsIEFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iODAwIj5SQzwvdGV4dD48L3N2Zz4=
             mimeType: image/svg+xml
           setupFlow:
             configure:
               steps:
-                - dataSources:
-                    demoResources:
-                      proxyRequest:
-                        headers:
-                          Accept: application/json
-                        method: GET
-                        url: http://dev-go-oauth2-server/test/resource/demo-resources
-                      transform: "Array.isArray(data.resources) ? data.resources.map(r => ({ value:
-                        r.id || r.value, label: r.name || r.label || r.id || r.value
-                        })) : [{ value: 'project-alpha', label: 'Project Alpha
-                        (demo)' }, { value: 'workspace-north', label: 'North
-                        Workspace (demo)' }, { value: 'reports-folder', label:
-                        'Reports Folder (demo)' }]"
-                  description: This post-connect step is populated by a data source request
-                    through the authenticated proxy. The options stand in for
-                    provider resources such as projects, calendars, or workspaces.
-                  id: select_resource
-                  jsonSchema:
-                    properties:
-                      resource_id:
-                        description: Options are loaded after OAuth using the new connection's
-                          credentials.
-                        title: Demo resource
-                        type: string
-                        x-data-source: demo_resources
-                    required:
-                      - resource_id
-                    type: object
-                  title: Select a pretend resource
-                  uiSchema:
-                    elements:
-                      - scope: "#/properties/resource_id"
-                        type: Control
-                    type: VerticalLayout
-        key: demo-oauth-configure
-        labels:
-          auth_method: oauth2
-          demo: "true"
-          showcase: postconnect-configure
-        namespace: root
+              - dataSources:
+                  demoResources:
+                    proxyRequest:
+                      headers:
+                        Accept: application/json
+                      method: GET
+                      url: http://dev-go-oauth2-server/test/resource/demo-resources
+                    transform: 'Array.isArray(data.resources) ? data.resources.map(r =>
+                      ({ value: r.id || r.value, label: r.name || r.label || r.id || r.value
+                      })) : [{ value: ''project-alpha'', label: ''Project Alpha (demo)''
+                      }, { value: ''workspace-north'', label: ''North Workspace (demo)''
+                      }, { value: ''reports-folder'', label: ''Reports Folder (demo)''
+                      }]'
+                description: This post-connect step is populated by a data source request
+                  through the authenticated proxy. The options stand in for provider resources
+                  such as projects, calendars, or workspaces.
+                id: select_resource
+                jsonSchema:
+                  properties:
+                    resource_id:
+                      description: Options are loaded after OAuth using the new connection's
+                        credentials.
+                      title: Demo resource
+                      type: string
+                      x-data-source: demo_resources
+                  required:
+                  - resource_id
+                  type: object
+                title: Select a pretend resource
+                uiSchema:
+                  elements:
+                  - scope: "#/properties/resource_id"
+                    type: Control
+                  type: VerticalLayout

--- a/docs/src/content/docs/development/cli.md
+++ b/docs/src/content/docs/development/cli.md
@@ -89,19 +89,22 @@ the name to recognize a resource, but pass the ID to commands and URLs that
 address it directly.
 
 ```bash
-ap list connectors --name salesforce --state active --output table
+ap list connectors --name salesforce --state active
 ap list connections --name production-crm --order "created_at DESC"
 ```
 
 `--name` is an exact, case-sensitive filter. If the caller can list several
 namespaces, the same name can produce more than one result; compare namespace
 and ID before acting. Other useful flags are `--state`, `--type` (connectors
-only), `--order "<field> ASC|DESC"`, plus the global output flags from the
-`Output` helper (`--output json|jsonl|table`, `--limit`, …).
+only), and `--order "<field> ASC|DESC"`. Pagination is automatic and the
+complete result is printed as a JSON array.
 
-JSON and JSONL output retain the existing `id` field and add `name`; scripts
-that need durable identity should continue reading `id`. The CLI does not yet
-have dedicated create or rename commands, so use the API for those operations.
+JSON output contains complete `authproxy.net/v1alpha1` resources, including
+`apiVersion`, `kind`, `metadata`, `spec`, and (when available) `status`.
+Scripts that need durable identity should read `metadata.id`; the display name
+is `metadata.name`, and connector generations use `metadata.generation`. The
+CLI does not yet have dedicated create or rename commands, so use the API for
+those operations.
 See [Resource identity and names](/reference/api/#resource-identity-and-names)
 for create, rename-by-ID, conflict, and query examples.
 

--- a/docs/src/content/docs/development/local-development.md
+++ b/docs/src/content/docs/development/local-development.md
@@ -55,6 +55,23 @@ go run ./cmd/server routes --config=./dev_config/default.yaml
 
 Verify the API at `http://localhost:8081/ping`.
 
+### Recreate data after breaking resource changes
+
+AuthProxy's `v1` API is still pre-production and may make breaking resource
+schema changes. There is no compatibility job that rewrites legacy connector
+definitions into the `authproxy.net/v1alpha1` envelope. If a checkout contains
+data created by the former flat resource format, recreate the local environment
+before starting the updated server:
+
+```bash
+./scripts/teardown-docker.sh
+docker compose up -d
+go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
+```
+
+This intentionally deletes the local Docker volumes. Preserve anything you
+need before running the teardown.
+
 ## Sign into the local UIs
 
 AuthProxy expects the host application to initiate UI sessions. During local

--- a/docs/src/content/docs/development/local-development.md
+++ b/docs/src/content/docs/development/local-development.md
@@ -55,23 +55,6 @@ go run ./cmd/server routes --config=./dev_config/default.yaml
 
 Verify the API at `http://localhost:8081/ping`.
 
-### Recreate data after breaking resource changes
-
-AuthProxy's `v1` API is still pre-production and may make breaking resource
-schema changes. There is no compatibility job that rewrites legacy connector
-definitions into the `authproxy.net/v1alpha1` envelope. If a checkout contains
-data created by the former flat resource format, recreate the local environment
-before starting the updated server:
-
-```bash
-./scripts/teardown-docker.sh
-docker compose up -d
-go run ./cmd/server serve --auto-migrate --config=./dev_config/default.yaml all
-```
-
-This intentionally deletes the local Docker volumes. Preserve anything you
-need before running the teardown.
-
 ## Sign into the local UIs
 
 AuthProxy expects the host application to initiate UI sessions. During local

--- a/docs/src/content/docs/operations/telemetry.md
+++ b/docs/src/content/docs/operations/telemetry.md
@@ -148,12 +148,17 @@ Per-connector overrides for trace context propagation live on the connector defi
 ```yaml
 connectors:
   loadFromList:
-    - name: google-drive
-      labels:
-        type: google-drive
-      auth: { type: OAuth2, ... }
-      telemetry:
-        propagateTraceContext: true   # overrides telemetry.propagation.injectOutboundDefault for this connector
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: google-drive
+        labels:
+          type: google-drive
+      spec:
+        definition:
+          auth: { type: OAuth2, ... }
+          telemetry:
+            propagateTraceContext: true # overrides telemetry.propagation.injectOutboundDefault for this connector
 ```
 
 ## Standard `OTEL_*` env vars

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -32,16 +32,23 @@ immutable `id`:
 ```yaml
 connectors:
   loadFromList:
-    - name: google-drive
-      namespace: root.integrations
-      labels:
-        type: google-drive
-      displayName: Google Drive
-      logo:
-        publicUrl: https://example.com/google-drive.svg
-      description: Connect to Google Drive.
-      auth:
-        type: no-auth
+    - apiVersion: authproxy.net/v1alpha1
+      kind: Connector
+      metadata:
+        name: google-drive
+        namespace: root.integrations
+        labels:
+          type: google-drive
+      spec:
+        release:
+          desiredState: primary
+        definition:
+          displayName: Google Drive
+          logo:
+            publicUrl: https://example.com/google-drive.svg
+          description: Connect to Google Drive.
+          auth:
+            type: no-auth
 ```
 
 With the development-only `serve --auto-migrate` option, AuthProxy reconciles
@@ -56,9 +63,11 @@ its ID fixed and change `name`. Changing the name of an ID-less entry describes
 a new connector, so the old config-managed connector enters the normal orphan
 cleanup flow.
 
-The former `connectors.identifyingLabels` setting has been removed. Delete it
-from existing configuration and add a stable `name` to every connector entry
-that does not already specify `id`.
+The former flat connector form and `connectors.identifyingLabels` setting have
+been removed. Every entry must be an `authproxy.net/v1alpha1` `Connector`
+resource. Delete `identifyingLabels` from existing configuration and add a
+stable `metadata.name` to every connector entry that does not already specify
+`metadata.id`.
 
 ## Kubernetes values
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -36,6 +36,18 @@ go test -tags integration -v -run TestRateLimiting429 ./proxy/...
 
 Integration tests use the `integration` build tag so they are excluded from `go test ./...`.
 
+The main database portion of the suite runs against either a fresh SQLite file
+or the PostgreSQL service above:
+
+```bash
+AUTH_PROXY_TEST_DATABASE_PROVIDER=sqlite go test -tags integration ./...
+AUTH_PROXY_TEST_DATABASE_PROVIDER=postgres go test -tags integration ./...
+```
+
+Fixtures exercise only the current `authproxy.net/v1alpha1` resource and action
+envelopes. They intentionally do not load or upgrade connector data written by
+the former flat API format.
+
 ## AWS Secrets Manager Integration Test
 
 This test hits real AWS Secrets Manager and is gated behind the `aws` build tag and an env flag.

--- a/integration_tests/api_key/auto_reauth_test.go
+++ b/integration_tests/api_key/auto_reauth_test.go
@@ -40,7 +40,7 @@ func TestApiKeyAutoReauth(t *testing.T) {
 	})
 
 	one := 1
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	conn := helpers.NewApiKeyConnector(connectorID, "api-key-auto-reauth", helpers.ApiKeyConnectorOptions{
 		Placement: connectors.ApiKeyPlacementBearer,
 		ProbeURL:  stub.BaseURL + "/probe",
@@ -60,7 +60,7 @@ func TestApiKeyAutoReauth(t *testing.T) {
 
 	// Drive to Ready with the v1 key.
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": keyV1})
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, map[string]any{"api_key": keyV1})
 	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 

--- a/integration_tests/api_key/initiate_flow_test.go
+++ b/integration_tests/api_key/initiate_flow_test.go
@@ -120,7 +120,7 @@ func runPerPlacementLifecycle(
 
 	// Connector definitions need a connector id; suffix with the placement
 	// label so parallel runs of this helper don't collide on the id namespace.
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connectorOpts.ProbeURL = stub.BaseURL + "/probe-" + label
 	conn := helpers.NewApiKeyConnector(connectorID, fmt.Sprintf("api-key-%s", label), connectorOpts)
 
@@ -131,15 +131,15 @@ func runPerPlacementLifecycle(
 	defer env.Cleanup()
 
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	require.Equalf(t, helpers.ApiKeySubmitFormStepId(), form.StepId,
-		"initiate should return the synthesized credentials step id; got %q", form.StepId)
+	require.Equalf(t, helpers.ApiKeySubmitFormStepId(), form.StepID,
+		"initiate should return the synthesized credentials step id; got %q", form.StepID)
 
 	// No prior credential bytes should ever appear in a form payload —
 	// even on first initiate the synthesized JSON schema is built from the
 	// connector definition only. Catching it here too costs nothing and
 	// guards against accidental regressions where the schema gains a
 	// pre-filled default field that leaks state.
-	rawSchema := string(form.JsonSchema)
+	rawSchema := string(form.JSONSchema)
 	for _, v := range credentialPayload {
 		if vs, ok := v.(string); ok {
 			assert.NotContainsf(t, rawSchema, vs,
@@ -147,7 +147,7 @@ func runPerPlacementLifecycle(
 		}
 	}
 
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, credentialPayload)
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, credentialPayload)
 	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
 
 	// Submit transitions the connection into the verify phase (probes

--- a/integration_tests/api_key/probe_acceleration_test.go
+++ b/integration_tests/api_key/probe_acceleration_test.go
@@ -40,7 +40,7 @@ func TestApiKeyProbeAcceleration_401EnqueuesProbeNow(t *testing.T) {
 		AcceptedKey: goodKey,
 	})
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	conn := helpers.NewApiKeyConnector(connectorID, "api-key-accel", helpers.ApiKeyConnectorOptions{
 		Placement: connectors.ApiKeyPlacementBearer,
 		ProbeURL:  stub.BaseURL + "/probe",
@@ -55,7 +55,7 @@ func TestApiKeyProbeAcceleration_401EnqueuesProbeNow(t *testing.T) {
 	// Drive to Ready with the good key. Subsequent proxy traffic uses
 	// this credential.
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": goodKey})
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, map[string]any{"api_key": goodKey})
 	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
@@ -116,7 +116,7 @@ func TestApiKeyProbeAcceleration_2xxDoesNotEnqueue(t *testing.T) {
 		AcceptedKey: goodKey,
 	})
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	conn := helpers.NewApiKeyConnector(connectorID, "api-key-accel-2xx", helpers.ApiKeyConnectorOptions{
 		Placement: connectors.ApiKeyPlacementBearer,
 		ProbeURL:  stub.BaseURL + "/probe",
@@ -129,7 +129,7 @@ func TestApiKeyProbeAcceleration_2xxDoesNotEnqueue(t *testing.T) {
 	defer env.Cleanup()
 
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": goodKey})
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, map[string]any{"api_key": goodKey})
 	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 

--- a/integration_tests/api_key/rotation_test.go
+++ b/integration_tests/api_key/rotation_test.go
@@ -31,7 +31,7 @@ func TestApiKeyManualRotation(t *testing.T) {
 		AcceptedKey: oldKey,
 	})
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	conn := helpers.NewApiKeyConnector(connectorID, "api-key-rotation", helpers.ApiKeyConnectorOptions{
 		Placement: connectors.ApiKeyPlacementBearer,
 		ProbeURL:  stub.BaseURL + "/probe",
@@ -45,7 +45,7 @@ func TestApiKeyManualRotation(t *testing.T) {
 
 	// 1. Drive to Ready with the old key.
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, map[string]any{
 		"api_key": oldKey,
 	})
 	require.Equalf(t, http.StatusOK, w.Code, "submit failed: %s", w.Body.String())

--- a/integration_tests/helpers/api_actions.go
+++ b/integration_tests/helpers/api_actions.go
@@ -1,0 +1,88 @@
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/stretchr/testify/require"
+)
+
+const defaultConnectionReturnToURL = "https://app.example.test/connections"
+
+func connectorReference(id apid.ID, generation uint64) meta.ObjectReference {
+	return meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       connectorschema.ConnectorKind,
+		ID:         id.String(),
+		Generation: generation,
+	}
+}
+
+func connectionReference(id string) meta.ObjectReference {
+	return meta.ObjectReference{
+		APIVersion: meta.APIVersionV1Alpha1,
+		Kind:       connectionschema.ConnectionKind,
+		ID:         id,
+	}
+}
+
+func connectionInitiateAction(
+	connectorID apid.ID,
+	intoNamespace string,
+	returnToURL string,
+) schemaapi.ConnectionInitiateAction {
+	if returnToURL == "" {
+		returnToURL = defaultConnectionReturnToURL
+	}
+	return schemaapi.ConnectionInitiateAction{Action: apiv1alpha1.NewActionRequest(
+		schemaapi.ConnectionInitiateActionKind,
+		connectorReference(connectorID, 0),
+		schemaapi.ConnectionInitiateSpec{
+			IntoNamespace: intoNamespace,
+			ReturnToURL:   returnToURL,
+		},
+	)}
+}
+
+func connectionSetupSubmitAction(
+	connectionID string,
+	stepID string,
+	data json.RawMessage,
+) schemaapi.ConnectionSetupSubmitAction {
+	return schemaapi.ConnectionSetupSubmitAction{Action: apiv1alpha1.NewActionRequest(
+		schemaapi.ConnectionSetupSubmitActionKind,
+		connectionReference(connectionID),
+		schemaapi.ConnectionSetupSubmitSpec{StepID: stepID, Data: data},
+	)}
+}
+
+func connectionSetupControlAction(
+	kind meta.Kind,
+	connectionID string,
+	returnToURL string,
+) schemaapi.ConnectionSetupControlAction {
+	return schemaapi.ConnectionSetupControlAction{Action: apiv1alpha1.NewActionRequest(
+		kind,
+		connectionReference(connectionID),
+		schemaapi.ConnectionSetupControlSpec{ReturnToURL: returnToURL},
+	)}
+}
+
+func decodeConnectionSetupAction(
+	t *testing.T,
+	data []byte,
+) schemaapi.ConnectionSetupAction {
+	t.Helper()
+
+	var action schemaapi.ConnectionSetupAction
+	require.NoError(t, json.Unmarshal(data, &action))
+	require.NoError(t, action.ValidateResponse(schemaapi.ConnectionSetupActionKind),
+		"invalid setup response: %s", string(data))
+	return action
+}

--- a/integration_tests/helpers/api_actions_test.go
+++ b/integration_tests/helpers/api_actions_test.go
@@ -1,0 +1,46 @@
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionActionFixturesUseV1Alpha1Envelopes(t *testing.T) {
+	connectorID := apid.MustParse("cxr_testconnector0001")
+	initiate := connectionInitiateAction(connectorID, "root.tenant", "https://app.example.test/return")
+	require.NoError(t, initiate.ValidateRequest(schemaapi.ConnectionInitiateActionKind))
+
+	data, err := json.Marshal(initiate)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+      "apiVersion":"authproxy.net/v1alpha1",
+      "kind":"ConnectionInitiate",
+      "metadata":{"target":{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","id":"cxr_testconnector0001"}},
+      "spec":{"intoNamespace":"root.tenant","returnToUrl":"https://app.example.test/return"}
+    }`, string(data))
+
+	withoutExplicitReturn := connectionInitiateAction(connectorID, "root.tenant", "")
+	require.NoError(t, withoutExplicitReturn.ValidateRequest(schemaapi.ConnectionInitiateActionKind))
+	data, err = json.Marshal(withoutExplicitReturn)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"returnToUrl":"https://app.example.test/connections"`)
+
+	submit := connectionSetupSubmitAction("cxn_testconnection01", "credentials", json.RawMessage(`{"apiKey":"test"}`))
+	require.NoError(t, submit.ValidateRequest(schemaapi.ConnectionSetupSubmitActionKind))
+	data, err = json.Marshal(submit)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"kind":"ConnectionSetupSubmit"`)
+	require.Contains(t, string(data), `"kind":"Connection"`)
+	require.Contains(t, string(data), `"stepId":"credentials"`)
+
+	reauth := connectionSetupControlAction(schemaapi.ConnectionReauthActionKind, "cxn_testconnection01", "https://app.example.test/return")
+	require.NoError(t, reauth.ValidateRequest(schemaapi.ConnectionReauthActionKind))
+	data, err = json.Marshal(reauth)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"kind":"ConnectionReauthenticate"`)
+	require.Contains(t, string(data), `"returnToUrl":"https://app.example.test/return"`)
+}

--- a/integration_tests/helpers/remote_authproxy.go
+++ b/integration_tests/helpers/remote_authproxy.go
@@ -19,6 +19,7 @@ import (
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	actorschema "github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -115,21 +116,22 @@ func (h *RemoteAuthProxy) CreateActor(t *testing.T, externalID string, labels ma
 	return actor
 }
 
-func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) schemaapi.ConnectorVersionJson {
+func (h *RemoteAuthProxy) CreateConnector(t *testing.T, connector sconfig.Connector) cschema.Connector {
 	t.Helper()
 
-	var created schemaapi.ConnectorVersionJson
-	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/connectors", schemaapi.CreateConnectorRequestJson{
-		Namespace:  h.Namespace,
-		Definition: connector.Spec.Definition,
-		Labels: map[string]string{
-			"smoke": "true",
-		},
-	}, true, http.StatusCreated, &created)
+	resource := connector.Clone()
+	resource.Metadata.Namespace = h.Namespace
+	if resource.Metadata.Labels == nil {
+		resource.Metadata.Labels = map[string]string{}
+	}
+	resource.Metadata.Labels["smoke"] = "true"
+
+	var created cschema.Connector
+	h.doSigned(t, h.AdminActorExternalID, http.MethodPost, h.AdminURL+"/api/v1/connectors", resource, true, http.StatusCreated, &created)
 	return created
 }
 
-func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []schemaapi.ConnectorJson {
+func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []cschema.Connector {
 	t.Helper()
 
 	endpoint := h.PublicURL + "/api/v1/connectors?limit=100"
@@ -142,24 +144,26 @@ func (h *RemoteAuthProxy) ListConnectors(t *testing.T, labelSelector string) []s
 	return list.Items
 }
 
-func (h *RemoteAuthProxy) FindConnectorBySeedKey(t *testing.T, seedKey string) schemaapi.ConnectorJson {
+func (h *RemoteAuthProxy) FindConnectorByName(t *testing.T, name string) cschema.Connector {
 	t.Helper()
 
-	connectors := h.ListConnectors(t, "demo.authproxy.net/seed-key="+seedKey)
-	require.Lenf(t, connectors, 1, "expected exactly one seeded connector with key %q; got %d", seedKey, len(connectors))
-	return connectors[0]
+	endpoint := h.PublicURL + "/api/v1/connectors?limit=100&name=" + url.QueryEscape(name)
+	var list schemaapi.ListConnectorsResponseJson
+	h.doSigned(t, h.UserActorExternalID, http.MethodGet, endpoint, nil, true, http.StatusOK, &list)
+	require.Lenf(t, list.Items, 1, "expected exactly one connector named %q; got %d", name, len(list.Items))
+	return list.Items[0]
 }
 
-func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID apid.ID, version uint64, state string) schemaapi.ConnectorVersionJson {
+func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID apid.ID, version uint64, state cschema.ConnectorReleaseState) cschema.Connector {
 	t.Helper()
 
-	var updated schemaapi.ConnectorVersionJson
+	var updated cschema.Connector
 	h.doSigned(
 		t,
 		h.AdminActorExternalID,
 		http.MethodPut,
 		fmt.Sprintf("%s/api/v1/connectors/%s/versions/%d/_forceState", h.AdminURL, connectorID, version),
-		schemaapi.ForceConnectorVersionStateRequestJson{State: state},
+		schemaapi.ForceConnectorVersionStateRequestJson{State: string(state)},
 		true,
 		http.StatusOK,
 		&updated,
@@ -170,28 +174,33 @@ func (h *RemoteAuthProxy) ForceConnectorVersionState(t *testing.T, connectorID a
 func (h *RemoteAuthProxy) InitiateOAuth2Connection(t *testing.T, connectorID apid.ID, returnToURL string) (connectionID, redirectURL string) {
 	t.Helper()
 
-	var redirect schemaapi.ConnectionSetupRedirect
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
-		ConnectorId:   connectorID,
-		IntoNamespace: h.Namespace,
-		ReturnToUrl:   returnToURL,
-	}, true, http.StatusOK, &redirect)
-	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, redirect.Type)
-	require.NotEmpty(t, redirect.RedirectUrl)
-	return redirect.Id.String(), redirect.RedirectUrl
+	var action schemaapi.ConnectionSetupAction
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", connectionInitiateAction(
+		connectorID,
+		h.Namespace,
+		returnToURL,
+	), true, http.StatusOK, &action)
+	require.NotNil(t, action.Status)
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, action.Status.Type)
+	require.NotEmpty(t, action.Status.RedirectURL)
+	require.NotEmpty(t, action.Metadata.Target.ID)
+	return action.Metadata.Target.ID, action.Status.RedirectURL
 }
 
 func (h *RemoteAuthProxy) InitiateAPIKeyConnection(t *testing.T, connectorID apid.ID) (connectionID, stepID string) {
 	t.Helper()
 
-	var form schemaapi.ConnectionSetupForm
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", schemaapi.InitiateConnectionRequest{
-		ConnectorId:   connectorID,
-		IntoNamespace: h.Namespace,
-	}, true, http.StatusOK, &form)
-	require.Equal(t, schemaapi.ConnectionSetupResponseTypeForm, form.Type)
-	require.NotEmpty(t, form.StepId)
-	return form.Id.String(), form.StepId
+	var action schemaapi.ConnectionSetupAction
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/_initiate", connectionInitiateAction(
+		connectorID,
+		h.Namespace,
+		"",
+	), true, http.StatusOK, &action)
+	require.NotNil(t, action.Status)
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeForm, action.Status.Type)
+	require.NotEmpty(t, action.Status.StepID)
+	require.NotEmpty(t, action.Metadata.Target.ID)
+	return action.Metadata.Target.ID, action.Status.StepID
 }
 
 func (h *RemoteAuthProxy) SubmitAPIKeyCredentials(t *testing.T, connectionID, stepID, apiKey string) schemaapi.ConnectionSetupResponseType {
@@ -200,15 +209,15 @@ func (h *RemoteAuthProxy) SubmitAPIKeyCredentials(t *testing.T, connectionID, st
 	rawData, err := json.Marshal(map[string]string{"api_key": apiKey})
 	require.NoError(t, err)
 
-	var generic struct {
-		Type schemaapi.ConnectionSetupResponseType `json:"type"`
-	}
-	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_submit", schemaapi.SubmitConnectionRequest{
-		StepId: stepID,
-		Data:   rawData,
-	}, true, http.StatusOK, &generic)
-	require.NotEmpty(t, generic.Type)
-	return generic.Type
+	var action schemaapi.ConnectionSetupAction
+	h.doSigned(t, h.UserActorExternalID, http.MethodPost, h.PublicURL+"/api/v1/connections/"+connectionID+"/_submit", connectionSetupSubmitAction(
+		connectionID,
+		stepID,
+		rawData,
+	), true, http.StatusOK, &action)
+	require.NotNil(t, action.Status)
+	require.NotEmpty(t, action.Status.Type)
+	return action.Status.Type
 }
 
 func (h *RemoteAuthProxy) WaitForSetupComplete(t *testing.T, connectionID string, timeout time.Duration) {
@@ -218,19 +227,17 @@ func (h *RemoteAuthProxy) WaitForSetupComplete(t *testing.T, connectionID string
 	var lastType schemaapi.ConnectionSetupResponseType
 	var lastError string
 	for time.Now().Before(deadline) {
-		var generic struct {
-			Type  schemaapi.ConnectionSetupResponseType `json:"type"`
-			Error string                                `json:"error,omitempty"`
-		}
-		h.doSigned(t, h.UserActorExternalID, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID+"/_setupStep", nil, true, http.StatusOK, &generic)
-		lastType = generic.Type
-		lastError = generic.Error
+		var action schemaapi.ConnectionSetupAction
+		h.doSigned(t, h.UserActorExternalID, http.MethodGet, h.PublicURL+"/api/v1/connections/"+connectionID+"/_setupStep", nil, true, http.StatusOK, &action)
+		require.NotNil(t, action.Status)
+		lastType = action.Status.Type
+		lastError = action.Status.Error
 
-		switch generic.Type {
+		switch action.Status.Type {
 		case schemaapi.ConnectionSetupResponseTypeComplete:
 			return
 		case schemaapi.ConnectionSetupResponseTypeError:
-			require.FailNowf(t, "connection setup failed", "connection %s setup error: %s", connectionID, generic.Error)
+			require.FailNowf(t, "connection setup failed", "connection %s setup error: %s", connectionID, action.Status.Error)
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/integration_tests/helpers/setup_api_key.go
+++ b/integration_tests/helpers/setup_api_key.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/auth_methods/api_key"
-	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
@@ -104,33 +104,24 @@ func NewApiKeyConnector(connectorID apid.ID, displayName string, opts ApiKeyConn
 // step), not a redirect. Returns the new connection id and the form payload.
 // Signed by default as actor "test-actor" in the root namespace; pass
 // WithActor(...) to mirror a specific tenant.
-func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorID apid.ID, opts ...ActorOption) (connectionID string, form *coreIface.ConnectionSetupForm) {
+func (env *IntegrationTestEnv) InitiateApiKeyConnection(t *testing.T, connectorID apid.ID, opts ...ActorOption) (connectionID string, form *schemaapi.ConnectionSetupActionStatus) {
 	t.Helper()
 	require.Truef(t, env.ApiGin != nil || env.ServerURL != "",
 		"InitiateApiKeyConnection requires either in-process gin or a running HTTP server")
 
 	cfg := env.resolveActorOptions(opts)
 
-	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
-		ConnectorId:   connectorID,
-		IntoNamespace: cfg.actorNamespace,
-	})
+	body, err := jsonMarshal(connectionInitiateAction(connectorID, cfg.actorNamespace, ""))
 	require.NoError(t, err)
 
 	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/_initiate", body, cfg)
 	require.Equalf(t, http.StatusOK, w.Code, "initiate failed: %s", w.Body.String())
 
-	var generic struct {
-		Type string `json:"type"`
-		Id   string `json:"id"`
-	}
-	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &generic))
-	require.Equal(t, string(coreIface.ConnectionSetupResponseTypeForm), generic.Type,
-		"expected api-key connector to return form response (got %s): %s", generic.Type, w.Body.String())
-
-	var resp coreIface.ConnectionSetupForm
-	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &resp))
-	return resp.Id.String(), &resp
+	response := decodeConnectionSetupAction(t, w.Body.Bytes())
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeForm, response.Status.Type,
+		"expected api-key connector to return form response (got %s): %s", response.Status.Type, w.Body.String())
+	require.NotEmpty(t, response.Metadata.Target.ID)
+	return response.Metadata.Target.ID, response.Status
 }
 
 // SubmitApiKeyCredentials POSTs to /api/v1/connections/{id}/_submit with the
@@ -142,10 +133,7 @@ func (env *IntegrationTestEnv) SubmitApiKeyCredentials(t *testing.T, connectionI
 
 	rawData, err := json.Marshal(data)
 	require.NoError(t, err)
-	body, err := jsonMarshal(coreIface.SubmitConnectionRequest{
-		StepId: stepID,
-		Data:   rawData,
-	})
+	body, err := jsonMarshal(connectionSetupSubmitAction(connectionID, stepID, rawData))
 	require.NoError(t, err)
 
 	return env.doSignedRequest(t, http.MethodPost,
@@ -159,9 +147,11 @@ func (env *IntegrationTestEnv) ReauthConnection(t *testing.T, connectionID strin
 	t.Helper()
 	cfg := env.resolveActorOptions(opts)
 
-	// Body is optional for api-key; sending an empty struct exercises the
-	// JSON unmarshal path on the route.
-	body, err := jsonMarshal(struct{}{})
+	body, err := jsonMarshal(connectionSetupControlAction(
+		schemaapi.ConnectionReauthActionKind,
+		connectionID,
+		"",
+	))
 	require.NoError(t, err)
 
 	return env.doSignedRequest(t, http.MethodPost,

--- a/integration_tests/helpers/setup_no_auth.go
+++ b/integration_tests/helpers/setup_no_auth.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/rmorlok/authproxy/internal/apid"
-	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,19 +22,15 @@ func (env *IntegrationTestEnv) InitiateNoAuthConnection(
 		"InitiateNoAuthConnection requires either in-process gin or a running HTTP server")
 
 	cfg := env.resolveActorOptions(opts)
-	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
-		ConnectorId:   connectorID,
-		IntoNamespace: cfg.actorNamespace,
-	})
+	body, err := jsonMarshal(connectionInitiateAction(connectorID, cfg.actorNamespace, ""))
 	require.NoError(t, err)
 
 	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/_initiate", body, cfg)
 	require.Equalf(t, http.StatusOK, w.Code, "initiate failed: %s", w.Body.String())
 
-	var response coreIface.ConnectionSetupComplete
-	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &response))
-	require.Equal(t, coreIface.ConnectionSetupResponseTypeComplete, response.Type,
+	response := decodeConnectionSetupAction(t, w.Body.Bytes())
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeComplete, response.Status.Type,
 		"expected no-auth connection to complete immediately: %s", w.Body.String())
-	require.NotEqual(t, apid.Nil, response.Id)
-	return response.Id.String()
+	require.NotEmpty(t, response.Metadata.Target.ID)
+	return response.Metadata.Target.ID
 }

--- a/integration_tests/helpers/setup_oauth2.go
+++ b/integration_tests/helpers/setup_oauth2.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
-	coreIface "github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	"github.com/rmorlok/authproxy/internal/encfield"
+	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
@@ -205,11 +205,7 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 	// namespace (root), which doesn't reflect how a real multi-tenant
 	// deployment isolates tenants — and breaks state-vs-connection
 	// namespace checks the security tests rely on.
-	body, err := jsonMarshal(coreIface.InitiateConnectionRequest{
-		ConnectorId:   connectorID,
-		ReturnToUrl:   returnToUrl,
-		IntoNamespace: cfg.actorNamespace,
-	})
+	body, err := jsonMarshal(connectionInitiateAction(connectorID, cfg.actorNamespace, returnToUrl))
 	require.NoError(t, err)
 
 	const path = "/api/v1/connections/_initiate"
@@ -242,12 +238,12 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 	}
 	require.Equalf(t, http.StatusOK, w.Code, "initiate failed: %s", w.Body.String())
 
-	var resp coreIface.ConnectionSetupRedirect
-	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, coreIface.ConnectionSetupResponseTypeRedirect, resp.Type, "expected OAuth2 connector to return redirect")
-	require.NotEmpty(t, resp.RedirectUrl)
+	resp := decodeConnectionSetupAction(t, w.Body.Bytes())
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, resp.Status.Type, "expected OAuth2 connector to return redirect")
+	require.NotEmpty(t, resp.Status.RedirectURL)
+	require.NotEmpty(t, resp.Metadata.Target.ID)
 
-	return resp.Id.String(), resp.RedirectUrl
+	return resp.Metadata.Target.ID, resp.Status.RedirectURL
 }
 
 // ReauthOAuth2Connection starts an OAuth2 reauthorization flow for an
@@ -257,11 +253,11 @@ func (env *IntegrationTestEnv) InitiateOAuth2Connection(t *testing.T, connectorI
 func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID, returnToUrl string, opts ...ActorOption) string {
 	t.Helper()
 
-	body, err := jsonMarshal(struct {
-		ReturnToUrl string `json:"returnToUrl,omitempty"`
-	}{
-		ReturnToUrl: returnToUrl,
-	})
+	body, err := jsonMarshal(connectionSetupControlAction(
+		schemaapi.ConnectionReauthActionKind,
+		connectionID,
+		returnToUrl,
+	))
 	require.NoError(t, err)
 
 	w := env.doSignedRequest(
@@ -273,11 +269,10 @@ func (env *IntegrationTestEnv) ReauthOAuth2Connection(t *testing.T, connectionID
 	)
 	require.Equalf(t, http.StatusOK, w.Code, "reauth failed: %s", w.Body.String())
 
-	var resp coreIface.ConnectionSetupRedirect
-	require.NoErrorf(t, jsonUnmarshal(w.Body.Bytes(), &resp), "decode reauth response: %s", w.Body.String())
-	require.Equal(t, coreIface.ConnectionSetupResponseTypeRedirect, resp.Type)
-	require.NotEmpty(t, resp.RedirectUrl)
-	return resp.RedirectUrl
+	resp := decodeConnectionSetupAction(t, w.Body.Bytes())
+	require.Equal(t, schemaapi.ConnectionSetupResponseTypeRedirect, resp.Status.Type)
+	require.NotEmpty(t, resp.Status.RedirectURL)
+	return resp.Status.RedirectURL
 }
 
 // FollowOAuth2Redirect issues an in-process GET to the public service's

--- a/integration_tests/helpers/version_migration.go
+++ b/integration_tests/helpers/version_migration.go
@@ -12,10 +12,13 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/apid"
-	"github.com/rmorlok/authproxy/internal/core/iface"
 	"github.com/rmorlok/authproxy/internal/database"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	connectorschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,21 +31,21 @@ func (env *IntegrationTestEnv) CreateConnector(
 	labels map[string]string,
 	annotations map[string]string,
 	opts ...ActorOption,
-) schemaapi.ConnectorVersionJson {
+) connectorschema.Connector {
 	t.Helper()
 
-	body, err := jsonMarshal(schemaapi.CreateConnectorRequestJson{
-		Namespace:   sconfig.RootNamespace,
-		Definition:  definition,
-		Labels:      labels,
-		Annotations: annotations,
-	})
+	resource := connectorschema.NewConnector()
+	resource.Metadata.Namespace = sconfig.RootNamespace
+	resource.Metadata.Labels = labels
+	resource.Metadata.Annotations = annotations
+	resource.Spec.Definition = definition
+	body, err := jsonMarshal(resource)
 	require.NoError(t, err)
 
 	w := env.doSignedRequest(t, http.MethodPost, "/api/v1/connectors", body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusCreated, w.Code, "create connector failed: %s", w.Body.String())
 
-	var out schemaapi.ConnectorVersionJson
+	var out connectorschema.Connector
 	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
 	return out
 }
@@ -56,16 +59,14 @@ func (env *IntegrationTestEnv) CreateDraftConnectorVersion(
 	labels map[string]string,
 	annotations map[string]string,
 	opts ...ActorOption,
-) schemaapi.ConnectorVersionJson {
+) connectorschema.Connector {
 	t.Helper()
 
-	req := schemaapi.CreateConnectorVersionRequestJson{Definition: &definition}
-	if labels != nil {
-		req.Labels = &labels
-	}
-	if annotations != nil {
-		req.Annotations = &annotations
-	}
+	req := connectorschema.NewConnector()
+	req.Metadata.Namespace = sconfig.RootNamespace
+	req.Metadata.Labels = labels
+	req.Metadata.Annotations = annotations
+	req.Spec.Definition = definition
 
 	body, err := jsonMarshal(req)
 	require.NoError(t, err)
@@ -74,7 +75,7 @@ func (env *IntegrationTestEnv) CreateDraftConnectorVersion(
 	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusCreated, w.Code, "create connector version failed: %s", w.Body.String())
 
-	var out schemaapi.ConnectorVersionJson
+	var out connectorschema.Connector
 	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
 	return out
 }
@@ -85,9 +86,9 @@ func (env *IntegrationTestEnv) ForceConnectorVersionState(
 	t *testing.T,
 	connectorID apid.ID,
 	version uint64,
-	state schemaapi.ConnectorVersionState,
+	state connectorschema.ConnectorReleaseState,
 	opts ...ActorOption,
-) schemaapi.ConnectorVersionJson {
+) connectorschema.Connector {
 	t.Helper()
 
 	body, err := jsonMarshal(schemaapi.ForceConnectorVersionStateRequestJson{State: string(state)})
@@ -97,7 +98,7 @@ func (env *IntegrationTestEnv) ForceConnectorVersionState(
 	w := env.doSignedRequest(t, http.MethodPut, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusOK, w.Code, "force connector version state failed: %s", w.Body.String())
 
-	var out schemaapi.ConnectorVersionJson
+	var out connectorschema.Connector
 	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
 	return out
 }
@@ -112,11 +113,11 @@ func (env *IntegrationTestEnv) PublishConnectorVersion(
 	labels map[string]string,
 	annotations map[string]string,
 	opts ...ActorOption,
-) schemaapi.ConnectorVersionJson {
+) connectorschema.Connector {
 	t.Helper()
 
 	draft := env.CreateDraftConnectorVersion(t, connectorID, definition, labels, annotations, opts...)
-	return env.ForceConnectorVersionState(t, connectorID, draft.Version, schemaapi.ConnectorVersionStatePrimary, opts...)
+	return env.ForceConnectorVersionState(t, connectorID, draft.Metadata.Generation, connectorschema.ConnectorReleaseStatePrimary, opts...)
 }
 
 // MigrateConnectionVersion starts the durable connection-version migration
@@ -127,13 +128,23 @@ func (env *IntegrationTestEnv) MigrateConnectionVersion(
 	targetVersion uint64,
 	timeoutSeconds int64,
 	opts ...ActorOption,
-) schemaapi.MigrateConnectionVersionResponseJson {
+) schemaapi.ConnectionVersionMigrationAction {
 	t.Helper()
 
-	req := schemaapi.MigrateConnectionVersionRequestJson{TargetVersion: targetVersion}
-	if timeoutSeconds > 0 {
-		req.TimeoutSeconds = &timeoutSeconds
+	parsedConnectionID, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	connection := env.GetConnection(t, connectionID)
+	spec := schemaapi.ConnectionVersionMigrationSpec{
+		ConnectorRef: connectorReference(connection.ConnectorId, targetVersion),
 	}
+	if timeoutSeconds > 0 {
+		spec.TimeoutSeconds = &timeoutSeconds
+	}
+	req := schemaapi.ConnectionVersionMigrationAction{Action: apiv1alpha1.Action[schemaapi.ConnectionVersionMigrationSpec, schemaapi.ConnectionVersionMigrationStatus]{
+		TypeMeta: meta.NewTypeMeta(schemaapi.ConnectionVersionMigrationActionKind),
+		Metadata: apiv1alpha1.ActionMeta{Target: connectionschema.NewConnectionReference(parsedConnectionID)},
+		Spec:     spec,
+	}}
 	body, err := jsonMarshal(req)
 	require.NoError(t, err)
 
@@ -141,11 +152,13 @@ func (env *IntegrationTestEnv) MigrateConnectionVersion(
 	w := env.doSignedRequest(t, http.MethodPost, path, body, env.resolveActorOptions(opts))
 	require.Equalf(t, http.StatusOK, w.Code, "migrate connection version failed: %s", w.Body.String())
 
-	var out schemaapi.MigrateConnectionVersionResponseJson
+	var out schemaapi.ConnectionVersionMigrationAction
 	require.NoError(t, jsonUnmarshal(w.Body.Bytes(), &out))
-	require.Equal(t, connectionID, out.ConnectionId.String())
-	require.Equal(t, targetVersion, out.TargetVersion)
-	require.NotEmpty(t, out.TaskId)
+	require.NoError(t, out.ValidateResponse(schemaapi.ConnectionVersionMigrationActionKind))
+	require.Equal(t, connectionID, out.Metadata.Target.ID)
+	require.Equal(t, targetVersion, out.Spec.ConnectorRef.Generation)
+	require.NotNil(t, out.Status)
+	require.NotEmpty(t, out.Status.TaskID)
 	return out
 }
 
@@ -158,7 +171,7 @@ func (env *IntegrationTestEnv) MigrateConnectionVersionAndWait(
 	targetVersion uint64,
 	timeout time.Duration,
 	opts ...ActorOption,
-) schemaapi.MigrateConnectionVersionResponseJson {
+) schemaapi.ConnectionVersionMigrationAction {
 	t.Helper()
 
 	timeoutSeconds := int64(timeout.Seconds())
@@ -166,7 +179,8 @@ func (env *IntegrationTestEnv) MigrateConnectionVersionAndWait(
 		timeoutSeconds = 10
 	}
 	resp := env.MigrateConnectionVersion(t, connectionID, targetVersion, timeoutSeconds, opts...)
-	RequireWorkflowTaskCompleted(t, env, resp.TaskId, timeout, opts...)
+	require.NotNil(t, resp.Status)
+	RequireWorkflowTaskCompleted(t, env, resp.Status.TaskID, timeout, opts...)
 	return resp
 }
 
@@ -183,10 +197,7 @@ func (env *IntegrationTestEnv) SubmitSetupForm(
 
 	rawData, err := json.Marshal(data)
 	require.NoError(t, err)
-	body, err := jsonMarshal(iface.SubmitConnectionRequest{
-		StepId: stepID,
-		Data:   rawData,
-	})
+	body, err := jsonMarshal(connectionSetupSubmitAction(connectionID, stepID, rawData))
 	require.NoError(t, err)
 
 	return env.doSignedRequest(t, http.MethodPost, "/api/v1/connections/"+connectionID+"/_submit", body, env.resolveActorOptions(opts))
@@ -254,13 +265,10 @@ func (env *IntegrationTestEnv) ListConnectionNotifications(
 ) []schemaapi.NotificationJson {
 	t.Helper()
 
-	id, err := apid.Parse(connectionID)
-	require.NoError(t, err)
-
 	items := env.ListNotifications(t, state, includeViewed, opts...)
 	filtered := make([]schemaapi.NotificationJson, 0, len(items))
 	for _, n := range items {
-		if n.ResourceType == "connection" && n.ResourceId == id {
+		if n.Spec.ResourceRef.Kind == connectionschema.ConnectionKind && n.Spec.ResourceRef.ID == connectionID {
 			filtered = append(filtered, n)
 		}
 	}
@@ -280,8 +288,8 @@ func (env *IntegrationTestEnv) RequireSingleActiveConnectionNotification(
 
 	items := env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateActive, false, opts...)
 	require.Len(t, items, 1, "expected one active connection notification")
-	require.Truef(t, strings.HasSuffix(items[0].Key, ":"+keySuffix),
-		"notification key %q should end with %q", items[0].Key, keySuffix)
+	require.Truef(t, strings.HasSuffix(items[0].Spec.Key, ":"+keySuffix),
+		"notification key %q should end with %q", items[0].Spec.Key, keySuffix)
 	return items[0]
 }
 
@@ -308,8 +316,8 @@ func (env *IntegrationTestEnv) RequireResolvedConnectionNotification(
 
 	items := env.ListConnectionNotifications(t, connectionID, schemaapi.NotificationStateResolved, true, opts...)
 	for _, n := range items {
-		if strings.HasSuffix(n.Key, ":"+keySuffix) {
-			require.NotNil(t, n.ResolvedAt, "resolved notification should include resolved_at")
+		if strings.HasSuffix(n.Spec.Key, ":"+keySuffix) {
+			require.NotNil(t, n.Status.ResolvedAt, "resolved notification should include status.resolvedAt")
 			return n
 		}
 	}

--- a/integration_tests/oauth2/callback_actor_mismatch_test.go
+++ b/integration_tests/oauth2/callback_actor_mismatch_test.go
@@ -42,7 +42,7 @@ func TestCallbackRejection_ActorMismatch(t *testing.T) {
 	providerUserPassword := "p4ssw0rd-" + suffix
 	providerUserEmail := "alice-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "actor-mismatch-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/callback_cross_namespace_test.go
+++ b/integration_tests/oauth2/callback_cross_namespace_test.go
@@ -52,7 +52,7 @@ func TestCallbackRejection_CrossNamespace(t *testing.T) {
 	providerUserPassword := "p4ssw0rd-" + suffix
 	providerUserEmail := "alice-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "cross-ns-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/callback_namespace_mismatch_test.go
+++ b/integration_tests/oauth2/callback_namespace_mismatch_test.go
@@ -42,7 +42,7 @@ func TestCallbackRejection_NamespaceMismatchActor(t *testing.T) {
 	clientKey := "ns-mismatch-actor-client-" + suffix
 	clientSecret := "ns-mismatch-actor-secret-" + suffix
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "ns-mismatch-actor-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,
@@ -153,7 +153,7 @@ func TestCallbackRejection_NamespaceMismatchConnection(t *testing.T) {
 	clientKey := "ns-mismatch-conn-client-" + suffix
 	clientSecret := "ns-mismatch-conn-secret-" + suffix
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "ns-mismatch-conn-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/callback_state_security_test.go
+++ b/integration_tests/oauth2/callback_state_security_test.go
@@ -58,7 +58,7 @@ func newCallbackStateSecurityRig(t *testing.T, name string) *callbackStateSecuri
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/callback_token_exchange_failure_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_failure_test.go
@@ -55,7 +55,7 @@ func newTokenExchangeFailureRig(t *testing.T, name string) *tokenExchangeFailure
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/callback_token_exchange_retry_test.go
+++ b/integration_tests/oauth2/callback_token_exchange_retry_test.go
@@ -45,7 +45,7 @@ func newTokenExchangeRetryRig(t *testing.T, name string) *tokenExchangeRetryRig 
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/connector_disconnect_all_test.go
+++ b/integration_tests/oauth2/connector_disconnect_all_test.go
@@ -51,7 +51,7 @@ func newConnectorDisconnectAllRig(t *testing.T, name string, connectorCount int)
 	for i := 0; i < connectorCount; i++ {
 		clientKey := fmt.Sprintf("%s-client-%d-%s", name, i, suffix)
 		clientSecret := fmt.Sprintf("%s-secret-%d-%s", name, i, suffix)
-		connectorID := apid.New(apid.PrefixConnectorVersion)
+		connectorID := apid.New(apid.PrefixConnector)
 		connector := helpers.NewOAuth2Connector(connectorID, fmt.Sprintf("%s-%d", name, i), provider, helpers.OAuth2ConnectorOptions{
 			ClientID:          clientKey,
 			ClientSecret:      clientSecret,

--- a/integration_tests/oauth2/disconnect_revocation_test.go
+++ b/integration_tests/oauth2/disconnect_revocation_test.go
@@ -17,9 +17,12 @@ import (
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
 	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	connectionschema "github.com/rmorlok/authproxy/internal/schema/resources/connection"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +48,7 @@ func newDisconnectRevocationRig(t *testing.T, name string) *disconnectRevocation
 	clientSecret := name + "-secret-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:          clientKey,
 		ClientSecret:      clientSecret,
@@ -123,9 +126,13 @@ func (r *disconnectRevocationRig) completeAuthFlow(t *testing.T) string {
 func (r *disconnectRevocationRig) disconnect(t *testing.T, connectionID string) {
 	t.Helper()
 
-	reqBody, err := json.Marshal(schemaapi.DisconnectConnectionRequestJson{
-		TimeoutSeconds: int64Ptr(10),
-	})
+	id, err := apid.Parse(connectionID)
+	require.NoError(t, err)
+	reqBody, err := json.Marshal(schemaapi.ConnectionDisconnectAction{Action: apiv1alpha1.Action[schemaapi.ConnectionDisconnectSpec, schemaapi.ConnectionDisconnectStatus]{
+		TypeMeta: meta.NewTypeMeta(schemaapi.ConnectionDisconnectActionKind),
+		Metadata: apiv1alpha1.ActionMeta{Target: connectionschema.NewConnectionReference(id)},
+		Spec:     schemaapi.ConnectionDisconnectSpec{TimeoutSeconds: int64Ptr(10)},
+	}})
 	require.NoError(t, err)
 
 	path := "/api/v1/connections/" + connectionID + "/_disconnect"
@@ -143,17 +150,14 @@ func (r *disconnectRevocationRig) disconnect(t *testing.T, connectionID string) 
 	r.env.ApiGin.ServeHTTP(w, req)
 	require.Equalf(t, http.StatusOK, w.Code, "disconnect failed: %s", w.Body.String())
 
-	var body struct {
-		Connection struct {
-			State string `json:"state"`
-		} `json:"connection"`
-		TaskID string `json:"taskId"`
-	}
+	var body schemaapi.ConnectionDisconnectAction
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.Equal(t, string(database.ConnectionStateDisconnecting), body.Connection.State)
-	assert.NotEmpty(t, body.TaskID)
+	require.NotNil(t, body.Status)
+	require.NotNil(t, body.Status.Connection.Status)
+	assert.Equal(t, connectionschema.ConnectionStateDisconnecting, body.Status.Connection.Status.Lifecycle.State)
+	assert.NotEmpty(t, body.Status.TaskID)
 
-	helpers.RequireWorkflowTaskCompleted(t, r.env, body.TaskID, 15*time.Second)
+	helpers.RequireWorkflowTaskCompleted(t, r.env, body.Status.TaskID, 15*time.Second)
 }
 
 func int64Ptr(v int64) *int64 {

--- a/integration_tests/oauth2/incremental_authorization_test.go
+++ b/integration_tests/oauth2/incremental_authorization_test.go
@@ -3,7 +3,6 @@
 package oauth2
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +15,6 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
-	coreIface "github.com/rmorlok/authproxy/internal/schema/api"
 	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
@@ -52,7 +50,7 @@ func newIncrementalAuthRig(t *testing.T, name string) *incrementalAuthRig {
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:       clientKey,
 		ClientSecret:   clientSecret,
@@ -122,43 +120,7 @@ func (r *incrementalAuthRig) startReauth(t *testing.T, connectionID string, scop
 		r.provider.Script(r.clientKey, helpers.EndpointToken, *failure)
 	}
 
-	body, err := json.Marshal(struct {
-		ReturnToUrl string `json:"returnToUrl,omitempty"`
-	}{
-		ReturnToUrl: r.returnToURL,
-	})
-	require.NoError(t, err)
-
-	path := "/api/v1/connections/" + connectionID + "/_reauth"
-	req, err := r.env.ApiAuthUtil.NewSignedRequestForActorExternalId(
-		http.MethodPost,
-		path,
-		bytes.NewReader(body),
-		sconfig.RootNamespace,
-		"test-actor",
-		aschema.AllPermissions(),
-	)
-	require.NoError(t, err)
-
-	abs, err := url.Parse(r.env.ServerURL + path)
-	require.NoError(t, err)
-	req.URL = abs
-	req.Host = abs.Host
-	req.RequestURI = ""
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equalf(t, http.StatusOK, resp.StatusCode, "reauth failed: %s", string(respBody))
-
-	var out coreIface.ConnectionSetupRedirect
-	require.NoErrorf(t, json.Unmarshal(respBody, &out), "decode reauth body: %s", string(respBody))
-	require.Equal(t, coreIface.ConnectionSetupResponseTypeRedirect, out.Type)
-	require.NotEmpty(t, out.RedirectUrl)
-	return out.RedirectUrl
+	return r.env.ReauthOAuth2Connection(t, connectionID, r.returnToURL)
 }
 
 func (r *incrementalAuthRig) approveOAuthRedirect(t *testing.T, redirectURL string, scopeOverride *string) {

--- a/integration_tests/oauth2/open_redirect_test.go
+++ b/integration_tests/oauth2/open_redirect_test.go
@@ -29,7 +29,7 @@ func TestOAuth2OpenRedirectProtection_InvalidReturnURLFallsBackToMarketplace(t *
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := "open-redirect-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "open-redirect-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/pkce_test.go
+++ b/integration_tests/oauth2/pkce_test.go
@@ -117,7 +117,7 @@ func TestPKCE_HappyPath_S256(t *testing.T) {
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := "alice-pkce-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "pkce-happy-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,
@@ -296,7 +296,7 @@ func TestPKCE_TokenExchangeRejected(t *testing.T) {
 			clientSecret := "pkce-rej-secret-" + suffix
 			userEmail := "alice-pkce-rej-" + suffix + "@example.com"
 
-			connectorID := apid.New(apid.PrefixConnectorVersion)
+			connectorID := apid.New(apid.PrefixConnector)
 			connector := helpers.NewOAuth2Connector(connectorID, "pkce-rejected", provider, helpers.OAuth2ConnectorOptions{
 				ClientID:     clientKey,
 				ClientSecret: clientSecret,

--- a/integration_tests/oauth2/provider_auth_method_compatibility_test.go
+++ b/integration_tests/oauth2/provider_auth_method_compatibility_test.go
@@ -49,7 +49,7 @@ func newAuthMethodCompatibilityRig(
 	clientSecret := name + "-secret-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	opts := helpers.OAuth2ConnectorOptions{
 		ClientID:                clientKey,
 		ClientSecret:            clientSecret,

--- a/integration_tests/oauth2/proxy_refresh_test.go
+++ b/integration_tests/oauth2/proxy_refresh_test.go
@@ -59,7 +59,7 @@ func newProxyRefreshRig(t *testing.T, name string) *proxyRefreshRig {
 	clientSecret := name + "-secret-" + suffix
 	userEmail := name + "-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/scope_mismatch_test.go
+++ b/integration_tests/oauth2/scope_mismatch_test.go
@@ -58,7 +58,7 @@ func newScopeMismatchSetup(t *testing.T, name string, required, optional []strin
 	scopes := append([]string{}, required...)
 	scopes = append(scopes, optional...)
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, name, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:       clientKey,
 		ClientSecret:   clientSecret,

--- a/integration_tests/oauth2/standard_flow_test.go
+++ b/integration_tests/oauth2/standard_flow_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/chromedp/chromedp"
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
-	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
+	aschema "github.com/rmorlok/authproxy/internal/schema/auth"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +39,7 @@ func TestStandardAuthorizationCodeFlow(t *testing.T) {
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := "alice-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "standard-flow-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/oauth2/standard_flow_test.md
+++ b/integration_tests/oauth2/standard_flow_test.md
@@ -127,5 +127,5 @@ The dockerized OAuth provider persists registered clients and users
 across runs of `go test`. The test suffixes the client key, secret, and
 user email with `time.Now().UnixNano()` so reruns don't 400 on
 "Client ID taken" or "Username taken". The connector ID is generated
-fresh via `apid.New(apid.PrefixConnectorVersion)` per run, and each test
+fresh via `apid.New(apid.PrefixConnector)` per run, and each test
 gets an isolated database via `pgtestdb`.

--- a/integration_tests/oauth2/user_denial_test.go
+++ b/integration_tests/oauth2/user_denial_test.go
@@ -41,7 +41,7 @@ func TestUserDenialFlow(t *testing.T) {
 	userPassword := "p4ssw0rd-" + suffix
 	userEmail := "deny-" + suffix + "@example.com"
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "user-denial-test", provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,

--- a/integration_tests/probes/oauth2_probe_health_test.go
+++ b/integration_tests/probes/oauth2_probe_health_test.go
@@ -41,7 +41,7 @@ func TestOAuth2ProbeHealth_FailureAndRecovery(t *testing.T) {
 	userEmail := "probe-health-" + suffix + "@example.com"
 	userPassword := "p4ssw0rd-" + suffix
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 
 	one := 1
 	probeURL := provider.ResourceURL("/probe-" + suffix)

--- a/integration_tests/smoke/oauth2_live_test.go
+++ b/integration_tests/smoke/oauth2_live_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/schema/api"
+	cschema "github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,20 +62,20 @@ func TestRemoteOAuth2ProxySmoke(t *testing.T) {
 	})
 	require.NotEmpty(t, user.ID)
 
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 	connector := helpers.NewOAuth2Connector(connectorID, "smoke-oauth2-"+suffix, provider, helpers.OAuth2ConnectorOptions{
 		ClientID:     clientKey,
 		ClientSecret: clientSecret,
 		Scopes:       []string{"read"},
 	})
 	created := rig.CreateConnector(t, connector)
-	require.Equal(t, uint64(1), created.Version)
-	rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStatePrimary))
+	require.Equal(t, uint64(1), created.Metadata.Generation)
+	rig.ForceConnectorVersionState(t, created.GetId(), created.Metadata.Generation, cschema.ConnectorReleaseStatePrimary)
 	t.Cleanup(func() {
-		rig.ForceConnectorVersionState(t, created.Id, created.Version, string(api.ConnectorVersionStateArchived))
+		rig.ForceConnectorVersionState(t, created.GetId(), created.Metadata.Generation, cschema.ConnectorReleaseStateArchived)
 	})
 
-	connectionID, redirectURL := rig.InitiateOAuth2Connection(t, created.Id, rig.PublicURL+"/connections")
+	connectionID, redirectURL := rig.InitiateOAuth2Connection(t, created.GetId(), rig.PublicURL+"/connections")
 	require.NotEmpty(t, connectionID)
 
 	authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
@@ -137,10 +138,10 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 
 	t.Run("catalog contains expected seeded connectors", func(t *testing.T) {
 		items := rig.ListConnectors(t, "demo=true")
-		bySeedKey := map[string]api.ConnectorJson{}
+		byName := map[string]cschema.Connector{}
 		for _, item := range items {
-			if key := item.Labels["demo.authproxy.net/seed-key"]; key != "" {
-				bySeedKey[key] = item
+			if item.Metadata.Name != "" {
+				byName[string(item.Metadata.Name)] = item
 			}
 		}
 
@@ -151,18 +152,19 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 			"demo-oauth-tenant":    "Demo OAuth: Tenant Selection",
 			"demo-oauth-configure": "Demo OAuth: Resource Configuration",
 		}
-		for seedKey, displayName := range expected {
-			connector, ok := bySeedKey[seedKey]
-			require.Truef(t, ok, "missing seeded connector %q (%s); present seed keys: %v", seedKey, displayName, sortedKeys(bySeedKey))
-			require.Equalf(t, displayName, connector.DisplayName, "seeded connector %q display name changed", seedKey)
-			require.Equalf(t, api.ConnectorVersionStatePrimary, connector.State, "seeded connector %q should be primary", seedKey)
+		for name, displayName := range expected {
+			connector, ok := byName[name]
+			require.Truef(t, ok, "missing seeded connector %q (%s); present names: %v", name, displayName, sortedKeys(byName))
+			require.Equalf(t, displayName, connector.Spec.Definition.DisplayName, "seeded connector %q display name changed", name)
+			require.NotNil(t, connector.Status)
+			require.Equalf(t, cschema.ConnectorReleaseStatePrimary, connector.Status.Release.State, "seeded connector %q should be primary", name)
 		}
 	})
 
 	t.Run("seeded basic OAuth connector completes and proxies", func(t *testing.T) {
 		startedAt := time.Now().Add(-1 * time.Second)
-		connector := rig.FindConnectorBySeedKey(t, "demo-oauth-simple")
-		connectionID, redirectURL := rig.InitiateOAuth2Connection(t, connector.Id, rig.PublicURL+"/connections")
+		connector := rig.FindConnectorByName(t, "demo-oauth-simple")
+		connectionID, redirectURL := rig.InitiateOAuth2Connection(t, connector.GetId(), rig.PublicURL+"/connections")
 
 		authorizeURL := rig.FollowOAuth2Redirect(t, redirectURL)
 		authorizeParams := parseQuery(t, authorizeURL)
@@ -196,8 +198,8 @@ func TestRemoteSeededConnectorsSmoke(t *testing.T) {
 	})
 
 	t.Run("seeded API key connector completes and proxies", func(t *testing.T) {
-		connector := rig.FindConnectorBySeedKey(t, "demo-api-key-bearer")
-		connectionID, stepID := rig.InitiateAPIKeyConnection(t, connector.Id)
+		connector := rig.FindConnectorByName(t, "demo-api-key-bearer")
+		connectionID, stepID := rig.InitiateAPIKeyConnection(t, connector.GetId())
 		respType := rig.SubmitAPIKeyCredentials(t, connectionID, stepID, "demo-api-key")
 		switch respType {
 		case api.ConnectionSetupResponseTypeComplete:
@@ -223,7 +225,7 @@ func parseQuery(t *testing.T, rawURL string) url.Values {
 	return parsed.Query()
 }
 
-func sortedKeys(connectors map[string]api.ConnectorJson) []string {
+func sortedKeys(connectors map[string]cschema.Connector) []string {
 	keys := make([]string, 0, len(connectors))
 	for key := range connectors {
 		keys = append(keys, key)

--- a/integration_tests/version_migration/api_key_test.go
+++ b/integration_tests/version_migration/api_key_test.go
@@ -47,7 +47,7 @@ func TestApiKeyVersionMigrationConfigureChangeRequiresSetup(t *testing.T) {
 		},
 	})
 	published := env.PublishConnectorVersion(t, connectorID, v2, nil, nil)
-	require.Equal(t, uint64(2), published.Version)
+	require.Equal(t, uint64(2), published.Metadata.Generation)
 
 	env.MigrateConnectionVersionAndWait(t, connectionID, 2, apiKeyMigrationTimeout)
 
@@ -64,8 +64,8 @@ func TestApiKeyVersionMigrationConfigureChangeRequiresSetup(t *testing.T) {
 		helpers.NotificationKeySuffixSetupRequired,
 	)
 	assertNoAuthProxyCopy(t, notification)
-	assert.True(t, notification.CanAction)
-	assert.Contains(t, notification.ActionUrl, "action=configure")
+	require.NotNil(t, notification.Status.Action)
+	assert.Contains(t, notification.Status.Action.URL, "action=configure")
 
 	w := env.SubmitSetupForm(t, connectionID, configureWorkspaceStepID, map[string]any{
 		"workspace": "north",
@@ -107,7 +107,7 @@ func TestApiKeyVersionMigrationPreconnectChangeRequiresReauth(t *testing.T) {
 		},
 	})
 	published := env.PublishConnectorVersion(t, connectorID, v2, nil, nil)
-	require.Equal(t, uint64(2), published.Version)
+	require.Equal(t, uint64(2), published.Metadata.Generation)
 
 	env.MigrateConnectionVersionAndWait(t, connectionID, 2, apiKeyMigrationTimeout)
 
@@ -123,20 +123,20 @@ func TestApiKeyVersionMigrationPreconnectChangeRequiresReauth(t *testing.T) {
 		helpers.NotificationKeySuffixAuthRequired,
 	)
 	assertNoAuthProxyCopy(t, notification)
-	assert.True(t, notification.CanAction)
-	assert.Contains(t, notification.ActionUrl, "action=reauth")
+	require.NotNil(t, notification.Status.Action)
+	assert.Contains(t, notification.Status.Action.URL, "action=reauth")
 
 	stub.RotateAcceptedKey(rotatedKey)
 
 	w := env.ReauthConnection(t, connectionID)
 	form := requireConnectionSetupForm(t, w)
-	require.Equal(t, preconnectRegionStepID, form.StepId)
+	require.Equal(t, preconnectRegionStepID, form.StepID)
 
 	w = env.SubmitSetupForm(t, connectionID, preconnectRegionStepID, map[string]any{
 		"region": "us-east-1",
 	})
 	form = requireConnectionSetupForm(t, w)
-	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepId)
+	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepID)
 
 	w = env.SubmitApiKeyCredentials(t, connectionID, helpers.ApiKeySubmitFormStepId(), map[string]any{
 		"api_key": rotatedKey,
@@ -169,12 +169,14 @@ func createPrimaryAPIKeyConnector(
 	t.Helper()
 
 	created := env.CreateConnector(t, apiKeyMigrationConnectorDefinition(displayName, stub, setupFlow), nil, nil)
-	require.Equal(t, uint64(1), created.Version)
-	require.Equal(t, schemaapi.ConnectorVersionStateDraft, created.State)
+	require.Equal(t, uint64(1), created.Metadata.Generation)
+	require.NotNil(t, created.Status)
+	require.Equal(t, connectors.ConnectorReleaseStateDraft, created.Status.Release.State)
 
-	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
-	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
-	return created.Id
+	primary := env.ForceConnectorVersionState(t, created.GetId(), created.Metadata.Generation, connectors.ConnectorReleaseStatePrimary)
+	require.NotNil(t, primary.Status)
+	require.Equal(t, connectors.ConnectorReleaseStatePrimary, primary.Status.Release.State)
+	return created.GetId()
 }
 
 func createHealthyAPIKeyConnection(
@@ -186,9 +188,9 @@ func createHealthyAPIKeyConnection(
 	t.Helper()
 
 	connectionID, form := env.InitiateApiKeyConnection(t, connectorID)
-	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepId)
+	require.Equal(t, helpers.ApiKeySubmitFormStepId(), form.StepID)
 
-	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepId, map[string]any{"api_key": apiKey})
+	w := env.SubmitApiKeyCredentials(t, connectionID, form.StepID, map[string]any{"api_key": apiKey})
 	requireConnectionSetupVerifying(t, w)
 	require.NoError(t, env.RunVerifyConnection(t, connectionID))
 
@@ -206,7 +208,7 @@ func apiKeyMigrationConnectorDefinition(
 	stub *helpers.ApiKeyStubUpstream,
 	setupFlow *connectors.SetupFlow,
 ) sconfig.ConnectorDefinition {
-	conn := helpers.NewApiKeyConnector(apid.New(apid.PrefixConnectorVersion), displayName, helpers.ApiKeyConnectorOptions{
+	conn := helpers.NewApiKeyConnector(apid.New(apid.PrefixConnector), displayName, helpers.ApiKeyConnectorOptions{
 		Placement: connectors.ApiKeyPlacementBearer,
 		ProbeURL:  stub.BaseURL + "/probe",
 	}).Spec.Definition
@@ -229,17 +231,25 @@ func requiredStringStep(stepID, title, fieldName string) connectors.SetupFlowSte
 			"required": ["` + fieldName + `"],
 			"additionalProperties": false
 		}`),
+		UiSchema: common.RawJSON(`{
+			"type": "VerticalLayout",
+			"elements": [{
+				"type": "Control",
+				"scope": "#/properties/` + fieldName + `"
+			}]
+		}`),
 	}
 }
 
-func requireConnectionSetupForm(t *testing.T, w *httptest.ResponseRecorder) schemaapi.ConnectionSetupForm {
+func requireConnectionSetupForm(t *testing.T, w *httptest.ResponseRecorder) *schemaapi.ConnectionSetupActionStatus {
 	t.Helper()
 	require.Equalf(t, http.StatusOK, w.Code, "setup request failed: %s", w.Body.String())
 	requireConnectionSetupResponseType(t, w, schemaapi.ConnectionSetupResponseTypeForm)
 
-	var form schemaapi.ConnectionSetupForm
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &form))
-	return form
+	var action schemaapi.ConnectionSetupAction
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &action))
+	require.NotNil(t, action.Status)
+	return action.Status
 }
 
 func requireConnectionSetupVerifying(t *testing.T, w *httptest.ResponseRecorder) {
@@ -261,15 +271,14 @@ func requireConnectionSetupResponseType(
 ) {
 	t.Helper()
 
-	var generic struct {
-		Type schemaapi.ConnectionSetupResponseType `json:"type"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &generic))
-	require.Equalf(t, expected, generic.Type, "unexpected setup response: %s", w.Body.String())
+	var action schemaapi.ConnectionSetupAction
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &action))
+	require.NotNil(t, action.Status)
+	require.Equalf(t, expected, action.Status.Type, "unexpected setup response: %s", w.Body.String())
 }
 
 func assertNoAuthProxyCopy(t *testing.T, notification schemaapi.NotificationJson) {
 	t.Helper()
-	assert.NotContains(t, strings.ToLower(notification.Title), "authproxy")
-	assert.NotContains(t, strings.ToLower(notification.Message), "authproxy")
+	assert.NotContains(t, strings.ToLower(notification.Spec.Title), "authproxy")
+	assert.NotContains(t, strings.ToLower(notification.Spec.Message), "authproxy")
 }

--- a/integration_tests/version_migration/no_auth_test.go
+++ b/integration_tests/version_migration/no_auth_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
-	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	"github.com/rmorlok/authproxy/internal/schema/common"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
@@ -53,11 +52,12 @@ func TestNoAuthVersionMigrationAppliesDefaultsAndRunsAllTargetProbes(t *testing.
 		nil,
 		nil,
 	)
-	require.Equal(t, uint64(1), created.Version)
-	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
-	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
+	require.Equal(t, uint64(1), created.Metadata.Generation)
+	primary := env.ForceConnectorVersionState(t, created.GetId(), created.Metadata.Generation, connectors.ConnectorReleaseStatePrimary)
+	require.NotNil(t, primary.Status)
+	require.Equal(t, connectors.ConnectorReleaseStatePrimary, primary.Status.Release.State)
 
-	connectionID := env.InitiateNoAuthConnection(t, created.Id)
+	connectionID := env.InitiateNoAuthConnection(t, created.GetId())
 	initial := env.GetConnection(t, connectionID)
 	require.Equal(t, uint64(1), initial.ConnectorVersion)
 	require.Equal(t, database.ConnectionStateConfigured, initial.State)
@@ -69,7 +69,7 @@ func TestNoAuthVersionMigrationAppliesDefaultsAndRunsAllTargetProbes(t *testing.
 
 	published := env.PublishConnectorVersion(
 		t,
-		created.Id,
+		created.GetId(),
 		noAuthMigrationConnectorDefinition(
 			"no-auth-migration-v2",
 			defaultedConfigureFlow("region", "us-east-1"),
@@ -81,11 +81,12 @@ func TestNoAuthVersionMigrationAppliesDefaultsAndRunsAllTargetProbes(t *testing.
 		nil,
 		nil,
 	)
-	require.Equal(t, uint64(2), published.Version)
+	require.Equal(t, uint64(2), published.Metadata.Generation)
 
 	migration := env.MigrateConnectionVersionAndWait(t, connectionID, 2, noAuthMigrationTimeout)
-	require.Equal(t, uint64(1), migration.SourceVersion)
-	require.Equal(t, uint64(2), migration.TargetVersion)
+	require.NotNil(t, migration.Status)
+	require.Equal(t, uint64(1), migration.Status.SourceConnectorRef.Generation)
+	require.Equal(t, uint64(2), migration.Status.TargetConnectorRef.Generation)
 
 	migrated := env.GetConnection(t, connectionID)
 	require.Equal(t, uint64(2), migrated.ConnectorVersion)
@@ -107,7 +108,7 @@ func noAuthMigrationConnectorDefinition(
 	probes []connectors.Probe,
 ) sconfig.ConnectorDefinition {
 	connector := helpers.NewNoAuthConnector(
-		apid.New(apid.PrefixConnectorVersion),
+		apid.New(apid.PrefixConnector),
 		displayName,
 		nil, // rateLimiting
 	).Spec.Definition

--- a/integration_tests/version_migration/oauth_test.go
+++ b/integration_tests/version_migration/oauth_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/rmorlok/authproxy/integration_tests/helpers"
 	"github.com/rmorlok/authproxy/internal/apid"
 	"github.com/rmorlok/authproxy/internal/database"
-	schemaapi "github.com/rmorlok/authproxy/internal/schema/api"
 	sconfig "github.com/rmorlok/authproxy/internal/schema/config"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,8 +59,8 @@ func TestOAuth2VersionMigrationScopeExpansionRequiresReauth(t *testing.T) {
 		helpers.NotificationKeySuffixAuthRequired,
 	)
 	assertNoAuthProxyCopy(t, notification)
-	assert.True(t, notification.CanAction)
-	assert.Contains(t, notification.ActionUrl, "action=reauth")
+	require.NotNil(t, notification.Status.Action)
+	assert.Contains(t, notification.Status.Action.URL, "action=reauth")
 
 	reauthRedirect := rig.env.ReauthOAuth2Connection(t, connectionID, rig.returnToURL)
 	rig.requireRedirectScopes(t, reauthRedirect, "read write")
@@ -102,8 +102,9 @@ func TestOAuth2VersionMigrationScopeExpansionRollbackRestoresConnection(t *testi
 	)
 
 	rollback := rig.env.MigrateConnectionVersionAndWait(t, connectionID, 1, oauthMigrationTimeout)
-	require.Equal(t, uint64(2), rollback.SourceVersion)
-	require.Equal(t, uint64(1), rollback.TargetVersion)
+	require.NotNil(t, rollback.Status)
+	require.Equal(t, uint64(2), rollback.Status.SourceConnectorRef.Generation)
+	require.Equal(t, uint64(1), rollback.Status.TargetConnectorRef.Generation)
 
 	restored := rig.env.GetConnection(t, connectionID)
 	require.Equal(t, uint64(1), restored.ConnectorVersion)
@@ -125,7 +126,7 @@ func newOAuthMigrationRig(t *testing.T, name string) *oauthMigrationRig {
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 	clientKey := name + "-client-" + suffix
 	clientSecret := name + "-secret-" + suffix
-	connectorID := apid.New(apid.PrefixConnectorVersion)
+	connectorID := apid.New(apid.PrefixConnector)
 
 	env := helpers.Setup(t, helpers.SetupOptions{
 		Service:       helpers.ServiceTypeAPI,
@@ -144,10 +145,11 @@ func newOAuthMigrationRig(t *testing.T, name string) *oauthMigrationRig {
 	}
 
 	created := env.CreateConnector(t, rig.connectorDefinition(name+"-v1", []string{"read"}), nil, nil)
-	require.Equal(t, uint64(1), created.Version)
-	rig.connectorID = created.Id
-	primary := env.ForceConnectorVersionState(t, created.Id, created.Version, schemaapi.ConnectorVersionStatePrimary)
-	require.Equal(t, schemaapi.ConnectorVersionStatePrimary, primary.State)
+	require.Equal(t, uint64(1), created.Metadata.Generation)
+	rig.connectorID = created.GetId()
+	primary := env.ForceConnectorVersionState(t, created.GetId(), created.Metadata.Generation, connectors.ConnectorReleaseStatePrimary)
+	require.NotNil(t, primary.Status)
+	require.Equal(t, connectors.ConnectorReleaseStatePrimary, primary.Status.Release.State)
 
 	registered := provider.CreateClient(helpers.CreateClientRequest{
 		Key:                     clientKey,
@@ -211,7 +213,7 @@ func (r *oauthMigrationRig) publishRequiredScopeVersion(t *testing.T, scopes []s
 		nil,
 		nil,
 	)
-	require.Equal(t, uint64(2), published.Version)
+	require.Equal(t, uint64(2), published.Metadata.Generation)
 }
 
 func (r *oauthMigrationRig) requireRedirectScopes(t *testing.T, redirectURL, want string) {

--- a/internal/loadtest/seeder/seed.go
+++ b/internal/loadtest/seeder/seed.go
@@ -146,7 +146,7 @@ func Seed(ctx context.Context, opts Options) (*Result, error) {
 
 	slug := slugForID(opts.Profile.Name)
 	baseNamespace := nschema.PathFromRoot("loadtest", slugForNamespace(opts.Profile.Name))
-	connectorID := apid.ID(fmt.Sprintf("%slt_%s_oauth2", apid.PrefixConnectorVersion, slug))
+	connectorID := apid.ID(fmt.Sprintf("%slt_%s_oauth2", apid.PrefixConnector, slug))
 	connectorVersion := uint64(1)
 	tenantCount := opts.Profile.TenantNamespaceCount()
 	connectionCount := opts.Profile.Objects.Connections


### PR DESCRIPTION
Closes #848

## Summary

- migrate integration and smoke-test clients from legacy flat connector/connection payloads to canonical `authproxy.net/v1alpha1` resources and action envelopes
- centralize valid connection action fixtures, including primary-generation connector references and required return URLs, and update assertions for canonical status/reference fields
- make the demo seed loader strictly parse and validate complete Actor and Connector resources; identify seeded connectors by `metadata.namespace` plus `metadata.name`
- convert demo/dev seed ConfigMaps to full resources and reject legacy flat seed data in tests
- verify CLI resource output retains the complete envelope and document `metadata.id`, current configuration examples, and the intentional environment rebuild boundary
- replace remaining load/integration fixture use of the legacy connector-version ID prefix

## Validation

- `./scripts/preflight.sh`
- `go test ./...`
- `go test ./...` in `integration_tests`
- `go test -tags=integration ./... -run ^$` in `integration_tests`
- `go test -tags=smoke ./... -run ^$` in `integration_tests`
- focused API-key, no-auth, disconnect, and reauthentication integration scenarios against fresh SQLite and PostgreSQL
- `yarn docs:build`
- Kustomize renders for both demo overlays
- Helm render using the load-test common and API values