### PR TITLE
Add ap apply manifest loading and client dry-run

### DIFF
--- a/cmd/cli/apply.go
+++ b/cmd/cli/apply.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rmorlok/authproxy/internal/apply"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func cmdApply() *cobra.Command {
+	var options apply.Options
+	var dryRun, output, validation string
+	cmd := &cobra.Command{
+		Use:   "apply -f FILENAME [flags]",
+		Short: "Validate resource manifests with client dry-run",
+		Long:  "Load AuthProxy resource manifests from files, directories, URLs or stdin. This initial implementation supports --dry-run=client only; cluster writes are not yet available.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRun != "client" {
+				return fmt.Errorf("only --dry-run=client is currently supported; cluster apply is not yet available")
+			}
+			if validation != "strict" && validation != "true" {
+				return fmt.Errorf("only --validate=strict is currently supported")
+			}
+			switch output {
+			case "", "name", "json", "yaml":
+			default:
+				return fmt.Errorf("unsupported output format %q", output)
+			}
+			options.Stdin = cmd.InOrStdin()
+			docs, err := apply.Load(cmd.Context(), options)
+			if err != nil {
+				return err
+			}
+			// Prepare all output before printing so validation/redaction errors cannot
+			// leave a misleading partial batch on stdout.
+			objects := make([]any, 0, len(docs))
+			for _, doc := range docs {
+				value, err := doc.RedactedObject()
+				if err != nil {
+					return err
+				}
+				objects = append(objects, value)
+			}
+			switch output {
+			case "json":
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(objects)
+			case "yaml":
+				encoder := yaml.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent(2)
+				for _, object := range objects {
+					if err := encoder.Encode(object); err != nil {
+						return err
+					}
+				}
+				return encoder.Close()
+			default:
+				for _, doc := range docs {
+					identity := doc.Metadata.ID
+					if identity == "" {
+						identity = string(doc.Metadata.Name)
+						if doc.Metadata.Namespace != "" {
+							identity = doc.Metadata.Namespace + "/" + identity
+						}
+					}
+					line := strings.ToLower(string(doc.Kind)) + "/" + identity
+					if output == "" {
+						line += " validated (client dry run)"
+					}
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), line); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+		},
+	}
+	cmd.Flags().StringArrayVarP(&options.Filenames, "filename", "f", nil, "File, directory, HTTP(S) URL, or - for stdin (repeatable)")
+	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", false, "Read manifest directories recursively")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Default namespace when omitted from a resource")
+	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Filter labels using =, ==, !=, key, or !key")
+	cmd.Flags().StringVar(&dryRun, "dry-run", "none", "Currently requires client; does not contact the cluster")
+	cmd.Flags().StringVar(&validation, "validate", "strict", "Validation mode (currently strict only)")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format: name, json, yaml (default: validation status)")
+	return cmd
+}

--- a/cmd/cli/apply_test.go
+++ b/cmd/cli/apply_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const applyActor = "apiVersion: authproxy.net/v1alpha1\nkind: Actor\nmetadata:\n  name: bob\nspec: {}\n"
+
+func TestApplyClientDryRun(t *testing.T) {
+	for _, format := range []string{"", "name", "json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			cmd := cmdApply()
+			var out bytes.Buffer
+			cmd.SetIn(strings.NewReader(applyActor))
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			args := []string{"-f", "-", "--dry-run=client", "-n", "root.prod"}
+			if format != "" {
+				args = append(args, "-o", format)
+			}
+			cmd.SetArgs(args)
+			require.NoError(t, cmd.Execute())
+			require.Contains(t, out.String(), "bob")
+			require.Contains(t, out.String(), "root.prod")
+			if format == "" {
+				require.Contains(t, out.String(), "validated (client dry run)")
+			}
+			require.NotContains(t, out.String(), "configured")
+		})
+	}
+}
+func TestApplyRejectsUnsupportedModesAndInvalidBatch(t *testing.T) {
+	cases := [][]string{
+		{"-f", "-"},
+		{"-f", "-", "--dry-run=server"},
+		{"-f", "-", "--dry-run=client", "--validate=ignore"},
+		{"-f", "-", "--dry-run=client", "-o", "unknown"},
+		{"--dry-run=client"},
+		{"-f", "-", "--dry-run=client"}, // Missing namespace.
+		{"-f", "-", "--dry-run=client", "--server-side"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cmd := cmdApply()
+			var out, stderr bytes.Buffer
+			cmd.SetIn(strings.NewReader(applyActor))
+			cmd.SetOut(&out)
+			cmd.SetErr(&stderr)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(args)
+			require.Error(t, cmd.Execute())
+			require.Empty(t, out.String())
+		})
+	}
+	cmd := cmdApply()
+	var out, stderr bytes.Buffer
+	cmd.SetIn(strings.NewReader(applyActor + "---\n" + strings.Replace(applyActor, "kind: Actor", "kind: NotAResource", 1)))
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"-f", "-", "--dry-run=client", "-n", "root", "-o", "json"})
+	require.ErrorContains(t, cmd.Execute(), "document 2")
+	require.Empty(t, out.String())
+}
+func TestApplyOutputRedaction(t *testing.T) {
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			cmd := cmdApply()
+			var out bytes.Buffer
+			cmd.SetIn(strings.NewReader("apiVersion: authproxy.net/v1alpha1\nkind: Key\nmetadata: {name: example}\nspec: {keyData: {value: sensitive-key-material}}"))
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"-f", "-", "--dry-run=client", "-n", "root", "-o", format})
+			require.NoError(t, cmd.Execute())
+			require.NotContains(t, out.String(), "sensitive-key-material")
+			require.Contains(t, out.String(), "***")
+		})
+	}
+}
+
+type applyFailWriter struct{}
+
+func (applyFailWriter) Write(p []byte) (int, error) { return 0, errors.New("output unavailable") }
+func TestApplyOutputFailure(t *testing.T) {
+	cmd := cmdApply()
+	cmd.SetIn(strings.NewReader(applyActor))
+	cmd.SetOut(applyFailWriter{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"-f", "-", "--dry-run=client", "-n", "root"})
+	require.ErrorContains(t, cmd.Execute(), "output unavailable")
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/rmorlok/authproxy/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +17,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmdList())
+	rootCmd.AddCommand(cmdApply())
 	rootCmd.AddCommand(cmdSignJwt())
 	rootCmd.AddCommand(cmdVerifyJwt())
 	rootCmd.AddCommand(cmdSigningProxy())
