### PR TITLE
Add authenticated resource adapters for ap apply

### DIFF
--- a/cmd/cli/config/apply_client.go
+++ b/cmd/cli/config/apply_client.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apply"
+)
+
+// ResolveApplyClient constructs the authenticated resource client for the
+// forthcoming apply executor. Client dry-run must never call this method.
+func (j *Resolver) ResolveApplyClient(timeout time.Duration) (*apply.Client, error) {
+	options := apply.ClientOptions{Admin: j.admin, Timeout: timeout}
+	var err error
+	if j.admin {
+		options.AdminAPIURL, err = j.ResolveAdminApiUrl()
+	} else {
+		options.APIURL, err = j.ResolveApiUrl()
+	}
+	if err != nil {
+		return nil, err
+	}
+	options.Signer, err = j.ResolveSigner()
+	if err != nil {
+		return nil, err
+	}
+	return apply.NewClient(options)
+}

--- a/cmd/cli/config/apply_client_test.go
+++ b/cmd/cli/config/apply_client_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apply"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveApplyClientSelectsServiceAndSignsRequests(t *testing.T) {
+	for _, admin := range []bool{false, true} {
+		t.Run(fmt.Sprint(admin), func(t *testing.T) {
+			var apiCalls, adminCalls int
+			handler := func(counter *int) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*counter++
+					require.Equal(t, "/api/v1/namespaces/root", r.URL.Path)
+					token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+					claims := parseTestToken(t, context.Background(), token, []byte("apply-test-secret"))
+					require.Equal(t, "operator", claims.Subject)
+					fmt.Fprint(w, `{"apiVersion":"authproxy.net/v1alpha1","kind":"Namespace","metadata":{"id":"root","name":"root"},"spec":{}}`)
+				}
+			}
+			api := httptest.NewServer(handler(&apiCalls))
+			defer api.Close()
+			adminAPI := httptest.NewServer(handler(&adminCalls))
+			defer adminAPI.Close()
+			r := &Resolver{admin: admin, actorId: "operator", apis: "all", secretKeyPath: writeTestFile(t, "apply-test-secret"), apiUrl: api.URL, adminApiUrl: adminAPI.URL}
+			c, err := r.ResolveApplyClient(apply.DefaultRequestTimeout)
+			require.NoError(t, err)
+			docs, err := apply.Load(context.Background(), apply.Options{Filenames: []string{"-"}, Stdin: strings.NewReader("apiVersion: authproxy.net/v1alpha1\nkind: Namespace\nmetadata: {id: root}\nspec: {}")})
+			require.NoError(t, err)
+			_, err = c.Resolve(context.Background(), docs[0])
+			require.NoError(t, err)
+			if admin {
+				require.Equal(t, 1, adminCalls)
+				require.Zero(t, apiCalls)
+			} else {
+				require.Equal(t, 1, apiCalls)
+				require.Zero(t, adminCalls)
+			}
+		})
+	}
+}
+
+func TestResolveApplyClientDoesNotFallbackFromMissingAdminEndpoint(t *testing.T) {
+	r := &Resolver{admin: true, actorId: "operator", apis: "all", secretKeyPath: writeTestFile(t, "apply-test-secret"), apiUrl: "http://localhost:8081", root: &Root{}}
+	_, err := r.ResolveApplyClient(apply.DefaultRequestTimeout)
+	require.ErrorContains(t, err, "admin API")
+}

--- a/internal/apply/README.md
+++ b/internal/apply/README.md
@@ -24,8 +24,9 @@ existing mutable metadata.
 and patch types, including immutable-field checks and omitted/null/empty patch
 semantics. `Update` accepts a calculated canonical patch; callers must perform
 three-way reconciliation before using it. Validation of the original document
-in `ResolveBatch` is not a generated execution plan. Resource recognition uses
-`schema/registry`; per-kind operation adapters live here.
+in `ResolveBatch` is not a generated execution plan. Resource recognition, patch factories, metadata access, ID validation and
+canonical lifecycle/merge capabilities come from `schema/registry`. Apply
+retains transport, target resolution, and operation policy.
 
 `LiveResource` retains typed responses, the redaction header, and known
 write-only field paths. Never derive mutations from masked values or assume

--- a/internal/apply/README.md
+++ b/internal/apply/README.md
@@ -1,0 +1,41 @@
+# Apply infrastructure
+
+The apply implementation is delivered in stages. `Load` remains an offline
+manifest loader (apart from explicit manifest URL downloads). The CLI currently
+exposes client dry-run only. `Client` supplies the ordinary authenticated REST
+operations for the future reconciler/executor; it does not enable cluster apply
+by itself.
+
+`cmd/cli/config.Resolver.ResolveApplyClient` reuses CLI configuration and JWT
+signing. It selects the API service normally and the admin API in admin mode,
+without silently falling back between them. Callers pass
+`DefaultRequestTimeout` (30 seconds) unless overridden; zero disables the
+per-request timeout. Client dry-run must not instantiate this client.
+
+`ResolveBatch` performs reads only. It rejects unsupported/admin-only kinds
+before requests, resolves IDs or exact namespaced names, follows pagination,
+checks supplied identity fields, detects aliases resolving to the same live ID,
+and validates create or patch contracts. Explicit IDs and connector generations
+must already exist. Namespace names derive a canonical path for direct lookup;
+a missing name-addressed Namespace can be created. Connections can only update
+existing mutable metadata.
+
+`Create` and `Update` submit one validated operation. They use canonical resource
+and patch types, including immutable-field checks and omitted/null/empty patch
+semantics. `Update` accepts a calculated canonical patch; callers must perform
+three-way reconciliation before using it. Validation of the original document
+in `ResolveBatch` is not a generated execution plan. Resource recognition uses
+`schema/registry`; per-kind operation adapters live here.
+
+`LiveResource` retains typed responses, the redaction header, and known
+write-only field paths. Never derive mutations from masked values or assume
+omitted write-only fields are absent on the server. Resources and documents may
+contain secrets and must not be logged. API errors expose HTTP status without
+reflecting response bodies, and the HTTP client refuses redirects so signing
+credentials are not forwarded elsewhere.
+
+Batch dependency ordering, reconciliation/history, automatic retries, and
+conditional writes are not implemented in this layer. A successful operation
+followed by a lost/invalid response has an uncertain outcome; the client does
+not retry mutations. Server validation and authorization remain authoritative,
+and ordinary read/patch sequences do not prevent concurrent writes.

--- a/internal/apply/README.md
+++ b/internal/apply/README.md
@@ -10,9 +10,10 @@ by itself.
 signing. It selects the API service normally and the admin API in admin mode,
 without silently falling back between them. Callers pass
 `DefaultRequestTimeout` (30 seconds) unless overridden; zero disables the
-per-request timeout. Client dry-run must not instantiate this client.
+per-request timeout. Key resources are supported on both services, subject to
+server authorization. Client dry-run must not instantiate this client.
 
-`ResolveBatch` performs reads only. It rejects unsupported/admin-only kinds
+`ResolveBatch` performs reads only. It rejects unsupported kinds
 before requests, resolves IDs or exact namespaced names, follows pagination,
 checks supplied identity fields, detects aliases resolving to the same live ID,
 and validates create or patch contracts. Explicit IDs and connector generations

