### PR TITLE
Fix unavailable MinIO images in CI

### DIFF
--- a/.github/workflows/aws-integration.yml
+++ b/.github/workflows/aws-integration.yml
@@ -59,7 +59,7 @@ jobs:
         docker run -d --name minio -p 9003:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
-          minio/minio:latest server /data
+          quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
         for i in $(seq 1 30); do
           curl -sf http://localhost:9003/minio/health/live && break
           sleep 1
@@ -69,7 +69,7 @@ jobs:
       run: |
         docker run --rm --network host \
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
-          minio/mc mb --ignore-existing minio/authproxy-request-logs
+          quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z mb --ignore-existing minio/authproxy-request-logs
 
     - name: Check AWS key provider configuration
       env:

--- a/.github/workflows/gcp-integration.yml
+++ b/.github/workflows/gcp-integration.yml
@@ -59,7 +59,7 @@ jobs:
         docker run -d --name minio -p 9003:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
-          minio/minio:latest server /data
+          quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
         for i in $(seq 1 30); do
           curl -sf http://localhost:9003/minio/health/live && break
           sleep 1
@@ -69,7 +69,7 @@ jobs:
       run: |
         docker run --rm --network host \
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
-          minio/mc mb --ignore-existing minio/authproxy-request-logs
+          quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z mb --ignore-existing minio/authproxy-request-logs
 
     - name: Write GCP service account credentials
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -199,7 +199,7 @@ jobs:
         docker run -d --name minio -p 9003:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
-          minio/minio:latest server /data
+          quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
         for i in $(seq 1 30); do
           curl -sf http://localhost:9003/minio/health/live && break
           sleep 1
@@ -210,7 +210,7 @@ jobs:
         docker run --rm --network host \
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
           --entrypoint /bin/sh \
-          minio/mc -c "
+          quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z -c "
             mc mb --ignore-existing minio/authproxy-request-logs &&
             mc mb --ignore-existing minio/authproxy-streaming-test &&
             mc anonymous set public minio/authproxy-streaming-test

--- a/.github/workflows/vault-integration.yml
+++ b/.github/workflows/vault-integration.yml
@@ -61,7 +61,7 @@ jobs:
         docker run -d --name minio -p 9003:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
-          minio/minio:latest server /data
+          quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
         for i in $(seq 1 30); do
           curl -sf http://localhost:9003/minio/health/live && break
           sleep 1
@@ -71,7 +71,7 @@ jobs:
       run: |
         docker run --rm --network host \
           -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9003 \
-          minio/mc mb --ignore-existing minio/authproxy-request-logs
+          quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z mb --ignore-existing minio/authproxy-request-logs
 
     - name: Start Vault (dev mode)
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -51,7 +51,7 @@ services:
       retries: 10
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9003:9000"
       - "9004:9001"
@@ -67,7 +67,7 @@ services:
       retries: 10
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- replace the unavailable Docker Hub `minio/minio` image with MinIO's retained official Quay image
- pin the server and client to explicit release tags instead of moving `latest` tags
- update all GitHub Actions and local/integration Compose references together

## Cause

The failing `main` workflows all stop in `Start MinIO` before tests run because Docker Hub now rejects pulls for `minio/minio:latest`. MinIO community distribution changed and the Docker Hub repository is no longer available.

## Verification

- `./scripts/preflight.sh`
- `docker compose config --quiet`
- `docker compose -f integration_tests/docker-compose.yml config --quiet`
- pulled and executed both pinned multi-architecture images
- ran the integration Compose MinIO services through healthy startup, bucket creation, and public test-bucket policy setup

The PR workflows provide the Linux/GitHub-hosted-runner verification for the same four jobs that failed on `main`.