@@ -22,5 +25,7 @@ func main() {
 	rootCmd.AddCommand(cmdSignMarketplaceLoginUrl())
 	rootCmd.AddCommand(cmdMarketplaceLoginRedirect())
 
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/docs/src/content/docs/development/cli.md
+++ b/docs/src/content/docs/development/cli.md
@@ -275,3 +275,88 @@ The matching `AUTHPROXY_HOST_APP_INITIATE_SESSION_URL` in each `.env` is templat
 - [Local development](/development/local-development/) — the surrounding source and UI workflow.
 - [AGENTS.md — Running locally](https://github.com/rmorlok/authproxy/blob/main/AGENTS.md#running-locally) — repository-specific contributor guidance.
 - [Telemetry](/operations/telemetry/) — what shows up in traces/metrics when these commands fire requests through the server.
+
+## Validate apply manifests (client dry-run)
+
+`ap apply` currently provides the manifest-loading stage of declarative apply.
+Use `--dry-run=client` to check resource types, fields, identity, and namespace
+selection without contacting the AuthProxy cluster. Cluster writes and
+operation-specific create/update validation are not implemented yet; invoking
+this command without `--dry-run=client` returns an error.
+
+```bash
+ap apply -f ./resources --recursive --namespace root.integrations --dry-run=client
+ap apply -f namespaces.yaml -f connectors.yaml --dry-run=client -o yaml
+cat resources.yaml | ap apply -f - --namespace root.integrations --dry-run=client
+```
+
+For example, save this as `namespace.yaml`:
+
+```yaml
+apiVersion: authproxy.net/v1alpha1
+kind: Namespace
+metadata:
+  name: integrations
+  namespace: root
+spec: {}
+```
+
+Then run `ap apply -f namespace.yaml --dry-run=client`. This validates the
+namespace `root.integrations`; it does not create it.
+
+### Identity and input rules
+
+Resources must contain `metadata.id` or both `metadata.namespace` and
+`metadata.name`. An explicit namespace takes precedence over `--namespace`.
+If a name-based resource omits its namespace and no flag supplies it, validation
+fails. There is no implicit `root` default. ID-only targets need no namespace;
+server lookup and consistency checks will be added with cluster execution.
+
+For `Namespace`, `metadata.namespace` is the parent path. A namespace ID supplies
+its canonical path, and any supplied name or parent must agree. `name: root`
+without a parent identifies the root namespace, which does not receive the
+flag's default parent.
+
+Supported kinds are `Namespace`, `Actor`, `Connector`, `Key`, `RateLimit`, and
+`Connection`, using `apiVersion: authproxy.net/v1alpha1`. Connection input is
+limited to mutable metadata and an omitted or empty spec; connection setup is
+not declarative creation. Status and timestamps are rejected. Only Connector
+manifests may address a generation.
+
+The loader accepts YAML, JSON, multi-document YAML, typed resource lists such as
+`ActorList`, and heterogeneous `List` envelopes. List items must carry their own
+API version and kind. Incomplete paginated lists are rejected. Duplicate keys,
+YAML aliases/merge keys, unknown fields, invalid identity, and duplicate selected
+resource identities fail the whole batch. Diagnostics identify the source,
+document, and list item. Multiple inputs retain their argument order; directory
+files are visited lexically. Symlinks discovered inside directories are skipped.
+
+### Available options
+
+| Option | Behavior |
+|---|---|
+| `-f`, `--filename` | Repeatable file, directory, HTTP(S) URL, or `-` for stdin. Stdin may appear only once. |
+| `-R`, `--recursive` | Traverse nested directories. Directory discovery includes `.yaml`, `.yml`, and `.json`. |
+| `-n`, `--namespace` | Supply a missing namespace or Namespace parent. |
+| `-l`, `--selector` | Filter input labels using `=`, `==`, `!=`, existence (`key`), or nonexistence (`!key`). |
+| `--dry-run=client` | Required in this initial implementation. No cluster access or signing configuration is needed. |
+| `--validate=strict` | The currently supported validation mode; unknown fields fail. `true` is an alias. |
+| `-o`, `--output` | `name`, `json` (an array), or `yaml` (a document stream). The default prints validation status. |
+
+The loader checks every resource before producing output, including resources
+excluded by a selector. A selector matching no resources succeeds with empty
+output (`[]` for JSON); input containing no resource documents fails.
+
+URL downloads use an independent, unsigned HTTP client, a 30-second timeout,
+and a 16 MiB limit per source. URL credentials and HTTPS-to-HTTP redirects are
+rejected. Local files and stdin use the same size limit. An HTTP source still
+requires network access during client dry-run.
+
+Structured output masks schema-declared secrets and retains explicit null and
+empty values. Redacted output is for inspection, not a replayable manifest;
+redacted secret placeholders are rejected as input. Dry-run does not verify
+resource existence, authorization, references, server defaults, or whether a
+subsequent apply would create or update a resource.
+
+Reconciliation, cluster execution, non-strict validation, and additional
+kubectl-style options are tracked in [the apply implementation plan](https://github.com/rmorlok/authproxy/issues/919).

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -186,10 +186,14 @@ func (l *inputLoader) object(
 		}
 
 		for field := range object {
-			if field != "apiVersion" && field != "kind" && field != "metadata" && field != "items" {
+			if field != "apiVersion" &&
+				field != "kind" &&
+				field != "metadata" &&
+				field != "items" {
 				return fail("unknown list field")
 			}
 		}
+
 		if value, ok := object["metadata"]; ok {
 			payload, _ := yaml.Marshal(value)
 			var m apiv1alpha1.ListMeta
@@ -200,52 +204,64 @@ func (l *inputLoader) object(
 				return fail("incomplete paginated list; supply all resources")
 			}
 		}
+
 		items, ok := object["items"].([]any)
 		if !ok {
 			return fail("list items must be an array")
 		}
+
 		if base == "" {
 			base = "*"
 		}
+
 		for i, item := range items {
 			child, ok := item.(map[string]any)
 			if !ok {
 				return fail(fmt.Sprintf("item %d: expected resource object", i+1))
 			}
+
 			if err := l.object(fmt.Sprintf("%s: item %d", source, i+1), child, base); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
+
 	if !supportedKind(kind) {
 		return fail("unsupported or missing resource kind")
 	}
+
 	if _, ok := object["status"]; ok {
 		return fail("status is server-owned")
 	}
+
 	metadata, ok := object["metadata"].(map[string]any)
 	if !ok {
 		return fail("metadata must be an object")
 	}
+
 	for _, field := range []string{"createdAt", "updatedAt"} {
 		if _, ok := metadata[field]; ok {
 			return fail("metadata." + field + " is server-owned")
 		}
 	}
+
 	if _, ok := metadata["generation"]; ok && kind != "Connector" {
 		return fail("metadata.generation is only supported for Connector targets")
 	}
+
 	if value, exists := object["spec"]; exists {
 		if _, ok := value.(map[string]any); !ok {
 			return fail("spec must be an object")
 		}
 	}
+
 	if kind == "Connection" {
 		if spec, ok := object["spec"].(map[string]any); ok && len(spec) > 0 {
 			return fail("Connection apply supports existing mutable metadata only")
 		}
 	}
+
 	for _, field := range []string{"id", "name", "namespace"} {
 		if value, exists := metadata[field]; exists {
 			if str, ok := value.(string); !ok || str == "" {
@@ -253,6 +269,7 @@ func (l *inputLoader) object(
 			}
 		}
 	}
+	
 	var m meta.ObjectMeta
 	payload, err := yaml.Marshal(metadata)
 	if err != nil {

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -76,7 +76,12 @@ func project(input, safe any) any {
 		}
 		// A field omitted by the typed serializer has no printable value. Retain
 		// explicit null/zero/empty scalars, but fail closed for other values.
-		if input == "" || input == false || input == 0 || input == int64(0) || input == uint64(0) || input == float64(0) {
+		if input == "" ||
+			input == false ||
+			input == 0 ||
+			input == int64(0) ||
+			input == uint64(0) ||
+			input == float64(0) {
 			return input
 		}
 		return nil
@@ -102,6 +107,7 @@ func (l *inputLoader) decode(source string, data []byte) error {
 		if err := l.ctx.Err(); err != nil {
 			return err
 		}
+
 		var node yaml.Node
 		err := dec.Decode(&node)
 		if err == io.EOF {
@@ -112,16 +118,20 @@ func (l *inputLoader) decode(source string, data []byte) error {
 		if err != nil {
 			return fmt.Errorf("%s: malformed YAML or JSON", location)
 		}
+
 		if util.YamlDocumentEmpty(&node) {
 			continue
 		}
+
 		if err := checkNode(&node); err != nil {
 			return fmt.Errorf("%s: %w", location, err)
 		}
+
 		var object map[string]any
 		if err := node.Decode(&object); err != nil || object == nil {
 			return fmt.Errorf("%s: expected a resource object", location)
 		}
+
 		if err := l.object(location, object, ""); err != nil {
 			return err
 		}
@@ -134,6 +144,7 @@ func checkNode(n *yaml.Node) error {
 	if n.Kind == yaml.AliasNode {
 		return fmt.Errorf("line %d: YAML aliases are unsupported", n.Line)
 	}
+
 	if n.Kind == yaml.MappingNode {
 		seen := map[string]bool{}
 		for i := 0; i < len(n.Content); i += 2 {
@@ -147,32 +158,45 @@ func checkNode(n *yaml.Node) error {
 			seen[k.Value] = true
 		}
 	}
+
 	for _, child := range n.Content {
 		if err := checkNode(child); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-func (l *inputLoader) object(source string, object map[string]any, expectedKind string) error {
+func (l *inputLoader) object(
+	source string,
+	object map[string]any,
+	expectedKind string,
+) error {
 	fail := func(message string) error { return fmt.Errorf("%s: %s", source, message) }
 	version, _ := object["apiVersion"].(string)
 	kind, _ := object["kind"].(string)
+
 	if version != string(meta.APIVersionV1Alpha1) {
 		return fail("unsupported or missing apiVersion (expected authproxy.net/v1alpha1)")
 	}
-	if expectedKind != "" && expectedKind != "*" && kind != expectedKind {
+
+	if expectedKind != "" &&
+		expectedKind != "*" &&
+		kind != expectedKind {
 		return fail("list item kind does not match its list")
 	}
+
 	if strings.HasSuffix(kind, "List") || kind == "List" {
 		if expectedKind != "" {
 			return fail("nested lists are unsupported")
 		}
+
 		base := strings.TrimSuffix(kind, "List")
 		if base != "" && !supportedKind(base) {
 			return fail("unsupported list kind")
 		}
+
 		for field := range object {
 			if field != "apiVersion" && field != "kind" && field != "metadata" && field != "items" {
 				return fail("unknown list field")
@@ -302,53 +326,71 @@ func (l *inputLoader) object(source string, object map[string]any, expectedKind 
 
 func supportedKind(kind string) bool {
 	switch kind {
-	case "Namespace", "Actor", "Connector", "Key", "RateLimit", "Connection":
+	case "Namespace",
+	"Actor",
+	"Connector",
+	"Key",
+	"RateLimit",
+	"Connection":
 		return true
 	}
 	return false
 }
+
 func validateNamespace(value string) error { return ns.ValidatePath(value) }
+
 func normalizeIdentity(kind string, m *meta.ObjectMeta, fallback string) error {
 	if kind == "Namespace" && m.ID != "" {
 		canonical, err := ns.NewResourceMetadata(m.ID)
 		if err != nil {
 			return fmt.Errorf("invalid Namespace metadata.id")
 		}
-		if (m.Name != "" && m.Name != canonical.Name) || (m.Namespace != "" && m.Namespace != canonical.Namespace) {
+
+		if (m.Name != "" && m.Name != canonical.Name) ||
+			(m.Namespace != "" && m.Namespace != canonical.Namespace) {
 			return fmt.Errorf("Namespace identity fields disagree")
 		}
+
 		m.Name = canonical.Name
 		m.Namespace = canonical.Namespace
 	} else {
-		root := kind == "Namespace" && m.Name == common.ResourceName(ns.Root) && m.Namespace == ""
+		root := kind == "Namespace" &&
+			m.Name == common.ResourceName(ns.Root) &&
+			m.Namespace == ""
 		if m.Namespace == "" && !root {
 			m.Namespace = fallback
 		}
 	}
+
 	if m.Namespace != "" {
 		if err := ns.ValidatePath(m.Namespace); err != nil {
 			return fmt.Errorf("invalid metadata.namespace")
 		}
 	}
+
 	if m.Name != "" {
 		if err := m.Name.Validate(); err != nil {
 			return fmt.Errorf("invalid metadata.name")
 		}
 	}
+
 	if kind == "Namespace" {
 		if _, err := ns.PathFromMetadata(*m); err != nil {
 			return fmt.Errorf("Namespace requires id or name and parent namespace (except root)")
 		}
 		return nil
 	}
+
 	if m.ID == "" && (m.Name == "" || m.Namespace == "") {
 		return fmt.Errorf("metadata.id or metadata.namespace and metadata.name are required; use --namespace to supply a missing namespace")
 	}
+
 	if m.ID != "" {
 		validators := map[string]func(string) error{"Actor": actor.ValidateID, "Connector": connectors.ValidateID, "Key": key.ValidateID, "RateLimit": rl.ValidateID, "Connection": connection.ValidateID}
 		if err := validators[kind](m.ID); err != nil {
 			return fmt.Errorf("invalid metadata.id for %s", kind)
 		}
 	}
+	
 	return nil
 }

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -101,6 +101,7 @@ func (l *inputLoader) decode(source string, data []byte) error {
 		if err == io.EOF {
 			return nil
 		}
+
 		location := fmt.Sprintf("%s: document %d", source, index)
 		// YAML/type conversion errors can embed scalar values, including secrets.
 		if err != nil {
@@ -196,11 +197,15 @@ func (l *inputLoader) object(
 
 		if value, ok := object["metadata"]; ok {
 			payload, _ := yaml.Marshal(value)
+
 			var m apiv1alpha1.ListMeta
+
 			if err := util.DecodeYAMLStrict(payload, &m); err != nil {
 				return fail("invalid list metadata")
 			}
-			if m.Continue != "" || (m.RemainingItemCount != nil && *m.RemainingItemCount > 0) {
+
+			if m.Continue != "" ||
+				(m.RemainingItemCount != nil && *m.RemainingItemCount > 0) {
 				return fail("incomplete paginated list; supply all resources")
 			}
 		}
@@ -269,63 +274,79 @@ func (l *inputLoader) object(
 			}
 		}
 	}
-	
+
 	var m meta.ObjectMeta
 	payload, err := yaml.Marshal(metadata)
 	if err != nil {
 		return fail("invalid metadata")
 	}
+
 	if err := util.DecodeYAMLStrict(payload, &m); err != nil {
 		return fail("invalid metadata fields or types")
 	}
+
 	if _, supplied := metadata["generation"]; supplied && m.Generation == 0 {
 		return fail("metadata.generation must be positive when supplied")
 	}
+
 	if err := normalizeIdentity(kind, &m, l.options.Namespace); err != nil {
 		return fail(err.Error())
 	}
+
 	if m.Namespace != "" {
 		metadata["namespace"] = m.Namespace
 	}
+
 	if m.Name != "" {
 		metadata["name"] = string(m.Name)
 	}
+
 	if err := meta.ValidateUserLabels(m.Labels); err != nil {
 		return fail("invalid metadata.labels")
 	}
+
 	if err := meta.ValidateAnnotations(m.Annotations); err != nil {
 		return fail("invalid metadata.annotations")
 	}
+
 	payload, err = yaml.Marshal(object)
 	if err != nil {
 		return fail("cannot encode resource")
 	}
+
 	typed, err := l.scheme.DecodeYAML(payload)
 	if err != nil {
 		return fail("resource contains unknown fields or invalid field types")
 	}
+
 	if err := apserde.ValidateNoRedactedPlaceholders(typed); err != nil {
 		return fail("redacted placeholders cannot be applied")
 	}
+
 	l.count++
 	if !l.selector.Matches(m.Labels) {
 		return nil
 	}
+
 	doc := Document{Source: source, Kind: meta.Kind(kind), Metadata: m, Object: object, Resource: typed}
 	identities := []string{}
 	if m.ID != "" {
 		identities = append(identities, kind+"/id/"+m.ID)
 	}
+
 	if m.Name != "" && (m.Namespace != "" || kind == "Namespace") {
 		identities = append(identities, kind+"/name/"+m.Namespace+"/"+string(m.Name))
 	}
+
 	for _, identity := range identities {
 		if previous, exists := l.seen[identity]; exists {
 			return fail("duplicate resource identity; first defined at " + previous)
 		}
 		l.seen[identity] = source
 	}
+
 	l.documents = append(l.documents, doc)
+	
 	return nil
 }
 

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -1,0 +1,354 @@
+package apply
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rmorlok/authproxy/internal/apserde"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/manifest"
+	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	ns "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	rl "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util"
+	"gopkg.in/yaml.v3"
+)
+
+// Document retains the normalized input, including explicit null and empty
+// values. Object may contain secrets: use RedactedObject for display, never log
+// Object or Resource. Source identifies the file, document and list item.
+type Document struct {
+	Source   string
+	Kind     meta.Kind
+	Metadata meta.ObjectMeta
+	Object   map[string]any
+	Resource any
+}
+
+// RedactedObject masks schema-declared secrets while preserving input field
+// presence. It never returns the underlying Object map.
+func (d Document) RedactedObject() (any, error) {
+	safe, _, err := apserde.SanitizeJSONForAPI(context.Background(), d.Resource)
+	if err != nil {
+		return nil, fmt.Errorf("%s: cannot redact resource", d.Source)
+	}
+	return project(d.Object, safe), nil
+}
+
+func project(input, safe any) any {
+	if input == nil {
+		return nil
+	}
+	switch value := input.(type) {
+	case map[string]any:
+		result := map[string]any{}
+		sanitized, _ := safe.(map[string]any)
+		for k, v := range value {
+			result[k] = project(v, sanitized[k])
+		}
+		return result
+	case []any:
+		result := make([]any, len(value))
+		sanitized, _ := safe.([]any)
+		for i, v := range value {
+			var s any
+			if i < len(sanitized) {
+				s = sanitized[i]
+			}
+			result[i] = project(v, s)
+		}
+		return result
+	default:
+		if _, ok := safe.(json.Number); ok {
+			return input
+		}
+		if safe != nil {
+			return safe
+		}
+		// A field omitted by the typed serializer has no printable value. Retain
+		// explicit null/zero/empty scalars, but fail closed for other values.
+		if input == "" || input == false || input == 0 || input == int64(0) || input == uint64(0) || input == float64(0) {
+			return input
+		}
+		return nil
+	}
+}
+
+type decoder interface{ DecodeYAML([]byte) (any, error) }
+
+func newScheme() *manifest.Scheme {
+	s := manifest.NewScheme()
+	manifest.MustRegisterType[actor.Actor](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: actor.ActorKind})
+	manifest.MustRegisterType[connection.Connection](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: connection.ConnectionKind})
+	manifest.MustRegisterType[connectors.Connector](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: connectors.ConnectorKind})
+	manifest.MustRegisterType[key.Key](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: key.KeyKind})
+	manifest.MustRegisterType[ns.Namespace](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: ns.NamespaceKind})
+	manifest.MustRegisterType[rl.RateLimit](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: rl.RateLimitKind})
+	return s
+}
+
+func (l *inputLoader) decode(source string, data []byte) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	for index := 1; ; index++ {
+		if err := l.ctx.Err(); err != nil {
+			return err
+		}
+		var node yaml.Node
+		err := dec.Decode(&node)
+		if err == io.EOF {
+			return nil
+		}
+		location := fmt.Sprintf("%s: document %d", source, index)
+		// YAML/type conversion errors can embed scalar values, including secrets.
+		if err != nil {
+			return fmt.Errorf("%s: malformed YAML or JSON", location)
+		}
+		if util.YamlDocumentEmpty(&node) {
+			continue
+		}
+		if err := checkNode(&node); err != nil {
+			return fmt.Errorf("%s: %w", location, err)
+		}
+		var object map[string]any
+		if err := node.Decode(&object); err != nil || object == nil {
+			return fmt.Errorf("%s: expected a resource object", location)
+		}
+		if err := l.object(location, object, ""); err != nil {
+			return err
+		}
+	}
+}
+
+// Reject duplicate/non-string keys even in arbitrary maps and JSON documents.
+// Aliases and merge keys are deliberately rejected to keep presence unambiguous.
+func checkNode(n *yaml.Node) error {
+	if n.Kind == yaml.AliasNode {
+		return fmt.Errorf("line %d: YAML aliases are unsupported", n.Line)
+	}
+	if n.Kind == yaml.MappingNode {
+		seen := map[string]bool{}
+		for i := 0; i < len(n.Content); i += 2 {
+			k := n.Content[i]
+			if k.Tag != "!!str" {
+				return fmt.Errorf("line %d: mapping keys must be strings; YAML merge keys are unsupported", k.Line)
+			}
+			if seen[k.Value] {
+				return fmt.Errorf("line %d: duplicate mapping key", k.Line)
+			}
+			seen[k.Value] = true
+		}
+	}
+	for _, child := range n.Content {
+		if err := checkNode(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *inputLoader) object(source string, object map[string]any, expectedKind string) error {
+	fail := func(message string) error { return fmt.Errorf("%s: %s", source, message) }
+	version, _ := object["apiVersion"].(string)
+	kind, _ := object["kind"].(string)
+	if version != string(meta.APIVersionV1Alpha1) {
+		return fail("unsupported or missing apiVersion (expected authproxy.net/v1alpha1)")
+	}
+	if expectedKind != "" && expectedKind != "*" && kind != expectedKind {
+		return fail("list item kind does not match its list")
+	}
+	if strings.HasSuffix(kind, "List") || kind == "List" {
+		if expectedKind != "" {
+			return fail("nested lists are unsupported")
+		}
+		base := strings.TrimSuffix(kind, "List")
+		if base != "" && !supportedKind(base) {
+			return fail("unsupported list kind")
+		}
+		for field := range object {
+			if field != "apiVersion" && field != "kind" && field != "metadata" && field != "items" {
+				return fail("unknown list field")
+			}
+		}
+		if value, ok := object["metadata"]; ok {
+			payload, _ := yaml.Marshal(value)
+			var m apiv1alpha1.ListMeta
+			if err := util.DecodeYAMLStrict(payload, &m); err != nil {
+				return fail("invalid list metadata")
+			}
+			if m.Continue != "" || (m.RemainingItemCount != nil && *m.RemainingItemCount > 0) {
+				return fail("incomplete paginated list; supply all resources")
+			}
+		}
+		items, ok := object["items"].([]any)
+		if !ok {
+			return fail("list items must be an array")
+		}
+		if base == "" {
+			base = "*"
+		}
+		for i, item := range items {
+			child, ok := item.(map[string]any)
+			if !ok {
+				return fail(fmt.Sprintf("item %d: expected resource object", i+1))
+			}
+			if err := l.object(fmt.Sprintf("%s: item %d", source, i+1), child, base); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !supportedKind(kind) {
+		return fail("unsupported or missing resource kind")
+	}
+	if _, ok := object["status"]; ok {
+		return fail("status is server-owned")
+	}
+	metadata, ok := object["metadata"].(map[string]any)
+	if !ok {
+		return fail("metadata must be an object")
+	}
+	for _, field := range []string{"createdAt", "updatedAt"} {
+		if _, ok := metadata[field]; ok {
+			return fail("metadata." + field + " is server-owned")
+		}
+	}
+	if _, ok := metadata["generation"]; ok && kind != "Connector" {
+		return fail("metadata.generation is only supported for Connector targets")
+	}
+	if value, exists := object["spec"]; exists {
+		if _, ok := value.(map[string]any); !ok {
+			return fail("spec must be an object")
+		}
+	}
+	if kind == "Connection" {
+		if spec, ok := object["spec"].(map[string]any); ok && len(spec) > 0 {
+			return fail("Connection apply supports existing mutable metadata only")
+		}
+	}
+	for _, field := range []string{"id", "name", "namespace"} {
+		if value, exists := metadata[field]; exists {
+			if str, ok := value.(string); !ok || str == "" {
+				return fail("metadata." + field + " must be a nonempty string when supplied")
+			}
+		}
+	}
+	var m meta.ObjectMeta
+	payload, err := yaml.Marshal(metadata)
+	if err != nil {
+		return fail("invalid metadata")
+	}
+	if err := util.DecodeYAMLStrict(payload, &m); err != nil {
+		return fail("invalid metadata fields or types")
+	}
+	if _, supplied := metadata["generation"]; supplied && m.Generation == 0 {
+		return fail("metadata.generation must be positive when supplied")
+	}
+	if err := normalizeIdentity(kind, &m, l.options.Namespace); err != nil {
+		return fail(err.Error())
+	}
+	if m.Namespace != "" {
+		metadata["namespace"] = m.Namespace
+	}
+	if m.Name != "" {
+		metadata["name"] = string(m.Name)
+	}
+	if err := meta.ValidateUserLabels(m.Labels); err != nil {
+		return fail("invalid metadata.labels")
+	}
+	if err := meta.ValidateAnnotations(m.Annotations); err != nil {
+		return fail("invalid metadata.annotations")
+	}
+	payload, err = yaml.Marshal(object)
+	if err != nil {
+		return fail("cannot encode resource")
+	}
+	typed, err := l.scheme.DecodeYAML(payload)
+	if err != nil {
+		return fail("resource contains unknown fields or invalid field types")
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(typed); err != nil {
+		return fail("redacted placeholders cannot be applied")
+	}
+	l.count++
+	if !l.selector.Matches(m.Labels) {
+		return nil
+	}
+	doc := Document{Source: source, Kind: meta.Kind(kind), Metadata: m, Object: object, Resource: typed}
+	identities := []string{}
+	if m.ID != "" {
+		identities = append(identities, kind+"/id/"+m.ID)
+	}
+	if m.Name != "" && (m.Namespace != "" || kind == "Namespace") {
+		identities = append(identities, kind+"/name/"+m.Namespace+"/"+string(m.Name))
+	}
+	for _, identity := range identities {
+		if previous, exists := l.seen[identity]; exists {
+			return fail("duplicate resource identity; first defined at " + previous)
+		}
+		l.seen[identity] = source
+	}
+	l.documents = append(l.documents, doc)
+	return nil
+}
+
+func supportedKind(kind string) bool {
+	switch kind {
+	case "Namespace", "Actor", "Connector", "Key", "RateLimit", "Connection":
+		return true
+	}
+	return false
+}
+func validateNamespace(value string) error { return ns.ValidatePath(value) }
+func normalizeIdentity(kind string, m *meta.ObjectMeta, fallback string) error {
+	if kind == "Namespace" && m.ID != "" {
+		canonical, err := ns.NewResourceMetadata(m.ID)
+		if err != nil {
+			return fmt.Errorf("invalid Namespace metadata.id")
+		}
+		if (m.Name != "" && m.Name != canonical.Name) || (m.Namespace != "" && m.Namespace != canonical.Namespace) {
+			return fmt.Errorf("Namespace identity fields disagree")
+		}
+		m.Name = canonical.Name
+		m.Namespace = canonical.Namespace
+	} else {
+		root := kind == "Namespace" && m.Name == common.ResourceName(ns.Root) && m.Namespace == ""
+		if m.Namespace == "" && !root {
+			m.Namespace = fallback
+		}
+	}
+	if m.Namespace != "" {
+		if err := ns.ValidatePath(m.Namespace); err != nil {
+			return fmt.Errorf("invalid metadata.namespace")
+		}
+	}
+	if m.Name != "" {
+		if err := m.Name.Validate(); err != nil {
+			return fmt.Errorf("invalid metadata.name")
+		}
+	}
+	if kind == "Namespace" {
+		if _, err := ns.PathFromMetadata(*m); err != nil {
+			return fmt.Errorf("Namespace requires id or name and parent namespace (except root)")
+		}
+		return nil
+	}
+	if m.ID == "" && (m.Name == "" || m.Namespace == "") {
+		return fmt.Errorf("metadata.id or metadata.namespace and metadata.name are required; use --namespace to supply a missing namespace")
+	}
+	if m.ID != "" {
+		validators := map[string]func(string) error{"Actor": actor.ValidateID, "Connector": connectors.ValidateID, "Key": key.ValidateID, "RateLimit": rl.ValidateID, "Connection": connection.ValidateID}
+		if err := validators[kind](m.ID); err != nil {
+			return fmt.Errorf("invalid metadata.id for %s", kind)
+		}
+	}
+	return nil
+}

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/apserde"
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/rmorlok/authproxy/internal/schema/manifest"
 	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
@@ -89,17 +88,6 @@ func project(input, safe any) any {
 }
 
 type decoder interface{ DecodeYAML([]byte) (any, error) }
-
-func newScheme() *manifest.Scheme {
-	s := manifest.NewScheme()
-	manifest.MustRegisterType[actor.Actor](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: actor.ActorKind})
-	manifest.MustRegisterType[connection.Connection](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: connection.ConnectionKind})
-	manifest.MustRegisterType[connectors.Connector](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: connectors.ConnectorKind})
-	manifest.MustRegisterType[key.Key](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: key.KeyKind})
-	manifest.MustRegisterType[ns.Namespace](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: ns.NamespaceKind})
-	manifest.MustRegisterType[rl.RateLimit](s, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: rl.RateLimitKind})
-	return s
-}
 
 func (l *inputLoader) decode(source string, data []byte) error {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
@@ -327,11 +315,11 @@ func (l *inputLoader) object(
 func supportedKind(kind string) bool {
 	switch kind {
 	case "Namespace",
-	"Actor",
-	"Connector",
-	"Key",
-	"RateLimit",
-	"Connection":
+		"Actor",
+		"Connector",
+		"Key",
+		"RateLimit",
+		"Connection":
 		return true
 	}
 	return false
@@ -391,6 +379,6 @@ func normalizeIdentity(kind string, m *meta.ObjectMeta, fallback string) error {
 			return fmt.Errorf("invalid metadata.id for %s", kind)
 		}
 	}
-	
+
 	return nil
 }

--- a/internal/apply/load.go
+++ b/internal/apply/load.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/rmorlok/authproxy/internal/database"
+	"github.com/rmorlok/authproxy/internal/schema/registry"
 )
 
 const maxSourceBytes = 16 << 20
@@ -44,7 +45,7 @@ func Load(ctx context.Context, options Options) ([]Document, error) {
 			return nil, fmt.Errorf("--namespace: %w", err)
 		}
 	}
-	loader := inputLoader{ctx: ctx, options: options, selector: selector, seen: map[string]string{}, scheme: newScheme()}
+	loader := inputLoader{ctx: ctx, options: options, selector: selector, seen: map[string]string{}, scheme: registry.NewResourceScheme()}
 	for _, filename := range options.Filenames {
 		if err := loader.load(filename); err != nil {
 			return nil, err

--- a/internal/apply/load.go
+++ b/internal/apply/load.go
@@ -1,0 +1,174 @@
+// Package apply loads declarative resource input without contacting an AuthProxy
+// cluster. Documents retain field presence for subsequent reconciliation.
+package apply
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/database"
+)
+
+const maxSourceBytes = 16 << 20
+
+// Options controls input discovery. HTTP is used only for manifest sources;
+// never supply an authenticated cluster client here.
+type Options struct {
+	Filenames []string
+	Recursive bool
+	Namespace string
+	Selector  string
+	Stdin     io.Reader
+}
+
+// Load validates the entire input before returning any documents. Files within
+// directories are visited lexically; explicit inputs retain command-line order.
+func Load(ctx context.Context, options Options) ([]Document, error) {
+	if len(options.Filenames) == 0 {
+		return nil, fmt.Errorf("at least one --filename is required")
+	}
+	selector, err := database.ParseLabelSelector(options.Selector)
+	if err != nil {
+		return nil, err
+	}
+	if options.Namespace != "" {
+		if err := validateNamespace(options.Namespace); err != nil {
+			return nil, fmt.Errorf("--namespace: %w", err)
+		}
+	}
+	loader := inputLoader{ctx: ctx, options: options, selector: selector, seen: map[string]string{}, scheme: newScheme()}
+	for _, filename := range options.Filenames {
+		if err := loader.load(filename); err != nil {
+			return nil, err
+		}
+	}
+	if loader.count == 0 {
+		return nil, fmt.Errorf("no resource documents found")
+	}
+	return loader.documents, nil
+}
+
+type inputLoader struct {
+	ctx       context.Context
+	options   Options
+	selector  database.LabelSelector
+	seen      map[string]string
+	stdinUsed bool
+	count     int
+	documents []Document
+	scheme    decoder
+}
+
+func (l *inputLoader) load(source string) error {
+	if err := l.ctx.Err(); err != nil {
+		return err
+	}
+	if source == "-" {
+		if l.stdinUsed {
+			return fmt.Errorf("stdin may only be specified once")
+		}
+		l.stdinUsed = true
+		if l.options.Stdin == nil {
+			return fmt.Errorf("stdin is not available")
+		}
+		return l.read("stdin", l.options.Stdin)
+	}
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		u, err := url.Parse(source)
+		if err != nil || u.Host == "" || u.User != nil {
+			return fmt.Errorf("manifest URL must have a host and must not contain credentials")
+		}
+		// Do not echo query strings, which can contain signed URL credentials.
+		label := u.Scheme + "://" + u.Host + u.EscapedPath()
+		req, err := http.NewRequestWithContext(l.ctx, http.MethodGet, source, nil)
+		if err != nil {
+			return fmt.Errorf("%s: invalid manifest URL", label)
+		}
+		client := &http.Client{Timeout: 30 * time.Second, CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			if req.URL.User != nil || (req.URL.Scheme != "http" && req.URL.Scheme != "https") {
+				return fmt.Errorf("invalid manifest redirect")
+			}
+			if via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return fmt.Errorf("insecure manifest redirect")
+			}
+			return nil
+		}}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("%s: manifest download failed", label)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("%s: HTTP %d", label, resp.StatusCode)
+		}
+		return l.read(label, resp.Body)
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("%s: %w", source, err)
+	}
+	if !info.IsDir() {
+		return l.file(source)
+	}
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := l.ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != source && !l.options.Recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Do not follow symlinks discovered within directories.
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".yaml", ".yml", ".json":
+			return l.file(path)
+		}
+		return nil
+	})
+}
+
+func (l *inputLoader) file(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s: expected a regular file", path)
+	}
+	return l.read(path, f)
+}
+
+func (l *inputLoader) read(source string, r io.Reader) error {
+	data, err := io.ReadAll(io.LimitReader(r, maxSourceBytes+1))
+	if err != nil {
+		return fmt.Errorf("%s: failed to read manifest", source)
+	}
+	if len(data) > maxSourceBytes {
+		return fmt.Errorf("%s: exceeds 16 MiB manifest limit", source)
+	}
+	return l.decode(source, data)
+}

--- a/internal/apply/load.go
+++ b/internal/apply/load.go
@@ -36,24 +36,35 @@ func Load(ctx context.Context, options Options) ([]Document, error) {
 	if len(options.Filenames) == 0 {
 		return nil, fmt.Errorf("at least one --filename is required")
 	}
+
 	selector, err := database.ParseLabelSelector(options.Selector)
 	if err != nil {
 		return nil, err
 	}
+
 	if options.Namespace != "" {
 		if err := validateNamespace(options.Namespace); err != nil {
 			return nil, fmt.Errorf("--namespace: %w", err)
 		}
 	}
-	loader := inputLoader{ctx: ctx, options: options, selector: selector, seen: map[string]string{}, scheme: registry.NewResourceScheme()}
+	loader := inputLoader{
+		ctx:      ctx,
+		options:  options,
+		selector: selector,
+		seen:     map[string]string{},
+		scheme:   registry.NewResourceScheme(),
+	}
+
 	for _, filename := range options.Filenames {
 		if err := loader.load(filename); err != nil {
 			return nil, err
 		}
 	}
+
 	if loader.count == 0 {
 		return nil, fmt.Errorf("no resource documents found")
 	}
+
 	return loader.documents, nil
 }
 
@@ -72,79 +83,110 @@ func (l *inputLoader) load(source string) error {
 	if err := l.ctx.Err(); err != nil {
 		return err
 	}
+
 	if source == "-" {
 		if l.stdinUsed {
 			return fmt.Errorf("stdin may only be specified once")
 		}
+
 		l.stdinUsed = true
 		if l.options.Stdin == nil {
 			return fmt.Errorf("stdin is not available")
 		}
+
 		return l.read("stdin", l.options.Stdin)
 	}
+
 	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
 		u, err := url.Parse(source)
 		if err != nil || u.Host == "" || u.User != nil {
 			return fmt.Errorf("manifest URL must have a host and must not contain credentials")
 		}
+
 		// Do not echo query strings, which can contain signed URL credentials.
 		label := u.Scheme + "://" + u.Host + u.EscapedPath()
-		req, err := http.NewRequestWithContext(l.ctx, http.MethodGet, source, nil)
+		req, err := http.NewRequestWithContext(
+			l.ctx,
+			http.MethodGet,
+			source,
+			nil, // body
+		)
 		if err != nil {
 			return fmt.Errorf("%s: invalid manifest URL", label)
 		}
-		client := &http.Client{Timeout: 30 * time.Second, CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
-			}
-			if req.URL.User != nil || (req.URL.Scheme != "http" && req.URL.Scheme != "https") {
-				return fmt.Errorf("invalid manifest redirect")
-			}
-			if via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
-				return fmt.Errorf("insecure manifest redirect")
-			}
-			return nil
-		}}
+
+		client := &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return fmt.Errorf("too many redirects")
+				}
+
+				if req.URL.User != nil || (req.URL.Scheme != "http" && req.URL.Scheme != "https") {
+					return fmt.Errorf("invalid manifest redirect")
+				}
+
+				if via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+					return fmt.Errorf("insecure manifest redirect")
+				}
+
+				return nil
+			},
+		}
+
 		resp, err := client.Do(req)
 		if err != nil {
 			return fmt.Errorf("%s: manifest download failed", label)
 		}
 		defer resp.Body.Close()