--- a/internal/apply/adapters.go
+++ b/internal/apply/adapters.go
@@ -30,36 +30,61 @@ type resourceAdapter struct {
 func adapterFor(kind meta.Kind) (resourceAdapter, error) {
 	switch kind {
 	case actor.ActorKind:
-		return resourceAdapter{"actors", func() lifecycleResource { return actor.NewActorPatch() }, func(current any, p lifecycleResource) error {
-			_, err := p.(*actor.ActorPatch).ApplyTo(current.(*actor.Actor), nil)
-			return err
-		}}, nil
+		return resourceAdapter{
+			"actors",
+			func() lifecycleResource { return actor.NewActorPatch() },
+			func(current any, p lifecycleResource) error {
+				_, err := p.(*actor.ActorPatch).ApplyTo(current.(*actor.Actor), nil)
+				return err
+			},
+		}, nil
 	case namespace.NamespaceKind:
-		return resourceAdapter{"namespaces", func() lifecycleResource { return namespace.NewNamespacePatch() }, func(current any, p lifecycleResource) error {
-			_, err := p.(*namespace.NamespacePatch).ApplyTo(current.(*namespace.Namespace), nil)
-			return err
-		}}, nil
+		return resourceAdapter{
+			"namespaces",
+			func() lifecycleResource { return namespace.NewNamespacePatch() },
+			func(current any, p lifecycleResource) error {
+				_, err := p.(*namespace.NamespacePatch).ApplyTo(current.(*namespace.Namespace), nil)
+				return err
+			},
+		}, nil
 	case key.KeyKind:
-		return resourceAdapter{"keys", func() lifecycleResource { return key.NewKeyPatch() }, func(current any, p lifecycleResource) error {
-			_, err := p.(*key.KeyPatch).ApplyTo(current.(*key.Key), nil)
-			return err
-		}}, nil
+		return resourceAdapter{
+			"keys",
+			func() lifecycleResource { return key.NewKeyPatch() },
+			func(current any, p lifecycleResource) error {
+				_, err := p.(*key.KeyPatch).ApplyTo(current.(*key.Key), nil)
+				return err
+			},
+		}, nil
 	case connectors.ConnectorKind:
-		return resourceAdapter{"connectors", func() lifecycleResource { return new(connectors.ConnectorPatch) }, func(current any, p lifecycleResource) error {
-			_, err := p.(*connectors.ConnectorPatch).ApplyTo(current.(*connectors.Connector), nil)
-			return err
-		}}, nil
+		return resourceAdapter{
+			"connectors",
+			func() lifecycleResource { return new(connectors.ConnectorPatch) },
+			func(current any, p lifecycleResource) error {
+				_, err := p.(*connectors.ConnectorPatch).ApplyTo(current.(*connectors.Connector), nil)
+				return err
+			},
+		}, nil
 	case rate_limit.RateLimitKind:
-		return resourceAdapter{"rate-limits", func() lifecycleResource { return rate_limit.NewRateLimitPatch() }, func(current any, p lifecycleResource) error {
-			_, err := p.(*rate_limit.RateLimitPatch).ApplyTo(current.(*rate_limit.RateLimit), nil)
-			return err
-		}}, nil
+		return resourceAdapter{
+			"rate-limits",
+			func() lifecycleResource { return rate_limit.NewRateLimitPatch() },
+			func(current any, p lifecycleResource) error {
+				_, err := p.(*rate_limit.RateLimitPatch).ApplyTo(current.(*rate_limit.RateLimit), nil)
+				return err
+			},
+		}, nil
 	case connection.ConnectionKind:
-		return resourceAdapter{"connections", func() lifecycleResource { return new(connection.ConnectionPatch) }, func(current any, p lifecycleResource) error {
-			_, err := current.(*connection.Connection).ApplyUpdate(p.(*connection.ConnectionPatch))
-			return err
-		}}, nil
+		return resourceAdapter{
+			"connections",
+			func() lifecycleResource { return new(connection.ConnectionPatch) },
+			func(current any, p lifecycleResource) error {
+				_, err := current.(*connection.Connection).ApplyUpdate(p.(*connection.ConnectionPatch))
+				return err
+			},
+		}, nil
 	}
+
 	return resourceAdapter{}, fmt.Errorf("unsupported apply kind %q", kind)
 }
 
@@ -83,27 +108,38 @@ func resourceMetadata(resource any) (meta.ObjectMeta, meta.Kind, error) {
 
 // decodePatch preserves presence using the canonical patch decoder. Callers
 // supply a calculated patch, not the entire live resource (which may be masked).
-func decodePatch(kind meta.Kind, data []byte, current any) (lifecycleResource, error) {
+func decodePatch(
+	kind meta.Kind,
+	data []byte,
+	current any,
+) (lifecycleResource, error) {
 	adapter, err := adapterFor(kind)
 	if err != nil {
 		return nil, err
 	}
+
 	patch := adapter.patch()
+
 	if err := util.DecodeJSONStrict(data, patch); err != nil {
 		return nil, fmt.Errorf("invalid %s patch fields or types", kind)
 	}
+
 	if err := apserde.ValidateNoRedactedPlaceholders(patch); err != nil {
 		return nil, fmt.Errorf("redacted placeholders cannot be submitted")
 	}
+
 	if err := patch.ValidateFor(meta.ValidationModeUpdate, nil); err != nil {
 		return nil, fmt.Errorf("%s patch failed semantic validation", kind)
 	}
+
 	_, currentKind, err := resourceMetadata(current)
 	if err != nil || currentKind != kind {
 		return nil, fmt.Errorf("patch target kind mismatch")
 	}
+
 	if err := adapter.merge(current, patch); err != nil {
 		return nil, fmt.Errorf("%s patch changes immutable identity/policy or produces an invalid resource", kind)
 	}
+
 	return patch, nil
 }

--- a/internal/apply/adapters.go
+++ b/internal/apply/adapters.go
@@ -1,0 +1,109 @@
+package apply
+
+import (
+	"fmt"
+
+	"github.com/rmorlok/authproxy/internal/apserde"
+	"github.com/rmorlok/authproxy/internal/schema/common"
+	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
+	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
+	"github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util"
+)
+
+type lifecycleResource interface {
+	ValidateFor(meta.ValidationMode, *common.ValidationContext) error
+}
+
+// Adapters contain operation contracts, not resource registrations. Resource
+// decoding continues to use the shared schema registry.
+type resourceAdapter struct {
+	collection string
+	patch      func() lifecycleResource
+	merge      func(any, lifecycleResource) error
+}
+
+func adapterFor(kind meta.Kind) (resourceAdapter, error) {
+	switch kind {
+	case actor.ActorKind:
+		return resourceAdapter{"actors", func() lifecycleResource { return actor.NewActorPatch() }, func(current any, p lifecycleResource) error {
+			_, err := p.(*actor.ActorPatch).ApplyTo(current.(*actor.Actor), nil)
+			return err
+		}}, nil
+	case namespace.NamespaceKind:
+		return resourceAdapter{"namespaces", func() lifecycleResource { return namespace.NewNamespacePatch() }, func(current any, p lifecycleResource) error {
+			_, err := p.(*namespace.NamespacePatch).ApplyTo(current.(*namespace.Namespace), nil)
+			return err
+		}}, nil
+	case key.KeyKind:
+		return resourceAdapter{"keys", func() lifecycleResource { return key.NewKeyPatch() }, func(current any, p lifecycleResource) error {
+			_, err := p.(*key.KeyPatch).ApplyTo(current.(*key.Key), nil)
+			return err
+		}}, nil
+	case connectors.ConnectorKind:
+		return resourceAdapter{"connectors", func() lifecycleResource { return new(connectors.ConnectorPatch) }, func(current any, p lifecycleResource) error {
+			_, err := p.(*connectors.ConnectorPatch).ApplyTo(current.(*connectors.Connector), nil)
+			return err
+		}}, nil
+	case rate_limit.RateLimitKind:
+		return resourceAdapter{"rate-limits", func() lifecycleResource { return rate_limit.NewRateLimitPatch() }, func(current any, p lifecycleResource) error {
+			_, err := p.(*rate_limit.RateLimitPatch).ApplyTo(current.(*rate_limit.RateLimit), nil)
+			return err
+		}}, nil
+	case connection.ConnectionKind:
+		return resourceAdapter{"connections", func() lifecycleResource { return new(connection.ConnectionPatch) }, func(current any, p lifecycleResource) error {
+			_, err := current.(*connection.Connection).ApplyUpdate(p.(*connection.ConnectionPatch))
+			return err
+		}}, nil
+	}
+	return resourceAdapter{}, fmt.Errorf("unsupported apply kind %q", kind)
+}
+
+func resourceMetadata(resource any) (meta.ObjectMeta, meta.Kind, error) {
+	switch r := resource.(type) {
+	case *actor.Actor:
+		return r.Metadata, r.Kind, nil
+	case *namespace.Namespace:
+		return r.Metadata, r.Kind, nil
+	case *key.Key:
+		return r.Metadata, r.Kind, nil
+	case *connectors.Connector:
+		return r.Metadata, r.Kind, nil
+	case *rate_limit.RateLimit:
+		return r.Metadata, r.Kind, nil
+	case *connection.Connection:
+		return r.Metadata, r.Kind, nil
+	}
+	return meta.ObjectMeta{}, "", fmt.Errorf("expected a canonical resource")
+}
+
+// decodePatch preserves presence using the canonical patch decoder. Callers
+// supply a calculated patch, not the entire live resource (which may be masked).
+func decodePatch(kind meta.Kind, data []byte, current any) (lifecycleResource, error) {
+	adapter, err := adapterFor(kind)
+	if err != nil {
+		return nil, err
+	}
+	patch := adapter.patch()
+	if err := util.DecodeJSONStrict(data, patch); err != nil {
+		return nil, fmt.Errorf("invalid %s patch fields or types", kind)
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(patch); err != nil {
+		return nil, fmt.Errorf("redacted placeholders cannot be submitted")
+	}
+	if err := patch.ValidateFor(meta.ValidationModeUpdate, nil); err != nil {
+		return nil, fmt.Errorf("%s patch failed semantic validation", kind)
+	}
+	_, currentKind, err := resourceMetadata(current)
+	if err != nil || currentKind != kind {
+		return nil, fmt.Errorf("patch target kind mismatch")
+	}
+	if err := adapter.merge(current, patch); err != nil {
+		return nil, fmt.Errorf("%s patch changes immutable identity/policy or produces an invalid resource", kind)
+	}
+	return patch, nil
+}

--- a/internal/apply/adapters.go
+++ b/internal/apply/adapters.go
@@ -4,106 +4,22 @@ import (
 	"fmt"
 
 	"github.com/rmorlok/authproxy/internal/apserde"
-	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
-	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
-	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
-	"github.com/rmorlok/authproxy/internal/schema/resources/key"
+	"github.com/rmorlok/authproxy/internal/schema/manifest"
+	"github.com/rmorlok/authproxy/internal/schema/registry"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
-	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
-	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
-	"github.com/rmorlok/authproxy/internal/util"
 )
 
-type lifecycleResource interface {
-	ValidateFor(meta.ValidationMode, *common.ValidationContext) error
-}
-
-// Adapters contain operation contracts, not resource registrations. Resource
-// decoding continues to use the shared schema registry.
-type resourceAdapter struct {
-	collection string
-	patch      func() lifecycleResource
-	merge      func(any, lifecycleResource) error
-}
-
-func adapterFor(kind meta.Kind) (resourceAdapter, error) {
-	switch kind {
-	case actor.ActorKind:
-		return resourceAdapter{
-			"actors",
-			func() lifecycleResource { return actor.NewActorPatch() },
-			func(current any, p lifecycleResource) error {
-				_, err := p.(*actor.ActorPatch).ApplyTo(current.(*actor.Actor), nil)
-				return err
-			},
-		}, nil
-	case namespace.NamespaceKind:
-		return resourceAdapter{
-			"namespaces",
-			func() lifecycleResource { return namespace.NewNamespacePatch() },
-			func(current any, p lifecycleResource) error {
-				_, err := p.(*namespace.NamespacePatch).ApplyTo(current.(*namespace.Namespace), nil)
-				return err
-			},
-		}, nil
-	case key.KeyKind:
-		return resourceAdapter{
-			"keys",
-			func() lifecycleResource { return key.NewKeyPatch() },
-			func(current any, p lifecycleResource) error {
-				_, err := p.(*key.KeyPatch).ApplyTo(current.(*key.Key), nil)
-				return err
-			},
-		}, nil
-	case connectors.ConnectorKind:
-		return resourceAdapter{
-			"connectors",
-			func() lifecycleResource { return new(connectors.ConnectorPatch) },
-			func(current any, p lifecycleResource) error {
-				_, err := p.(*connectors.ConnectorPatch).ApplyTo(current.(*connectors.Connector), nil)
-				return err
-			},
-		}, nil
-	case rate_limit.RateLimitKind:
-		return resourceAdapter{
-			"rate-limits",
-			func() lifecycleResource { return rate_limit.NewRateLimitPatch() },
-			func(current any, p lifecycleResource) error {
-				_, err := p.(*rate_limit.RateLimitPatch).ApplyTo(current.(*rate_limit.RateLimit), nil)
-				return err
-			},
-		}, nil
-	case connection.ConnectionKind:
-		return resourceAdapter{
-			"connections",
-			func() lifecycleResource { return new(connection.ConnectionPatch) },
-			func(current any, p lifecycleResource) error {
-				_, err := current.(*connection.Connection).ApplyUpdate(p.(*connection.ConnectionPatch))
-				return err
-			},
-		}, nil
-	}
-
-	return resourceAdapter{}, fmt.Errorf("unsupported apply kind %q", kind)
+func resourceType(kind meta.Kind) (registry.ResourceType, error) {
+	return registry.LookupResource(manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind})
 }
 
 func resourceMetadata(resource any) (meta.ObjectMeta, meta.Kind, error) {
-	switch r := resource.(type) {
-	case *actor.Actor:
-		return r.Metadata, r.Kind, nil
-	case *namespace.Namespace:
-		return r.Metadata, r.Kind, nil
-	case *key.Key:
-		return r.Metadata, r.Kind, nil
-	case *connectors.Connector:
-		return r.Metadata, r.Kind, nil
-	case *rate_limit.RateLimit:
-		return r.Metadata, r.Kind, nil
-	case *connection.Connection:
-		return r.Metadata, r.Kind, nil
+	descriptor, err := registry.TypeOf(resource)
+	if err != nil {
+		return meta.ObjectMeta{}, "", err
 	}
-	return meta.ObjectMeta{}, "", fmt.Errorf("expected a canonical resource")
+	metadata, err := descriptor.Metadata(resource)
+	return metadata, descriptor.GVK.Kind, err
 }
 
 // decodePatch preserves presence using the canonical patch decoder. Callers
@@ -112,24 +28,19 @@ func decodePatch(
 	kind meta.Kind,
 	data []byte,
 	current any,
-) (lifecycleResource, error) {
-	adapter, err := adapterFor(kind)
+) (registry.Value, error) {
+	descriptor, err := resourceType(kind)
 	if err != nil {
 		return nil, err
 	}
 
-	patch := adapter.patch()
-
-	if err := util.DecodeJSONStrict(data, patch); err != nil {
-		return nil, fmt.Errorf("invalid %s patch fields or types", kind)
+	patch, err := descriptor.DecodePatchJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s patch fields, types or semantics", kind)
 	}
 
 	if err := apserde.ValidateNoRedactedPlaceholders(patch); err != nil {
 		return nil, fmt.Errorf("redacted placeholders cannot be submitted")
-	}
-
-	if err := patch.ValidateFor(meta.ValidationModeUpdate, nil); err != nil {
-		return nil, fmt.Errorf("%s patch failed semantic validation", kind)
 	}
 
 	_, currentKind, err := resourceMetadata(current)
@@ -137,7 +48,7 @@ func decodePatch(
 		return nil, fmt.Errorf("patch target kind mismatch")
 	}
 
-	if err := adapter.merge(current, patch); err != nil {
+	if _, err := descriptor.ApplyPatch(current, patch); err != nil {
 		return nil, fmt.Errorf("%s patch changes immutable identity/policy or produces an invalid resource", kind)
 	}
 

--- a/internal/apply/adapters_test.go
+++ b/internal/apply/adapters_test.go
@@ -1,0 +1,100 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEveryAdapterCreateAndMetadataUpdate(t *testing.T) {
+	cases := []struct {
+		kind, collection, spec string
+		prefix                 apid.Prefix
+	}{
+		{"Namespace", "namespaces", `{}`, ""},
+		{"Actor", "actors", `{"externalId":"subject"}`, apid.PrefixActor},
+		{"Key", "keys", `{"keyData":{"value":"test-key"}}`, apid.PrefixKey},
+		{"Connector", "connectors", `{"definition":{"displayName":"Example","auth":{"type":"no-auth"}}}`, apid.PrefixConnector},
+		{"RateLimit", "rate-limits", `{"algorithm":{"tokenBucket":{"capacity":10,"refillRate":1}}}`, apid.PrefixRateLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			id := "root.example"
+			if tc.prefix != "" {
+				id = apid.New(tc.prefix).String()
+			}
+			var methods []string
+			c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+				methods = append(methods, r.Method)
+				if r.Method == "POST" {
+					require.Equal(t, "/api/v1/"+tc.collection, r.URL.Path)
+				} else {
+					require.Equal(t, "/api/v1/"+tc.collection+"/"+id, r.URL.Path)
+				}
+				fmt.Fprint(w, liveJSON(tc.kind, id, "example", "root", tc.spec))
+			}, true)
+			doc := clientDoc(t, tc.kind, "  name: example\n  namespace: root", tc.spec)
+			live, err := c.Create(context.Background(), doc)
+			require.NoError(t, err)
+			patch := []byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{"labels":{"env":"prod"}},"spec":{}}`, tc.kind))
+			_, err = c.Update(context.Background(), Target{Document: doc, Current: live}, patch)
+			require.NoError(t, err)
+			require.Equal(t, []string{"POST", "PATCH"}, methods)
+		})
+	}
+}
+
+func TestConnectionMetadataOnly(t *testing.T) {
+	id := apid.New(apid.PrefixConnection).String()
+	connectorID := apid.New(apid.PrefixConnector).String()
+	response := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Connection","metadata":{"id":%q,"name":"example","namespace":"root","createdAt":"2026-09-01T00:00:00Z","updatedAt":"2026-09-01T00:00:00Z"},"spec":{"connectorRef":{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","id":%q,"generation":1}},"status":{"lifecycle":{"state":"configured"},"health":{"state":"healthy"},"configuration":{"configured":true,"schema":{"type":"object"}}}}`, id, connectorID)
+	var methods []string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		fmt.Fprint(w, response)
+	}, false)
+	doc := clientDoc(t, "Connection", "  id: "+id, "{}")
+	targets, err := c.ResolveBatch(context.Background(), []Document{doc})
+	require.NoError(t, err)
+	patch := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Connection","metadata":{"labels":{}},"spec":{}}`)
+	_, err = c.Update(context.Background(), targets[0], patch)
+	require.NoError(t, err)
+	invalid := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Connection","metadata":{},"spec":{"configuration":{"token":"secret"}}}`)
+	_, err = c.Update(context.Background(), targets[0], invalid)
+	require.Error(t, err)
+	_, err = c.Create(context.Background(), doc)
+	require.ErrorContains(t, err, "setup actions")
+	require.Equal(t, []string{"GET", "PATCH"}, methods)
+}
+
+func TestPatchPresenceAndImmutableKeyPolicy(t *testing.T) {
+	id := apid.New(apid.PrefixKey).String()
+	var calls int
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, liveJSON("Key", id, "example", "root", `{"usage":"data_encryption","materialType":"symmetric","desiredState":"active"}`))
+	}, true)
+	doc := clientDoc(t, "Key", "  id: "+id, "{}")
+	live, err := c.Resolve(context.Background(), doc)
+	require.NoError(t, err)
+	require.Equal(t, []string{"spec.keyData"}, live.WriteOnlyFields)
+	for _, spec := range []string{`{"keyData":null}`, `{"keyData":{"value":"********"}}`, `{"materialType":"private"}`, `{"desiredState":"not-valid"}`} {
+		patch := []byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Key","metadata":{},"spec":%s}`, spec))
+		_, err = c.Update(context.Background(), Target{Document: doc, Current: live}, patch)
+		require.Error(t, err)
+	}
+	require.Equal(t, 1, calls)
+	// Nullable Namespace references preserve an explicit clear through the typed patch.
+	nsLive, err := c.decodeLive("Namespace", []byte(liveJSON("Namespace", "root.example", "example", "root", `{}`)), false)
+	require.NoError(t, err)
+	patch, err := decodePatch("Namespace", []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Namespace","metadata":{"annotations":{}},"spec":{"encryptionKeyRef":null}}`), nsLive.Resource)
+	require.NoError(t, err)
+	data, err := json.Marshal(patch)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"encryptionKeyRef":null`)
+}

--- a/internal/apply/client.go
+++ b/internal/apply/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rmorlok/authproxy/internal/apauth/jwt"
 	"github.com/rmorlok/authproxy/internal/apserde"
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
-	"github.com/rmorlok/authproxy/internal/schema/manifest"
 	"github.com/rmorlok/authproxy/internal/schema/registry"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
@@ -42,7 +41,7 @@ type Client struct {
 	admin   bool
 	signer  jwt.Signer
 	http    *http.Client
-	scheme  *manifest.Scheme
+	scheme  *registry.ResourceScheme
 }
 
 func NewClient(options ClientOptions) (*Client, error) {
@@ -90,7 +89,7 @@ type Target struct {
 }
 
 func (c *Client) checkKind(kind meta.Kind) error {
-	if _, err := adapterFor(kind); err != nil {
+	if _, err := resourceType(kind); err != nil {
 		return err
 	}
 	if kind == "Key" && !c.admin {
@@ -144,7 +143,7 @@ func (c *Client) Resolve(ctx context.Context, doc Document) (*LiveResource, erro
 	if err := c.checkKind(doc.Kind); err != nil {
 		return nil, err
 	}
-	adapter, _ := adapterFor(doc.Kind)
+	adapter, _ := resourceType(doc.Kind)
 	m := doc.Metadata
 	if err := normalizeIdentity(string(doc.Kind), &m, ""); err != nil {
 		return nil, err
@@ -156,13 +155,13 @@ func (c *Client) Resolve(ctx context.Context, doc Document) (*LiveResource, erro
 	var live *LiveResource
 	var err error
 	if id != "" {
-		live, err = c.get(ctx, doc.Kind, adapter.collection+"/"+url.PathEscape(id))
+		live, err = c.get(ctx, doc.Kind, adapter.Collection+"/"+url.PathEscape(id))
 		var apiErr *APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound && doc.Metadata.ID == "" && doc.Kind == "Namespace" {
 			return nil, nil
 		}
 	} else {
-		live, err = c.findByName(ctx, doc.Kind, adapter.collection, m)
+		live, err = c.findByName(ctx, doc.Kind, adapter.Collection, m)
 	}
 	if err != nil {
 		return nil, err
@@ -178,7 +177,7 @@ func (c *Client) Resolve(ctx context.Context, doc Document) (*LiveResource, erro
 	}
 	if m.Generation != 0 {
 		resolvedID := live.Metadata.ID
-		live, err = c.get(ctx, doc.Kind, adapter.collection+"/"+url.PathEscape(live.Metadata.ID)+"/generations/"+strconv.FormatUint(m.Generation, 10))
+		live, err = c.get(ctx, doc.Kind, adapter.Collection+"/"+url.PathEscape(live.Metadata.ID)+"/generations/"+strconv.FormatUint(m.Generation, 10))
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +343,8 @@ func (c *Client) createBody(doc Document) ([]byte, error) {
 	if err := apserde.ValidateNoRedactedPlaceholders(resource); err != nil {
 		return nil, fmt.Errorf("redacted placeholders cannot be submitted")
 	}
-	if err := resource.(lifecycleResource).ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+	descriptor, _ := resourceType(kind)
+	if err := descriptor.ValidateResource(resource, meta.ValidationModeCreate); err != nil {
 		return nil, fmt.Errorf("%s create failed semantic validation", kind)
 	}
 	return data, nil
@@ -357,8 +357,8 @@ func (c *Client) Create(ctx context.Context, doc Document) (*LiveResource, error
 	if err != nil {
 		return nil, err
 	}
-	adapter, _ := adapterFor(doc.Kind)
-	data, redacted, err := c.request(ctx, http.MethodPost, adapter.collection, nil, body)
+	adapter, _ := resourceType(doc.Kind)
+	data, redacted, err := c.request(ctx, http.MethodPost, adapter.Collection, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -378,8 +378,8 @@ func (c *Client) Update(ctx context.Context, target Target, patch []byte) (*Live
 	if _, err := decodePatch(kind, patch, target.Current.Resource); err != nil {
 		return nil, err
 	}
-	adapter, _ := adapterFor(kind)
-	path := adapter.collection + "/" + url.PathEscape(target.Current.Metadata.ID)
+	adapter, _ := resourceType(kind)
+	path := adapter.Collection + "/" + url.PathEscape(target.Current.Metadata.ID)
 	if target.Document.Metadata.Generation != 0 {
 		path += "/generations/" + strconv.FormatUint(target.Document.Metadata.Generation, 10)
 	}

--- a/internal/apply/client.go
+++ b/internal/apply/client.go
@@ -1,0 +1,406 @@
+package apply
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/apserde"
+	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/manifest"
+	"github.com/rmorlok/authproxy/internal/schema/registry"
+	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
+	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
+	"github.com/rmorlok/authproxy/internal/util"
+)
+
+const DefaultRequestTimeout = 30 * time.Second
+
+// ClientOptions selects a single cluster service. Timeout zero disables the
+// deadline; CLI callers should use DefaultRequestTimeout unless overridden.
+type ClientOptions struct {
+	APIURL      string
+	AdminAPIURL string
+	Admin       bool
+	Signer      jwt.Signer
+	Timeout     time.Duration
+}
+
+// Client performs ordinary REST operations. It does not reconcile, retry
+// mutations, or imply transactional batch semantics.
+type Client struct {
+	baseURL string
+	admin   bool
+	signer  jwt.Signer
+	http    *http.Client
+	scheme  *manifest.Scheme
+}
+
+func NewClient(options ClientOptions) (*Client, error) {
+	endpoint := options.APIURL
+	if options.Admin {
+		endpoint = options.AdminAPIURL
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("a valid %s service URL without credentials, query or fragment is required", map[bool]string{false: "API", true: "admin API"}[options.Admin])
+	}
+	if options.Signer == nil {
+		return nil, fmt.Errorf("request signer is required")
+	}
+	if options.Timeout < 0 {
+		return nil, fmt.Errorf("request timeout cannot be negative")
+	}
+	return &Client{baseURL: strings.TrimRight(endpoint, "/") + "/api/v1", admin: options.Admin, signer: options.Signer, scheme: registry.NewResourceScheme(), http: &http.Client{Timeout: options.Timeout, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}, nil
+}
+
+// APIError exposes the status without echoing response bodies that may contain
+// sensitive submitted values. It remains inspectable with errors.As.
+type APIError struct{ StatusCode int }
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("AuthProxy API returned HTTP %d (%s)", e.StatusCode, http.StatusText(e.StatusCode))
+}
+
+// LiveResource contains a typed resource and transport redaction information.
+// Resource may contain secrets and must not be logged. Redacted means some
+// readable values were masked; WriteOnlyFields cannot be compared from GET.
+type LiveResource struct {
+	Resource        any
+	Metadata        meta.ObjectMeta
+	Kind            meta.Kind
+	Redacted        bool
+	WriteOnlyFields []string
+}
+
+// Target is a resolved document. Current nil means a namespaced-name lookup
+// found no resource; explicit IDs and generation targets never become creates.
+type Target struct {
+	Document Document
+	Current  *LiveResource
+}
+
+func (c *Client) checkKind(kind meta.Kind) error {
+	if _, err := adapterFor(kind); err != nil {
+		return err
+	}
+	if kind == "Key" && !c.admin {
+		return fmt.Errorf("Key resources require admin mode and an admin API endpoint")
+	}
+	return nil
+}
+
+// ResolveBatch resolves and validates the complete batch without mutations.
+// Check every kind before any requests, then detect aliases resolving to one ID.
+func (c *Client) ResolveBatch(ctx context.Context, documents []Document) ([]Target, error) {
+	for _, doc := range documents {
+		if err := c.checkKind(doc.Kind); err != nil {
+			return nil, fmt.Errorf("%s: %w", doc.Source, err)
+		}
+	}
+	var targets []Target
+	seen := map[string]string{}
+	for _, doc := range documents {
+		live, err := c.Resolve(ctx, doc)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", doc.Source, err)
+		}
+		target := Target{Document: doc, Current: live}
+		if live == nil {
+			if _, err := c.createBody(doc); err != nil {
+				return nil, fmt.Errorf("%s: %w", doc.Source, err)
+			}
+		} else {
+			identity := string(live.Kind) + "/" + live.Metadata.ID
+			if previous, ok := seen[identity]; ok {
+				return nil, fmt.Errorf("%s: duplicate live target; also defined at %s", doc.Source, previous)
+			}
+			seen[identity] = doc.Source
+			data, err := patchDocument(doc)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := decodePatch(doc.Kind, data, live.Resource); err != nil {
+				return nil, fmt.Errorf("%s: %w", doc.Source, err)
+			}
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+// Resolve looks up an ID or exact namespaced name. List filtering is repeated
+// locally because server namespace filters may include descendant namespaces.
+func (c *Client) Resolve(ctx context.Context, doc Document) (*LiveResource, error) {
+	if err := c.checkKind(doc.Kind); err != nil {
+		return nil, err
+	}
+	adapter, _ := adapterFor(doc.Kind)
+	m := doc.Metadata
+	if err := normalizeIdentity(string(doc.Kind), &m, ""); err != nil {
+		return nil, err
+	}
+	id := m.ID
+	if doc.Kind == "Namespace" && id == "" {
+		id, _ = namespace.PathFromMetadata(m)
+	}
+	var live *LiveResource
+	var err error
+	if id != "" {
+		live, err = c.get(ctx, doc.Kind, adapter.collection+"/"+url.PathEscape(id))
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound && doc.Metadata.ID == "" && doc.Kind == "Namespace" {
+			return nil, nil
+		}
+	} else {
+		live, err = c.findByName(ctx, doc.Kind, adapter.collection, m)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if live == nil {
+		if doc.Kind == "Connection" || m.Generation != 0 {
+			return nil, fmt.Errorf("existing %s target was not found", doc.Kind)
+		}
+		return nil, nil
+	}
+	if (m.ID != "" && m.ID != live.Metadata.ID) || (m.Name != "" && m.Name != live.Metadata.Name) || (m.Namespace != "" && m.Namespace != live.Metadata.Namespace) {
+		return nil, fmt.Errorf("resolved resource does not match supplied identity")
+	}
+	if m.Generation != 0 {
+		resolvedID := live.Metadata.ID
+		live, err = c.get(ctx, doc.Kind, adapter.collection+"/"+url.PathEscape(live.Metadata.ID)+"/generations/"+strconv.FormatUint(m.Generation, 10))
+		if err != nil {
+			return nil, err
+		}
+		if live.Metadata.ID != resolvedID || live.Metadata.Generation != m.Generation || (m.ID != "" && m.ID != live.Metadata.ID) || (m.Name != "" && m.Name != live.Metadata.Name) || (m.Namespace != "" && m.Namespace != live.Metadata.Namespace) {
+			return nil, fmt.Errorf("resolved generation does not match supplied identity")
+		}
+	}
+	return live, nil
+}
+
+func (c *Client) findByName(ctx context.Context, kind meta.Kind, collection string, m meta.ObjectMeta) (*LiveResource, error) {
+	query := url.Values{"namespace": {m.Namespace}, "name": {string(m.Name)}}
+	seen := map[string]bool{}
+	var found *LiveResource
+	for {
+		data, redacted, err := c.request(ctx, http.MethodGet, collection, query, nil)
+		if err != nil {
+			return nil, err
+		}
+		var page apiv1alpha1.ResourceList[json.RawMessage]
+		if err := util.DecodeJSONStrict(data, &page); err != nil {
+			return nil, fmt.Errorf("invalid resource list response")
+		}
+		if page.APIVersion != meta.APIVersionV1Alpha1 || page.Kind != apiv1alpha1.ListKind(kind) || page.Items == nil {
+			return nil, fmt.Errorf("unexpected resource list response")
+		}
+		for _, item := range page.Items {
+			live, err := c.decodeLive(kind, item, redacted)
+			if err != nil {
+				return nil, err
+			}
+			if live.Metadata.Namespace != m.Namespace || live.Metadata.Name != m.Name {
+				continue
+			}
+			if found != nil && found.Metadata.ID != live.Metadata.ID {
+				return nil, fmt.Errorf("ambiguous namespaced resource name")
+			}
+			found = live
+		}
+		cursor := page.Metadata.Continue
+		if cursor == "" {
+			if page.Metadata.RemainingItemCount != nil && *page.Metadata.RemainingItemCount > 0 {
+				return nil, fmt.Errorf("incomplete resource list response")
+			}
+			return found, nil
+		}
+		if seen[cursor] {
+			return nil, fmt.Errorf("resource list repeated a pagination cursor")
+		}
+		seen[cursor] = true
+		query = url.Values{"cursor": {cursor}}
+	}
+}
+
+func (c *Client) get(ctx context.Context, kind meta.Kind, path string) (*LiveResource, error) {
+	data, redacted, err := c.request(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.decodeLive(kind, data, redacted)
+}
+func (c *Client) decodeLive(kind meta.Kind, data []byte, redacted bool) (*LiveResource, error) {
+	resource, err := c.scheme.DecodeJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s response fields or types", kind)
+	}
+	m, actual, err := resourceMetadata(resource)
+	if err != nil || actual != kind || m.ID == "" {
+		return nil, fmt.Errorf("unexpected resource response identity")
+	}
+	if m.Name == "" || (kind != "Namespace" && m.Namespace == "") {
+		return nil, fmt.Errorf("incomplete response identity")
+	}
+	normalized := m
+	if err := normalizeIdentity(string(kind), &normalized, ""); err != nil {
+		return nil, fmt.Errorf("invalid response identity")
+	}
+	if normalized.Name != m.Name || normalized.Namespace != m.Namespace {
+		return nil, fmt.Errorf("incomplete response identity")
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(resource); err != nil {
+		redacted = true
+	}
+	live := &LiveResource{Resource: resource, Metadata: m, Kind: kind, Redacted: redacted}
+	switch kind {
+	case "Actor":
+		live.WriteOnlyFields = []string{"spec.signingKey"}
+	case "Key":
+		live.WriteOnlyFields = []string{"spec.keyData"}
+	}
+	return live, nil
+}
+
+func (c *Client) request(ctx context.Context, method, path string, query url.Values, body []byte) ([]byte, bool, error) {
+	endpoint := c.baseURL + "/" + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot construct API request")
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	c.signer.SignAuthHeader(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, false, ctx.Err()
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, false, fmt.Errorf("API request timed out: %w", context.DeadlineExceeded)
+		}
+		return nil, false, fmt.Errorf("API request failed")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, false, &APIError{StatusCode: resp.StatusCode}
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxSourceBytes+1))
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, false, ctx.Err()
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, false, fmt.Errorf("API response timed out: %w", context.DeadlineExceeded)
+		}
+		return nil, false, fmt.Errorf("cannot read API response")
+	}
+	if len(data) > maxSourceBytes {
+		return nil, false, fmt.Errorf("API response exceeds 16 MiB limit")
+	}
+	return data, resp.Header.Get(apserde.RedactedHeader) == "true", nil
+}
+
+func (c *Client) createBody(doc Document) ([]byte, error) {
+	if err := c.checkKind(doc.Kind); err != nil {
+		return nil, err
+	}
+	if doc.Kind == "Connection" {
+		return nil, fmt.Errorf("Connection creation requires setup actions")
+	}
+	if doc.Metadata.ID != "" || doc.Metadata.Generation != 0 {
+		return nil, fmt.Errorf("explicit ID or generation targets cannot be created")
+	}
+	data, err := json.Marshal(doc.Object)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode resource")
+	}
+	resource, err := c.scheme.DecodeJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid create resource")
+	}
+	m, kind, err := resourceMetadata(resource)
+	if err != nil || kind != doc.Kind {
+		return nil, fmt.Errorf("create kind mismatch")
+	}
+	if m.Name == "" {
+		return nil, fmt.Errorf("create requires a resource name")
+	}
+	if err := apserde.ValidateNoRedactedPlaceholders(resource); err != nil {
+		return nil, fmt.Errorf("redacted placeholders cannot be submitted")
+	}
+	if err := resource.(lifecycleResource).ValidateFor(meta.ValidationModeCreate, nil); err != nil {
+		return nil, fmt.Errorf("%s create failed semantic validation", kind)
+	}
+	return data, nil
+}
+
+// Create sends one validated resource. Batch execution and create-race handling
+// belong to the executor; this method never retries a POST.
+func (c *Client) Create(ctx context.Context, doc Document) (*LiveResource, error) {
+	body, err := c.createBody(doc)
+	if err != nil {
+		return nil, err
+	}
+	adapter, _ := adapterFor(doc.Kind)
+	data, redacted, err := c.request(ctx, http.MethodPost, adapter.collection, nil, body)
+	if err != nil {
+		return nil, err
+	}
+	return c.decodeLive(doc.Kind, data, redacted)
+}
+
+// Update submits a calculated canonical patch against a previously resolved
+// resource. It never derives a patch from a redacted server response.
+func (c *Client) Update(ctx context.Context, target Target, patch []byte) (*LiveResource, error) {
+	if target.Current == nil {
+		return nil, fmt.Errorf("update requires a resolved resource")
+	}
+	kind := target.Document.Kind
+	if err := c.checkKind(kind); err != nil {
+		return nil, err
+	}
+	if _, err := decodePatch(kind, patch, target.Current.Resource); err != nil {
+		return nil, err
+	}
+	adapter, _ := adapterFor(kind)
+	path := adapter.collection + "/" + url.PathEscape(target.Current.Metadata.ID)
+	if target.Document.Metadata.Generation != 0 {
+		path += "/generations/" + strconv.FormatUint(target.Document.Metadata.Generation, 10)
+	}
+	data, redacted, err := c.request(ctx, http.MethodPatch, path, nil, patch)
+	if err != nil {
+		return nil, err
+	}
+	return c.decodeLive(kind, data, redacted)
+}
+
+func patchDocument(doc Document) ([]byte, error) {
+	object := make(map[string]any, len(doc.Object)+1)
+	for k, v := range doc.Object {
+		object[k] = v
+	}
+	if _, exists := object["spec"]; !exists {
+		object["spec"] = map[string]any{}
+	}
+	data, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode patch document")
+	}
+	return data, nil
+}

--- a/internal/apply/client.go
+++ b/internal/apply/client.go
@@ -38,7 +38,6 @@ type ClientOptions struct {
 // mutations, or imply transactional batch semantics.
 type Client struct {
 	baseURL string
-	admin   bool
 	signer  jwt.Signer
 	http    *http.Client
 	scheme  *registry.ResourceScheme
@@ -59,7 +58,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	if options.Timeout < 0 {
 		return nil, fmt.Errorf("request timeout cannot be negative")
 	}
-	return &Client{baseURL: strings.TrimRight(endpoint, "/") + "/api/v1", admin: options.Admin, signer: options.Signer, scheme: registry.NewResourceScheme(), http: &http.Client{Timeout: options.Timeout, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}, nil
+	return &Client{baseURL: strings.TrimRight(endpoint, "/") + "/api/v1", signer: options.Signer, scheme: registry.NewResourceScheme(), http: &http.Client{Timeout: options.Timeout, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}, nil
 }
 
 // APIError exposes the status without echoing response bodies that may contain
@@ -89,13 +88,8 @@ type Target struct {
 }
 
 func (c *Client) checkKind(kind meta.Kind) error {
-	if _, err := resourceType(kind); err != nil {
-		return err
-	}
-	if kind == "Key" && !c.admin {
-		return fmt.Errorf("Key resources require admin mode and an admin API endpoint")
-	}
-	return nil
+	_, err := resourceType(kind)
+	return err
 }
 
 // ResolveBatch resolves and validates the complete batch without mutations.

--- a/internal/apply/client_test.go
+++ b/internal/apply/client_test.go
@@ -93,11 +93,9 @@ func TestResolveIDConsistencyAndMissingIDs(t *testing.T) {
 	require.NotContains(t, err.Error(), "secret")
 }
 
-func TestResolveBatchAliasesAndKeyPrecheck(t *testing.T) {
+func TestResolveBatchAliases(t *testing.T) {
 	id := apid.New(apid.PrefixActor).String()
-	var calls int
 	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
-		calls++
 		if r.URL.Path == "/api/v1/actors" {
 			fmt.Fprint(w, listJSON("Actor", []string{actorJSON(id, "bob", "root")}, ""))
 		} else {
@@ -109,11 +107,54 @@ func TestResolveBatchAliasesAndKeyPrecheck(t *testing.T) {
 	targets, err := c.ResolveBatch(context.Background(), []Document{doc, byID})
 	require.Nil(t, targets)
 	require.ErrorContains(t, err, "duplicate live target")
-	calls = 0
-	keyDoc := clientDoc(t, "Key", "  name: key\n  namespace: root", "{keyData: {value: secret}}")
-	_, err = c.ResolveBatch(context.Background(), []Document{doc, keyDoc})
-	require.ErrorContains(t, err, "admin")
-	require.Zero(t, calls)
+}
+
+func TestKeyOperationsOnBothServices(t *testing.T) {
+	for _, admin := range []bool{false, true} {
+		t.Run(fmt.Sprintf("admin=%t", admin), func(t *testing.T) {
+			id := apid.New(apid.PrefixKey).String()
+			response := liveJSON("Key", id, "example", "root", `{"usage":"data_encryption","materialType":"symmetric","desiredState":"active"}`)
+			var requests []string
+			c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r.Method+" "+r.URL.Path)
+				if r.Method == "GET" && r.URL.Path == "/api/v1/keys" {
+					fmt.Fprint(w, listJSON("Key", []string{response}, ""))
+				} else {
+					fmt.Fprint(w, response)
+				}
+			}, admin)
+			doc := clientDoc(t, "Key", "  name: example\n  namespace: root", "{}")
+			targets, err := c.ResolveBatch(context.Background(), []Document{doc})
+			require.NoError(t, err)
+			require.Equal(t, id, targets[0].Current.Metadata.ID)
+			byID := clientDoc(t, "Key", "  id: "+id, "{}")
+			_, err = c.Resolve(context.Background(), byID)
+			require.NoError(t, err)
+			create := clientDoc(t, "Key", "  name: example\n  namespace: root", "{keyData: {value: test-key}}")
+			_, err = c.Create(context.Background(), create)
+			require.NoError(t, err)
+			patch := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Key","metadata":{"labels":{"env":"prod"}},"spec":{}}`)
+			_, err = c.Update(context.Background(), targets[0], patch)
+			require.NoError(t, err)
+			require.Equal(t, []string{"GET /api/v1/keys", "GET /api/v1/keys/" + id, "POST /api/v1/keys", "PATCH /api/v1/keys/" + id}, requests)
+		})
+	}
+}
+
+func TestKeyAPIPermissionDenied(t *testing.T) {
+	var calls int
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message":"sensitive server detail"}`)
+	}, false)
+	doc := clientDoc(t, "Key", "  name: example\n  namespace: root", "{}")
+	_, err := c.ResolveBatch(context.Background(), []Document{doc})
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+	require.NotContains(t, err.Error(), "sensitive")
+	require.Equal(t, 1, calls)
 }
 
 func TestMissingResourcesAndCreateValidation(t *testing.T) {

--- a/internal/apply/client_test.go
+++ b/internal/apply/client_test.go
@@ -1,0 +1,298 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rmorlok/authproxy/internal/apauth/jwt"
+	"github.com/rmorlok/authproxy/internal/apid"
+	"github.com/rmorlok/authproxy/internal/apserde"
+	"github.com/stretchr/testify/require"
+)
+
+func clientDoc(t *testing.T, kind, metadata, spec string) Document {
+	t.Helper()
+	docs, err := loadText(t, manifestText(kind, metadata, spec), "")
+	require.NoError(t, err)
+	return docs[0]
+}
+func testClient(t *testing.T, handler http.HandlerFunc, admin bool) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c, err := NewClient(ClientOptions{APIURL: server.URL, AdminAPIURL: server.URL, Admin: admin, Signer: jwt.NewSigner("test-token"), Timeout: time.Second})
+	require.NoError(t, err)
+	return c
+}
+func liveJSON(kind, id, name, ns, spec string) string {
+	return fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{"id":%q,"name":%q,"namespace":%q},"spec":%s}`, kind, id, name, ns, spec)
+}
+func actorJSON(id, name, ns string) string {
+	return liveJSON("Actor", id, name, ns, `{"externalId":"external-bob"}`)
+}
+func listJSON(kind string, items []string, cursor string) string {
+	return fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{"continue":%q},"items":[%s]}`, kind+"List", cursor, strings.Join(items, ","))
+}
+
+func TestResolveNamespacedNameAcrossPages(t *testing.T) {
+	id := apid.New(apid.PrefixActor).String()
+	var calls int
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		require.Equal(t, "/api/v1/actors", r.URL.Path)
+		calls++
+		if calls == 1 {
+			require.Equal(t, "root.prod", r.URL.Query().Get("namespace"))
+			require.Equal(t, "bob", r.URL.Query().Get("name"))
+			fmt.Fprint(w, listJSON("Actor", []string{actorJSON(apid.New(apid.PrefixActor).String(), "bob", "root.prod.child")}, "next+cursor"))
+		} else {
+			require.Equal(t, "next+cursor", r.URL.Query().Get("cursor"))
+			require.Len(t, r.URL.Query(), 1)
+			fmt.Fprint(w, listJSON("Actor", []string{actorJSON(id, "bob", "root.prod")}, ""))
+		}
+	}, false)
+	doc := clientDoc(t, "Actor", "  name: bob\n  namespace: root.prod", "{}")
+	targets, err := c.ResolveBatch(context.Background(), []Document{doc})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, id, targets[0].Current.Metadata.ID)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []string{"spec.signingKey"}, targets[0].Current.WriteOnlyFields)
+}
+
+func TestResolveIDConsistencyAndMissingIDs(t *testing.T) {
+	id := apid.New(apid.PrefixActor).String()
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, id) {
+			fmt.Fprint(w, actorJSON(id, "bob", "root.prod"))
+			return
+		}
+		http.Error(w, "secret server message", http.StatusNotFound)
+	}, false)
+	doc := clientDoc(t, "Actor", "  id: "+id, "{}")
+	live, err := c.Resolve(context.Background(), doc)
+	require.NoError(t, err)
+	require.Equal(t, "root.prod", live.Metadata.Namespace)
+	for _, metadata := range []string{"  id: " + id + "\n  name: other", "  id: " + id + "\n  namespace: root.other"} {
+		_, err := c.Resolve(context.Background(), clientDoc(t, "Actor", metadata, "{}"))
+		require.ErrorContains(t, err, "does not match")
+	}
+	_, err = c.Resolve(context.Background(), clientDoc(t, "Actor", "  id: "+apid.New(apid.PrefixActor).String(), "{}"))
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, 404, apiErr.StatusCode)
+	require.NotContains(t, err.Error(), "secret")
+}
+
+func TestResolveBatchAliasesAndKeyPrecheck(t *testing.T) {
+	id := apid.New(apid.PrefixActor).String()
+	var calls int
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path == "/api/v1/actors" {
+			fmt.Fprint(w, listJSON("Actor", []string{actorJSON(id, "bob", "root")}, ""))
+		} else {
+			fmt.Fprint(w, actorJSON(id, "bob", "root"))
+		}
+	}, false)
+	doc := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}")
+	byID := clientDoc(t, "Actor", "  id: "+id, "{}")
+	targets, err := c.ResolveBatch(context.Background(), []Document{doc, byID})
+	require.Nil(t, targets)
+	require.ErrorContains(t, err, "duplicate live target")
+	calls = 0
+	keyDoc := clientDoc(t, "Key", "  name: key\n  namespace: root", "{keyData: {value: secret}}")
+	_, err = c.ResolveBatch(context.Background(), []Document{doc, keyDoc})
+	require.ErrorContains(t, err, "admin")
+	require.Zero(t, calls)
+}
+
+func TestMissingResourcesAndCreateValidation(t *testing.T) {
+	var writes int
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			writes++
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/v1/namespaces/") {
+			w.WriteHeader(404)
+			return
+		}
+		collection := strings.TrimPrefix(r.URL.Path, "/api/v1/")
+		kind := map[string]string{"actors": "Actor", "connections": "Connection", "connectors": "Connector"}[collection]
+		fmt.Fprint(w, listJSON(kind, nil, ""))
+	}, false)
+	valid := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{externalId: external-bob}")
+	targets, err := c.ResolveBatch(context.Background(), []Document{valid})
+	require.NoError(t, err)
+	require.Nil(t, targets[0].Current)
+	invalid := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}")
+	_, err = c.ResolveBatch(context.Background(), []Document{invalid})
+	require.ErrorContains(t, err, "semantic")
+	_, err = c.ResolveBatch(context.Background(), []Document{clientDoc(t, "Connection", "  name: cxn\n  namespace: root", "{}")})
+	require.ErrorContains(t, err, "not found")
+	_, err = c.Resolve(context.Background(), clientDoc(t, "Connector", "  name: cxr\n  namespace: root\n  generation: 3", "{}"))
+	require.ErrorContains(t, err, "not found")
+	targets, err = c.ResolveBatch(context.Background(), []Document{clientDoc(t, "Namespace", "  name: prod\n  namespace: root", "{}")})
+	require.NoError(t, err)
+	require.Nil(t, targets[0].Current)
+	_, err = c.Resolve(context.Background(), clientDoc(t, "Namespace", "  id: root.prod", "{}"))
+	require.Error(t, err)
+	require.Zero(t, writes)
+}
+
+func TestPaginationErrors(t *testing.T) {
+	for _, scenario := range []string{"cycle", "ambiguous", "invalid-list", "wrong-kind"} {
+		t.Run(scenario, func(t *testing.T) {
+			c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+				switch scenario {
+				case "cycle":
+					fmt.Fprint(w, listJSON("Actor", nil, "same"))
+				case "ambiguous":
+					fmt.Fprint(w, listJSON("Actor", []string{actorJSON(apid.New(apid.PrefixActor).String(), "bob", "root"), actorJSON(apid.New(apid.PrefixActor).String(), "bob", "root")}, ""))
+				case "invalid-list":
+					fmt.Fprint(w, `{}`)
+				case "wrong-kind":
+					fmt.Fprint(w, listJSON("Actor", []string{liveJSON("Key", apid.New(apid.PrefixKey).String(), "bob", "root", `{}`)}, ""))
+				}
+			}, false)
+			_, err := c.Resolve(context.Background(), clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}"))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestHTTPFailuresTimeoutCancellationAndRedirect(t *testing.T) {
+	for _, status := range []int{401, 403, 409, 500} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			var calls int
+			c := testClient(t, func(w http.ResponseWriter, r *http.Request) { calls++; http.Error(w, "must-not-leak", status) }, false)
+			_, err := c.Resolve(context.Background(), clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}"))
+			var apiErr *APIError
+			require.ErrorAs(t, err, &apiErr)
+			require.Equal(t, status, apiErr.StatusCode)
+			require.NotContains(t, err.Error(), "must-not-leak")
+			require.Equal(t, 1, calls)
+		})
+	}
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) { <-r.Context().Done() }, false)
+	c.http.Timeout = 10 * time.Millisecond
+	_, err := c.Resolve(context.Background(), clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = c.Resolve(ctx, clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}"))
+	require.ErrorIs(t, err, context.Canceled)
+	var destinationCalls atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { destinationCalls.Add(1) }))
+	defer destination.Close()
+	redirect := testClient(t, func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, destination.URL, 302) }, false)
+	_, err = redirect.Resolve(context.Background(), clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}"))
+	require.Error(t, err)
+	require.Zero(t, destinationCalls.Load())
+}
+
+func TestCreateAndPatchHTTPContracts(t *testing.T) {
+	id := apid.New(apid.PrefixActor).String()
+	var methods []string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		methods = append(methods, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var value map[string]any
+		require.NoError(t, json.Unmarshal(body, &value))
+		if r.Method == "POST" {
+			require.Equal(t, "/api/v1/actors", r.URL.Path)
+			require.NotContains(t, value["metadata"], "id")
+		} else {
+			require.Equal(t, "/api/v1/actors/"+id, r.URL.Path)
+			require.Equal(t, map[string]any{}, value["metadata"].(map[string]any)["labels"])
+			require.NotContains(t, value["spec"], "signingKey")
+		}
+		fmt.Fprint(w, actorJSON(id, "bob", "root"))
+	}, false)
+	doc := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{externalId: external-bob}")
+	live, err := c.Create(context.Background(), doc)
+	require.NoError(t, err)
+	patch := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{"labels":{}},"spec":{}}`)
+	_, err = c.Update(context.Background(), Target{Document: doc, Current: live}, patch)
+	require.NoError(t, err)
+	require.Equal(t, []string{"POST", "PATCH"}, methods)
+	invalid := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{},"spec":{"externalId":"different"}}`)
+	_, err = c.Update(context.Background(), Target{Document: doc, Current: live}, invalid)
+	require.ErrorContains(t, err, "immutable")
+	require.Len(t, methods, 2)
+}
+
+func TestRedactionMetadataAndExplicitGeneration(t *testing.T) {
+	id := apid.New(apid.PrefixConnector).String()
+	var paths []string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set(apserde.RedactedHeader, "true")
+		fmt.Fprintf(w, `{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{"id":%q,"name":"example","namespace":"root","generation":3},"spec":{}}`, id)
+	}, false)
+	doc := clientDoc(t, "Connector", "  id: "+id+"\n  generation: 3", "{}")
+	live, err := c.Resolve(context.Background(), doc)
+	require.NoError(t, err)
+	require.True(t, live.Redacted)
+	require.Equal(t, []string{"/api/v1/connectors/" + id, "/api/v1/connectors/" + id + "/generations/3"}, paths)
+	patch := []byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Connector","metadata":{},"spec":{}}`)
+	_, err = c.Update(context.Background(), Target{Document: doc, Current: live}, patch)
+	require.NoError(t, err)
+	require.Equal(t, "/api/v1/connectors/"+id+"/generations/3", paths[2])
+}
+
+func TestClientOptions(t *testing.T) {
+	for _, options := range []ClientOptions{
+		{}, {APIURL: "http://example", Admin: true, Signer: jwt.NewSigner("token")},
+		{APIURL: "http://user:secret@example", Signer: jwt.NewSigner("token")},
+		{APIURL: "http://example?token=secret", Signer: jwt.NewSigner("token")},
+		{APIURL: "http://example", Signer: jwt.NewSigner("token"), Timeout: -1},
+	} {
+		_, err := NewClient(options)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+	}
+}
+
+// Ensure API errors remain useful to the future executor without body replay.
+var _ error = (*APIError)(nil)
+
+func TestIncompletePageAndBodyTimeout(t *testing.T) {
+	doc := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{}")
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"apiVersion":"authproxy.net/v1alpha1","kind":"ActorList","metadata":{"remainingItemCount":1},"items":[]}`)
+	}, false)
+	_, err := c.Resolve(context.Background(), doc)
+	require.ErrorContains(t, err, "incomplete")
+	c = testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}, false)
+	c.http.Timeout = 10 * time.Millisecond
+	_, err = c.Resolve(context.Background(), doc)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFailedMutationIsNotRetried(t *testing.T) {
+	calls := 0
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) { calls++; w.WriteHeader(http.StatusConflict) }, false)
+	doc := clientDoc(t, "Actor", "  name: bob\n  namespace: root", "{externalId: external-bob}")
+	_, err := c.Create(context.Background(), doc)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, 409, apiErr.StatusCode)
+	require.Equal(t, 1, calls)
+}

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -11,13 +11,8 @@ import (
 	"github.com/rmorlok/authproxy/internal/apserde"
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
 	"github.com/rmorlok/authproxy/internal/schema/common"
-	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
-	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
-	"github.com/rmorlok/authproxy/internal/schema/resources/connectors"
-	"github.com/rmorlok/authproxy/internal/schema/resources/key"
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	ns "github.com/rmorlok/authproxy/internal/schema/resources/namespace"
-	rl "github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
 	"github.com/rmorlok/authproxy/internal/util"
 	"gopkg.in/yaml.v3"
 )
@@ -412,8 +407,11 @@ func normalizeIdentity(kind string, m *meta.ObjectMeta, fallback string) error {
 	}
 
 	if m.ID != "" {
-		validators := map[string]func(string) error{"Actor": actor.ValidateID, "Connector": connectors.ValidateID, "Key": key.ValidateID, "RateLimit": rl.ValidateID, "Connection": connection.ValidateID}
-		if err := validators[kind](m.ID); err != nil {
+		descriptor, err := resourceType(meta.Kind(kind))
+		if err != nil {
+			return err
+		}
+		if err := descriptor.ValidateID(m.ID); err != nil {
 			return fmt.Errorf("invalid metadata.id for %s", kind)
 		}
 	}

--- a/internal/apply/document.go
+++ b/internal/apply/document.go
@@ -346,7 +346,7 @@ func (l *inputLoader) object(
 	}
 
 	l.documents = append(l.documents, doc)
-	
+
 	return nil
 }
 

--- a/internal/schema/registry/README.md
+++ b/internal/schema/registry/README.md
@@ -1,22 +1,34 @@
 # Resource Registry
 
-`NewResourceScheme()` is the central registration list for AuthProxy's canonical
-resources and typed resource-list envelopes. Each call returns an independent
-`manifest.Scheme`; there is no mutable global scheme or `init()` registration.
+`NewResourceScheme()` combines generic manifest decoding with the shared
+capabilities of every canonical AuthProxy resource. The catalogue in
+`resourceTypes()` registers each resource and typed list together with its patch
+factory, metadata accessor, ID validator, lifecycle validation and patch
+application bindings, and REST collection name.
 
-Add new resources here once, using `registerResource[T]` to register the resource
-and its `api/v1alpha1.ResourceList[T]` envelope together. Application consumers
-such as `internal/apply` use this constructor rather than maintaining their own
-GVK-to-Go-type registrations. The generic decoding machinery remains in
-`internal/schema/manifest`.
+Use `scheme.Lookup(gvk)` or `LookupResource(gvk)` to obtain a descriptor.
+`TypeOf(resource)` identifies a concrete resource without a caller-side type
+switch. Descriptors are fresh values; metadata access returns a detached copy.
+Wrong concrete types and typed nil pointers return errors.
 
-Recognition is separate from operation support. Consumers still decide which
-resources they can apply, create, or update, and perform lifecycle validation.
-Typed API handlers should keep decoding their specific request contracts:
-resource patches share a resource's GVK and cannot be distinguished by GVK
-alone. Actions, projections, and heterogeneous `List` input are not canonical
-resource registrations; consumers handle those separately.
+`scheme.DecodeJSON` and `scheme.DecodeYAML` decode resources and typed lists.
+`descriptor.DecodePatchJSON` explicitly selects and validates the patch contract,
+which shares the resource's GVK. `descriptor.ApplyPatch` delegates to the
+resource package's immutable-field and merge rules and returns the resulting
+resource without modifying the original. Lifecycle validation is available
+through `descriptor.ValidateResource` and stays implemented in resource packages.
+
+Each constructor returns an independent generic scheme. Additional custom
+contracts can be registered on its embedded `Scheme`; this does not grant them
+canonical resource capabilities. There is no mutable global registry or `init()`
+registration. Actions, projections, and heterogeneous `List` input remain
+consumer-specific contracts.
+
+Application policy remains outside this package: which resources an operation
+supports, namespace defaults, authorization and endpoint selection, HTTP calls,
+reconciliation, dependency ordering, and execution. The generic
+`internal/schema/manifest` package remains independent of concrete resource types.
 
 This package composes resource types and API list envelopes from outside both
-packages, preserving schema dependency direction. It defines no new serialized
-contracts and therefore needs no independent JSON Schema.
+packages, preserving schema dependency direction. It defines capabilities, not
+new serialized contracts, and therefore needs no independent JSON Schema.

--- a/internal/schema/registry/resources.go
+++ b/internal/schema/registry/resources.go
@@ -3,7 +3,11 @@
 package registry
 
 import (
+	"fmt"
+	"reflect"
+
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
+	"github.com/rmorlok/authproxy/internal/schema/common"
 	"github.com/rmorlok/authproxy/internal/schema/manifest"
 	"github.com/rmorlok/authproxy/internal/schema/resources/actor"
 	"github.com/rmorlok/authproxy/internal/schema/resources/connection"
@@ -12,25 +16,177 @@ import (
 	"github.com/rmorlok/authproxy/internal/schema/resources/meta"
 	"github.com/rmorlok/authproxy/internal/schema/resources/namespace"
 	"github.com/rmorlok/authproxy/internal/schema/resources/rate_limit"
+	"github.com/rmorlok/authproxy/internal/util"
 )
 
-// NewResourceScheme returns an independent scheme containing every canonical
-// resource and its typed list envelope. Registration recognizes wire types;
-// callers must separately enforce operation support and lifecycle validation.
-// Patches and actions are deliberately excluded: patches share a resource's
-// GVK but require an operation-specific decoder.
-func NewResourceScheme() *manifest.Scheme {
-	scheme := manifest.NewScheme()
-	registerResource[actor.Actor](scheme, actor.ActorKind)
-	registerResource[connection.Connection](scheme, connection.ConnectionKind)
-	registerResource[connectors.Connector](scheme, connectors.ConnectorKind)
-	registerResource[key.Key](scheme, key.KeyKind)
-	registerResource[namespace.Namespace](scheme, namespace.NamespaceKind)
-	registerResource[rate_limit.RateLimit](scheme, rate_limit.RateLimitKind)
-	return scheme
+// Value is the lifecycle validation contract shared by resources and patches.
+type Value interface {
+	ValidateFor(meta.ValidationMode, *common.ValidationContext) error
 }
 
-func registerResource[T any](scheme *manifest.Scheme, kind meta.Kind) {
-	manifest.MustRegisterType[T](scheme, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind})
-	manifest.MustRegisterType[apiv1alpha1.ResourceList[T]](scheme, manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: apiv1alpha1.ListKind(kind)})
+// ResourceType describes reusable schema capabilities. Operation policy and
+// transport execution belong to callers. Descriptors are returned by value.
+type ResourceType struct {
+	GVK          manifest.GVK
+	Collection   string
+	NewResource  func() Value
+	NewPatch     func() Value
+	ValidateID   func(string) error
+	resourceType reflect.Type
+	metadata     func(any) (meta.ObjectMeta, error)
+	applyPatch   func(any, any) (Value, error)
+	newList      manifest.Factory
+}
+
+// Metadata returns detached metadata after checking the concrete resource type
+// and GVK. Wrong types and typed nil pointers produce errors, never panics.
+func (r ResourceType) Metadata(resource any) (meta.ObjectMeta, error) {
+	return r.metadata(resource)
+}
+
+// ValidateResource delegates lifecycle semantics to the canonical schema.
+func (r ResourceType) ValidateResource(resource any, mode meta.ValidationMode) error {
+	if _, err := r.Metadata(resource); err != nil {
+		return err
+	}
+	return resource.(Value).ValidateFor(mode, nil)
+}
+
+// DecodePatchJSON explicitly selects the patch contract for this GVK. Resource
+// decoding stays on Scheme.DecodeJSON; the two contracts share a GVK.
+func (r ResourceType) DecodePatchJSON(data []byte) (Value, error) {
+	patch := r.NewPatch()
+	if err := util.DecodeJSONStrict(data, patch); err != nil {
+		return nil, err
+	}
+	if err := patch.ValidateFor(meta.ValidationModeUpdate, nil); err != nil {
+		return nil, err
+	}
+	return patch, nil
+}
+
+// ApplyPatch validates and applies a patch using the resource package's own
+// implementation. The original resource is not modified.
+func (r ResourceType) ApplyPatch(resource, patch any) (Value, error) {
+	if _, err := r.Metadata(resource); err != nil {
+		return nil, err
+	}
+	return r.applyPatch(resource, patch)
+}
+
+// ResourceScheme composes generic decoding with resource capabilities. It has
+// no HTTP client or application policy. Each constructor creates a fresh scheme.
+type ResourceScheme struct{ *manifest.Scheme }
+
+func NewResourceScheme() *ResourceScheme {
+	scheme := manifest.NewScheme()
+	for _, r := range resourceTypes() {
+		resource := r
+		if err := scheme.Register(r.GVK, func() any { return resource.NewResource() }); err != nil {
+			panic(err)
+		}
+		if err := scheme.Register(manifest.GVK{APIVersion: r.GVK.APIVersion, Kind: apiv1alpha1.ListKind(r.GVK.Kind)}, r.newList); err != nil {
+			panic(err)
+		}
+	}
+	return &ResourceScheme{Scheme: scheme}
+}
+
+// Lookup returns canonical capabilities; registering a custom decoder on the
+// embedded scheme does not give that type resource or mutation capabilities.
+func (s *ResourceScheme) Lookup(gvk manifest.GVK) (ResourceType, error) { return LookupResource(gvk) }
+
+// LookupResource provides schema capabilities without allocating a decoder.
+func LookupResource(gvk manifest.GVK) (ResourceType, error) {
+	for _, r := range resourceTypes() {
+		if r.GVK == gvk {
+			return r, nil
+		}
+	}
+	return ResourceType{}, fmt.Errorf("unsupported resource %s", gvk)
+}
+
+// TypeOf identifies a concrete canonical resource without a caller-side switch.
+func TypeOf(resource any) (ResourceType, error) {
+	for _, r := range resourceTypes() {
+		if reflect.TypeOf(resource) == r.resourceType {
+			if _, err := r.Metadata(resource); err != nil {
+				return ResourceType{}, err
+			}
+			return r, nil
+		}
+	}
+	return ResourceType{}, fmt.Errorf("expected a canonical resource")
+}
+
+// This is the sole catalogue of resource, list, patch and metadata bindings.
+// Constructing descriptor values avoids a mutable global registry.
+func resourceTypes() []ResourceType {
+	return []ResourceType{
+		describe[actor.Actor, actor.ActorPatch](actor.ActorKind, "actors", actor.ValidateID,
+			func(r *actor.Actor) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *actor.Actor, patch *actor.ActorPatch) (*actor.Actor, error) {
+				return patch.ApplyTo(current, nil)
+			}),
+		describe[connection.Connection, connection.ConnectionPatch](connection.ConnectionKind, "connections", connection.ValidateID,
+			func(r *connection.Connection) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *connection.Connection, patch *connection.ConnectionPatch) (*connection.Connection, error) {
+				return current.ApplyUpdate(patch)
+			}),
+		describe[connectors.Connector, connectors.ConnectorPatch](connectors.ConnectorKind, "connectors", connectors.ValidateID,
+			func(r *connectors.Connector) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *connectors.Connector, patch *connectors.ConnectorPatch) (*connectors.Connector, error) {
+				return patch.ApplyTo(current, nil)
+			}),
+		describe[key.Key, key.KeyPatch](key.KeyKind, "keys", key.ValidateID,
+			func(r *key.Key) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *key.Key, patch *key.KeyPatch) (*key.Key, error) { return patch.ApplyTo(current, nil) }),
+		describe[namespace.Namespace, namespace.NamespacePatch](namespace.NamespaceKind, "namespaces", namespace.ValidatePath,
+			func(r *namespace.Namespace) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *namespace.Namespace, patch *namespace.NamespacePatch) (*namespace.Namespace, error) {
+				return patch.ApplyTo(current, nil)
+			}),
+		describe[rate_limit.RateLimit, rate_limit.RateLimitPatch](rate_limit.RateLimitKind, "rate-limits", rate_limit.ValidateID,
+			func(r *rate_limit.RateLimit) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
+			func(current *rate_limit.RateLimit, patch *rate_limit.RateLimitPatch) (*rate_limit.RateLimit, error) {
+				return patch.ApplyTo(current, nil)
+			}),
+	}
+}
+
+func describe[R, P any](kind meta.Kind, collection string, validateID func(string) error,
+	metadata func(*R) (meta.TypeMeta, meta.ObjectMeta), merge func(*R, *P) (*R, error)) ResourceType {
+	return ResourceType{
+		GVK: manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind}, Collection: collection,
+		NewResource: func() Value { return any(new(R)).(Value) },
+		NewPatch:    func() Value { return any(new(P)).(Value) },
+		ValidateID:  validateID, resourceType: reflect.TypeOf(new(R)),
+		newList: func() any { return new(apiv1alpha1.ResourceList[R]) },
+		metadata: func(value any) (meta.ObjectMeta, error) {
+			r, ok := value.(*R)
+			if !ok || r == nil {
+				return meta.ObjectMeta{}, fmt.Errorf("expected a non-nil %s resource", kind)
+			}
+			tm, m := metadata(r)
+			if err := meta.ValidateTypeMeta(tm, meta.APIVersionV1Alpha1, kind, nil); err != nil {
+				return meta.ObjectMeta{}, err
+			}
+			return meta.CloneObjectMeta(m), nil
+		},
+		applyPatch: func(current, patch any) (Value, error) {
+			r, ok := current.(*R)
+			if !ok || r == nil {
+				return nil, fmt.Errorf("expected a non-nil %s resource", kind)
+			}
+			p, ok := patch.(*P)
+			if !ok || p == nil {
+				return nil, fmt.Errorf("expected a non-nil %s patch", kind)
+			}
+			result, err := merge(r, p)
+			if err != nil {
+				return nil, err
+			}
+			return any(result).(Value), nil
+		},
+	}
 }

--- a/internal/schema/registry/resources.go
+++ b/internal/schema/registry/resources.go
@@ -45,10 +45,14 @@ func (r ResourceType) Metadata(resource any) (meta.ObjectMeta, error) {
 }
 
 // ValidateResource delegates lifecycle semantics to the canonical schema.
-func (r ResourceType) ValidateResource(resource any, mode meta.ValidationMode) error {
+func (r ResourceType) ValidateResource(
+	resource any,
+	mode meta.ValidationMode,
+) error {
 	if _, err := r.Metadata(resource); err != nil {
 		return err
 	}
+	
 	return resource.(Value).ValidateFor(mode, nil)
 }
 
@@ -59,9 +63,11 @@ func (r ResourceType) DecodePatchJSON(data []byte) (Value, error) {
 	if err := util.DecodeJSONStrict(data, patch); err != nil {
 		return nil, err
 	}
+
 	if err := patch.ValidateFor(meta.ValidationModeUpdate, nil); err != nil {
 		return nil, err
 	}
+
 	return patch, nil
 }
 
@@ -82,19 +88,29 @@ func NewResourceScheme() *ResourceScheme {
 	scheme := manifest.NewScheme()
 	for _, r := range resourceTypes() {
 		resource := r
-		if err := scheme.Register(r.GVK, func() any { return resource.NewResource() }); err != nil {
+		if err := scheme.Register(
+			r.GVK,
+			func() any { return resource.NewResource() },
+		); err != nil {
 			panic(err)
 		}
-		if err := scheme.Register(manifest.GVK{APIVersion: r.GVK.APIVersion, Kind: apiv1alpha1.ListKind(r.GVK.Kind)}, r.newList); err != nil {
+
+		if err := scheme.Register(manifest.GVK{
+			APIVersion: r.GVK.APIVersion,
+			Kind:       apiv1alpha1.ListKind(r.GVK.Kind),
+		}, r.newList); err != nil {
 			panic(err)
 		}
 	}
+
 	return &ResourceScheme{Scheme: scheme}
 }
 
 // Lookup returns canonical capabilities; registering a custom decoder on the
 // embedded scheme does not give that type resource or mutation capabilities.
-func (s *ResourceScheme) Lookup(gvk manifest.GVK) (ResourceType, error) { return LookupResource(gvk) }
+func (s *ResourceScheme) Lookup(gvk manifest.GVK) (ResourceType, error) {
+	return LookupResource(gvk)
+}
 
 // LookupResource provides schema capabilities without allocating a decoder.
 func LookupResource(gvk manifest.GVK) (ResourceType, error) {
@@ -103,6 +119,7 @@ func LookupResource(gvk manifest.GVK) (ResourceType, error) {
 			return r, nil
 		}
 	}
+
 	return ResourceType{}, fmt.Errorf("unsupported resource %s", gvk)
 }
 
@@ -116,6 +133,7 @@ func TypeOf(resource any) (ResourceType, error) {
 			return r, nil
 		}
 	}
+
 	return ResourceType{}, fmt.Errorf("expected a canonical resource")
 }
 
@@ -123,30 +141,48 @@ func TypeOf(resource any) (ResourceType, error) {
 // Constructing descriptor values avoids a mutable global registry.
 func resourceTypes() []ResourceType {
 	return []ResourceType{
-		describe[actor.Actor, actor.ActorPatch](actor.ActorKind, "actors", actor.ValidateID,
+		describe[actor.Actor, actor.ActorPatch](
+			actor.ActorKind,
+			"actors",
+			actor.ValidateID,
 			func(r *actor.Actor) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *actor.Actor, patch *actor.ActorPatch) (*actor.Actor, error) {
 				return patch.ApplyTo(current, nil)
 			}),
-		describe[connection.Connection, connection.ConnectionPatch](connection.ConnectionKind, "connections", connection.ValidateID,
+		describe[connection.Connection, connection.ConnectionPatch](
+			connection.ConnectionKind,
+			"connections",
+			connection.ValidateID,
 			func(r *connection.Connection) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *connection.Connection, patch *connection.ConnectionPatch) (*connection.Connection, error) {
 				return current.ApplyUpdate(patch)
 			}),
-		describe[connectors.Connector, connectors.ConnectorPatch](connectors.ConnectorKind, "connectors", connectors.ValidateID,
+		describe[connectors.Connector, connectors.ConnectorPatch](
+			connectors.ConnectorKind,
+			"connectors",
+			connectors.ValidateID,
 			func(r *connectors.Connector) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *connectors.Connector, patch *connectors.ConnectorPatch) (*connectors.Connector, error) {
 				return patch.ApplyTo(current, nil)
 			}),
-		describe[key.Key, key.KeyPatch](key.KeyKind, "keys", key.ValidateID,
+		describe[key.Key, key.KeyPatch](
+			key.KeyKind,
+			"keys",
+			key.ValidateID,
 			func(r *key.Key) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *key.Key, patch *key.KeyPatch) (*key.Key, error) { return patch.ApplyTo(current, nil) }),
-		describe[namespace.Namespace, namespace.NamespacePatch](namespace.NamespaceKind, "namespaces", namespace.ValidatePath,
+		describe[namespace.Namespace, namespace.NamespacePatch](
+			namespace.NamespaceKind,
+			"namespaces",
+			namespace.ValidatePath,
 			func(r *namespace.Namespace) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *namespace.Namespace, patch *namespace.NamespacePatch) (*namespace.Namespace, error) {
 				return patch.ApplyTo(current, nil)
 			}),
-		describe[rate_limit.RateLimit, rate_limit.RateLimitPatch](rate_limit.RateLimitKind, "rate-limits", rate_limit.ValidateID,
+		describe[rate_limit.RateLimit, rate_limit.RateLimitPatch](
+			rate_limit.RateLimitKind,
+			"rate-limits",
+			rate_limit.ValidateID,
 			func(r *rate_limit.RateLimit) (meta.TypeMeta, meta.ObjectMeta) { return r.TypeMeta, r.Metadata },
 			func(current *rate_limit.RateLimit, patch *rate_limit.RateLimitPatch) (*rate_limit.RateLimit, error) {
 				return patch.ApplyTo(current, nil)
@@ -154,13 +190,19 @@ func resourceTypes() []ResourceType {
 	}
 }
 
-func describe[R, P any](kind meta.Kind, collection string, validateID func(string) error,
-	metadata func(*R) (meta.TypeMeta, meta.ObjectMeta), merge func(*R, *P) (*R, error)) ResourceType {
+func describe[R, P any](
+	kind meta.Kind,
+	collection string,
+	validateID func(string) error,
+	metadata func(*R) (meta.TypeMeta, meta.ObjectMeta), merge func(*R, *P) (*R, error),
+) ResourceType {
 	return ResourceType{
-		GVK: manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind}, Collection: collection,
+		GVK: manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: kind},
+		Collection: collection,
 		NewResource: func() Value { return any(new(R)).(Value) },
 		NewPatch:    func() Value { return any(new(P)).(Value) },
-		ValidateID:  validateID, resourceType: reflect.TypeOf(new(R)),
+		ValidateID:  validateID,
+		resourceType: reflect.TypeOf(new(R)),
 		newList: func() any { return new(apiv1alpha1.ResourceList[R]) },
 		metadata: func(value any) (meta.ObjectMeta, error) {
 			r, ok := value.(*R)

--- a/internal/schema/registry/resources_test.go
+++ b/internal/schema/registry/resources_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"github.com/rmorlok/authproxy/internal/apid"
 	"testing"
 
 	apiv1alpha1 "github.com/rmorlok/authproxy/internal/schema/api/v1alpha1"
@@ -57,7 +58,7 @@ func checkRegistration[T any](t *testing.T, kind meta.Kind) {
 func TestIndependentSchemesAndUnsupportedContracts(t *testing.T) {
 	first, second := NewResourceScheme(), NewResourceScheme()
 	gvk := manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "LocalExtension"}
-	require.NoError(t, manifest.RegisterType[actor.Actor](first, gvk))
+	require.NoError(t, manifest.RegisterType[actor.Actor](first.Scheme, gvk))
 	require.NotContains(t, second.RegisteredGVKs(), gvk)
 	for _, payload := range []string{
 		`{"apiVersion":"authproxy.net/v999","kind":"Actor"}`,
@@ -67,4 +68,94 @@ func TestIndependentSchemesAndUnsupportedContracts(t *testing.T) {
 		_, err := second.DecodeJSON([]byte(payload))
 		require.Error(t, err)
 	}
+}
+
+func TestResourceCapabilities(t *testing.T) {
+	cases := []struct {
+		kind       meta.Kind
+		collection string
+		id         string
+		patch      any
+	}{
+		{actor.ActorKind, "actors", apid.New(apid.PrefixActor).String(), new(actor.ActorPatch)},
+		{connection.ConnectionKind, "connections", apid.New(apid.PrefixConnection).String(), new(connection.ConnectionPatch)},
+		{connectors.ConnectorKind, "connectors", apid.New(apid.PrefixConnector).String(), new(connectors.ConnectorPatch)},
+		{key.KeyKind, "keys", apid.New(apid.PrefixKey).String(), new(key.KeyPatch)},
+		{namespace.NamespaceKind, "namespaces", "root.example", new(namespace.NamespacePatch)},
+		{rate_limit.RateLimitKind, "rate-limits", apid.New(apid.PrefixRateLimit).String(), new(rate_limit.RateLimitPatch)},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			scheme := NewResourceScheme()
+			descriptor, err := scheme.Lookup(manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: tc.kind})
+			require.NoError(t, err)
+			require.Equal(t, tc.collection, descriptor.Collection)
+			require.NoError(t, descriptor.ValidateID(tc.id))
+			require.Error(t, descriptor.ValidateID("invalid"))
+			require.IsType(t, tc.patch, descriptor.NewPatch())
+			require.NotSame(t, descriptor.NewPatch(), descriptor.NewPatch())
+			data := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{"id":%q,"name":"example","namespace":"root","labels":{"team":"one"}},"spec":{}}`, tc.kind, tc.id)
+			resource, err := scheme.DecodeJSON([]byte(data))
+			require.NoError(t, err)
+			require.IsType(t, resource, descriptor.NewResource())
+			inferred, err := TypeOf(resource)
+			require.NoError(t, err)
+			require.Equal(t, descriptor.GVK, inferred.GVK)
+			metadata, err := descriptor.Metadata(resource)
+			require.NoError(t, err)
+			require.Equal(t, tc.id, metadata.ID)
+			metadata.Labels["team"] = "changed"
+			unchanged, err := descriptor.Metadata(resource)
+			require.NoError(t, err)
+			require.Equal(t, "one", unchanged.Labels["team"])
+			patchData := fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{},"spec":{}}`, tc.kind)
+			patch, err := descriptor.DecodePatchJSON([]byte(patchData))
+			require.NoError(t, err)
+			require.IsType(t, tc.patch, patch)
+			_, err = descriptor.DecodePatchJSON([]byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"spec":{}}`, tc.kind)))
+			require.Error(t, err, "missing patch metadata must not be defaulted")
+			_, err = descriptor.DecodePatchJSON([]byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":%q,"metadata":{},"spec":{},"unknown":true}`, tc.kind)))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPatchApplicationAndTypeSafety(t *testing.T) {
+	scheme := NewResourceScheme()
+	d, err := scheme.Lookup(manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: actor.ActorKind})
+	require.NoError(t, err)
+	current, err := scheme.DecodeJSON([]byte(fmt.Sprintf(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{"id":%q,"name":"example","namespace":"root"},"spec":{"externalId":"subject"}}`, apid.New(apid.PrefixActor))))
+	require.NoError(t, err)
+	patch, err := d.DecodePatchJSON([]byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{"labels":{"team":"two"}},"spec":{}}`))
+	require.NoError(t, err)
+	updated, err := d.ApplyPatch(current, patch)
+	require.NoError(t, err)
+	require.Equal(t, "two", updated.(*actor.Actor).Metadata.Labels["team"])
+	require.Empty(t, current.(*actor.Actor).Metadata.Labels)
+	immutable, err := d.DecodePatchJSON([]byte(`{"apiVersion":"authproxy.net/v1alpha1","kind":"Actor","metadata":{},"spec":{"externalId":"other"}}`))
+	require.NoError(t, err)
+	_, err = d.ApplyPatch(current, immutable)
+	require.ErrorContains(t, err, "immutable")
+	for _, bad := range []any{nil, (*actor.Actor)(nil), new(key.Key)} {
+		_, err = d.Metadata(bad)
+		require.Error(t, err)
+		_, err = d.ApplyPatch(bad, patch)
+		require.Error(t, err)
+		require.Error(t, d.ValidateResource(bad, meta.ValidationModeCreate))
+	}
+	for _, bad := range []any{nil, (*actor.ActorPatch)(nil), new(key.KeyPatch)} {
+		_, err = d.ApplyPatch(current, bad)
+		require.Error(t, err)
+	}
+	_, err = TypeOf((*actor.Actor)(nil))
+	require.Error(t, err)
+	// Lifecycle validation stays with the resource implementation.
+	fresh := actor.NewActor()
+	fresh.Metadata.Namespace = "root"
+	fresh.Spec.ExternalId = "subject"
+	require.NoError(t, d.ValidateResource(fresh, meta.ValidationModeCreate))
+	fresh.Spec.ExternalId = ""
+	require.Error(t, d.ValidateResource(fresh, meta.ValidationModeCreate))
+	_, err = LookupResource(manifest.GVK{APIVersion: meta.APIVersionV1Alpha1, Kind: "ActorList"})
+	require.Error(t, err)
 }


