### PR TITLE
Expose keys endpoints on the main API

### DIFF
--- a/docs/src/content/docs/security/permission-resources-and-verbs.md
+++ b/docs/src/content/docs/security/permission-resources-and-verbs.md
@@ -19,7 +19,7 @@ dimension. Prefer the explicit values below for least-privilege grants.
 | `app-metrics` | `query`, `schema` | Aggregate application-metric queries and metric-schema discovery |
 | `connections` | `create`, `disconnect`, `force_state`, `get`, `list`, `proxy`, `update` | Connection setup, configuration, lifecycle, and authenticated proxy requests |
 | `connectors` | `archive`, `create`, `disconnect_all`, `force_state`, `get`, `list`, `list/generations`, `update` | Connector definitions, generations, metadata, and lifecycle operations |
-| `keys` | `create`, `delete`, `get`, `list`, `update` | Reusable signing and encryption-key resources on both the main API and admin API |
+| `keys` | `create`, `delete`, `get`, `list`, `update` | Reusable signing and encryption-key resources |
 | `namespaces` | `create`, `get`, `list`, `update` | Namespace records, metadata, and namespace key assignments |
 | `rate_limits` | `create`, `delete`, `get`, `list`, `update` | Rate-limit rules, overrides, and related evaluation endpoints |
 | `request-events` | `get`, `list` | Individual and listed proxy request events |

--- a/docs/src/content/docs/security/permission-resources-and-verbs.md
+++ b/docs/src/content/docs/security/permission-resources-and-verbs.md
@@ -19,7 +19,7 @@ dimension. Prefer the explicit values below for least-privilege grants.
 | `app-metrics` | `query`, `schema` | Aggregate application-metric queries and metric-schema discovery |
 | `connections` | `create`, `disconnect`, `force_state`, `get`, `list`, `proxy`, `update` | Connection setup, configuration, lifecycle, and authenticated proxy requests |
 | `connectors` | `archive`, `create`, `disconnect_all`, `force_state`, `get`, `list`, `list/generations`, `update` | Connector definitions, generations, metadata, and lifecycle operations |
-| `keys` | `create`, `delete`, `get`, `list`, `update` | Reusable signing and encryption-key resources |
+| `keys` | `create`, `delete`, `get`, `list`, `update` | Reusable signing and encryption-key resources on both the main API and admin API |
 | `namespaces` | `create`, `get`, `list`, `update` | Namespace records, metadata, and namespace key assignments |
 | `rate_limits` | `create`, `delete`, `get`, `list`, `update` | Rate-limit rules, overrides, and related evaluation endpoints |
 | `request-events` | `get`, `list` | Individual and listed proxy request events |

--- a/internal/service/api/server.go
+++ b/internal/service/api/server.go
@@ -144,6 +144,11 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 		authService,
 		dm.GetCoreService(),
 	)
+	routesKeys := common_routes.NewKeysRoutes(
+		dm.GetConfig(),
+		authService,
+		dm.GetCoreService(),
+	)
 	routesNotifications := common_routes.NewNotificationsRoutes(
 		authService,
 		dm.GetCoreService(),
@@ -154,6 +159,7 @@ func GetGinServer(dm *service.DependencyManager) (httpServer *http.Server, httpH
 	routesConnectors.Register(api)
 	routesConnections.Register(api)
 	routesNamespaces.Register(api)
+	routesKeys.Register(api)
 	routesProxy.Register(api)
 	routesTasks.Register(api)
 	routesRequestEvents.Register(api)


### PR DESCRIPTION
The main API advertised keys in Swagger but did not register their routes. Register the shared keys handlers under `/api/v1` so API clients can list, create, get, update, and delete keys with the existing authentication and resource permission checks.

Update the permission reference to state that keys are available on both APIs.

Validation:
- Existing keys route tests and OpenAPI contract test passed.
- Main API package compiled (`go test ./internal/service/api`).
- `yarn docs:build` passed.
- `./scripts/preflight.sh` passed.