+
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("%s: HTTP %d", label, resp.StatusCode)
 		}
+
 		return l.read(label, resp.Body)
 	}
+
 	info, err := os.Stat(source)
 	if err != nil {
 		return fmt.Errorf("%s: %w", source, err)
 	}
+
 	if !info.IsDir() {
 		return l.file(source)
 	}
-	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if err := l.ctx.Err(); err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			if path != source && !l.options.Recursive {
-				return filepath.SkipDir
+
+	return filepath.WalkDir(
+		source,
+		func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
+
+			if err := l.ctx.Err(); err != nil {
+				return err
+			}
+
+			if entry.IsDir() {
+				if path != source && !l.options.Recursive {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// Do not follow symlinks discovered within directories.
+			if !entry.Type().IsRegular() {
+				return nil
+			}
+
+			switch strings.ToLower(filepath.Ext(path)) {
+			case ".yaml", ".yml", ".json":
+				return l.file(path)
+			}
+
 			return nil
-		}
-		// Do not follow symlinks discovered within directories.
-		if !entry.Type().IsRegular() {
-			return nil
-		}
-		switch strings.ToLower(filepath.Ext(path)) {
-		case ".yaml", ".yml", ".json":
-			return l.file(path)
-		}
-		return nil
-	})
+		},
+	)
 }
 
 func (l *inputLoader) file(path string) error {
@@ -153,13 +195,16 @@ func (l *inputLoader) file(path string) error {
 		return err
 	}
 	defer f.Close()
+
 	info, err := f.Stat()
 	if err != nil {
 		return err
 	}
+
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("%s: expected a regular file", path)
 	}