### PR DESCRIPTION
Adds the authenticated REST layer for the next stages of `ap apply`. Documents can now be resolved by explicit ID or exact namespace/name across paginated results, checked against supplied identity, and validated using each resource's canonical create/patch contract. Batch resolution detects aliases targeting one live ID. Key resources are supported through both the API and admin API, with authorization enforced by the server. Explicit IDs and connector generations must exist; connections only support existing metadata updates.

The client provides single-resource create and patch methods, per-request timeouts, safe HTTP status errors, redaction metadata and write-only field information. Resource/patch factories, metadata access, ID validation, lifecycle validation, patch application and REST collection names are centralized in `internal/schema/registry`. The generic manifest scheme remains a decoder; the richer resource scheme exposes capability lookup and explicit patch decoding. Apply retains target resolution, endpoint selection and execution policy. The client reuses this registry and the CLI signing resolver, selects the API or admin API according to admin mode, refuses redirects, and does not retry mutations. Tests exercise all six resource adapters, signing/service selection, Key operations on both services and API permission denials, pagination and namespace filtering, conflicts/missing identities, nullable and immutable fields, redaction, deadlines and cancellation.

This is infrastructure for reconciliation and execution (#922/#923). The command still exposes offline client dry-run only; this PR does not enable cluster apply or promise concurrency protection. The package README documents that boundary.

Closes #921
Part of #919

## Validation
- `go test ./internal/schema/registry ./internal/schema/manifest ./internal/apply ./cmd/cli/config ./cmd/cli`
- `./scripts/preflight.sh`