+
 	return l.read(path, f)
 }
 
@@ -168,8 +213,10 @@ func (l *inputLoader) read(source string, r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("%s: failed to read manifest", source)
 	}
+
 	if len(data) > maxSourceBytes {
 		return fmt.Errorf("%s: exceeds 16 MiB manifest limit", source)
 	}
+
 	return l.decode(source, data)
 }

--- a/internal/apply/load_test.go
+++ b/internal/apply/load_test.go
@@ -1,0 +1,261 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+func manifestText(kind, metadata, spec string) string {
+	return fmt.Sprintf("apiVersion: authproxy.net/v1alpha1\nkind: %s\nmetadata:\n%s\nspec: %s\n", kind, metadata, spec)
+}
+func loadText(t *testing.T, input, namespace string) ([]Document, error) {
+	t.Helper()
+	return Load(context.Background(), Options{Filenames: []string{"-"}, Stdin: strings.NewReader(input), Namespace: namespace})
+}
+func TestNamespaceAndIdentity(t *testing.T) {
+	id := apid.New(apid.PrefixActor).String()
+	cases := []struct {
+		name, kind, metadata, namespace, wantNS, wantName string
+		wantErr                                           bool
+	}{
+		{"explicit wins", "Actor", "  name: bob\n  namespace: root.prod", "root.dev", "root.prod", "bob", false},
+		{"flag fills missing", "Actor", "  name: bob", "root.prod", "root.prod", "bob", false},
+		{"no root default", "Actor", "  name: bob", "", "", "", true},
+		{"ID only", "Actor", "  id: " + id, "", "", "", false},
+		{"ID and default", "Actor", "  id: " + id, "root.prod", "root.prod", "", false},
+		{"missing identity", "Actor", "  namespace: root", "", "", "", true},
+		{"invalid ID", "Actor", "  id: cxr_wrong", "", "", "", true},
+		{"parent default", "Namespace", "  name: prod", "root", "root", "prod", false},
+		{"namespace requires parent", "Namespace", "  name: prod", "", "", "", true},
+		{"root special", "Namespace", "  name: root", "root.prod", "", "root", false},
+		{"namespace ID", "Namespace", "  id: root.prod", "root.other", "root", "prod", false},
+		{"namespace ID mismatch", "Namespace", "  id: root.prod\n  name: other", "", "", "", true},
+		{"root ID mismatch", "Namespace", "  id: root\n  namespace: root.other", "", "", "", true},
+		{"empty namespace", "Actor", "  name: bob\n  namespace: ''", "root", "", "", true},
+		{"null namespace", "Actor", "  name: bob\n  namespace: null", "root", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			docs, err := loadText(t, manifestText(tc.kind, tc.metadata, "{}"), tc.namespace)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, docs)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, docs, 1)
+			require.Equal(t, tc.wantNS, docs[0].Metadata.Namespace)
+			require.Equal(t, tc.wantName, string(docs[0].Metadata.Name))
+		})
+	}
+}
+
+func TestAllKindsAndPresence(t *testing.T) {
+	for _, kind := range []string{"Namespace", "Actor", "Connector", "Key", "RateLimit", "Connection"} {
+		t.Run(kind, func(t *testing.T) {
+			docs, err := loadText(t, manifestText(kind, "  name: example\n  labels: {}", "{}"), "root")
+			require.NoError(t, err)
+			require.Len(t, docs, 1)
+			require.Equal(t, map[string]any{}, docs[0].Object["spec"])
+			safe, err := docs[0].RedactedObject()
+			require.NoError(t, err)
+			require.Equal(t, docs[0].Object, safe)
+		})
+	}
+	input := manifestText("Actor", "  name: bob", "{externalId: '', permissions: null}")
+	docs, err := loadText(t, input, "root")
+	require.NoError(t, err)
+	spec := docs[0].Object["spec"].(map[string]any)
+	require.Contains(t, spec, "permissions")
+	require.Nil(t, spec["permissions"])
+	require.NotContains(t, spec, "signingKey")
+	safe, err := docs[0].RedactedObject()
+	require.NoError(t, err)
+	require.Equal(t, docs[0].Object, safe)
+	safe.(map[string]any)["spec"].(map[string]any)["externalId"] = "changed"
+	require.Equal(t, "", spec["externalId"], "display must not mutate retained input")
+}
+
+func TestInvalidInputIsAtomicAndSourceLocated(t *testing.T) {
+	valid := manifestText("Actor", "  name: bob", "{}")
+	invalid := []string{
+		strings.Replace(valid, "kind: Actor", "kind: Unknown", 1),
+		strings.Replace(valid, "v1alpha1", "v999", 1),
+		strings.Replace(valid, "spec: {}", "spec: {typo: secret-value}", 1),
+		valid + "status: {}\n",
+		strings.Replace(valid, "name: bob", "name: bob\n  createdAt: null", 1),
+		strings.Replace(valid, "name: bob", "name: bob\n  name: duplicate", 1),
+		strings.Replace(valid, "name: bob", "name: bob\n  labels: {x: a, x: b}", 1),
+		strings.Replace(valid, "spec: {}", "spec: [bad]", 1),
+		"[one, two]",
+		strings.Replace(valid, "spec: {}", "spec: {externalId: [secret-value]}", 1),
+		strings.Replace(valid, "spec: {}", "spec: &alias {}\nother: *alias", 1),
+		manifestText("Connection", "  name: example", "{configuration: {secret: value}}"),
+		`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{"name":"a","name":"b"},"spec":{}}`,
+	}
+	for i, input := range invalid {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			docs, err := loadText(t, valid+"---\n"+input, "root")
+			require.Error(t, err)
+			require.Nil(t, docs)
+			require.Contains(t, err.Error(), "stdin: document 2")
+			require.NotContains(t, err.Error(), "secret-value")
+		})
+	}
+}
+
+func TestListsAndDuplicates(t *testing.T) {
+	item := map[string]any{"apiVersion": "authproxy.net/v1alpha1", "kind": "Actor", "metadata": map[string]any{"name": "bob"}, "spec": map[string]any{}}
+	for _, kind := range []string{"ActorList", "List"} {
+		data, err := json.Marshal(map[string]any{"apiVersion": "authproxy.net/v1alpha1", "kind": kind, "items": []any{item}})
+		require.NoError(t, err)
+		docs, err := loadText(t, string(data), "root")
+		require.NoError(t, err)
+		require.Len(t, docs, 1)
+		require.Contains(t, docs[0].Source, "item 1")
+	}
+	data, _ := json.Marshal(map[string]any{"apiVersion": "authproxy.net/v1alpha1", "kind": "KeyList", "items": []any{item}})
+	_, err := loadText(t, string(data), "root")
+	require.ErrorContains(t, err, "does not match")
+	data, _ = json.Marshal(map[string]any{"apiVersion": "authproxy.net/v1alpha1", "kind": "ActorList", "metadata": map[string]any{"continue": "cursor"}, "items": []any{item}})
+	_, err = loadText(t, string(data), "root")
+	require.ErrorContains(t, err, "incomplete")
+	a := manifestText("Actor", "  name: bob", "{}")
+	docs, err := loadText(t, a+"---\n"+a, "root")
+	require.Nil(t, docs)
+	require.ErrorContains(t, err, "duplicate resource identity")
+	require.Contains(t, err.Error(), "document 1")
+	require.Contains(t, err.Error(), "document 2")
+	id := apid.New(apid.PrefixActor).String()
+	a = manifestText("Actor", "  id: "+id, "{}")
+	_, err = loadText(t, a+"---\n"+manifestText("Actor", "  id: "+id+"\n  name: bob\n  namespace: root", "{}"), "")
+	require.ErrorContains(t, err, "duplicate resource identity")
+}
+
+func TestDiscoverySelectionAndEmptyDocuments(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0700))
+	write := func(path, name, label string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, path), []byte(manifestText("Actor", "  name: "+name+"\n  labels: {env: "+label+"}", "{}")), 0600))
+	}
+	write("b.yaml", "b", "prod")
+	write("a.json", "a", "dev")
+	write("ignored.txt", "ignored", "prod")
+	write("nested/c.yml", "c", "prod")
+	opts := Options{Filenames: []string{dir}, Namespace: "root"}
+	docs, err := Load(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	require.Equal(t, "a", string(docs[0].Metadata.Name))
+	opts.Recursive = true
+	opts.Selector = "env=prod"
+	docs, err = Load(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	require.Equal(t, "b", string(docs[0].Metadata.Name))
+	require.Equal(t, "c", string(docs[1].Metadata.Name))
+	opts.Selector = "env=missing"
+	docs, err = Load(context.Background(), opts)
+	require.NoError(t, err)
+	require.Empty(t, docs)
+	_, err = loadText(t, "# comment\n---\n", "")
+	require.ErrorContains(t, err, "no resource")
+	docs, err = loadText(t, "---\n# comment\n---\n"+manifestText("Actor", "  name: bob", "{}"), "root")
+	require.NoError(t, err)
+	require.Contains(t, docs[0].Source, "document 2")
+	_, err = Load(context.Background(), Options{Filenames: []string{"-", "-"}, Stdin: strings.NewReader(manifestText("Namespace", "  name: root", "{}"))})
+	require.ErrorContains(t, err, "stdin may only")
+}
+
+func TestURLInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		require.Empty(t, r.Header.Get("Cookie"))
+		if r.URL.Path == "/missing" {
+			http.Error(w, "sensitive body", http.StatusNotFound)
+			return
+		}
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/ok", http.StatusFound)
+			return
+		}
+		fmt.Fprint(w, manifestText("Namespace", "  name: root", "{}"))
+	}))
+	defer srv.Close()
+	docs, err := Load(context.Background(), Options{Filenames: []string{srv.URL + "/redirect?token=secret"}})
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.NotContains(t, docs[0].Source, "token")
+	_, err = Load(context.Background(), Options{Filenames: []string{srv.URL + "/missing?token=secret"}})
+	require.ErrorContains(t, err, "HTTP 404")
+	require.NotContains(t, err.Error(), "secret")
+	require.NotContains(t, err.Error(), "sensitive body")
+	_, err = Load(context.Background(), Options{Filenames: []string{strings.Replace(srv.URL, "://", "://user:password@", 1)}})
+	require.ErrorContains(t, err, "credentials")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = Load(ctx, Options{Filenames: []string{srv.URL}})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestKeyOutputRedacted(t *testing.T) {
+	input := manifestText("Key", "  name: secret-key", "{keyData: {value: do-not-print-this}}")
+	docs, err := loadText(t, input, "root")
+	require.NoError(t, err)
+	safe, err := docs[0].RedactedObject()
+	require.NoError(t, err)
+	data, err := json.Marshal(safe)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "do-not-print-this")
+	require.Contains(t, string(data), "***")
+	require.Contains(t, fmt.Sprint(docs[0].Object), "do-not-print-this")
+	_, err = loadText(t, strings.Replace(input, "do-not-print-this", "'********'", 1), "root")
+	require.ErrorContains(t, err, "redacted placeholders")
+}
+
+func TestNumericPresenceAndInvalidGeneration(t *testing.T) {
+	input := manifestText("Connector", "  name: example\n  generation: 9007199254740993", "{}")
+	docs, err := loadText(t, input, "root")
+	require.NoError(t, err)
+	safe, err := docs[0].RedactedObject()
+	require.NoError(t, err)
+	require.Equal(t, docs[0].Object, safe)
+	for _, value := range []string{"0", "null", "-1"} {
+		_, err := loadText(t, manifestText("Connector", "  name: example\n  generation: "+value, "{}"), "root")
+		require.Error(t, err)
+	}
+}
+
+func TestNestedSecretRedaction(t *testing.T) {
+	cases := []struct{ kind, spec string }{
+		{"Actor", "{signingKey: {sharedKey: {value: confidential-material}}}"},
+		{"Connector", "{definition: {auth: {type: OAuth2, clientSecret: {value: confidential-material}}}}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			docs, err := loadText(t, manifestText(tc.kind, "  name: example", tc.spec), "root")
+			require.NoError(t, err)
+			safe, err := docs[0].RedactedObject()
+			require.NoError(t, err)
+			encoded, err := json.Marshal(safe)
+			require.NoError(t, err)
+			require.NotContains(t, string(encoded), "confidential-material")
+			require.Contains(t, string(encoded), "***")
+		})
+	}
+}
+
+func TestSourceSizeLimit(t *testing.T) {
+	_, err := loadText(t, strings.Repeat(" ", maxSourceBytes+1), "")
+	require.ErrorContains(t, err, "16 MiB")
+}

--- a/internal/schema/manifest/README.md
+++ b/internal/schema/manifest/README.md
@@ -9,3 +9,9 @@ Multi-document support is intentionally YAML-only. A JSON list is itself a
 registered `<Kind>List` object rather than an untyped array of manifests. This
 package owns decoding infrastructure, not a serialized contract, so it has no
 independent JSON Schema.
+
+Application code decoding canonical AuthProxy resources should use
+[`registry.NewResourceScheme()`](../registry/README.md), which centralizes
+resource and typed-list registrations. Keep this package independent of
+concrete resource types; specialized schemes can still register their own
+contracts explicitly.

--- a/internal/schema/registry/README.md
+++ b/internal/schema/registry/README.md
@@ -1,0 +1,22 @@
+# Resource Registry
+
+`NewResourceScheme()` is the central registration list for AuthProxy's canonical
+resources and typed resource-list envelopes. Each call returns an independent
+`manifest.Scheme`; there is no mutable global scheme or `init()` registration.
+
+Add new resources here once, using `registerResource[T]` to register the resource
+and its `api/v1alpha1.ResourceList[T]` envelope together. Application consumers
+such as `internal/apply` use this constructor rather than maintaining their own
+GVK-to-Go-type registrations. The generic decoding machinery remains in
+`internal/schema/manifest`.
+
+Recognition is separate from operation support. Consumers still decide which
+resources they can apply, create, or update, and perform lifecycle validation.
+Typed API handlers should keep decoding their specific request contracts:
+resource patches share a resource's GVK and cannot be distinguished by GVK
+alone. Actions, projections, and heterogeneous `List` input are not canonical
+resource registrations; consumers handle those separately.
+
+This package composes resource types and API list envelopes from outside both
+packages, preserving schema dependency direction. It defines no new serialized
+contracts and therefore needs no independent JSON Schema.

--- a/internal/schema/registry/resources.go
+++ b/internal/schema/registry/resources.go
@@ -1,0 +1,36 @@
+// Package registry assembles AuthProxy's canonical resource types for callers
+// that dispatch manifests by apiVersion and kind.
+package registry
+
+import (
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/manifest"
+	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+)
+
+// NewResourceScheme returns an independent scheme containing every canonical
+// resource and its typed list envelope. Registration recognizes wire types;
+// callers must separately enforce operation support and lifecycle validation.
+// Patches and actions are deliberately excluded: patches share a resource's
+// GVK but require an operation-specific decoder.
+func NewResourceScheme() *manifest.Scheme {
+	scheme := manifest.NewScheme()
+	registerResource[actor.Actor](scheme, actor.ActorKind)
+	registerResource[connection.Connection](scheme, connection.ConnectionKind)
+	registerResource[connectors.Connector](scheme, connectors.ConnectorKind)
+	registerResource[key.Key](scheme, key.KeyKind)
+	registerResource[namespace.Namespace](scheme, namespace.NamespaceKind)
+	registerResource[rate_limit.RateLimit](scheme, rate_limit.RateLimitKind)
+	return scheme
+}
+
+func registerResource[T any](scheme *manifest.Scheme, kind meta.Kind) {
+	manifest.MustRegisterType[T](scheme, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind})
+	manifest.MustRegisterType[apiv1alpha1.ResourceList[T]](scheme, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: apiv1alpha1.ListKind(kind)})
+}

--- a/internal/schema/registry/resources_test.go
+++ b/internal/schema/registry/resources_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/manifest"
+	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalResourcesAndLists(t *testing.T) {
+	checkRegistration[actor.Actor](t, actor.ActorKind)
+	checkRegistration[connection.Connection](t, connection.ConnectionKind)
+	checkRegistration[connectors.Connector](t, connectors.ConnectorKind)
+	checkRegistration[key.Key](t, key.KeyKind)
+	checkRegistration[namespace.Namespace](t, namespace.NamespaceKind)
+	checkRegistration[rate_limit.RateLimit](t, rate_limit.RateLimitKind)
+	require.Len(t, NewResourceScheme().RegisteredGVKs(), 12)
+}
+
+func checkRegistration[T any](t *testing.T, kind meta.Kind) {
+	t.Helper()
+	t.Run(string(kind), func(t *testing.T) {
+		scheme := NewResourceScheme()
+		payload := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{"name":"example","namespace":"root"},"spec":{}}`, kind)
+		resource, err := scheme.DecodeJSON([]byte(payload))
+		require.NoError(t, err)
+		require.IsType(t, new(T), resource)
+		again, err := scheme.DecodeJSON([]byte(payload))
+		require.NoError(t, err)
+		require.NotSame(t, resource, again)
+
+		listPayload := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{},"items":[%s]}`, apiv1alpha1.ListKind(kind), payload)
+		list, err := scheme.DecodeJSON([]byte(listPayload))
+		require.NoError(t, err)
+		require.IsType(t, new(apiv1alpha1.ResourceList[T]), list)
+		require.Len(t, list.(*apiv1alpha1.ResourceList[T]).Items, 1)
+
+		// JSON is also valid YAML; exercise both scheme decoding paths.
+		yamlList, err := scheme.DecodeYAML([]byte(listPayload))
+		require.NoError(t, err)
+		require.Equal(t, list, yamlList)
+		badItem := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{},"spec":{},"unknown":true}`, kind)
+		_, err = scheme.DecodeJSON([]byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"items":[%s]}`, apiv1alpha1.ListKind(kind), badItem)))
+		require.ErrorContains(t, err, "unknown")
+	})
+}
+
+func TestIndependentSchemesAndUnsupportedContracts(t *testing.T) {
+	first, second := NewResourceScheme(), NewResourceScheme()
+	gvk := manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "LocalExtension"}
+	require.NoError(t, manifest.RegisterType[actor.Actor](first, gvk))
+	require.NotContains(t, second.RegisteredGVKs(), gvk)
+	for _, payload := range []string{
+		`{"apiVersion":"authproxy.net/v999","kind":"Actor"}`,
+		`{"apiVersion":"authproxy.net/v1alpha1","kind":"ActorPatch"}`,
+		`{"apiVersion":"authproxy.net/v1alpha1","kind":"ConnectorForceState"}`,
+	} {
+		_, err := second.DecodeJSON([]byte(payload))
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
Adds the first stage of `ap apply`: operators can load and inspect resource manifests with `ap apply -f ./resources --dry-run=client -n root.integrations`. A resource's explicit namespace wins over the flag; name-based resources with no namespace fail, while ID-only targets are accepted. Normal apply fails explicitly until the reconciliation and execution issues land.

Canonical resources and their typed list envelopes are registered centrally by `internal/schema/registry.NewResourceScheme()`. The apply loader uses this shared constructor; operation support stays in apply, and the generic manifest decoder remains independent of concrete types. Each constructor call returns an independent scheme.

The reusable loader accepts repeated files/directories/HTTP(S) URLs/stdin, recursive directory discovery, YAML streams and resource lists. It retains field presence, rejects invalid/duplicate identities and unsupported fields, validates the entire input before output, and reports source/document/item locations. Client output supports name/JSON/YAML and masks schema-declared secrets. URL input uses an unsigned client with timeout and size limits. The CLI now returns a nonzero process status on command errors.

This increment checks manifest structure and identity. Server lookup, operation-specific validation, reconciliation and writes remain tracked in the parent plan; no cluster changes occur. See the CLI documentation for the available flags and staged limitations.

Closes #920
Part of #919

## Validation
- `go test ./internal/schema/registry ./internal/schema/manifest ./internal/apply ./cmd/cli`
- Built CLI smoke checks: dry-run JSON exits 0; unsupported real apply and unknown flags exit 1.
- `yarn docs:build`
- `./scripts/preflight.sh`

